### PR TITLE
Add option to encrypt Etcd volumes

### DIFF
--- a/upup/models/proto/_aws/master_volumes.yaml
+++ b/upup/models/proto/_aws/master_volumes.yaml
@@ -6,6 +6,8 @@ ebsVolume/{{$m.Name}}.etcd-{{$etcd.Name}}.{{ ClusterName }}:
   availabilityZone: {{ $m.Zone }}
   sizeGB: {{ or $m.VolumeSize 20 }}
   volumeType: {{ or $m.VolumeType "gp2" }}
+  kmsKeyId: {{ $m.KmsKeyId }}
+  encrypted: {{ or $m.EncryptedVolume false }}
   tags:
   {{ range $k, $v := EtcdClusterMemberTags $etcd $m }}
     {{ $k }}: "{{ $v }}"

--- a/upup/pkg/api/cluster.go
+++ b/upup/pkg/api/cluster.go
@@ -240,11 +240,13 @@ type EtcdClusterSpec struct {
 
 type EtcdMemberSpec struct {
 	// Name is the name of the member within the etcd cluster
-	Name string `json:"name,omitempty"`
-	Zone string `json:"zone,omitempty"`
+	Name            string `json:"name,omitempty"`
+	Zone            string `json:"zone,omitempty"`
 
-	VolumeType string `json:"volumeType,omitempty"`
-	VolumeSize int    `json:"volumeSize,omitempty"`
+	VolumeType      string `json:"volumeType,omitempty"`
+	VolumeSize      int    `json:"volumeSize,omitempty"`
+	KmsKeyId        string `json:"kmsKeyId,omitempty"`
+	EncryptedVolume bool   `json:"encryptedVolume,omitempty"`
 }
 
 type ClusterZoneSpec struct {

--- a/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
+++ b/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
@@ -17,6 +17,8 @@ type EBSVolume struct {
 	AvailabilityZone *string
 	VolumeType       *string
 	SizeGB           *int64
+	KmsKeyId         *string
+	Encrypted        *bool
 	Tags             map[string]string
 }
 
@@ -76,6 +78,8 @@ func (e *EBSVolume) find(cloud *awsup.AWSCloud) (*EBSVolume, error) {
 		AvailabilityZone: v.AvailabilityZone,
 		VolumeType:       v.VolumeType,
 		SizeGB:           v.Size,
+		KmsKeyId:         v.KmsKeyId,
+		Encrypted:        v.Encrypted,
 		Name:             e.Name,
 	}
 
@@ -111,6 +115,8 @@ func (_ *EBSVolume) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *EBSVolume) e
 			Size:             e.SizeGB,
 			AvailabilityZone: e.AvailabilityZone,
 			VolumeType:       e.VolumeType,
+			KmsKeyId:         e.KmsKeyId,
+			Encrypted:        e.Encrypted,
 		}
 
 		response, err := t.Cloud.EC2.CreateVolume(request)
@@ -128,6 +134,8 @@ type terraformVolume struct {
 	AvailabilityZone *string           `json:"availability_zone"`
 	Size             *int64            `json:"size"`
 	Type             *string           `json:"type"`
+	KmsKeyId         *string           `json:"kmsKeyId"`
+	Encrypted        *bool             `json:"encrypted"`
 	Tags             map[string]string `json:"tags,omitempty"`
 }
 
@@ -136,6 +144,8 @@ func (_ *EBSVolume) RenderTerraform(t *terraform.TerraformTarget, a, e, changes 
 		AvailabilityZone: e.AvailabilityZone,
 		Size:             e.SizeGB,
 		Type:             e.VolumeType,
+		KmsKeyId:         e.KmsKeyId,
+		Encrypted:        e.Encrypted,
 		Tags:             e.Tags,
 	}
 


### PR DESCRIPTION
Partially addresses https://github.com/kubernetes/kops/issues/372

Procedure for adding encryption using default AWS key:

1. `kops create cluster --state=<state> --name=<name> --zones=<zones>`
2. `kops edit cluster --state=<state> --name=<name>`
3.  Add `encryptedVolume: true` to each etcd volume
4. Save config
5. `kops update cluster --state=<state> --name=<name> --yes`

You will now have a Kubernetes cluster with encrypted Etcd volumes.

If you want to use a custom KMS encryption key, the procedure is almost identical, but with the small wrinkle that you have to allow the `masters.your.domain` role permission to use the KMS encryption key:

1. `kops create cluster --state=<state> --name=<name> --zones=<zones>`
2. `kops edit cluster --state=<state> --name=<name>`
3.  Add `encryptedVolume: true` and `kmsKeyId: <full-arn-of-your-KMS-key>` to each etcd volume
4. Save config
5. `kops update cluster --state=<state> --name=<name> --yes`
6. Edit your KMS key to add the `masters.your.domain` role to the Key Users list - this has to be done before the master(s) attempt to to mount the volumes.  You should have at least a several minute window between the `masters.your.domain` role being created and the master(s) mounting the volume, but if you somehow miss this window, you can just delete the master(s) and the ASG will kick in and once new masters start up they should be able to mount successfully.

You will now have a Kubernetes cluster with encrypted Etcd volumes using your custom KMS key.