### PR TITLE
Export kubecfg after as create cluster by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,13 @@ ${GOPATH}/bin/kops create cluster --v=0 --cloud=aws --zones=us-east-1c --name=${
 
 If you have problems, please set `--v=8` and open an issue, and ping justinsb on slack!
 
-## Build a kubectl file
+## Create kubecfg settings for kubectl
 
-The kops tool is a CLI for doing administrative tasks.  You can use it to create the kubecfg configuration,
-for use with kubectl:
+(This step is actually optional; `create cluster` will do it automatically after cluster creation.
+ But we expect that if you're part of a team you might share the KOPS_STATE_STORE, and then you can do
+ this on different machines instead of having to share kubecfg files)
+
+To create the kubecfg configuration settings for use with kubectl:
 
 ```
 export NAME=<kubernetes.mydomain.com>

--- a/cmd/kops/export_kubecfg.go
+++ b/cmd/kops/export_kubecfg.go
@@ -2,14 +2,11 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
-	"io"
-	"io/ioutil"
 	"k8s.io/kops/upup/pkg/fi"
-	"k8s.io/kops/upup/pkg/kubecfg"
-	"os"
-	"path"
+	"k8s.io/kops/upup/pkg/kutil"
 )
 
 type ExportKubecfgCommand struct {
@@ -49,94 +46,12 @@ func (c *ExportKubecfgCommand) Run() error {
 		master = "api." + clusterName
 	}
 
-	//cloudProvider := config.CloudProvider
-	//if cloudProvider == "" {
-	//	return fmt.Errorf("cloud must be specified")
-	//}
-
-	c.tmpdir, err = ioutil.TempDir("", "k8s")
-	if err != nil {
-		return fmt.Errorf("error creating temporary directory: %v", err)
+	x := &kutil.CreateKubecfg{
+		ClusterName:      clusterName,
+		KeyStore:         clusterRegistry.KeyStore(clusterName),
+		MasterPublicName: master,
 	}
-	defer os.RemoveAll(c.tmpdir)
+	defer x.Close()
 
-	b := &kubecfg.KubeconfigBuilder{}
-	b.Init()
-
-	b.Context = clusterName
-	//switch cloudProvider {
-	//case "aws":
-	//	b.Context = "aws_" + clusterName
-	//
-	//case "gce":
-	//	if config.Project == "" {
-	//		return fmt.Errorf("Project must be configured (for GCE)")
-	//	}
-	//	b.Context = config.Project + "_" + clusterName
-	//
-	//default:
-	//	return fmt.Errorf("Unknown cloud provider %q", cloudProvider)
-	//}
-
-	c.keyStore = clusterRegistry.KeyStore(clusterName)
-
-	if b.CACert, err = c.copyCertificate(fi.CertificateId_CA); err != nil {
-		return err
-	}
-
-	if b.KubecfgCert, err = c.copyCertificate("kubecfg"); err != nil {
-		return err
-	}
-
-	if b.KubecfgKey, err = c.copyPrivateKey("kubecfg"); err != nil {
-		return err
-	}
-
-	b.KubeMasterIP = master
-
-	err = b.CreateKubeconfig()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (c *ExportKubecfgCommand) copyCertificate(id string) (string, error) {
-	p := path.Join(c.tmpdir, id+".crt")
-	cert, err := c.keyStore.Cert(id)
-	if err != nil {
-		return "", fmt.Errorf("error fetching certificate %q: %v", id, err)
-	}
-
-	_, err = writeFile(p, cert)
-	if err != nil {
-		return "", fmt.Errorf("error writing certificate %q: %v", id, err)
-	}
-
-	return p, nil
-}
-
-func (c *ExportKubecfgCommand) copyPrivateKey(id string) (string, error) {
-	p := path.Join(c.tmpdir, id+".key")
-	cert, err := c.keyStore.PrivateKey(id)
-	if err != nil {
-		return "", fmt.Errorf("error fetching private key %q: %v", id, err)
-	}
-
-	_, err = writeFile(p, cert)
-	if err != nil {
-		return "", fmt.Errorf("error writing private key %q: %v", id, err)
-	}
-
-	return p, nil
-}
-
-func writeFile(dst string, src io.WriterTo) (int64, error) {
-	f, err := os.Create(dst)
-	if err != nil {
-		return 0, fmt.Errorf("error creating file %q: %v", dst, err)
-	}
-	defer fi.SafeClose(f)
-	return src.WriteTo(f)
+	return x.WriteKubecfg()
 }

--- a/cmd/kops/version.go
+++ b/cmd/kops/version.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/golang/glog"
 	"fmt"
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -39,4 +39,3 @@ func (c *VersionCmd) Run() error {
 
 	return nil
 }
-

--- a/upup/pkg/kutil/create_kubecfg.go
+++ b/upup/pkg/kutil/create_kubecfg.go
@@ -1,0 +1,108 @@
+package kutil
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/golang/glog"
+	"k8s.io/kops/upup/pkg/fi"
+)
+
+type CreateKubecfg struct {
+	ClusterName      string
+	KeyStore         fi.CAStore
+	MasterPublicName string
+
+	tmpdir string
+}
+
+func (c *CreateKubecfg) WriteKubecfg() error {
+	if c.tmpdir == "" {
+		tmpdir, err := ioutil.TempDir("", "k8s")
+		if err != nil {
+			return fmt.Errorf("error creating temporary directory: %v", err)
+		}
+		c.tmpdir = tmpdir
+
+	}
+
+	b := &KubeconfigBuilder{}
+	b.Init()
+
+	b.Context = c.ClusterName
+
+	var err error
+	if b.CACert, err = c.copyCertificate(fi.CertificateId_CA); err != nil {
+		return err
+	}
+
+	if b.KubecfgCert, err = c.copyCertificate("kubecfg"); err != nil {
+		return err
+	}
+
+	if b.KubecfgKey, err = c.copyPrivateKey("kubecfg"); err != nil {
+		return err
+	}
+
+	b.KubeMasterIP = c.MasterPublicName
+
+	err = b.WriteKubecfg()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *CreateKubecfg) Close() {
+	if c.tmpdir != "" {
+		err := os.RemoveAll(c.tmpdir)
+		if err != nil {
+			glog.Warningf("error deleting tempdir %q: %v", c.tmpdir, err)
+		} else {
+			c.tmpdir = ""
+		}
+	}
+}
+
+func (c *CreateKubecfg) copyCertificate(id string) (string, error) {
+	p := path.Join(c.tmpdir, id+".crt")
+	cert, err := c.KeyStore.Cert(id)
+	if err != nil {
+		return "", fmt.Errorf("error fetching certificate %q: %v", id, err)
+	}
+
+	_, err = writeFile(p, cert)
+	if err != nil {
+		return "", fmt.Errorf("error writing certificate %q: %v", id, err)
+	}
+
+	return p, nil
+}
+
+func (c *CreateKubecfg) copyPrivateKey(id string) (string, error) {
+	p := path.Join(c.tmpdir, id+".key")
+	cert, err := c.KeyStore.PrivateKey(id)
+	if err != nil {
+		return "", fmt.Errorf("error fetching private key %q: %v", id, err)
+	}
+
+	_, err = writeFile(p, cert)
+	if err != nil {
+		return "", fmt.Errorf("error writing private key %q: %v", id, err)
+	}
+
+	return p, nil
+}
+
+func writeFile(dst string, src io.WriterTo) (int64, error) {
+	f, err := os.Create(dst)
+	if err != nil {
+		return 0, fmt.Errorf("error creating file %q: %v", dst, err)
+	}
+	defer fi.SafeClose(f)
+	return src.WriteTo(f)
+}

--- a/upup/pkg/kutil/kubecfg_builder.go
+++ b/upup/pkg/kutil/kubecfg_builder.go
@@ -1,4 +1,4 @@
-package kubecfg
+package kutil
 
 import (
 	"fmt"
@@ -39,7 +39,7 @@ func (c *KubeconfigBuilder) Init() {
 	c.KubeconfigPath = kubeconfig
 }
 
-func (c *KubeconfigBuilder) CreateKubeconfig() error {
+func (c *KubeconfigBuilder) WriteKubecfg() error {
 	if _, err := os.Stat(c.KubeconfigPath); os.IsNotExist(err) {
 		err := os.MkdirAll(path.Dir(c.KubeconfigPath), 0700)
 		if err != nil {


### PR DESCRIPTION
It is scoped to a particular context, so seems harmless, and users will
(almost?) always do it after creation.

Fix #129