### PR TITLE
De-duplicate documentation

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -1,5 +1,7 @@
 # Bringing up a cluster on AWS
 
+[This guide is incomplete.  See here for updated documentation](http://kubernetes.io/docs/getting-started-guides/kops/)
+
 * Ensure you have kubectl installed and on your path.  (We need it to set kubecfg configuration.)
 
 * Set up a DNS hosted zone in Route 53, e.g. `mydomain.com`, and set up the DNS nameservers as normal


### PR DESCRIPTION
There are two versions of this documentation.  Neither describe how to make a separate zone correctly on AWS, and this causes issues like: https://github.com/kubernetes/kops/issues/859