### PR TITLE
Fetch ELB tags in chunks of 20

### DIFF
--- a/upup/pkg/kutil/delete_cluster.go
+++ b/upup/pkg/kutil/delete_cluster.go
@@ -1169,6 +1169,8 @@ func DescribeELBs(cloud fi.Cloud) ([]*elb.LoadBalancerDescription, map[string][]
 	glog.V(2).Infof("Listing all ELBs")
 
 	request := &elb.DescribeLoadBalancersInput{}
+	// ELB DescribeTags has a limit of 20 names, so we set the page size here to 20 also
+	request.PageSize = aws.Int64(20)
 
 	var elbs []*elb.LoadBalancerDescription
 	elbTags := make(map[string][]*elb.Tag)


### PR DESCRIPTION
ELB DescribeTags has a limit of 20 ELBs / call.  So we paginate the
DescribeLoadBalancers call with page size = 20 also.