### PR TITLE
Topology added in the create_cluster guide

### DIFF
--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -35,6 +35,8 @@ kops create cluster
       --vpc string                  Set to use a shared VPC
       --yes                         Specify --yes to immediately create the cluster
       --zones string                Zones in which to run the cluster
+      --topology string             Specify --topology=[public|private] to enable/disable public/private networking for all master and nodes. Default is 'public'
+
 ```
 
 ### Options inherited from parent commands
@@ -54,4 +56,3 @@ kops create cluster
 
 ### SEE ALSO
 * [kops create](kops_create.md)	 - Create a resource by filename or stdin
-


### PR DESCRIPTION
**What?**
Toplogy was not updated in the create_cluster doc

Added the `--topology` documentation in the create_cluster guide