### PR TITLE
Adding backwards support for non-topology validation

### DIFF
--- a/pkg/apis/kops/validation.go
+++ b/pkg/apis/kops/validation.go
@@ -293,6 +293,18 @@ func (c *Cluster) Validate(strict bool) error {
 	}
 
 	// Topology support
+	if c.Spec.Topology == nil {
+		// This is a case of an older cluster making changes with newer code.. Adding this in for backwards
+		// compatibility.. Putting this in validation because it can be called from a few places in the code
+		// base.. all of which make the assumption that the validation should work for their current
+		// representation of the cluster..
+		// @kris-nova
+		// #960
+		// #943
+		c.Spec.Topology = &TopologySpec{Masters: TopologyPublic, Nodes: TopologyPublic}
+	}
+
+
 	if c.Spec.Topology.Masters != "" && c.Spec.Topology.Nodes != "" {
 		if c.Spec.Topology.Masters != TopologyPublic && c.Spec.Topology.Masters != TopologyPrivate {
 			return fmt.Errorf("Invalid Masters value for Topology")


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kops/issues/960 and https://github.com/kubernetes/kops/issues/943

See my note in the codebase - this is for **backwards compatibility** only..

This is a huge contender in the API discussion, and a great example of how delicate our codebase is and how we need to be strict whenever possible.

