### PR TITLE
Skip DNS precreation if we have no records

### DIFF
--- a/upup/pkg/fi/cloudup/dns.go
+++ b/upup/pkg/fi/cloudup/dns.go
@@ -181,12 +181,17 @@ func precreateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
 	var created []string
 
 	for _, dnsHostname := range dnsHostnames {
+		dnsHostname = strings.TrimSuffix(dnsHostname, ".")
 		dnsRecord := recordsMap["A::"+dnsHostname]
 		found := false
 		if dnsRecord != nil {
 			rrdatas := dnsRecord.Rrdatas()
 			if len(rrdatas) > 0 {
 				glog.V(4).Infof("Found DNS record %s => %s; won't create", dnsHostname, rrdatas)
+				found = true
+			} else {
+				// This is probably an alias target; leave it alone...
+				glog.V(4).Infof("Found DNS record %s, but no records", dnsHostname)
 				found = true
 			}
 		}
@@ -195,7 +200,7 @@ func precreateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
 			continue
 		}
 
-		glog.V(2).Infof("Pre-creating DNS record %s => %s", dnsHostnames, PlaceholderIP)
+		glog.V(2).Infof("Pre-creating DNS record %s => %s", dnsHostname, PlaceholderIP)
 
 		changeset.Add(rrs.New(dnsHostname, []string{PlaceholderIP}, PlaceholderTTL, rrstype.A))
 		created = append(created, dnsHostname)


### PR DESCRIPTION
This seems to be a limitation/issue in the route53 dnsprovider; it skips
over alias targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1310)
<!-- Reviewable:end -->
