### PR TITLE
Add support for shared subnets

### DIFF
--- a/docs/run_in_existing_vpc.md
+++ b/docs/run_in_existing_vpc.md
@@ -1,7 +1,7 @@
 ## Running in a shared VPC
 
-When launching into a shared VPC, the VPC & the Internet Gateway will be reused, but we create a new subnet per zone,
-and a new route table.
+When launching into a shared VPC, the VPC & the Internet Gateway will be reused. By default we create a new subnet per zone,
+and a new route table, but you can also use a shared subnet (see [below](#running-in-a-shared-subnet)).
 
 Use kops create cluster with the `--vpc` and `--network-cidr` arguments for your existing VPC:
 
@@ -60,3 +60,34 @@ Finally, if your shared VPC has a KubernetesCluster tag (because it was created 
 probably remove that tag to indicate to indicate that the resources are not owned by that cluster, and so
 deleting the cluster won't try to delete the VPC.  (Deleting the VPC won't succeed anyway, because it's in use,
 but it's better to avoid the later confusion!)
+
+## Running in a shared subnet
+
+You can also use a shared subnet. Doing so is not recommended unless you are using external networking.
+
+Edit your cluster to add the ID of the subnet:
+
+`kops edit cluster ${CLUSTER_NAME}`
+
+```
+metadata:
+  creationTimestamp: "2016-06-27T14:23:34Z"
+  name: ${CLUSTER_NAME}
+spec:
+  cloudProvider: aws
+  networkCIDR: 10.100.0.0/16
+  networkID: vpc-a80734c1
+  nonMasqueradeCIDR: 100.64.0.0/10
+  zones:
+  - cidr: 10.100.32.0/19
+    name: eu-central-1a
+    id: subnet-1234567 # Replace this with the ID of your subnet
+```
+
+Make sure that the CIDR matches the CIDR of your subnet. Then update your cluster through the normal update procedure:
+
+```
+kops update cluster ${CLUSTER_NAME}
+# Review changes
+kops update cluster ${CLUSTER_NAME} --yes
+```

--- a/upup/models/cloudup/_aws/network.yaml
+++ b/upup/models/cloudup/_aws/network.yaml
@@ -33,16 +33,19 @@ route/0.0.0.0/0:
   internetGateway: internetGateway/{{ ClusterName }}
   vpc: vpc/{{ ClusterName }}
 
-{{ range $zone := .Zones }}
+{{ range $index, $zone := .Zones }}
 
 subnet/{{ $zone.Name }}.{{ ClusterName }}:
   vpc: vpc/{{ ClusterName }}
   availabilityZone: {{ $zone.Name }}
   cidr: {{ $zone.CIDR }}
   id: {{ $zone.ProviderID }}
+  shared: {{ SharedZone $index }}
 
+{{ if not (SharedZone $index) }}
 routeTableAssociation/{{ $zone.Name }}.{{ ClusterName }}:
   routeTable: routeTable/{{ ClusterName }}
   subnet: subnet/{{ $zone.Name }}.{{ ClusterName }}
+{{ end}}
 
 {{ end }}

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -57,6 +57,10 @@ func (tf *TemplateFunctions) WellKnownServiceIP(id int) (net.IP, error) {
 func (tf *TemplateFunctions) AddTo(dest template.FuncMap) {
 	dest["EtcdClusterMemberTags"] = tf.EtcdClusterMemberTags
 	dest["SharedVPC"] = tf.SharedVPC
+
+	dest["SharedZone"] = func(index int) bool {
+		return tf.SharedZone(index)
+	}
 	dest["WellKnownServiceIP"] = tf.WellKnownServiceIP
 	dest["AdminCIDR"] = tf.AdminCIDR
 
@@ -121,6 +125,11 @@ func (tf *TemplateFunctions) EtcdClusterMemberTags(etcd *api.EtcdClusterSpec, m 
 // SharedVPC is a simple helper function which makes the templates for a shared VPC clearer
 func (tf *TemplateFunctions) SharedVPC() bool {
 	return tf.cluster.Spec.NetworkID != ""
+}
+
+// SharedZone is a simple helper function which makes the templates for a shared Zone clearer
+func (tf *TemplateFunctions) SharedZone(index int) bool {
+	return tf.cluster.Spec.Zones[index].ProviderID != ""
 }
 
 // AdminCIDR returns the single CIDR that is allowed access to the admin ports of the cluster (22, 443 on master)


### PR DESCRIPTION
If a zone has an ID specified, the subnet will be treated as shared and won't be tagged with cluster tags. This will prevent it from being deleted on cluster tear down. Additionally, a route table will not be associated with that subnet, so that an existing route table can be used instead.
 