### PR TITLE
fixes issue #1120 - User can specify CNI_VERSION_URL

### DIFF
--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -194,21 +194,11 @@ func (c *ApplyClusterCmd) Run() error {
 		}
 
 		if usesCNI(cluster) {
-			// TODO: we really need to sort this out:
-			// https://github.com/kubernetes/kops/issues/724
-			// https://github.com/kubernetes/kops/issues/626
-			// https://github.com/kubernetes/kubernetes/issues/30338
+			cniAsset, cniAssetHashString := findCNIAssets(cluster)
 
-			// CNI version for 1.3
-			//defaultCNIAsset = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-8a936732094c0941e1543ef5d292a1f4fffa1ac5.tar.gz"
-			//hashString := "86966c78cc9265ee23f7892c5cad0ec7590cec93"
+			glog.V(2).Infof("Adding CNI asset: %s", cniAsset)
 
-			defaultCNIAsset := "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz"
-			hashString := "19d49f7b2b99cd2493d5ae0ace896c64e289ccbb"
-
-			glog.V(2).Infof("Adding default CNI asset: %s", defaultCNIAsset)
-
-			c.Assets = append(c.Assets, hashString+"@"+defaultCNIAsset)
+			c.Assets = append(c.Assets, cniAssetHashString+"@"+cniAsset)
 		}
 	}
 

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -195,9 +195,6 @@ func (c *ApplyClusterCmd) Run() error {
 
 		if usesCNI(cluster) {
 			cniAsset, cniAssetHashString := findCNIAssets(cluster)
-
-			glog.V(2).Infof("Adding CNI asset: %s", cniAsset)
-
 			c.Assets = append(c.Assets, cniAssetHashString+"@"+cniAsset)
 		}
 	}

