### PR TITLE
Add .dockerignore file to improve build times

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!.build
+!protokube


### PR DESCRIPTION
Running
```
time make protokube-builder-image protokube-image \
  dns-controller-image dns-controller-builder-image
```

I saw `Sending build context to Docker daemon 1.791 GB` twice, first in `protokube` and then in `dns-controller` images, when all this content is not required to build the images

Before this PR:
```
real  5m8.911s
user  0m9.355s
sys 0m17.330s
```

After this PR:

the content sent changes to:
```
Sending build context to Docker daemon 205.7 MB
```


```
real  2m49.398s
user  0m0.655s
sys 0m1.225s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1353)
<!-- Reviewable:end -->
