### PR TITLE
Clearer error message when importing a cluster with a custom subnet

### DIFF
--- a/cmd/kops/import_cluster.go
+++ b/cmd/kops/import_cluster.go
@@ -42,7 +42,7 @@ func (c *ImportClusterCmd) Run() error {
 		return fmt.Errorf("--name is required")
 	}
 
-	tags := map[string]string{"KubernetesCluster": clusterName}
+	tags := map[string]string{awsup.TagClusterName: clusterName}
 	cloud, err := awsup.NewAWSCloud(c.Region, tags)
 	if err != nil {
 		return fmt.Errorf("error initializing AWS client: %v", err)

--- a/upup/pkg/kutil/import_cluster.go
+++ b/upup/pkg/kutil/import_cluster.go
@@ -32,7 +32,7 @@ func (x *ImportCluster) ImportAWSCluster() error {
 	var instanceGroups []*api.InstanceGroup
 
 	cluster := &api.Cluster{}
-	cluster.Spec.CloudProvider = "aws"
+	cluster.Spec.CloudProvider = fi.CloudProviderAWS
 	cluster.Name = clusterName
 
 	cluster.Spec.KubeControllerManager = &api.KubeControllerManagerConfig{}
@@ -94,7 +94,7 @@ func (x *ImportCluster) ImportAWSCluster() error {
 		}
 	}
 	if masterSubnet == nil {
-		return fmt.Errorf("cannot find subnet %q", masterSubnetID)
+		return fmt.Errorf("cannot find subnet %q.  If you used an existing subnet, please tag it with %s=%s and retry the import", masterSubnetID, awsup.TagClusterName, clusterName)
 	}
 
 	vpcID := aws.StringValue(masterInstance.VpcId)


### PR DESCRIPTION
We can at least give the user better instructions on how to proceed.
Because this is not in general safe though, I'm not sure we want to
gloss over this.

Issue #69