### PR TITLE
fix build directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install glide from [http://glide.sh/](http://glide.sh/)
 Build the code (make sure you have set GOPATH):
 ```
 go get -d k8s.io/kops
-cd ${GOPATH}/src/k8s.io/kops/cmd/...
+cd ${GOPATH}/src/k8s.io/kops/
 make
 ```
 


### PR DESCRIPTION
I think maybe the three dots was mean to be two so it goes back up a directory, but I don't see any reason we can't go directly to the correct directory.