### PR TITLE
Support for multiple admin access CIDRs

### DIFF
--- a/upup/models/cloudup/_aws/master/_master_lb/master_lb.yaml
+++ b/upup/models/cloudup/_aws/master/_master_lb/master_lb.yaml
@@ -33,12 +33,15 @@ securityGroupRule/egress-api-lb:
   cidr: 0.0.0.0/0
 
 # HTTPS to the master ELB is allowed (for API access)
-securityGroupRule/https-external-to-api:
+# One security group rule is necessary per admin CIDR
+{{ range $index, $cidr := AdminCIDR }}
+securityGroupRule/https-external-to-api-{{ $index }}:
   securityGroup: securityGroup/api.{{ ClusterName }}
-  cidr: {{ AdminCIDR }}
+  cidr: {{ $cidr }}
   protocol: tcp
   fromPort: 443
   toPort: 443
+{{ end }}
 
 # Allow HTTPS to the master from the master ELB
 securityGroupRule/https-elb-to-master:
@@ -54,5 +57,3 @@ dnsName/{{ .MasterPublicName }}:
   Zone: dnsZone/{{ .DNSZone }}
   ResourceType: "A"
   TargetLoadBalancer: loadBalancer/api.{{ ClusterName }}
-
-

--- a/upup/models/cloudup/_aws/master/_not_master_lb/not_master_lb.yaml
+++ b/upup/models/cloudup/_aws/master/_not_master_lb/not_master_lb.yaml
@@ -3,9 +3,11 @@
 # We need to open security groups directly to the master nodes (instead of via the ELB)
 
 # HTTPS to the master is allowed (for API access)
-securityGroupRule/https-external-to-master:
+{{ range $index, $cidr := AdminCIDR }}
+securityGroupRule/https-external-to-master-{{ $index }}:
   securityGroup: securityGroup/masters.{{ ClusterName }}
-  cidr: {{ AdminCIDR }}
+  cidr: {{ $cidr }}
   protocol: tcp
   fromPort: 443
   toPort: 443
+{{ end }}

--- a/upup/models/cloudup/_aws/master/master.yaml
+++ b/upup/models/cloudup/_aws/master/master.yaml
@@ -25,13 +25,15 @@ securityGroupRule/master-egress:
   egress: true
   cidr: 0.0.0.0/0
 
-# SSH is open to AdminCIDR
-securityGroupRule/ssh-external-to-master:
+# SSH is open to AdminCIDR set
+{{ range $index, $cidr := AdminCIDR }}
+securityGroupRule/ssh-external-to-master-{{ $index }}:
   securityGroup: securityGroup/masters.{{ ClusterName }}
-  cidr: {{ AdminCIDR }}
+  cidr: {{ $cidr }}
   protocol: tcp
   fromPort: 22
   toPort: 22
+{{ end }}
 
 # Masters can talk to masters
 securityGroupRule/all-master-to-master:

--- a/upup/models/cloudup/_aws/nodes.yaml
+++ b/upup/models/cloudup/_aws/nodes.yaml
@@ -25,13 +25,15 @@ securityGroupRule/node-egress:
   egress: true
   cidr: 0.0.0.0/0
 
-# SSH is open to the world
-securityGroupRule/ssh-external-to-node:
+# SSH is open to CIDRs defined in the cluster configuration
+{{ range $index, $cidr := AdminCIDR }}
+securityGroupRule/ssh-external-to-node-{{ $index }}:
   securityGroup: securityGroup/nodes.{{ ClusterName }}
-  cidr: {{ AdminCIDR }}
+  cidr: {{ $cidr }}
   protocol: tcp
   fromPort: 22
   toPort: 22
+{{ end }}
 
 # Nodes can talk to nodes
 securityGroupRule/all-node-to-node:

--- a/upup/models/cloudup/_gce/network.yaml
+++ b/upup/models/cloudup/_gce/network.yaml
@@ -15,6 +15,8 @@ firewallRule/{{ $networkName }}-default-internal:
 # SSH is open to the world
 firewallRule/{{ $networkName }}-default-ssh-{{ AdminCIDR }}:
   network: network/default
-  sourceRanges: {{ AdminCIDR }}
   allowed: tcp:22
-
+  sourceRanges:
+{{ range $cidr := AdminCIDR }}
+    - {{ $cidr }}
+{{ end }}

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -155,15 +155,13 @@ func (tf *TemplateFunctions) SharedZone(zone *api.ClusterZoneSpec) bool {
 	return zone.ProviderID != ""
 }
 
-// AdminCIDR returns the single CIDR that is allowed access to the admin ports of the cluster (22, 443 on master)
-func (tf *TemplateFunctions) AdminCIDR() (string, error) {
+// AdminCIDR returns the CIDRs that are allowed to access the admin ports of the cluster
+// (22, 443 on master and 22 on nodes)
+func (tf *TemplateFunctions) AdminCIDR() ([]string, error) {
 	if len(tf.cluster.Spec.AdminAccess) == 0 {
-		return "0.0.0.0/0", nil
+		return []string{"0.0.0.0/0"}, nil
 	}
-	if len(tf.cluster.Spec.AdminAccess) == 1 {
-		return tf.cluster.Spec.AdminAccess[0], nil
-	}
-	return "", fmt.Errorf("Multiple AdminAccess rules are not (currently) supported")
+	return tf.cluster.Spec.AdminAccess, nil
 }
 
 // IAMServiceEC2 returns the name of the IAM service for EC2 in the current region

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -157,11 +157,11 @@ func (tf *TemplateFunctions) SharedZone(zone *api.ClusterZoneSpec) bool {
 
 // AdminCIDR returns the CIDRs that are allowed to access the admin ports of the cluster
 // (22, 443 on master and 22 on nodes)
-func (tf *TemplateFunctions) AdminCIDR() ([]string, error) {
+func (tf *TemplateFunctions) AdminCIDR() []string {
 	if len(tf.cluster.Spec.AdminAccess) == 0 {
-		return []string{"0.0.0.0/0"}, nil
+		return []string{"0.0.0.0/0"}
 	}
-	return tf.cluster.Spec.AdminAccess, nil
+	return tf.cluster.Spec.AdminAccess
 }
 
 // IAMServiceEC2 returns the name of the IAM service for EC2 in the current region


### PR DESCRIPTION
This adds support for multiple admin access CIDRs in the cluster configuration. The field is currently already a list, however it is limited to one item.

The interesting implication of this on AWS is that a unique security group rule is created per configured CIDR. Cleanup of those is currently not performed, with the issue being tracked in #145 

The GCE template matches the type of the GCE resource, however I did not test it.