### PR TITLE
When exposing secrets, output a blank line afterwards

### DIFF
--- a/cmd/kops/secrets_expose.go
+++ b/cmd/kops/secrets_expose.go
@@ -100,7 +100,7 @@ func (cmd *ExposeSecretsCommand) Run() error {
 		return fmt.Errorf("secret type not known: %q", cmd.Type)
 	}
 
-	_, err := fmt.Fprint(os.Stdout, value)
+	_, err := fmt.Fprint(os.Stdout, value + "\n")
 	if err != nil {
 		return fmt.Errorf("error writing to output: %v", err)
 	}


### PR DESCRIPTION
Otherwise it becomes hard to copy and paste