### PR TITLE
docs: add documentation for cluster.spec, namely runtimeConfig

### DIFF
--- a/docs/adding_a_feature.md
+++ b/docs/adding_a_feature.md
@@ -71,8 +71,6 @@ Each file in the tree describes a Task.
 On the nodeup side, Tasks can manage files, systemd services, packages etc.
 On the `kops update cluster` side, Tasks manage cloud resources: instances, networks, disks etc.
 
-
-
 ## Validation
 
 We should add some validation that the value entered is valid.  We only accept nil or `external` right now.
@@ -176,6 +174,8 @@ Values:
 * unset means to use the default policy, which is currently to apply OS security updates unless they require a reboot
 ```
 
+Additionally, consider adding documentation of your new feature to the docs in [/docs](/). If your feature touches configuration options in `config` or `cluster.spec`, document them in [cluster_spec.md](cluster_spec.md).
+
 ## Testing
 
 
@@ -220,4 +220,4 @@ very often.
 ## Other steps
 
 * We could also create a CLI flag on `create cluster`.  This doesn't seem worth it in this case; this is a relatively advanced option
-for people that already have an external software update mechanism.  All the flag would do is save the default
+for people that already have an external software update mechanism.  All the flag would do is save the default.

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -27,7 +27,7 @@ The login credentials are:
 * Password: get by running `kops get secrets kube --type secret -oplaintext` or `kubectl config view --minify`
 
 
-### Monitoring - Standalone
+### Monitoring with Heapster - Standalone
 
 Monitoring supports the horizontal pod autoscaler.
 

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -4,8 +4,6 @@
 
 `admin-access` controls the CIDR which can access the admin endpoints (SSH to each node, HTTPS to the master).
 
-It maps to `Cluster.Spec.AdminAccess`
-
 If not specified, no IP level restrictions will apply (though there are still restrictions, for example you need
 a permitted SSH key to access the SSH service!).
 
@@ -13,16 +11,13 @@ Currently this can only be a single CIDR.
 
 Examples:
 
-CLI:
+**CLI:**
+
 `--admin-access=18.0.0.0/8` to restrict to IPs in the 18.0.0.0/8 CIDR
 
-YAML:
+**YAML:**
 
-```
-spec:
-  adminAccess:
-  - 18.0.0.0/8
-```
+See the docs in [cluster_spec.md#adminaccess](cluster_spec.md#adminaccess)
 
 ## dns-zone
 

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -34,7 +34,7 @@ spec:
       apps/v1alpha1: "true"
 ```
 
-Will result in the flag `--runtime-config=batch/v2alpha1=true,apps/v1alpha1=true`. Note that `kube-apiserver` accepts `true` as a value switch-like flags.
+Will result in the flag `--runtime-config=batch/v2alpha1=true,apps/v1alpha1=true`. Note that `kube-apiserver` accepts `true` as a value for switch-like flags.
 
 ### networkID
 

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -1,0 +1,46 @@
+# Description of Keys in `config` and `cluster.spec`
+
+This list is not complete, but aims to document any keys that are less than self-explanatory.
+
+## spec
+
+### adminAccess
+
+This array configures the CIDRs that are able to ssh into nodes. On AWS this is manifested as inbound security group rules on the `nodes` and `master` security groups.
+
+Use this key to restrict cluster access to an office ip address range, for example.
+
+```yaml
+spec:
+  adminAccess:
+    - 12.34.56.78/32
+```
+
+### kubeAPIServer
+
+This block contains configuration for the `kube-apiserver`.
+
+#### runtimeConfig
+
+Keys and values here are translated into `--runtime-config` values for `kube-apiserver`, separated by commas.
+
+Use this to enable alpha features, for example:
+
+```yaml
+spec:
+  kubeAPIServer:
+    runtimeConfig:
+      batch/v2alpha1: "true"
+      apps/v1alpha1: "true"
+```
+
+Will result in the flag `--runtime-config=batch/v2alpha1=true,apps/v1alpha1=true`. Note that `kube-apiserver` accepts `true` as a value switch-like flags.
+
+### networkID
+
+On AWS, this is the id of the VPC the cluster is created in. If creating a cluster from scratch, this field doesn't need to be specified at create time; `kops` will create a `VPC` for you.
+
+```yaml
+spec:
+  networkID: vpc-abcdefg1
+```

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -388,6 +388,9 @@ type KubeAPIServerConfig struct {
 	TokenAuthFile         string            `json:"tokenAuthFile,omitempty" flag:"token-auth-file"`
 	AllowPrivileged       *bool             `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
 	APIServerCount        *int              `json:"apiServerCount,omitempty" flag:"apiserver-count"`
+    // keys and values in RuntimeConfig are parsed into the `--runtime-config` parameter
+    // for KubeAPIServer, concatenated with commas. ex: `--runtime-config=key1=value1,key2=value2`.
+    // Use this to enable alpha resources on kube-apiserver
 	RuntimeConfig         map[string]string `json:"runtimeConfig,omitempty" flag:"runtime-config"`
 }
 


### PR DESCRIPTION
This PR adds a doc aiming to describe the fields in cluster.spec that are less than obvious. It is certainly not complete, but it fulfills its main purpose of documenting `kuberAPIServer.runtimeConfig`.
