### PR TITLE
kops build: Log gcloud info instead of gcloud auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,9 @@ upload: kops version-dist
 	aws s3 sync --acl public-read .build/upload/ ${S3_BUCKET}
 
 gcs-upload: version-dist
-	gcloud auth list
+	@echo "== Logging gcloud info =="
+	@gcloud info
+	@echo "== Uploading kops =="
 	gsutil -m rsync -r .build/upload/kops ${GCS_LOCATION}
 
 gcs-publish-ci: gcs-upload


### PR DESCRIPTION
Testing a theory for #664