### PR TITLE
Update makefiles to include git, exclude glide

### DIFF
--- a/images/dns-controller-builder/Dockerfile
+++ b/images/dns-controller-builder/Dockerfile
@@ -2,8 +2,9 @@ FROM debian:jessie
 
 # Install packages:
 #  curl (to download golang)
-#  gcc & make (for building)
-RUN apt-get update && apt-get install --yes curl gcc make
+#  git (for getting the current head)
+#  gcc make (for compilation)
+RUN apt-get update && apt-get install --yes curl git gcc make
 
 # Install golang
 RUN curl -L https://storage.googleapis.com/golang/go1.6.3.linux-amd64.tar.gz | tar zx -C /usr/local

--- a/images/protokube-builder/Dockerfile
+++ b/images/protokube-builder/Dockerfile
@@ -1,14 +1,13 @@
 FROM debian:jessie
 
 # Install packages:
-#  curl (to download glide & golang)
-#  git, mercurial (for go get)
-RUN apt-get update && apt-get install --yes curl mercurial git gcc make
+#  curl (to download golang)
+#  git (for getting the current head)
+#  gcc make (for compilation)
+RUN apt-get update && apt-get install --yes curl git gcc make
 
 # Install golang
 RUN curl -L https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz | tar zx -C /usr/local
 ENV PATH $PATH:/usr/local/go/bin
-# Install glide
-RUN curl -L https://github.com/Masterminds/glide/releases/download/0.10.2/glide-0.10.2-linux-amd64.tar.gz | tar zx --strip-components 1 -C /usr/bin
 
 COPY images/protokube-builder/onbuild.sh /onbuild.sh


### PR DESCRIPTION
We need git to get the HEAD version for including in the built
executable (for e.g. `kops version`)

We don't need glide to build - our deps should already be in vendor