### PR TITLE
Run the master on the pod network, unless IsolateMaster=true

### DIFF
--- a/upup/models/cloudup/resources/config.yaml.template
+++ b/upup/models/cloudup/resources/config.yaml.template
@@ -1,8 +1,5 @@
 Tags:
-{{ range $tag := Args }}
-  - {{ $tag }}
-{{ end }}
-{{ range $tag := NodeUpTags }}
+{{ range $tag := ComputeNodeTags Args }}
   - {{ $tag }}
 {{ end }}
 

--- a/upup/models/config/components/kubelet/_isolate_masters/kubelet.options
+++ b/upup/models/config/components/kubelet/_isolate_masters/kubelet.options
@@ -1,0 +1,4 @@
+MasterKubelet:
+  ReconcileCIDR: false
+  EnableDebuggingHandlers: false
+  HairpinMode: none

--- a/upup/models/config/components/kubelet/kubelet.options
+++ b/upup/models/config/components/kubelet/kubelet.options
@@ -12,8 +12,11 @@ Kubelet:
 
 MasterKubelet:
   RegisterSchedulable: false
-  ReconcileCIDR: false
-  EnableDebuggingHandlers: false
-  HairpinMode: none
-  PodCIDR: 10.123.45.0/30
   APIServers: http://127.0.0.1:8080
+  # We bootstrap with a fake CIDR, but then this will be replaced (unless we're running with _isolated_master)
+  PodCIDR: 10.123.45.0/30
+  # Replace the CIDR with a CIDR allocated by KCM (the default, but included for clarity)
+  ReconcileCIDR: true
+  # We _do_ allow debugging handlers, so we can do logs
+  # This does allow more access than we would like though
+  EnableDebuggingHandlers: true

--- a/upup/pkg/api/cluster.go
+++ b/upup/pkg/api/cluster.go
@@ -94,6 +94,15 @@ type ClusterSpec struct {
 	// Currently only a single CIDR is supported (though a richer grammar could be added in future)
 	AdminAccess []string `json:"adminAccess,omitempty"`
 
+	// IsolatesMasters determines whether we should lock down masters so that they are not on the pod network.
+	// true is the kube-up behaviour, but it is very surprising: it means that daemonsets only work on the master
+	// if they have hostNetwork=true.
+	// false is now the default, and it will:
+	//  * give the master a normal PodCIDR
+	//  * run kube-proxy on the master
+	//  * enable debugging handlers on the master, so kubectl logs works
+	IsolateMasters *bool `json:"isolateMasters,omitempty"`
+
 	//NetworkProvider               string `json:",omitempty"`
 	//
 	//HairpinMode                   string `json:",omitempty"`

--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -262,6 +262,10 @@ func (c *populateClusterSpec) run() error {
 		tags["_master_dns"] = struct{}{}
 	}
 
+	if fi.BoolValue(cluster.Spec.IsolateMasters) {
+		tags["_isolate_masters"] = struct{}{}
+	}
+
 	cloud, err := BuildCloud(cluster)
 	if err != nil {
 		return err


### PR DESCRIPTION
The master is now registered as a Node.  It is marked as Unschedulable,
so normal pods will not run on it.  But Daemonsets will, and it is
surprising that they don't work unless hostNetwork=true.

The default is now what seems to be expected:
* we allocate the master a real CIDR on the pod network
* kube-proxy runs on the master, so it can talk to pods
* we run kubelet on the master with enable-debugging-handlers, so
  kubectl logs etc works

To get the old behaviour, edit the cluster spec and set
`isolateMasters: true`

Fix #204