### PR TITLE
Remove {{- ... -}} from AWS templates for 1.5 compatability

### DIFF
--- a/upup/models/cloudup/_aws/resources/iam/kubernetes-master-policy.json.template
+++ b/upup/models/cloudup/_aws/resources/iam/kubernetes-master-policy.json.template
@@ -16,7 +16,7 @@
       "Action": ["elasticloadbalancing:*"],
       "Resource": ["*"]
     }
-{{- if .MasterPermissions.S3Buckets -}}
+{{ if .MasterPermissions.S3Buckets }}
     ,
     {
       "Effect": "Allow",

--- a/upup/models/cloudup/_aws/resources/iam/kubernetes-node-policy.json.template
+++ b/upup/models/cloudup/_aws/resources/iam/kubernetes-node-policy.json.template
@@ -34,7 +34,7 @@
       ],
       "Resource": "*"
     }
-{{- if .NodePermissions.S3Buckets -}}
+{{ if .NodePermissions.S3Buckets }}
     ,
     {
       "Effect": "Allow",


### PR DESCRIPTION
This syntax was added in 1.6 (https://github.com/golang/go/commit/e6ee26a03b79d0e8b658463bdb29349ca68e1460) and breaks `kops` for 1.5.

I don't believe this is necessary in these templates and I've confirment it fixes my issue.

```
go version go1.5.4 linux/amd64
```

Errors in 1.5
```
W0725 18:24:54.580988   13514 executor.go:86] error running task "iamRolePolicy/nodes.${HOSTNAME}": error rendering PolicyDocument: error opening resource: error executing resource template "iam/kubernetes-node-policy.json": error parsing template "iam/kubernetes-node-policy.json": template: iam/kubernetes-node-policy.json:37: illegal number syntax: "-"
W0725 18:24:54.581007   13514 executor.go:86] error running task "iamRolePolicy/masters.${HOSTNAME}": error rendering PolicyDocument: error opening resource: error executing resource template "iam/kubernetes-master-policy.json": error parsing template "iam/kubernetes-master-policy.json": template: iam/kubernetes-master-policy.json:19: illegal number syntax: "-"
```