### PR TITLE
Wait for NatGateway creation to complete

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/route.go
+++ b/upup/pkg/fi/cloudup/awstasks/route.go
@@ -155,6 +155,15 @@ func (_ *Route) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Route) error {
 		} else if e.InternetGateway != nil {
 			request.GatewayId = checkNotNil(e.InternetGateway.ID)
 		} else if e.NatGateway != nil {
+			// It takes 'forever' (up to 5 min...) for a NatGateway to become available after it has been created
+			// We have to wait untill it is actualy up
+			params := &ec2.DescribeNatGatewaysInput{
+				NatGatewayIds: []*string{e.NatGateway.ID},
+			}
+			err := t.Cloud.EC2().WaitUntilNatGatewayAvailable(params)
+			if err != nil {
+				return fmt.Errorf("error creating Route: %v", err)
+			}
 			request.NatGatewayId = checkNotNil(e.NatGateway.ID)
 		}
 
@@ -182,6 +191,15 @@ func (_ *Route) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Route) error {
 		} else if e.InternetGateway != nil {
 			request.GatewayId = checkNotNil(e.InternetGateway.ID)
 		} else if e.NatGateway != nil {
+			// It takes 'forever' (up to 5 min...) for a NatGateway to become available after it has been created
+			// We have to wait untill it is actualy up
+			params := &ec2.DescribeNatGatewaysInput{
+				NatGatewayIds: []*string{e.NatGateway.ID},
+			}
+			err := t.Cloud.EC2().WaitUntilNatGatewayAvailable(params)
+			if err != nil {
+				return fmt.Errorf("error creating Route: %v", err)
+			}
 			request.NatGatewayId = checkNotNil(e.NatGateway.ID)
 		}
 


### PR DESCRIPTION
NatGateway creation in AWS is a long procedure. It can take up to 10 min for NatGateway to go from Pending to Available state.
We have to use WaitUntilNatGatewayAvailable function to make sure that NatGateway is fully up before trying to use it.
Without this change all my tests attempts to create or update (add nodes to) kubernetis cluster with private topology in us-east-1 region failed with error:

```
W1117 12:14:08.719010   51863 executor.go:100] error running task "route/private-us-east-1c.kubpriv.pink-ptdevcloud.com": error creating Route: InvalidNatGatewayID.NotFound: The natGateway ID 'nat-08be6e70ddffd44d4' does not exist
	status code: 400, request id: 5adf5c0a-c12f-4d6b-8dfd-186c51efff9f
```