### PR TITLE
Create a role for networking addons; use as selector

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kope.io/v1.0.20161116.yaml
+++ b/upup/models/cloudup/resources/addons/networking.kope.io/v1.0.20161116.yaml
@@ -5,11 +5,13 @@ metadata:
   namespace: kube-system
   labels:
     k8s-addon: networking.addons.k8s.io
+    role.kubernetes.io/networking: "1"
 spec:
   template:
     metadata:
       labels:
         name: kopeio-networking-agent
+        role.kubernetes.io/networking: "1"
     spec:
       hostPID: true
       hostIPC: true

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/v2.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/v2.0.yaml.template
@@ -60,6 +60,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-node
+    role.kubernetes.io/networking: "1"
 spec:
   selector:
     matchLabels:
@@ -68,6 +69,7 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
+        role.kubernetes.io/networking: "1"
     spec:
       hostNetwork: true
       containers:
@@ -165,6 +167,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-policy
+    role.kubernetes.io/networking: "1"
 spec:
   # The policy controller can only have a single active instance.
   replicas: 1
@@ -174,6 +177,7 @@ spec:
       namespace: kube-system
       labels:
         k8s-app: calico-policy-controller
+        role.kubernetes.io/networking: "1"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
@@ -217,6 +221,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico
+    role.kubernetes.io/networking: "1"
 spec:
   template:
     metadata:

--- a/upup/models/cloudup/resources/addons/networking.weave/v1.8.2.yaml
+++ b/upup/models/cloudup/resources/addons/networking.weave/v1.8.2.yaml
@@ -3,11 +3,14 @@ kind: DaemonSet
 metadata:
   name: weave-net
   namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   template:
     metadata:
       labels:
         name: weave-net
+        role.kubernetes.io/networking: "1"
       annotations:
         scheduler.alpha.kubernetes.io/tolerations: |
           [

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -143,6 +143,19 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		manifests[key] = "addons/" + location
 	}
 
+	// The role.kubernetes.io/networking is used to label anything related to a networking addin,
+	// so that if we switch networking plugins (e.g. calico -> weave or vice-versa), we'll replace the
+	// old networking plugin, and there won't be old pods "floating around".
+
+	// This means whenever we create or update a networking plugin, we should be sure that:
+	// 1. the selector is role.kubernetes.io/networking=1
+	// 2. every object in the manifest is labeleled with role.kubernetes.io/networking=1
+
+	// TODO: Some way to test/enforce this?
+
+	// TODO: Create "empty" configurations for others, so we can delete e.g. the kopeio configuration
+	// if we switch to kubenet?
+
 	if b.cluster.Spec.Networking.Kopeio != nil {
 		key := "networking.kope.io"
 		version := "1.0.20161116"
@@ -153,7 +166,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 			Name:     fi.String(key),
 			Version:  fi.String(version),
-			Selector: map[string]string{"k8s-addon": key},
+			Selector: map[string]string{"role.kubernetes.io/networking": "1"},
 			Manifest: fi.String(location),
 		})
 
@@ -170,7 +183,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 			Name:     fi.String(key),
 			Version:  fi.String(version),
-			Selector: map[string]string{"k8s-addon": key},
+			Selector: map[string]string{"role.kubernetes.io/networking": "1"},
 			Manifest: fi.String(location),
 		})
 
@@ -187,7 +200,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 			Name:     fi.String(key),
 			Version:  fi.String(version),
-			Selector: map[string]string{"k8s-addon": key},
+			Selector: map[string]string{"role.kubernetes.io/networking": "1"},
 			Manifest: fi.String(location),
 		})
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
@@ -32,6 +32,6 @@ spec:
   - manifest: networking.kope.io/v1.0.20161116.yaml
     name: networking.kope.io
     selector:
-      k8s-addon: networking.kope.io
+      role.kubernetes.io/networking: "1"
     version: 1.0.20161116
 


### PR DESCRIPTION
role.kubernetes.io/networking

This ensures that when we switch networking providers, we replace all
the components of the prior tool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1400)
<!-- Reviewable:end -->
