### PR TITLE
docs: clarify delay on the api.* routes in Route53

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -32,6 +32,8 @@ ${GOPATH}/bin/kops update cluster ${NAME} --yes
 
 If you have problems, please set `--v=8` and open an issue, and ping justinsb on slack!
 
+Note that the `etcd` routes in Route53 will appear immediately, but the `api.cluster.mydomain.com` routes will not appear for a few minutes; wait for all of the EC2 instances, particularly the masters, to become `running` before attempting to debug.
+
 # Other interesting modes
 
 Learn about our [other interesting modes](commands.md#other-interesting-modes).


### PR DESCRIPTION
We get a lot of questions in the slack channel about waiting for the `api.*` routes to be created in Route53; because people can't `kubectl get nodes` after a few minutes, they get the `dial` error and then check Route53 and see that the routes aren't there and then ask about it in slack. In reality, we just need to wait a bit longer before attempting to debug.