### PR TITLE
fixing CLUSTER_NAME reference in terraform docs

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,8 +18,8 @@ For example, a complete setup might be:
 ```
 export KOPS_STATE_STORE=s3://<somes3bucket>
 export CLUSTER_NAME=<kubernetes.mydomain.com>
-${GOPATH}/bin/kops create cluster ${NAME} --zones us-east-1c
-${GOPATH}/bin/kops update cluster ${NAME} --target=terraform
+${GOPATH}/bin/kops create cluster ${CLUSTER_NAME} --zones us-east-1c
+${GOPATH}/bin/kops update cluster ${CLUSTER_NAME} --target=terraform
 
 cd out/terraform
 terraform plan


### PR DESCRIPTION
`${NAME}` was referenced where I believe the author intended `${CLUSTER_NAME}`
