### PR TITLE
protokube / nodeup: Up kubectl to v1.5.1, bump protokube tag to 1.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))
 
 # Keep in sync with upup/models/cloudup/resources/addons/dns-controller/
 DNS_CONTROLLER_TAG=1.4.1
-PROTOKUBE_TAG=1.4.1
+PROTOKUBE_TAG=1.5.0
 
 ifndef VERSION
   VERSION := git-$(shell git describe --always)

--- a/images/protokube-builder/onbuild.sh
+++ b/images/protokube-builder/onbuild.sh
@@ -34,5 +34,5 @@ cp /go/bin/channels /src/.build/artifacts/
 
 # channels uses protokube
 cd /src/.build/artifacts/
-curl -O https://storage.googleapis.com/kubernetes-release/release/v1.3.7/bin/linux/amd64/kubectl
+curl -O https://storage.googleapis.com/kubernetes-release/release/v1.5.1/bin/linux/amd64/kubectl
 chmod +x kubectl

--- a/upup/pkg/fi/nodeup/template_functions.go
+++ b/upup/pkg/fi/nodeup/template_functions.go
@@ -31,7 +31,7 @@ import (
 
 const TagMaster = "_kubernetes_master"
 
-const DefaultProtokubeImage = "b.gcr.io/kops-images/protokube:1.4.1"
+const DefaultProtokubeImage = "b.gcr.io/kops-images/protokube:1.5.0"
 
 // templateFunctions is a simple helper-class for the functions accessible to templates
 type templateFunctions struct {


### PR DESCRIPTION
Other half of fix to kubernetes/kops#1278

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1279)
<!-- Reviewable:end -->
