### PR TITLE
Avoid a race between etcd start and volume mount

### DIFF
--- a/protokube/pkg/protokube/models.go
+++ b/protokube/pkg/protokube/models.go
@@ -6,15 +6,13 @@ import (
 	"text/template"
 )
 
-func ExecuteTemplate(key string, contents string, model interface{}) (string, error) {
+// ExecuteTemplate renders the specified template with the model
+func ExecuteTemplate(key string, templateDefinition string, model interface{}) ([]byte, error) {
 	t := template.New(key)
 
-	//funcMap := make(template.FuncMap)
-	//t.Funcs(funcMap)
-
-	_, err := t.Parse(contents)
+	_, err := t.Parse(templateDefinition)
 	if err != nil {
-		return "", fmt.Errorf("error parsing template %q: %v", key, err)
+		return nil, fmt.Errorf("error parsing template %q: %v", key, err)
 	}
 
 	t.Option("missingkey=zero")
@@ -22,8 +20,8 @@ func ExecuteTemplate(key string, contents string, model interface{}) (string, er
 	var buffer bytes.Buffer
 	err = t.ExecuteTemplate(&buffer, key, model)
 	if err != nil {
-		return "", fmt.Errorf("error executing template %q: %v", key, err)
+		return nil, fmt.Errorf("error executing template %q: %v", key, err)
 	}
 
-	return buffer.String(), nil
+	return buffer.Bytes(), nil
 }

--- a/protokube/pkg/protokube/volume_mounter.go
+++ b/protokube/pkg/protokube/volume_mounter.go
@@ -9,8 +9,6 @@ import (
 	"time"
 )
 
-//const MasterMountpoint = "/mnt/master-pd"
-
 type VolumeMountController struct {
 	mounted map[string]*Volume
 

--- a/protokube/pkg/protokube/volumes.go
+++ b/protokube/pkg/protokube/volumes.go
@@ -21,6 +21,7 @@ type Volume struct {
 	AttachedTo string
 
 	// Mountpoint is the path on which the volume is mounted, if mounted
+	// It will likely be "/mnt/master-" + ID
 	Mountpoint string
 
 	// Status is a volume provider specific Status string; it makes it easier for the volume provider


### PR DESCRIPTION
If the instance restarted but lost the volume mount, there might be a
short or indefinite delay before protokube can mount the volume again.
But the etcd manifest would probably still be in
/etc/kubernetes/manifests from the previous run.

To ensure that kubelet doesn't run etcd until the volume is actually
mounted, we use a symlink to a directory on the volume itself.  Thus
kubelet can't start etcd until we put the volume there.  We can also
delete the symlink before mounting, so we have full control.

Issue #73