### PR TITLE
Adding label k8s-app to manifests on master

### DIFF
--- a/protokube/templates/etcd/manifest.template
+++ b/protokube/templates/etcd/manifest.template
@@ -4,6 +4,8 @@ kind: Pod
 metadata:
   name: {{ .PodName }}
   namespace: kube-system
+  labels:
+    k8s-app: {{ .PodName }}
 spec:
   hostNetwork: true
   containers:

--- a/upup/models/nodeup/_kubernetes_master/etcd/_not_protokube/etc/kubernetes/manifests/etcd-events.manifest
+++ b/upup/models/nodeup/_kubernetes_master/etcd/_not_protokube/etc/kubernetes/manifests/etcd-events.manifest
@@ -3,7 +3,10 @@
 "kind": "Pod",
 "metadata": {
   "name":"etcd-server-events",
-  "namespace": "kube-system"
+  "namespace": "kube-system",
+  "labels": {
+    "k8s-app" : "etcd-server-events"
+  }
 },
 "spec":{
 "hostNetwork": true,

--- a/upup/models/nodeup/_kubernetes_master/etcd/_not_protokube/etc/kubernetes/manifests/etcd.manifest
+++ b/upup/models/nodeup/_kubernetes_master/etcd/_not_protokube/etc/kubernetes/manifests/etcd.manifest
@@ -3,7 +3,10 @@
 "kind": "Pod",
 "metadata": {
   "name":"etcd-server",
-  "namespace": "kube-system"
+  "namespace": "kube-system",
+  "labels": {
+    "k8s-app" : "etcd-server"
+  }
 },
 "spec":{
 "hostNetwork": true,

--- a/upup/models/nodeup/_kubernetes_master/kube-apiserver/files/etc/kubernetes/manifests/kube-apiserver.manifest.template
+++ b/upup/models/nodeup/_kubernetes_master/kube-apiserver/files/etc/kubernetes/manifests/kube-apiserver.manifest.template
@@ -8,6 +8,8 @@ metadata:
     dns.alpha.kubernetes.io/internal: {{ .MasterInternalName }}
   name: kube-apiserver
   namespace: kube-system
+  labels:
+    k8s-app: kube-apiserver
 spec:
   hostNetwork: true
   containers:

--- a/upup/models/nodeup/_kubernetes_master/kube-controller-manager/files/etc/kubernetes/manifests/kube-controller-manager.template
+++ b/upup/models/nodeup/_kubernetes_master/kube-controller-manager/files/etc/kubernetes/manifests/kube-controller-manager.template
@@ -3,7 +3,10 @@
 "kind": "Pod",
 "metadata": {
   "name":"kube-controller-manager",
-  "namespace": "kube-system"
+  "namespace": "kube-system",
+  "labels": {
+    "k8s-app" : "kube-controller-manager"
+  }
 },
 "spec":{
 "hostNetwork": true,

--- a/upup/models/nodeup/_kubernetes_master/kube-scheduler/files/etc/kubernetes/manifests/kube-scheduler.template
+++ b/upup/models/nodeup/_kubernetes_master/kube-scheduler/files/etc/kubernetes/manifests/kube-scheduler.template
@@ -3,7 +3,10 @@
 "kind": "Pod",
 "metadata": {
   "name":"kube-scheduler",
-  "namespace": "kube-system"
+  "namespace": "kube-system",
+  "labels": {
+    "k8s-app" : "kube-scheduler"
+  }
 },
 "spec":{
 "hostNetwork": true,

--- a/vendor/k8s.io/kubernetes/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/vendor/k8s.io/kubernetes/cluster/saltbase/salt/etcd/etcd.manifest
@@ -32,10 +32,7 @@
 "kind": "Pod",
 "metadata": {
   "name":"etcd-server{{ suffix }}",
-  "namespace": "kube-system",
-  "labels": {
-    "k8s-app" : "etcd-server{{ suffix }}"
-  }
+  "namespace": "kube-system"
 },
 "spec":{
 "hostNetwork": true,

--- a/vendor/k8s.io/kubernetes/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/vendor/k8s.io/kubernetes/cluster/saltbase/salt/etcd/etcd.manifest
@@ -32,7 +32,10 @@
 "kind": "Pod",
 "metadata": {
   "name":"etcd-server{{ suffix }}",
-  "namespace": "kube-system"
+  "namespace": "kube-system",
+  "labels": {
+    "k8s-app" : "etcd-server{{ suffix }}"
+  }
 },
 "spec":{
 "hostNetwork": true,


### PR DESCRIPTION
Adding k8s-app label to manifests on master.
Ref: https://github.com/kubernetes/kops/issues/1226
Already in kube-proxy (https://github.com/kubernetes/kops/pull/617)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1314)
<!-- Reviewable:end -->
