### PR TITLE
WIP: Fill in RenderTerraform methods for private topology

### DIFF
--- a/upup/models/cloudup/_aws/topologies/_topology_private/network.yaml
+++ b/upup/models/cloudup/_aws/topologies/_topology_private/network.yaml
@@ -190,6 +190,12 @@ loadBalancer/api.{{ ClusterName }}:
   {{ end }}
   listeners:
     443: { instancePort: 443 }
+  healthCheck:
+    target: TCP:443
+    healthyThreshold: 2
+    unhealthyThreshold: 2
+    interval: 10
+    timeout: 5
 
 # ---------------------------------------------------------------
 # Kube-Proxy - Healthz - 10249

--- a/upup/models/cloudup/_aws/topologies/_topology_private/network.yaml
+++ b/upup/models/cloudup/_aws/topologies/_topology_private/network.yaml
@@ -190,6 +190,7 @@ loadBalancer/api.{{ ClusterName }}:
   {{ end }}
   listeners:
     443: { instancePort: 443 }
+  scheme: internal
   healthCheck:
     target: TCP:443
     healthyThreshold: 2

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -302,6 +302,7 @@ func (c *ApplyClusterCmd) Run() error {
 				// ELB
 				"loadBalancer":                       &awstasks.LoadBalancer{},
 				"loadBalancerAttachment":             &awstasks.LoadBalancerAttachment{},
+				"loadBalancerHealthCheck":            &awstasks.LoadBalancerHealthCheck{},
 				"loadBalancerHealthChecks":           &awstasks.LoadBalancerHealthChecks{},
 				"loadBalancerAccessLog":              &awstasks.LoadBalancerAccessLog{},
 				"loadBalancerAdditionalAttribute":    &awstasks.LoadBalancerAdditionalAttribute{},

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
@@ -20,11 +20,13 @@ import (
 	//"fmt"
 	//
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/glog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
 )
 
 //go:generate fitask -type=ElasticIP

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
@@ -210,4 +210,18 @@ func (_ *ElasticIP) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *ElasticIP) e
 	return nil
 }
 
-// TODO Kris - We need to support EIP for Terraform
+type terraformElasticIP struct {
+	VPC *bool `json:"vpc"`
+}
+
+func (_ *ElasticIP) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *ElasticIP) error {
+	tf := &terraformElasticIP{
+		VPC: aws.Bool(true),
+	}
+
+	return t.RenderResource("aws_eip", *e.Name, tf)
+}
+
+func (e *ElasticIP) TerraformLink() *terraform.Literal {
+	return terraform.LiteralProperty("aws_eip", *e.Name, "id")
+}

--- a/upup/pkg/fi/cloudup/awstasks/load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/load_balancer.go
@@ -21,6 +21,8 @@ import (
 
 	"strconv"
 
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/elb"
@@ -28,7 +30,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
-	"strings"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
 )
 
 //go:generate fitask -type=LoadBalancer
@@ -46,6 +48,8 @@ type LoadBalancer struct {
 	SecurityGroups []*SecurityGroup
 
 	Listeners map[string]*LoadBalancerListener
+
+	HealthCheck LoadBalancerHealthCheck
 }
 
 var _ fi.CompareWithID = &LoadBalancer{}
@@ -186,6 +190,7 @@ func (e *LoadBalancer) Find(c *fi.Context) (*LoadBalancer, error) {
 	actual.ID = lb.LoadBalancerName
 	actual.DNSName = lb.DNSName
 	actual.HostedZoneId = lb.CanonicalHostedZoneNameID
+
 	for _, subnet := range lb.Subnets {
 		actual.Subnets = append(actual.Subnets, &Subnet{ID: subnet})
 	}
@@ -322,4 +327,78 @@ func (_ *LoadBalancer) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *LoadBalan
 	}
 
 	return t.AddELBTags(*e.ID, t.Cloud.BuildTags(e.Name))
