### PR TITLE
Export kubecfg after as create cluster by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: gocode
 
-DOCKER_REGISTRY=gcr.io/must-override/
-S3_BUCKET=s3://must-override/
+DOCKER_REGISTRY=justinsb
+S3_BUCKET=s3://development-justinsb/
 
 ifndef VERSION
   VERSION := git-$(shell git rev-parse --short HEAD)

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -368,18 +368,20 @@ func (c *CreateClusterCmd) Run() error {
 		return err
 	}
 
-	glog.Infof("Exporting kubecfg for cluster")
+	if !isDryrun {
+		glog.Infof("Exporting kubecfg for cluster")
 
-	x := &kutil.CreateKubecfg{
-		ClusterName:      cluster.Name,
-		KeyStore:         clusterRegistry.KeyStore(cluster.Name),
-		MasterPublicName: cluster.Spec.MasterPublicName,
-	}
-	defer x.Close()
+		x := &kutil.CreateKubecfg{
+			ClusterName:      cluster.Name,
+			KeyStore:         clusterRegistry.KeyStore(cluster.Name),
+			MasterPublicName: cluster.Spec.MasterPublicName,
+		}
+		defer x.Close()
 
-	err = x.WriteKubecfg()
-	if err != nil {
-		return err
+		err = x.WriteKubecfg()
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/upup/models/nodeup/_protokube/services/protokube.service
+++ b/upup/models/nodeup/_protokube/services/protokube.service
@@ -5,8 +5,8 @@ After=docker.service
 
 [Service]
 EnvironmentFile=/etc/sysconfig/protokube
-ExecStartPre=/usr/bin/docker pull kope/protokube:1.3
-ExecStart=/usr/bin/docker run -v /:/rootfs/ --privileged kope/protokube:1.3 /usr/bin/protokube "$DAEMON_ARGS"
+ExecStartPre=/usr/bin/docker pull justinsb/protokube:1.3
+ExecStart=/usr/bin/docker run -v /:/rootfs/ --privileged justinsb/protokube:1.3 /usr/bin/protokube "$DAEMON_ARGS"
 Restart=always
 RestartSec=2s
 StartLimitInterval=0

--- a/upup/pkg/fi/cloudup/create_cluster.go
+++ b/upup/pkg/fi/cloudup/create_cluster.go
@@ -302,7 +302,8 @@ func (c *CreateClusterCmd) Run() error {
 	}
 
 	if c.NodeUpSource == "" {
-		location := "https://kubeupv2.s3.amazonaws.com/nodeup/nodeup-1.3.tar.gz"
+		location := "https://development-justinsb.s3.amazonaws.com/nodeup/nodeup-1.3.tar.gz"
+		//location := "https://kubeupv2.s3.amazonaws.com/nodeup/nodeup-1.3.tar.gz"
 		glog.Infof("Using default nodeup location: %q", location)
 		c.NodeUpSource = location
 	}


### PR DESCRIPTION
It is scoped to a particular context, so seems harmless, and users will
(almost?) always do it after creation.

Fix #129