### PR TITLE
Don't pass ConfigureCBR0 to k8s 1.5 (or later) (backport)

### DIFF
--- a/upup/models/config/components/kubelet/_k8s_1_3/kubelet.1_3.options
+++ b/upup/models/config/components/kubelet/_k8s_1_3/kubelet.1_3.options
@@ -1,0 +1,3 @@
+Kubelet:
+  # ConfigureCBR0 was removed from 1.5
+  ConfigureCBR0: true

--- a/upup/models/config/components/kubelet/_k8s_1_4/kubelet.1_4.options
+++ b/upup/models/config/components/kubelet/_k8s_1_4/kubelet.1_4.options
@@ -1,0 +1,3 @@
+Kubelet:
+  # ConfigureCBR0 was removed from 1.5
+  ConfigureCBR0: true

--- a/upup/models/config/components/kubelet/kubelet.options
+++ b/upup/models/config/components/kubelet/kubelet.options
@@ -5,7 +5,6 @@ Kubelet:
   LogLevel: 2
   ClusterDNS: {{ WellKnownServiceIP 10 }}
   ClusterDomain: {{ .ClusterDNSDomain }}
-  ConfigureCBR0: true
   BabysitDaemons: true
   APIServers: https://{{ .MasterInternalName }}
   NonMasqueradeCIDR: {{ .NonMasqueradeCIDR }}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1157)
<!-- Reviewable:end -->
