### PR TITLE
Update golang version to 1.7.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ GCS_URL=$(GCS_LOCATION:gs://%=https://storage.googleapis.com/%)
 LATEST_FILE?=latest-ci.txt
 GOPATH_1ST=$(shell echo ${GOPATH} | cut -d : -f 1)
 UNIQUE:=$(shell date +%s)
-GOVERSION=1.6
+GOVERSION=1.7.1
 
 # See http://stackoverflow.com/questions/18136918/how-to-get-current-relative-directory-of-your-makefile
 MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))


### PR DESCRIPTION
It's not ideal, because golang 1.7.1 is so new, but it fixes some pretty
serious issues with MacOS Sierra, which end users are now getting
prompted to install.