### PR TITLE
Make AWSCloud an interface, mock it out in tests

### DIFF
--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -211,8 +211,8 @@ func (c *ApplyClusterCmd) Run() error {
 
 	case "aws":
 		{
-			awsCloud := cloud.(*awsup.AWSCloud)
-			region = awsCloud.Region
+			awsCloud := cloud.(awsup.AWSCloud)
+			region = awsCloud.Region()
 
 			l.AddTypes(map[string]interface{}{
 				// EC2
@@ -459,7 +459,7 @@ func (c *ApplyClusterCmd) Run() error {
 		case "gce":
 			target = gce.NewGCEAPITarget(cloud.(*gce.GCECloud))
 		case "aws":
-			target = awsup.NewAWSAPITarget(cloud.(*awsup.AWSCloud))
+			target = awsup.NewAWSAPITarget(cloud.(awsup.AWSCloud))
 		default:
 			return fmt.Errorf("direct configuration not supported with CloudProvider:%q", cluster.Spec.CloudProvider)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
+++ b/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
@@ -28,7 +28,7 @@ func (e *DHCPOptions) CompareWithID() *string {
 }
 
 func (e *DHCPOptions) Find(c *fi.Context) (*DHCPOptions, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	request := &ec2.DescribeDhcpOptionsInput{}
 	if e.ID != nil {
@@ -37,7 +37,7 @@ func (e *DHCPOptions) Find(c *fi.Context) (*DHCPOptions, error) {
 		request.Filters = cloud.BuildFilters(e.Name)
 	}
 
-	response, err := cloud.EC2.DescribeDhcpOptions(request)
+	response, err := cloud.EC2().DescribeDhcpOptions(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing DHCPOptions: %v", err)
 	}
@@ -127,7 +127,7 @@ func (_ *DHCPOptions) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *DHCPOption
 			request.DhcpConfigurations = append(request.DhcpConfigurations, o)
 		}
 
-		response, err := t.Cloud.EC2.CreateDhcpOptions(request)
+		response, err := t.Cloud.EC2().CreateDhcpOptions(request)
 		if err != nil {
 			return fmt.Errorf("error creating DHCPOptions: %v", err)
 		}
@@ -145,7 +145,7 @@ type terraformDHCPOptions struct {
 }
 
 func (_ *DHCPOptions) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *DHCPOptions) error {
-	cloud := t.Cloud.(*awsup.AWSCloud)
+	cloud := t.Cloud.(awsup.AWSCloud)
 
 	tf := &terraformDHCPOptions{
 		DomainName: e.DomainName,

--- a/upup/pkg/fi/cloudup/awstasks/dnsname.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname.go
@@ -23,7 +23,7 @@ type DNSName struct {
 }
 
 func (e *DNSName) Find(c *fi.Context) (*DNSName, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	findName := fi.StringValue(e.Name)
 	if findName == "" {
@@ -43,7 +43,7 @@ func (e *DNSName) Find(c *fi.Context) (*DNSName, error) {
 
 	var found *route53.ResourceRecordSet
 
-	err := cloud.Route53.ListResourceRecordSetsPages(request, func(p *route53.ListResourceRecordSetsOutput, lastPage bool) (shouldContinue bool) {
+	err := cloud.Route53().ListResourceRecordSetsPages(request, func(p *route53.ListResourceRecordSetsOutput, lastPage bool) (shouldContinue bool) {
 		for _, rr := range p.ResourceRecordSets {
 			resourceType := aws.StringValue(rr.Type)
 			name := aws.StringValue(rr.Name)
@@ -124,7 +124,7 @@ func (_ *DNSName) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *DNSName) error
 
 	glog.V(2).Infof("Updating DNS record %q", *e.Name)
 
-	response, err := t.Cloud.Route53.ChangeResourceRecordSets(request)
+	response, err := t.Cloud.Route53().ChangeResourceRecordSets(request)
 	if err != nil {
 		return fmt.Errorf("error creating ResourceRecordSets: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/awstasks/dnszone.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnszone.go
@@ -27,7 +27,7 @@ func (e *DNSZone) CompareWithID() *string {
 }
 
 func (e *DNSZone) Find(c *fi.Context) (*DNSZone, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	z, err := e.findExisting(cloud)
 	if err != nil {
@@ -49,7 +49,7 @@ func (e *DNSZone) Find(c *fi.Context) (*DNSZone, error) {
 	return actual, nil
 }
 
-func (e *DNSZone) findExisting(cloud *awsup.AWSCloud) (*route53.HostedZone, error) {
+func (e *DNSZone) findExisting(cloud awsup.AWSCloud) (*route53.HostedZone, error) {
 	findID := ""
 	if e.ID != nil {
 		findID = *e.ID
@@ -62,7 +62,7 @@ func (e *DNSZone) findExisting(cloud *awsup.AWSCloud) (*route53.HostedZone, erro
 			Id: aws.String(findID),
 		}
 
-		response, err := cloud.Route53.GetHostedZone(request)
+		response, err := cloud.Route53().GetHostedZone(request)
 		if err != nil {
 			if awsup.AWSErrorCode(err) == "NoSuchHostedZone" {
 				if e.ID != nil {
@@ -88,7 +88,7 @@ func (e *DNSZone) findExisting(cloud *awsup.AWSCloud) (*route53.HostedZone, erro
 		DNSName: aws.String(findName),
 	}
 
-	response, err := cloud.Route53.ListHostedZonesByName(request)
+	response, err := cloud.Route53().ListHostedZonesByName(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing DNS HostedZones: %v", err)
 	}
@@ -129,7 +129,7 @@ func (_ *DNSZone) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *DNSZone) error
 
 		glog.V(2).Infof("Creating Route53 HostedZone with Name %q", e.Name)
 
-		response, err := t.Cloud.Route53.CreateHostedZone(request)
+		response, err := t.Cloud.Route53().CreateHostedZone(request)
 		if err != nil {
 			return fmt.Errorf("error creating DNS HostedZone: %v", err)
 		}
@@ -148,7 +148,7 @@ type terraformRoute53Zone struct {
 }
 
 func (_ *DNSZone) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *DNSZone) error {
-	cloud := t.Cloud.(*awsup.AWSCloud)
+	cloud := t.Cloud.(awsup.AWSCloud)
 
 	// As a special case, we check for an existing zone
 	// It is really painful to have TF create a new one...

--- a/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
+++ b/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
@@ -35,7 +35,7 @@ type TaggableResource interface {
 var _ TaggableResource = &EBSVolume{}
 
 func (e *EBSVolume) FindResourceID(c fi.Cloud) (*string, error) {
-	actual, err := e.find(c.(*awsup.AWSCloud))
+	actual, err := e.find(c.(awsup.AWSCloud))
 	if err != nil {
 		return nil, fmt.Errorf("error querying for EBSVolume: %v", err)
 	}
@@ -46,20 +46,20 @@ func (e *EBSVolume) FindResourceID(c fi.Cloud) (*string, error) {
 }
 
 func (e *EBSVolume) Find(context *fi.Context) (*EBSVolume, error) {
-	actual, err := e.find(context.Cloud.(*awsup.AWSCloud))
+	actual, err := e.find(context.Cloud.(awsup.AWSCloud))
 	if actual != nil && err == nil {
 		e.ID = actual.ID
 	}
 	return actual, err
 }
 
-func (e *EBSVolume) find(cloud *awsup.AWSCloud) (*EBSVolume, error) {
+func (e *EBSVolume) find(cloud awsup.AWSCloud) (*EBSVolume, error) {
 	filters := cloud.BuildFilters(e.Name)
 	request := &ec2.DescribeVolumesInput{
 		Filters: filters,
 	}
 
-	response, err := cloud.EC2.DescribeVolumes(request)
+	response, err := cloud.EC2().DescribeVolumes(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing volumes: %v", err)
 	}
@@ -89,7 +89,7 @@ func (e *EBSVolume) find(cloud *awsup.AWSCloud) (*EBSVolume, error) {
 }
 
 func (e *EBSVolume) Run(c *fi.Context) error {
-	c.Cloud.(*awsup.AWSCloud).AddTags(e.Name, e.Tags)
+	c.Cloud.(awsup.AWSCloud).AddTags(e.Name, e.Tags)
 	return fi.DefaultDeltaRunMethod(e, c)
 }
 
@@ -119,7 +119,7 @@ func (_ *EBSVolume) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *EBSVolume) e
 			Encrypted:        e.Encrypted,
 		}
 
-		response, err := t.Cloud.EC2.CreateVolume(request)
+		response, err := t.Cloud.EC2().CreateVolume(request)
 		if err != nil {
 			return fmt.Errorf("error creating PersistentVolume: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
@@ -26,7 +26,7 @@ type ElasticIP struct {
 var _ fi.HasAddress = &ElasticIP{}
 
 func (e *ElasticIP) FindAddress(context *fi.Context) (*string, error) {
-	actual, err := e.find(context.Cloud.(*awsup.AWSCloud))
+	actual, err := e.find(context.Cloud.(awsup.AWSCloud))
 	if err != nil {
 		return nil, fmt.Errorf("error querying for ElasticIP: %v", err)
 	}
@@ -37,10 +37,10 @@ func (e *ElasticIP) FindAddress(context *fi.Context) (*string, error) {
 }
 
 func (e *ElasticIP) Find(context *fi.Context) (*ElasticIP, error) {
-	return e.find(context.Cloud.(*awsup.AWSCloud))
+	return e.find(context.Cloud.(awsup.AWSCloud))
 }
 
-func (e *ElasticIP) findTagOnResourceID(cloud *awsup.AWSCloud) (*string, error) {
+func (e *ElasticIP) findTagOnResourceID(cloud awsup.AWSCloud) (*string, error) {
 	if e.TagOnResource == nil {
 		return nil, nil
 	}
@@ -58,7 +58,7 @@ func (e *ElasticIP) findTagOnResourceID(cloud *awsup.AWSCloud) (*string, error) 
 	return id, err
 }
 
-func (e *ElasticIP) find(cloud *awsup.AWSCloud) (*ElasticIP, error) {
+func (e *ElasticIP) find(cloud awsup.AWSCloud) (*ElasticIP, error) {
 	publicIP := e.PublicIP
 	allocationID := e.ID
 
@@ -76,7 +76,7 @@ func (e *ElasticIP) find(cloud *awsup.AWSCloud) (*ElasticIP, error) {
 			Filters: filters,
 		}
 
-		response, err := cloud.EC2.DescribeTags(request)
+		response, err := cloud.EC2().DescribeTags(request)
 		if err != nil {
 			return nil, fmt.Errorf("error listing tags: %v", err)
 		}
@@ -101,7 +101,7 @@ func (e *ElasticIP) find(cloud *awsup.AWSCloud) (*ElasticIP, error) {
 			request.Filters = []*ec2.Filter{awsup.NewEC2Filter("public-ip", *publicIP)}
 		}
 
-		response, err := cloud.EC2.DescribeAddresses(request)
+		response, err := cloud.EC2().DescribeAddresses(request)
 		if err != nil {
 			return nil, fmt.Errorf("error listing ElasticIPs: %v", err)
 		}
@@ -156,7 +156,7 @@ func (_ *ElasticIP) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *ElasticIP) e
 		request := &ec2.AllocateAddressInput{}
 		request.Domain = aws.String(ec2.DomainTypeVpc)
 
-		response, err := t.Cloud.EC2.AllocateAddress(request)
+		response, err := t.Cloud.EC2().AllocateAddress(request)
 		if err != nil {
 			return fmt.Errorf("error creating ElasticIP: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile.go
@@ -27,10 +27,10 @@ func (e *IAMInstanceProfile) CompareWithID() *string {
 
 // findIAMInstanceProfile retrieves the InstanceProfile with specified name
 // It returns nil,nil if not found
-func findIAMInstanceProfile(cloud *awsup.AWSCloud, name string) (*iam.InstanceProfile, error) {
+func findIAMInstanceProfile(cloud awsup.AWSCloud, name string) (*iam.InstanceProfile, error) {
 	request := &iam.GetInstanceProfileInput{InstanceProfileName: aws.String(name)}
 
-	response, err := cloud.IAM.GetInstanceProfile(request)
+	response, err := cloud.IAM().GetInstanceProfile(request)
 	if awsErr, ok := err.(awserr.Error); ok {
 		if awsErr.Code() == "NoSuchEntity" {
 			return nil, nil
@@ -45,7 +45,7 @@ func findIAMInstanceProfile(cloud *awsup.AWSCloud, name string) (*iam.InstancePr
 }
 
 func (e *IAMInstanceProfile) Find(c *fi.Context) (*IAMInstanceProfile, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	p, err := findIAMInstanceProfile(cloud, *e.Name)
 	if err != nil {
@@ -88,7 +88,7 @@ func (_ *IAMInstanceProfile) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *IAM
 			InstanceProfileName: e.Name,
 		}
 
-		response, err := t.Cloud.IAM.CreateInstanceProfile(request)
+		response, err := t.Cloud.IAM().CreateInstanceProfile(request)
 		if err != nil {
 			return fmt.Errorf("error creating IAMInstanceProfile: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
@@ -22,7 +22,7 @@ func (e *IAMInstanceProfileRole) String() string {
 }
 
 func (e *IAMInstanceProfileRole) Find(c *fi.Context) (*IAMInstanceProfileRole, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	if e.Role == nil || e.Role.ID == nil {
 		glog.V(2).Infof("Role/RoleID not set")
@@ -32,7 +32,7 @@ func (e *IAMInstanceProfileRole) Find(c *fi.Context) (*IAMInstanceProfileRole, e
 
 	request := &iam.GetInstanceProfileInput{InstanceProfileName: e.InstanceProfile.Name}
 
-	response, err := cloud.IAM.GetInstanceProfile(request)
+	response, err := cloud.IAM().GetInstanceProfile(request)
 	if awsErr, ok := err.(awserr.Error); ok {
 		if awsErr.Code() == "NoSuchEntity" {
 			return nil, nil
@@ -79,7 +79,7 @@ func (_ *IAMInstanceProfileRole) RenderAWS(t *awsup.AWSAPITarget, a, e, changes 
 			RoleName:            e.Role.Name,
 		}
 
-		_, err := t.Cloud.IAM.AddRoleToInstanceProfile(request)
+		_, err := t.Cloud.IAM().AddRoleToInstanceProfile(request)
 		if err != nil {
 			return fmt.Errorf("error creating IAMInstanceProfileRole: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/iamrole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrole.go
@@ -30,11 +30,11 @@ func (e *IAMRole) CompareWithID() *string {
 }
 
 func (e *IAMRole) Find(c *fi.Context) (*IAMRole, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	request := &iam.GetRoleInput{RoleName: e.Name}
 
-	response, err := cloud.IAM.GetRole(request)
+	response, err := cloud.IAM().GetRole(request)
 	if awsErr, ok := err.(awserr.Error); ok {
 		if awsErr.Code() == "NoSuchEntity" {
 			return nil, nil
@@ -119,7 +119,7 @@ func (_ *IAMRole) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *IAMRole) error
 		request.AssumeRolePolicyDocument = aws.String(policy)
 		request.RoleName = e.Name
 
-		response, err := t.Cloud.IAM.CreateRole(request)
+		response, err := t.Cloud.IAM().CreateRole(request)
 		if err != nil {
 			return fmt.Errorf("error creating IAMRole: %v", err)
 		}
@@ -150,7 +150,7 @@ func (_ *IAMRole) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *IAMRole) error
 			request.PolicyDocument = aws.String(policy)
 			request.RoleName = e.Name
 
-			_, err = t.Cloud.IAM.UpdateAssumeRolePolicy(request)
+			_, err = t.Cloud.IAM().UpdateAssumeRolePolicy(request)
 			if err != nil {
 				return fmt.Errorf("error updating IAMRole: %v", err)
 			}

--- a/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
@@ -23,14 +23,14 @@ type IAMRolePolicy struct {
 }
 
 func (e *IAMRolePolicy) Find(c *fi.Context) (*IAMRolePolicy, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	request := &iam.GetRolePolicyInput{
 		RoleName:   e.Role.Name,
 		PolicyName: e.Name,
 	}
 
-	response, err := cloud.IAM.GetRolePolicy(request)
+	response, err := cloud.IAM().GetRolePolicy(request)
 	if awsErr, ok := err.(awserr.Error); ok {
 		if awsErr.Code() == "NoSuchEntity" {
 			return nil, nil
@@ -117,7 +117,7 @@ func (_ *IAMRolePolicy) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *IAMRoleP
 		request.RoleName = e.Name
 		request.PolicyName = e.Name
 
-		_, err = t.Cloud.IAM.PutRolePolicy(request)
+		_, err = t.Cloud.IAM().PutRolePolicy(request)
 		if err != nil {
 			return fmt.Errorf("error creating/updating IAMRolePolicy: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/instance.go
+++ b/upup/pkg/fi/cloudup/awstasks/instance.go
@@ -41,7 +41,7 @@ func (s *Instance) CompareWithID() *string {
 }
 
 func (e *Instance) Find(c *fi.Context) (*Instance, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	filters := cloud.BuildFilters(e.Name)
 	filters = append(filters, awsup.NewEC2Filter("instance-state-name", "pending", "running", "stopping", "stopped"))
@@ -49,7 +49,7 @@ func (e *Instance) Find(c *fi.Context) (*Instance, error) {
 		Filters: filters,
 	}
 
-	response, err := cloud.EC2.DescribeInstances(request)
+	response, err := cloud.EC2().DescribeInstances(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing instances: %v", err)
 	}
@@ -91,7 +91,7 @@ func (e *Instance) Find(c *fi.Context) (*Instance, error) {
 		request := &ec2.DescribeInstanceAttributeInput{}
 		request.InstanceId = i.InstanceId
 		request.Attribute = aws.String("userData")
-		response, err := cloud.EC2.DescribeInstanceAttribute(request)
+		response, err := cloud.EC2().DescribeInstanceAttribute(request)
 		if err != nil {
 			return nil, fmt.Errorf("error querying EC2 for user metadata for instance %q: %v", *i.InstanceId, err)
 		}
@@ -163,7 +163,7 @@ func nameFromIAMARN(arn *string) *string {
 }
 
 func (e *Instance) Run(c *fi.Context) error {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	cloud.AddTags(e.Name, e.Tags)
 
@@ -252,7 +252,7 @@ func (_ *Instance) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Instance) err
 			}
 		}
 
-		response, err := t.Cloud.EC2.RunInstances(request)
+		response, err := t.Cloud.EC2().RunInstances(request)
 		if err != nil {
 			return fmt.Errorf("error creating Instance: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/instance_elasticip_attachment.go
+++ b/upup/pkg/fi/cloudup/awstasks/instance_elasticip_attachment.go
@@ -19,7 +19,7 @@ func (e *InstanceElasticIPAttachment) String() string {
 }
 
 func (e *InstanceElasticIPAttachment) Find(c *fi.Context) (*InstanceElasticIPAttachment, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	instanceID := e.Instance.ID
 	eipID := e.ElasticIP.ID
@@ -32,7 +32,7 @@ func (e *InstanceElasticIPAttachment) Find(c *fi.Context) (*InstanceElasticIPAtt
 		AllocationIds: []*string{eipID},
 	}
 
-	response, err := cloud.EC2.DescribeAddresses(request)
+	response, err := cloud.EC2().DescribeAddresses(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing ElasticIPs: %v", err)
 	}
@@ -72,7 +72,7 @@ func (_ *InstanceElasticIPAttachment) RenderAWS(t *awsup.AWSAPITarget, a, e, cha
 		request.InstanceId = e.Instance.ID
 		request.AllocationId = a.ElasticIP.ID
 
-		_, err = t.Cloud.EC2.AssociateAddress(request)
+		_, err = t.Cloud.EC2().AssociateAddress(request)
 		if err != nil {
 			return fmt.Errorf("error creating InstanceElasticIPAttachment: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/instance_volume_attachment.go
+++ b/upup/pkg/fi/cloudup/awstasks/instance_volume_attachment.go
@@ -21,7 +21,7 @@ func (e *InstanceVolumeAttachment) String() string {
 }
 
 func (e *InstanceVolumeAttachment) Find(c *fi.Context) (*InstanceVolumeAttachment, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	instanceID := e.Instance.ID
 	volumeID := e.Volume.ID
@@ -89,7 +89,7 @@ func (_ *InstanceVolumeAttachment) RenderAWS(t *awsup.AWSAPITarget, a, e, change
 			Device:     e.Device,
 		}
 
-		_, err = t.Cloud.EC2.AttachVolume(request)
+		_, err = t.Cloud.EC2().AttachVolume(request)
 		if err != nil {
 			return fmt.Errorf("error creating InstanceVolumeAttachment: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway.go
@@ -24,8 +24,8 @@ func (e *InternetGateway) CompareWithID() *string {
 	return e.ID
 }
 
-func findInternetGateway(cloud *awsup.AWSCloud, request *ec2.DescribeInternetGatewaysInput) (*ec2.InternetGateway, error) {
-	response, err := cloud.EC2.DescribeInternetGateways(request)
+func findInternetGateway(cloud awsup.AWSCloud, request *ec2.DescribeInternetGatewaysInput) (*ec2.InternetGateway, error) {
+	response, err := cloud.EC2().DescribeInternetGateways(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing InternetGateways: %v", err)
 	}
@@ -41,7 +41,7 @@ func findInternetGateway(cloud *awsup.AWSCloud, request *ec2.DescribeInternetGat
 }
 
 func (e *InternetGateway) Find(c *fi.Context) (*InternetGateway, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	request := &ec2.DescribeInternetGatewaysInput{}
 
@@ -118,7 +118,7 @@ func (_ *InternetGateway) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Intern
 
 		request := &ec2.CreateInternetGatewayInput{}
 
-		response, err := t.Cloud.EC2.CreateInternetGateway(request)
+		response, err := t.Cloud.EC2().CreateInternetGateway(request)
 		if err != nil {
 			return fmt.Errorf("error creating InternetGateway: %v", err)
 		}
@@ -134,7 +134,7 @@ func (_ *InternetGateway) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Intern
 			InternetGatewayId: e.ID,
 		}
 
-		_, err := t.Cloud.EC2.AttachInternetGateway(attachRequest)
+		_, err := t.Cloud.EC2().AttachInternetGateway(attachRequest)
 		if err != nil {
 			return fmt.Errorf("error attaching InternetGateway to VPC: %v", err)
 		}
@@ -166,7 +166,7 @@ func (_ *InternetGateway) RenderTerraform(t *terraform.TerraformTarget, a, e, ch
 				return fmt.Errorf("VPC ID is required when InternetGateway is shared")
 			}
 			request.Filters = []*ec2.Filter{awsup.NewEC2Filter("attachment.vpc-id", vpcID)}
-			igw, err := findInternetGateway(t.Cloud.(*awsup.AWSCloud), request)
+			igw, err := findInternetGateway(t.Cloud.(awsup.AWSCloud), request)
 			if err != nil {
 				return err
 			}
@@ -180,7 +180,7 @@ func (_ *InternetGateway) RenderTerraform(t *terraform.TerraformTarget, a, e, ch
 		return nil
 	}
 
-	cloud := t.Cloud.(*awsup.AWSCloud)
+	cloud := t.Cloud.(awsup.AWSCloud)
 
 	tf := &terraformInternetGateway{
 		VPCID: e.VPC.TerraformLink(),

--- a/upup/pkg/fi/cloudup/awstasks/load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/load_balancer.go
@@ -56,13 +56,13 @@ func (e *LoadBalancerListener) GetDependencies(tasks map[string]fi.Task) []fi.Ta
 	return nil
 }
 
-func findELB(cloud *awsup.AWSCloud, name string) (*elb.LoadBalancerDescription, error) {
+func findELB(cloud awsup.AWSCloud, name string) (*elb.LoadBalancerDescription, error) {
 	request := &elb.DescribeLoadBalancersInput{
 		LoadBalancerNames: []*string{&name},
 	}
 
 	var found []*elb.LoadBalancerDescription
-	err := cloud.ELB.DescribeLoadBalancersPages(request, func(p *elb.DescribeLoadBalancersOutput, lastPage bool) (shouldContinue bool) {
+	err := cloud.ELB().DescribeLoadBalancersPages(request, func(p *elb.DescribeLoadBalancersOutput, lastPage bool) (shouldContinue bool) {
 		for _, lb := range p.LoadBalancerDescriptions {
 			if aws.StringValue(lb.LoadBalancerName) == name {
 				found = append(found, lb)
@@ -96,7 +96,7 @@ func findELB(cloud *awsup.AWSCloud, name string) (*elb.LoadBalancerDescription, 
 }
 
 func (e *LoadBalancer) Find(c *fi.Context) (*LoadBalancer, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	elbName := fi.StringValue(e.ID)
 	if elbName == "" {
@@ -206,7 +206,7 @@ func (_ *LoadBalancer) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *LoadBalan
 
 		glog.V(2).Infof("Creating ELB with Name:%q", *e.ID)
 
-		response, err := t.Cloud.ELB.CreateLoadBalancer(request)
+		response, err := t.Cloud.ELB().CreateLoadBalancer(request)
 		if err != nil {
 			return fmt.Errorf("error creating ELB: %v", err)
 		}
@@ -244,7 +244,7 @@ func (_ *LoadBalancer) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *LoadBalan
 
 			glog.V(2).Infof("Creating LoadBalancer listeners")
 
-			_, err := t.Cloud.ELB.CreateLoadBalancerListeners(request)
+			_, err := t.Cloud.ELB().CreateLoadBalancerListeners(request)
 			if err != nil {
 				return fmt.Errorf("error creating LoadBalancerListeners: %v", err)
 			}

--- a/upup/pkg/fi/cloudup/awstasks/load_balancer_attachment.go
+++ b/upup/pkg/fi/cloudup/awstasks/load_balancer_attachment.go
@@ -20,7 +20,7 @@ func (e *LoadBalancerAttachment) String() string {
 }
 
 func (e *LoadBalancerAttachment) Find(c *fi.Context) (*LoadBalancerAttachment, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	if e.AutoscalingGroup != nil {
 		g, err := findAutoscalingGroup(cloud, *e.AutoscalingGroup.Name)
@@ -69,7 +69,7 @@ func (_ *LoadBalancerAttachment) RenderAWS(t *awsup.AWSAPITarget, a, e, changes 
 
 	glog.V(2).Infof("Attaching autoscaling group %q to ELB %q", *e.AutoscalingGroup.Name, *e.LoadBalancer.Name)
 
-	_, err := t.Cloud.Autoscaling.AttachLoadBalancers(request)
+	_, err := t.Cloud.Autoscaling().AttachLoadBalancers(request)
 	if err != nil {
 		return fmt.Errorf("error attaching autoscaling group to ELB: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/awstasks/loadbalancer_healthchecks.go
+++ b/upup/pkg/fi/cloudup/awstasks/loadbalancer_healthchecks.go
@@ -26,7 +26,7 @@ func (e *LoadBalancerHealthChecks) String() string {
 }
 
 func (e *LoadBalancerHealthChecks) Find(c *fi.Context) (*LoadBalancerHealthChecks, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	elbName := fi.StringValue(e.LoadBalancer.ID)
 
@@ -81,7 +81,7 @@ func (_ *LoadBalancerHealthChecks) RenderAWS(t *awsup.AWSAPITarget, a, e, change
 
 	glog.V(2).Infof("Configuring health checks on ELB %q", *e.LoadBalancer.ID)
 
-	_, err := t.Cloud.ELB.ConfigureHealthCheck(request)
+	_, err := t.Cloud.ELB().ConfigureHealthCheck(request)
 	if err != nil {
 		return fmt.Errorf("error attaching autoscaling group to ELB: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/awstasks/route.go
+++ b/upup/pkg/fi/cloudup/awstasks/route.go
@@ -22,7 +22,7 @@ type Route struct {
 }
 
 func (e *Route) Find(c *fi.Context) (*Route, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	if e.RouteTable == nil || e.CIDR == nil {
 		// TODO: Move to validate?
@@ -37,7 +37,7 @@ func (e *Route) Find(c *fi.Context) (*Route, error) {
 		RouteTableIds: []*string{e.RouteTable.ID},
 	}
 
-	response, err := cloud.EC2.DescribeRouteTables(request)
+	response, err := cloud.EC2().DescribeRouteTables(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing RouteTables: %v", err)
 	}
@@ -134,7 +134,7 @@ func (_ *Route) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Route) error {
 
 		glog.V(2).Infof("Creating Route with RouteTable:%q CIDR:%q", *e.RouteTable.ID, *e.CIDR)
 
-		response, err := t.Cloud.EC2.CreateRoute(request)
+		response, err := t.Cloud.EC2().CreateRoute(request)
 		if err != nil {
 			return fmt.Errorf("error creating Route: %v", err)
 		}
@@ -157,7 +157,7 @@ func (_ *Route) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Route) error {
 
 		glog.V(2).Infof("Updating Route with RouteTable:%q CIDR:%q", *e.RouteTable.ID, *e.CIDR)
 
-		_, err := t.Cloud.EC2.ReplaceRoute(request)
+		_, err := t.Cloud.EC2().ReplaceRoute(request)
 		if err != nil {
 			return fmt.Errorf("error updating Route: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/routetable.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetable.go
@@ -24,7 +24,7 @@ func (e *RouteTable) CompareWithID() *string {
 }
 
 func (e *RouteTable) Find(c *fi.Context) (*RouteTable, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	request := &ec2.DescribeRouteTablesInput{}
 	if e.ID != nil {
@@ -33,7 +33,7 @@ func (e *RouteTable) Find(c *fi.Context) (*RouteTable, error) {
 		request.Filters = cloud.BuildFilters(e.Name)
 	}
 
-	response, err := cloud.EC2.DescribeRouteTables(request)
+	response, err := cloud.EC2().DescribeRouteTables(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing RouteTables: %v", err)
 	}
@@ -88,7 +88,7 @@ func (_ *RouteTable) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *RouteTable)
 			VpcId: vpcID,
 		}
 
-		response, err := t.Cloud.EC2.CreateRouteTable(request)
+		response, err := t.Cloud.EC2().CreateRouteTable(request)
 		if err != nil {
 			return fmt.Errorf("error creating RouteTable: %v", err)
 		}
@@ -106,7 +106,7 @@ type terraformRouteTable struct {
 }
 
 func (_ *RouteTable) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *RouteTable) error {
-	cloud := t.Cloud.(*awsup.AWSCloud)
+	cloud := t.Cloud.(awsup.AWSCloud)
 
 	tf := &terraformRouteTable{
 		VPCID: e.VPC.TerraformLink(),

--- a/upup/pkg/fi/cloudup/awstasks/routetableassociation.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetableassociation.go
@@ -24,7 +24,7 @@ func (s *RouteTableAssociation) CompareWithID() *string {
 }
 
 func (e *RouteTableAssociation) Find(c *fi.Context) (*RouteTableAssociation, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	routeTableID := e.RouteTable.ID
 	subnetID := e.Subnet.ID
@@ -37,7 +37,7 @@ func (e *RouteTableAssociation) Find(c *fi.Context) (*RouteTableAssociation, err
 		RouteTableIds: []*string{routeTableID},
 	}
 
-	response, err := cloud.EC2.DescribeRouteTables(request)
+	response, err := cloud.EC2().DescribeRouteTables(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing RouteTables: %v", err)
 	}
@@ -91,7 +91,7 @@ func (s *RouteTableAssociation) CheckChanges(a, e, changes *RouteTableAssociatio
 	return nil
 }
 
-func findExistingRouteTableForSubnet(cloud *awsup.AWSCloud, subnet *Subnet) (*ec2.RouteTable, error) {
+func findExistingRouteTableForSubnet(cloud awsup.AWSCloud, subnet *Subnet) (*ec2.RouteTable, error) {
 	if subnet == nil {
 		return nil, fmt.Errorf("subnet not set")
 	}
@@ -102,7 +102,7 @@ func findExistingRouteTableForSubnet(cloud *awsup.AWSCloud, subnet *Subnet) (*ec
 	request := &ec2.DescribeRouteTablesInput{
 		Filters: []*ec2.Filter{awsup.NewEC2Filter("association.subnet-id", fi.StringValue(subnet.ID))},
 	}
-	response, err := cloud.EC2.DescribeRouteTables(request)
+	response, err := cloud.EC2().DescribeRouteTables(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing RouteTables: %v", err)
 	}
@@ -137,7 +137,7 @@ func (_ *RouteTableAssociation) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *
 					AssociationId: a.RouteTableAssociationId,
 				}
 
-				_, err := t.Cloud.EC2.DisassociateRouteTable(request)
+				_, err := t.Cloud.EC2().DisassociateRouteTable(request)
 				if err != nil {
 					return fmt.Errorf("error disassociating existing RouteTable from subnet: %v", err)
 				}
@@ -150,7 +150,7 @@ func (_ *RouteTableAssociation) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *
 			RouteTableId: e.RouteTable.ID,
 		}
 
-		response, err := t.Cloud.EC2.AssociateRouteTable(request)
+		response, err := t.Cloud.EC2().AssociateRouteTable(request)
 		if err != nil {
 			return fmt.Errorf("error creating RouteTableAssociation: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -53,7 +53,7 @@ func (e *SecurityGroup) Find(c *fi.Context) (*SecurityGroup, error) {
 }
 
 func (e *SecurityGroup) findEc2(c *fi.Context) (*ec2.SecurityGroup, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	var vpcID *string
 	if e.VPC != nil {
@@ -76,7 +76,7 @@ func (e *SecurityGroup) findEc2(c *fi.Context) (*ec2.SecurityGroup, error) {
 		request.Filters = cloud.BuildFilters(e.Name)
 	}
 
-	response, err := cloud.EC2.DescribeSecurityGroups(request)
+	response, err := cloud.EC2().DescribeSecurityGroups(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing SecurityGroups: %v", err)
 	}
@@ -120,7 +120,7 @@ func (_ *SecurityGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Security
 			Description: e.Description,
 		}
 
-		response, err := t.Cloud.EC2.CreateSecurityGroup(request)
+		response, err := t.Cloud.EC2().CreateSecurityGroup(request)
 		if err != nil {
 			return fmt.Errorf("error creating SecurityGroup: %v", err)
 		}
@@ -139,7 +139,7 @@ type terraformSecurityGroup struct {
 }
 
 func (_ *SecurityGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *SecurityGroup) error {
-	cloud := t.Cloud.(*awsup.AWSCloud)
+	cloud := t.Cloud.(awsup.AWSCloud)
 
 	tf := &terraformSecurityGroup{
 		Name:        e.Name,
@@ -178,7 +178,7 @@ func (d *deleteSecurityGroupRule) Delete(t fi.Target) error {
 		request.IpPermissions = []*ec2.IpPermission{d.permission}
 
 		glog.V(2).Infof("Calling EC2 RevokeSecurityGroupEgress")
-		_, err := awsTarget.Cloud.EC2.RevokeSecurityGroupEgress(request)
+		_, err := awsTarget.Cloud.EC2().RevokeSecurityGroupEgress(request)
 		if err != nil {
 			return fmt.Errorf("error revoking SecurityGroupEgress: %v", err)
 		}
@@ -189,7 +189,7 @@ func (d *deleteSecurityGroupRule) Delete(t fi.Target) error {
 		request.IpPermissions = []*ec2.IpPermission{d.permission}
 
 		glog.V(2).Infof("Calling EC2 RevokeSecurityGroupIngress")
-		_, err := awsTarget.Cloud.EC2.RevokeSecurityGroupIngress(request)
+		_, err := awsTarget.Cloud.EC2().RevokeSecurityGroupIngress(request)
 		if err != nil {
 			return fmt.Errorf("error revoking SecurityGroupIngress: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
@@ -29,7 +29,7 @@ type SecurityGroupRule struct {
 }
 
 func (e *SecurityGroupRule) Find(c *fi.Context) (*SecurityGroupRule, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	if e.SecurityGroup == nil || e.SecurityGroup.ID == nil {
 		return nil, nil
@@ -41,7 +41,7 @@ func (e *SecurityGroupRule) Find(c *fi.Context) (*SecurityGroupRule, error) {
 		},
 	}
 
-	response, err := cloud.EC2.DescribeSecurityGroups(request)
+	response, err := cloud.EC2().DescribeSecurityGroups(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing SecurityGroup: %v", err)
 	}
@@ -188,7 +188,7 @@ func (_ *SecurityGroupRule) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Secu
 			request.IpPermissions = []*ec2.IpPermission{ipPermission}
 
 			glog.V(2).Infof("Calling EC2 AuthorizeSecurityGroupEgress")
-			_, err := t.Cloud.EC2.AuthorizeSecurityGroupEgress(request)
+			_, err := t.Cloud.EC2().AuthorizeSecurityGroupEgress(request)
 			if err != nil {
 				return fmt.Errorf("error creating SecurityGroupEgress: %v", err)
 			}
@@ -199,7 +199,7 @@ func (_ *SecurityGroupRule) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Secu
 			request.IpPermissions = []*ec2.IpPermission{ipPermission}
 
 			glog.V(2).Infof("Calling EC2 AuthorizeSecurityGroupIngress")
-			_, err := t.Cloud.EC2.AuthorizeSecurityGroupIngress(request)
+			_, err := t.Cloud.EC2().AuthorizeSecurityGroupIngress(request)
 			if err != nil {
 				return fmt.Errorf("error creating SecurityGroupIngress: %v", err)
 			}

--- a/upup/pkg/fi/cloudup/awstasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/awstasks/sshkey.go
@@ -37,13 +37,13 @@ func (e *SSHKey) CompareWithID() *string {
 }
 
 func (e *SSHKey) Find(c *fi.Context) (*SSHKey, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	request := &ec2.DescribeKeyPairsInput{
 		KeyNames: []*string{e.Name},
 	}
 
-	response, err := cloud.EC2.DescribeKeyPairs(request)
+	response, err := cloud.EC2().DescribeKeyPairs(request)
 	if awsErr, ok := err.(awserr.Error); ok {
 		if awsErr.Code() == "InvalidKeyPair.NotFound" {
 			return nil, nil
@@ -212,7 +212,7 @@ func (_ *SSHKey) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *SSHKey) error {
 			request.PublicKeyMaterial = d
 		}
 
-		response, err := t.Cloud.EC2.ImportKeyPair(request)
+		response, err := t.Cloud.EC2().ImportKeyPair(request)
 		if err != nil {
 			return fmt.Errorf("error creating SSHKey: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -28,7 +28,7 @@ func (e *Subnet) CompareWithID() *string {
 }
 
 func (e *Subnet) Find(c *fi.Context) (*Subnet, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	request := &ec2.DescribeSubnetsInput{}
 	if e.ID != nil {
@@ -37,7 +37,7 @@ func (e *Subnet) Find(c *fi.Context) (*Subnet, error) {
 		request.Filters = cloud.BuildFilters(e.Name)
 	}
 
-	response, err := cloud.EC2.DescribeSubnets(request)
+	response, err := cloud.EC2().DescribeSubnets(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing Subnets: %v", err)
 	}
@@ -118,7 +118,7 @@ func (_ *Subnet) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Subnet) error {
 			VpcId:            e.VPC.ID,
 		}
 
-		response, err := t.Cloud.EC2.CreateSubnet(request)
+		response, err := t.Cloud.EC2().CreateSubnet(request)
 		if err != nil {
 			return fmt.Errorf("error creating subnet: %v", err)
 		}
@@ -153,7 +153,7 @@ type terraformSubnet struct {
 }
 
 func (_ *Subnet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Subnet) error {
-	cloud := t.Cloud.(*awsup.AWSCloud)
+	cloud := t.Cloud.(awsup.AWSCloud)
 
 	shared := fi.BoolValue(e.Shared)
 	if shared {

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -30,7 +30,7 @@ func (e *VPC) CompareWithID() *string {
 }
 
 func (e *VPC) Find(c *fi.Context) (*VPC, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	request := &ec2.DescribeVpcsInput{}
 
@@ -40,7 +40,7 @@ func (e *VPC) Find(c *fi.Context) (*VPC, error) {
 		request.Filters = cloud.BuildFilters(e.Name)
 	}
 
-	response, err := cloud.EC2.DescribeVpcs(request)
+	response, err := cloud.EC2().DescribeVpcs(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing VPCs: %v", err)
 	}
@@ -62,7 +62,7 @@ func (e *VPC) Find(c *fi.Context) (*VPC, error) {
 
 	if actual.ID != nil {
 		request := &ec2.DescribeVpcAttributeInput{VpcId: actual.ID, Attribute: aws.String(ec2.VpcAttributeNameEnableDnsSupport)}
-		response, err := cloud.EC2.DescribeVpcAttribute(request)
+		response, err := cloud.EC2().DescribeVpcAttribute(request)
 		if err != nil {
 			return nil, fmt.Errorf("error querying for dns support: %v", err)
 		}
@@ -71,7 +71,7 @@ func (e *VPC) Find(c *fi.Context) (*VPC, error) {
 
 	if actual.ID != nil {
 		request := &ec2.DescribeVpcAttributeInput{VpcId: actual.ID, Attribute: aws.String(ec2.VpcAttributeNameEnableDnsHostnames)}
-		response, err := cloud.EC2.DescribeVpcAttribute(request)
+		response, err := cloud.EC2().DescribeVpcAttribute(request)
 		if err != nil {
 			return nil, fmt.Errorf("error querying for dns support: %v", err)
 		}
@@ -133,7 +133,7 @@ func (_ *VPC) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *VPC) error {
 			CidrBlock: e.CIDR,
 		}
 
-		response, err := t.Cloud.EC2.CreateVpc(request)
+		response, err := t.Cloud.EC2().CreateVpc(request)
 		if err != nil {
 			return fmt.Errorf("error creating VPC: %v", err)
 		}
@@ -147,7 +147,7 @@ func (_ *VPC) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *VPC) error {
 			EnableDnsSupport: &ec2.AttributeBooleanValue{Value: changes.EnableDNSSupport},
 		}
 
-		_, err := t.Cloud.EC2.ModifyVpcAttribute(request)
+		_, err := t.Cloud.EC2().ModifyVpcAttribute(request)
 		if err != nil {
 			return fmt.Errorf("error modifying VPC attribute: %v", err)
 		}
@@ -159,7 +159,7 @@ func (_ *VPC) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *VPC) error {
 			EnableDnsHostnames: &ec2.AttributeBooleanValue{Value: changes.EnableDNSHostnames},
 		}
 
-		_, err := t.Cloud.EC2.ModifyVpcAttribute(request)
+		_, err := t.Cloud.EC2().ModifyVpcAttribute(request)
 		if err != nil {
 			return fmt.Errorf("error modifying VPC attribute: %v", err)
 		}
@@ -181,7 +181,7 @@ type terraformVPC struct {
 }
 
 func (_ *VPC) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VPC) error {
-	cloud := t.Cloud.(*awsup.AWSCloud)
+	cloud := t.Cloud.(awsup.AWSCloud)
 
 	shared := fi.BoolValue(e.Shared)
 	if shared {

--- a/upup/pkg/fi/cloudup/awstasks/vpc_dhcpoptions_association.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc_dhcpoptions_association.go
@@ -20,7 +20,7 @@ func (e *VPCDHCPOptionsAssociation) String() string {
 }
 
 func (e *VPCDHCPOptionsAssociation) Find(c *fi.Context) (*VPCDHCPOptionsAssociation, error) {
-	cloud := c.Cloud.(*awsup.AWSCloud)
+	cloud := c.Cloud.(awsup.AWSCloud)
 
 	vpcID := e.VPC.ID
 	dhcpOptionsID := e.DHCPOptions.ID
@@ -70,7 +70,7 @@ func (_ *VPCDHCPOptionsAssociation) RenderAWS(t *awsup.AWSAPITarget, a, e, chang
 			DhcpOptionsId: e.DHCPOptions.ID,
 		}
 
-		_, err := t.Cloud.EC2.AssociateDhcpOptions(request)
+		_, err := t.Cloud.EC2().AssociateDhcpOptions(request)
 		if err != nil {
 			return fmt.Errorf("error creating VPCDHCPOptionsAssociation: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awsup/aws_apitarget.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_apitarget.go
@@ -10,12 +10,12 @@ import (
 )
 
 type AWSAPITarget struct {
-	Cloud *AWSCloud
+	Cloud AWSCloud
 }
 
 var _ fi.Target = &AWSAPITarget{}
 
-func NewAWSAPITarget(cloud *AWSCloud) *AWSAPITarget {
+func NewAWSAPITarget(cloud AWSCloud) *AWSAPITarget {
 	return &AWSAPITarget{
 		Cloud: cloud,
 	}

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -23,36 +23,96 @@ const MaxCreateTagsAttempts = 60
 
 const TagClusterName = "KubernetesCluster"
 
-type AWSCloud struct {
-	EC2         *ec2.EC2
-	IAM         *iam.IAM
-	ELB         *elb.ELB
-	Autoscaling *autoscaling.AutoScaling
-	Route53     *route53.Route53
+type AWSCloud interface {
+	fi.Cloud
 
-	Region string
+	Region() string
+
+	EC2() *ec2.EC2
+	IAM() *iam.IAM
+	ELB() *elb.ELB
+	Autoscaling() *autoscaling.AutoScaling
+	Route53() *route53.Route53
+
+	// TODO: Document and rationalize these tags/filters methods
+	AddTags(name *string, tags map[string]string)
+	BuildFilters(name *string) []*ec2.Filter
+	BuildTags(name *string) map[string]string
+	Tags() map[string]string
+
+	// GetTags will fetch the tags for the specified resource, retrying (up to MaxDescribeTagsAttempts) if it hits an eventual-consistency type error
+	GetTags(resourceId string) (map[string]string, error)
+
+	// CreateTags will add tags to the specified resource, retrying up to MaxCreateTagsAttempts times if it hits an eventual-consistency type error
+	CreateTags(resourceId string, tags map[string]string) error
+
+	AddAWSTags(id string, expected map[string]string) error
+	GetELBTags(loadBalancerName string) (map[string]string, error)
+
+	// CreateELBTags will add tags to the specified loadBalancer, retrying up to MaxCreateTagsAttempts times if it hits an eventual-consistency type error
+	CreateELBTags(loadBalancerName string, tags map[string]string) error
+
+	// DescribeInstance is a helper that queries for the specified instance by id
+	DescribeInstance(instanceID string) (*ec2.Instance, error)
+
+	// DescribeVPC is a helper that queries for the specified vpc by id
+	DescribeVPC(vpcID string) (*ec2.Vpc, error)
+
+	DescribeAvailabilityZones() ([]*ec2.AvailabilityZone, error)
+
+	// ResolveImage finds an AMI image based on the given name.
+	// The name can be one of:
+	// `ami-...` in which case it is presumed to be an id
+	// owner/name in which case we find the image with the specified name, owned by owner
+	// name in which case we find the image with the specified name, with the current owner
+	ResolveImage(name string) (*ec2.Image, error)
+
+	// WithTags created a copy of AWSCloud with the specified default-tags bound
+	WithTags(tags map[string]string) AWSCloud
+}
+
+type awsCloudImplementation struct {
+	ec2         *ec2.EC2
+	iam         *iam.IAM
+	elb         *elb.ELB
+	autoscaling *autoscaling.AutoScaling
+	route53     *route53.Route53
+
+	region string
 
 	tags map[string]string
 }
 
-var _ fi.Cloud = &AWSCloud{}
+var _ fi.Cloud = &awsCloudImplementation{}
 
-func (c *AWSCloud) ProviderID() fi.CloudProviderID {
+func (c *awsCloudImplementation) ProviderID() fi.CloudProviderID {
 	return fi.CloudProviderAWS
 }
 
-func NewAWSCloud(region string, tags map[string]string) (*AWSCloud, error) {
-	c := &AWSCloud{Region: region}
+func (c *awsCloudImplementation) Region() string {
+	return c.region
+}
 
-	config := aws.NewConfig().WithRegion(region)
-	c.EC2 = ec2.New(session.New(), config)
-	c.IAM = iam.New(session.New(), config)
-	c.ELB = elb.New(session.New(), config)
-	c.Autoscaling = autoscaling.New(session.New(), config)
-	c.Route53 = route53.New(session.New(), config)
+var awsCloudInstances map[string]AWSCloud = make(map[string]AWSCloud)
 
-	c.tags = tags
-	return c, nil
+func NewAWSCloud(region string, tags map[string]string) (AWSCloud, error) {
+	c := awsCloudInstances[region]
+	if c == nil {
+		c := &awsCloudImplementation{region: region}
+
+		config := aws.NewConfig().WithRegion(region)
+		c.ec2 = ec2.New(session.New(), config)
+		c.iam = iam.New(session.New(), config)
+		c.elb = elb.New(session.New(), config)
+		c.autoscaling = autoscaling.New(session.New(), config)
+		c.route53 = route53.New(session.New(), config)
+
+		awsCloudInstances[region] = c
+	}
+
+	i := c.WithTags(tags)
+
+	return i, nil
 }
 
 func NewEC2Filter(name string, values ...string) *ec2.Filter {
@@ -67,13 +127,20 @@ func NewEC2Filter(name string, values ...string) *ec2.Filter {
 	return filter
 }
 
-func (c *AWSCloud) Tags() map[string]string {
+func (c *awsCloudImplementation) Tags() map[string]string {
 	// Defensive copy
 	tags := make(map[string]string)
 	for k, v := range c.tags {
 		tags[k] = v
 	}
 	return tags
+}
+
+func (c *awsCloudImplementation) WithTags(tags map[string]string) AWSCloud {
+	i := &awsCloudImplementation{}
+	*i = *c
+	i.tags = tags
+	return i
 }
 
 // isTagsEventualConsistencyError checks if the error is one of the errors encountered when we try to create/get tags before the resource has fully 'propagated' in EC2
@@ -91,7 +158,7 @@ func isTagsEventualConsistencyError(err error) bool {
 }
 
 // GetTags will fetch the tags for the specified resource, retrying (up to MaxDescribeTagsAttempts) if it hits an eventual-consistency type error
-func (c *AWSCloud) GetTags(resourceId string) (map[string]string, error) {
+func (c *awsCloudImplementation) GetTags(resourceId string) (map[string]string, error) {
 	tags := map[string]string{}
 
 	request := &ec2.DescribeTagsInput{
@@ -104,7 +171,7 @@ func (c *AWSCloud) GetTags(resourceId string) (map[string]string, error) {
 	for {
 		attempt++
 
-		response, err := c.EC2.DescribeTags(request)
+		response, err := c.EC2().DescribeTags(request)
 		if err != nil {
 			if isTagsEventualConsistencyError(err) {
 				if attempt > MaxDescribeTagsAttempts {
@@ -132,7 +199,7 @@ func (c *AWSCloud) GetTags(resourceId string) (map[string]string, error) {
 }
 
 // CreateTags will add tags to the specified resource, retrying up to MaxCreateTagsAttempts times if it hits an eventual-consistency type error
-func (c *AWSCloud) CreateTags(resourceId string, tags map[string]string) error {
+func (c *awsCloudImplementation) CreateTags(resourceId string, tags map[string]string) error {
 	if len(tags) == 0 {
 		return nil
 	}
@@ -151,7 +218,7 @@ func (c *AWSCloud) CreateTags(resourceId string, tags map[string]string) error {
 			Resources: []*string{&resourceId},
 		}
 
-		_, err := c.EC2.CreateTags(request)
+		_, err := c.EC2().CreateTags(request)
 		if err != nil {
 			if isTagsEventualConsistencyError(err) {
 				if attempt > MaxCreateTagsAttempts {
@@ -171,7 +238,7 @@ func (c *AWSCloud) CreateTags(resourceId string, tags map[string]string) error {
 }
 
 // DeleteTags will remove tags from the specified resource, retrying up to MaxCreateTagsAttempts times if it hits an eventual-consistency type error
-func (c *AWSCloud) DeleteTags(resourceId string, tags map[string]string) error {
+func (c *awsCloudImplementation) DeleteTags(resourceId string, tags map[string]string) error {
 	if len(tags) == 0 {
 		return nil
 	}
@@ -190,7 +257,7 @@ func (c *AWSCloud) DeleteTags(resourceId string, tags map[string]string) error {
 			Resources: []*string{&resourceId},
 		}
 
-		_, err := c.EC2.DeleteTags(request)
+		_, err := c.EC2().DeleteTags(request)
 		if err != nil {
 			if isTagsEventualConsistencyError(err) {
 				if attempt > MaxCreateTagsAttempts {
@@ -209,7 +276,7 @@ func (c *AWSCloud) DeleteTags(resourceId string, tags map[string]string) error {
 	}
 }
 
-func (c *AWSCloud) AddAWSTags(id string, expected map[string]string) error {
+func (c *awsCloudImplementation) AddAWSTags(id string, expected map[string]string) error {
 	actual, err := c.GetTags(id)
 	if err != nil {
 		return fmt.Errorf("unexpected error fetching tags for resource: %v", err)
@@ -236,7 +303,7 @@ func (c *AWSCloud) AddAWSTags(id string, expected map[string]string) error {
 	return nil
 }
 
-func (c *AWSCloud) GetELBTags(loadBalancerName string) (map[string]string, error) {
+func (c *awsCloudImplementation) GetELBTags(loadBalancerName string) (map[string]string, error) {
 	tags := map[string]string{}
 
 	request := &elb.DescribeTagsInput{
@@ -247,7 +314,7 @@ func (c *AWSCloud) GetELBTags(loadBalancerName string) (map[string]string, error
 	for {
 		attempt++
 
-		response, err := c.ELB.DescribeTags(request)
+		response, err := c.ELB().DescribeTags(request)
 		if err != nil {
 			return nil, fmt.Errorf("error listing tags on %v: %v", loadBalancerName, err)
 		}
@@ -263,7 +330,7 @@ func (c *AWSCloud) GetELBTags(loadBalancerName string) (map[string]string, error
 }
 
 // CreateELBTags will add tags to the specified loadBalancer, retrying up to MaxCreateTagsAttempts times if it hits an eventual-consistency type error
-func (c *AWSCloud) CreateELBTags(loadBalancerName string, tags map[string]string) error {
+func (c *awsCloudImplementation) CreateELBTags(loadBalancerName string, tags map[string]string) error {
 	if len(tags) == 0 {
 		return nil
 	}
@@ -282,7 +349,7 @@ func (c *AWSCloud) CreateELBTags(loadBalancerName string, tags map[string]string
 			LoadBalancerNames: []*string{&loadBalancerName},
 		}
 
-		_, err := c.ELB.AddTags(request)
+		_, err := c.ELB().AddTags(request)
 		if err != nil {
 			return fmt.Errorf("error creating tags on %v: %v", loadBalancerName, err)
 		}
@@ -291,7 +358,7 @@ func (c *AWSCloud) CreateELBTags(loadBalancerName string, tags map[string]string
 	}
 }
 
-func (c *AWSCloud) BuildTags(name *string) map[string]string {
+func (c *awsCloudImplementation) BuildTags(name *string) map[string]string {
 	tags := make(map[string]string)
 	if name != nil {
 		tags["Name"] = *name
@@ -304,7 +371,7 @@ func (c *AWSCloud) BuildTags(name *string) map[string]string {
 	return tags
 }
 
-func (c *AWSCloud) AddTags(name *string, tags map[string]string) {
+func (c *awsCloudImplementation) AddTags(name *string, tags map[string]string) {
 	if name != nil {
 		tags["Name"] = *name
 	}
@@ -313,7 +380,7 @@ func (c *AWSCloud) AddTags(name *string, tags map[string]string) {
 	}
 }
 
-func (c *AWSCloud) BuildFilters(name *string) []*ec2.Filter {
+func (c *awsCloudImplementation) BuildFilters(name *string) []*ec2.Filter {
 	filters := []*ec2.Filter{}
 
 	merged := make(map[string]string)
@@ -334,13 +401,13 @@ func (c *AWSCloud) BuildFilters(name *string) []*ec2.Filter {
 }
 
 // DescribeInstance is a helper that queries for the specified instance by id
-func (t *AWSCloud) DescribeInstance(instanceID string) (*ec2.Instance, error) {
+func (t *awsCloudImplementation) DescribeInstance(instanceID string) (*ec2.Instance, error) {
 	glog.V(2).Infof("Calling DescribeInstances for instance %q", instanceID)
 	request := &ec2.DescribeInstancesInput{
 		InstanceIds: []*string{&instanceID},
 	}
 
-	response, err := t.EC2.DescribeInstances(request)
+	response, err := t.EC2().DescribeInstances(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing Instances: %v", err)
 	}
@@ -365,13 +432,13 @@ func (t *AWSCloud) DescribeInstance(instanceID string) (*ec2.Instance, error) {
 }
 
 // DescribeVPC is a helper that queries for the specified vpc by id
-func (t *AWSCloud) DescribeVPC(vpcID string) (*ec2.Vpc, error) {
+func (t *awsCloudImplementation) DescribeVPC(vpcID string) (*ec2.Vpc, error) {
 	glog.V(2).Infof("Calling DescribeVPC for VPC %q", vpcID)
 	request := &ec2.DescribeVpcsInput{
 		VpcIds: []*string{&vpcID},
 	}
 
-	response, err := t.EC2.DescribeVpcs(request)
+	response, err := t.EC2().DescribeVpcs(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing VPCs: %v", err)
 	}
@@ -391,7 +458,7 @@ func (t *AWSCloud) DescribeVPC(vpcID string) (*ec2.Vpc, error) {
 // `ami-...` in which case it is presumed to be an id
 // owner/name in which case we find the image with the specified name, owned by owner
 // name in which case we find the image with the specified name, with the current owner
-func (c *AWSCloud) ResolveImage(name string) (*ec2.Image, error) {
+func (c *awsCloudImplementation) ResolveImage(name string) (*ec2.Image, error) {
 	// TODO: Cache this result during a single execution (we get called multiple times)
 	glog.V(2).Infof("Calling DescribeImages to resolve name %q", name)
 	request := &ec2.DescribeImagesInput{}
@@ -414,7 +481,7 @@ func (c *AWSCloud) ResolveImage(name string) (*ec2.Image, error) {
 		}
 	}
 
-	response, err := c.EC2.DescribeImages(request)
+	response, err := c.EC2().DescribeImages(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing images: %v", err)
 	}
@@ -430,28 +497,39 @@ func (c *AWSCloud) ResolveImage(name string) (*ec2.Image, error) {
 	return image, nil
 }
 
-// ValidateZones checks that every zone in the sliced passed is recognized
-func (c *AWSCloud) ValidateZones(zones []string) error {
-	glog.V(2).Infof("Querying EC2 for all valid zones in region %q", c.Region)
+func (c *awsCloudImplementation) DescribeAvailabilityZones() ([]*ec2.AvailabilityZone, error) {
+	glog.V(2).Infof("Querying EC2 for all valid zones in region %q", c.region)
 
 	request := &ec2.DescribeAvailabilityZonesInput{}
-	response, err := c.EC2.DescribeAvailabilityZones(request)
-
+	response, err := c.EC2().DescribeAvailabilityZones(request)
 	if err != nil {
-		return fmt.Errorf("Got an error while querying for valid AZs in %q (verify your AWS credentials?)", c.Region)
+		return nil, fmt.Errorf("Got an error while querying for valid AZs in %q (verify your AWS credentials?)", c.region)
+	}
+
+	return response.AvailabilityZones, nil
+}
+
+// ValidateZones checks that every zone in the sliced passed is recognized
+func ValidateZones(zones []string, cloud AWSCloud) error {
+	azs, err := cloud.DescribeAvailabilityZones()
+	if err != nil {
+		return err
 	}
 
 	zoneMap := make(map[string]*ec2.AvailabilityZone)
-	var knownZones []string
-	for _, z := range response.AvailabilityZones {
+	for _, z := range azs {
 		name := aws.StringValue(z.ZoneName)
 		zoneMap[name] = z
-		knownZones = append(knownZones, name)
 	}
 
 	for _, zone := range zones {
 		z := zoneMap[zone]
 		if z == nil {
+			var knownZones []string
+			for z := range zoneMap {
+				knownZones = append(knownZones, z)
+			}
+
 			glog.Infof("Known zones: %q", strings.Join(knownZones, ","))
 			return fmt.Errorf("Zone is not a recognized AZ: %q (check you have specified a valid zone?)", zone)
 		}
@@ -468,7 +546,7 @@ func (c *AWSCloud) ValidateZones(zones []string) error {
 	return nil
 }
 
-func (c *AWSCloud) DNS() (dnsprovider.Interface, error) {
+func (c *awsCloudImplementation) DNS() (dnsprovider.Interface, error) {
 	provider, err := dnsprovider.GetDnsProvider(k8sroute53.ProviderName, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Error building (k8s) DNS provider: %v", err)
@@ -476,14 +554,14 @@ func (c *AWSCloud) DNS() (dnsprovider.Interface, error) {
 	return provider, nil
 }
 
-func (c *AWSCloud) FindDNSHostedZone(clusterDNSName string) (string, error) {
+func (c *awsCloudImplementation) FindDNSHostedZone(clusterDNSName string) (string, error) {
 	glog.V(2).Infof("Querying for all route53 zones to find match for %q", clusterDNSName)
 
 	clusterDNSName = "." + strings.TrimSuffix(clusterDNSName, ".")
 
 	var zones []*route53.HostedZone
 	request := &route53.ListHostedZonesInput{}
-	err := c.Route53.ListHostedZonesPages(request, func(p *route53.ListHostedZonesOutput, lastPage bool) bool {
+	err := c.Route53().ListHostedZonesPages(request, func(p *route53.ListHostedZonesOutput, lastPage bool) bool {
 		for _, zone := range p.HostedZones {
 			zoneName := aws.StringValue(zone.Name)
 			zoneName = "." + strings.TrimSuffix(zoneName, ".")
@@ -531,4 +609,24 @@ func (c *AWSCloud) FindDNSHostedZone(clusterDNSName string) (string, error) {
 	}
 
 	return "", fmt.Errorf("Found multiple hosted zones matching cluster %q; please specify the ID of the zone to use", clusterDNSName)
+}
+
+func (c *awsCloudImplementation) EC2() *ec2.EC2 {
+	return c.ec2
+}
+
+func (c *awsCloudImplementation) IAM() *iam.IAM {
+	return c.iam
+}
+
+func (c *awsCloudImplementation) ELB() *elb.ELB {
+	return c.elb
+}
+
+func (c *awsCloudImplementation) Autoscaling() *autoscaling.AutoScaling {
+	return c.autoscaling
+}
+
+func (c *awsCloudImplementation) Route53() *route53.Route53 {
+	return c.route53
 }

--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -12,20 +12,26 @@ import (
 	"os"
 )
 
+// allRegions is the list of all regions; tests will set the values
+var allRegions []*ec2.Region
+
 // ValidateRegion checks that an AWS region name is valid
 func ValidateRegion(region string) error {
-	glog.V(2).Infof("Querying EC2 for all valid regions")
+	if allRegions == nil {
+		glog.V(2).Infof("Querying EC2 for all valid regions")
 
-	request := &ec2.DescribeRegionsInput{}
-	config := aws.NewConfig().WithRegion("us-east-1")
-	client := ec2.New(session.New(), config)
+		request := &ec2.DescribeRegionsInput{}
+		config := aws.NewConfig().WithRegion("us-east-1")
+		client := ec2.New(session.New(), config)
 
-	response, err := client.DescribeRegions(request)
-
-	if err != nil {
-		return fmt.Errorf("Got an error while querying for valid regions (verify your AWS credentials?)")
+		response, err := client.DescribeRegions(request)
+		if err != nil {
+			return fmt.Errorf("Got an error while querying for valid regions (verify your AWS credentials?)")
+		}
+		allRegions = response.Regions
 	}
-	for _, r := range response.Regions {
+
+	for _, r := range allRegions {
 		name := aws.StringValue(r.RegionName)
 		if name == region {
 			return nil

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -1,0 +1,148 @@
+package awsup
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/golang/glog"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+)
+
+type MockAWSCloud struct {
+	MockCloud
+	region string
+	tags   map[string]string
+
+	zones []*ec2.AvailabilityZone
+}
+
+var _ fi.Cloud = (*MockAWSCloud)(nil)
+
+func InstallMockAWSCloud(region string, zoneLetters string) {
+	i := &MockAWSCloud{region: region}
+	awsCloudInstances[region] = i
+	for _, c := range zoneLetters {
+		azName := fmt.Sprintf("%s%c", region, c)
+		az := &ec2.AvailabilityZone{
+			RegionName: aws.String(region),
+			ZoneName:   aws.String(azName),
+			State:      aws.String("available"),
+		}
+		i.zones = append(i.zones, az)
+	}
+
+	allRegions = []*ec2.Region{
+		{RegionName: aws.String(region)},
+	}
+}
+
+type MockCloud struct {
+}
+
+func (c *MockCloud) ProviderID() fi.CloudProviderID {
+	return "mock"
+}
+
+func (c *MockCloud) FindDNSHostedZone(dnsName string) (string, error) {
+	return "", fmt.Errorf("MockCloud FindDNSHostedZone not implemented")
+}
+
+func (c *MockCloud) DNS() (dnsprovider.Interface, error) {
+	return nil, fmt.Errorf("MockCloud DNS not implemented")
+}
+
+func (c *MockAWSCloud) Region() string {
+	return c.region
+}
+
+func (c *MockAWSCloud) DescribeAvailabilityZones() ([]*ec2.AvailabilityZone, error) {
+	return c.zones, nil
+}
+
+func (c *MockAWSCloud) AddTags(name *string, tags map[string]string) {
+	glog.Fatalf("MockAWSCloud AddTags not implemented")
+}
+
+func (c *MockAWSCloud) BuildFilters(name *string) []*ec2.Filter {
+	glog.Fatalf("MockAWSCloud BuildFilters not implemented")
+	return nil
+}
+
+func (c *MockAWSCloud) AddAWSTags(id string, expected map[string]string) error {
+	return fmt.Errorf("MockAWSCloud AddAWSTags not implemented")
+}
+
+func (c *MockAWSCloud) BuildTags(name *string) map[string]string {
+	glog.Fatalf("MockAWSCloud BuildTags not implemented")
+	return nil
+}
+
+func (c *MockAWSCloud) Tags() map[string]string {
+	glog.Fatalf("MockAWSCloud Tags not implemented")
+	return nil
+}
+
+func (c *MockAWSCloud) CreateTags(resourceId string, tags map[string]string) error {
+	return fmt.Errorf("MockAWSCloud CreateTags not implemented")
+}
+
+func (c *MockAWSCloud) GetTags(resourceID string) (map[string]string, error) {
+	return nil, fmt.Errorf("MockAWSCloud GetTags not implemented")
+}
+
+func (c *MockAWSCloud) GetELBTags(loadBalancerName string) (map[string]string, error) {
+	return nil, fmt.Errorf("MockAWSCloud GetELBTags not implemented")
+}
+
+func (c *MockAWSCloud) CreateELBTags(loadBalancerName string, tags map[string]string) error {
+	return fmt.Errorf("MockAWSCloud CreateELBTags not implemented")
+}
+
+func (c *MockAWSCloud) DescribeInstance(instanceID string) (*ec2.Instance, error) {
+	return nil, fmt.Errorf("MockAWSCloud DescribeInstance not implemented")
+}
+
+func (c *MockAWSCloud) DescribeVPC(vpcID string) (*ec2.Vpc, error) {
+	return nil, fmt.Errorf("MockAWSCloud DescribeVPC not implemented")
+}
+
+func (c *MockAWSCloud) ResolveImage(name string) (*ec2.Image, error) {
+	return nil, fmt.Errorf("MockAWSCloud ResolveImage not implemented")
+}
+
+func (c *MockAWSCloud) WithTags(tags map[string]string) AWSCloud {
+	m := &MockAWSCloud{}
+	*m = *c
+	m.tags = tags
+	return m
+}
+
+func (c *MockAWSCloud) EC2() *ec2.EC2 {
+	glog.Fatalf("MockAWSCloud EC2 not implemented")
+	return nil
+}
+
+func (c *MockAWSCloud) IAM() *iam.IAM {
+	glog.Fatalf("MockAWSCloud IAM not implemented")
+	return nil
+}
+
+func (c *MockAWSCloud) ELB() *elb.ELB {
+	glog.Fatalf("MockAWSCloud ELB not implemented")
+	return nil
+}
+
+func (c *MockAWSCloud) Autoscaling() *autoscaling.AutoScaling {
+	glog.Fatalf("MockAWSCloud Autoscaling not implemented")
+	return nil
+}
+
+func (c *MockAWSCloud) Route53() *route53.Route53 {
+	glog.Fatalf("MockAWSCloud Route53 not implemented")
+	return nil
+}

--- a/upup/pkg/fi/cloudup/deepvalidate_test.go
+++ b/upup/pkg/fi/cloudup/deepvalidate_test.go
@@ -11,8 +11,8 @@ import (
 func TestDeepValidate_OK(t *testing.T) {
 	c := buildDefaultCluster(t)
 	var groups []*api.InstanceGroup
-	groups = append(groups, buildMinimalMasterInstanceGroup("us-east-1a"))
-	groups = append(groups, buildMinimalNodeInstanceGroup("us-east-1a"))
+	groups = append(groups, buildMinimalMasterInstanceGroup("us-mock-1a"))
+	groups = append(groups, buildMinimalNodeInstanceGroup("us-mock-1a"))
 	err := api.DeepValidate(c, groups, true)
 	if err != nil {
 		t.Fatalf("Expected no error from DeepValidate")
@@ -22,14 +22,14 @@ func TestDeepValidate_OK(t *testing.T) {
 func TestDeepValidate_NoNodeZones(t *testing.T) {
 	c := buildDefaultCluster(t)
 	var groups []*api.InstanceGroup
-	groups = append(groups, buildMinimalMasterInstanceGroup("us-east-1a"))
+	groups = append(groups, buildMinimalMasterInstanceGroup("us-mock-1a"))
 	expectErrorFromDeepValidate(t, c, groups, "must configure at least one Node InstanceGroup")
 }
 
 func TestDeepValidate_NoMasterZones(t *testing.T) {
 	c := buildDefaultCluster(t)
 	var groups []*api.InstanceGroup
-	groups = append(groups, buildMinimalNodeInstanceGroup("us-east-1a"))
+	groups = append(groups, buildMinimalNodeInstanceGroup("us-mock-1a"))
 	expectErrorFromDeepValidate(t, c, groups, "must configure at least one Master InstanceGroup")
 }
 
@@ -37,11 +37,11 @@ func TestDeepValidate_BadZone(t *testing.T) {
 	t.Skipf("Zone validation not checked by DeepValidate")
 	c := buildDefaultCluster(t)
 	c.Spec.Zones = []*api.ClusterZoneSpec{
-		{Name: "us-east-1z", CIDR: "172.20.1.0/24"},
+		{Name: "us-mock-1z", CIDR: "172.20.1.0/24"},
 	}
 	var groups []*api.InstanceGroup
-	groups = append(groups, buildMinimalMasterInstanceGroup("us-east-1z"))
-	groups = append(groups, buildMinimalNodeInstanceGroup("us-east-1z"))
+	groups = append(groups, buildMinimalMasterInstanceGroup("us-mock-1z"))
+	groups = append(groups, buildMinimalNodeInstanceGroup("us-mock-1z"))
 	expectErrorFromDeepValidate(t, c, groups, "Zone is not a recognized AZ")
 }
 
@@ -49,12 +49,12 @@ func TestDeepValidate_MixedRegion(t *testing.T) {
 	t.Skipf("Region validation not checked by DeepValidate")
 	c := buildDefaultCluster(t)
 	c.Spec.Zones = []*api.ClusterZoneSpec{
-		{Name: "us-east-1a", CIDR: "172.20.1.0/24"},
+		{Name: "us-mock-1a", CIDR: "172.20.1.0/24"},
 		{Name: "us-west-1b", CIDR: "172.20.2.0/24"},
 	}
 	var groups []*api.InstanceGroup
-	groups = append(groups, buildMinimalMasterInstanceGroup("us-east-1a"))
-	groups = append(groups, buildMinimalNodeInstanceGroup("us-east-1a", "us-west-1b"))
+	groups = append(groups, buildMinimalMasterInstanceGroup("us-mock-1a"))
+	groups = append(groups, buildMinimalNodeInstanceGroup("us-mock-1a", "us-west-1b"))
 
 	expectErrorFromDeepValidate(t, c, groups, "Clusters cannot span multiple regions")
 }
@@ -63,11 +63,11 @@ func TestDeepValidate_RegionAsZone(t *testing.T) {
 	t.Skipf("Region validation not checked by DeepValidate")
 	c := buildDefaultCluster(t)
 	c.Spec.Zones = []*api.ClusterZoneSpec{
-		{Name: "us-east-1", CIDR: "172.20.1.0/24"},
+		{Name: "us-mock-1", CIDR: "172.20.1.0/24"},
 	}
 	var groups []*api.InstanceGroup
-	groups = append(groups, buildMinimalMasterInstanceGroup("us-east-1"))
-	groups = append(groups, buildMinimalNodeInstanceGroup("us-east-1"))
+	groups = append(groups, buildMinimalMasterInstanceGroup("us-mock-1"))
+	groups = append(groups, buildMinimalNodeInstanceGroup("us-mock-1"))
 
 	expectErrorFromDeepValidate(t, c, groups, "Region is not a recognized EC2 region: \"us-east-\" (check you have specified valid zones?)")
 }
@@ -75,8 +75,8 @@ func TestDeepValidate_RegionAsZone(t *testing.T) {
 func TestDeepValidate_NotIncludedZone(t *testing.T) {
 	c := buildDefaultCluster(t)
 	var groups []*api.InstanceGroup
-	groups = append(groups, buildMinimalMasterInstanceGroup("us-east-1d"))
-	groups = append(groups, buildMinimalNodeInstanceGroup("us-east-1d"))
+	groups = append(groups, buildMinimalMasterInstanceGroup("us-mock-1d"))
+	groups = append(groups, buildMinimalNodeInstanceGroup("us-mock-1d"))
 
 	expectErrorFromDeepValidate(t, c, groups, "not configured as a Zone in the cluster")
 }
@@ -84,24 +84,24 @@ func TestDeepValidate_NotIncludedZone(t *testing.T) {
 func TestDeepValidate_DuplicateZones(t *testing.T) {
 	c := buildDefaultCluster(t)
 	c.Spec.Zones = []*api.ClusterZoneSpec{
-		{Name: "us-east-1a", CIDR: "172.20.1.0/24"},
-		{Name: "us-east-1a", CIDR: "172.20.2.0/24"},
+		{Name: "us-mock-1a", CIDR: "172.20.1.0/24"},
+		{Name: "us-mock-1a", CIDR: "172.20.2.0/24"},
 	}
 	var groups []*api.InstanceGroup
-	groups = append(groups, buildMinimalMasterInstanceGroup("us-east-1a"))
-	groups = append(groups, buildMinimalNodeInstanceGroup("us-east-1a"))
-	expectErrorFromDeepValidate(t, c, groups, "Zones contained a duplicate value: us-east-1a")
+	groups = append(groups, buildMinimalMasterInstanceGroup("us-mock-1a"))
+	groups = append(groups, buildMinimalNodeInstanceGroup("us-mock-1a"))
+	expectErrorFromDeepValidate(t, c, groups, "Zones contained a duplicate value: us-mock-1a")
 }
 
 func TestDeepValidate_ExtraMasterZone(t *testing.T) {
 	c := buildDefaultCluster(t)
 	c.Spec.Zones = []*api.ClusterZoneSpec{
-		{Name: "us-east-1a", CIDR: "172.20.1.0/24"},
-		{Name: "us-east-1b", CIDR: "172.20.2.0/24"},
+		{Name: "us-mock-1a", CIDR: "172.20.1.0/24"},
+		{Name: "us-mock-1b", CIDR: "172.20.2.0/24"},
 	}
 	var groups []*api.InstanceGroup
-	groups = append(groups, buildMinimalMasterInstanceGroup("us-east-1a", "us-east-1b", "us-east-1c"))
-	groups = append(groups, buildMinimalNodeInstanceGroup("us-east-1a", "us-east-1b"))
+	groups = append(groups, buildMinimalMasterInstanceGroup("us-mock-1a", "us-mock-1b", "us-mock-1c"))
+	groups = append(groups, buildMinimalNodeInstanceGroup("us-mock-1a", "us-mock-1b"))
 
 	expectErrorFromDeepValidate(t, c, groups, "is not configured as a Zone in the cluster")
 }
@@ -112,15 +112,15 @@ func TestDeepValidate_EvenEtcdClusterSize(t *testing.T) {
 		{
 			Name: "main",
 			Members: []*api.EtcdMemberSpec{
-				{Name: "us-east-1a", Zone: fi.String("us-east-1a")},
-				{Name: "us-east-1b", Zone: fi.String("us-east-1b")},
+				{Name: "us-mock-1a", Zone: fi.String("us-mock-1a")},
+				{Name: "us-mock-1b", Zone: fi.String("us-mock-1b")},
 			},
 		},
 	}
 
 	var groups []*api.InstanceGroup
-	groups = append(groups, buildMinimalMasterInstanceGroup("us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d"))
-	groups = append(groups, buildMinimalNodeInstanceGroup("us-east-1a"))
+	groups = append(groups, buildMinimalMasterInstanceGroup("us-mock-1a", "us-mock-1b", "us-mock-1c", "us-mock-1d"))
+	groups = append(groups, buildMinimalNodeInstanceGroup("us-mock-1a"))
 
 	expectErrorFromDeepValidate(t, c, groups, "There should be an odd number of master-zones, for etcd's quorum.  Hint: Use --zones and --master-zones to declare node zones and master zones separately.")
 }

--- a/upup/pkg/fi/cloudup/populatecluster_test.go
+++ b/upup/pkg/fi/cloudup/populatecluster_test.go
@@ -13,9 +13,9 @@ func buildMinimalCluster() *api.Cluster {
 	c := &api.Cluster{}
 	c.Name = "testcluster.test.com"
 	c.Spec.Zones = []*api.ClusterZoneSpec{
-		{Name: "us-east-1a", CIDR: "172.20.1.0/24"},
-		{Name: "us-east-1b", CIDR: "172.20.2.0/24"},
-		{Name: "us-east-1c", CIDR: "172.20.3.0/24"},
+		{Name: "us-mock-1a", CIDR: "172.20.1.0/24"},
+		{Name: "us-mock-1b", CIDR: "172.20.2.0/24"},
+		{Name: "us-mock-1c", CIDR: "172.20.3.0/24"},
 	}
 	c.Spec.NetworkCIDR = "172.20.0.0/16"
 	c.Spec.NonMasqueradeCIDR = "100.64.0.0/10"
@@ -114,7 +114,7 @@ func TestPopulateCluster_Kubenet(t *testing.T) {
 
 	full, err := build(c)
 	if err != nil {
-		t.Fatal("error during build: %v", err)
+		t.Fatalf("error during build: %v", err)
 	}
 
 	if full.Spec.Kubelet.NetworkPluginName != "kubenet" {
@@ -134,9 +134,9 @@ func TestPopulateCluster_Custom_CIDR(t *testing.T) {
 	c := buildMinimalCluster()
 	c.Spec.NetworkCIDR = "172.20.2.0/24"
 	c.Spec.Zones = []*api.ClusterZoneSpec{
-		{Name: "us-east-1a", CIDR: "172.20.2.0/27"},
-		{Name: "us-east-1b", CIDR: "172.20.2.32/27"},
-		{Name: "us-east-1c", CIDR: "172.20.2.64/27"},
+		{Name: "us-mock-1a", CIDR: "172.20.2.0/27"},
+		{Name: "us-mock-1b", CIDR: "172.20.2.32/27"},
+		{Name: "us-mock-1c", CIDR: "172.20.2.64/27"},
 	}
 
 	err := c.PerformAssignments()

--- a/upup/pkg/fi/cloudup/utils.go
+++ b/upup/pkg/fi/cloudup/utils.go
@@ -18,7 +18,6 @@ func BuildCloud(cluster *api.Cluster) (fi.Cloud, error) {
 	switch cluster.Spec.CloudProvider {
 	case "gce":
 		{
-
 			nodeZones := make(map[string]bool)
 			for _, zone := range cluster.Spec.Zones {
 				nodeZones[zone.Name] = true
@@ -82,7 +81,7 @@ func BuildCloud(cluster *api.Cluster) (fi.Cloud, error) {
 			for _, z := range cluster.Spec.Zones {
 				zoneNames = append(zoneNames, z.Name)
 			}
-			err = awsCloud.ValidateZones(zoneNames)
+			err = awsup.ValidateZones(zoneNames, awsCloud)
 			if err != nil {
 				return nil, err
 			}

--- a/upup/pkg/fi/cloudup/validation_test.go
+++ b/upup/pkg/fi/cloudup/validation_test.go
@@ -5,11 +5,14 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kops/upup/pkg/api"
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/vfs"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"strings"
 	"testing"
 )
+
+const MockAWSRegion = "us-mock-1"
 
 func buildInmemoryClusterRegistry() *api.ClusterRegistry {
 	memfs := vfs.NewMemFSContext()
@@ -48,6 +51,8 @@ func buildDefaultCluster(t *testing.T) *api.Cluster {
 		}
 	}
 
+	awsup.InstallMockAWSCloud(MockAWSRegion, "abcd")
+
 	fullSpec, err := PopulateClusterSpec(c, registry)
 	if err != nil {
 		t.Fatalf("error from PopulateClusterSpec: %v", err)
@@ -57,8 +62,8 @@ func buildDefaultCluster(t *testing.T) *api.Cluster {
 	//c.Cluster = &api.Cluster{}
 	//c.Cluster.Name = "testcluster.mydomain.com"
 
-	//c.InstanceGroups = append(c.InstanceGroups, buildNodeInstanceGroup("us-east-1a"))
-	//c.InstanceGroups = append(c.InstanceGroups, buildMasterInstanceGroup("us-east-1a"))
+	//c.InstanceGroups = append(c.InstanceGroups, buildNodeInstanceGroup("us-mock-1a"))
+	//c.InstanceGroups = append(c.InstanceGroups, buildMasterInstanceGroup("us-mock-1a"))
 	//c.SSHPublicKey = path.Join(os.Getenv("HOME"), ".ssh", "id_rsa.pub")
 	//
 	//c.Cluster.Spec.Kubelet = &api.KubeletConfig{}
@@ -175,13 +180,13 @@ func expectNoErrorFromValidate(t *testing.T, c *api.Cluster) {
 //	c.Cluster = &api.Cluster{}
 //	c.Cluster.Name = "testcluster.mydomain.com"
 //	c.Cluster.Spec.Zones = []*api.ClusterZoneSpec{
-//		{Name: "us-east-1a", CIDR: "172.20.1.0/24"},
-//		{Name: "us-east-1b", CIDR: "172.20.2.0/24"},
-//		{Name: "us-east-1c", CIDR: "172.20.3.0/24"},
-//		{Name: "us-east-1d", CIDR: "172.20.4.0/24"},
+//		{Name: "us-mock-1a", CIDR: "172.20.1.0/24"},
+//		{Name: "us-mock-1b", CIDR: "172.20.2.0/24"},
+//		{Name: "us-mock-1c", CIDR: "172.20.3.0/24"},
+//		{Name: "us-mock-1d", CIDR: "172.20.4.0/24"},
 //	}
-//	c.InstanceGroups = append(c.InstanceGroups, buildNodeInstanceGroup("us-east-1a"))
-//	c.InstanceGroups = append(c.InstanceGroups, buildMasterInstanceGroup("us-east-1a"))
+//	c.InstanceGroups = append(c.InstanceGroups, buildNodeInstanceGroup("us-mock-1a"))
+//	c.InstanceGroups = append(c.InstanceGroups, buildMasterInstanceGroup("us-mock-1a"))
 //	c.SSHPublicKey = path.Join(os.Getenv("HOME"), ".ssh", "id_rsa.pub")
 //
 //	c.Cluster.Spec.Kubelet = &api.KubeletConfig{}

--- a/upup/pkg/kutil/convert_kubeup_cluster.go
+++ b/upup/pkg/kutil/convert_kubeup_cluster.go
@@ -26,7 +26,7 @@ type ConvertKubeupCluster struct {
 }
 
 func (x *ConvertKubeupCluster) Upgrade() error {
-	awsCloud := x.Cloud.(*awsup.AWSCloud)
+	awsCloud := x.Cloud.(awsup.AWSCloud)
 
 	cluster := x.ClusterConfig
 
@@ -124,7 +124,7 @@ func (x *ConvertKubeupCluster) Upgrade() error {
 			MaxSize:              aws.Int64(0),
 		}
 
-		_, err := awsCloud.Autoscaling.UpdateAutoScalingGroup(request)
+		_, err := awsCloud.Autoscaling().UpdateAutoScalingGroup(request)
 		if err != nil {
 			return fmt.Errorf("error updating autoscaling group %q: %v", name, err)
 		}
@@ -148,7 +148,7 @@ func (x *ConvertKubeupCluster) Upgrade() error {
 			InstanceIds: []*string{master.InstanceId},
 		}
 
-		_, err := awsCloud.EC2.StopInstances(request)
+		_, err := awsCloud.EC2().StopInstances(request)
 		if err != nil {
 			return fmt.Errorf("error stopping master instance: %v", err)
 		}
@@ -205,7 +205,7 @@ func (x *ConvertKubeupCluster) Upgrade() error {
 			}
 
 			for {
-				_, err := awsCloud.EC2.DetachVolume(request)
+				_, err := awsCloud.EC2().DetachVolume(request)
 				if err != nil {
 					if awsup.AWSErrorCode(err) == "IncorrectState" {
 						glog.Infof("will retry volume detach (master has probably not stopped yet): %q", err)

--- a/upup/pkg/kutil/import_cluster.go
+++ b/upup/pkg/kutil/import_cluster.go
@@ -23,7 +23,7 @@ type ImportCluster struct {
 }
 
 func (x *ImportCluster) ImportAWSCluster() error {
-	awsCloud := x.Cloud.(*awsup.AWSCloud)
+	awsCloud := x.Cloud.(awsup.AWSCloud)
 	clusterName := x.ClusterName
 
 	if clusterName == "" {
@@ -495,7 +495,7 @@ func parseInt(s string) (int, error) {
 //	return nil
 //}
 //
-//func findInternetGateway(cloud *awsup.AWSCloud, vpcID string) (*ec2.InternetGateway, error) {
+//func findInternetGateway(cloud awsup.AWSCloud, vpcID string) (*ec2.InternetGateway, error) {
 //	request := &ec2.DescribeInternetGatewaysInput{
 //		Filters: []*ec2.Filter{fi.NewEC2Filter("attachment.vpc-id", vpcID)},
 //	}
@@ -515,7 +515,7 @@ func parseInt(s string) (int, error) {
 //	return igw, nil
 //}
 
-//func findRouteTable(cloud *awsup.AWSCloud, subnetID string) (*ec2.RouteTable, error) {
+//func findRouteTable(cloud awsup.AWSCloud, subnetID string) (*ec2.RouteTable, error) {
 //	request := &ec2.DescribeRouteTablesInput{
 //		Filters: []*ec2.Filter{fi.NewEC2Filter("association.subnet-id", subnetID)},
 //	}
@@ -535,7 +535,7 @@ func parseInt(s string) (int, error) {
 //	return rt, nil
 //}
 //
-//func findElasticIP(cloud *awsup.AWSCloud, publicIP string) (*ec2.Address, error) {
+//func findElasticIP(cloud awsup.AWSCloud, publicIP string) (*ec2.Address, error) {
 //	request := &ec2.DescribeAddressesInput{
 //		PublicIps: []*string{&publicIP},
 //	}
@@ -559,7 +559,7 @@ func parseInt(s string) (int, error) {
 //	return response.Addresses[0], nil
 //}
 
-func findInstances(c *awsup.AWSCloud) ([]*ec2.Instance, error) {
+func findInstances(c awsup.AWSCloud) ([]*ec2.Instance, error) {
 	filters := buildEC2Filters(c)
 
 	request := &ec2.DescribeInstancesInput{
@@ -570,7 +570,7 @@ func findInstances(c *awsup.AWSCloud) ([]*ec2.Instance, error) {
 
 	var instances []*ec2.Instance
 
-	err := c.EC2.DescribeInstancesPages(request, func(p *ec2.DescribeInstancesOutput, lastPage bool) bool {
+	err := c.EC2().DescribeInstancesPages(request, func(p *ec2.DescribeInstancesOutput, lastPage bool) bool {
 		for _, reservation := range p.Reservations {
 			for _, instance := range reservation.Instances {
 				instances = append(instances, instance)
@@ -617,11 +617,11 @@ func findInstances(c *awsup.AWSCloud) ([]*ec2.Instance, error) {
 //}
 
 // Fetch instance UserData
-func GetInstanceUserData(cloud *awsup.AWSCloud, instanceID string) ([]byte, error) {
+func GetInstanceUserData(cloud awsup.AWSCloud, instanceID string) ([]byte, error) {
 	request := &ec2.DescribeInstanceAttributeInput{}
 	request.InstanceId = aws.String(instanceID)
 	request.Attribute = aws.String("userData")
-	response, err := cloud.EC2.DescribeInstanceAttribute(request)
+	response, err := cloud.EC2().DescribeInstanceAttribute(request)
 	if err != nil {
 		return nil, fmt.Errorf("error querying EC2 for user metadata for instance %q: %v", instanceID, err)
 	}

--- a/upup/pkg/kutil/rollingupdate_cluster.go
+++ b/upup/pkg/kutil/rollingupdate_cluster.go
@@ -21,7 +21,7 @@ type RollingUpdateCluster struct {
 }
 
 func FindCloudInstanceGroups(cloud fi.Cloud, cluster *api.Cluster, instancegroups []*api.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*CloudInstanceGroup, error) {
-	awsCloud := cloud.(*awsup.AWSCloud)
+	awsCloud := cloud.(awsup.AWSCloud)
 
 	groups := make(map[string]*CloudInstanceGroup)
 
@@ -207,7 +207,7 @@ func buildCloudInstanceGroup(ig *api.InstanceGroup, g *autoscaling.Group, nodeMa
 }
 
 func (n *CloudInstanceGroup) RollingUpdate(cloud fi.Cloud, force bool, k8sClient *release_1_3.Clientset) error {
-	c := cloud.(*awsup.AWSCloud)
+	c := cloud.(awsup.AWSCloud)
 
 	update := n.NeedUpdate
 	if force {
@@ -227,7 +227,7 @@ func (n *CloudInstanceGroup) RollingUpdate(cloud fi.Cloud, force bool, k8sClient
 		request := &ec2.TerminateInstancesInput{
 			InstanceIds: []*string{i.ASGInstance.InstanceId},
 		}
-		_, err := c.EC2.TerminateInstances(request)
+		_, err := c.EC2().TerminateInstances(request)
 		if err != nil {
 			return fmt.Errorf("error deleting instance %q: %v", i.ASGInstance.InstanceId, err)
 		}
@@ -240,7 +240,7 @@ func (n *CloudInstanceGroup) RollingUpdate(cloud fi.Cloud, force bool, k8sClient
 }
 
 func (g *CloudInstanceGroup) Delete(cloud fi.Cloud) error {
-	c := cloud.(*awsup.AWSCloud)
+	c := cloud.(awsup.AWSCloud)
 
 	// TODO: Graceful?
 
@@ -252,7 +252,7 @@ func (g *CloudInstanceGroup) Delete(cloud fi.Cloud) error {
 			AutoScalingGroupName: g.asg.AutoScalingGroupName,
 			ForceDelete:          aws.Bool(true),
 		}
-		_, err := c.Autoscaling.DeleteAutoScalingGroup(request)
+		_, err := c.Autoscaling().DeleteAutoScalingGroup(request)
 		if err != nil {
 			return fmt.Errorf("error deleting autoscaling group %q: %v", asgName, err)
 		}
@@ -265,7 +265,7 @@ func (g *CloudInstanceGroup) Delete(cloud fi.Cloud) error {
 		request := &autoscaling.DeleteLaunchConfigurationInput{
 			LaunchConfigurationName: g.asg.LaunchConfigurationName,
 		}
-		_, err := c.Autoscaling.DeleteLaunchConfiguration(request)
+		_, err := c.Autoscaling().DeleteLaunchConfiguration(request)
 		if err != nil {
 			return fmt.Errorf("error deleting autoscaling launch configuration %q: %v", lcName, err)
 		}

--- a/upup/pkg/kutil/utils.go
+++ b/upup/pkg/kutil/utils.go
@@ -9,8 +9,8 @@ import (
 )
 
 // findAutoscalingGroups finds autoscaling groups matching the specified tags
-// This isn't entirely trivial because autoscaling doesn't let us filter with as much precision as we wouldlike
-func findAutoscalingGroups(cloud *awsup.AWSCloud, tags map[string]string) ([]*autoscaling.Group, error) {
+// This isn't entirely trivial because autoscaling doesn't let us filter with as much precision as we would like
+func findAutoscalingGroups(cloud awsup.AWSCloud, tags map[string]string) ([]*autoscaling.Group, error) {
 	var asgs []*autoscaling.Group
 
 	glog.V(2).Infof("Listing all Autoscaling groups matching cluster tags")
@@ -28,7 +28,7 @@ func findAutoscalingGroups(cloud *awsup.AWSCloud, tags map[string]string) ([]*au
 			Filters: asFilters,
 		}
 
-		err := cloud.Autoscaling.DescribeTagsPages(request, func(p *autoscaling.DescribeTagsOutput, lastPage bool) bool {
+		err := cloud.Autoscaling().DescribeTagsPages(request, func(p *autoscaling.DescribeTagsOutput, lastPage bool) bool {
 			for _, t := range p.Tags {
 				switch *t.ResourceType {
 				case "auto-scaling-group":
@@ -49,7 +49,7 @@ func findAutoscalingGroups(cloud *awsup.AWSCloud, tags map[string]string) ([]*au
 		request := &autoscaling.DescribeAutoScalingGroupsInput{
 			AutoScalingGroupNames: asgNames,
 		}
-		err := cloud.Autoscaling.DescribeAutoScalingGroupsPages(request, func(p *autoscaling.DescribeAutoScalingGroupsOutput, lastPage bool) bool {
+		err := cloud.Autoscaling().DescribeAutoScalingGroupsPages(request, func(p *autoscaling.DescribeAutoScalingGroupsOutput, lastPage bool) bool {
 			for _, asg := range p.AutoScalingGroups {
 				if !matchesAsgTags(tags, asg.Tags) {
 					// We used an inexact filter above
@@ -68,7 +68,7 @@ func findAutoscalingGroups(cloud *awsup.AWSCloud, tags map[string]string) ([]*au
 	return asgs, nil
 }
 
-func findAutoscalingLaunchConfiguration(cloud *awsup.AWSCloud, name string) (*autoscaling.LaunchConfiguration, error) {
+func findAutoscalingLaunchConfiguration(cloud awsup.AWSCloud, name string) (*autoscaling.LaunchConfiguration, error) {
 	glog.V(2).Infof("Retrieving Autoscaling LaunchConfigurations %q", name)
 
 	var results []*autoscaling.LaunchConfiguration
@@ -76,7 +76,7 @@ func findAutoscalingLaunchConfiguration(cloud *awsup.AWSCloud, name string) (*au
 	request := &autoscaling.DescribeLaunchConfigurationsInput{
 		LaunchConfigurationNames: []*string{&name},
 	}
-	err := cloud.Autoscaling.DescribeLaunchConfigurationsPages(request, func(p *autoscaling.DescribeLaunchConfigurationsOutput, lastPage bool) bool {
+	err := cloud.Autoscaling().DescribeLaunchConfigurationsPages(request, func(p *autoscaling.DescribeLaunchConfigurationsOutput, lastPage bool) bool {
 		for _, t := range p.LaunchConfigurations {
 			results = append(results, t)
 		}


### PR DESCRIPTION
Beginnings of a mock for the AWSCloud, so that hopefully we aren't
calling out to AWS at all in the tests.  We will likely start mocking
the actual EC2 APIs in future, but this seems a good starting point.

Fix #425