### PR TITLE
Just a couple of 1 liners to get the example (relatively) working again

### DIFF
--- a/examples/kops-api-example/up.go
+++ b/examples/kops-api-example/up.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"k8s.io/kops/pkg/apis/kops"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/registry"
 	"k8s.io/kops/pkg/client/simple/vfsclientset"
@@ -32,13 +31,16 @@ func up() error {
 	clientset := vfsclientset.NewVFSClientset(registryBase)
 
 	cluster := &api.Cluster{}
-
 	cluster.Name = clusterName
 	cluster.Spec = api.ClusterSpec{
 		Channel:       "stable",
 		CloudProvider: "aws",
 		ConfigBase:    registryBase.Join(cluster.Name).Path(),
+		Topology:      &api.TopologySpec{},
 	}
+	cluster.Spec.Topology.Masters = api.TopologyPublic
+	cluster.Spec.Topology.Nodes = api.TopologyPublic
+
 
 	for _, z := range nodeZones {
 		cluster.Spec.Zones = append(cluster.Spec.Zones, &api.ClusterZoneSpec{


### PR DESCRIPTION
So I am trying to get the kops API example working - still running into issues

Please can I get some feedback if you guys get time @chrislovecnm or @justinsb - This looks like a k8s API issue.. maybe something to do with `kops.InstanceGroup` not being registered as `api.InstanceGroup` as well

Anyway - you will want this code to replicate the problem..

**The problem**

```
Queen-Of-Production-2:kops kris$ make examples && kops-api-example -name api1.example.com -zones us-east-1c
go install k8s.io/kops/examples/kops-api-example/...
error from up: error writing instancegroup: error marshalling object: error encoding object: no kind is registered for the type kops.InstanceGroup
```