### PR TITLE
Fix bug in security group matching

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -91,7 +91,7 @@ func (e *SecurityGroup) findEc2(c *fi.Context) (*ec2.SecurityGroup, error) {
 		filters = append(filters, awsup.NewEC2Filter("vpc-id", *vpcID))
 		filters = append(filters, awsup.NewEC2Filter("group-name", *e.Name))
 
-		request.Filters = cloud.BuildFilters(e.Name)
+		request.Filters = filters
 	}
 
 	response, err := cloud.EC2().DescribeSecurityGroups(request)


### PR DESCRIPTION
We were matching only by the name tag, instead of using the group-name

If users had an SG with the same Name in different VPCs we could have
matched SGs in both VPCs.  This seems unlikely, and particularly tricky
to then get through the remaining sanity checks (even in the find
function itself).

Fix #813