### PR TITLE
kops get clusters should print zones

### DIFF
--- a/cmd/kops/get_cluster.go
+++ b/cmd/kops/get_cluster.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kops/pkg/apis/kops/registry"
 	"k8s.io/kops/util/pkg/tables"
 	k8sapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 type GetClusterOptions struct {
@@ -126,14 +127,14 @@ func RunGetClusters(context Factory, out io.Writer, options *GetClusterOptions) 
 		t.AddColumn("CLOUD", func(c *api.Cluster) string {
 			return c.Spec.CloudProvider
 		})
-		t.AddColumn("SUBNETS", func(c *api.Cluster) string {
-			var subnetNames []string
+		t.AddColumn("ZONES", func(c *api.Cluster) string {
+			zones := sets.NewString()
 			for _, s := range c.Spec.Subnets {
-				subnetNames = append(subnetNames, s.Name)
+				zones.Insert(s.Zone)
 			}
-			return strings.Join(subnetNames, ",")
+			return strings.Join(zones.List(), ",")
 		})
-		return t.Render(clusters, out, "NAME", "CLOUD", "SUBNETS")
+		return t.Render(clusters, out, "NAME", "CLOUD", "ZONES")
 
 	case OutputYaml:
 		for i, cluster := range clusters {


### PR DESCRIPTION
The list of subnets just isn't very interesting

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1405)
<!-- Reviewable:end -->
