### PR TITLE
Specify storage-backend=etcd2 explicitly

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -382,6 +382,8 @@ type KubeAPIServerConfig struct {
 	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"anonymous-auth"`
 
 	KubeletPreferredAddressTypes []string `json:"kubeletPreferredAddressTypes,omitempty" flag:"kubelet-preferred-address-types"`
+
+	StorageBackend *string `json:"storageBackend,omitempty" flag:"storage-backend"`
 }
 
 type KubeControllerManagerConfig struct {

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -379,6 +379,8 @@ type KubeAPIServerConfig struct {
 	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"anonymous-auth"`
 
 	KubeletPreferredAddressTypes []string `json:"kubeletPreferredAddressTypes,omitempty" flag:"kubelet-preferred-address-types"`
+
+	StorageBackend *string `json:"storageBackend,omitempty" flag:"storage-backend"`
 }
 
 type KubeControllerManagerConfig struct {

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -787,6 +787,7 @@ func autoConvert_v1alpha1_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.RuntimeConfig = in.RuntimeConfig
 	out.AnonymousAuth = in.AnonymousAuth
 	out.KubeletPreferredAddressTypes = in.KubeletPreferredAddressTypes
+	out.StorageBackend = in.StorageBackend
 	return nil
 }
 
@@ -816,6 +817,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha1_KubeAPIServerConfig(in *ko
 	out.RuntimeConfig = in.RuntimeConfig
 	out.AnonymousAuth = in.AnonymousAuth
 	out.KubeletPreferredAddressTypes = in.KubeletPreferredAddressTypes
+	out.StorageBackend = in.StorageBackend
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -137,6 +137,8 @@ type KubeAPIServerConfig struct {
 	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"anonymous-auth"`
 
 	KubeletPreferredAddressTypes []string `json:"kubeletPreferredAddressTypes,omitempty" flag:"kubelet-preferred-address-types"`
+
+	StorageBackend *string `json:"storageBackend,omitempty" flag:"storage-backend"`
 }
 
 type KubeControllerManagerConfig struct {

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -44,6 +44,11 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 		options.KubeAPIServer.APIServerCount = fi.Int(count)
 	}
 
+	if options.KubeAPIServer.StorageBackend == nil {
+		// For the moment, we continue to use etcd2
+		options.KubeAPIServer.StorageBackend = fi.String("etcd2")
+	}
+
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/populatecluster_test.go
+++ b/upup/pkg/fi/cloudup/populatecluster_test.go
@@ -117,6 +117,24 @@ func TestPopulateCluster_Docker_Spec(t *testing.T) {
 	}
 }
 
+func TestPopulateCluster_StorageDefault(t *testing.T) {
+	c := buildMinimalCluster()
+	err := PerformAssignments(c)
+	if err != nil {
+		t.Fatalf("error from PerformAssignments: %v", err)
+	}
+
+	addEtcdClusters(c)
+	full, err := PopulateClusterSpec(c)
+	if err != nil {
+		t.Fatalf("Unexpected error from PopulateCluster: %v", err)
+	}
+
+	if fi.StringValue(full.Spec.KubeAPIServer.StorageBackend) != "etcd2" {
+		t.Fatalf("Unexpected StorageBackend: %v", full.Spec.KubeAPIServer.StorageBackend)
+	}
+}
+
 func build(c *api.Cluster) (*api.Cluster, error) {
 	err := PerformAssignments(c)
 	if err != nil {


### PR DESCRIPTION
The default may change to etcd3, but we want to stick with etcd2 until
upgrade has been fully vetted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1348)
<!-- Reviewable:end -->
