### PR TITLE
Don't delete NatGateways if there were none found

### DIFF
--- a/upup/pkg/kutil/delete_cluster.go
+++ b/upup/pkg/kutil/delete_cluster.go
@@ -1468,7 +1468,7 @@ func FindNatGateways(cloud fi.Cloud, routeTableIds sets.String) ([]*ResourceTrac
 
 	var trackers []*ResourceTracker
 
-	{
+	if len(natGatewayIds) != 0 {
 		request := &ec2.DescribeNatGatewaysInput{}
 		for natGatewayId := range natGatewayIds {
 			request.NatGatewayIds = append(request.NatGatewayIds, aws.String(natGatewayId))


### PR DESCRIPTION
Because an empty filter means "list all NatGateways".

Thanks to @tsupertramp for finding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1439)
<!-- Reviewable:end -->
