### PR TITLE
Protokube should mount volumes in a consistent order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ codegen: kops-gobindata
 test:
 	go test k8s.io/kops/pkg/... -args -v=1 -logtostderr
 	go test k8s.io/kops/upup/pkg/... -args -v=1 -logtostderr
+	go test k8s.io/kops/protokube/... -args -v=1 -logtostderr
 	go test k8s.io/kops/dns-controller/pkg/... -args -v=1 -logtostderr
 	go test k8s.io/kops/cmd/... -args -v=1 -logtostderr
 

--- a/protokube/pkg/protokube/volume_mounter.go
+++ b/protokube/pkg/protokube/volume_mounter.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"os"
+	"sort"
 	"time"
 )
 
@@ -193,6 +194,8 @@ func (k *VolumeMountController) attachMasterVolumes() ([]*Volume, error) {
 	}
 
 	if len(tryAttach) != 0 {
+		sort.Stable(ByEtcdClusterName(tryAttach))
+
 		for _, v := range tryAttach {
 			glog.V(2).Infof("Trying to mount master volume: %q", v.ID)
 
@@ -209,4 +212,27 @@ func (k *VolumeMountController) attachMasterVolumes() ([]*Volume, error) {
 	}
 
 	return attached, nil
+}
+
+// ByEtcdClusterName sorts volumes so that we mount in a consistent order,
+// and in particular we try to mount the main etcd volume before the events etcd volume
+type ByEtcdClusterName []*Volume
+
+func (a ByEtcdClusterName) Len() int {
+	return len(a)
+}
+func (a ByEtcdClusterName) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+func (a ByEtcdClusterName) Less(i, j int) bool {
+	nameI := ""
+	if len(a[i].Info.EtcdClusters) > 0 {
+		nameI = a[i].Info.EtcdClusters[0].ClusterKey
+	}
+	nameJ := ""
+	if len(a[j].Info.EtcdClusters) > 0 {
+		nameJ = a[j].Info.EtcdClusters[0].ClusterKey
+	}
+	// reverse so "main" comes before "events"
+	return nameI > nameJ
 }

--- a/protokube/pkg/protokube/volume_mounter_test.go
+++ b/protokube/pkg/protokube/volume_mounter_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protokube
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+func getIDs(volumes []*Volume) string {
+	var ids []string
+	for _, v := range volumes {
+		ids = append(ids, v.ID)
+	}
+	return strings.Join(ids, ",")
+}
+
+func Test_VolumeSort_ByEtcdClusterName(t *testing.T) {
+	v1 := &Volume{}
+	v1.ID = "1"
+	v2 := &Volume{}
+	v2.ID = "2"
+	v3 := &Volume{}
+	v3.ID = "3"
+
+	volumes := []*Volume{v1, v2, v3}
+	sort.Stable(ByEtcdClusterName(volumes))
+	if getIDs(volumes) != "1,2,3" {
+		t.Fatalf("Fail at sort 1: %v", getIDs(volumes))
+	}
+
+	v2.Info.EtcdClusters = append(v2.Info.EtcdClusters, &EtcdClusterSpec{ClusterKey: "events"})
+	sort.Stable(ByEtcdClusterName(volumes))
+	if getIDs(volumes) != "2,1,3" {
+		t.Fatalf("Fail at sort 2: %v", getIDs(volumes))
+	}
+
+	v3.Info.EtcdClusters = append(v3.Info.EtcdClusters, &EtcdClusterSpec{ClusterKey: "main"})
+	sort.Stable(ByEtcdClusterName(volumes))
+	if getIDs(volumes) != "3,2,1" {
+		t.Fatalf("Fail at sort 3: %v", getIDs(volumes))
+	}
+
+}


### PR DESCRIPTION
And always mounting the main volume first should be a little faster

Fix #934

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/947)
<!-- Reviewable:end -->
