### PR TITLE
Allow channels to cope with non-local URLs

### DIFF
--- a/channels/pkg/channels/apply.go
+++ b/channels/pkg/channels/apply.go
@@ -6,12 +6,37 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"io/ioutil"
+	"k8s.io/kops/util/pkg/vfs"
+	"path"
 )
 
 // Apply calls kubectl apply to apply the manifest.
 // We will likely in future change this to create things directly (or more likely embed this logic into kubectl itself)
 func Apply(manifest string) error {
-	_, err := execKubectl("apply", "-f", manifest)
+	// We copy the manifest to a temp file because it is likely e.g. an s3 URL, which kubectl can't read
+	data, err := vfs.Context.ReadFile(manifest)
+	if err != nil {
+		return fmt.Errorf("error reading manifest: %v", err)
+	}
+
+	tmpDir, err := ioutil.TempDir("", "channel")
+	if err != nil {
+		return fmt.Errorf("error creating temp dir: %v", err)
+	}
+
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			glog.Warningf("error deleting temp dir %q: %v", tmpDir, err)
+		}
+	}()
+
+	localManifestFile := path.Join(tmpDir, "manifest.yaml")
+	if err := ioutil.WriteFile(localManifestFile, data, 0600); err != nil {
+		return fmt.Errorf("error writing temp file: %v", err)
+	}
+
+	_, err = execKubectl("apply", "-f", localManifestFile)
 	return err
 }
 


### PR DESCRIPTION
We copy to a temp file before calling kubectl apply