### PR TITLE
Fix issues related to cross-account S3 bucket sharing

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -215,6 +215,14 @@ aws s3api create-bucket --bucket kubernetes-com-state-store --region us-east-1
 
 Note: We **STRONGLY** recommend versioning your S3 bucket in case you ever need to revert or recover a previous state store.
 
+### Sharing an S3 bucket across multiple accounts
+
+If you configure a single S3 bucket to maintain kops state for clusters across multiple accounts, you may want to override the object ACLs which kops places on the state files.
+
+To do this you should set the environment variable `KOPS_STATE_S3_ACL` to the preferred object ACL, for example `bucket-owner-full-control`.
+
+For available canned ACLs please consult [Amazon's S3 documentation](http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl).
+
 ## Creating your first cluster
 
 #### Setup your environment for kops

--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -142,7 +142,7 @@ func bruteforceBucketLocation(region *string, bucket *string) (*s3.GetBucketLoca
 	select {
 	case bucketLocation := <-out:
 		return bucketLocation, nil
-	case <-time.After(5 * 1e9):
+	case <-time.After(5 * time.Second):
 		return nil, fmt.Errorf("Could not retrieve location for AWS bucket %s", *bucket)
 	}
 }

--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/golang/glog"
 	"os"
 	"sync"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"time"
 )
 
@@ -121,7 +121,7 @@ func bruteforceBucketLocation(region *string, request *s3.GetBucketLocationInput
 	session, _ := session.NewSession(&aws.Config{Region: region})
 	regions, err := ec2.New(session).DescribeRegions(nil)
 
-	if (err != nil) {
+	if err != nil {
 		return nil, fmt.Errorf("Unable to list AWS regions: %v", err)
 	}
 
@@ -133,16 +133,16 @@ func bruteforceBucketLocation(region *string, request *s3.GetBucketLocationInput
 			s3Client := s3.New(session, &aws.Config{Region: aws.String(regionName)})
 			result, bucketError := s3Client.GetBucketLocation(request)
 
-			if (bucketError == nil) {
+			if bucketError == nil {
 				out <- result
 			}
-		} (*region.RegionName);
+		}(*region.RegionName)
 	}
 
 	select {
 	case bucketLocation := <-out:
 		return bucketLocation, nil
-	case <- time.After(5 * 1e9):
+	case <-time.After(5 * 1e9):
 		return nil, fmt.Errorf("Could not retrieve location for AWS bucket %s", *request.Bucket)
 	}
 }

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -120,7 +120,6 @@ func (p *S3Path) WriteFile(data []byte) error {
 		request.ACL = aws.String(acl)
 	}
 
-
 	// We don't need Content-MD5: https://github.com/aws/aws-sdk-go/issues/208
 
 	_, err = client.PutObject(request)

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -115,6 +115,12 @@ func (p *S3Path) WriteFile(data []byte) error {
 	request.Key = aws.String(p.key)
 	request.ServerSideEncryption = aws.String("AES256")
 
+	acl := os.Getenv("KOPS_STATE_S3_ACL")
+	if acl != "" {
+		request.ACL = aws.String(acl)
+	}
+
+
 	// We don't need Content-MD5: https://github.com/aws/aws-sdk-go/issues/208
 
 	_, err = client.PutObject(request)


### PR DESCRIPTION
(This text has been updated)

This pull request fixes two issues related to using a shared S3 bucket for clusters in multiple accounts:

1. An environment variable is added to control the canned ACLs that are applied to new files in the bucket. This is documented in `aws.md`.

2. The logic for retrieving the bucket location (required for talking to the correct S3 endpoint) has been modified to deal with an AWS issue (described [below](https://github.com/kubernetes/kops/pull/1247#issuecomment-274763348)). A more detailed description is added in a comment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1247)
<!-- Reviewable:end -->
