### PR TITLE
cleaning up go versions in ci and Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: go
 go:
-  #- 1.5  go test arguments are different in 1.5 :-(
-  - 1.6
   - 1.7
   - tip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 go:
+  #- 1.5  go test arguments are different in 1.5 :-(
+  #- 1.6 issues with OSX release, and 1.7 is required now by core
   - 1.7
   - tip
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ GCS_URL=$(GCS_LOCATION:gs://%=https://storage.googleapis.com/%)
 LATEST_FILE?=latest-ci.txt
 GOPATH_1ST=$(shell echo ${GOPATH} | cut -d : -f 1)
 UNIQUE:=$(shell date +%s)
-GOVERSION=1.7.1
+GOVERSION=1.7.4
 
 # See http://stackoverflow.com/questions/18136918/how-to-get-current-relative-directory-of-your-makefile
 MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))


### PR DESCRIPTION
Removing 1.6 build from travis, and bumping go version to 1.7.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1061)
<!-- Reviewable:end -->
