### PR TITLE
Revert "Revert "Load protokube from http/https""

### DIFF
--- a/cmd/kops/main.go
+++ b/cmd/kops/main.go
@@ -18,13 +18,7 @@ package main // import "k8s.io/kops/cmd/kops"
 
 import (
 	"fmt"
-	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"os"
-)
-
-var (
-	// value overwritten during build. This can be used to resolve issues.
-	BuildVersion = cloudup.NodeUpVersion
 )
 
 func main() {

--- a/docs/development/adding_a_feature.md
+++ b/docs/development/adding_a_feature.md
@@ -198,7 +198,7 @@ and then push nodeup using:
 export S3_BUCKET_NAME=<yourbucketname>
 make upload S3_BUCKET=s3://${S3_BUCKET_NAME} VERSION=dev
 
-export NODEUP_URL=https://${S3_BUCKET_NAME}.s3.amazonaws.com/kops/dev/linux/amd64/nodeup
+export KOPS_BASE_URL=https://${S3_BUCKET_NAME}.s3.amazonaws.com/kops/dev/
 
 kops create cluster <clustername> --zones us-east-1b
 ...

--- a/hack/dev-build.sh
+++ b/hack/dev-build.sh
@@ -75,7 +75,7 @@ cd $KOPS_DIRECTORY/..
 GIT_VER=git-$(git describe --always)
 [ -z "$GIT_VER" ] && echo "we do not have GIT_VER something is very wrong" && exit 1;
 
-NODEUP_URL="https://${NODEUP_BUCKET}.s3.amazonaws.com/kops/${GIT_VER}/linux/amd64/nodeup"
+KOPS_BASE_URL="https://${NODEUP_BUCKET}.s3.amazonaws.com/kops/${GIT_VER}/"
 
 echo ==========
 echo "Starting build"
@@ -94,7 +94,7 @@ kops delete cluster \
 echo ==========
 echo "Creating cluster ${CLUSTER_NAME}"
 
-NODEUP_URL=${NODEUP_URL} kops create cluster \
+KOPS_BASE_URL=${KOPS_BASE_URL} kops create cluster \
   --name $CLUSTER_NAME \
   --state $KOPS_STATE_STORE \
   --node-count $NODE_COUNT \

--- a/upup/models/nodeup/_protokube/services/protokube.service.template
+++ b/upup/models/nodeup/_protokube/services/protokube.service.template
@@ -5,8 +5,8 @@ After=docker.service
 
 [Service]
 EnvironmentFile=/etc/sysconfig/protokube
-ExecStartPre=/usr/bin/docker pull {{ ProtokubeImage }}
-ExecStart=/usr/bin/docker run -v /:/rootfs/ -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd --net=host --privileged {{ ProtokubeImage }} /usr/bin/protokube "$DAEMON_ARGS"
+ExecStartPre={{ ProtokubeImagePullCommand }}
+ExecStart=/usr/bin/docker run -v /:/rootfs/ -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd --net=host --privileged {{ ProtokubeImageName }} /usr/bin/protokube "$DAEMON_ARGS"
 Restart=always
 RestartSec=2s
 StartLimitInterval=0

--- a/upup/pkg/fi/cloudup/urls.go
+++ b/upup/pkg/fi/cloudup/urls.go
@@ -17,10 +17,11 @@ limitations under the License.
 package cloudup
 
 import (
-	"github.com/golang/glog"
-	"k8s.io/kops"
 	"os"
 	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/kops"
 )
 
 // baseUrl caches the BaseUrl value
@@ -33,15 +34,7 @@ func BaseUrl() string {
 		return baseUrl
 	}
 
-	// We prefer KOPS_BASE_URL, but we will accept KOPS_URL (for now!)
 	baseUrl = os.Getenv("KOPS_BASE_URL")
-	if baseUrl == "" {
-		baseUrl = os.Getenv("KOPS_URL")
-		if baseUrl != "" {
-			glog.Warningf("Using deprecated KOPS_URL envrionment variable - please use KOPS_BASE_URL instead")
-		}
-	}
-
 	if baseUrl == "" {
 		baseUrl = "https://kubeupv2.s3.amazonaws.com/kops/" + kops.Version + "/"
 		glog.V(4).Infof("Using default base url: %q", baseUrl)

--- a/upup/pkg/fi/cloudup/urls.go
+++ b/upup/pkg/fi/cloudup/urls.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudup
+
+import (
+	"github.com/golang/glog"
+	"k8s.io/kops"
+	"os"
+	"strings"
+)
+
+// baseUrl caches the BaseUrl value
+var baseUrl string
+
+// BaseUrl returns the base url for the distribution of kops - in particular for nodeup & docker images
+func BaseUrl() string {
+	if baseUrl != "" {
+		// Avoid repeated logging
+		return baseUrl
+	}
+
+	// We prefer KOPS_BASE_URL, but we will accept KOPS_URL (for now!)
+	baseUrl = os.Getenv("KOPS_BASE_URL")
+	if baseUrl == "" {
+		baseUrl = os.Getenv("KOPS_URL")
+		if baseUrl != "" {
+			glog.Warningf("Using deprecated KOPS_URL envrionment variable - please use KOPS_BASE_URL instead")
+		}
+	}
+
+	if baseUrl == "" {
+		baseUrl = "https://kubeupv2.s3.amazonaws.com/kops/" + kops.Version + "/"
+		glog.V(4).Infof("Using default base url: %q", baseUrl)
+	} else {
+		glog.Warningf("Using base url from KOPS_BASE_URL env var: %q", baseUrl)
+	}
+
+	if !strings.HasSuffix(baseUrl, "/") {
+		baseUrl += "/"
+	}
+
+	return baseUrl
+}
+
+// nodeUpLocation caches the NodeUpLocation value
+var nodeUpLocation string
+
+// NodeUpLocation returns the URL where nodeup should be downloaded
+func NodeUpLocation() string {
+	if nodeUpLocation != "" {
+		// Avoid repeated logging
+		return nodeUpLocation
+	}
+	nodeUpLocation = os.Getenv("NODEUP_URL")
+	if nodeUpLocation == "" {
+		nodeUpLocation = BaseUrl() + "linux/amd64/nodeup"
+		glog.V(4).Infof("Using default nodeup location: %q", nodeUpLocation)
+	} else {
+		glog.Warningf("Using nodeup location from NODEUP_URL env var: %q", nodeUpLocation)
+	}
+	return nodeUpLocation
+}
+
+// protokubeImageSource caches the ProtokubeImageSource value
+var protokubeImageSource string
+
+// ProtokubeImageSource returns the source for the docker image for protokube.
+// Either a docker name (e.g. gcr.io/protokube:1.4), or a URL (https://...) in which case we download
+// the contents of the url and docker load it
+func ProtokubeImageSource() string {
+	if protokubeImageSource != "" {
+		// Avoid repeated logging
+		return protokubeImageSource
+	}
+	protokubeImageSource = os.Getenv("PROTOKUBE_IMAGE")
+	if protokubeImageSource == "" {
+		protokubeImageSource = BaseUrl() + "images/protokube.tar.gz"
+		glog.V(4).Infof("Using default protokube location: %q", protokubeImageSource)
+	} else {
+		glog.Warningf("Using protokube location from PROTOKUBE_IMAGE env var: %q", protokubeImageSource)
+	}
+	return protokubeImageSource
+}

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -213,6 +213,12 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 			Hash:   image.Hash,
 		}
 	}
