### PR TITLE
Temporarily ignore changes on the ASG

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -186,6 +186,13 @@ func (_ *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 			changes.Subnets = nil
 		}
 
+		// Temporary workaround for user-added tags, until we have #241
+		// TODO: Remove once we have #241
+		if changes.Tags != nil {
+			glog.Warning("Ignoring tag changes until we have #241: %v", changes.Tags)
+			changes.Tags = nil
+		}
+
 		empty := &AutoscalingGroup{}
 		if !reflect.DeepEqual(empty, changes) {
 			glog.Warningf("cannot apply changes to AutoScalingGroup: %v", changes)


### PR DESCRIPTION
This is to permit users to add tags to the ASG.

The long-term fix is to allow specification of additional tags at the
cluster level; the canonical use-case is for the AWS billing tags.

Issue #241