### PR TITLE
Recognize CI=1 to makefile, use git sha for VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,23 @@ MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))
 # Keep in sync with upup/models/cloudup/resources/addons/dns-controller/
 DNS_CONTROLLER_TAG=1.4.1
 
-VERSION?=1.5.0-alpha1
+ifndef VERSION
+  # To keep both CI and end-users building from source happy,
+  # we expect that CI sets CI=1.
+  #
+  # For end users, they need only build kops, and they can use the last
+  # released version of nodeup/protokube.
+  # For CI, we continue to build a synthetic version from the git SHA, so
+  # we never cross versions.
+  #
+  # We expect that if you are uploading nodeup/protokube, you will set
+  # VERSION (along with S3_BUCKET), either directly or by setting CI=1
+  ifndef CI
+    VERSION=1.5.0-alpha1
+  else
+    VERSION := git-$(shell git describe --always)
+  endif
+endif
 
 
 # Go exports:


### PR DESCRIPTION
This means that end-users can have an easy experience without needing to
upload nodeup/protokube, but CI can still get the git-based unique
version as long as it sets CI=1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1380)
<!-- Reviewable:end -->
