### PR TITLE
Refactor Channel FindImage

### DIFF
--- a/channels/pkg/channels/apply.go
+++ b/channels/pkg/channels/apply.go
@@ -3,12 +3,12 @@ package channels
 import (
 	"fmt"
 	"github.com/golang/glog"
-	"os"
-	"os/exec"
-	"strings"
 	"io/ioutil"
 	"k8s.io/kops/util/pkg/vfs"
+	"os"
+	"os/exec"
 	"path"
+	"strings"
 )
 
 // Apply calls kubectl apply to apply the manifest.

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -128,11 +128,8 @@ func defaultMasterMachineType(cluster *api.Cluster) string {
 // defaultImage returns the default Image, based on the cloudprovider
 func defaultImage(cluster *api.Cluster, channel *api.Channel) string {
 	if channel != nil {
-		for _, image := range channel.Spec.Images {
-			if image.ProviderID != cluster.Spec.CloudProvider {
-				continue
-			}
-
+		image := channel.FindImage(fi.CloudProviderID(cluster.Spec.CloudProvider))
+		if image != nil {
 			return image.Name
 		}
 	}


### PR DESCRIPTION
Also fixes an issue where `kops upgrade` can't find the latest image in
the manifest.