--- a/upup/pkg/fi/cloudup/networking.go
+++ b/upup/pkg/fi/cloudup/networking.go
@@ -19,6 +19,7 @@ package cloudup
 import (
 	"github.com/golang/glog"
 	api "k8s.io/kops/pkg/apis/kops"
+	"os"
 )
 
 func usesCNI(c *api.Cluster) bool {
@@ -56,4 +57,21 @@ func usesCNI(c *api.Cluster) bool {
 	// Assume other modes also use CNI
 	glog.Warningf("Unknown networking mode configured")
 	return true
+}
+
+// TODO: we really need to sort this out:
+// https://github.com/kubernetes/kops/issues/724
+// https://github.com/kubernetes/kops/issues/626
+// https://github.com/kubernetes/kubernetes/issues/30338
+const defaultCNIAsset = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz"
+const defaultCNIAssetHashString = "19d49f7b2b99cd2493d5ae0ace896c64e289ccbb"
+const CNI_VERSION_URL = "CNI_VERSION_URL"
+
+func findCNIAssets(c *api.Cluster) (string, string) {
+
+	if cniVersionURL := os.Getenv(CNI_VERSION_URL); cniVersionURL != "" {
+		return cniVersionURL, ""
+	}
+
+	return defaultCNIAsset, defaultCNIAssetHashString
 }

--- a/upup/pkg/fi/cloudup/networking.go
+++ b/upup/pkg/fi/cloudup/networking.go
@@ -63,15 +63,19 @@ func usesCNI(c *api.Cluster) bool {
 // https://github.com/kubernetes/kops/issues/724
 // https://github.com/kubernetes/kops/issues/626
 // https://github.com/kubernetes/kubernetes/issues/30338
-const defaultCNIAsset = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz"
-const defaultCNIAssetHashString = "19d49f7b2b99cd2493d5ae0ace896c64e289ccbb"
-const CNI_VERSION_URL = "CNI_VERSION_URL"
+const (
+	defaultCNIAsset = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz"
+	defaultCNIAssetHashString = "19d49f7b2b99cd2493d5ae0ace896c64e289ccbb"
+	ENV_VAR_CNI_VERSION_URL = "CNI_VERSION_URL"
+)
 
 func findCNIAssets(c *api.Cluster) (string, string) {
 
-	if cniVersionURL := os.Getenv(CNI_VERSION_URL); cniVersionURL != "" {
+	if cniVersionURL := os.Getenv(ENV_VAR_CNI_VERSION_URL); cniVersionURL != "" {
+		glog.Infof("Using CNI asset version %q, as set in %s", cniVersionURL, ENV_VAR_CNI_VERSION_URL)
 		return cniVersionURL, ""
 	}
 
+	glog.V(2).Infof("Adding default CNI asset: %s", defaultCNIAsset)
 	return defaultCNIAsset, defaultCNIAssetHashString
 }

--- a/upup/pkg/fi/cloudup/networking_test.go
+++ b/upup/pkg/fi/cloudup/networking_test.go
@@ -25,20 +25,20 @@ import (
 func Test_FindCNIAssetFromEnvironmentVariable(t *testing.T) {
 
 	desiredCNIVersion := "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-TEST-VERSION.tar.gz"
-	os.Setenv(CNI_VERSION_URL, desiredCNIVersion)
+	os.Setenv(ENV_VAR_CNI_VERSION_URL, desiredCNIVersion)
 	defer func(){
-		os.Unsetenv(CNI_VERSION_URL)
+		os.Unsetenv(ENV_VAR_CNI_VERSION_URL)
 	}()
 
 	cluster := &api.Cluster{}
 	cniAsset, cniAssetHashString := findCNIAssets(cluster)
 
 	if cniAsset != desiredCNIVersion {
-		t.Errorf("Expected CNI version from Environment variable %v, but got %v instead\n", desiredCNIVersion, cniAsset)
+		t.Errorf("Expected CNI version from Environment variable %q, but got %q instead", desiredCNIVersion, cniAsset)
 	}
 
 	if cniAssetHashString != "" {
-		t.Errorf("Expected Empty CNI Version Hash String, but got %v instead\n", cniAssetHashString)
+		t.Errorf("Expected Empty CNI Version Hash String, but got %q instead", cniAssetHashString)
 	}
 }
 
@@ -48,11 +48,11 @@ func Test_FindCNIAssetDefaultValue(t *testing.T) {
 	cniAsset, cniAssetHashString := findCNIAssets(cluster)
 
 	if cniAsset != defaultCNIAsset {
-		 t.Errorf("Expected default CNI version %v and got %v\n", defaultCNIAsset, cniAsset)
+		 t.Errorf("Expected default CNI version %q and got %q", defaultCNIAsset, cniAsset)
 	}
 
 	if cniAssetHashString != defaultCNIAssetHashString {
-		t.Errorf("Expected default CNI Version Hash String %v and got %v\n", defaultCNIAssetHashString, cniAssetHashString)
+		t.Errorf("Expected default CNI Version Hash String %q and got %q", defaultCNIAssetHashString, cniAssetHashString)
 	}
 
 }

--- a/upup/pkg/fi/cloudup/networking_test.go
+++ b/upup/pkg/fi/cloudup/networking_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudup
+
+import (
+	"testing"
+	api "k8s.io/kops/pkg/apis/kops"
+	"os"
+)
+
+func Test_FindCNIAssetFromEnvironmentVariable(t *testing.T) {
+
+	desiredCNIVersion := "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-TEST-VERSION.tar.gz"
+	os.Setenv(CNI_VERSION_URL, desiredCNIVersion)
+	defer func(){
+		os.Unsetenv(CNI_VERSION_URL)
+	}()
+
+	cluster := &api.Cluster{}
+	cniAsset, cniAssetHashString := findCNIAssets(cluster)
+
+	if cniAsset != desiredCNIVersion {
+		t.Errorf("Expected CNI version from Environment variable %v, but got %v instead\n", desiredCNIVersion, cniAsset)
+	}
+
+	if cniAssetHashString != "" {
+		t.Errorf("Expected Empty CNI Version Hash String, but got %v instead\n", cniAssetHashString)
+	}
+}
+
+func Test_FindCNIAssetDefaultValue(t *testing.T) {
+
+	cluster := &api.Cluster{}
+	cniAsset, cniAssetHashString := findCNIAssets(cluster)
+
+	if cniAsset != defaultCNIAsset {
+		 t.Errorf("Expected default CNI version %v and got %v\n", defaultCNIAsset, cniAsset)
+	}
+
+	if cniAssetHashString != defaultCNIAssetHashString {
+		t.Errorf("Expected default CNI Version Hash String %v and got %v\n", defaultCNIAssetHashString, cniAssetHashString)
+	}
+
+}


### PR DESCRIPTION
fixes issue #1120 - User can specify CNI_VERSION_URL to override the default CNI Asset.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1165)
<!-- Reviewable:end -->
