### PR TITLE
Add canonical import paths

### DIFF
--- a/cmd/kops/main.go
+++ b/cmd/kops/main.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package main // import "k8s.io/kops/cmd/kops"
 
 import (
 	"fmt"

--- a/cmd/nodeup/main.go
+++ b/cmd/nodeup/main.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package main // import "k8s.io/kops/cmd/nodeup"
 
 import (
 	"flag"

--- a/doc.go
+++ b/doc.go
@@ -15,4 +15,4 @@ limitations under the License.
 */
 
 // Package kops is the parent package for the kops kubernetes-ops tool..
-package kops
+package kops // import "k8s.io/kops"


### PR DESCRIPTION
Should warn if not using the vanity alias (k8s.io/kops) for an import.