### PR TITLE
Unclear labels example, added `spec:` to clarify which section

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -15,6 +15,7 @@ An example:
 
 ```
 ...
+spec: 
   nodeLabels:
     spot: "false"
   cloudLabels:


### PR DESCRIPTION
The example was missing which section the labels should be added to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1414)
<!-- Reviewable:end -->
