### PR TITLE
VFS: Be more lenient in List if ClusterVFS.find can't read the cluster

### DIFF
--- a/pkg/client/simple/vfsclientset/cluster.go
+++ b/pkg/client/simple/vfsclientset/cluster.go
@@ -69,11 +69,13 @@ func (c *ClusterVFS) List(options k8sapi.ListOptions) (*api.ClusterList, error) 
 	for _, clusterName := range names {
 		cluster, err := c.find(clusterName)
 		if err != nil {
-			return nil, err
+			glog.Warningf("cluster %q found in state store listing, but cannot be loaded: %v", clusterName, err)
+			continue
 		}
 
 		if cluster == nil {
-			return nil, fmt.Errorf("cluster not found %q", clusterName)
+			glog.Warningf("cluster %q found in state store listing, but doesn't exist now", clusterName)
+			continue
 		}
 
 		items = append(items, *cluster)


### PR DESCRIPTION
I believe S3 eventual consistency doesn't really guarantee much here,
so a delete by one kops instance and a list by another could easily
generate this.

Fixes #917