### PR TITLE
Generate default bastion public DNS name from dns zone

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -475,7 +475,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 
 		// Default to a DNS name for the bastion
 		cluster.Spec.Topology.Bastion = &api.BastionSpec{
-			BastionPublicName: "bastion." + DNSZone,
+			BastionPublicName: "bastion." + cluster.Spec.DNSZone,
 		}
 
 		if c.Bastion {

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -475,7 +475,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 
 		// Default to a DNS name for the bastion
 		cluster.Spec.Topology.Bastion = &api.BastionSpec{
-			BastionPublicName: "bastion-" + clusterName,
+			BastionPublicName: "bastion." + DNSZone,
 		}
 
 		if c.Bastion {

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -475,7 +475,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 
 		// Default to a DNS name for the bastion
 		cluster.Spec.Topology.Bastion = &api.BastionSpec{
-			BastionPublicName: "bastion." + cluster.Spec.DNSZone,
+			BastionPublicName: "bastion." + c.DNSZone,
 		}
 
 		if c.Bastion {

--- a/tests/integration/create_cluster/private/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha1.yaml
@@ -25,7 +25,7 @@ spec:
   topology:
     bastion:
       enable: true
-      name: bastion-private.example.com
+      name: bastion.private.example.com
     masters: private
     nodes: private
   zones:

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -33,7 +33,7 @@ spec:
     zone: us-test-1a
   topology:
     bastion:
-      bastionPublicName: bastion-private.example.com
+      bastionPublicName: bastion.private.example.com
     masters: private
     nodes: private
 


### PR DESCRIPTION
An attempt to address https://github.com/kubernetes/kops/issues/1322.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1323)
<!-- Reviewable:end -->
