### PR TITLE
Use correct Terraform teardown command in Terraform docs

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -26,7 +26,7 @@ terraform plan
 terraform apply
 ```
 
-When you eventually `terraform delete` the cluster, you should still run `kops delete cluster ${CLUSTER_NAME}`,
+When you eventually `terraform destroy` the cluster, you should still run `kops delete cluster ${CLUSTER_NAME}`,
 to remove the kops cluster specification and any dynamically created Kubernetes resources (ELBs or volumes).
 
 ### Workaround for Terraform versions before 0.7


### PR DESCRIPTION
There's no command like `teardown delete`. I think the origin author had `teardown destroy` and likely confused this with `kubectl detele ...`.

Official Terraform CLI has only the [destroy parameter][1].

[1]: https://www.terraform.io/docs/commands/destroy.html