### PR TITLE
kubecfg_builder.go: Don't add basic auth creds if TLS data present

### DIFF
--- a/upup/pkg/kutil/kubecfg_builder.go
+++ b/upup/pkg/kutil/kubecfg_builder.go
@@ -122,13 +122,6 @@ func (c *KubeconfigBuilder) WriteKubecfg() error {
 
 	var userArgs []string
 
-	if c.KubeBearerToken != "" {
-		userArgs = append(userArgs, "--token="+c.KubeBearerToken)
-	} else if c.KubeUser != "" && c.KubePassword != "" {
-		userArgs = append(userArgs, "--username="+c.KubeUser)
-		userArgs = append(userArgs, "--password="+c.KubePassword)
-	}
-
 	if c.ClientCert != nil && c.ClientKey != nil {
 		clientCert := path.Join(tmpdir, "client.crt")
 		if err := ioutil.WriteFile(clientCert, c.ClientCert, 0600); err != nil {
@@ -142,6 +135,11 @@ func (c *KubeconfigBuilder) WriteKubecfg() error {
 		userArgs = append(userArgs, "--client-certificate="+clientCert)
 		userArgs = append(userArgs, "--client-key="+clientKey)
 		userArgs = append(userArgs, "--embed-certs=true")
+	} else if c.KubeBearerToken != "" {
+		userArgs = append(userArgs, "--token="+c.KubeBearerToken)
+	} else if c.KubeUser != "" && c.KubePassword != "" {
+		userArgs = append(userArgs, "--username="+c.KubeUser)
+		userArgs = append(userArgs, "--password="+c.KubePassword)
 	}
 
 	setClusterArgs := []string{"config", "set-cluster", c.Context}


### PR DESCRIPTION
As far as I can tell, when TLS data is presented as part of the client request and the API is
configured to authenticate via TLS certs, basic auth headers will be ignored by the API, so 
this data is redundant.  My understanding is based on 
http://kubernetes.io/docs/admin/authentication/#x509-client-certs

Furthermore, it's confusing because the common name in the client certificate is `kubecfg` 
but the username is `admin`, so it's hard to know whom the server will authenticate the 
request for unless you know the above behaviour where the API ignores basic auth headers 
in this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1128)
<!-- Reviewable:end -->
