### PR TITLE
Add link in networking docs for Romana install

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -32,6 +32,7 @@ support Kubernetes CNI networking, listed in alphabetical order:
 - [Calico](http://docs.projectcalico.org/v1.5/getting-started/kubernetes/installation/hosted/)
 - [Canal](https://github.com/tigera/canal/tree/master/k8s-install/kubeadm)
 - [Flannel](https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel.yml)
+- [Romana](https://github.com/romana/romana/tree/master/containerize#using-kops)
 - [Weave Net](https://github.com/weaveworks/weave-kube)
 
 This is not an all comprehensive list. At the time of writing this documentation, weave has


### PR DESCRIPTION
The documentation mainly consists of this step:
`kubectl apply -f https://raw.githubusercontent.com/romana/romana/master/containerize/specs/romana-kops.yml`

It has been tested after creating a cluster with this command and SSH to the master node as `admin`:
`KOPS_STATE_STORE=s3://store /.../bin/kops create cluster --cloud aws --zones us-west-1b --dns-zone x.y.com --name kops.x.y.com --networking cni --master-size t2.medium --node-size t2.medium --network-cidr=192.168.99.0/24 --yes`