### PR TITLE
AWS: set hostname-override from metadata service

### DIFF
--- a/upup/models/config/components/kubelet/_aws/kubelet.aws.options
+++ b/upup/models/config/components/kubelet/_aws/kubelet.aws.options
@@ -1,3 +1,5 @@
 Kubelet:
   CloudProvider: aws
   CgroupRoot: docker
+  # Use the hostname from the AWS metadata service
+  HostnameOverride: "@aws"

--- a/upup/pkg/api/componentconfig.go
+++ b/upup/pkg/api/componentconfig.go
@@ -48,9 +48,11 @@ type KubeletConfig struct {
 	//// default /var/run/kubernetes). If tlsCertFile and tlsPrivateKeyFile
 	//// are provided, this flag will be ignored.
 	//CertDirectory string `json:"certDirectory"`
-	//// hostnameOverride is the hostname used to identify the kubelet instead
-	//// of the actual hostname.
-	//HostnameOverride string `json:"hostnameOverride"`
+	// hostnameOverride is the hostname used to identify the kubelet instead
+	// of the actual hostname.
+	// Note: We recognize some additional values:
+	//  @aws uses the hostname from the AWS metadata service
+	HostnameOverride string `json:"hostnameOverride" flag:"hostname-override"`
 	//// podInfraContainerImage is the image whose network/ipc namespaces
 	//// containers in each pod will use.
 	//PodInfraContainerImage string `json:"podInfraContainerImage"`


### PR DESCRIPTION
This is a weird edge case, because it can't be determined in advance.

We carve out a special well-known name, `@aws`, which nodeup/protokube
will expand to the local-hostname from the aws metadata service when it
is found in the HostnameOverride value.

Ideally we wouldn't do this at all now that we have DNS integration, but
we first want to get into the tested & working configuration!