### PR TITLE
Add diagnostic message when updating DNS

### DIFF
--- a/dns-controller/pkg/dns/dnscontroller.go
+++ b/dns-controller/pkg/dns/dnscontroller.go
@@ -257,6 +257,8 @@ func (c *DNSController) runOnce() error {
 		ttl := DefaultTTL
 		glog.Infof("Using default TTL of %v", ttl)
 
+		glog.V(4).Infof("updating records for %s: %v -> %v", k, newValues, oldValues)
+
 		err := op.updateRecords(k, newValues, int64(ttl.Seconds()))
 		if err != nil {
 			glog.Infof("error updating records for %s: %v", k, err)


### PR DESCRIPTION
In debugging, it would have been useful to see the old & new values
sometimes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1387)
<!-- Reviewable:end -->
