### PR TITLE
kops: Always enable CI versioning on gcs-upload-ci target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,11 +140,11 @@ upload: kops version-dist
 	aws s3 sync --acl public-read .build/upload/ ${S3_BUCKET}
 
 gcs-upload: version-dist
-	@echo "== Logging gcloud info =="
-	@gcloud info
 	@echo "== Uploading kops =="
 	gsutil -h "Cache-Control:private, max-age=0, no-transform" -m cp -n -r .build/upload/kops/* ${GCS_LOCATION}
 
+# In CI testing, always upload the CI version.
+gcs-publish-ci: VERSION := git-$(shell git describe --always)
 gcs-publish-ci: gcs-upload
 	echo "${GCS_URL}/${VERSION}" > .build/upload/${LATEST_FILE}
 	gsutil -h "Cache-Control:private, max-age=0, no-transform" cp .build/upload/${LATEST_FILE} ${GCS_LOCATION}


### PR DESCRIPTION
Follow-on to https://github.com/kubernetes/kops/pull/1380, relies on
https://www.gnu.org/software/make/manual/make.html#Target_002dspecific
to override the target used for CI upload.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1416)
<!-- Reviewable:end -->
