### PR TITLE
Simpler upgrade procedure: reuse subnet

### DIFF
--- a/upup/models/cloudup/_aws/network.yaml
+++ b/upup/models/cloudup/_aws/network.yaml
@@ -39,6 +39,7 @@ subnet/{{ $zone.Name }}.{{ ClusterName }}:
   vpc: vpc/{{ ClusterName }}
   availabilityZone: {{ $zone.Name }}
   cidr: {{ $zone.CIDR }}
+  id: {{ $zone.ProviderID }}
 
 routeTableAssociation/{{ $zone.Name }}.{{ ClusterName }}:
   routeTable: routeTable/{{ ClusterName }}

--- a/upup/pkg/api/cluster.go
+++ b/upup/pkg/api/cluster.go
@@ -238,6 +238,9 @@ type EtcdMemberSpec struct {
 type ClusterZoneSpec struct {
 	Name string `json:"name,omitempty"`
 	CIDR string `json:"cidr,omitempty"`
+
+	// ProviderID is the cloud provider id for the objects associated with the zone (the subnet on AWS)
+	ProviderID string `json:"id,omitempty"`
 }
 
 //type NodeUpConfig struct {

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway.go
@@ -129,7 +129,12 @@ func (_ *InternetGateway) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Intern
 		}
 	}
 
-	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name))
+	tags := t.Cloud.BuildTags(e.Name)
+	if shared {
+		// Don't tag shared resources
+		tags = nil
+	}
+	return t.AddAWSTags(*e.ID, tags)
 }
 
 type terraformInternetGateway struct {

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -33,16 +33,20 @@ func (e *SecurityGroup) Find(c *fi.Context) (*SecurityGroup, error) {
 		vpcID = e.VPC.ID
 	}
 
-	if vpcID == nil || e.Name == nil {
+	if vpcID == nil {
 		return nil, nil
 	}
 
-	filters := cloud.BuildFilters(e.Name)
-	filters = append(filters, awsup.NewEC2Filter("vpc-id", *vpcID))
-	filters = append(filters, awsup.NewEC2Filter("group-name", *e.Name))
+	request := &ec2.DescribeSecurityGroupsInput{}
 
-	request := &ec2.DescribeSecurityGroupsInput{
-		Filters: filters,
+	if fi.StringValue(e.ID) != "" {
+		request.GroupIds = []*string{e.ID}
+	} else {
+		filters := cloud.BuildFilters(e.Name)
+		filters = append(filters, awsup.NewEC2Filter("vpc-id", *vpcID))
+		filters = append(filters, awsup.NewEC2Filter("group-name", *e.Name))
+
+		request.Filters = cloud.BuildFilters(e.Name)
 	}
 
 	response, err := cloud.EC2.DescribeSecurityGroups(request)

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -165,7 +165,12 @@ func (_ *VPC) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *VPC) error {
 		}
 	}
 
-	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name))
+	tags := t.Cloud.BuildTags(e.Name)
+	if shared {
+		// Don't tag shared resources
+		tags = nil
+	}
+	return t.AddAWSTags(*e.ID, tags)
 }
 
 type terraformVPC struct {


### PR DESCRIPTION
By reusing the subnet & security groups, we are able to skip the ELB
steps of the upgrade procedure.  The new cluster also has the same
identity as the old cluster for security groups, so we don't need to
reconfigure ELB etc.

Fixes #175
Fixes #174