### PR TITLE
gcs-upload: Use a no-clobber copy instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ gcs-upload: version-dist
 	@echo "== Logging gcloud info =="
 	@gcloud info
 	@echo "== Uploading kops =="
-	gsutil -h "Cache-Control:private, max-age=0, no-transform" -m rsync -r .build/upload/kops ${GCS_LOCATION}
+	gsutil -h "Cache-Control:private, max-age=0, no-transform" -m cp -n -r .build/upload/kops/* ${GCS_LOCATION}
 
 gcs-publish-ci: gcs-upload
 	echo "${GCS_URL}/${VERSION}" > .build/upload/${LATEST_FILE}


### PR DESCRIPTION
This skips the upload entirely if the contents are there, which should eliminate any remote chance of slicing the binary objects while I wait for https://github.com/kubernetes/test-infra/pull/1213 to be resolved.

c.f. #1011 