### PR TITLE
Delete route tables, even if untagged, if we are deleting the VPC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,7 @@ copydeps:
 
 gofmt:
 	gofmt -w -s channels/
+	gofmt -w -s cloudmock/
 	gofmt -w -s cmd/
 	gofmt -w -s examples/
 	gofmt -w -s util/

--- a/cloudmock/aws/mockec2/api.go
+++ b/cloudmock/aws/mockec2/api.go
@@ -1,0 +1,12 @@
+package mockec2
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+)
+
+type MockEC2 struct {
+	RouteTables []*ec2.RouteTable
+}
+
+var _ ec2iface.EC2API = &MockEC2{}

--- a/cloudmock/aws/mockec2/routetable.go
+++ b/cloudmock/aws/mockec2/routetable.go
@@ -1,0 +1,30 @@
+package mockec2
+
+import (
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/glog"
+)
+
+func (m *MockEC2) DescribeRouteTablesRequest(*ec2.DescribeRouteTablesInput) (*request.Request, *ec2.DescribeRouteTablesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+
+func (m *MockEC2) DescribeRouteTables(request *ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error) {
+	if request.Filters != nil {
+		glog.Fatalf("filters not implemented: %v", request.Filters)
+	}
+	if request.DryRun != nil {
+		glog.Fatalf("DryRun not implemented")
+	}
+	if request.RouteTableIds != nil {
+		glog.Fatalf("RouteTableIds not implemented")
+	}
+
+	response := &ec2.DescribeRouteTablesOutput{}
+	for _, rt := range m.RouteTables {
+		response.RouteTables = append(response.RouteTables, rt)
+	}
+	return response, nil
+}

--- a/cloudmock/aws/mockec2/unimplemented.go
+++ b/cloudmock/aws/mockec2/unimplemented.go
@@ -1,0 +1,1698 @@
+package mockec2
+
+import (
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+func (m *MockEC2) AcceptVpcPeeringConnectionRequest(*ec2.AcceptVpcPeeringConnectionInput) (*request.Request, *ec2.AcceptVpcPeeringConnectionOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+
+func (m *MockEC2) AcceptVpcPeeringConnection(*ec2.AcceptVpcPeeringConnectionInput) (*ec2.AcceptVpcPeeringConnectionOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+
+func (m *MockEC2) AllocateAddressRequest(*ec2.AllocateAddressInput) (*request.Request, *ec2.AllocateAddressOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+
+func (m *MockEC2) AllocateAddress(*ec2.AllocateAddressInput) (*ec2.AllocateAddressOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+
+func (m *MockEC2) AllocateHostsRequest(*ec2.AllocateHostsInput) (*request.Request, *ec2.AllocateHostsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+
+func (m *MockEC2) AllocateHosts(*ec2.AllocateHostsInput) (*ec2.AllocateHostsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+
+func (m *MockEC2) AssignPrivateIpAddressesRequest(*ec2.AssignPrivateIpAddressesInput) (*request.Request, *ec2.AssignPrivateIpAddressesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+
+func (m *MockEC2) AssignPrivateIpAddresses(*ec2.AssignPrivateIpAddressesInput) (*ec2.AssignPrivateIpAddressesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+
+func (m *MockEC2) AssociateAddressRequest(*ec2.AssociateAddressInput) (*request.Request, *ec2.AssociateAddressOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+
+func (m *MockEC2) AssociateAddress(*ec2.AssociateAddressInput) (*ec2.AssociateAddressOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+
+func (m *MockEC2) AssociateDhcpOptionsRequest(*ec2.AssociateDhcpOptionsInput) (*request.Request, *ec2.AssociateDhcpOptionsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+
+func (m *MockEC2) AssociateDhcpOptions(*ec2.AssociateDhcpOptionsInput) (*ec2.AssociateDhcpOptionsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) AssociateRouteTableRequest(*ec2.AssociateRouteTableInput) (*request.Request, *ec2.AssociateRouteTableOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) AssociateRouteTable(*ec2.AssociateRouteTableInput) (*ec2.AssociateRouteTableOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) AttachClassicLinkVpcRequest(*ec2.AttachClassicLinkVpcInput) (*request.Request, *ec2.AttachClassicLinkVpcOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) AttachClassicLinkVpc(*ec2.AttachClassicLinkVpcInput) (*ec2.AttachClassicLinkVpcOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) AttachInternetGatewayRequest(*ec2.AttachInternetGatewayInput) (*request.Request, *ec2.AttachInternetGatewayOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) AttachInternetGateway(*ec2.AttachInternetGatewayInput) (*ec2.AttachInternetGatewayOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) AttachNetworkInterfaceRequest(*ec2.AttachNetworkInterfaceInput) (*request.Request, *ec2.AttachNetworkInterfaceOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) AttachNetworkInterface(*ec2.AttachNetworkInterfaceInput) (*ec2.AttachNetworkInterfaceOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) AttachVolumeRequest(*ec2.AttachVolumeInput) (*request.Request, *ec2.VolumeAttachment) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) AttachVolume(*ec2.AttachVolumeInput) (*ec2.VolumeAttachment, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) AttachVpnGatewayRequest(*ec2.AttachVpnGatewayInput) (*request.Request, *ec2.AttachVpnGatewayOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) AttachVpnGateway(*ec2.AttachVpnGatewayInput) (*ec2.AttachVpnGatewayOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) AuthorizeSecurityGroupEgressRequest(*ec2.AuthorizeSecurityGroupEgressInput) (*request.Request, *ec2.AuthorizeSecurityGroupEgressOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) AuthorizeSecurityGroupEgress(*ec2.AuthorizeSecurityGroupEgressInput) (*ec2.AuthorizeSecurityGroupEgressOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) AuthorizeSecurityGroupIngressRequest(*ec2.AuthorizeSecurityGroupIngressInput) (*request.Request, *ec2.AuthorizeSecurityGroupIngressOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) AuthorizeSecurityGroupIngress(*ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) BundleInstanceRequest(*ec2.BundleInstanceInput) (*request.Request, *ec2.BundleInstanceOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) BundleInstance(*ec2.BundleInstanceInput) (*ec2.BundleInstanceOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CancelBundleTaskRequest(*ec2.CancelBundleTaskInput) (*request.Request, *ec2.CancelBundleTaskOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CancelBundleTask(*ec2.CancelBundleTaskInput) (*ec2.CancelBundleTaskOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CancelConversionTaskRequest(*ec2.CancelConversionTaskInput) (*request.Request, *ec2.CancelConversionTaskOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CancelConversionTask(*ec2.CancelConversionTaskInput) (*ec2.CancelConversionTaskOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CancelExportTaskRequest(*ec2.CancelExportTaskInput) (*request.Request, *ec2.CancelExportTaskOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CancelExportTask(*ec2.CancelExportTaskInput) (*ec2.CancelExportTaskOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CancelImportTaskRequest(*ec2.CancelImportTaskInput) (*request.Request, *ec2.CancelImportTaskOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CancelImportTask(*ec2.CancelImportTaskInput) (*ec2.CancelImportTaskOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CancelReservedInstancesListingRequest(*ec2.CancelReservedInstancesListingInput) (*request.Request, *ec2.CancelReservedInstancesListingOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CancelReservedInstancesListing(*ec2.CancelReservedInstancesListingInput) (*ec2.CancelReservedInstancesListingOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CancelSpotFleetRequestsRequest(*ec2.CancelSpotFleetRequestsInput) (*request.Request, *ec2.CancelSpotFleetRequestsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CancelSpotFleetRequests(*ec2.CancelSpotFleetRequestsInput) (*ec2.CancelSpotFleetRequestsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CancelSpotInstanceRequestsRequest(*ec2.CancelSpotInstanceRequestsInput) (*request.Request, *ec2.CancelSpotInstanceRequestsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CancelSpotInstanceRequests(*ec2.CancelSpotInstanceRequestsInput) (*ec2.CancelSpotInstanceRequestsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ConfirmProductInstanceRequest(*ec2.ConfirmProductInstanceInput) (*request.Request, *ec2.ConfirmProductInstanceOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ConfirmProductInstance(*ec2.ConfirmProductInstanceInput) (*ec2.ConfirmProductInstanceOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CopyImageRequest(*ec2.CopyImageInput) (*request.Request, *ec2.CopyImageOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CopyImage(*ec2.CopyImageInput) (*ec2.CopyImageOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CopySnapshotRequest(*ec2.CopySnapshotInput) (*request.Request, *ec2.CopySnapshotOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CopySnapshot(*ec2.CopySnapshotInput) (*ec2.CopySnapshotOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateCustomerGatewayRequest(*ec2.CreateCustomerGatewayInput) (*request.Request, *ec2.CreateCustomerGatewayOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateCustomerGateway(*ec2.CreateCustomerGatewayInput) (*ec2.CreateCustomerGatewayOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateDhcpOptionsRequest(*ec2.CreateDhcpOptionsInput) (*request.Request, *ec2.CreateDhcpOptionsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateDhcpOptions(*ec2.CreateDhcpOptionsInput) (*ec2.CreateDhcpOptionsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateFlowLogsRequest(*ec2.CreateFlowLogsInput) (*request.Request, *ec2.CreateFlowLogsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateFlowLogs(*ec2.CreateFlowLogsInput) (*ec2.CreateFlowLogsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateImageRequest(*ec2.CreateImageInput) (*request.Request, *ec2.CreateImageOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateImage(*ec2.CreateImageInput) (*ec2.CreateImageOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateInstanceExportTaskRequest(*ec2.CreateInstanceExportTaskInput) (*request.Request, *ec2.CreateInstanceExportTaskOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateInstanceExportTask(*ec2.CreateInstanceExportTaskInput) (*ec2.CreateInstanceExportTaskOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateInternetGatewayRequest(*ec2.CreateInternetGatewayInput) (*request.Request, *ec2.CreateInternetGatewayOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateInternetGateway(*ec2.CreateInternetGatewayInput) (*ec2.CreateInternetGatewayOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateKeyPairRequest(*ec2.CreateKeyPairInput) (*request.Request, *ec2.CreateKeyPairOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateKeyPair(*ec2.CreateKeyPairInput) (*ec2.CreateKeyPairOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateNatGatewayRequest(*ec2.CreateNatGatewayInput) (*request.Request, *ec2.CreateNatGatewayOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateNatGateway(*ec2.CreateNatGatewayInput) (*ec2.CreateNatGatewayOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateNetworkAclRequest(*ec2.CreateNetworkAclInput) (*request.Request, *ec2.CreateNetworkAclOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateNetworkAcl(*ec2.CreateNetworkAclInput) (*ec2.CreateNetworkAclOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateNetworkAclEntryRequest(*ec2.CreateNetworkAclEntryInput) (*request.Request, *ec2.CreateNetworkAclEntryOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateNetworkAclEntry(*ec2.CreateNetworkAclEntryInput) (*ec2.CreateNetworkAclEntryOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateNetworkInterfaceRequest(*ec2.CreateNetworkInterfaceInput) (*request.Request, *ec2.CreateNetworkInterfaceOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateNetworkInterface(*ec2.CreateNetworkInterfaceInput) (*ec2.CreateNetworkInterfaceOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreatePlacementGroupRequest(*ec2.CreatePlacementGroupInput) (*request.Request, *ec2.CreatePlacementGroupOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreatePlacementGroup(*ec2.CreatePlacementGroupInput) (*ec2.CreatePlacementGroupOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateReservedInstancesListingRequest(*ec2.CreateReservedInstancesListingInput) (*request.Request, *ec2.CreateReservedInstancesListingOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateReservedInstancesListing(*ec2.CreateReservedInstancesListingInput) (*ec2.CreateReservedInstancesListingOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateRouteRequest(*ec2.CreateRouteInput) (*request.Request, *ec2.CreateRouteOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateRoute(*ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateRouteTableRequest(*ec2.CreateRouteTableInput) (*request.Request, *ec2.CreateRouteTableOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateRouteTable(*ec2.CreateRouteTableInput) (*ec2.CreateRouteTableOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateSecurityGroupRequest(*ec2.CreateSecurityGroupInput) (*request.Request, *ec2.CreateSecurityGroupOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateSecurityGroup(*ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateSnapshotRequest(*ec2.CreateSnapshotInput) (*request.Request, *ec2.Snapshot) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateSnapshot(*ec2.CreateSnapshotInput) (*ec2.Snapshot, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateSpotDatafeedSubscriptionRequest(*ec2.CreateSpotDatafeedSubscriptionInput) (*request.Request, *ec2.CreateSpotDatafeedSubscriptionOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateSpotDatafeedSubscription(*ec2.CreateSpotDatafeedSubscriptionInput) (*ec2.CreateSpotDatafeedSubscriptionOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateSubnetRequest(*ec2.CreateSubnetInput) (*request.Request, *ec2.CreateSubnetOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateSubnet(*ec2.CreateSubnetInput) (*ec2.CreateSubnetOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateTagsRequest(*ec2.CreateTagsInput) (*request.Request, *ec2.CreateTagsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateTags(*ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateVolumeRequest(*ec2.CreateVolumeInput) (*request.Request, *ec2.Volume) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateVolume(*ec2.CreateVolumeInput) (*ec2.Volume, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateVpcRequest(*ec2.CreateVpcInput) (*request.Request, *ec2.CreateVpcOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateVpc(*ec2.CreateVpcInput) (*ec2.CreateVpcOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateVpcEndpointRequest(*ec2.CreateVpcEndpointInput) (*request.Request, *ec2.CreateVpcEndpointOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateVpcEndpoint(*ec2.CreateVpcEndpointInput) (*ec2.CreateVpcEndpointOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateVpcPeeringConnectionRequest(*ec2.CreateVpcPeeringConnectionInput) (*request.Request, *ec2.CreateVpcPeeringConnectionOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateVpcPeeringConnection(*ec2.CreateVpcPeeringConnectionInput) (*ec2.CreateVpcPeeringConnectionOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateVpnConnectionRequest(*ec2.CreateVpnConnectionInput) (*request.Request, *ec2.CreateVpnConnectionOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateVpnConnection(*ec2.CreateVpnConnectionInput) (*ec2.CreateVpnConnectionOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateVpnConnectionRouteRequest(*ec2.CreateVpnConnectionRouteInput) (*request.Request, *ec2.CreateVpnConnectionRouteOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateVpnConnectionRoute(*ec2.CreateVpnConnectionRouteInput) (*ec2.CreateVpnConnectionRouteOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateVpnGatewayRequest(*ec2.CreateVpnGatewayInput) (*request.Request, *ec2.CreateVpnGatewayOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) CreateVpnGateway(*ec2.CreateVpnGatewayInput) (*ec2.CreateVpnGatewayOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteCustomerGatewayRequest(*ec2.DeleteCustomerGatewayInput) (*request.Request, *ec2.DeleteCustomerGatewayOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteCustomerGateway(*ec2.DeleteCustomerGatewayInput) (*ec2.DeleteCustomerGatewayOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteDhcpOptionsRequest(*ec2.DeleteDhcpOptionsInput) (*request.Request, *ec2.DeleteDhcpOptionsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteDhcpOptions(*ec2.DeleteDhcpOptionsInput) (*ec2.DeleteDhcpOptionsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteFlowLogsRequest(*ec2.DeleteFlowLogsInput) (*request.Request, *ec2.DeleteFlowLogsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteFlowLogs(*ec2.DeleteFlowLogsInput) (*ec2.DeleteFlowLogsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteInternetGatewayRequest(*ec2.DeleteInternetGatewayInput) (*request.Request, *ec2.DeleteInternetGatewayOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteInternetGateway(*ec2.DeleteInternetGatewayInput) (*ec2.DeleteInternetGatewayOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteKeyPairRequest(*ec2.DeleteKeyPairInput) (*request.Request, *ec2.DeleteKeyPairOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteKeyPair(*ec2.DeleteKeyPairInput) (*ec2.DeleteKeyPairOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteNatGatewayRequest(*ec2.DeleteNatGatewayInput) (*request.Request, *ec2.DeleteNatGatewayOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteNatGateway(*ec2.DeleteNatGatewayInput) (*ec2.DeleteNatGatewayOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteNetworkAclRequest(*ec2.DeleteNetworkAclInput) (*request.Request, *ec2.DeleteNetworkAclOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteNetworkAcl(*ec2.DeleteNetworkAclInput) (*ec2.DeleteNetworkAclOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteNetworkAclEntryRequest(*ec2.DeleteNetworkAclEntryInput) (*request.Request, *ec2.DeleteNetworkAclEntryOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteNetworkAclEntry(*ec2.DeleteNetworkAclEntryInput) (*ec2.DeleteNetworkAclEntryOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteNetworkInterfaceRequest(*ec2.DeleteNetworkInterfaceInput) (*request.Request, *ec2.DeleteNetworkInterfaceOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteNetworkInterface(*ec2.DeleteNetworkInterfaceInput) (*ec2.DeleteNetworkInterfaceOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeletePlacementGroupRequest(*ec2.DeletePlacementGroupInput) (*request.Request, *ec2.DeletePlacementGroupOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeletePlacementGroup(*ec2.DeletePlacementGroupInput) (*ec2.DeletePlacementGroupOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteRouteRequest(*ec2.DeleteRouteInput) (*request.Request, *ec2.DeleteRouteOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteRoute(*ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteRouteTableRequest(*ec2.DeleteRouteTableInput) (*request.Request, *ec2.DeleteRouteTableOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteRouteTable(*ec2.DeleteRouteTableInput) (*ec2.DeleteRouteTableOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteSecurityGroupRequest(*ec2.DeleteSecurityGroupInput) (*request.Request, *ec2.DeleteSecurityGroupOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteSecurityGroup(*ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteSnapshotRequest(*ec2.DeleteSnapshotInput) (*request.Request, *ec2.DeleteSnapshotOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteSnapshot(*ec2.DeleteSnapshotInput) (*ec2.DeleteSnapshotOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteSpotDatafeedSubscriptionRequest(*ec2.DeleteSpotDatafeedSubscriptionInput) (*request.Request, *ec2.DeleteSpotDatafeedSubscriptionOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteSpotDatafeedSubscription(*ec2.DeleteSpotDatafeedSubscriptionInput) (*ec2.DeleteSpotDatafeedSubscriptionOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteSubnetRequest(*ec2.DeleteSubnetInput) (*request.Request, *ec2.DeleteSubnetOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteSubnet(*ec2.DeleteSubnetInput) (*ec2.DeleteSubnetOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteTagsRequest(*ec2.DeleteTagsInput) (*request.Request, *ec2.DeleteTagsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteTags(*ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteVolumeRequest(*ec2.DeleteVolumeInput) (*request.Request, *ec2.DeleteVolumeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteVolume(*ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteVpcRequest(*ec2.DeleteVpcInput) (*request.Request, *ec2.DeleteVpcOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteVpc(*ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteVpcEndpointsRequest(*ec2.DeleteVpcEndpointsInput) (*request.Request, *ec2.DeleteVpcEndpointsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteVpcEndpoints(*ec2.DeleteVpcEndpointsInput) (*ec2.DeleteVpcEndpointsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteVpcPeeringConnectionRequest(*ec2.DeleteVpcPeeringConnectionInput) (*request.Request, *ec2.DeleteVpcPeeringConnectionOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteVpcPeeringConnection(*ec2.DeleteVpcPeeringConnectionInput) (*ec2.DeleteVpcPeeringConnectionOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteVpnConnectionRequest(*ec2.DeleteVpnConnectionInput) (*request.Request, *ec2.DeleteVpnConnectionOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteVpnConnection(*ec2.DeleteVpnConnectionInput) (*ec2.DeleteVpnConnectionOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteVpnConnectionRouteRequest(*ec2.DeleteVpnConnectionRouteInput) (*request.Request, *ec2.DeleteVpnConnectionRouteOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteVpnConnectionRoute(*ec2.DeleteVpnConnectionRouteInput) (*ec2.DeleteVpnConnectionRouteOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteVpnGatewayRequest(*ec2.DeleteVpnGatewayInput) (*request.Request, *ec2.DeleteVpnGatewayOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeleteVpnGateway(*ec2.DeleteVpnGatewayInput) (*ec2.DeleteVpnGatewayOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeregisterImageRequest(*ec2.DeregisterImageInput) (*request.Request, *ec2.DeregisterImageOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DeregisterImage(*ec2.DeregisterImageInput) (*ec2.DeregisterImageOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeAccountAttributesRequest(*ec2.DescribeAccountAttributesInput) (*request.Request, *ec2.DescribeAccountAttributesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeAccountAttributes(*ec2.DescribeAccountAttributesInput) (*ec2.DescribeAccountAttributesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeAddressesRequest(*ec2.DescribeAddressesInput) (*request.Request, *ec2.DescribeAddressesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeAddresses(*ec2.DescribeAddressesInput) (*ec2.DescribeAddressesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeAvailabilityZonesRequest(*ec2.DescribeAvailabilityZonesInput) (*request.Request, *ec2.DescribeAvailabilityZonesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeAvailabilityZones(*ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeBundleTasksRequest(*ec2.DescribeBundleTasksInput) (*request.Request, *ec2.DescribeBundleTasksOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeBundleTasks(*ec2.DescribeBundleTasksInput) (*ec2.DescribeBundleTasksOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeClassicLinkInstancesRequest(*ec2.DescribeClassicLinkInstancesInput) (*request.Request, *ec2.DescribeClassicLinkInstancesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeClassicLinkInstances(*ec2.DescribeClassicLinkInstancesInput) (*ec2.DescribeClassicLinkInstancesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeConversionTasksRequest(*ec2.DescribeConversionTasksInput) (*request.Request, *ec2.DescribeConversionTasksOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeConversionTasks(*ec2.DescribeConversionTasksInput) (*ec2.DescribeConversionTasksOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeCustomerGatewaysRequest(*ec2.DescribeCustomerGatewaysInput) (*request.Request, *ec2.DescribeCustomerGatewaysOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeCustomerGateways(*ec2.DescribeCustomerGatewaysInput) (*ec2.DescribeCustomerGatewaysOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeDhcpOptionsRequest(*ec2.DescribeDhcpOptionsInput) (*request.Request, *ec2.DescribeDhcpOptionsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeDhcpOptions(*ec2.DescribeDhcpOptionsInput) (*ec2.DescribeDhcpOptionsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeExportTasksRequest(*ec2.DescribeExportTasksInput) (*request.Request, *ec2.DescribeExportTasksOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeExportTasks(*ec2.DescribeExportTasksInput) (*ec2.DescribeExportTasksOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeFlowLogsRequest(*ec2.DescribeFlowLogsInput) (*request.Request, *ec2.DescribeFlowLogsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeFlowLogs(*ec2.DescribeFlowLogsInput) (*ec2.DescribeFlowLogsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeHostsRequest(*ec2.DescribeHostsInput) (*request.Request, *ec2.DescribeHostsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeHosts(*ec2.DescribeHostsInput) (*ec2.DescribeHostsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeIdFormatRequest(*ec2.DescribeIdFormatInput) (*request.Request, *ec2.DescribeIdFormatOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeIdFormat(*ec2.DescribeIdFormatInput) (*ec2.DescribeIdFormatOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeIdentityIdFormatRequest(*ec2.DescribeIdentityIdFormatInput) (*request.Request, *ec2.DescribeIdentityIdFormatOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeIdentityIdFormat(*ec2.DescribeIdentityIdFormatInput) (*ec2.DescribeIdentityIdFormatOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeImageAttributeRequest(*ec2.DescribeImageAttributeInput) (*request.Request, *ec2.DescribeImageAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeImageAttribute(*ec2.DescribeImageAttributeInput) (*ec2.DescribeImageAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeImagesRequest(*ec2.DescribeImagesInput) (*request.Request, *ec2.DescribeImagesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeImages(*ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeImportImageTasksRequest(*ec2.DescribeImportImageTasksInput) (*request.Request, *ec2.DescribeImportImageTasksOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeImportImageTasks(*ec2.DescribeImportImageTasksInput) (*ec2.DescribeImportImageTasksOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeImportSnapshotTasksRequest(*ec2.DescribeImportSnapshotTasksInput) (*request.Request, *ec2.DescribeImportSnapshotTasksOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeImportSnapshotTasks(*ec2.DescribeImportSnapshotTasksInput) (*ec2.DescribeImportSnapshotTasksOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeInstanceAttributeRequest(*ec2.DescribeInstanceAttributeInput) (*request.Request, *ec2.DescribeInstanceAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeInstanceAttribute(*ec2.DescribeInstanceAttributeInput) (*ec2.DescribeInstanceAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeInstanceStatusRequest(*ec2.DescribeInstanceStatusInput) (*request.Request, *ec2.DescribeInstanceStatusOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeInstanceStatus(*ec2.DescribeInstanceStatusInput) (*ec2.DescribeInstanceStatusOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeInstanceStatusPages(*ec2.DescribeInstanceStatusInput, func(*ec2.DescribeInstanceStatusOutput, bool) bool) error {
+	panic("Not implemented")
+	return nil
+}
+func (m *MockEC2) DescribeInstancesRequest(*ec2.DescribeInstancesInput) (*request.Request, *ec2.DescribeInstancesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeInstancesPages(*ec2.DescribeInstancesInput, func(*ec2.DescribeInstancesOutput, bool) bool) error {
+	panic("Not implemented")
+	return nil
+}
+func (m *MockEC2) DescribeInternetGatewaysRequest(*ec2.DescribeInternetGatewaysInput) (*request.Request, *ec2.DescribeInternetGatewaysOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeInternetGateways(*ec2.DescribeInternetGatewaysInput) (*ec2.DescribeInternetGatewaysOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeKeyPairsRequest(*ec2.DescribeKeyPairsInput) (*request.Request, *ec2.DescribeKeyPairsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeKeyPairs(*ec2.DescribeKeyPairsInput) (*ec2.DescribeKeyPairsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeMovingAddressesRequest(*ec2.DescribeMovingAddressesInput) (*request.Request, *ec2.DescribeMovingAddressesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeMovingAddresses(*ec2.DescribeMovingAddressesInput) (*ec2.DescribeMovingAddressesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeNatGatewaysRequest(*ec2.DescribeNatGatewaysInput) (*request.Request, *ec2.DescribeNatGatewaysOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeNatGateways(*ec2.DescribeNatGatewaysInput) (*ec2.DescribeNatGatewaysOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeNetworkAclsRequest(*ec2.DescribeNetworkAclsInput) (*request.Request, *ec2.DescribeNetworkAclsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeNetworkAcls(*ec2.DescribeNetworkAclsInput) (*ec2.DescribeNetworkAclsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeNetworkInterfaceAttributeRequest(*ec2.DescribeNetworkInterfaceAttributeInput) (*request.Request, *ec2.DescribeNetworkInterfaceAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeNetworkInterfaceAttribute(*ec2.DescribeNetworkInterfaceAttributeInput) (*ec2.DescribeNetworkInterfaceAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeNetworkInterfacesRequest(*ec2.DescribeNetworkInterfacesInput) (*request.Request, *ec2.DescribeNetworkInterfacesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeNetworkInterfaces(*ec2.DescribeNetworkInterfacesInput) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribePlacementGroupsRequest(*ec2.DescribePlacementGroupsInput) (*request.Request, *ec2.DescribePlacementGroupsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribePlacementGroups(*ec2.DescribePlacementGroupsInput) (*ec2.DescribePlacementGroupsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribePrefixListsRequest(*ec2.DescribePrefixListsInput) (*request.Request, *ec2.DescribePrefixListsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribePrefixLists(*ec2.DescribePrefixListsInput) (*ec2.DescribePrefixListsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeRegionsRequest(*ec2.DescribeRegionsInput) (*request.Request, *ec2.DescribeRegionsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeRegions(*ec2.DescribeRegionsInput) (*ec2.DescribeRegionsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeReservedInstancesRequest(*ec2.DescribeReservedInstancesInput) (*request.Request, *ec2.DescribeReservedInstancesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeReservedInstances(*ec2.DescribeReservedInstancesInput) (*ec2.DescribeReservedInstancesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeReservedInstancesListingsRequest(*ec2.DescribeReservedInstancesListingsInput) (*request.Request, *ec2.DescribeReservedInstancesListingsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeReservedInstancesListings(*ec2.DescribeReservedInstancesListingsInput) (*ec2.DescribeReservedInstancesListingsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeReservedInstancesModificationsRequest(*ec2.DescribeReservedInstancesModificationsInput) (*request.Request, *ec2.DescribeReservedInstancesModificationsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeReservedInstancesModifications(*ec2.DescribeReservedInstancesModificationsInput) (*ec2.DescribeReservedInstancesModificationsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeReservedInstancesModificationsPages(*ec2.DescribeReservedInstancesModificationsInput, func(*ec2.DescribeReservedInstancesModificationsOutput, bool) bool) error {
+	panic("Not implemented")
+	return nil
+}
+func (m *MockEC2) DescribeReservedInstancesOfferingsRequest(*ec2.DescribeReservedInstancesOfferingsInput) (*request.Request, *ec2.DescribeReservedInstancesOfferingsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeReservedInstancesOfferings(*ec2.DescribeReservedInstancesOfferingsInput) (*ec2.DescribeReservedInstancesOfferingsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeReservedInstancesOfferingsPages(*ec2.DescribeReservedInstancesOfferingsInput, func(*ec2.DescribeReservedInstancesOfferingsOutput, bool) bool) error {
+	panic("Not implemented")
+	return nil
+}
+func (m *MockEC2) DescribeScheduledInstanceAvailabilityRequest(*ec2.DescribeScheduledInstanceAvailabilityInput) (*request.Request, *ec2.DescribeScheduledInstanceAvailabilityOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeScheduledInstanceAvailability(*ec2.DescribeScheduledInstanceAvailabilityInput) (*ec2.DescribeScheduledInstanceAvailabilityOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeScheduledInstancesRequest(*ec2.DescribeScheduledInstancesInput) (*request.Request, *ec2.DescribeScheduledInstancesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeScheduledInstances(*ec2.DescribeScheduledInstancesInput) (*ec2.DescribeScheduledInstancesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSecurityGroupReferencesRequest(*ec2.DescribeSecurityGroupReferencesInput) (*request.Request, *ec2.DescribeSecurityGroupReferencesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSecurityGroupReferences(*ec2.DescribeSecurityGroupReferencesInput) (*ec2.DescribeSecurityGroupReferencesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSecurityGroupsRequest(*ec2.DescribeSecurityGroupsInput) (*request.Request, *ec2.DescribeSecurityGroupsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSecurityGroups(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSnapshotAttributeRequest(*ec2.DescribeSnapshotAttributeInput) (*request.Request, *ec2.DescribeSnapshotAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSnapshotAttribute(*ec2.DescribeSnapshotAttributeInput) (*ec2.DescribeSnapshotAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSnapshotsRequest(*ec2.DescribeSnapshotsInput) (*request.Request, *ec2.DescribeSnapshotsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSnapshots(*ec2.DescribeSnapshotsInput) (*ec2.DescribeSnapshotsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSnapshotsPages(*ec2.DescribeSnapshotsInput, func(*ec2.DescribeSnapshotsOutput, bool) bool) error {
+	panic("Not implemented")
+	return nil
+}
+func (m *MockEC2) DescribeSpotDatafeedSubscriptionRequest(*ec2.DescribeSpotDatafeedSubscriptionInput) (*request.Request, *ec2.DescribeSpotDatafeedSubscriptionOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSpotDatafeedSubscription(*ec2.DescribeSpotDatafeedSubscriptionInput) (*ec2.DescribeSpotDatafeedSubscriptionOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSpotFleetInstancesRequest(*ec2.DescribeSpotFleetInstancesInput) (*request.Request, *ec2.DescribeSpotFleetInstancesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSpotFleetInstances(*ec2.DescribeSpotFleetInstancesInput) (*ec2.DescribeSpotFleetInstancesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSpotFleetRequestHistoryRequest(*ec2.DescribeSpotFleetRequestHistoryInput) (*request.Request, *ec2.DescribeSpotFleetRequestHistoryOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSpotFleetRequestHistory(*ec2.DescribeSpotFleetRequestHistoryInput) (*ec2.DescribeSpotFleetRequestHistoryOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSpotFleetRequestsRequest(*ec2.DescribeSpotFleetRequestsInput) (*request.Request, *ec2.DescribeSpotFleetRequestsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSpotFleetRequests(*ec2.DescribeSpotFleetRequestsInput) (*ec2.DescribeSpotFleetRequestsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSpotFleetRequestsPages(*ec2.DescribeSpotFleetRequestsInput, func(*ec2.DescribeSpotFleetRequestsOutput, bool) bool) error {
+	panic("Not implemented")
+	return nil
+}
+func (m *MockEC2) DescribeSpotInstanceRequestsRequest(*ec2.DescribeSpotInstanceRequestsInput) (*request.Request, *ec2.DescribeSpotInstanceRequestsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSpotInstanceRequests(*ec2.DescribeSpotInstanceRequestsInput) (*ec2.DescribeSpotInstanceRequestsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSpotPriceHistoryRequest(*ec2.DescribeSpotPriceHistoryInput) (*request.Request, *ec2.DescribeSpotPriceHistoryOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSpotPriceHistory(*ec2.DescribeSpotPriceHistoryInput) (*ec2.DescribeSpotPriceHistoryOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSpotPriceHistoryPages(*ec2.DescribeSpotPriceHistoryInput, func(*ec2.DescribeSpotPriceHistoryOutput, bool) bool) error {
+	panic("Not implemented")
+	return nil
+}
+func (m *MockEC2) DescribeStaleSecurityGroupsRequest(*ec2.DescribeStaleSecurityGroupsInput) (*request.Request, *ec2.DescribeStaleSecurityGroupsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeStaleSecurityGroups(*ec2.DescribeStaleSecurityGroupsInput) (*ec2.DescribeStaleSecurityGroupsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSubnetsRequest(*ec2.DescribeSubnetsInput) (*request.Request, *ec2.DescribeSubnetsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeSubnets(*ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeTagsRequest(*ec2.DescribeTagsInput) (*request.Request, *ec2.DescribeTagsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeTags(*ec2.DescribeTagsInput) (*ec2.DescribeTagsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeTagsPages(*ec2.DescribeTagsInput, func(*ec2.DescribeTagsOutput, bool) bool) error {
+	panic("Not implemented")
+	return nil
+}
+func (m *MockEC2) DescribeVolumeAttributeRequest(*ec2.DescribeVolumeAttributeInput) (*request.Request, *ec2.DescribeVolumeAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVolumeAttribute(*ec2.DescribeVolumeAttributeInput) (*ec2.DescribeVolumeAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVolumeStatusRequest(*ec2.DescribeVolumeStatusInput) (*request.Request, *ec2.DescribeVolumeStatusOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVolumeStatus(*ec2.DescribeVolumeStatusInput) (*ec2.DescribeVolumeStatusOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVolumeStatusPages(*ec2.DescribeVolumeStatusInput, func(*ec2.DescribeVolumeStatusOutput, bool) bool) error {
+	panic("Not implemented")
+	return nil
+}
+func (m *MockEC2) DescribeVolumesRequest(*ec2.DescribeVolumesInput) (*request.Request, *ec2.DescribeVolumesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVolumes(*ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVolumesPages(*ec2.DescribeVolumesInput, func(*ec2.DescribeVolumesOutput, bool) bool) error {
+	panic("Not implemented")
+	return nil
+}
+func (m *MockEC2) DescribeVpcAttributeRequest(*ec2.DescribeVpcAttributeInput) (*request.Request, *ec2.DescribeVpcAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpcAttribute(*ec2.DescribeVpcAttributeInput) (*ec2.DescribeVpcAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpcClassicLinkRequest(*ec2.DescribeVpcClassicLinkInput) (*request.Request, *ec2.DescribeVpcClassicLinkOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpcClassicLink(*ec2.DescribeVpcClassicLinkInput) (*ec2.DescribeVpcClassicLinkOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpcClassicLinkDnsSupportRequest(*ec2.DescribeVpcClassicLinkDnsSupportInput) (*request.Request, *ec2.DescribeVpcClassicLinkDnsSupportOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpcClassicLinkDnsSupport(*ec2.DescribeVpcClassicLinkDnsSupportInput) (*ec2.DescribeVpcClassicLinkDnsSupportOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpcEndpointServicesRequest(*ec2.DescribeVpcEndpointServicesInput) (*request.Request, *ec2.DescribeVpcEndpointServicesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpcEndpointServices(*ec2.DescribeVpcEndpointServicesInput) (*ec2.DescribeVpcEndpointServicesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpcEndpointsRequest(*ec2.DescribeVpcEndpointsInput) (*request.Request, *ec2.DescribeVpcEndpointsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpcEndpoints(*ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpcPeeringConnectionsRequest(*ec2.DescribeVpcPeeringConnectionsInput) (*request.Request, *ec2.DescribeVpcPeeringConnectionsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpcPeeringConnections(*ec2.DescribeVpcPeeringConnectionsInput) (*ec2.DescribeVpcPeeringConnectionsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpcsRequest(*ec2.DescribeVpcsInput) (*request.Request, *ec2.DescribeVpcsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpcs(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpnConnectionsRequest(*ec2.DescribeVpnConnectionsInput) (*request.Request, *ec2.DescribeVpnConnectionsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpnConnections(*ec2.DescribeVpnConnectionsInput) (*ec2.DescribeVpnConnectionsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpnGatewaysRequest(*ec2.DescribeVpnGatewaysInput) (*request.Request, *ec2.DescribeVpnGatewaysOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DescribeVpnGateways(*ec2.DescribeVpnGatewaysInput) (*ec2.DescribeVpnGatewaysOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DetachClassicLinkVpcRequest(*ec2.DetachClassicLinkVpcInput) (*request.Request, *ec2.DetachClassicLinkVpcOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DetachClassicLinkVpc(*ec2.DetachClassicLinkVpcInput) (*ec2.DetachClassicLinkVpcOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DetachInternetGatewayRequest(*ec2.DetachInternetGatewayInput) (*request.Request, *ec2.DetachInternetGatewayOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DetachInternetGateway(*ec2.DetachInternetGatewayInput) (*ec2.DetachInternetGatewayOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DetachNetworkInterfaceRequest(*ec2.DetachNetworkInterfaceInput) (*request.Request, *ec2.DetachNetworkInterfaceOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DetachNetworkInterface(*ec2.DetachNetworkInterfaceInput) (*ec2.DetachNetworkInterfaceOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DetachVolumeRequest(*ec2.DetachVolumeInput) (*request.Request, *ec2.VolumeAttachment) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DetachVolume(*ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DetachVpnGatewayRequest(*ec2.DetachVpnGatewayInput) (*request.Request, *ec2.DetachVpnGatewayOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DetachVpnGateway(*ec2.DetachVpnGatewayInput) (*ec2.DetachVpnGatewayOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DisableVgwRoutePropagationRequest(*ec2.DisableVgwRoutePropagationInput) (*request.Request, *ec2.DisableVgwRoutePropagationOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DisableVgwRoutePropagation(*ec2.DisableVgwRoutePropagationInput) (*ec2.DisableVgwRoutePropagationOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DisableVpcClassicLinkRequest(*ec2.DisableVpcClassicLinkInput) (*request.Request, *ec2.DisableVpcClassicLinkOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DisableVpcClassicLink(*ec2.DisableVpcClassicLinkInput) (*ec2.DisableVpcClassicLinkOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DisableVpcClassicLinkDnsSupportRequest(*ec2.DisableVpcClassicLinkDnsSupportInput) (*request.Request, *ec2.DisableVpcClassicLinkDnsSupportOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DisableVpcClassicLinkDnsSupport(*ec2.DisableVpcClassicLinkDnsSupportInput) (*ec2.DisableVpcClassicLinkDnsSupportOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DisassociateAddressRequest(*ec2.DisassociateAddressInput) (*request.Request, *ec2.DisassociateAddressOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DisassociateAddress(*ec2.DisassociateAddressInput) (*ec2.DisassociateAddressOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DisassociateRouteTableRequest(*ec2.DisassociateRouteTableInput) (*request.Request, *ec2.DisassociateRouteTableOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) DisassociateRouteTable(*ec2.DisassociateRouteTableInput) (*ec2.DisassociateRouteTableOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) EnableVgwRoutePropagationRequest(*ec2.EnableVgwRoutePropagationInput) (*request.Request, *ec2.EnableVgwRoutePropagationOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) EnableVgwRoutePropagation(*ec2.EnableVgwRoutePropagationInput) (*ec2.EnableVgwRoutePropagationOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) EnableVolumeIORequest(*ec2.EnableVolumeIOInput) (*request.Request, *ec2.EnableVolumeIOOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) EnableVolumeIO(*ec2.EnableVolumeIOInput) (*ec2.EnableVolumeIOOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) EnableVpcClassicLinkRequest(*ec2.EnableVpcClassicLinkInput) (*request.Request, *ec2.EnableVpcClassicLinkOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) EnableVpcClassicLink(*ec2.EnableVpcClassicLinkInput) (*ec2.EnableVpcClassicLinkOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) EnableVpcClassicLinkDnsSupportRequest(*ec2.EnableVpcClassicLinkDnsSupportInput) (*request.Request, *ec2.EnableVpcClassicLinkDnsSupportOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) EnableVpcClassicLinkDnsSupport(*ec2.EnableVpcClassicLinkDnsSupportInput) (*ec2.EnableVpcClassicLinkDnsSupportOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) GetConsoleOutputRequest(*ec2.GetConsoleOutputInput) (*request.Request, *ec2.GetConsoleOutputOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) GetConsoleOutput(*ec2.GetConsoleOutputInput) (*ec2.GetConsoleOutputOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) GetConsoleScreenshotRequest(*ec2.GetConsoleScreenshotInput) (*request.Request, *ec2.GetConsoleScreenshotOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) GetConsoleScreenshot(*ec2.GetConsoleScreenshotInput) (*ec2.GetConsoleScreenshotOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) GetPasswordDataRequest(*ec2.GetPasswordDataInput) (*request.Request, *ec2.GetPasswordDataOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) GetPasswordData(*ec2.GetPasswordDataInput) (*ec2.GetPasswordDataOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ImportImageRequest(*ec2.ImportImageInput) (*request.Request, *ec2.ImportImageOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ImportImage(*ec2.ImportImageInput) (*ec2.ImportImageOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ImportInstanceRequest(*ec2.ImportInstanceInput) (*request.Request, *ec2.ImportInstanceOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ImportInstance(*ec2.ImportInstanceInput) (*ec2.ImportInstanceOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ImportKeyPairRequest(*ec2.ImportKeyPairInput) (*request.Request, *ec2.ImportKeyPairOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ImportKeyPair(*ec2.ImportKeyPairInput) (*ec2.ImportKeyPairOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ImportSnapshotRequest(*ec2.ImportSnapshotInput) (*request.Request, *ec2.ImportSnapshotOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ImportSnapshot(*ec2.ImportSnapshotInput) (*ec2.ImportSnapshotOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ImportVolumeRequest(*ec2.ImportVolumeInput) (*request.Request, *ec2.ImportVolumeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ImportVolume(*ec2.ImportVolumeInput) (*ec2.ImportVolumeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyHostsRequest(*ec2.ModifyHostsInput) (*request.Request, *ec2.ModifyHostsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyHosts(*ec2.ModifyHostsInput) (*ec2.ModifyHostsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyIdFormatRequest(*ec2.ModifyIdFormatInput) (*request.Request, *ec2.ModifyIdFormatOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyIdFormat(*ec2.ModifyIdFormatInput) (*ec2.ModifyIdFormatOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyIdentityIdFormatRequest(*ec2.ModifyIdentityIdFormatInput) (*request.Request, *ec2.ModifyIdentityIdFormatOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyIdentityIdFormat(*ec2.ModifyIdentityIdFormatInput) (*ec2.ModifyIdentityIdFormatOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyImageAttributeRequest(*ec2.ModifyImageAttributeInput) (*request.Request, *ec2.ModifyImageAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyImageAttribute(*ec2.ModifyImageAttributeInput) (*ec2.ModifyImageAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyInstanceAttributeRequest(*ec2.ModifyInstanceAttributeInput) (*request.Request, *ec2.ModifyInstanceAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyInstanceAttribute(*ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyInstancePlacementRequest(*ec2.ModifyInstancePlacementInput) (*request.Request, *ec2.ModifyInstancePlacementOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyInstancePlacement(*ec2.ModifyInstancePlacementInput) (*ec2.ModifyInstancePlacementOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyNetworkInterfaceAttributeRequest(*ec2.ModifyNetworkInterfaceAttributeInput) (*request.Request, *ec2.ModifyNetworkInterfaceAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyNetworkInterfaceAttribute(*ec2.ModifyNetworkInterfaceAttributeInput) (*ec2.ModifyNetworkInterfaceAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyReservedInstancesRequest(*ec2.ModifyReservedInstancesInput) (*request.Request, *ec2.ModifyReservedInstancesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyReservedInstances(*ec2.ModifyReservedInstancesInput) (*ec2.ModifyReservedInstancesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifySnapshotAttributeRequest(*ec2.ModifySnapshotAttributeInput) (*request.Request, *ec2.ModifySnapshotAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifySnapshotAttribute(*ec2.ModifySnapshotAttributeInput) (*ec2.ModifySnapshotAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifySpotFleetRequestRequest(*ec2.ModifySpotFleetRequestInput) (*request.Request, *ec2.ModifySpotFleetRequestOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifySpotFleetRequest(*ec2.ModifySpotFleetRequestInput) (*ec2.ModifySpotFleetRequestOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifySubnetAttributeRequest(*ec2.ModifySubnetAttributeInput) (*request.Request, *ec2.ModifySubnetAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifySubnetAttribute(*ec2.ModifySubnetAttributeInput) (*ec2.ModifySubnetAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyVolumeAttributeRequest(*ec2.ModifyVolumeAttributeInput) (*request.Request, *ec2.ModifyVolumeAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyVolumeAttribute(*ec2.ModifyVolumeAttributeInput) (*ec2.ModifyVolumeAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyVpcAttributeRequest(*ec2.ModifyVpcAttributeInput) (*request.Request, *ec2.ModifyVpcAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyVpcAttribute(*ec2.ModifyVpcAttributeInput) (*ec2.ModifyVpcAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyVpcEndpointRequest(*ec2.ModifyVpcEndpointInput) (*request.Request, *ec2.ModifyVpcEndpointOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyVpcEndpoint(*ec2.ModifyVpcEndpointInput) (*ec2.ModifyVpcEndpointOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyVpcPeeringConnectionOptionsRequest(*ec2.ModifyVpcPeeringConnectionOptionsInput) (*request.Request, *ec2.ModifyVpcPeeringConnectionOptionsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ModifyVpcPeeringConnectionOptions(*ec2.ModifyVpcPeeringConnectionOptionsInput) (*ec2.ModifyVpcPeeringConnectionOptionsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) MonitorInstancesRequest(*ec2.MonitorInstancesInput) (*request.Request, *ec2.MonitorInstancesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) MonitorInstances(*ec2.MonitorInstancesInput) (*ec2.MonitorInstancesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) MoveAddressToVpcRequest(*ec2.MoveAddressToVpcInput) (*request.Request, *ec2.MoveAddressToVpcOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) MoveAddressToVpc(*ec2.MoveAddressToVpcInput) (*ec2.MoveAddressToVpcOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) PurchaseReservedInstancesOfferingRequest(*ec2.PurchaseReservedInstancesOfferingInput) (*request.Request, *ec2.PurchaseReservedInstancesOfferingOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) PurchaseReservedInstancesOffering(*ec2.PurchaseReservedInstancesOfferingInput) (*ec2.PurchaseReservedInstancesOfferingOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) PurchaseScheduledInstancesRequest(*ec2.PurchaseScheduledInstancesInput) (*request.Request, *ec2.PurchaseScheduledInstancesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) PurchaseScheduledInstances(*ec2.PurchaseScheduledInstancesInput) (*ec2.PurchaseScheduledInstancesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RebootInstancesRequest(*ec2.RebootInstancesInput) (*request.Request, *ec2.RebootInstancesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RebootInstances(*ec2.RebootInstancesInput) (*ec2.RebootInstancesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RegisterImageRequest(*ec2.RegisterImageInput) (*request.Request, *ec2.RegisterImageOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RegisterImage(*ec2.RegisterImageInput) (*ec2.RegisterImageOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RejectVpcPeeringConnectionRequest(*ec2.RejectVpcPeeringConnectionInput) (*request.Request, *ec2.RejectVpcPeeringConnectionOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RejectVpcPeeringConnection(*ec2.RejectVpcPeeringConnectionInput) (*ec2.RejectVpcPeeringConnectionOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ReleaseAddressRequest(*ec2.ReleaseAddressInput) (*request.Request, *ec2.ReleaseAddressOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ReleaseAddress(*ec2.ReleaseAddressInput) (*ec2.ReleaseAddressOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ReleaseHostsRequest(*ec2.ReleaseHostsInput) (*request.Request, *ec2.ReleaseHostsOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ReleaseHosts(*ec2.ReleaseHostsInput) (*ec2.ReleaseHostsOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ReplaceNetworkAclAssociationRequest(*ec2.ReplaceNetworkAclAssociationInput) (*request.Request, *ec2.ReplaceNetworkAclAssociationOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ReplaceNetworkAclAssociation(*ec2.ReplaceNetworkAclAssociationInput) (*ec2.ReplaceNetworkAclAssociationOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ReplaceNetworkAclEntryRequest(*ec2.ReplaceNetworkAclEntryInput) (*request.Request, *ec2.ReplaceNetworkAclEntryOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ReplaceNetworkAclEntry(*ec2.ReplaceNetworkAclEntryInput) (*ec2.ReplaceNetworkAclEntryOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ReplaceRouteRequest(*ec2.ReplaceRouteInput) (*request.Request, *ec2.ReplaceRouteOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ReplaceRoute(*ec2.ReplaceRouteInput) (*ec2.ReplaceRouteOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ReplaceRouteTableAssociationRequest(*ec2.ReplaceRouteTableAssociationInput) (*request.Request, *ec2.ReplaceRouteTableAssociationOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ReplaceRouteTableAssociation(*ec2.ReplaceRouteTableAssociationInput) (*ec2.ReplaceRouteTableAssociationOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ReportInstanceStatusRequest(*ec2.ReportInstanceStatusInput) (*request.Request, *ec2.ReportInstanceStatusOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ReportInstanceStatus(*ec2.ReportInstanceStatusInput) (*ec2.ReportInstanceStatusOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RequestSpotFleetRequest(*ec2.RequestSpotFleetInput) (*request.Request, *ec2.RequestSpotFleetOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RequestSpotFleet(*ec2.RequestSpotFleetInput) (*ec2.RequestSpotFleetOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RequestSpotInstancesRequest(*ec2.RequestSpotInstancesInput) (*request.Request, *ec2.RequestSpotInstancesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RequestSpotInstances(*ec2.RequestSpotInstancesInput) (*ec2.RequestSpotInstancesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ResetImageAttributeRequest(*ec2.ResetImageAttributeInput) (*request.Request, *ec2.ResetImageAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ResetImageAttribute(*ec2.ResetImageAttributeInput) (*ec2.ResetImageAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ResetInstanceAttributeRequest(*ec2.ResetInstanceAttributeInput) (*request.Request, *ec2.ResetInstanceAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ResetInstanceAttribute(*ec2.ResetInstanceAttributeInput) (*ec2.ResetInstanceAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ResetNetworkInterfaceAttributeRequest(*ec2.ResetNetworkInterfaceAttributeInput) (*request.Request, *ec2.ResetNetworkInterfaceAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ResetNetworkInterfaceAttribute(*ec2.ResetNetworkInterfaceAttributeInput) (*ec2.ResetNetworkInterfaceAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ResetSnapshotAttributeRequest(*ec2.ResetSnapshotAttributeInput) (*request.Request, *ec2.ResetSnapshotAttributeOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) ResetSnapshotAttribute(*ec2.ResetSnapshotAttributeInput) (*ec2.ResetSnapshotAttributeOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RestoreAddressToClassicRequest(*ec2.RestoreAddressToClassicInput) (*request.Request, *ec2.RestoreAddressToClassicOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RestoreAddressToClassic(*ec2.RestoreAddressToClassicInput) (*ec2.RestoreAddressToClassicOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RevokeSecurityGroupEgressRequest(*ec2.RevokeSecurityGroupEgressInput) (*request.Request, *ec2.RevokeSecurityGroupEgressOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RevokeSecurityGroupEgress(*ec2.RevokeSecurityGroupEgressInput) (*ec2.RevokeSecurityGroupEgressOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RevokeSecurityGroupIngressRequest(*ec2.RevokeSecurityGroupIngressInput) (*request.Request, *ec2.RevokeSecurityGroupIngressOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RevokeSecurityGroupIngress(*ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RunInstancesRequest(*ec2.RunInstancesInput) (*request.Request, *ec2.Reservation) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RunInstances(*ec2.RunInstancesInput) (*ec2.Reservation, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RunScheduledInstancesRequest(*ec2.RunScheduledInstancesInput) (*request.Request, *ec2.RunScheduledInstancesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) RunScheduledInstances(*ec2.RunScheduledInstancesInput) (*ec2.RunScheduledInstancesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) StartInstancesRequest(*ec2.StartInstancesInput) (*request.Request, *ec2.StartInstancesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) StartInstances(*ec2.StartInstancesInput) (*ec2.StartInstancesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) StopInstancesRequest(*ec2.StopInstancesInput) (*request.Request, *ec2.StopInstancesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) StopInstances(*ec2.StopInstancesInput) (*ec2.StopInstancesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) TerminateInstancesRequest(*ec2.TerminateInstancesInput) (*request.Request, *ec2.TerminateInstancesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) TerminateInstances(*ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) UnassignPrivateIpAddressesRequest(*ec2.UnassignPrivateIpAddressesInput) (*request.Request, *ec2.UnassignPrivateIpAddressesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) UnassignPrivateIpAddresses(*ec2.UnassignPrivateIpAddressesInput) (*ec2.UnassignPrivateIpAddressesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) UnmonitorInstancesRequest(*ec2.UnmonitorInstancesInput) (*request.Request, *ec2.UnmonitorInstancesOutput) {
+	panic("Not implemented")
+	return nil, nil
+}
+func (m *MockEC2) UnmonitorInstances(*ec2.UnmonitorInstancesInput) (*ec2.UnmonitorInstancesOutput, error) {
+	panic("Not implemented")
+	return nil, nil
+}

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/route53"
@@ -53,7 +54,7 @@ type AWSCloud interface {
 
 	Region() string
 
-	EC2() *ec2.EC2
+	EC2() ec2iface.EC2API
 	IAM() *iam.IAM
 	ELB() *elb.ELB
 	Autoscaling() *autoscaling.AutoScaling
@@ -662,7 +663,7 @@ func (c *awsCloudImplementation) FindDNSHostedZone(clusterDNSName string) (strin
 	return "", fmt.Errorf("Found multiple hosted zones matching cluster %q; please specify the ID of the zone to use", clusterDNSName)
 }
 
-func (c *awsCloudImplementation) EC2() *ec2.EC2 {
+func (c *awsCloudImplementation) EC2() ec2iface.EC2API {
 	return c.ec2
 }
 

--- a/upup/pkg/kutil/delete_cluster.go
+++ b/upup/pkg/kutil/delete_cluster.go
@@ -164,6 +164,45 @@ func (c *DeleteCluster) ListResources() (map[string]*ResourceTracker, error) {
 		}
 	}
 
+	{
+		// We sometimes have trouble tagging the route table (eventual consistency, e.g. #597)
+		// If we are deleting the VPC, we should delete the route table
+		// (no real reason not to; easy to recreate; no real state etc)
+		routeTables, err := DescribeRouteTablesIgnoreTags(cloud)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, rt := range routeTables {
+			rtID := aws.StringValue(rt.RouteTableId)
+			vpcID := aws.StringValue(rt.VpcId)
+			if vpcID == "" || rtID == "" {
+				continue
+			}
+
+			if resources["vpc:"+vpcID] == nil {
+				// Not deleting this VPC; ignore
+				continue
+			}
+
+			isMain := true
+			for _, a := range rt.Associations {
+				if aws.BoolValue(a.Main) == false {
+					isMain = false
+				}
+			}
+			if isMain {
+				glog.V(4).Infof("ignoring main routetable %q", rtID)
+				continue
+			}
+
+			t := buildTrackerForRouteTable(rt)
+			if resources[t.Type+":"+t.ID] == nil {
+				resources[t.Type+":"+t.ID] = t
+			}
+		}
+	}
+
 	for k, t := range resources {
 		if t.done {
 			delete(resources, k)
@@ -801,40 +840,21 @@ func DeleteRouteTable(cloud fi.Cloud, r *ResourceTracker) error {
 	return nil
 }
 
-func ListRouteTables(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
-	routeTables, err := DescribeRouteTables(cloud)
+// DescribeRouteTablesIgnoreTags returns all ec2.RouteTable, ignoring tags
+func DescribeRouteTablesIgnoreTags(cloud fi.Cloud) ([]*ec2.RouteTable, error) {
+	c := cloud.(awsup.AWSCloud)
+
+	glog.V(2).Infof("Listing all RouteTables")
+	request := &ec2.DescribeRouteTablesInput{}
+	response, err := c.EC2().DescribeRouteTables(request)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error listing RouteTables: %v", err)
 	}
 
-	var trackers []*ResourceTracker
-
-	for _, rt := range routeTables {
-		tracker := &ResourceTracker{
-			Name:    FindName(rt.Tags),
-			ID:      aws.StringValue(rt.RouteTableId),
-			Type:    "route-table",
-			deleter: DeleteRouteTable,
-		}
-
-		var blocks []string
-		var blocked []string
-
-		blocks = append(blocks, "vpc:"+aws.StringValue(rt.VpcId))
-
-		for _, a := range rt.Associations {
-			blocked = append(blocked, "subnet:"+aws.StringValue(a.SubnetId))
-		}
-
-		tracker.blocks = blocks
-		tracker.blocked = blocked
-
-		trackers = append(trackers, tracker)
-	}
-
-	return trackers, nil
+	return response.RouteTables, nil
 }
 
+// DescribeRouteTables lists route-tables tagged for the cloud
 func DescribeRouteTables(cloud fi.Cloud) ([]*ec2.RouteTable, error) {
 	c := cloud.(awsup.AWSCloud)
 
@@ -848,6 +868,45 @@ func DescribeRouteTables(cloud fi.Cloud) ([]*ec2.RouteTable, error) {
 	}
 
 	return response.RouteTables, nil
+}
+
+func ListRouteTables(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
+	routeTables, err := DescribeRouteTables(cloud)
+	if err != nil {
+		return nil, err
+	}
+
+	var trackers []*ResourceTracker
+
+	for _, rt := range routeTables {
+		tracker := buildTrackerForRouteTable(rt)
+		trackers = append(trackers, tracker)
+	}
+
+	return trackers, nil
+}
+
+func buildTrackerForRouteTable(rt *ec2.RouteTable) *ResourceTracker {
+	tracker := &ResourceTracker{
+		Name:    FindName(rt.Tags),
+		ID:      aws.StringValue(rt.RouteTableId),
+		Type:    "route-table",
+		deleter: DeleteRouteTable,
+	}
+
+	var blocks []string
+	var blocked []string
+
+	blocks = append(blocks, "vpc:"+aws.StringValue(rt.VpcId))
+
+	for _, a := range rt.Associations {
+		blocked = append(blocked, "subnet:"+aws.StringValue(a.SubnetId))
+	}
+
+	tracker.blocks = blocks
+	tracker.blocked = blocked
+
+	return tracker
 }
 
 func DeleteDhcpOptions(cloud fi.Cloud, r *ResourceTracker) error {
@@ -1065,7 +1124,7 @@ func DeleteVPC(cloud fi.Cloud, r *ResourceTracker) error {
 	return nil
 }
 
-func ListVPCs(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
+func DescribeVPCs(cloud fi.Cloud) ([]*ec2.Vpc, error) {
 	c := cloud.(awsup.AWSCloud)
 
 	glog.V(2).Infof("Listing EC2 VPC")
@@ -1077,9 +1136,17 @@ func ListVPCs(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
 		return nil, fmt.Errorf("error listing VPCs: %v", err)
 	}
 
-	var trackers []*ResourceTracker
+	return response.Vpcs, nil
+}
 
-	for _, v := range response.Vpcs {
+func ListVPCs(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
+	vpcs, err := DescribeVPCs(cloud)
+	if err != nil {
+		return nil, err
+	}
+
+	var trackers []*ResourceTracker
+	for _, v := range vpcs {
 		tracker := &ResourceTracker{
 			Name:    FindName(v.Tags),
 			ID:      aws.StringValue(v.VpcId),

--- a/upup/pkg/kutil/deletecluster_test.go
+++ b/upup/pkg/kutil/deletecluster_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kutil
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"k8s.io/kops/cloudmock/aws/mockec2"
+	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestAddUntaggedRouteTables(t *testing.T) {
+	cloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
+	resources := make(map[string]*ResourceTracker)
+
+	c := &mockec2.MockEC2{}
+	cloud.MockEC2 = c
+
+	// Matches by vpc id
+	c.RouteTables = append(c.RouteTables, &ec2.RouteTable{
+		VpcId:        aws.String("vpc-1234"),
+		RouteTableId: aws.String("rt-1234"),
+	})
+
+	// Skips main route tables
+	c.RouteTables = append(c.RouteTables, &ec2.RouteTable{
+		VpcId:        aws.String("vpc-1234"),
+		RouteTableId: aws.String("rt-1234main"),
+		Associations: []*ec2.RouteTableAssociation{
+			{
+				Main: aws.Bool(true),
+			},
+		},
+	})
+
+	// Ignores non-matching vpcs
+	c.RouteTables = append(c.RouteTables, &ec2.RouteTable{
+		VpcId:        aws.String("vpc-5555"),
+		RouteTableId: aws.String("rt-5555"),
+	})
+
+	resources["vpc:vpc-1234"] = &ResourceTracker{}
+
+	err := addUntaggedRouteTables(cloud, resources)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var keys []string
+	for k := range resources {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	expected := []string{"route-table:rt-1234", "vpc:vpc-1234"}
+	if !reflect.DeepEqual(expected, keys) {
+		t.Fatalf("expected=%q, actual=%q", expected, keys)
+	}
+}


### PR DESCRIPTION
The route table cannot exist without a VPC; if we're deleting the VPC we
must delete the route table also.

This will help fix problems when we fail to tag the route-table.

Issue #597