### PR TITLE
CI: Add an obvious failure if the GITISH can't be computed

### DIFF
--- a/docker/build-squash-push.sh
+++ b/docker/build-squash-push.sh
@@ -5,6 +5,8 @@ set -o nounset
 set -o pipefail
 
 readonly DOCKER_ROOT=$(dirname "${BASH_SOURCE}")
+cd "${DOCKER_ROOT}" # To ensure we're in the git tree
+
 readonly GITISH=${BUILD_GITISH:-"$(git show-ref -s --abbrev HEAD)"}
 readonly ARCH=${BUILD_ARCH:-"linux/amd64"}
 readonly NAME=${BUILD_NAME:-"ci-${GITISH}-${ARCH/\//-}"} # e.g. ci-bef7faf-linux-amd64
@@ -16,6 +18,12 @@ readonly SYMBOLIC_TAG=${BUILD_TAG:-"b.gcr.io/kops-ci/kops:ci-${LINK}-${ARCH/\//-
 
 if [[ "${ARCH}" != "linux/amd64" ]]; then
   echo "!!! Alternate architecture build not supported yet. !!!"
+  exit 1
+fi
+
+if [[ -z "${GITISH}" ]]; then
+  echo "!!! git hash not found, are you sure you're in a git tree and git is installed? !!!"
+  git config -l
   exit 1
 fi
 


### PR DESCRIPTION
Not sure why the first build failed, but this might help.