### PR TITLE
Bumping stable channel to k8s 1.4.6

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -3,6 +3,6 @@ spec:
     - name: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
       providerID: aws
   cluster:
-    kubernetesVersion: v1.4.3
+    kubernetesVersion: v1.4.6
     networking:
       kubenet: {}


### PR DESCRIPTION
Have not done integration testing. Will test and move out of [WIP] when I do.  This will close https://github.com/kubernetes/kops/issues/978