### PR TITLE
Do not check DNS when Topology is Private

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -58,6 +58,7 @@ type CreateClusterOptions struct {
 	AdminAccess       string
 	Networking        string
 	AssociatePublicIP bool
+	IgnoreNSCheck     bool
 
 	// Channel is the location of the api.Channel to use for our defaults
 	Channel string
@@ -144,6 +145,8 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 
 	// Bastion
 	cmd.Flags().BoolVar(&options.Bastion, "bastion", options.Bastion, "Specify --bastion=[true|false] to turn enable/disable bastion setup. Default to 'false' when topology is 'public' and defaults to 'true' if topology is 'private'.")
+
+	cmd.Flags().BoolVar(&options.IgnoreNSCheck, "ignore-ns-check", false, "Specify --ignore-ns-check=[true|false] to ignore NS record checks. Default is 'false'.")
 
 	return cmd
 }

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -58,7 +58,6 @@ type CreateClusterOptions struct {
 	AdminAccess       string
 	Networking        string
 	AssociatePublicIP bool
-	IgnoreNSCheck     bool
 
 	// Channel is the location of the api.Channel to use for our defaults
 	Channel string
@@ -145,8 +144,6 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 
 	// Bastion
 	cmd.Flags().BoolVar(&options.Bastion, "bastion", options.Bastion, "Specify --bastion=[true|false] to turn enable/disable bastion setup. Default to 'false' when topology is 'public' and defaults to 'true' if topology is 'private'.")
-
-	cmd.Flags().BoolVar(&options.IgnoreNSCheck, "ignore-ns-check", false, "Specify --ignore-ns-check=[true|false] to ignore NS record checks. Default is 'false'.")
 
 	return cmd
 }
@@ -436,6 +433,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		cluster.Spec.Topology = &api.TopologySpec{
 			Masters: api.TopologyPublic,
 			Nodes:   api.TopologyPublic,
+			DNS:     api.TopologyPublic,
 			//Bastion: &api.BastionSpec{Enable: c.Bastion},
 		}
 
