### PR TITLE
dns-controller: don't make spurious updates in buffer

### DIFF
--- a/dns-controller/cmd/dns-controller/main.go
+++ b/dns-controller/cmd/dns-controller/main.go
@@ -23,8 +23,8 @@ import (
 	"k8s.io/kops/dns-controller/pkg/dns"
 	"k8s.io/kops/dns-controller/pkg/watchers"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
-	client "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5/typed/core/v1"
-	client_extensions "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1"
+	client "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/core/v1"
+	client_extensions "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/extensions/v1beta1"
 	kubectl_util "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"os"
 


### PR DESCRIPTION
These will be caught later anyway, but we can save a false invalidation
and a spurious log message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1397)
<!-- Reviewable:end -->
