### PR TITLE
Create stable channel for kops

### DIFF
--- a/channels/stable.yaml
+++ b/channels/stable.yaml
@@ -1,11 +1,9 @@
 spec:
   images:
-    - name: 721322707521/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-09-23
+    - name: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-09-30
       labels:
         k8s.io/cloudprovider: aws
   cluster:
-    docker:
-      storage: overlay
-    kubernetesVersion: v1.4.0-beta.10
+    kubernetesVersion: v1.4.0
     networking:
       kubenet: {}

--- a/docs/images.md
+++ b/docs/images.md
@@ -24,3 +24,8 @@ You can find the name for an image using e.g. `aws ec2 describe-images --image-i
 
 If you are creating a new cluster you can use the `--image` flag when running `kops create cluster`,
 which should be easier than editing your instance groups.
+
+
+In addition, we support a few-well known aliases for the owner:
+
+`kope.io` => `383156758163`

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -475,7 +475,15 @@ func (c *awsCloudImplementation) ResolveImage(name string) (*ec2.Image, error) {
 			request.Owners = aws.StringSlice([]string{"self"})
 			request.Filters = append(request.Filters, NewEC2Filter("name", name))
 		} else if len(tokens) == 2 {
-			request.Owners = []*string{&tokens[0]}
+			owner := tokens[0]
+
+			// Check for well known owner aliases
+			switch owner {
+			case "kope.io":
+				owner = "383156758163"
+			}
+
+			request.Owners = []*string{&owner}
 			request.Filters = append(request.Filters, NewEC2Filter("name", tokens[1]))
 		} else {
 			return nil, fmt.Errorf("image name specification not recognized: %q", name)


### PR DESCRIPTION
The idea being we don't necessarily always want to pick up the latest
change immediately, without validating it first.

Also this is an easy way to recommend the latest AMI without having to
search for it.  We also create an alias to the owner id, so that it is
readable / verifiable.