### PR TITLE
apiserver needs /etc/pki/ca-trust, at least on RHEL

### DIFF
--- a/upup/models/nodeup/_kubernetes_master/kube-apiserver/files/etc/kubernetes/manifests/kube-apiserver.manifest.template
+++ b/upup/models/nodeup/_kubernetes_master/kube-apiserver/files/etc/kubernetes/manifests/kube-apiserver.manifest.template
@@ -62,6 +62,9 @@ spec:
     - mountPath: /etc/pki/tls
       name: etcpkitls
       readOnly: true
+    - mountPath: /etc/pki/ca-trust
+      name: etcpkicatrust
+      readOnly: true
     - mountPath: "{{ KubeAPIServer.PathSrvSshproxy }}"
       name: srvsshproxy
   volumes:
@@ -95,6 +98,9 @@ spec:
   - hostPath:
       path: /etc/pki/tls
     name: etcpkitls
+  - hostPath:
+      path: /etc/pki/ca-trust
+    name: etcpkicatrust
   - hostPath:
       path: "{{ KubeAPIServer.PathSrvSshproxy }}"
     name: srvsshproxy


### PR DESCRIPTION
/etc/pki/ca-trust has the actual CA certs, on RHEL & derivatives, and
thus must be mounted by apiserver.  It is used in the volume admission
controller, for example.

Fix #668