### PR TITLE
Report less-scary message when IAM instance profile is not ready yet

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
@@ -221,7 +221,12 @@ func (_ *LaunchConfiguration) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *La
 	}
 
 	_, err = t.Cloud.Autoscaling.CreateLaunchConfiguration(request)
+
 	if err != nil {
+		if awsup.AWSErrorCode(err) == "ValidationError" && strings.Contains(awsup.AWSErrorMessage(err), "Invalid IamInstanceProfile") {
+			// IAM instance profile creation is notoriously async
+			return fmt.Errorf("IAM instance profile %q not yet created/propagated", err)
+		}
 		return fmt.Errorf("error creating AutoscalingLaunchConfiguration: %v", err)
 	}
 

--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -3,6 +3,7 @@ package awsup
 import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -67,4 +68,20 @@ func FindELBTag(tags []*elb.Tag, key string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// AWSErrorCode returns the aws error code, if it is an awserr.Error, otherwise ""
+func AWSErrorCode(err error) string {
+	if awsError, ok := err.(awserr.Error); ok {
+		return awsError.Code()
+	}
+	return ""
+}
+
+// AWSErrorMessage returns the aws error message, if it is an awserr.Error, otherwise ""
+func AWSErrorMessage(err error) string {
+	if awsError, ok := err.(awserr.Error); ok {
+		return awsError.Message()
+	}
+	return ""
 }

--- a/upup/pkg/kutil/delete_cluster.go
+++ b/upup/pkg/kutil/delete_cluster.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
@@ -477,7 +476,7 @@ func DeleteVolume(cloud fi.Cloud, r *ResourceTracker) error {
 		if IsDependencyViolation(err) {
 			return err
 		}
-		if AWSErrorCode(err) == "InvalidVolume.NotFound" {
+		if awsup.AWSErrorCode(err) == "InvalidVolume.NotFound" {
 			// Concurrently deleted
 			return nil
 		}
@@ -579,16 +578,8 @@ func DescribeVolumes(cloud fi.Cloud) ([]*ec2.Volume, error) {
 	return volumes, nil
 }
 
-// AWSErrorCode returns the aws error code, if it is an awserr.Error, otherwise ""
-func AWSErrorCode(err error) string {
-	if awsError, ok := err.(awserr.Error); ok {
-		return awsError.Code()
-	}
-	return ""
-}
-
 func IsDependencyViolation(err error) bool {
-	code := AWSErrorCode(err)
+	code := awsup.AWSErrorCode(err)
 	switch code {
 	case "":
 		return false
@@ -792,7 +783,7 @@ func DeleteInternetGateway(cloud fi.Cloud, r *ResourceTracker) error {
 		}
 		response, err := c.EC2.DescribeInternetGateways(request)
 		if err != nil {
-			if AWSErrorCode(err) == "InvalidInternetGatewayID.NotFound" {
+			if awsup.AWSErrorCode(err) == "InvalidInternetGatewayID.NotFound" {
 				glog.Infof("Internet gateway %q not found; assuming already deleted", id)
 				return nil
 			}
@@ -833,7 +824,7 @@ func DeleteInternetGateway(cloud fi.Cloud, r *ResourceTracker) error {
 			if IsDependencyViolation(err) {
 				return err
 			}
-			if AWSErrorCode(err) == "InvalidInternetGatewayID.NotFound" {
+			if awsup.AWSErrorCode(err) == "InvalidInternetGatewayID.NotFound" {
 				glog.Infof("Internet gateway %q not found; assuming already deleted", id)
 				return nil
 			}

--- a/upup/pkg/kutil/upgrade_cluster.go
+++ b/upup/pkg/kutil/upgrade_cluster.go
@@ -140,7 +140,7 @@ func (x *UpgradeCluster) Upgrade() error {
 			for {
 				_, err := awsCloud.EC2.DetachVolume(request)
 				if err != nil {
-					if AWSErrorCode(err) == "IncorrectState" {
+					if awsup.AWSErrorCode(err) == "IncorrectState" {
 						glog.Infof("retrying to detach volume (master has probably not stopped yet): %q", err)
 						time.Sleep(5 * time.Second)
 						continue


### PR DESCRIPTION
IAM instance profile creation is very async, and this causes dependent
resources to fail.  That's fine - we have good retry logic - but we
should output a less frightening error message.

Issue #35