### PR TITLE
support more zones(cn-north-1a/b) for cloud provider guess

### DIFF
--- a/upup/pkg/fi/cloud.go
+++ b/upup/pkg/fi/cloud.go
@@ -103,6 +103,9 @@ var zonesToCloud = map[string]CloudProviderID{
 	"sa-east-1c": CloudProviderAWS,
 	"sa-east-1d": CloudProviderAWS,
 	"sa-east-1e": CloudProviderAWS,
+
+	"cn-north-1a": CloudProviderAWS,
+	"cn-north-1b": CloudProviderAWS,
 }
 
 // GuessCloudForZone tries to infer the cloudprovider from the zone name


### PR DESCRIPTION
When running kops with `--zones=cn-north-1a` it reports `unable to infer CloudProvider from Zones (is there a typo in --zones?)`

So add the only two available zones for that:)