### PR TITLE
If the user tries to save a SubnetID into v1alpha1, fail

### DIFF
--- a/pkg/apis/kops/v1alpha1/conversion.go
+++ b/pkg/apis/kops/v1alpha1/conversion.go
@@ -156,6 +156,11 @@ func Convert_kops_ClusterSpec_To_v1alpha1_ClusterSpec(in *kops.ClusterSpec, out 
 					}
 					zone.CIDR = s.CIDR
 
+					// We simple can't express this in v1alpha1
+					if s.ProviderID != "" {
+						return fmt.Errorf("cannot convert to v1alpha1: utility subnet had ProviderID %v", s.Name)
+					}
+
 				case kops.SubnetTypePublic:
 					return fmt.Errorf("cannot convert to v1alpha1 when subnet type is public")
 


### PR DESCRIPTION
Rather than failing silently.

Will not be an issue once we switch the default to v1alpha2, but in the
meantime this is surprising.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1215)
<!-- Reviewable:end -->
