### PR TITLE
Support Private DNS HostedZones via FeatureFlag

### DIFF
--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -18,7 +18,9 @@ package model
 
 import (
 	"fmt"
+	"github.com/golang/glog"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/featureflag"
 	"strings"
 )
 
@@ -150,4 +152,12 @@ func (m *KopsModelContext) CloudTagsForInstanceGroup(ig *kops.InstanceGroup) (ma
 
 func (m *KopsModelContext) UseLoadBalancerForAPI() bool {
 	return m.Cluster.Spec.Topology.Masters == kops.TopologyPrivate
+}
+
+func (m *KopsModelContext) UsePrivateDNS() bool {
+	if featureflag.PreviewPrivateDNS.Enabled {
+		glog.Infof("PreviewPrivateDNS enabled; using private DNS")
+		return true
+	}
+	return false
 }

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -577,6 +577,19 @@ func findHash(url string) (*hashing.Hash, error) {
 }
 
 func validateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
+	kopsModelContext := &model.KopsModelContext{
+		//Region: cloud.Region(),
+		Cluster: cluster,
+		//InstanceGroups []*kops.InstanceGroup
+
+		//SSHPublicKeys [][]byte
+	}
+
+	if kopsModelContext.UsePrivateDNS() {
+		glog.Infof("Private DNS: skipping DNS validation")
+		return nil
+	}
+
 	dns, err := cloud.DNS()
 	if err != nil {
 		return fmt.Errorf("error building DNS provider: %v", err)


### PR DESCRIPTION
* Simple feature-flag implementation, so we can ship things quickly
* Support for automatically linking a VPC to a private hosted zone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1264)
<!-- Reviewable:end -->