+}
+
+type terraformLoadBalancer struct {
+	Name           *string                           `json:"name"`
+	Listener       []*terraformLoadBalancerListener  `json:"listener"`
+	SecurityGroups []*terraform.Literal              `json:"security_groups"`
+	Subnets        []*terraform.Literal              `json:"subnets"`
+	HealthCheck    *terraformLoadBalancerHealthCheck `json:"health_check"`
+}
+
+type terraformLoadBalancerListener struct {
+	InstancePort     int    `json:"instance_port"`
+	InstanceProtocol string `json:"instance_protocol"`
+	LBPort           int64  `json:"lb_port"`
+	LBProtocol       string `json:"lb_protocol"`
+}
+
+type terraformLoadBalancerHealthCheck struct {
+	Target             *string `json:"target"`
+	HealthyThreshold   *int64  `json:"healthy_threshold"`
+	UnhealthyThreshold *int64  `json:"unhealthy_threshold"`
+	Interval           *int64  `json:"interval"`
+	Timeout            *int64  `json:"timeout"`
+}
+
+func (_ *LoadBalancer) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *LoadBalancer) error {
+	elbName := e.ID
+	if elbName == nil {
+		elbName = e.Name
+	}
+
+	tf := &terraformLoadBalancer{
+		Name: elbName,
+	}
+
+	for _, subnet := range e.Subnets {
+		tf.Subnets = append(tf.Subnets, subnet.TerraformLink())
+	}
+
+	for _, sg := range e.SecurityGroups {
+		tf.SecurityGroups = append(tf.SecurityGroups, sg.TerraformLink())
+	}
+
+	for loadBalancerPort, listener := range e.Listeners {
+		loadBalancerPortInt, err := strconv.ParseInt(loadBalancerPort, 10, 64)
+		if err != nil {
+			return fmt.Errorf("error parsing load balancer listener port: %q", loadBalancerPort)
+		}
+
+		tf.Listener = append(tf.Listener, &terraformLoadBalancerListener{
+			InstanceProtocol: "TCP",
+			InstancePort:     listener.InstancePort,
+			LBPort:           loadBalancerPortInt,
+			LBProtocol:       "TCP",
+		})
+	}
+
+	tf.HealthCheck = &terraformLoadBalancerHealthCheck{
+		Target:             e.HealthCheck.Target,
+		HealthyThreshold:   e.HealthCheck.HealthyThreshold,
+		UnhealthyThreshold: e.HealthCheck.UnhealthyThreshold,
+		Interval:           e.HealthCheck.Interval,
+		Timeout:            e.HealthCheck.Timeout,
+	}
+
+	return t.RenderResource("aws_elb", *e.Name, tf)
+}
+
+func (e *LoadBalancer) TerraformLink(params ...string) *terraform.Literal {
+	prop := "id"
+	if len(params) > 0 {
+		prop = params[0]
+	}
+	return terraform.LiteralProperty("aws_elb", *e.Name, prop)
 }

--- a/upup/pkg/fi/cloudup/awstasks/loadbalancer_connsettings.go
+++ b/upup/pkg/fi/cloudup/awstasks/loadbalancer_connsettings.go
@@ -19,6 +19,7 @@ package awstasks
 import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
 )
 
 //go:generate fitask -type=LoadBalancerConnectionSettings
@@ -80,5 +81,9 @@ func (s *LoadBalancerConnectionSettings) CheckChanges(a, e, changes *LoadBalance
 }
 
 func (_ *LoadBalancerConnectionSettings) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *LoadBalancerConnectionSettings) error {
+	return nil
+}
+
+func (_ *LoadBalancerConnectionSettings) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *LoadBalancerConnectionSettings) error {
 	return nil
 }

--- a/upup/pkg/fi/cloudup/awstasks/loadbalancer_healthchecks.go
+++ b/upup/pkg/fi/cloudup/awstasks/loadbalancer_healthchecks.go
@@ -23,11 +23,10 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
 )
 
-type LoadBalancerHealthChecks struct {
-	LoadBalancer *LoadBalancer
-
+type LoadBalancerHealthCheck struct {
 	Target *string
 
 	HealthyThreshold   *int64
@@ -35,6 +34,18 @@ type LoadBalancerHealthChecks struct {
 
 	Interval *int64
 	Timeout  *int64
+}
+
+var _ fi.HasDependencies = &LoadBalancerHealthCheck{}
+
+func (e *LoadBalancerHealthCheck) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+	return nil
+}
+
+type LoadBalancerHealthChecks struct {
+	LoadBalancerHealthCheck
+
+	LoadBalancer *LoadBalancer
 }
 
 func (e *LoadBalancerHealthChecks) String() string {
@@ -102,5 +113,10 @@ func (_ *LoadBalancerHealthChecks) RenderAWS(t *awsup.AWSAPITarget, a, e, change
 		return fmt.Errorf("error attaching autoscaling group to ELB: %v", err)
 	}
 
+	return nil
+}
+
+func (_ *LoadBalancerHealthChecks) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *LoadBalancerHealthChecks) error {
+	// This happens in the load balancer definition
 	return nil
 }

