### PR TITLE
Require a confirmation when deleting resources #1302

### DIFF
--- a/cmd/kops/delete.go
+++ b/cmd/kops/delete.go
@@ -50,6 +50,7 @@ var deleteCmd = &cobra.Command{
 				Out:     os.Stdout,
 				Message: message,
 				Default: "no",
+				Retries: 2,
 			}
 
 			if !ui.GetConfirm(c) {

--- a/cmd/kops/delete.go
+++ b/cmd/kops/delete.go
@@ -53,7 +53,11 @@ var deleteCmd = &cobra.Command{
 				Retries: 2,
 			}
 
-			if !ui.GetConfirm(c) {
+			confirmed, err := ui.GetConfirm(c)
+			if err != nil {
+				exitWithError(err)
+			}
+			if !confirmed {
 				os.Exit(1)
 			}
 

--- a/cmd/kops/delete.go
+++ b/cmd/kops/delete.go
@@ -43,7 +43,7 @@ var deleteCmd = &cobra.Command{
 		if !confirmDelete && len(args) >= 3 {
 			message := fmt.Sprintf(
 				"Do you really want to %s? This action cannot be undone.",
-				strings.Join(args, " "),
+				strings.Join(args[1:], " "),
 			)
 
 			c := &ui.ConfirmArgs{

--- a/cmd/kops/delete.go
+++ b/cmd/kops/delete.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/kops/util/pkg/ui"
 
 	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
 )
 
 var confirmDelete bool
@@ -37,8 +36,7 @@ var deleteCmd = &cobra.Command{
 	SuggestFor: []string{"rm"},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// cobra doesn't give you the full arg list even though it should.
-		flag.Parse()
-		args = flag.Args()
+		args = os.Args
 
 		// args should be [delete, resource, resource name]
 		// if there are less args than 3 confirming isnt necessary as the child command will fail

--- a/cmd/kops/delete.go
+++ b/cmd/kops/delete.go
@@ -17,8 +17,17 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+	"os"
+	"strings"
+
+	"k8s.io/kops/util/pkg/ui"
+
 	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 )
+
+var confirmDelete bool
 
 // deleteCmd represents the delete command
 var deleteCmd = &cobra.Command{
@@ -26,8 +35,24 @@ var deleteCmd = &cobra.Command{
 	Short:      "delete clusters",
 	Long:       `Delete clusters`,
 	SuggestFor: []string{"rm"},
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		flag.Parse()
+		args = flag.Args()
+		if !confirmDelete {
+			fmt.Printf(
+				"Do you really want to %s? This action cannot be undone. (Y/n)\n",
+				strings.Join(args, " "),
+			)
+			if !ui.GetConfirm() {
+				os.Exit(1)
+			}
+
+		}
+	},
 }
 
 func init() {
+	deleteCmd.PersistentFlags().BoolVarP(&confirmDelete, "yes", "y", false, "Auto confirm deletetion.")
+
 	rootCommand.AddCommand(deleteCmd)
 }

--- a/cmd/kops/delete.go
+++ b/cmd/kops/delete.go
@@ -42,10 +42,17 @@ var deleteCmd = &cobra.Command{
 		// if there are less args than 3 confirming isnt necessary as the child command will fail
 		if !confirmDelete && len(args) >= 3 {
 			message := fmt.Sprintf(
-				"Do you really want to %s? This action cannot be undone. (Y/n)",
+				"Do you really want to %s? This action cannot be undone.",
 				strings.Join(args, " "),
 			)
-			if !ui.GetConfirm(os.Stdout, message, "") {
+
+			c := &ui.ConfirmArgs{
+				Out:     os.Stdout,
+				Message: message,
+				Default: "no",
+			}
+
+			if !ui.GetConfirm(c) {
 				os.Exit(1)
 			}
 
@@ -55,6 +62,5 @@ var deleteCmd = &cobra.Command{
 
 func init() {
 	deleteCmd.PersistentFlags().BoolVarP(&confirmDelete, "yes", "y", false, "Auto confirm deletetion.")
-
 	rootCommand.AddCommand(deleteCmd)
 }

--- a/cmd/kops/delete.go
+++ b/cmd/kops/delete.go
@@ -38,7 +38,8 @@ var deleteCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		flag.Parse()
 		args = flag.Args()
-		if !confirmDelete {
+
+		if !confirmDelete && len(args) >= 3 {
 			fmt.Printf(
 				"Do you really want to %s? This action cannot be undone. (Y/n)\n",
 				strings.Join(args, " "),

--- a/cmd/kops/delete.go
+++ b/cmd/kops/delete.go
@@ -36,15 +36,18 @@ var deleteCmd = &cobra.Command{
 	Long:       `Delete clusters`,
 	SuggestFor: []string{"rm"},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// cobra doesn't give you the full arg list even though it should.
 		flag.Parse()
 		args = flag.Args()
 
+		// args should be [delete, resource, resource name]
+		// if there are less args than 3 confirming isnt necessary as the child command will fail
 		if !confirmDelete && len(args) >= 3 {
-			fmt.Printf(
-				"Do you really want to %s? This action cannot be undone. (Y/n)\n",
+			message := fmt.Sprintf(
+				"Do you really want to %s? This action cannot be undone. (Y/n)",
 				strings.Join(args, " "),
 			)
-			if !ui.GetConfirm() {
+			if !ui.GetConfirm(os.Stdout, message, "") {
 				os.Exit(1)
 			}
 

--- a/cmd/kops/delete_cluster.go
+++ b/cmd/kops/delete_cluster.go
@@ -56,9 +56,12 @@ func init() {
 	}
 
 	deleteCmd.AddCommand(cmd)
-	argString := strings.ToLower(strings.Join(os.Args, " "))
-	if strings.Contains(argString, "--yes") || strings.Contains(argString, "-y") {
-		deleteCluster.Yes = true
+	for _, arg := range os.Args {
+		arg = strings.ToLower(arg)
+		if arg == "-y" || arg == "--yes" {
+			deleteCluster.Yes = true
+			break
+		}
 	}
 
 	cmd.Flags().BoolVar(&deleteCluster.Unregister, "unregister", false, "Don't delete cloud resources, just unregister the cluster")

--- a/cmd/kops/delete_cluster.go
+++ b/cmd/kops/delete_cluster.go
@@ -56,6 +56,8 @@ func init() {
 	}
 
 	deleteCmd.AddCommand(cmd)
+
+	// had to do this because this init function is running before the flag is set
 	for _, arg := range os.Args {
 		arg = strings.ToLower(arg)
 		if arg == "-y" || arg == "--yes" {

--- a/cmd/kops/delete_cluster.go
+++ b/cmd/kops/delete_cluster.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	api "k8s.io/kops/pkg/apis/kops"
@@ -55,8 +56,11 @@ func init() {
 	}
 
 	deleteCmd.AddCommand(cmd)
+	argString := strings.ToLower(strings.Join(os.Args, " "))
+	if strings.Contains(argString, "--yes") || strings.Contains(argString, "-y") {
+		deleteCluster.Yes = true
+	}
 
-	deleteCluster.Yes = confirmDelete
 	cmd.Flags().BoolVar(&deleteCluster.Unregister, "unregister", false, "Don't delete cloud resources, just unregister the cluster")
 	cmd.Flags().BoolVar(&deleteCluster.External, "external", false, "Delete an external cluster")
 

--- a/cmd/kops/delete_cluster.go
+++ b/cmd/kops/delete_cluster.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/registry"
@@ -28,7 +30,6 @@ import (
 	"k8s.io/kops/upup/pkg/kutil"
 	"k8s.io/kops/util/pkg/tables"
 	"k8s.io/kops/util/pkg/vfs"
-	"os"
 )
 
 type DeleteClusterCmd struct {
@@ -55,7 +56,7 @@ func init() {
 
 	deleteCmd.AddCommand(cmd)
 
-	cmd.Flags().BoolVar(&deleteCluster.Yes, "yes", false, "Delete without confirmation")
+	deleteCluster.Yes = confirmDelete
 	cmd.Flags().BoolVar(&deleteCluster.Unregister, "unregister", false, "Don't delete cloud resources, just unregister the cluster")
 	cmd.Flags().BoolVar(&deleteCluster.External, "external", false, "Delete an external cluster")
 

--- a/cmd/kops/delete_confirm_test.go
+++ b/cmd/kops/delete_confirm_test.go
@@ -51,7 +51,10 @@ func TestConfirmation(t *testing.T) {
 		Default: "no",
 	}
 
-	answer := ui.GetConfirm(c)
+	answer, err := ui.GetConfirm(c)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !strings.Contains(out.String(), "Are you sure") {
 		t.Fatal("Confirmation not in output")
 	}
@@ -63,13 +66,19 @@ func TestConfirmation(t *testing.T) {
 	}
 
 	c.Default = "yes"
-	answer = ui.GetConfirm(c)
+	answer, err = ui.GetConfirm(c)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !strings.Contains(out.String(), "Y/n") {
 		t.Fatal("Default 'Yes' was not set")
 	}
 
 	c.TestVal = "yes"
-	answer = ui.GetConfirm(c)
+	answer, err = ui.GetConfirm(c)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if answer != true {
 		t.Fatal("Confirmation should have been approved.")
 	}

--- a/cmd/kops/delete_confirm_test.go
+++ b/cmd/kops/delete_confirm_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"k8s.io/kops/util/pkg/ui"
+)
+
+// TestContainsString tests the ContainsString() function
+func TestContainsString(t *testing.T) {
+	testString := "my test string"
+	answer := ui.ContainsString(strings.Split(testString, " "), "my")
+	if !answer {
+		t.Fatal("Failed to find string using ui.ContainsString()")
+	}
+	answer = ui.ContainsString(strings.Split(testString, " "), "string")
+	if !answer {
+		t.Fatal("Failed to find string using ui.ContainsString()")
+	}
+	answer = ui.ContainsString(strings.Split(testString, " "), "random")
+	if answer {
+		t.Fatal("Found string that does not exist using ui.ContainsString()")
+	}
+}
+
+// TestConfirmation attempts to test the majority of the ui.GetConfirm function used in the 'kogs delete' commands
+func TestConfirmation(t *testing.T) {
+	var answer bool
+	var out bytes.Buffer
+	message := "Are you sure you want to remove?"
+
+	answer = ui.GetConfirm(&out, message, "no")
+	if !strings.Contains(out.String(), "Are you sure") {
+		t.Fatal("Confirmation not in output")
+	}
+	if answer == true {
+		t.Fatal("Confirmation should have been denied.")
+	}
+
+	answer = ui.GetConfirm(&out, message, "yes")
+	if answer != true {
+		t.Fatal("Confirmation should have been approved.")
+	}
+
+}

--- a/cmd/kops/delete_confirm_test.go
+++ b/cmd/kops/delete_confirm_test.go
@@ -43,11 +43,14 @@ func TestContainsString(t *testing.T) {
 
 // TestConfirmation attempts to test the majority of the ui.GetConfirm function used in the 'kogs delete' commands
 func TestConfirmation(t *testing.T) {
-	var answer bool
 	var out bytes.Buffer
-	message := "Are you sure you want to remove?"
+	c := &ui.ConfirmArgs{
+		Message: "Are you sure you want to remove?",
+		Out:     &out,
+		TestVal: "no",
+	}
 
-	answer = ui.GetConfirm(&out, message, "no")
+	answer := ui.GetConfirm(c)
 	if !strings.Contains(out.String(), "Are you sure") {
 		t.Fatal("Confirmation not in output")
 	}
@@ -55,7 +58,8 @@ func TestConfirmation(t *testing.T) {
 		t.Fatal("Confirmation should have been denied.")
 	}
 
-	answer = ui.GetConfirm(&out, message, "yes")
+	c.TestVal = "yes"
+	answer = ui.GetConfirm(c)
 	if answer != true {
 		t.Fatal("Confirmation should have been approved.")
 	}

--- a/cmd/kops/delete_confirm_test.go
+++ b/cmd/kops/delete_confirm_test.go
@@ -48,14 +48,24 @@ func TestConfirmation(t *testing.T) {
 		Message: "Are you sure you want to remove?",
 		Out:     &out,
 		TestVal: "no",
+		Default: "no",
 	}
 
 	answer := ui.GetConfirm(c)
 	if !strings.Contains(out.String(), "Are you sure") {
 		t.Fatal("Confirmation not in output")
 	}
+	if !strings.Contains(out.String(), "y/N") {
+		t.Fatal("Default 'No' was not set")
+	}
 	if answer == true {
 		t.Fatal("Confirmation should have been denied.")
+	}
+
+	c.Default = "yes"
+	answer = ui.GetConfirm(c)
+	if !strings.Contains(out.String(), "Y/n") {
+		t.Fatal("Default 'Yes' was not set")
 	}
 
 	c.TestVal = "yes"

--- a/hack/.packages
+++ b/hack/.packages
@@ -57,4 +57,5 @@ k8s.io/kops/upup/tools/generators/fitask
 k8s.io/kops/upup/tools/generators/pkg/codegen
 k8s.io/kops/util/pkg/hashing
 k8s.io/kops/util/pkg/tables
+k8s.io/kops/util/pkg/ui
 k8s.io/kops/util/pkg/vfs

--- a/util/pkg/ui/user.go
+++ b/util/pkg/ui/user.go
@@ -81,7 +81,7 @@ func GetConfirm(c *ConfirmArgs) (bool, error) {
 
 	fmt.Printf("invalid response: %s\n\n", response)
 
-	// if c.RetryCount exceeds the requested number of retries then five up
+	// if c.RetryCount exceeds the requested number of retries then give up
 	if c.RetryCount >= c.Retries {
 		return false, nil
 	}

--- a/util/pkg/ui/user.go
+++ b/util/pkg/ui/user.go
@@ -38,7 +38,7 @@ type ConfirmArgs struct {
 // out: an io.Writer that allows you to direct prints to stdout or another location
 // message: the string that will be printed just before prompting for a yes or no.
 // answer: "", "yes", or "no" - this allows for easier testing
-func GetConfirm(c *ConfirmArgs) bool {
+func GetConfirm(c *ConfirmArgs) (bool, error) {
 	if c.Default != "" {
 		c.Default = strings.ToLower(c.Default)
 	}
@@ -62,28 +62,28 @@ func GetConfirm(c *ConfirmArgs) bool {
 	if response == "" {
 		_, err := fmt.Scanln(&response)
 		if err != nil {
-			return false
+			return false, err
 		}
 	}
 
 	responseLower := strings.ToLower(response)
 	// make sure the response is valid
 	if ContainsString(okayResponses, responseLower) {
-		return true
+		return true, nil
 	} else if ContainsString(nokayResponses, responseLower) {
-		return false
+		return false, nil
 	} else if c.Default != "" && response == "" {
 		if string(c.Default[0]) == "y" {
-			return true
+			return true, nil
 		}
-		return false
+		return false, nil
 	}
 
 	fmt.Printf("invalid response: %s\n\n", response)
 
 	// if c.RetryCount exceeds the requested number of retries then five up
 	if c.RetryCount >= c.Retries {
-		return false
+		return false, nil
 	}
 
 	c.RetryCount++

--- a/util/pkg/ui/user.go
+++ b/util/pkg/ui/user.go
@@ -6,22 +6,29 @@ import (
 	"strings"
 )
 
+type ConfirmArgs struct {
+	Out     io.Writer
+	Message string
+	Default string
+	TestVal string
+}
+
 // GetConfirm prompts a user for a yes or no answer.
 // In order to test this function som extra parameters are reqired:
 //
 // out: an io.Writer that allows you to direct prints to stdout or another location
 // message: the string that will be printed just before prompting for a yes or no.
 // answer: "", "yes", or "no" - this allows for easier testing
-func GetConfirm(out io.Writer, message string, answer string) bool {
-	fmt.Fprintln(out, message)
+func GetConfirm(c *ConfirmArgs) bool {
+	fmt.Fprintln(c.Out, c.Message)
 
 	// these are the acceptable answers
 	okayResponses := []string{"y", "yes"}
 	nokayResponses := []string{"n", "no"}
-	response := answer
+	response := c.TestVal
 
 	// only prompt user if you predefined answer was passed in
-	if answer == "" {
+	if response == "" {
 		_, err := fmt.Scanln(&response)
 		if err != nil {
 			return false
@@ -35,7 +42,7 @@ func GetConfirm(out io.Writer, message string, answer string) bool {
 	} else if ContainsString(nokayResponses, responseLower) {
 		return false
 	} else {
-		return GetConfirm(out, "Please type yes or no and then press enter:", answer)
+		return GetConfirm(c)
 	}
 }
 

--- a/util/pkg/ui/user.go
+++ b/util/pkg/ui/user.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package ui
 
 import (

--- a/util/pkg/ui/user.go
+++ b/util/pkg/ui/user.go
@@ -2,45 +2,44 @@ package ui
 
 import (
 	"fmt"
-	"log"
+	"io"
 	"strings"
 )
 
-// GetConfirm prompts a user for a yes or no answer
-func GetConfirm() bool {
+// GetConfirm prompts a user for a yes or no answer.
+// In order to test this function som extra parameters are reqired:
+//
+// out: an io.Writer that allows you to direct prints to stdout or another location
+// message: the string that will be printed just before prompting for a yes or no.
+// answer: "", "yes", or "no" - this allows for easier testing
+func GetConfirm(out io.Writer, message string, answer string) bool {
+	fmt.Fprintln(out, message)
+
+	// these are the acceptable answers
 	okayResponses := []string{"y", "yes"}
 	nokayResponses := []string{"n", "no"}
+	response := answer
 
-	var response string
-	_, err := fmt.Scanln(&response)
-	if err != nil {
-		log.Fatal(err)
+	// only prompt user if you predefined answer was passed in
+	if answer == "" {
+		_, err := fmt.Scanln(&response)
+		if err != nil {
+			return false
+		}
 	}
 
 	responseLower := strings.ToLower(response)
-
-	if containsString(okayResponses, responseLower) {
+	// make sure the response is valid
+	if ContainsString(okayResponses, responseLower) {
 		return true
-	} else if containsString(nokayResponses, responseLower) {
+	} else if ContainsString(nokayResponses, responseLower) {
 		return false
 	} else {
-		fmt.Println("Please type yes or no and then press enter:")
-		return GetConfirm()
+		return GetConfirm(out, "Please type yes or no and then press enter:", answer)
 	}
 }
 
-// containsString returns true if slice contains element
-func containsString(slice []string, element string) bool {
-	return !(posString(slice, element) == -1)
-}
-
-// posString returns the first index of element in slice.
-// If slice does not contain element, returns -1.
-func posString(slice []string, element string) int {
-	for index, elem := range slice {
-		if elem == element {
-			return index
-		}
-	}
-	return -1
+// ContainsString returns true if slice contains the element
+func ContainsString(slice []string, element string) bool {
+	return !(strings.Index(strings.Join(slice, " "), element) == -1)
 }

--- a/util/pkg/ui/user.go
+++ b/util/pkg/ui/user.go
@@ -1,0 +1,46 @@
+package ui
+
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+// GetConfirm prompts a user for a yes or no answer
+func GetConfirm() bool {
+	okayResponses := []string{"y", "yes"}
+	nokayResponses := []string{"n", "no"}
+
+	var response string
+	_, err := fmt.Scanln(&response)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	responseLower := strings.ToLower(response)
+
+	if containsString(okayResponses, responseLower) {
+		return true
+	} else if containsString(nokayResponses, responseLower) {
+		return false
+	} else {
+		fmt.Println("Please type yes or no and then press enter:")
+		return GetConfirm()
+	}
+}
+
+// containsString returns true if slice contains element
+func containsString(slice []string, element string) bool {
+	return !(posString(slice, element) == -1)
+}
+
+// posString returns the first index of element in slice.
+// If slice does not contain element, returns -1.
+func posString(slice []string, element string) int {
+	for index, elem := range slice {
+		if elem == element {
+			return index
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## The problem:

When running the `kops delete` command there are no confirmation attempts made before deleting the resource. This can lead to mishaps that could be devastating to an organization.

## The fix:

To solve this issue I created a PersistentPreRun hook on the deleteCmd which is the parent command for all resource deleting commands. This hook alerts the user that their actions cannot be undone and then asks for a confirmation. If the flag --yes is passed to the command the confirmation will be skipped.

## The test:

1. Check out the branch from my fork.
2. Run `make`
3. now run`kops delete ig mctester`. You should see output like:

```
kops delete ig mctester
Do you really want to delete ig mctester? This action cannot be undone. (Y/n)
```

Select `no` and ensure the program exits. Run it again and select `yes` and ensure the normal error for non existing resources is displayed..
4. Run the same commands agains with `--yes` and ensure no confirmation attempt is made.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1367)
<!-- Reviewable:end -->
