### PR TITLE
Don't try to run travis with go 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.5
+  #- 1.5  go test arguments are different in 1.5 :-(
   - 1.6
   - 1.7
   - tip


### PR DESCRIPTION
It fails because `go test` apparently took different arguments then