### PR TITLE
Bind internal names for services to their ClusterIPs.

### DIFF
--- a/dns-controller/README.md
+++ b/dns-controller/README.md
@@ -10,13 +10,12 @@ we just expose it via DNS.
 
 The dns-controller recognizes annotations on nodes.
 
-`dns.alpha.kubernetes.io/external` will set up records for accessing the resource externally
-
-`dns.alpha.kubernetes.io/internal` will set up records for accessing the resource internally
+* `dns.alpha.kubernetes.io/external` will set up records for accessing the resource externally
+* `dns.alpha.kubernetes.io/internal` will set up records for accessing the resource internally
 
 When added on `Service` controllers:
 
-`dns.alpha.kubernetes.io/external` creates a Route53 A record with `public` IPs of all the nodes
-`dns.alpha.kubernetes.io/internal` creates a Route53 A record with `private` IPs of all the nodes
+* `dns.alpha.kubernetes.io/external` creates a Route53 A record with the IPs of the load balancer (type=LoadBalancer) or all the nodes (type=NodePort)
+* `dns.alpha.kubernetes.io/internal` creates a Route53 A record with spec.clusterIP of the service
 
 The syntax is a comma separated list of fully qualified domain names.

--- a/dns-controller/pkg/watchers/annotations.go
+++ b/dns-controller/pkg/watchers/annotations.go
@@ -21,5 +21,5 @@ package watchers
 const AnnotationNameDnsExternal = "dns.alpha.kubernetes.io/external"
 
 // AnnotationNameDnsInternal is used to set up a DNS name for accessing the resource from inside the cluster
-// This is only supported on Pods currently, and maps to the Internal address
+// For Pods it maps to the Internal address, for Services it maps to the ClusterIP.
 const AnnotationNameDnsInternal = "dns.alpha.kubernetes.io/internal"


### PR DESCRIPTION
All types of services have clusterIPs, and that's the most performant way to access them internally, so they should be used for all internal records.

Somewhat reverts https://github.com/kubernetes/kops/pull/922.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1104)
<!-- Reviewable:end -->
