### PR TITLE
Proposal: Reduce size of images using ubuntu-slim

### DIFF
--- a/images/dns-controller-builder/Dockerfile
+++ b/images/dns-controller-builder/Dockerfile
@@ -12,16 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM gcr.io/google_containers/debian-base-amd64:0.1
 
 # Install packages:
 #  curl (to download golang)
 #  git (for getting the current head)
 #  gcc make (for compilation)
-RUN apt-get update && apt-get install --yes curl git gcc make
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    curl ca-certificates git gcc make bash \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install golang
-RUN curl -L https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz | tar zx -C /usr/local
+RUN curl -sSL https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz | tar zx -C /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 COPY onbuild.sh /onbuild.sh

--- a/images/dns-controller/Dockerfile
+++ b/images/dns-controller/Dockerfile
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM gcr.io/google_containers/debian-base-amd64:0.1
 
 # ca-certificates: Needed to talk to EC2 API
-RUN apt-get update && apt-get install --yes ca-certificates
+RUN apt-get update && apt-get install --yes ca-certificates bash \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY /.build/artifacts/dns-controller /usr/bin/dns-controller
 

--- a/images/protokube-builder/Dockerfile
+++ b/images/protokube-builder/Dockerfile
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM gcr.io/google_containers/debian-base-amd64:0.1
 
 # Install packages:
 #  curl (to download golang)
 #  git (for getting the current head)
 #  gcc make (for compilation)
-RUN apt-get update && apt-get install --yes curl git gcc make
+RUN apt-get update && apt-get install --yes --reinstall lsb-base \
+  && apt-get install --yes curl git gcc make bash \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install golang
 RUN curl -L https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz | tar zx -C /usr/local

--- a/images/protokube/Dockerfile
+++ b/images/protokube/Dockerfile
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM gcr.io/google_containers/debian-base-amd64:0.1
 
 # ca-certificates: Needed to talk to EC2 API
 # e2fsprogs: Needed to mount / format ext4 filesytems
-RUN apt-get update && apt-get install --yes ca-certificates e2fsprogs
+RUN apt-get update && apt-get install --yes ca-certificates e2fsprogs bash \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY /.build/artifacts/kubectl /usr/bin/kubectl
 

--- a/images/utils-builder/Dockerfile
+++ b/images/utils-builder/Dockerfile
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM gcr.io/google_containers/debian-base-amd64:0.1
 
 RUN echo "deb-src http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list
 RUN echo "deb-src http://ftp.us.debian.org/debian/ jessie main" >> /etc/apt/sources.list
 
-RUN apt-get update
-
-RUN apt-get install --yes dpkg-dev
-RUN apt-get build-dep --yes socat
+RUN apt-get update && apt-get install --yes dpkg-dev bash \
+  && apt-get build-dep --yes socat \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /socat
 


### PR DESCRIPTION
```
gcr.io/must-override/dns-controller   1.4.1         d59baae6c0e3  51 seconds ago  145.8 MB
kope/dns-controller                   1.4.0         eded35237e99  3 months ago    205.9 MB

dns-controller-builder                latest        881611903bf0  3 minutes ago   441.7 MB
protokube                             latest        359f351096bd  3 minutes ago   249.4 MB
protokube-builder                     latest        110dcdc47eae  8 minutes ago   441.7 MB

dns-controller-builder                git-de16272c8 c5ce7fb623d9  4 minutes ago   553.4 MB
protokube                             git-de16272c8 3e8b16c0c1a6  4 minutes ago   292.1 MB
protokube-builder                     git-de16272c8 71dcb03c43bc  7 minutes ago   553.4 MB
```

Where is [ubuntu-slim](https://github.com/kubernetes/contrib/tree/master/images/ubuntu-slim) located?

*Official releases in gcr:* [gcr.io/google_containers/ubuntu-slim](https://console.cloud.google.com/kubernetes/images/tags/ubuntu-slim?location=GLOBAL&project=google-containers&pli=1)

[Security scanning information](https://quay.io/repository/aledbf/ubuntu-slim?tab=tags) (image in quay.io before each release in gcr)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1355)
<!-- Reviewable:end -->
