### PR TITLE
Remove security group rules that match our filter

### DIFF
--- a/upup/models/cloudup/_aws/master/master.yaml
+++ b/upup/models/cloudup/_aws/master/master.yaml
@@ -17,7 +17,9 @@ iamInstanceProfileRole/masters.{{ ClusterName }}:
 securityGroup/masters.{{ ClusterName }}:
   vpc: vpc/{{ ClusterName }}
   description: 'Security group for masters'
-  removeExtraRules: true
+  removeExtraRules:
+  - port=22
+  - port=443
 
 # Allow full egress
 securityGroupRule/master-egress:

--- a/upup/models/cloudup/_aws/nodes.yaml
+++ b/upup/models/cloudup/_aws/nodes.yaml
@@ -17,7 +17,8 @@ iamInstanceProfileRole/nodes.{{ ClusterName }}:
 securityGroup/nodes.{{ ClusterName }}:
   vpc: vpc/{{ ClusterName }}
   description: 'Security group for nodes'
-  removeExtraRules: true
+  removeExtraRules:
+  - port=22
 
 # Allow full egress
 securityGroupRule/node-egress:

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup_test.go
@@ -1,0 +1,73 @@
+package awstasks
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"testing"
+)
+
+func TestParseRemovalRule(t *testing.T) {
+	testNotParse(t, "port 22")
+	testNotParse(t, "port22")
+	testNotParse(t, "port=a")
+	testNotParse(t, "port=22-23")
+
+	testParsesAsPort(t, "port=22", 22)
+	testParsesAsPort(t, "port=443", 443)
+}
+
+func testNotParse(t *testing.T, rule string) {
+	r, err := ParseRemovalRule(rule)
+	if err == nil {
+		t.Fatalf("expected failure to parse removal rule %q, got %v", rule, r)
+	}
+}
+
+func testParsesAsPort(t *testing.T, rule string, port int) {
+	r, err := ParseRemovalRule(rule)
+	if err != nil {
+		t.Fatalf("unexpected failure to parse rule %q: %v", rule, err)
+	}
+	portRemovalRule, ok := r.(*PortRemovalRule)
+	if !ok {
+		t.Fatalf("unexpected rule type for rule %q: %T", r, err)
+	}
+	if portRemovalRule.Port != port {
+		t.Fatalf("unexpected port for %q, expecting %d, got %q", rule, port, r)
+	}
+}
+
+func TestPortRemovalRule(t *testing.T) {
+	r := &PortRemovalRule{Port: 22}
+	testMatches(t, r, &ec2.IpPermission{FromPort: aws.Int64(22), ToPort: aws.Int64(22)})
+
+	testNotMatches(t, r, &ec2.IpPermission{FromPort: aws.Int64(0), ToPort: aws.Int64(0)})
+	testNotMatches(t, r, &ec2.IpPermission{FromPort: aws.Int64(23), ToPort: aws.Int64(23)})
+	testNotMatches(t, r, &ec2.IpPermission{FromPort: aws.Int64(20), ToPort: aws.Int64(22)})
+	testNotMatches(t, r, &ec2.IpPermission{FromPort: aws.Int64(22), ToPort: aws.Int64(23)})
+	testNotMatches(t, r, &ec2.IpPermission{ToPort: aws.Int64(22)})
+	testNotMatches(t, r, &ec2.IpPermission{FromPort: aws.Int64(22)})
+	testNotMatches(t, r, &ec2.IpPermission{})
+}
+
+func TestPortRemovalRule_Zero(t *testing.T) {
+	r := &PortRemovalRule{Port: 0}
+	testMatches(t, r, &ec2.IpPermission{FromPort: aws.Int64(0), ToPort: aws.Int64(0)})
+
+	testNotMatches(t, r, &ec2.IpPermission{FromPort: aws.Int64(0), ToPort: aws.Int64(20)})
+	testNotMatches(t, r, &ec2.IpPermission{ToPort: aws.Int64(0)})
+	testNotMatches(t, r, &ec2.IpPermission{FromPort: aws.Int64(0)})
+	testNotMatches(t, r, &ec2.IpPermission{})
+}
+
+func testMatches(t *testing.T, rule *PortRemovalRule, permission *ec2.IpPermission) {
+	if !rule.Matches(permission) {
+		t.Fatalf("rule %q failed to match permission %q", rule, permission)
+	}
+}
+
+func testNotMatches(t *testing.T, rule *PortRemovalRule, permission *ec2.IpPermission) {
+	if rule.Matches(permission) {
+		t.Fatalf("rule %q unexpectedly matched permission %q", rule, permission)
+	}
+}


### PR DESCRIPTION
We configure a filter so that we only remove rules on port 22 & 443

Fix #478