### PR TITLE
Update integration tests for version bump

### DIFF
--- a/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
@@ -24,7 +24,7 @@ spec:
     - name: us-test-1c
       zone: us-test-1c
     name: events
-  kubernetesVersion: v1.4.6
+  kubernetesVersion: v1.4.7
   masterPublicName: api.ha.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -24,7 +24,7 @@ spec:
     - instanceGroup: master-us-test-1c
       name: us-test-1c
     name: events
-  kubernetesVersion: v1.4.6
+  kubernetesVersion: v1.4.7
   masterPublicName: api.ha.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/create_cluster/minimal/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha1.yaml
@@ -16,7 +16,7 @@ spec:
     - name: us-test-1a
       zone: us-test-1a
     name: events
-  kubernetesVersion: v1.4.6
+  kubernetesVersion: v1.4.7
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
@@ -16,7 +16,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.4.6
+  kubernetesVersion: v1.4.7
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/create_cluster/private/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha1.yaml
@@ -16,7 +16,7 @@ spec:
     - name: us-test-1a
       zone: us-test-1a
     name: events
-  kubernetesVersion: v1.4.6
+  kubernetesVersion: v1.4.7
   masterPublicName: api.private.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -16,7 +16,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.4.6
+  kubernetesVersion: v1.4.7
   masterPublicName: api.private.example.com
   networkCIDR: 172.20.0.0/16
   networking:


### PR DESCRIPTION
We really should be using a copy of the stable channel, but for now we
want to get the tests working.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1296)
<!-- Reviewable:end -->
