### PR TITLE
Remove kubeconfig path from log

### DIFF
--- a/upup/pkg/kutil/kubecfg_builder.go
+++ b/upup/pkg/kutil/kubecfg_builder.go
@@ -184,7 +184,7 @@ func (c *KubeconfigBuilder) WriteKubecfg() error {
 		}
 	}
 
-	fmt.Printf("Wrote config for %s to %q\n", c.Context, c.KubeconfigPath)
+	fmt.Printf("Wrote config for %s\n", c.Context)
 	return nil
 }
 

--- a/upup/pkg/kutil/kubecfg_builder.go
+++ b/upup/pkg/kutil/kubecfg_builder.go
@@ -184,7 +184,12 @@ func (c *KubeconfigBuilder) WriteKubecfg() error {
 		}
 	}
 
-	fmt.Printf("Wrote config for %s\n", c.Context)
+	split := strings.Split(c.KubeconfigPath, ":")
+	path := c.KubeconfigPath
+	if len(split) > 1 {
+		path = split[0]
+	}
+	fmt.Printf("Wrote config for %s to %q\n", c.Context, path)
 	return nil
 }
 


### PR DESCRIPTION
- Just removing the `to` part of the log message. I don't think its a huge win to have that in the logs, and was causing problems This closes #670