### PR TITLE
Suggest `kops get` for `kops list`

### DIFF
--- a/cmd/kops/get.go
+++ b/cmd/kops/get.go
@@ -6,9 +6,10 @@ import (
 
 // getCmd represents the get command
 var getCmd = &cobra.Command{
-	Use:   "get",
-	Short: "list or get obejcts",
-	Long:  `list or get obejcts`,
+	Use:        "get",
+	SuggestFor: []string{"list"},
+	Short:      "list or get obejcts",
+	Long:       `list or get obejcts`,
 }
 
 func init() {


### PR DESCRIPTION
Fix #134