### PR TITLE
Allow configurable RootDeviceSize & RootDeviceType

### DIFF
--- a/upup/models/cloudup/_aws/master/_master_asg/master_asg.yaml
+++ b/upup/models/cloudup/_aws/master/_master_asg/master_asg.yaml
@@ -10,6 +10,8 @@ launchConfiguration/{{ $m.Name }}.masters.{{ ClusterName }}:
   instanceType: {{ $m.Spec.MachineType }}
   associatePublicIP: true
   userData: resources/nodeup.sh _kubernetes_master
+  rootVolumeSize: {{ or $m.Spec.RootVolumeSize "20" }}
+  rootVolumeType: {{ or $m.Spec.RootVolumeType "gp2" }}
 
 autoscalingGroup/{{ $m.Name}}.masters.{{ ClusterName }}:
   minSize: 1

--- a/upup/models/cloudup/_aws/nodes.yaml
+++ b/upup/models/cloudup/_aws/nodes.yaml
@@ -54,6 +54,8 @@ launchConfiguration/{{ $nodeset.Name }}.{{ ClusterName }}:
   instanceType: {{ $nodeset.Spec.MachineType }}
   associatePublicIP: true
   userData: resources/nodeup.sh _kubernetes_pool
+  rootVolumeSize: {{ or $nodeset.Spec.RootVolumeSize "20" }}
+  rootVolumeType: {{ or $nodeset.Spec.RootVolumeType "gp2" }}
 
 autoscalingGroup/{{ $nodeset.Name }}.{{ ClusterName }}:
   launchConfiguration: launchConfiguration/{{ $nodeset.Name }}.{{ ClusterName }}

--- a/upup/pkg/api/instancegroup.go
+++ b/upup/pkg/api/instancegroup.go
@@ -35,6 +35,11 @@ type InstanceGroupSpec struct {
 	MachineType string `json:"machineType,omitempty"`
 	//NodeTag            string `json:",omitempty"`
 
+	// RootVolumeSize is the size of the EBS root volume to use, in GB
+	RootVolumeSize *int `json:"rootVolumeSize",omitempty`
+	// RootVolumeType is the type of the EBS root volume to use (e.g. gp2)
+	RootVolumeType *string `json:"rootVolumeType",omitempty`
+
 	Zones []string `json:"zones,omitempty"`
 }
 

--- a/upup/pkg/fi/cloudup/awstasks/block_device_mappings.go
+++ b/upup/pkg/fi/cloudup/awstasks/block_device_mappings.go
@@ -9,11 +9,20 @@ import (
 
 type BlockDeviceMapping struct {
 	VirtualName *string
+
+	EbsDeleteOnTermination *bool
+	EbsVolumeSize          *int64
+	EbsVolumeType          *string
 }
 
 func BlockDeviceMappingFromEC2(i *ec2.BlockDeviceMapping) (string, *BlockDeviceMapping) {
 	o := &BlockDeviceMapping{}
 	o.VirtualName = i.VirtualName
+	if i.Ebs != nil {
+		o.EbsDeleteOnTermination = i.Ebs.DeleteOnTermination
+		o.EbsVolumeSize = i.Ebs.VolumeSize
+		o.EbsVolumeType = i.Ebs.VolumeType
+	}
 	return aws.StringValue(i.DeviceName), o
 }
 
@@ -21,12 +30,23 @@ func (i *BlockDeviceMapping) ToEC2(deviceName string) *ec2.BlockDeviceMapping {
 	o := &ec2.BlockDeviceMapping{}
 	o.DeviceName = aws.String(deviceName)
 	o.VirtualName = i.VirtualName
+	if i.EbsDeleteOnTermination != nil || i.EbsVolumeSize != nil || i.EbsVolumeType != nil {
+		o.Ebs = &ec2.EbsBlockDevice{}
+		o.Ebs.DeleteOnTermination = i.EbsDeleteOnTermination
+		o.Ebs.VolumeSize = i.EbsVolumeSize
+		o.Ebs.VolumeType = i.EbsVolumeType
+	}
 	return o
 }
 
 func BlockDeviceMappingFromAutoscaling(i *autoscaling.BlockDeviceMapping) (string, *BlockDeviceMapping) {
 	o := &BlockDeviceMapping{}
 	o.VirtualName = i.VirtualName
+	if i.Ebs != nil {
+		o.EbsDeleteOnTermination = i.Ebs.DeleteOnTermination
+		o.EbsVolumeSize = i.Ebs.VolumeSize
+		o.EbsVolumeType = i.Ebs.VolumeType
+	}
 	return aws.StringValue(i.DeviceName), o
 }
 
@@ -34,6 +54,14 @@ func (i *BlockDeviceMapping) ToAutoscaling(deviceName string) *autoscaling.Block
 	o := &autoscaling.BlockDeviceMapping{}
 	o.DeviceName = aws.String(deviceName)
 	o.VirtualName = i.VirtualName
+
+	if i.EbsDeleteOnTermination != nil || i.EbsVolumeSize != nil || i.EbsVolumeType != nil {
+		o.Ebs = &autoscaling.Ebs{}
+		o.Ebs.DeleteOnTermination = i.EbsDeleteOnTermination
+		o.Ebs.VolumeSize = i.EbsVolumeSize
+		o.Ebs.VolumeType = i.EbsVolumeType
+	}
+
 	return o
 }
 


### PR DESCRIPTION
This allows for a larger EBS root volume (and we now default to 20GB,
just like kube-up did).

We remove the BlockDeviceMappings support because it wasn't used and
made things a lot more complicated.  We always map the ephemeral
devices.

Issue #24