### PR TITLE
Default bastion name should be bastion.<clusterName>

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -493,16 +493,8 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 			bastionGroup.ObjectMeta.Name = "bastions"
 			instanceGroups = append(instanceGroups, bastionGroup)
 
-			// Logic to handle default bastion names
-			if c.DNSZone != "" {
-				cluster.Spec.Topology.Bastion = &api.BastionSpec{
-					BastionPublicName: "bastion-" + c.DNSZone,
-				}
-			} else {
-				// Use default zone and cluster name
-				cluster.Spec.Topology.Bastion = &api.BastionSpec{
-					BastionPublicName: "bastion-" + clusterName,
-				}
+			cluster.Spec.Topology.Bastion = &api.BastionSpec{
+				BastionPublicName: "bastion." + clusterName,
 			}
 		}
 

--- a/tests/integration/create_cluster/private/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha1.yaml
@@ -28,7 +28,7 @@ spec:
   topology:
     bastion:
       enable: true
-      name: bastion-private.example.com
+      name: bastion.private.example.com
     dns:
       type: Public
     masters: private

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -36,7 +36,7 @@ spec:
     zone: us-test-1a
   topology:
     bastion:
-      bastionPublicName: bastion-private.example.com
+      bastionPublicName: bastion.private.example.com
     dns:
       type: Public
     masters: private


### PR DESCRIPTION
`bastion-<clustername>` is not necessarily in the same hosted zone, nor is
`bastion-<dnszone>`, and `bastion-<dnszone>` is not necessarily unique
across clusters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1404)
<!-- Reviewable:end -->
