### PR TITLE
Default version to `1.5.0-alpha1`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,7 @@ MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))
 # Keep in sync with upup/models/cloudup/resources/addons/dns-controller/
 DNS_CONTROLLER_TAG=1.4.1
 
-ifndef VERSION
-  VERSION := git-$(shell git describe --always)
-endif
+VERSION?=1.5.0-alpha1
 
 
 # Go exports:


### PR DESCRIPTION
Otherwise people that build from source need to upload a custom build

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1343)
<!-- Reviewable:end -->
