### PR TITLE
WIP: Support Weave

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -51,6 +51,24 @@ kops create cluster \
 
 #### `weave`
 
+Weave Net creates a virtual network that connects containers across multiple
+hosts running anywhere: on any cloud, on your laptop or in your datacenter,
+even across clouds and datacenters.
+
+Weave Net has two transport options that can be used with kops: one based on
+the VXLAN kernel module and one implemented over UDP which is more flexible -
+it can traverse a NAT firewall for instance. Weave Net automatically picks the
+fastest transport available between two nodes.
+
+Weave Net also implements the Kubernetes Network Policy specification
+http://kubernetes.io/docs/user-guide/networkpolicies/ which lets you define
+rules to restrict communication into pods.
+
+For more details see:
+https://www.weave.works/docs/net/latest/introducing-weave/
+
+##### Example Cluster Creation with `kubenet`
+
 > TODO
 
 #### `cni`

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,130 +1,104 @@
-## Kubernetes Networking Setup
+## Networking
 
-Kubernetes Operations (kops) currently supports 4 networking modes:
+### Common Tasks
 
-* `kubenet` kubernetes native networking via a CNI plugin.  This is the default.
-* `cni` Container Network Interface(CNI) style networking, often installed via a Daemonset.
-* `classic` kubernetes native networking, done in-process.
-* `external` networking is done via a Daemonset. This is used in some custom implementations.
+* [Specifying a Network Plugin at Cluster Creation]
+* [Modifying the Network Plugin of an Existing Cluster]
+* [Troubleshooting]
 
-### kops Default Networking
+### Specifying a Network Plugin at Cluster Creation
 
-Kubernetes Operations (kops) uses `kubenet` networking by default. This sets up networking on AWS using VPC
-networking, where the  master allocates a /24 CIDR to each Node, drawing from the Node network.  
-Using `kubenet` mode routes for  each node are then configured in the AWS VPC routing tables.
+`kops create cluster` currently supports the following options, which can be
+specified using the `--networking` flag:
 
-One important limitation when using `kubenet` networking is that an AWS routing table cannot have more than
-50 entries, which sets a limit of 50 nodes per cluster. AWS support will sometimes raise the limit to 100,
-but their documentation notes that routing tables over 50 may take a performance hit.
+* [`kubenet`]
+* [`weave`]
+* [`cni`]
+* [`external`]
+* [`classic`]
 
-Because k8s modifies the AWS routing table, this means that realistically kubernetes needs to own the
-routing table, and thus it requires its own subnet.  It is theoretically possible to share a routing table
-with other infrastructure (but not a second cluster!), but this is not really recommended.  Certain
-`cni` networking solutions claim to address these problems.
+#### `kubenet`
 
-### CNI Networking
+`kops` uses `kubenet` by default. This sets up networking on AWS using VPC
+networking, where the master allocates a /24 CIDR to each Pod, drawing from the
+Pod network. Using `kubenet`, routes for each node are then configured in the
+AWS VPC routing tables.
 
