### PR TITLE
Docker build: Fix models

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,15 +12,15 @@ ARG KUBECTL_TRACK=latest.txt
 ARG KUBECTL_ARCH=linux/amd64
 
 RUN apk add --no-cache --update build-base curl git mercurial  --virtual .kops-deps && \
-    cd "${GOPATH}/src/k8s.io/kops" && make && ln -s /go/bin/kops /bin && \
-    MODELS=$(readlink "${GOPATH}/bin/models") && rm "${GOPATH}/bin/models" && mv "${MODELS}" "${GOPATH}/bin/models" && \
+    cd "${GOPATH}/src/k8s.io/kops" && make && \
+    MODELS=$(readlink "${GOPATH}/bin/models") && mv "${MODELS}" /usr/local/bin && rm "${GOPATH}/bin/models" && mv ${GOPATH}/bin/* /usr/local/bin && \
     GITISH=$(git describe --always) && \
     KUBECTL_VERSION=${KUBECTL_VERSION:-$(curl -SsL --retry 5 "https://storage.googleapis.com/${KUBECTL_SOURCE}/${KUBECTL_TRACK}")} && \
     echo "=== Fetching kubectl ${KUBECTL_VERSION} ===" && \
     curl -SsL --retry 5 "https://storage.googleapis.com/${KUBECTL_SOURCE}/${KUBECTL_VERSION}/${KUBECTL_ARCH}/kubectl" > /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl && \
     /usr/local/bin/kubectl version --client && \
-    cd / && rm -rf "${GOPATH}/src" && rm -rf "${GOPATH}/pkg" && rm -rf "/usr/local/go" && rm /usr/local/bin/go-wrapper && apk del .kops-deps && \
+    cd / && rm -rf "${GOPATH}" && rm -rf /usr/local/go && rm /usr/local/bin/go-wrapper && apk del .kops-deps && \
     echo "=== Built kops at ${GITISH}, fetched kubectl ${KUBECTL_VERSION} ==="
 
 CMD "/go/bin/kops"


### PR DESCRIPTION
After playing with the pulled Docker container again, we need to make
sure the models are really alongside the executed binary (kops doesn't
resolve the symlink). Simplify this a bit, too.