@@ -454,6 +452,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		cluster.Spec.Topology = &api.TopologySpec{
 			Masters: api.TopologyPrivate,
 			Nodes:   api.TopologyPrivate,
+			DNS:     api.TopologyPrivate,
 		}
 
 		for i := range cluster.Spec.Subnets {

--- a/examples/kops-api-example/up.go
+++ b/examples/kops-api-example/up.go
@@ -40,6 +40,7 @@ func up() error {
 	}
 	cluster.Spec.Topology.Masters = api.TopologyPublic
 	cluster.Spec.Topology.Nodes = api.TopologyPublic
+	cluster.Spec.Topology.DNS = api.TopologyPublic
 
 	for _, z := range nodeZones {
 		cluster.Spec.Subnets = append(cluster.Spec.Subnets, api.ClusterSubnetSpec{

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -135,9 +135,6 @@ type ClusterSpec struct {
 	//   missing: default policy (currently OS security upgrades that do not require a reboot)
 	UpdatePolicy *string `json:"updatePolicy,omitempty"`
 
-	// IgnoreNSCheck determines whether to ignore checks that verify the NS record is available.
-	IgnoreNSCheck *bool `json:"ignoreNSCheck,omitempty"`
-
 	//HairpinMode                   string `json:",omitempty"`
 	//
 	//OpencontrailTag               string `json:",omitempty"`

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -135,6 +135,9 @@ type ClusterSpec struct {
 	//   missing: default policy (currently OS security upgrades that do not require a reboot)
 	UpdatePolicy *string `json:"updatePolicy,omitempty"`
 
+	// IgnoreNSCheck determines whether to ignore checks that verify the NS record is available.
+	IgnoreNSCheck *bool `json:"ignoreNSCheck,omitempty"`
+
 	//HairpinMode                   string `json:",omitempty"`
 	//
 	//OpencontrailTag               string `json:",omitempty"`

--- a/pkg/apis/kops/topology.go
+++ b/pkg/apis/kops/topology.go
@@ -34,4 +34,7 @@ type TopologySpec struct {
 	// or disable inbound SSH communication from the Internet, some call bastion
 	// as the "jump server".
 	Bastion *BastionSpec `json:"bastion,omitempty"`
+
+	// DNS Hosted Zone can be specified as public|private
+	DNS string `json:"dns,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha1/topology.go
+++ b/pkg/apis/kops/v1alpha1/topology.go
@@ -35,4 +35,7 @@ type TopologySpec struct {
 	// or disable inbound SSH communication from the Internet, some call bastion
 	// as the "jump server".
 	Bastion *BastionSpec `json:"bastion,omitempty"`
+
+	// DNS Hosted Zone can be specified as public|private
+	DNS string `json:"dns,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/topology.go
+++ b/pkg/apis/kops/v1alpha2/topology.go
@@ -34,4 +34,7 @@ type TopologySpec struct {
 	// or disable inbound SSH communication from the Internet, some call bastion
 	// as the "jump server".
 	Bastion *BastionSpec `json:"bastion,omitempty"`
+
+	// DNS Hosted Zone can be specified as public|private
+	DNS string `json:"dns,omitempty"`
 }

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -612,24 +612,24 @@ func validateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
 	zone := matches[0]
 	dnsName := strings.TrimSuffix(zone.Name(), ".")
 
-	glog.V(2).Infof("Doing DNS lookup to verify NS records for %q", dnsName)
-	ns, err := net.LookupNS(dnsName)
-	if err != nil {
-		return fmt.Errorf("error doing DNS lookup for NS records for %q: %v", dnsName, err)
-	}
+	if os.Getenv("DNS_IGNORE_NS_CHECK") == "" {
+		glog.V(2).Infof("Doing DNS lookup to verify NS records for %q", dnsName)
+		ns, err := net.LookupNS(dnsName)
+		if err != nil {
+			return fmt.Errorf("error doing DNS lookup for NS records for %q: %v", dnsName, err)
+		}
 
-	if len(ns) == 0 {
-		if os.Getenv("DNS_IGNORE_NS_CHECK") == "" {
+		if len(ns) == 0 {
 			return fmt.Errorf("NS records not found for %q - please make sure they are correctly configured", dnsName)
 		} else {
-			glog.Warningf("Ignoring failed NS record check because DNS_IGNORE_NS_CHECK is set")
+			var hosts []string
+			for _, n := range ns {
+				hosts = append(hosts, n.Host)
+			}
+			glog.V(2).Infof("Found NS records for %q: %v", dnsName, hosts)
 		}
 	} else {
-		var hosts []string
-		for _, n := range ns {
-			hosts = append(hosts, n.Host)
-		}
-		glog.V(2).Infof("Found NS records for %q: %v", dnsName, hosts)
+		glog.Warningf("Ignoring NS record check because DNS_IGNORE_NS_CHECK is set")
 	}
 
 	return nil

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -612,7 +612,7 @@ func validateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
 	zone := matches[0]
 	dnsName := strings.TrimSuffix(zone.Name(), ".")
 
-	if os.Getenv("DNS_IGNORE_NS_CHECK") == "" {
+	if !fi.BoolValue(cluster.Spec.IgnoreNSCheck) {
 		glog.V(2).Infof("Doing DNS lookup to verify NS records for %q", dnsName)
 		ns, err := net.LookupNS(dnsName)
 		if err != nil {
@@ -629,7 +629,7 @@ func validateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
 			glog.V(2).Infof("Found NS records for %q: %v", dnsName, hosts)
 		}
 	} else {
-		glog.Warningf("Ignoring NS record check because DNS_IGNORE_NS_CHECK is set")
+		glog.Warningf("Ignoring NS record check")
 	}
 
 	return nil


### PR DESCRIPTION
Based on @billyshambrook PR #810 and conversation.

I was not 100% certain how to implement @justinsb comments but wanted to give this an attempt using the new `--topology private` settings.

Preference on the name? `DNS` = `public` or `private`

The feature (or similar) would certainly be useful in our configurations where `<env>.company.internal` designation is typically used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1063)
<!-- Reviewable:end -->
