### PR TITLE
When outputing to terraform, don't say the cluster is starting

### DIFF
--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -203,9 +203,16 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 
 		if !hasKubecfg {
 			// Assume initial creation
-			fmt.Printf("\n")
-			fmt.Printf("Cluster is starting.  It should be ready in a few minutes.\n")
-			fmt.Printf("\n")
+			if c.Target == cloudup.TargetTerraform {
+				fmt.Printf("\n")
+				fmt.Printf("Terraform output has been placed into %s\n", c.OutDir)
+				fmt.Printf("You likely want to run terraform plan and apply in that directory\n")
+				fmt.Printf("\n")
+			} else {
+				fmt.Printf("\n")
+				fmt.Printf("Cluster is starting.  It should be ready in a few minutes.\n")
+				fmt.Printf("\n")
+			}
 			fmt.Printf("Suggestions:\n")
 			fmt.Printf(" * list nodes: kubectl get nodes --show-labels\n")
 			if cluster.Spec.Topology.Masters == kops.TopologyPublic {

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -206,7 +206,10 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 			if c.Target == cloudup.TargetTerraform {
 				fmt.Printf("\n")
 				fmt.Printf("Terraform output has been placed into %s\n", c.OutDir)
-				fmt.Printf("You likely want to run terraform plan and apply in that directory\n")
+				fmt.Printf("Run these commands to apply the configuration:\n")
+				fmt.Printf("   cd %s\n", c.OutDir)
+				fmt.Printf("   terraform plan\n")
+				fmt.Printf("   terraform apply\n")
 				fmt.Printf("\n")
 			} else {
 				fmt.Printf("\n")


### PR DESCRIPTION
Suggest the user goes into the output directory and runs terraform plan
& apply instead.

Fix #1141

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1382)
<!-- Reviewable:end -->
