### PR TITLE
update links to use latest addon manifests

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -14,7 +14,7 @@ The [dashboard project](https://github.com/kubernetes/dashboard) provides a nice
 
 Install using:
 ```
-kubectl create -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/kubernetes-dashboard/v1.1.0.yaml
+kubectl create -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/kubernetes-dashboard/v1.4.0.yaml
 ```
 
 And then navigate to `https://api.<clustername>/ui`
@@ -33,5 +33,5 @@ Monitoring supports the horizontal pod autoscaler.
 
 Install using:
 ```
-kubectl create -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/monitoring-standalone/v1.1.0.yaml
+kubectl create -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/monitoring-standalone/v1.2.0.yaml
 ```


### PR DESCRIPTION
I didn't notice this was an old version until after I had deployed it. There are newer versions in this repo so we should link to them in the docs.