### PR TITLE
Restrict access to state store bucket

### DIFF
--- a/upup/models/cloudup/_aws/resources/iam/kubernetes-master-policy.json.template
+++ b/upup/models/cloudup/_aws/resources/iam/kubernetes-master-policy.json.template
@@ -24,7 +24,8 @@
       "Resource": [
         {{ range $i, $b := .MasterPermissions.S3Buckets }}
         {{if $i}},{{end}}
-        "{{ IAMPrefix }}:s3:::{{ $b }}/*"
+        "{{ IAMPrefix }}:s3:::{{ $b }}/{{ ClusterName }}",
+        "{{ IAMPrefix }}:s3:::{{ $b }}/{{ ClusterName }}/*"
         {{ end }}
       ]
     },

--- a/upup/models/cloudup/_aws/resources/iam/kubernetes-node-policy.json.template
+++ b/upup/models/cloudup/_aws/resources/iam/kubernetes-node-policy.json.template
@@ -42,7 +42,8 @@
       "Resource": [
         {{ range $i, $b := .NodePermissions.S3Buckets }}
         {{if $i}},{{end}}
-        "{{ IAMPrefix }}:s3:::{{ $b }}/*"
+        "{{ IAMPrefix }}:s3:::{{ $b }}/{{ ClusterName }}",
+        "{{ IAMPrefix }}:s3:::{{ $b }}/{{ ClusterName }}/*"
         {{ end }}
       ]
     },


### PR DESCRIPTION
This change increases the specificity of the master and node state store bucket contents permission to only the top-level folder named after the cluster.

Fixes #364 and #365 