### PR TITLE
Always set CredentialsChainVerboseErrors when initializing AWS

### DIFF
--- a/protokube/pkg/protokube/aws_dns.go
+++ b/protokube/pkg/protokube/aws_dns.go
@@ -52,6 +52,7 @@ func NewRoute53DNSProvider(zoneName string) (*Route53DNSProvider, error) {
 	})
 
 	config := aws.NewConfig()
+	config = config.WithCredentialsChainVerboseErrors(true)
 
 	p.client = route53.New(s, config)
 

--- a/protokube/pkg/protokube/aws_volume.go
+++ b/protokube/pkg/protokube/aws_volume.go
@@ -72,6 +72,8 @@ func NewAWSVolumes() (*AWSVolumes, error) {
 	})
 
 	config := aws.NewConfig()
+	config = config.WithCredentialsChainVerboseErrors(true)
+
 	a.metadata = ec2metadata.New(s, config)
 
 	region, err := a.metadata.Region()

--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -43,6 +43,8 @@ func ValidateRegion(region string) error {
 			awsRegion = "us-east-1"
 		}
 		config := aws.NewConfig().WithRegion(awsRegion)
+		config = config.WithCredentialsChainVerboseErrors(true)
+
 		client := ec2.New(session.New(), config)
 
 		response, err := client.DescribeRegions(request)

--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -46,6 +46,8 @@ func (s *S3Context) getClient(region string) (*s3.S3, error) {
 	s3Client := s.clients[region]
 	if s3Client == nil {
 		config := aws.NewConfig().WithRegion(region)
+		config = config.WithCredentialsChainVerboseErrors(true)
+
 		session := session.New()
 		s3Client = s3.New(session, config)
 	}


### PR DESCRIPTION
Fix #605

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1325)
<!-- Reviewable:end -->
