### PR TITLE
DryRun output: Don't print task type twice

### DIFF
--- a/upup/pkg/fi/dryrun_target.go
+++ b/upup/pkg/fi/dryrun_target.go
@@ -82,9 +82,14 @@ func (t *DryRunTarget) Delete(deletion Deletion) error {
 	return nil
 }
 
-func IdForTask(taskMap map[string]Task, t Task) string {
+func idForTask(taskMap map[string]Task, t Task) string {
 	for k, v := range taskMap {
 		if v == t {
+			// Skip task type, if present (taskType/taskName)
+			firstSlash := strings.Index(k, "/")
+			if firstSlash != -1 {
+				k = k[firstSlash+1:]
+			}
 			return k
 		}
 	}
@@ -111,7 +116,7 @@ func (t *DryRunTarget) PrintReport(taskMap map[string]Task, out io.Writer) error
 			fmt.Fprintf(b, "Will create resources:\n")
 			for _, r := range creates {
 				taskName := getTaskName(r.changes)
-				fmt.Fprintf(b, "  %-20s\t%s\n", taskName, IdForTask(taskMap, r.e))
+				fmt.Fprintf(b, "  %s/%s\n", taskName, idForTask(taskMap, r.e))
 
 				changes := reflect.ValueOf(r.changes)
 				if changes.Kind() == reflect.Ptr && !changes.IsNil() {
@@ -217,7 +222,7 @@ func (t *DryRunTarget) PrintReport(taskMap map[string]Task, out io.Writer) error
 				}
 
 				taskName := getTaskName(r.changes)
-				fmt.Fprintf(b, "  %-20s\t%s\n", taskName, IdForTask(taskMap, r.e))
+				fmt.Fprintf(b, "  %s/%s\n", taskName, idForTask(taskMap, r.e))
 				for _, change := range changeList {
 					lines := strings.Split(change.Description, "\n")
 					if len(lines) == 1 {


### PR DESCRIPTION
We were printing the task type, and then the task key, which includes
the task type.  So we were printing `TaskName TaskName/TaskKey`

Strip the task type out of the task key: `TaskName/TaskKey`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1102)
<!-- Reviewable:end -->
