### PR TITLE
ConfigureCBR0 was removed from kubernetes 1.5.0

### DIFF
--- a/upup/models/config/components/kubelet/_networking_cni/kubelet.cni.options
+++ b/upup/models/config/components/kubelet/_networking_cni/kubelet.cni.options
@@ -1,3 +1,2 @@
 Kubelet:
   NetworkPluginName: cni
-  ConfigureCBR0: false


### PR DESCRIPTION
Kubernetes 1.5.0 with private topology did not work with kops until removing this parameter for kubelet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1178)
<!-- Reviewable:end -->