-[Container Network Interface](https://github.com/containernetworking/cni)  provides a specification
-and libraries for writing plugins to configure network interfaces in Linux containers.  Kubernetes
-has built in support for CNI networking components.  Various solutions exist that
-support Kubernetes CNI networking, listed in alphabetical order:
+One important limitation when using `kubenet` is that an AWS routing table
+cannot have more than 50 entries, which sets a limit of 50 nodes per cluster.
+AWS support will sometimes raise the limit to 100, but their documentation
+notes that routing tables over 50 may take a performance hit.
 
-- [Calico](http://docs.projectcalico.org/v1.5/getting-started/kubernetes/installation/hosted/)
-- [Canal](https://github.com/tigera/canal/tree/master/k8s-install/kubeadm)
-- [Flannel](https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel.yml)
-- [Romana](https://github.com/romana/romana/tree/master/containerize#using-kops)
-- [Weave Net](https://github.com/weaveworks/weave-kube)
+Because k8s modifies the AWS routing table, this means that realistically
+kubernetes needs to own the routing table, and thus it requires its own subnet.
+It is theoretically possible to share a routing table with other infrastructure
+(but not a second cluster!), but this is not really recommended. Certain
+[`cni`] networking solutions claim to address these problems.
 
-This is not an all comprehensive list. At the time of writing this documentation, weave has
-been tested and used in the example below.  This project has no bias over the CNI provider
-that you run, we care that we provide the correct setup to run CNI providers.
+##### Example Cluster Creation with `kubenet`
 
-Both `kubenet` and `classic` networking options are completely baked into kops, while since
-CNI networking providers are not part of the Kubernetes project, we do not maintain
-their installation processes.  With that in mind, we do not support problems with
-different CNI providers but support configuring Kubernetes to run CNI providers.
-
-## Specifying network option for cluster creation
-
-You are able to specify your networking type via command line switch or in your yaml file.
-The `--networking` option accepts the three different values defined above: `kubenet`, `cni`,
-`classic`, and `external`. If `--networking` is left undefined `kubenet` is installed.
-
-### Weave Example for CNI
-
-Weave is currently the only tested CNI provider.
-
-#### Installation of CNI on a new Cluster
-
-The following command setups a cluster, in HA mode, that is ready for a CNI installation.
-
-```console
-$ export $ZONE=mylistofzones
-$ kops create cluster \
+```bash
+export ZONES=mylistofzones KOPS_STATE_STORE=s3://my-store
+kops create cluster \
   --zones $ZONES \
   --master-zones $ZONES \
   --master-size m4.large \
   --node-size m4.large \
-  --networking cni \
+  --networking kubenet \
   --yes \
   --name myclustername.mydns.io
 ```
 
-Once the cluster is stable, which you can check with a `kubectl cluster-info` command, the next
-step is to install CNI networking. Most of the CNI network providers are
-moving to installing their components plugins via a Daemonset.  For instance weave will
-install with the following command:
+#### `weave`
 
-```console
-$ kubectl create -f https://git.io/weave-kube
-```
+> TODO
 
-The above daemonset installation requires K8s 1.4.x or above.
+#### `cni`
+
+[Container Network Interface] provides a specification and libraries for
+writing plugins to configure network interfaces in Linux containers.
+Kubernetes has built in support for CNI networking components. The `cni` option
+only enables CNI networking, and does not actually install any particular
+plugin. This is meant to provide users a more advanced way to configure
+networking. To see a full list of CNI plugins that are baked directly into
+`kops`, see [Specifying a Network Plugin at Cluster Creation].
+
+#### `external`
+
+> TODO
+
+#### `classic`
+
+> TODO
+
+## Modifying the Network Plugin of an Existing Cluster
+
+> TODO
+
+## Troubleshooting
 
 ### Validating CNI Installation
 
-You will notice that `kube-dns` fails to start properly until you deploy your CNI provider.
-Pod networking and IP addresses are provided by the CNI provider.
+You will notice that `kube-dns` fails to start properly until you deploy your
+CNI provider.  Pod networking and IP addresses are provided by the CNI
+provider.
 
 Here are some steps items that will confirm a good CNI install:
 
-- `kubelet` is running with the with `--network-plugin=cni` option.
-- The CNS provider started without errors.
-- `kube-dns` daesonset starts.
-- Logging on a node will display messages on pod create and delete.
+* `kubelet` is running with the with `--network-plugin=cni` option.
+* The CNI  provider started without errors.
+* `kube-dns` daemonset starts.
+* Logging on a node will display messages on pod create and delete.
 
-The sig-networking and sig-cluster-lifecycle channels on K8s slack are always good starting places
-for Kubernetes specific CNI challenges.
+The `#sig-networking` and `#sig-cluster-lifecycle` channels on K8s slack are
+always good starting places for Kubernetes-specific CNI challenges.
 
-## Switching between networking providers
-
-`kops edit cluster` and you will see a block like:
-
-```
-  networking:
-    classic: {}
-```
-
-That means you are running with `classic` networking.  The `{}` means there are
-no configuration options, beyond the setting `classic`.
-
-To switch to kubenet, change the word classic to kubenet.
-
-```
-  networking:
-    kubenet: {}
-```
-
-Now follow the normal update / rolling-update procedure:
-
-```console
-$ kops update cluster # to preview
-$ kops update cluster --yes # to apply
-$ kops rolling-update cluster # to preview the rolling-update
-$ kops rolling-update cluster --yes # to roll all your instances
-```
-Your cluster should be ready in a few minutes. It is not trivial to see that this
-has worked; the easiest way seems to be to SSH to the master and verify
-that kubelet has been run with `--network-plugin=kubenet`.
-
-Switching from `kubenet` to a CNI network provider has not been tested at this time.
+[Container Network Interface]: https://github.com/kubernetes/kops/pull/819
+[Specifying a Network Plugin at Cluster Creation]: #specifying-a-network-plugin-at-cluster-creation
+[Modifying the Network Plugin of an Existing Cluster]: #modifying-the-network-plugin-of-an-existing-cluster
+[Troubleshooting]: #troubleshooting
+[`kubenet`]: #kubenet
+[`weave`]: #weave
+[`cni`]: #cni
+[`external`]: #external
+[`classic`]: #classic


### PR DESCRIPTION
## Overview 

Support for CNI was initially brought in here #621; However, the current state of networking in `kops` fails to produce a healthy cluster, when enabling CNI. This is because the current implementation does not configure/install any CNI plugin.

Here is a list of related issues:

* #537
* #709
* #764
* #773
* #777
* #778
* #787

It is my understanding the original intent of `kops`, was to decouple the task of configuring/installing CNI. Ultimately, leaving it up to the user to *get things working*.

Unfortunately, users are unable to simply `kubectl create -f https://git.io/weave-kube`, after a cluster has come up. It's the classic ["Chicken or the egg"](https://en.wikipedia.org/wiki/Chicken_or_the_egg) dilemma — the `dns-controller` (responsible for the creation of the public endpoint to your cluster's API servers) can't be scheduled because networking is not yet set-up. You can work-around this, by `ssh`ing to your cluster to manually bring up networking.

After a little persuasion, @kris-nova and I were able to convince @chrislovecnm that baking support for popular CNI plugins directly into `kops`, was the right approach.

## Proposal

I know everyone is aching for this support, and big pull-requests suck. So I'll do my scientific best to limit the scope of changes to be the absolute minimum.

### Scope

This list will be constantly updated to reflect the desired scope for this pull-request. These are, at a minimum, what the pull should address:

* Add an option to the `--networking` flag for `kops create cluster` with at least one CNI provider; most likely, Weave.

### Usage

To spin up a cluster with CNI enabled and Weave installed:

```bash
kops create cluster --networking weave ...
```