### PR TITLE
fix the aws region that hardcoded to "us-east-1" 

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -38,7 +38,11 @@ func ValidateRegion(region string) error {
 		glog.V(2).Infof("Querying EC2 for all valid regions")
 
 		request := &ec2.DescribeRegionsInput{}
-		config := aws.NewConfig().WithRegion("us-east-1")
+		awsRegion := os.Getenv("KOPS_AWS_REGION")
+		if awsRegion == "" {
+			awsRegion = "us-east-1"
+		}
+		config := aws.NewConfig().WithRegion(awsRegion)
 		client := ec2.New(session.New(), config)
 
 		response, err := client.DescribeRegions(request)

--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -38,7 +38,7 @@ func ValidateRegion(region string) error {
 		glog.V(2).Infof("Querying EC2 for all valid regions")
 
 		request := &ec2.DescribeRegionsInput{}
-		awsRegion := os.Getenv("KOPS_AWS_REGION")
+		awsRegion := os.Getenv("AWS_REGION")
 		if awsRegion == "" {
 			awsRegion = "us-east-1"
 		}

--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -67,7 +67,7 @@ func (s *S3Context) getRegionForBucket(bucket string) (string, error) {
 	}
 
 	// Probe to find correct region for bucket
-	awsRegion := os.Getenv("KOPS_AWS_REGION")
+	awsRegion := os.Getenv("AWS_REGION")
 	if awsRegion == "" {
 		awsRegion = "us-east-1"
 	}

--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/golang/glog"
+	"os"
 	"sync"
 )
 
@@ -66,7 +67,11 @@ func (s *S3Context) getRegionForBucket(bucket string) (string, error) {
 	}
 
 	// Probe to find correct region for bucket
-	s3Client, err := s.getClient("us-east-1")
+	awsRegion := os.Getenv("KOPS_AWS_REGION")
+	if awsRegion == "" {
+		awsRegion = "us-east-1"
+	}
+	s3Client, err := s.getClient(awsRegion)
 	if err != nil {
 		return "", fmt.Errorf("unable to get client for querying s3 bucket location: %v", err)
 	}


### PR DESCRIPTION
When i run `kops` in some isolated region, it does not work as expected.

the error message looks like this:
```
Using config file: /home/vagrant/.kops.yaml
I1121 09:05:25.618724   21083 s3context.go:82] Querying S3 for bucket location for "xxx"

error reading cluster configuration "xxx": error reading s3://xxx/config: error getting location for S3 bucket "xxx": InvalidAccessKeyId: The AWS Access Key Id you provided does not exist in our records.
	status code: 403, request id: xxx
```

So i add an env `KOPS_AWS_REGION` which can be overriden in such situation:)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/961)
<!-- Reviewable:end -->