+	if c.config.ProtokubeImage != nil {
+		taskMap["LoadImage.protokube"] = &nodetasks.LoadImageTask{
+			Source: c.config.ProtokubeImage.Source,
+			Hash:   c.config.ProtokubeImage.Hash,
+		}
+	}
 
 	var cloud fi.Cloud
 	var keyStore fi.Keystore

--- a/upup/pkg/fi/nodeup/config.go
+++ b/upup/pkg/fi/nodeup/config.go
@@ -54,6 +54,11 @@ type NodeUpConfig struct {
 
 // Image is a docker image we should pre-load
 type Image struct {
+	// Name is the name of the tagged image
+	// This is the name we would pass to "docker run", whereas source could be a URL from which
+	// we would download an image.
+	Name string `json:"name,omitempty"`
+
 	// Source is the URL from which we should download the image
 	Source string `json:"source,omitempty"`
 

--- a/upup/pkg/fi/nodeup/template_functions.go
+++ b/upup/pkg/fi/nodeup/template_functions.go
@@ -19,20 +19,20 @@ package nodeup
 import (
 	"encoding/base64"
 	"fmt"
+	"runtime"
+	"strings"
 	"text/template"
 
 	"github.com/golang/glog"
+	"k8s.io/kops"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/secrets"
 	"k8s.io/kops/util/pkg/vfs"
 	"k8s.io/kubernetes/pkg/util/sets"
-	"runtime"
 )
 
 const TagMaster = "_kubernetes_master"
-
-const DefaultProtokubeImage = "b.gcr.io/kops-images/protokube:1.5.0"
 
 // templateFunctions is a simple helper-class for the functions accessible to templates
 type templateFunctions struct {
@@ -155,7 +155,8 @@ func (t *templateFunctions) populate(dest template.FuncMap) {
 		return t.cluster.ObjectMeta.Name
 	}
 
-	dest["ProtokubeImage"] = t.ProtokubeImage
+	dest["ProtokubeImageName"] = t.ProtokubeImageName
+	dest["ProtokubeImagePullCommand"] = t.ProtokubeImagePullCommand
 
 	dest["ProtokubeFlags"] = t.ProtokubeFlags
 }
@@ -235,17 +236,34 @@ func (t *templateFunctions) GetToken(key string) (string, error) {
 	return string(token.Data), nil
 }
 
-// ProtokubeImage returns the docker image for protokube
-func (t *templateFunctions) ProtokubeImage() string {
-	image := ""
-	if t.nodeupConfig.ProtokubeImage != nil {
-		image = t.nodeupConfig.ProtokubeImage.Source
+// ProtokubeImageName returns the docker image for protokube
+func (t *templateFunctions) ProtokubeImageName() string {
+	name := ""
+	if t.nodeupConfig.ProtokubeImage != nil && t.nodeupConfig.ProtokubeImage.Name != "" {
+		name = t.nodeupConfig.ProtokubeImage.Name
 	}
-	if image == "" {
+	if name == "" {
 		// use current default corresponding to this version of nodeup
-		image = DefaultProtokubeImage
+		name = kops.DefaultProtokubeImageName()
 	}
-	return image
+	return name
+}
+
+// ProtokubeImagePullCommand returns the command to pull the image
+func (t *templateFunctions) ProtokubeImagePullCommand() string {
+	source := ""
+	if t.nodeupConfig.ProtokubeImage != nil {
+		source = t.nodeupConfig.ProtokubeImage.Source
+	}
+	if source == "" {
+		// Nothing to pull; return dummy value
+		return "/bin/true"
+	}
+	if strings.HasPrefix(source, "http:") || strings.HasPrefix(source, "https:") || strings.HasPrefix(source, "s3:") {
+		// We preloaded the image; return a dummy value
+		return "/bin/true"
+	}
+	return "/usr/bin/docker pull " + t.nodeupConfig.ProtokubeImage.Source
 }
 
 // ProtokubeFlags returns the flags object for protokube

--- a/version.go
+++ b/version.go
@@ -14,40 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package kops
 
-import (
-	"fmt"
+// This should be replaced by the makefile
+var Version = "1.5.0"
 
-	"github.com/spf13/cobra"
-	"k8s.io/kops"
-)
-
-type VersionCmd struct {
-	cobraCommand *cobra.Command
-}
-
-var versionCmd = VersionCmd{
-	cobraCommand: &cobra.Command{
-		Use:   "version",
-		Short: "Print the client version information",
-	},
-}
-
-func init() {
-	cmd := versionCmd.cobraCommand
-	rootCommand.cobraCommand.AddCommand(cmd)
-
-	cmd.Run = func(cmd *cobra.Command, args []string) {
-		err := versionCmd.Run()
-		if err != nil {
-			exitWithError(err)
-		}
-	}
-}
-
-func (c *VersionCmd) Run() error {
-	fmt.Printf("Version %s\n", kops.Version)
-
-	return nil
+// DefaultProtokubeImageName is the name of the protokube image, as we would pass to "docker run"
+func DefaultProtokubeImageName() string {
+	return "protokube:" + Version
 }


### PR DESCRIPTION
Reverts kubernetes/kops#1347, which unreverts kubernetes/kops#1318

Along the way: Adding a commit to remove the `KOPS_URL` fallback, we don't need it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1349)
<!-- Reviewable:end -->
