### PR TITLE
Show the details of what resources will be created

### DIFF
--- a/upup/pkg/fi/dryrun_target.go
+++ b/upup/pkg/fi/dryrun_target.go
@@ -79,6 +79,27 @@ func (t *DryRunTarget) PrintReport(taskMap map[string]Task, out io.Writer) error
 			for _, r := range creates {
 				taskName := getTaskName(r.changes)
 				fmt.Fprintf(b, "  %s\t%s\n", taskName, IdForTask(taskMap, r.e))
+
+				changes := reflect.ValueOf(r.changes)
+				if changes.Kind() == reflect.Ptr && !changes.IsNil() {
+					changes = changes.Elem()
+				}
+
+				if changes.Kind() == reflect.Struct {
+					for i := 0; i < changes.NumField(); i++ {
+
+						field := changes.Field(i)
+
+						fieldName := changes.Type().Field(i).Name
+						fieldValue := ValueAsString(field)
+
+						// The field name is already printed above, no need to repeat it.
+						// Additionally, ignore any output that is not informative
+						if fieldName != "Name" && fieldValue != "<nil>" && fieldValue != "id:<nil>" && fieldValue != "<resource>" {
+							fmt.Fprintf(b, "  \t%s\t%s\n", fieldName, fieldValue)
+						}
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kops/issues/394

Current output of create/update (only using small portion of output for brevity):

```
LaunchConfiguration launchConfiguration/master-us-east-1e.masters.foo.bar.com
LaunchConfiguration launchConfiguration/nodes.foo.bar.com
AutoscalingGroup    autoscalingGroup/nodes.foo.bar.com
AutoscalingGroup    autoscalingGroup/master-us-east-1e.masters.foo.bar.com
```

After this PR:

```
LaunchConfiguration	launchConfiguration/nodes.foo.bar.com
  	ImageID	282335181503/k8s-1.3-debian-jessie-amd64-hvm-ebs-2016-06-18
  	InstanceType	t2.medium
  	SSHKey	id:foo.bar.baz.com-2e:a2:34:3a:19:b1:b2:58:26:40:7c:a0:1a:1b:23:83
  	SecurityGroups	[id:<nil>]
  	AssociatePublicIP	true
  	IAMInstanceProfile	id:nodes.foo.bar.com
  	RootVolumeSize	20
  	RootVolumeType	gp2
LaunchConfiguration	launchConfiguration/master-us-east-1e.masters.foo.bar.com
  	ImageID	282335181503/k8s-1.3-debian-jessie-amd64-hvm-ebs-2016-06-18
  	InstanceType	t2.medium
  	SSHKey	id:foo.bar.baz.com-2e:a2:34:3a:19:b1:b2:58:26:40:7c:a0:1a:1b:23:83
  	SecurityGroups	[id:<nil>]
  	AssociatePublicIP	true
  	IAMInstanceProfile	id:masters.foo.bar.com
  	RootVolumeSize	20
  	RootVolumeType	gp2
AutoscalingGroup	autoscalingGroup/master-us-east-1e.masters.foo.bar.com
  	MinSize	1
  	MaxSize	1
  	Subnets	[id:<nil>]
  	Tags	{k8s.io/dns/internal: api.internal.foo.bar.com, k8s.io/dns/public: api.foo.bar.com, k8s.io/role/master: 1, Name: master-us-east-1e.masters.foo.bar.com, KubernetesCluster: foo.bar.com}
AutoscalingGroup	autoscalingGroup/nodes.foo.bar.com
  	MinSize	1
  	MaxSize	1
  	Subnets	[id:<nil>]
  	Tags	{KubernetesCluster: foo.bar.com, k8s.io/role/node: 1, Name: nodes.foo.bar.com}
```