### PR TITLE
Specify --anonymous-auth=false for k8s 1.5

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -392,6 +392,8 @@ type KubeAPIServerConfig struct {
 	// for KubeAPIServer, concatenated with commas. ex: `--runtime-config=key1=value1,key2=value2`.
 	// Use this to enable alpha resources on kube-apiserver
 	RuntimeConfig map[string]string `json:"runtimeConfig,omitempty" flag:"runtime-config"`
+
+	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"anonymous-auth"`
 }
 
 type KubeControllerManagerConfig struct {

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -389,6 +389,8 @@ type KubeAPIServerConfig struct {
 	AllowPrivileged       *bool             `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
 	APIServerCount        *int              `json:"apiServerCount,omitempty" flag:"apiserver-count"`
 	RuntimeConfig         map[string]string `json:"runtimeConfig,omitempty" flag:"runtime-config"`
+
+	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"anonymous-auth"`
 }
 
 type KubeControllerManagerConfig struct {

--- a/upup/models/config/components/kube-apiserver/_k8s_1_5/kube-apiserver.options
+++ b/upup/models/config/components/kube-apiserver/_k8s_1_5/kube-apiserver.options
@@ -7,3 +7,5 @@ KubeAPIServer:
   - PersistentVolumeLabel
   - DefaultStorageClass
   - ResourceQuota
+  # Stick with the pre-1.5 anonymous authentication modes
+  AnonymousAuth: false

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	NodeUpVersion = "1.4.1"
+	NodeUpVersion = "1.4.2"
 )
 
 const DefaultMaxTaskDuration = 10 * time.Minute

--- a/upup/pkg/fi/cloudup/populatecluster_test.go
+++ b/upup/pkg/fi/cloudup/populatecluster_test.go
@@ -379,3 +379,49 @@ func TestPopulateCluster_APIServerCount(t *testing.T) {
 		t.Fatalf("Unexpected APIServerCount: %v", fi.IntValue(full.Spec.KubeAPIServer.APIServerCount))
 	}
 }
+
+func TestPopulateCluster_AnonymousAuth(t *testing.T) {
+	c := buildMinimalCluster()
+	c.Spec.KubernetesVersion = "1.5.0"
+
+	err := c.PerformAssignments()
+	if err != nil {
+		t.Fatalf("error from PerformAssignments: %v", err)
+	}
+
+	addEtcdClusters(c)
+
+	full, err := PopulateClusterSpec(c)
+	if err != nil {
+		t.Fatalf("Unexpected error from PopulateCluster: %v", err)
+	}
+
+	if full.Spec.KubeAPIServer.AnonymousAuth == nil {
+		t.Fatalf("AnonymousAuth not specified")
+	}
+
+	if fi.BoolValue(full.Spec.KubeAPIServer.AnonymousAuth) != false {
+		t.Fatalf("Unexpected AnonymousAuth: %v", fi.BoolValue(full.Spec.KubeAPIServer.AnonymousAuth))
+	}
+}
+
+func TestPopulateCluster_AnonymousAuth_14(t *testing.T) {
+	c := buildMinimalCluster()
+	c.Spec.KubernetesVersion = "1.4.0"
+
+	err := c.PerformAssignments()
+	if err != nil {
+		t.Fatalf("error from PerformAssignments: %v", err)
+	}
+
+	addEtcdClusters(c)
+
+	full, err := PopulateClusterSpec(c)
+	if err != nil {
+		t.Fatalf("Unexpected error from PopulateCluster: %v", err)
+	}
+
+	if full.Spec.KubeAPIServer.AnonymousAuth != nil {
+		t.Fatalf("AnonymousAuth is not supported in 1.4")
+	}
+}


### PR DESCRIPTION
We'll expose this option as part of RBAC, but in the meantime explicitly
specify the existing behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1144)
<!-- Reviewable:end -->
