### PR TITLE
Add path.module to Terraform output

### DIFF
--- a/upup/pkg/fi/cloudup/terraform/target.go
+++ b/upup/pkg/fi/cloudup/terraform/target.go
@@ -84,7 +84,7 @@ func (t *TerraformTarget) AddFile(resourceType string, resourceName string, key 
 	p := path.Join("data", id)
 	t.files[p] = d
 
-	l := LiteralExpression(fmt.Sprintf("${file(%q)}", p))
+	l := LiteralExpression(fmt.Sprintf("${file(%q)}", path.Join("${path.module}", p)))
 	return l, nil
 }
 


### PR DESCRIPTION
Adds `${path.module}` to `data/...` references so one can nest the `--target terraform --out ./cluster-1` generated terraform scripts as a module.

e.g.

```terraform
module "vpc" {
    source = "./vpc"

    cidr_block = "${var.vpc_cidr}"
    enable_dns_support = true
    enable_dns_hostnames = true
}

module "dns" {
    source = "./dns"

    name = "${var.private_dns_name}"
    vpc_id = "${module.vpc.id}"
}

module "rds_network" {
    source = "./rds-network"

    vpc_id = "${module.vpc.id}"
    az1 = "${var.az1}"
    az2 = "${var.az2}"
    private_cidr_az1 = "${var.az1_rds_private_cidr}"
    private_cidr_az2 = "${var.az2_rds_private_cidr}"
}

module "cluster_1" {
    source = "./cluster-1"
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1062)
<!-- Reviewable:end -->
