### PR TITLE
Run CI versions of k8s

### DIFF
--- a/cmd/nodeup/main.go
+++ b/cmd/nodeup/main.go
@@ -13,8 +13,8 @@ func main() {
 	flag.StringVar(&flagModel, "model", flagModel, "directory to use as model for desired configuration")
 	var flagConf string
 	flag.StringVar(&flagConf, "conf", "node.yaml", "configuration location")
-	var flagAssetDir string
-	flag.StringVar(&flagAssetDir, "assets", "/var/cache/nodeup", "the location for the local asset cache")
+	var flagCacheDir string
+	flag.StringVar(&flagCacheDir, "cache", "/var/cache/nodeup", "the location for the local asset cache")
 	var flagRootFS string
 	flag.StringVar(&flagRootFS, "rootfs", "/", "the location of the machine root (for running in a container)")
 
@@ -38,7 +38,7 @@ func main() {
 		ConfigLocation: flagConf,
 		ModelDir:       flagModel,
 		Target:         target,
-		AssetDir:       flagAssetDir,
+		CacheDir:       flagCacheDir,
 		FSRoot:         flagRootFS,
 	}
 	err := cmd.Run(os.Stdout)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,42 @@
+## Testing tips
+
+If you are running kops as part of an e2e test, the following tips may be useful.
+
+### CI Kubernetes Build
+
+Set the KubernetesVersion to a `http://` or `https://` base url, such as `https://storage.googleapis.com/kubernetes-release-dev/ci/v1.4.0-alpha.2.677+ea69570f61af8e/`
+
+We expect the base url to have `bin/linux/amd64` directory containing:
+
+* kubelet
+* kubelet.sha1
+* kubectl
+* kubectl.sha1
+* kube-apiserver.docker_tag
+* kube-apiserver.tar
+* kube-apiserver.tar.sha1
+* kube-controller-manager.docker_tag
+* kube-controller-manager.tar
+* kube-controller-manager.tar.sha1
+* kube-proxy.docker_tag
+* kube-proxy.tar
+* kube-proxy.tar.sha1
+* kube-scheduler.docker_tag
+* kube-scheduler.tar
+* kube-scheduler.tar.sha1
+
+
+Do this with `kops edit cluster <clustername>`.  The spec should look like
+
+```
+...
+spec:
+  kubernetesVersion: "https://storage.googleapis.com/kubernetes-release-dev/ci/v1.4.0-alpha.2.677+ea69570f61af8e/"
+  cloudProvider: aws
+  etcdClusters:
+  - etcdMembers:
+    - name: us-east-1c
+      zone: us-east-1c
+    name: main
+...
+```

--- a/upup/models/cloudup/_aws/resources/nodeup.sh.template
+++ b/upup/models/cloudup/_aws/resources/nodeup.sh.template
@@ -113,7 +113,7 @@ echo "== nodeup node config starting =="
 ensure-install-dir
 
 cat > kube_env.yaml << __EOF_KUBE_ENV
-{{ RenderResource "resources/config.yaml" Args }}
+{{ RenderNodeUpConfig Args }}
 __EOF_KUBE_ENV
 
 download-release

--- a/upup/models/cloudup/resources/config.yaml.template
+++ b/upup/models/cloudup/resources/config.yaml.template
@@ -1,13 +1,1 @@
-Tags:
-{{ range $tag := ComputeNodeTags Args }}
-  - {{ $tag }}
-{{ end }}
-
-
-Assets:
-{{ range $asset := Assets }}
-  - {{ $asset }}
-{{ end }}
-
-ClusterName: {{ ClusterName }}
-ClusterLocation: {{ ClusterLocation }}
+{{ RenderNodeUpConfig Args }}

--- a/upup/models/config/components/kube-apiserver/kube-apiserver.options
+++ b/upup/models/config/components/kube-apiserver/kube-apiserver.options
@@ -14,4 +14,4 @@ KubeAPIServer:
   TokenAuthFile: /srv/kubernetes/known_tokens.csv
   LogLevel: 2
   AllowPrivileged: true
-  Image: gcr.io/google_containers/kube-apiserver:v{{ .KubernetesVersion }}
+  Image: {{ Image "kube-apiserver" }}

--- a/upup/models/config/components/kube-controller-manager/kube-controller-manager.options
+++ b/upup/models/config/components/kube-controller-manager/kube-controller-manager.options
@@ -6,7 +6,7 @@ KubeControllerManager:
   LogLevel: 2
   RootCAFile: /srv/kubernetes/ca.crt
   ClusterName: {{ ClusterName }}
-  Image: gcr.io/google_containers/kube-controller-manager:v{{ .KubernetesVersion }}
+  Image: {{ Image "kube-controller-manager" }}
   # Doesn't seem to be any real downside to always doing a leader election
   LeaderElection:
     LeaderElect: true

--- a/upup/models/config/components/kube-dns/kube-dns.options
+++ b/upup/models/config/components/kube-dns/kube-dns.options
@@ -2,3 +2,5 @@ KubeDNS:
   Replicas: 1
   ServerIP: {{ WellKnownServiceIP 10 }}
   Domain: {{ .ClusterDNSDomain }}
+  # TODO: Once we start shipping more images, start using them
+  Image: gcr.io/google_containers/kubedns-amd64:1.3

--- a/upup/models/config/components/kube-proxy/kube-proxy.options
+++ b/upup/models/config/components/kube-proxy/kube-proxy.options
@@ -7,6 +7,6 @@ KubeProxy:
   # requests of other per-node add-ons (e.g. fluentd).
   CPURequest: 20m
 
-  Image: gcr.io/google_containers/kube-proxy:v{{ .KubernetesVersion }}
+  Image: {{ Image "kube-proxy" }}
 
   Master: https://{{ .MasterInternalName }}

--- a/upup/models/config/components/kube-scheduler/kube-scheduler.options
+++ b/upup/models/config/components/kube-scheduler/kube-scheduler.options
@@ -1,7 +1,7 @@
 KubeScheduler:
   Master: 127.0.0.1:8080
   LogLevel: 2
-  Image: gcr.io/google_containers/kube-scheduler:v{{ .KubernetesVersion }}
+  Image: {{ Image "kube-scheduler" }}
   # Doesn't seem to be any real downside to always doing a leader election
   LeaderElection:
     LeaderElect: true

--- a/upup/pkg/api/cluster.go
+++ b/upup/pkg/api/cluster.go
@@ -212,6 +212,9 @@ type ClusterSpec struct {
 }
 
 type KubeDNSConfig struct {
+	// Image is the name of the docker image to run
+	Image string `json:"image,omitempty"`
+
 	Replicas int    `json:"replicas,omitempty"`
 	Domain   string `json:"domain,omitempty"`
 	ServerIP string `json:"serverIP,omitempty"`

--- a/upup/pkg/fi/assetstore.go
+++ b/upup/pkg/fi/assetstore.go
@@ -69,13 +69,13 @@ func (r *assetResource) GetSource() *Source {
 }
 
 type AssetStore struct {
-	assetDir string
+	cacheDir string
 	assets   []*asset
 }
 
-func NewAssetStore(assetDir string) *AssetStore {
+func NewAssetStore(cacheDir string) *AssetStore {
 	a := &AssetStore{
-		assetDir: assetDir,
+		cacheDir: cacheDir,
 	}
 	return a
 }
@@ -163,7 +163,7 @@ func (a *AssetStore) addURL(url string, hash *hashing.Hash) error {
 		}
 	}
 
-	localFile := path.Join(a.assetDir, hash.String()+"_"+utils.SanitizeString(url))
+	localFile := path.Join(a.cacheDir, hash.String()+"_"+utils.SanitizeString(url))
 	_, err = DownloadURL(url, localFile, hash)
 	if err != nil {
 		return err
@@ -237,7 +237,7 @@ func (a *AssetStore) addURL(url string, hash *hashing.Hash) error {
 //}
 
 func (a *AssetStore) addArchive(archiveSource *Source, archiveFile string) error {
-	extracted := path.Join(a.assetDir, "extracted/"+path.Base(archiveFile))
+	extracted := path.Join(a.cacheDir, "extracted/"+path.Base(archiveFile))
 
 	// TODO: Use a temp file so this is atomic
 	if _, err := os.Stat(extracted); os.IsNotExist(err) {

--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -6,7 +6,6 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kops/upup/pkg/api"
 	"k8s.io/kops/upup/pkg/fi"
-	"k8s.io/kops/upup/pkg/fi/hashing"
 	"k8s.io/kops/upup/pkg/fi/loader"
 	"k8s.io/kops/upup/pkg/fi/utils"
 	"k8s.io/kops/upup/pkg/fi/vfs"
@@ -87,10 +86,6 @@ func PopulateClusterSpec(cluster *api.Cluster, clusterRegistry *api.ClusterRegis
 }
 
 func (c *populateClusterSpec) run() error {
-	// TODO: Make these configurable?
-	useMasterASG := true
-	useMasterLB := false
-
 	err := c.InputCluster.Validate(false)
 	if err != nil {
 		return err
@@ -170,8 +165,6 @@ func (c *populateClusterSpec) run() error {
 		return fmt.Errorf("ClusterRegistry is required")
 	}
 
-	tags := make(map[string]struct{})
-
 	keyStore := c.ClusterRegistry.KeyStore(cluster.Name)
 	// Always assume a dry run during this phase
 	keyStore.(*fi.VFSCAStore).DryRun = true
@@ -246,45 +239,9 @@ func (c *populateClusterSpec) run() error {
 		cluster.Spec.KubernetesVersion = versionWithoutV
 	}
 
-	if useMasterASG {
-		tags["_master_asg"] = struct{}{}
-	} else {
-		tags["_master_single"] = struct{}{}
-	}
-
-	if useMasterLB {
-		tags["_master_lb"] = struct{}{}
-	} else {
-		tags["_not_master_lb"] = struct{}{}
-	}
-
-	if cluster.Spec.MasterPublicName != "" {
-		tags["_master_dns"] = struct{}{}
-	}
-
-	if fi.BoolValue(cluster.Spec.IsolateMasters) {
-		tags["_isolate_masters"] = struct{}{}
-	}
-
 	cloud, err := BuildCloud(cluster)
 	if err != nil {
 		return err
-	}
-
-	switch cluster.Spec.CloudProvider {
-	case "gce":
-		{
-			glog.Fatalf("GCE is (probably) not working currently - please ping @justinsb for cleanup")
-			tags["_gce"] = struct{}{}
-		}
-
-	case "aws":
-		{
-			tags["_aws"] = struct{}{}
-		}
-
-	default:
-		return fmt.Errorf("unknown CloudProvider %q", cluster.Spec.CloudProvider)
 	}
 
 	if cluster.Spec.DNSZone == "" {
@@ -294,6 +251,11 @@ func (c *populateClusterSpec) run() error {
 		}
 		glog.Infof("Defaulting DNS zone to: %s", dnsZone)
 		cluster.Spec.DNSZone = dnsZone
+	}
+
+	tags, err := buildClusterTags(cluster)
+	if err != nil {
+		return err
 	}
 
 	tf := &TemplateFunctions{
@@ -327,22 +289,6 @@ func (c *populateClusterSpec) run() error {
 	c.fullCluster = fullCluster
 
 	return nil
-}
-
-func findHash(url string) (*hashing.Hash, error) {
-	for _, ext := range []string{".sha1"} {
-		hashURL := url + ext
-		b, err := vfs.Context.ReadFile(hashURL)
-		if err != nil {
-			glog.Infof("error reading hash file %q: %v", hashURL, err)
-			continue
-		}
-		hashString := strings.TrimSpace(string(b))
-		glog.Infof("Found hash %q for %q", hashString, url)
-
-		return hashing.FromString(hashString)
-	}
-	return nil, fmt.Errorf("cannot determine hash for %v (have you specified a valid KubernetesVersion?)", url)
 }
 
 func (c *populateClusterSpec) assignSubnets(cluster *api.Cluster) error {

--- a/upup/pkg/fi/cloudup/tagbuilder.go
+++ b/upup/pkg/fi/cloudup/tagbuilder.go
@@ -1,0 +1,96 @@
+package cloudup
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"k8s.io/kops/upup/pkg/api"
+	"k8s.io/kops/upup/pkg/fi"
+)
+
+func buildClusterTags(cluster *api.Cluster) (map[string]struct{}, error) {
+	// TODO: Make these configurable?
+	useMasterASG := true
+	useMasterLB := false
+
+	tags := make(map[string]struct{})
+
+	//tags["_networking_kubenet"] = struct{}{}
+	//tags["_networking_builtin"] = struct{}{}
+
+	if useMasterASG {
+		tags["_master_asg"] = struct{}{}
+	} else {
+		tags["_master_single"] = struct{}{}
+	}
+
+	if useMasterLB {
+		tags["_master_lb"] = struct{}{}
+	} else {
+		tags["_not_master_lb"] = struct{}{}
+	}
+
+	if cluster.Spec.MasterPublicName != "" {
+		tags["_master_dns"] = struct{}{}
+	}
+
+	if fi.BoolValue(cluster.Spec.IsolateMasters) {
+		tags["_isolate_masters"] = struct{}{}
+	}
+
+	switch cluster.Spec.CloudProvider {
+	case "gce":
+		{
+			glog.Fatalf("GCE is (probably) not working currently - please ping @justinsb for cleanup")
+			tags["_gce"] = struct{}{}
+		}
+
+	case "aws":
+		{
+			tags["_aws"] = struct{}{}
+		}
+
+	default:
+		return nil, fmt.Errorf("unknown CloudProvider %q", cluster.Spec.CloudProvider)
+	}
+
+	return tags, nil
+}
+
+func buildNodeupTags(role api.InstanceGroupRole, cluster *api.Cluster, clusterTags map[string]struct{}) ([]string, error) {
+	var tags []string
+
+	switch role {
+	case api.InstanceGroupRoleNode:
+		// No special tags
+
+		// TODO: Should we run _protokube on the nodes?
+		tags = append(tags, "_protokube")
+
+	case api.InstanceGroupRoleMaster:
+		if !fi.BoolValue(cluster.Spec.IsolateMasters) {
+			// Run this master as a pool node also (start kube-proxy etc)
+			tags = append(tags, "_kubernetes_pool")
+		}
+		tags = append(tags, "_protokube")
+	default:
+		return nil, fmt.Errorf("Unrecognized role: %v", role)
+	}
+
+	//// TODO: Replace with list of CNI plugins
+	//if _, found := clusterTags["_networking_kubenet"]; found {
+	//	tags = append(tags, "_cni_bridge")
+	//	tags = append(tags, "_cni_host_local")
+	//	tags = append(tags, "_cni_loopback")
+	//	tags = append(tags, "_cni_ptp")
+	//	//tags = append(tags, "_cni_tuning")
+	//}
+
+	if _, found := clusterTags["_gce"]; found {
+		tags = append(tags, "_gce")
+	}
+	if _, found := clusterTags["_aws"]; found {
+		tags = append(tags, "_aws")
+	}
+
+	return tags, nil
+}

--- a/upup/pkg/fi/cloudup/tagbuilder_test.go
+++ b/upup/pkg/fi/cloudup/tagbuilder_test.go
@@ -1,0 +1,41 @@
+package cloudup
+
+import (
+	"k8s.io/kops/upup/pkg/api"
+	"testing"
+)
+
+func TestBuildTags_CloudProvider_AWS(t *testing.T) {
+	c := &api.Cluster{
+		Spec: api.ClusterSpec{
+			CloudProvider: "aws",
+		},
+	}
+
+	tags, err := buildClusterTags(c)
+	if err != nil {
+		t.Fatalf("buildTags error: %v", err)
+	}
+
+	if _, found := tags["_aws"]; !found {
+		t.Fatalf("tag _aws not found")
+	}
+
+	nodeUpTags, err := buildNodeupTags(api.InstanceGroupRoleNode, c, tags)
+	if err != nil {
+		t.Fatalf("buildNodeupTags error: %v", err)
+	}
+
+	if !stringSliceContains(nodeUpTags, "_aws") {
+		t.Fatalf("nodeUpTag _aws not found")
+	}
+}
+
+func stringSliceContains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if needle == s {
+			return true
+		}
+	}
+	return false
+}

--- a/upup/pkg/fi/context.go
+++ b/upup/pkg/fi/context.go
@@ -38,11 +38,11 @@ func NewContext(target Target, cloud Cloud, castore CAStore, secretStore SecretS
 	return c, nil
 }
 
-func (c *Context) RunTasks(taskMap map[string]Task) error {
+func (c *Context) RunTasks(taskMap map[string]Task, maxAttemptsWithNoProgress int) error {
 	e := &executor{
 		context: c,
 	}
-	return e.RunTasks(taskMap)
+	return e.RunTasks(taskMap, maxAttemptsWithNoProgress)
 }
 
 func (c *Context) Close() {

--- a/upup/pkg/fi/executor.go
+++ b/upup/pkg/fi/executor.go
@@ -8,8 +8,6 @@ import (
 	"time"
 )
 
-const MaxAttemptsWithNoProgress = 3
-
 type executor struct {
 	context *Context
 }
@@ -22,8 +20,8 @@ type taskState struct {
 }
 
 // RunTasks executes all the tasks, considering their dependencies
-// It will perform some re-execution on error, retrying as long as progess is still being made
-func (e *executor) RunTasks(taskMap map[string]Task) error {
+// It will perform some re-execution on error, retrying as long as progress is still being made
+func (e *executor) RunTasks(taskMap map[string]Task, maxAttemptsWithNoProgress int) error {
 	dependencies := FindTaskDependencies(taskMap)
 
 	taskStates := make(map[string]*taskState)
@@ -94,7 +92,7 @@ func (e *executor) RunTasks(taskMap map[string]Task) error {
 		if !progress {
 			if len(errors) != 0 {
 				noProgressCount++
-				if noProgressCount == MaxAttemptsWithNoProgress {
+				if noProgressCount == maxAttemptsWithNoProgress {
 					return fmt.Errorf("did not make any progress executing task.  Example error: %v", errors[0])
 				} else {
 					glog.Infof("No progress made, sleeping before retrying failed tasks")

--- a/upup/pkg/fi/nodeup/config.go
+++ b/upup/pkg/fi/nodeup/config.go
@@ -11,6 +11,9 @@ type NodeUpConfig struct {
 	// TODO: Remove once everything is in containers?
 	Assets []string `json:",omitempty"`
 
+	// Images are a list of images we should preload
+	Images []*Image `json:"images,omitempty"`
+
 	// ClusterLocation is the VFS path to the cluster spec
 	ClusterLocation string `json:",omitempty"`
 
@@ -20,38 +23,11 @@ type NodeUpConfig struct {
 	ClusterName string `json:",omitempty"`
 }
 
-// Our client configuration structure
-// Wherever possible, we try to use the types & names in https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
+// Image is a docker image we should pre-load
+type Image struct {
+	// Source is the URL from which we should download the image
+	Source string `json:"source,omitempty"`
 
-//type NodeConfig struct {
-//	Kubelet               *KubeletConfig               `json:",omitempty"`
-//	KubeProxy             *KubeProxyConfig             `json:",omitempty"`
-//	KubeControllerManager *KubeControllerManagerConfig `json:",omitempty"`
-//	KubeScheduler         *KubeSchedulerConfig         `json:",omitempty"`
-//	Docker                *DockerConfig                `json:",omitempty"`
-//	APIServer             *APIServerConfig             `json:",omitempty"`
-//
-//	DNS *DNSConfig `json:",omitempty"`
-//
-//	// NodeConfig can directly access a store of secrets, keys or configuration
-//	// (for example on S3) and then configure based on that
-//	// This supports (limited) dynamic reconfiguration also
-//	SecretStore string `json:",omitempty"`
-//	KeyStore    string `json:",omitempty"`
-//	ConfigStore string `json:",omitempty"`
-//
-//	KubeUser string `json:",omitempty"`
-//
-//	Tags   []string `json:",omitempty"`
-//	Assets []string `json:",omitempty"`
-//
-//	MasterInternalName string `json:",omitempty"`
-//
-//	// The DNS zone to use if configuring a cloud provided DNS zone
-//	DNSZone string `json:",omitempty"`
-//
-//	// Deprecated in favor of KeyStore / SecretStore
-//	Tokens       map[string]string          `json:",omitempty"`
-//	Certificates map[string]*fi.Certificate `json:",omitempty"`
-//	PrivateKeys  map[string]*fi.PrivateKey  `json:",omitempty"`
-//}
+	// Hash is the hash of the file, to verify image integrity (even over http)
+	Hash string `json:"hash,omitempty"`
+}

--- a/upup/pkg/fi/nodeup/local/local_target.go
+++ b/upup/pkg/fi/nodeup/local/local_target.go
@@ -3,6 +3,7 @@ package local
 import "k8s.io/kops/upup/pkg/fi"
 
 type LocalTarget struct {
+	CacheDir string
 }
 
 var _ fi.Target = &LocalTarget{}

--- a/upup/pkg/fi/nodeup/nodetasks/load_image.go
+++ b/upup/pkg/fi/nodeup/nodetasks/load_image.go
@@ -1,0 +1,71 @@
+package nodetasks
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/hashing"
+	"k8s.io/kops/upup/pkg/fi/nodeup/cloudinit"
+	"k8s.io/kops/upup/pkg/fi/nodeup/local"
+	"k8s.io/kops/upup/pkg/fi/utils"
+	"os/exec"
+	"path"
+	"strings"
+)
+
+// LoadImageTask is responsible for downloading a docker image
+type LoadImageTask struct {
+	Source string
+	Hash   string
+}
+
+var _ fi.Task = &LoadImageTask{}
+
+func (t *LoadImageTask) String() string {
+	return fmt.Sprintf("LoadImageTask: %s", t.Source)
+}
+
+func (e *LoadImageTask) Find(c *fi.Context) (*LoadImageTask, error) {
+	glog.Warningf("LoadImageTask checking if image present not yet implemented")
+	return nil, nil
+}
+
+func (e *LoadImageTask) Run(c *fi.Context) error {
+	return fi.DefaultDeltaRunMethod(e, c)
+}
+
+func (_ *LoadImageTask) CheckChanges(a, e, changes *LoadImageTask) error {
+	return nil
+}
+
+func (_ *LoadImageTask) RenderLocal(t *local.LocalTarget, a, e, changes *LoadImageTask) error {
+	hash, err := hashing.FromString(e.Hash)
+	if err != nil {
+		return err
+	}
+
+	url := e.Source
+
+	localFile := path.Join(t.CacheDir, hash.String()+"_"+utils.SanitizeString(url))
+	_, err = fi.DownloadURL(url, localFile, hash)
+	if err != nil {
+		return err
+	}
+
+	// Load the image into docker
+	args := []string{"docker", "load", "-i", localFile}
+	human := strings.Join(args, " ")
+
+	glog.Infof("running command %s", human)
+	cmd := exec.Command(args[0], args[1:]...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error loading docker image with '%s': %v: %s", human, err, string(output))
+	}
+
+	return nil
+}
+
+func (_ *LoadImageTask) RenderCloudInit(t *cloudinit.CloudInitTarget, a, e, changes *LoadImageTask) error {
+	return fmt.Errorf("LoadImageTask::RenderCloudInit not implemented")
+}


### PR DESCRIPTION
CI versions are not pushed to gcr.io, so we need to preload the images
by downloading them and doing a docker load.