### PR TITLE
Remove glide from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Some of the more interesting features:
 
 ## Installation
 
-Install glide from [http://glide.sh/](http://glide.sh/)
-
 Build the code (make sure you have set GOPATH):
 ```
 go get -d k8s.io/kops


### PR DESCRIPTION
It isn't required to build the code, now that we checked in the vendor
directory.

Fix #49