### PR TITLE
Validate that the cluster name is a valid DNS name

### DIFF
--- a/upup/pkg/api/validation.go
+++ b/upup/pkg/api/validation.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"fmt"
+	"k8s.io/kubernetes/pkg/util/validation"
 	"net"
 	"net/url"
+	"strings"
 )
 
 func (c *Cluster) Validate(strict bool) error {
@@ -11,6 +13,18 @@ func (c *Cluster) Validate(strict bool) error {
 
 	if c.Name == "" {
 		return fmt.Errorf("Cluster Name is required (e.g. --name=mycluster.myzone.com)")
+	}
+
+	{
+		// Must be a dns name
+		errs := validation.IsDNS1123Subdomain(c.Name)
+		if len(errs) != 0 {
+			return fmt.Errorf("Cluster Name must be a valid DNS name (e.g. --name=mycluster.myzone.com) errors: %s", strings.Join(errs, ", "))
+		}
+
+		if !strings.Contains(c.Name, ".") {
+			return fmt.Errorf("Cluster Name must be a fully-qualified DNS name (e.g. --name=mycluster.myzone.com)")
+		}
 	}
 
 	if len(c.Spec.Zones) == 0 {

--- a/upup/pkg/api/validation_test.go
+++ b/upup/pkg/api/validation_test.go
@@ -1,0 +1,15 @@
+package api
+
+import (
+	"testing"
+	"k8s.io/kubernetes/pkg/util/validation"
+)
+
+func Test_Validate_DNS(t *testing.T) {
+	for _, name := range []string{"test.-", "!", "-"} {
+		errs := validation.IsDNS1123Subdomain(name)
+		if len(errs) == 0 {
+			t.Fatalf("Expected errors validating name %q", name)
+		}
+	}
+}

--- a/upup/pkg/fi/cloudup/validation_test.go
+++ b/upup/pkg/fi/cloudup/validation_test.go
@@ -104,6 +104,18 @@ func TestValidateFull_Default_Validates(t *testing.T) {
 	}
 }
 
+func TestValidateFull_ClusterName_InvalidDNS_NoDot(t *testing.T) {
+	c := buildDefaultCluster(t)
+	c.Name = "test"
+	expectErrorFromValidate(t, c, "DNS name")
+}
+
+func TestValidateFull_ClusterName_InvalidDNS_Invalid(t *testing.T) {
+	c := buildDefaultCluster(t)
+	c.Name = "test.-"
+	expectErrorFromValidate(t, c, "DNS name")
+}
+
 func TestValidateFull_ClusterName_Required(t *testing.T) {
 	c := buildDefaultCluster(t)
 	c.Name = ""


### PR DESCRIPTION
This should help users avoid the common mistake of just specifying the
name, not a fully-qualified domain name.

Fix #46