### PR TITLE
Increase the master CIDR to a /28

### DIFF
--- a/upup/models/config/components/kubelet/kubelet.options
+++ b/upup/models/config/components/kubelet/kubelet.options
@@ -14,7 +14,7 @@ MasterKubelet:
   RegisterSchedulable: false
   APIServers: http://127.0.0.1:8080
   # We bootstrap with a fake CIDR, but then this will be replaced (unless we're running with _isolated_master)
-  PodCIDR: 10.123.45.0/29
+  PodCIDR: 10.123.45.0/28
   # Replace the CIDR with a CIDR allocated by KCM (the default, but included for clarity)
   ReconcileCIDR: true
   # We _do_ allow debugging handlers, so we can do logs


### PR DESCRIPTION
This should allow pods to run on the master until the real fix arrives
in 1.5.