### PR TITLE
Default to `bastion-$clustername` for new bastion clusters

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -473,6 +473,12 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		}
 		cluster.Spec.Subnets = append(cluster.Spec.Subnets, utilitySubnets...)
 
+		// Default to a DNS name for the bastion
+		cluster.Spec.Topology.Bastion = &api.BastionSpec{
+			BastionPublicName: "bastion-" + clusterName,
+		}
+
+
 		if c.Bastion {
 			bastionGroup := &api.InstanceGroup{}
 			bastionGroup.Spec.Role = api.InstanceGroupRoleBastion


### PR DESCRIPTION
Closes https://github.com/kubernetes/kops/issues/1235

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1257)
<!-- Reviewable:end -->
