### PR TITLE
Change node role tag to match master pattern

### DIFF
--- a/upup/models/cloudup/_aws/nodes.yaml
+++ b/upup/models/cloudup/_aws/nodes.yaml
@@ -64,6 +64,6 @@ autoscalingGroup/{{ $nodeset.Name }}.{{ ClusterName }}:
     - subnet/{{ $zone }}.{{ ClusterName }}
 {{ end }}
   tags:
-    k8s.io/role: node
+    k8s.io/role/node: 1
 
 {{ end }}


### PR DESCRIPTION
It's not currently used, and we hadn't updated it to match the better
pattern.

k8s.io/role=master can only be in one role
k8s.io/role/master=1 allows for multiple roles