### PR TITLE
dryrun output: include name instead of id:nil

### DIFF
--- a/upup/pkg/fi/dryrun_target.go
+++ b/upup/pkg/fi/dryrun_target.go
@@ -338,7 +338,17 @@ func ValueAsString(value reflect.Value) string {
 			} else if compareWithID, ok := intf.(CompareWithID); ok {
 				id := compareWithID.CompareWithID()
 				if id == nil {
-					fmt.Fprintf(b, "id:<nil>")
+					// Uninformative, but we can often print the name instead
+					name := ""
+					hasName, ok := intf.(HasName)
+					if ok {
+						name = StringValue(hasName.GetName())
+					}
+					if name != "" {
+						fmt.Fprintf(b, "name:%s", name)
+					} else {
+						fmt.Fprintf(b, "id:<nil>")
+					}
 				} else {
 					fmt.Fprintf(b, "id:%s", *id)
 				}


### PR DESCRIPTION
When we're creating objects, we tend not to have an id.  Rather than
drop them entirely though, we can print their name (where we have one)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1105)
<!-- Reviewable:end -->
