### PR TITLE
Map runtime-config on kube-apiserver

### DIFF
--- a/upup/pkg/api/cluster.go
+++ b/upup/pkg/api/cluster.go
@@ -150,7 +150,6 @@ type ClusterSpec struct {
 	////KubecfgKey                    []byte
 	//
 	//AdmissionControl              string `json:",omitempty"`
-	//RuntimeConfig                 string `json:",omitempty"`
 	//
 	//KubeImageTag                  string `json:",omitempty"`
 	//KubeDockerRegistry            string `json:",omitempty"`

--- a/upup/pkg/api/componentconfig.go
+++ b/upup/pkg/api/componentconfig.go
@@ -354,21 +354,21 @@ type KubeAPIServerConfig struct {
 
 	LogLevel int `json:"logLevel,omitempty" flag:"v"`
 
-	CloudProvider        string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
-	SecurePort           int    `json:"securePort,omitempty" flag:"secure-port"`
-	Address              string `json:"address,omitempty" flag:"address"`
-	EtcdServers          string `json:"etcdServers,omitempty" flag:"etcd-servers"`
-	EtcdServersOverrides string `json:"etcdServersOverrides,omitempty" flag:"etcd-servers-overrides"`
-	// TODO: []string and join with commas?
-	AdmissionControl      string `json:"admissionControl,omitempty" flag:"admission-control"`
-	ServiceClusterIPRange string `json:"serviceClusterIPRange,omitempty" flag:"service-cluster-ip-range"`
-	ClientCAFile          string `json:"clientCAFile,omitempty" flag:"client-ca-file"`
-	BasicAuthFile         string `json:"basicAuthFile,omitempty" flag:"basic-auth-file"`
-	TLSCertFile           string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
-	TLSPrivateKeyFile     string `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
-	TokenAuthFile         string `json:"tokenAuthFile,omitempty" flag:"token-auth-file"`
-	AllowPrivileged       *bool  `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
-	APIServerCount        *int   `json:"apiServerCount,omitempty" flag:"apiserver-count"`
+	CloudProvider         string            `json:"cloudProvider,omitempty" flag:"cloud-provider"`
+	SecurePort            int               `json:"securePort,omitempty" flag:"secure-port"`
+	Address               string            `json:"address,omitempty" flag:"address"`
+	EtcdServers           string            `json:"etcdServers,omitempty" flag:"etcd-servers"`
+	EtcdServersOverrides  string            `json:"etcdServersOverrides,omitempty" flag:"etcd-servers-overrides"`
+	AdmissionControl      []string          `json:"admissionControl,omitempty" flag:"admission-control"`
+	ServiceClusterIPRange string            `json:"serviceClusterIPRange,omitempty" flag:"service-cluster-ip-range"`
+	ClientCAFile          string            `json:"clientCAFile,omitempty" flag:"client-ca-file"`
+	BasicAuthFile         string            `json:"basicAuthFile,omitempty" flag:"basic-auth-file"`
+	TLSCertFile           string            `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
+	TLSPrivateKeyFile     string            `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
+	TokenAuthFile         string            `json:"tokenAuthFile,omitempty" flag:"token-auth-file"`
+	AllowPrivileged       *bool             `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
+	APIServerCount        *int              `json:"apiServerCount,omitempty" flag:"apiserver-count"`
+	RuntimeConfig         map[string]string `json:"runtimeConfig,omitempty" flag:"runtime-config"`
 }
 
 type KubeControllerManagerConfig struct {

--- a/upup/pkg/fi/nodeup/build_flags.go
+++ b/upup/pkg/fi/nodeup/build_flags.go
@@ -61,6 +61,22 @@ func buildFlags(options interface{}) (string, error) {
 			}
 		}
 
+		if val.Kind() == reflect.Slice {
+			if val.IsNil() {
+				return nil
+			}
+			// We handle a []string like --admision-control=v1,v2 etc
+			if stringSlice, ok := val.Interface().([]string); ok {
+				if len(stringSlice) != 0 {
+					flag := fmt.Sprintf("--%s=%s", flagName, strings.Join(stringSlice, ","))
+					flags = append(flags, flag)
+				}
+				return utils.SkipReflection
+			} else {
+				return fmt.Errorf("BuildFlags of value type not handled: %T %s=%v", val.Interface(), path, val.Interface())
+			}
+		}
+
 		var flag string
 		switch v := val.Interface().(type) {
 		case string:


### PR DESCRIPTION
Provide a way to specify the runtime-config option

Fix #474