### PR TITLE
Honor minSize/maxSize for ASGs for master

### DIFF
--- a/upup/models/cloudup/_aws/master/_master_asg/master_asg.yaml
+++ b/upup/models/cloudup/_aws/master/_master_asg/master_asg.yaml
@@ -16,9 +16,9 @@ launchConfiguration/{{ $m.Name }}.masters.{{ ClusterName }}:
   spotPrice: "{{ $m.Spec.MaxPrice }}"
 {{ end }}
 
-autoscalingGroup/{{ $m.Name}}.masters.{{ ClusterName }}:
-  minSize: 1
-  maxSize: 1
+autoscalingGroup/{{ $m.Name }}.masters.{{ ClusterName }}:
+  minSize: {{ $m.Spec.MinSize }}
+  maxSize: {{ $m.Spec.MaxSize }}
   subnets:
   {{ range $z := $m.Spec.Zones }}
     - subnet/{{ $z }}.{{ ClusterName }}


### PR DESCRIPTION
Normally we expect the size to be 1, but it turns out there is an
exception - in the case when we want to suspend a cluster.  So honor the
values if the user sets them.

Thanks for spotting @sekka1

Fix #403