### PR TITLE
Fix reference to heapster Deployment in addon

### DIFF
--- a/addons/monitoring-standalone/v1.1.0.yaml
+++ b/addons/monitoring-standalone/v1.1.0.yaml
@@ -58,7 +58,7 @@ spec:
             - --memory=140Mi
             - --extra-memory=4Mi
             - --threshold=5
-            - --deployment=heapster-v1.1.0
+            - --deployment=heapster
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential

--- a/addons/monitoring-standalone/v1.2.0.yaml
+++ b/addons/monitoring-standalone/v1.2.0.yaml
@@ -69,7 +69,7 @@ spec:
             - --memory=140Mi
             - --extra-memory=4Mi
             - --threshold=5
-            - --deployment=heapster-v1.2.0
+            - --deployment=heapster
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential


### PR DESCRIPTION
The `heapster-nanny` container requires a reference to its own
deployment, which is named `heapster` in these manifests.

Fix #581