### PR TITLE
docs: clarify /24 CIDR allocation

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -10,7 +10,7 @@ Kubernetes Operations (kops) currently supports 4 networking modes:
 ### kops Default Networking
 
 Kubernetes Operations (kops) uses `kubenet` networking by default. This sets up networking on AWS using VPC
-networking, where the  master allocates a /24 CIDR to each Pod, drawing from the Pod network.  
+networking, where the  master allocates a /24 CIDR to each Node, drawing from the Node network.  
 Using `kubenet` mode routes for  each node are then configured in the AWS VPC routing tables.
 
 One important limitation when using `kubenet` networking is that an AWS routing table cannot have more than


### PR DESCRIPTION
Kubenet allocates /24 CIDR to each Node, not Pod