--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -18,11 +18,13 @@ package awstasks
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/glog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
 )
 
 //go:generate fitask -type=NatGateway
@@ -203,24 +205,20 @@ func (_ *NatGateway) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *NatGateway)
 	return nil
 }
 
-// TODO Kris - We need to support NGW for Terraform
+type terraformNATGateway struct {
+	AllocationID *terraform.Literal `json:"allocation_id,omitempty"`
+	SubnetID     *terraform.Literal `json:"subnet_id,omitempty"`
+}
 
-//type terraformNATGateway struct {
-//	AllocationId *string           `json:"AllocationID,omitempty"`
-//	SubnetID     *bool             `json:"SubnetID,omitempty"`
-//}
-//
-//func (_ *NATGateway) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *NATGateway) error {
-//	//	cloud := t.Cloud.(awsup.AWSCloud)
-//
-//	tf := &terraformNatGateway{
-//		AllocationId:  e.AllocationID,
-//		//SubnetID:      e.SubnetID,
-//	}
-//
-//	return t.RenderResource("aws_natgateway", *e.AllocationID, tf)
-//}
-//
-//func (e *NATGateway) TerraformLink() *terraform.Literal {
-//	return terraform.LiteralProperty("aws_natgateway", *e.AllocationID, "id")
-//}
+func (_ *NatGateway) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *NatGateway) error {
+	tf := &terraformNATGateway{
+		AllocationID: e.ElasticIp.TerraformLink(),
+		SubnetID:     e.Subnet.TerraformLink(),
+	}
+
+	return t.RenderResource("aws_nat_gateway", *e.Name, tf)
+}
+
+func (e *NatGateway) TerraformLink() *terraform.Literal {
+	return terraform.LiteralProperty("aws_nat_gateway", *e.Name, "id")
+}

--- a/upup/pkg/fi/cloudup/awstasks/route.go
+++ b/upup/pkg/fi/cloudup/awstasks/route.go
@@ -219,6 +219,7 @@ type terraformRoute struct {
 	RouteTableID      *terraform.Literal `json:"route_table_id"`
 	CIDR              *string            `json:"destination_cidr_block,omitempty"`
 	InternetGatewayID *terraform.Literal `json:"gateway_id,omitempty"`
+	NATGatewayID      *terraform.Literal `json:"nat_gateway_id,omitempty"`
 	InstanceID        *terraform.Literal `json:"instance_id,omitempty"`
 	// TODO Kris - Add terraform support for NAT Gateway routes
 }
@@ -229,8 +230,12 @@ func (_ *Route) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Rou
 		RouteTableID: e.RouteTable.TerraformLink(),
 	}
 
-	if e.InternetGateway != nil {
+	if e.InternetGateway == nil && e.NatGateway == nil {
+		return fmt.Errorf("missing target for route")
+	} else if e.InternetGateway != nil {
 		tf.InternetGatewayID = e.InternetGateway.TerraformLink()
+	} else if e.NatGateway != nil {
+		tf.NATGatewayID = e.NatGateway.TerraformLink()
 	}
 
 	if e.Instance != nil {


### PR DESCRIPTION
Several `awstasks` are missing `RenderTerraform` methods, this is an attempt to fill them in so that we can render a cluster with private networking to Terraform output.

The work is kind of rough as we are not very familiar with the internals of the project, feel free to make changes or send feedback.

Might be a non-issue once #1055 is resolved.

NOTE: [loadbalancer_attributes.go](https://github.com/kubernetes/kops/blob/master/upup/pkg/fi/cloudup/awstasks/loadbalancer_attributes.go) still needs Terraform output when using the bastion. Terraform only supports inserting attributes in the `aws_elb` definition [same situation as health checks](https://github.com/kubernetes/kops/pull/1114/files#diff-00b0d5945b4937a8f4a4ef5bde97975aR193).

cc @jmcarp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1114)
<!-- Reviewable:end -->
