### PR TITLE
Fix generated private subenet CIDR overlap with VPC range

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -488,7 +488,7 @@ func (z *ClusterZoneSpec) assignCIDR(c *Cluster) error {
 	// We assume a maximum of 8 subnets per network
 	// TODO: Does this make sense on GCE?
 	// TODO: Should we limit this to say 1000 IPs per subnet? (any reason to?)
-	index = index % 8
+	index = index % 8 - 1
 	networkLength += 3
 
 	ip4 := cidr.IP.To4()


### PR DESCRIPTION
Without this fix, last generated private subnet address overlaps with main CIDR range provided via --network-cidr= option, which causes error.
For example before change, with  --network-cidr=10.0.0.0/22, the list of subnets generated by the code was:

```
I1117 07:34:24.720380   47964 cluster.go:503] Assigned CIDR 10.0.1.128/25 to zone us-east-1c
I1117 07:34:24.720397   47964 cluster.go:514] Assigned Private CIDR 10.0.3.0/25 to zone us-east-1c
I1117 07:34:24.720404   47964 cluster.go:503] Assigned CIDR 10.0.2.0/25 to zone us-east-1d
I1117 07:34:24.720409   47964 cluster.go:514] Assigned Private CIDR 10.0.3.128/25 to zone us-east-1d
I1117 07:34:24.720415   47964 cluster.go:503] Assigned CIDR 10.0.2.128/25 to zone us-east-1e
I1117 07:34:24.720420   47964 cluster.go:514] Assigned Private CIDR 10.0.4.0/25 to zone us-east-1e
```

The last CIDR 10.0.4.0/25 is beyond 10.0.0.0/22 boundaries, which causes the error:

```
W1117 07:39:29.240474   48009 executor.go:100] error running task "subnet/private-us-east-1e.kubpriv.pink-ptdevcloud.com": error creating subnet: InvalidSubnet.Range: The CIDR '10.0.4.0/25' is invalid.
	status code: 400, request id: b195c64b-0a35-413c-b6ec-d7ee40d49adb
```

With a code fix, subnets get generated in a correct way:

```
I1118 07:22:31.466899   55710 cluster.go:503] Assigned CIDR 10.0.1.0/25 to zone us-east-1c
I1118 07:22:31.466908   55710 cluster.go:514] Assigned Private CIDR 10.0.2.128/25 to zone us-east-1c
I1118 07:22:31.466913   55710 cluster.go:503] Assigned CIDR 10.0.1.128/25 to zone us-east-1d
I1118 07:22:31.466917   55710 cluster.go:514] Assigned Private CIDR 10.0.3.0/25 to zone us-east-1d
I1118 07:22:31.466922   55710 cluster.go:503] Assigned CIDR 10.0.2.0/25 to zone us-east-1e
I1118 07:22:31.466925   55710 cluster.go:514] Assigned Private CIDR 10.0.3.128/25 to zone us-east-1e

```