### PR TITLE
Adding sanity check for natgateways

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -49,6 +49,7 @@ func (e *NatGateway) Find(c *fi.Context) (*NatGateway, error) {
 		var filters []*ec2.Filter
 		filters = append(filters, awsup.NewEC2Filter("key", "AssociatedNatgateway"))
 		if e.Subnet.ID == nil {
+			glog.V(2).Infof("Unable to find subnet, bypassing Find() for NGW")
 			return nil, nil
 		}
 		filters = append(filters, awsup.NewEC2Filter("resource-id", *e.Subnet.ID))

--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -48,6 +48,9 @@ func (e *NatGateway) Find(c *fi.Context) (*NatGateway, error) {
 	if id == nil && e.Subnet != nil {
 		var filters []*ec2.Filter
 		filters = append(filters, awsup.NewEC2Filter("key", "AssociatedNatgateway"))
+		if e.Subnet.ID == nil {
+			return nil, nil
+		}
 		filters = append(filters, awsup.NewEC2Filter("resource-id", *e.Subnet.ID))
 
 		request := &ec2.DescribeTagsInput{


### PR DESCRIPTION
Found an edge case where this was breaking with single nested cluster names. This fix will patch the bug.

```
Goddess-Of-Production:kops kris$ make; kops create cluster --node-count 3   --zones us-west-2a,us-west-2b,us-west-2c   --master-zones us-west-2a,us-west-2b,us-west-2c   --cloud aws --dns-zone nivenly.com --topology private --networking weave --image 293135079892/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-11-16 $NAME 
go build  -ldflags "" -o /go/bin/go-bindata k8s.io/kops/vendor/github.com/jteeuwen/go-bindata/go-bindata
cd /go/src/k8s.io/kops; /go/bin/go-bindata -o upup/models/bindata.go -pkg models -ignore="\\.DS_Store" -ignore="bindata\\.go" -ignore="vfs\\.go" -prefix upup/models/ upup/models/...
cd /go/src/k8s.io/kops; /go/bin/go-bindata -o federation/model/bindata.go -pkg model -ignore="\\.DS_Store" -ignore="bindata\\.go" -prefix federation/model/ federation/model/...
go install  -ldflags "-X main.BuildVersion=git-be5fd71 " k8s.io/kops/cmd/kops/...
I1206 23:42:30.168980    8350 cluster.go:513] Assigned CIDR 172.20.32.0/19 to zone us-west-2a
I1206 23:42:30.169013    8350 cluster.go:519] Assigned Private CIDR 172.20.4.0/22 to zone us-west-2a
I1206 23:42:30.169033    8350 cluster.go:513] Assigned CIDR 172.20.64.0/19 to zone us-west-2b
I1206 23:42:30.169040    8350 cluster.go:519] Assigned Private CIDR 172.20.8.0/22 to zone us-west-2b
I1206 23:42:30.169053    8350 cluster.go:513] Assigned CIDR 172.20.96.0/19 to zone us-west-2c
I1206 23:42:30.169060    8350 cluster.go:519] Assigned Private CIDR 172.20.12.0/22 to zone us-west-2c
Previewing changes that will be made:

I1206 23:42:33.682286    8350 executor.go:91] Tasks: 0 done / 104 total; 32 can run
I1206 23:42:34.688817    8350 executor.go:91] Tasks: 32 done / 104 total; 21 can run
I1206 23:42:35.216878    8350 executor.go:91] Tasks: 53 done / 104 total; 32 can run
I1206 23:42:35.552523    8350 executor.go:91] Tasks: 85 done / 104 total; 11 can run
*awstasks.Subnet {"Name":"utility-us-west-2c.testcluster.nivenly.com","ID":null,"VPC":{"Name":"testcluster.nivenly.com","ID":null,"CIDR":"172.20.0.0/16","EnableDNSHostnames":true,"EnableDNSSupport":true,"Shared":false},"AvailabilityZone":"us-west-2c","CIDR":"172.20.96.0/19","Shared":false}
*awstasks.Subnet {"Name":"utility-us-west-2a.testcluster.nivenly.com","ID":null,"VPC":{"Name":"testcluster.nivenly.com","ID":null,"CIDR":"172.20.0.0/16","EnableDNSHostnames":true,"EnableDNSSupport":true,"Shared":false},"AvailabilityZone":"us-west-2a","CIDR":"172.20.32.0/19","Shared":false}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa9826a]

goroutine 423 [running]:
panic(0x17ebaa0, 0xc4200120e0)
	/usr/local/Cellar/go/1.7.3/libexec/src/runtime/panic.go:500 +0x1a1
k8s.io/kops/upup/pkg/fi/cloudup/awstasks.(*NatGateway).Find(0xc4206179a0, 0xc420d44460, 0x0, 0x0, 0x0)
	/go/src/k8s.io/kops/upup/pkg/fi/cloudup/awstasks/natgateway.go:52 +0x8ca
reflect.Value.call(0x19663c0, 0xc4206179a0, 0xa13, 0x1a89d70, 0x4, 0xc420f30c60, 0x1, 0x1, 0xc420352980, 0x13, ...)
	/usr/local/Cellar/go/1.7.3/libexec/src/reflect/value.go:434 +0x5c8
reflect.Value.Call(0x19663c0, 0xc4206179a0, 0xa13, 0xc420f30c60, 0x1, 0x1, 0xc4206179a0, 0xa13, 0xc420f08c60)
	/usr/local/Cellar/go/1.7.3/libexec/src/reflect/value.go:302 +0xa4
k8s.io/kops/upup/pkg/fi/utils.InvokeMethod(0x19663c0, 0xc4206179a0, 0x1a89df4, 0x4, 0xc420b87d60, 0x1, 0x1, 0x0, 0x0, 0xc4204aa400, ...)
	/go/src/k8s.io/kops/upup/pkg/fi/utils/reflect.go:58 +0x41a
k8s.io/kops/upup/pkg/fi.invokeFind(0x27937e0, 0xc4206179a0, 0xc420d44460, 0xc420a4feb8, 0x1bc9b00, 0x10, 0x10)
	/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:97 +0xd0
k8s.io/kops/upup/pkg/fi.DefaultDeltaRunMethod(0x27937e0, 0xc4206179a0, 0xc420d44460, 0xc420469b30, 0xc420951f88)
	/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:36 +0x6f9
k8s.io/kops/upup/pkg/fi/cloudup/awstasks.(*NatGateway).Run(0xc4206179a0, 0xc420d44460, 0x16, 0xc420a4ff58)
	/go/src/k8s.io/kops/upup/pkg/fi/cloudup/awstasks/natgateway.go:139 +0x41
k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc420e8c2c0, 0xb, 0xb, 0xc4202de2f0, 0xc420030370, 0xc420951f80, 0x2)
	/go/src/k8s.io/kops/upup/pkg/fi/executor.go:157 +0x1df
created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
	/go/src/k8s.io/kops/upup/pkg/fi/executor.go:158 +0x132
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1084)
<!-- Reviewable:end -->
