### PR TITLE
Fix retries for AutoScalingGroup pending delete

### DIFF
--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -18,6 +18,11 @@ package cloudup
 
 import (
 	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/golang/glog"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/registry"
@@ -34,16 +39,13 @@ import (
 	"k8s.io/kops/util/pkg/vfs"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	k8sapi "k8s.io/kubernetes/pkg/api"
-	"net"
-	"os"
-	"strings"
 )
 
 const (
 	NodeUpVersion = "1.4.1"
 )
 
-const MaxAttemptsWithNoProgress = 3
+const MaxTaskDuration = 10 * time.Minute
 
 var CloudupModels = []string{"config", "proto", "cloudup"}
 
@@ -555,7 +557,7 @@ func (c *ApplyClusterCmd) Run() error {
 	}
 	defer context.Close()
 
-	err = context.RunTasks(MaxAttemptsWithNoProgress)
+	err = context.RunTasks(MaxTaskDuration)
 	if err != nil {
 		return fmt.Errorf("error running tasks: %v", err)
 	}

--- a/upup/pkg/fi/context.go
+++ b/upup/pkg/fi/context.go
@@ -18,12 +18,14 @@ package fi
 
 import (
 	"fmt"
-	"github.com/golang/glog"
 	"io/ioutil"
-	"k8s.io/kops/util/pkg/vfs"
 	"os"
 	"reflect"
 	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/kops/util/pkg/vfs"
 )
 
 type Context struct {
@@ -64,11 +66,11 @@ func (c *Context) AllTasks() map[string]Task {
 	return c.tasks
 }
 
-func (c *Context) RunTasks(maxAttemptsWithNoProgress int) error {
+func (c *Context) RunTasks(maxTaskDuration time.Duration) error {
 	e := &executor{
 		context: c,
 	}
-	return e.RunTasks(c.tasks, maxAttemptsWithNoProgress)
+	return e.RunTasks(c.tasks, maxTaskDuration)
 }
 
 func (c *Context) Close() {

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	api "k8s.io/kops/pkg/apis/kops"
@@ -37,7 +38,7 @@ import (
 )
 
 // We should probably retry for a long time - there is not really any great fallback
-const MaxAttemptsWithNoProgress = 100
+const MaxTaskDuration = 365 * 24 * time.Hour
 
 type NodeUpCommand struct {
 	config         *NodeUpConfig
@@ -230,7 +231,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 	}
 	defer context.Close()
 
-	err = context.RunTasks(MaxAttemptsWithNoProgress)
+	err = context.RunTasks(MaxTaskDuration)
 	if err != nil {
 		glog.Exitf("error running tasks: %v", err)
 	}

--- a/upup/pkg/kutil/utils.go
+++ b/upup/pkg/kutil/utils.go
@@ -18,6 +18,7 @@ package kutil
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/golang/glog"
@@ -69,6 +70,11 @@ func findAutoscalingGroups(cloud awsup.AWSCloud, tags map[string]string) ([]*aut
 			for _, asg := range p.AutoScalingGroups {
 				if !matchesAsgTags(tags, asg.Tags) {
 					// We used an inexact filter above
+					continue
+				}
+				// Check for "Delete in progress" (the only use of .Status)
+				if asg.Status != nil {
+					glog.Warningf("Skipping ASG %v (which matches tags): %v", *asg.AutoScalingGroupARN, *asg.Status)
 					continue
 				}
 				asgs = append(asgs, asg)


### PR DESCRIPTION
This:
- reworks how retries are handled in fi/executor.go to a time-based scheme
- changes the single-task limit to 10m (from about 30s of no-progress)
- eliminates the inner IAM propagation retry for `LaunchConfigurations`, because the task itself will just be redriven for a while. This also eliminates any long-pole delay caused by this error (since task `Run()` should be 'fast').

Fixes #844 