### PR TITLE
Fix build with golang 1.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ gocode:
 	GO15VENDOREXPERIMENT=1 go install -ldflags "-X main.BuildVersion=${VERSION}" k8s.io/kops/cmd/...
 	ln -sfn ${GOPATH_1ST}/src/k8s.io/kops/upup/models/ ${GOPATH_1ST}/bin/models
 
+# Build in a docker container with golang 1.5
+# Used to test we have not broken 1.5
+check-builds-in-go15:
+	docker run -v ${GOPATH_1ST}/src/k8s.io/kops:/go/src/k8s.io/kops golang:1.5 make -f /go/src/k8s.io/kops/Makefile gocode
+
 codegen:
 	GO15VENDOREXPERIMENT=1 go install k8s.io/kops/upup/tools/generators/...
 	GO15VENDOREXPERIMENT=1 go generate k8s.io/kops/upup/pkg/fi/cloudup/awstasks

--- a/upup/pkg/fi/vfs_castore.go
+++ b/upup/pkg/fi/vfs_castore.go
@@ -118,7 +118,7 @@ func (c *VFSCAStore) generateCACertificate() (*certificates, *privateKeys, error
 	if err != nil {
 		return nil, nil, err
 	}
-	if privateKeys == nil || privateKeys.primary != serial.Text(10) {
+	if privateKeys == nil || privateKeys.primary != serial.String() {
 		return nil, nil, fmt.Errorf("failed to round-trip CA private key")
 	}
 
@@ -134,7 +134,7 @@ func (c *VFSCAStore) generateCACertificate() (*certificates, *privateKeys, error
 		return nil, nil, err
 	}
 
-	if certificates == nil || certificates.primary != serial.Text(10) {
+	if certificates == nil || certificates.primary != serial.String() {
 		return nil, nil, fmt.Errorf("failed to round-trip CA certifiacate")
 	}
 
@@ -146,7 +146,7 @@ func (c *VFSCAStore) buildCertificatePoolPath(id string) vfs.Path {
 }
 
 func (c *VFSCAStore) buildCertificatePath(id string, serial *big.Int) vfs.Path {
-	return c.basedir.Join("issued", id, serial.Text(10)+".crt")
+	return c.basedir.Join("issued", id, serial.String()+".crt")
 }
 
 func (c *VFSCAStore) buildPrivateKeyPoolPath(id string) vfs.Path {
@@ -154,7 +154,7 @@ func (c *VFSCAStore) buildPrivateKeyPoolPath(id string) vfs.Path {
 }
 
 func (c *VFSCAStore) buildPrivateKeyPath(id string, serial *big.Int) vfs.Path {
-	return c.basedir.Join("private", id, serial.Text(10)+".key")
+	return c.basedir.Join("private", id, serial.String()+".key")
 }
 
 type certificates struct {


### PR DESCRIPTION
Replace big.Int Text(10) with String()

Also create a makefile target to test building with golang 1.5:
check-builds-in-go15

Fixes #163