### PR TITLE
Add docs on AWS VPC 50 node limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ You can now use kubernetes using the kubectl tool (after allowing a few minutes 
 
 * Learn about [InstanceGroups](docs/instance_groups.md), which let you change instance types, cluster sizes etc.
 
+## Learn more:
+
+* Read about [networking options](docs/networking.md), including a 50 node limit in the default configuration.
+
 ## Delete the cluster
 
 When you're done, you can also have kops delete the cluster.  It will delete all AWS resources tagged

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,0 +1,14 @@
+## Kubernetes Networking Options
+
+kops sets up networking on AWS using VPC networking, where the master allocates a /24 CIDR to each Pod,
+drawing from the Pod network.  Routes for each node are then configured in the AWS VPC routing tables.
+
+One important limitation to note is that an AWS routing table cannot have more than 50 entries, which sets a limit of
+50 nodes per cluster.  AWS support will sometimes raise the limit to 100, but performance limitations mean
+they are unlikely to raise it further.
+
+Because k8s modifies the AWS routing table, this means that realistically kubernetes needs to own the
+routing table, and thus it requires its own subnet.  It is theoretically possible to share a routing table
+with other infrastructure (but not a second cluster!), but this is not really recommended.
+
+kops will support other networking options as they add support for the daemonset method of deployment.


### PR DESCRIPTION
Also on subnets & routing tables.

Fix #246