### PR TITLE
doc: should be us-west-2 instead of us-west-1

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -155,7 +155,7 @@ Note: You don’t have to use environmental variables here. You can always defin
 
 #### Form your create cluster command
 
-We will need to note which availability zones are available to us. In this example we will be deploying our cluster to the us-west-1 region.
+We will need to note which availability zones are available to us. In this example we will be deploying our cluster to the us-west-2 region.
 
 ```bash
 aws ec2 describe-availability-zones --region us-west-2


### PR DESCRIPTION
Seems like this should be `us-west-2` since that is what is listed below. Also when creating the s3 bucket, are there any gotchas swapping `us-east-1` to `us-west-2` to matin consistency in a single region?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1245)
<!-- Reviewable:end -->
