### PR TITLE
gcs-upload: Fix cache-control on other files as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ gcs-upload: version-dist
 	@echo "== Logging gcloud info =="
 	@gcloud info
 	@echo "== Uploading kops =="
-	gsutil -m rsync -r .build/upload/kops ${GCS_LOCATION}
+	gsutil -h "Cache-Control:private, max-age=0, no-transform" -m rsync -r .build/upload/kops ${GCS_LOCATION}
 
 gcs-publish-ci: gcs-upload
 	echo "${GCS_URL}/${VERSION}" > .build/upload/${LATEST_FILE}


### PR DESCRIPTION
This is a quick fix to the `updown` issues. I also need a test-infra fix to stop it. c.f. https://github.com/kubernetes/kubernetes/issues/36328

Slamming this in TBR to stabilize the build.