### PR TITLE
Allow adding existing security groups

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -37,29 +37,29 @@ import (
 )
 
 type CreateClusterOptions struct {
-	ClusterName            string
-	Yes                    bool
-	Target                 string
-	Models                 string
-	Cloud                  string
-	Zones                  string
-	MasterZones            string
-	NodeSize               string
-	MasterSize             string
-	NodeCount              int32
-	Project                string
-	KubernetesVersion      string
-	OutDir                 string
-	Image                  string
-	SSHPublicKey           string
-	VPCID                  string
-	NetworkCIDR            string
-	DNSZone                string
-	AdminAccess            []string
-	Networking             string
-	NodeSecurityGroupIDs   string
-	MasterSecurityGroupIDs string
-	AssociatePublicIP      *bool
+	ClusterName          string
+	Yes                  bool
+	Target               string
+	Models               string
+	Cloud                string
+	Zones                []string
+	MasterZones          []string
+	NodeSize             string
+	MasterSize           string
+	NodeCount            int32
+	Project              string
+	KubernetesVersion    string
+	OutDir               string
+	Image                string
+	SSHPublicKey         string
+	VPCID                string
+	NetworkCIDR          string
+	DNSZone              string
+	AdminAccess          []string
+	Networking           string
+	NodeSecurityGroups   []string
+	MasterSecurityGroups []string
+	AssociatePublicIP    *bool
 
 	// Channel is the location of the api.Channel to use for our defaults
 	Channel string

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -257,7 +257,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 			subnet := &cluster.Spec.Subnets[i]
 			existingSubnets[subnet.Name] = subnet
 		}
-		for _, zoneName := range parseZoneList(c.Zones) {
+		for _, zoneName := range parseInputList(c.Zones) {
 			// We create default subnets named the same as the zones
 			subnetName := zoneName
 			if existingSubnets[subnetName] == nil {
@@ -300,7 +300,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 	} else {
 		if len(masters) == 0 {
 			// Use the specified master zones (this is how the user gets HA master)
-			for _, subnetName := range parseZoneList(c.MasterZones) {
+			for _, subnetName := range parseInputList(c.MasterZones) {
 				g := &api.InstanceGroup{}
 				g.Spec.Role = api.InstanceGroupRoleMaster
 				g.Spec.Subnets = []string{subnetName}
@@ -684,7 +684,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 	return nil
 }
 
-func parseZoneList(s string) []string {
+func parseInputList(s string) []string {
 	var filtered []string
 	for _, v := range strings.Split(s, ",") {
 		v = strings.TrimSpace(v)

--- a/docs/advanced_create.md
+++ b/docs/advanced_create.md
@@ -10,6 +10,8 @@ kops create cluster \
     --dns-zone kubernetes.com \
     --node-size t2.medium \
     --master-size t2.medium \
+    --node-security-groups i-123456 \
+    --master-security-groups i-123456,i-123457 \
     --topology private \
     --networking weave \
     --image 293135079892/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-11-16 \

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -14,29 +14,31 @@ kops create cluster
 ### Options
 
 ```
-      --admin-access string         Restrict access to admin endpoints (SSH, HTTPS) to this CIDR.  If not set, access will not be restricted by IP.
-      --associate-public-ip         Specify --associate-public-ip=[true|false] to enable/disable association of public IP for master ASG and nodes. Default is 'true'. (default true)
-      --bastion                     Pass the --bastion flag to enable a bastion instance group. Only applies to private topology.
-      --channel string              Channel for default versions and configuration to use (default "stable")
-      --cloud string                Cloud provider to use - gce, aws
-      --dns-zone string             DNS hosted zone to use (defaults to longest matching zone)
-      --image string                Image to use
-      --kubernetes-version string   Version of kubernetes to run (defaults to version in channel)
-      --master-size string          Set instance size for masters
-      --master-zones string         Zones in which to run masters (must be an odd number)
-      --model string                Models to apply (separate multiple models with commas) (default "config,proto,cloudup")
-      --network-cidr string         Set to override the default network CIDR
-      --networking string           Networking mode to use.  kubenet (default), classic, external, cni, kopeio-vxlan, weave, calico. (default "kubenet")
-      --node-count int              Set the number of nodes
-      --node-size string            Set instance size for nodes
-      --out string                  Path to write any local output
-      --project string              Project to use (must be set on GCE)
-      --ssh-public-key string       SSH public key to use (default "~/.ssh/id_rsa.pub")
-      --target string               Target - direct, terraform (default "direct")
-  -t, --topology string             Controls network topology for the cluster. public|private. Default is 'public'. (default "public")
-      --vpc string                  Set to use a shared VPC
-      --yes                         Specify --yes to immediately create the cluster
-      --zones string                Zones in which to run the cluster
+      --admin-access string             Restrict access to admin endpoints (SSH, HTTPS) to this CIDR.  If not set, access will not be restricted by IP.
+      --associate-public-ip             Specify --associate-public-ip=[true|false] to enable/disable association of public IP for master ASG and nodes. Default is 'true'. (default true)
+      --bastion                         Pass the --bastion flag to enable a bastion instance group. Only applies to private topology.
+      --channel string                  Channel for default versions and configuration to use (default "stable")
+      --cloud string                    Cloud provider to use - gce, aws
+      --dns-zone string                 DNS hosted zone to use (defaults to longest matching zone)
+      --image string                    Image to use
+      --kubernetes-version string       Version of kubernetes to run (defaults to version in channel)
+      --master-security-groups string   Add precreated additional security groups to masters.
+      --master-size string              Set instance size for masters
+      --master-zones string             Zones in which to run masters (must be an odd number)
+      --model string                    Models to apply (separate multiple models with commas) (default "config,proto,cloudup")
+      --network-cidr string             Set to override the default network CIDR
+      --networking string               Networking mode to use.  kubenet (default), classic, external, cni, kopeio-vxlan, weave, calico. (default "kubenet")
+      --node-count int                  Set the number of nodes
+      --node-security-groups string     Add precreated additional security groups to nodes.
+      --node-size string                Set instance size for nodes
+      --out string                      Path to write any local output
+      --project string                  Project to use (must be set on GCE)
+      --ssh-public-key string           SSH public key to use (default "~/.ssh/id_rsa.pub")
+      --target string                   Target - direct, terraform (default "direct")
+  -t, --topology string                 Controls network topology for the cluster. public|private. Default is 'public'. (default "public")
+      --vpc string                      Set to use a shared VPC
+      --yes                             Specify --yes to immediately create the cluster
+      --zones string                    Zones in which to run the cluster
 ```
 
 ### Options inherited from parent commands

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -81,8 +81,8 @@ type InstanceGroupSpec struct {
 	// AssociatePublicIP is true if we want instances to have a public IP
 	AssociatePublicIP *bool `json:"associatePublicIp,omitempty"`
 
-	// AdditionalSecurityGroupIDs attaches additional security groups (e.g. i-123456)
-	AdditionalSecurityGroupIDs []string `json:"additionalSecurityGroupIDs,omitempty"`
+	// AdditionalSecurityGroups attaches additional security groups (e.g. i-123456)
+	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
 
 	// CloudLabels indicates the labels for instances in this group, at the AWS level
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -81,6 +81,9 @@ type InstanceGroupSpec struct {
 	// AssociatePublicIP is true if we want instances to have a public IP
 	AssociatePublicIP *bool `json:"associatePublicIp,omitempty"`
 
+	// AdditionalSecurityGroupIDs attaches additional security groups (e.g. i-123456)
+	AdditionalSecurityGroupIDs []string `json:"additionalSecurityGroupIDs,omitempty"`
+
 	// CloudLabels indicates the labels for instances in this group, at the AWS level
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`
 

--- a/pkg/apis/kops/v1alpha1/instancegroup.go
+++ b/pkg/apis/kops/v1alpha1/instancegroup.go
@@ -69,6 +69,9 @@ type InstanceGroupSpec struct {
 	// AssociatePublicIP is true if we want instances to have a public IP
 	AssociatePublicIP *bool `json:"associatePublicIp,omitempty"`
 
+	// AdditionalSecurityGroupIDs attaches additional security groups (e.g. i-123456)
+	AdditionalSecurityGroupIDs []string `json:"additionalSecurityGroupIDs,omitempty"`
+
 	// CloudLabels indicates the labels for instances in this group, at the AWS level
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`
 

--- a/pkg/apis/kops/v1alpha1/instancegroup.go
+++ b/pkg/apis/kops/v1alpha1/instancegroup.go
@@ -69,8 +69,8 @@ type InstanceGroupSpec struct {
 	// AssociatePublicIP is true if we want instances to have a public IP
 	AssociatePublicIP *bool `json:"associatePublicIp,omitempty"`
 
-	// AdditionalSecurityGroupIDs attaches additional security groups (e.g. i-123456)
-	AdditionalSecurityGroupIDs []string `json:"additionalSecurityGroupIDs,omitempty"`
+	// AdditionalSecurityGroups attaches additional security groups (e.g. i-123456)
+	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
 
 	// CloudLabels indicates the labels for instances in this group, at the AWS level
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -899,7 +899,7 @@ func autoConvert_v1alpha1_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	// WARNING: in.Zones requires manual conversion: does not exist in peer-type
 	out.MaxPrice = in.MaxPrice
 	out.AssociatePublicIP = in.AssociatePublicIP
-	out.AdditionalSecurityGroupIDs = in.AdditionalSecurityGroupIDs
+	out.AdditionalSecurityGroups = in.AdditionalSecurityGroups
 	out.CloudLabels = in.CloudLabels
 	out.NodeLabels = in.NodeLabels
 	return nil
@@ -916,7 +916,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha1_InstanceGroupSpec(in *kops.I
 	// WARNING: in.Subnets requires manual conversion: does not exist in peer-type
 	out.MaxPrice = in.MaxPrice
 	out.AssociatePublicIP = in.AssociatePublicIP
-	out.AdditionalSecurityGroupIDs = in.AdditionalSecurityGroupIDs
+	out.AdditionalSecurityGroups = in.AdditionalSecurityGroups
 	out.CloudLabels = in.CloudLabels
 	out.NodeLabels = in.NodeLabels
 	return nil

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -899,6 +899,7 @@ func autoConvert_v1alpha1_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	// WARNING: in.Zones requires manual conversion: does not exist in peer-type
 	out.MaxPrice = in.MaxPrice
 	out.AssociatePublicIP = in.AssociatePublicIP
+	out.AdditionalSecurityGroupIDs = in.AdditionalSecurityGroupIDs
 	out.CloudLabels = in.CloudLabels
 	out.NodeLabels = in.NodeLabels
 	return nil
@@ -915,6 +916,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha1_InstanceGroupSpec(in *kops.I
 	// WARNING: in.Subnets requires manual conversion: does not exist in peer-type
 	out.MaxPrice = in.MaxPrice
 	out.AssociatePublicIP = in.AssociatePublicIP
+	out.AdditionalSecurityGroupIDs = in.AdditionalSecurityGroupIDs
 	out.CloudLabels = in.CloudLabels
 	out.NodeLabels = in.NodeLabels
 	return nil

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -76,8 +76,8 @@ type InstanceGroupSpec struct {
 	// AssociatePublicIP is true if we want instances to have a public IP
 	AssociatePublicIP *bool `json:"associatePublicIp,omitempty"`
 
-	// AdditionalSecurityGroupIDs attaches additional security groups (e.g. i-123456)
-	AdditionalSecurityGroupIDs []string `json:"additionalSecurityGroupIDs,omitempty"`
+	// AdditionalSecurityGroups attaches additional security groups (e.g. i-123456)
+	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
 
 	// CloudLabels indicates the labels for instances in this group, at the AWS level
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -76,6 +76,9 @@ type InstanceGroupSpec struct {
 	// AssociatePublicIP is true if we want instances to have a public IP
 	AssociatePublicIP *bool `json:"associatePublicIp,omitempty"`
 
+	// AdditionalSecurityGroupIDs attaches additional security groups (e.g. i-123456)
+	AdditionalSecurityGroupIDs []string `json:"additionalSecurityGroupIDs,omitempty"`
+
 	// CloudLabels indicates the labels for instances in this group, at the AWS level
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`
 

--- a/pkg/model/autoscalinggroup.go
+++ b/pkg/model/autoscalinggroup.go
@@ -66,9 +66,10 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 				SecurityGroups: []*awstasks.SecurityGroup{
 					b.LinkToSecurityGroup(ig.Spec.Role),
 				},
-				IAMInstanceProfile: b.LinkToIAMInstanceProfile(ig),
-				ImageID:            s(ig.Spec.Image),
-				InstanceType:       s(ig.Spec.MachineType),
+				AdditionalSecurityGroupIDs: ig.Spec.AdditionalSecurityGroupIDs,
+				IAMInstanceProfile:         b.LinkToIAMInstanceProfile(ig),
+				ImageID:                    s(ig.Spec.Image),
+				InstanceType:               s(ig.Spec.MachineType),
 
 				RootVolumeSize: i64(int64(volumeSize)),
 				RootVolumeType: s(volumeType),

--- a/pkg/model/autoscalinggroup.go
+++ b/pkg/model/autoscalinggroup.go
@@ -66,7 +66,7 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 				SecurityGroups: []*awstasks.SecurityGroup{
 					b.LinkToSecurityGroup(ig.Spec.Role),
 				},
-				AdditionalSecurityGroupIDs: ig.Spec.AdditionalSecurityGroupIDs,
+				AdditionalSecurityGroupIDs: ig.Spec.AdditionalSecurityGroups,
 				IAMInstanceProfile:         b.LinkToIAMInstanceProfile(ig),
 				ImageID:                    s(ig.Spec.Image),
 				InstanceType:               s(ig.Spec.MachineType),

--- a/tests/integration/create_cluster/private/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha1.yaml
@@ -68,6 +68,9 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: master-us-test-1a
 spec:
+  additionalSecurityGroupIDs:
+  - i-exampleid3
+  - i-exampleid4
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
   machineType: m3.medium
   maxSize: 1
@@ -86,6 +89,9 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: nodes
 spec:
+  additionalSecurityGroupIDs:
+  - i-exampleid
+  - i-exampleid2
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
   machineType: t2.medium
   maxSize: 2

--- a/tests/integration/create_cluster/private/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha1.yaml
@@ -68,7 +68,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: master-us-test-1a
 spec:
-  additionalSecurityGroupIDs:
+  additionalSecurityGroups:
   - i-exampleid3
   - i-exampleid4
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
@@ -89,7 +89,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: nodes
 spec:
-  additionalSecurityGroupIDs:
+  additionalSecurityGroups:
   - i-exampleid
   - i-exampleid2
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -74,6 +74,9 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: master-us-test-1a
 spec:
+  additionalSecurityGroupIDs:
+  - i-exampleid3
+  - i-exampleid4
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
   machineType: m3.medium
   maxSize: 1
@@ -92,6 +95,9 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: nodes
 spec:
+  additionalSecurityGroupIDs:
+  - i-exampleid
+  - i-exampleid2
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
   machineType: t2.medium
   maxSize: 2

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -74,7 +74,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: master-us-test-1a
 spec:
-  additionalSecurityGroupIDs:
+  additionalSecurityGroups:
   - i-exampleid3
   - i-exampleid4
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
@@ -95,7 +95,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: nodes
 spec:
-  additionalSecurityGroupIDs:
+  additionalSecurityGroups:
   - i-exampleid
   - i-exampleid2
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21

--- a/tests/integration/create_cluster/private/options.yaml
+++ b/tests/integration/create_cluster/private/options.yaml
@@ -4,3 +4,5 @@ Cloud: aws
 Topology: private
 Networking: kopeio-vxlan
 Bastion: true
+NodeSecurityGroupIDs: i-exampleid, i-exampleid2
+MasterSecurityGroupIDs: i-exampleid3, i-exampleid4

--- a/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
@@ -238,7 +238,7 @@ func (_ *LaunchConfiguration) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *La
 		securityGroupIDs = append(securityGroupIDs, sg.ID)
 	}
 
-	for i, _ := range e.AdditionalSecurityGroupIDs {
+	for i := range e.AdditionalSecurityGroupIDs {
 		securityGroupIDs = append(securityGroupIDs, &e.AdditionalSecurityGroupIDs[i])
 	}
 

--- a/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
@@ -36,12 +36,13 @@ type LaunchConfiguration struct {
 
 	UserData *fi.ResourceHolder
 
-	ImageID            *string
-	InstanceType       *string
-	SSHKey             *SSHKey
-	SecurityGroups     []*SecurityGroup
-	AssociatePublicIP  *bool
-	IAMInstanceProfile *IAMInstanceProfile
+	ImageID                    *string
+	InstanceType               *string
+	SSHKey                     *SSHKey
+	SecurityGroups             []*SecurityGroup
+	AdditionalSecurityGroupIDs []string
+	AssociatePublicIP          *bool
+	IAMInstanceProfile         *IAMInstanceProfile
 
 	// RootVolumeSize is the size of the EBS root volume to use, in GB
 	RootVolumeSize *int64
@@ -227,13 +228,20 @@ func (_ *LaunchConfiguration) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *La
 	request.LaunchConfigurationName = &launchConfigurationName
 	request.ImageId = image.ImageId
 	request.InstanceType = e.InstanceType
+
 	if e.SSHKey != nil {
 		request.KeyName = e.SSHKey.Name
 	}
+
 	securityGroupIDs := []*string{}
 	for _, sg := range e.SecurityGroups {
 		securityGroupIDs = append(securityGroupIDs, sg.ID)
 	}
+
+	for i, _ := range e.AdditionalSecurityGroupIDs {
+		securityGroupIDs = append(securityGroupIDs, &e.AdditionalSecurityGroupIDs[i])
+	}
+
 	request.SecurityGroups = securityGroupIDs
 	request.AssociatePublicIpAddress = e.AssociatePublicIP
 	if e.SpotPrice != "" {


### PR DESCRIPTION
Hey Ho,

i tried to implement https://github.com/kubernetes/kops/issues/224
As this is my first golang pull request, please look twice.

Manually tested creation (with one, with two, without security groups for master/nodes), update, rolling-update, deletion of a cluster.

Everything seemed to work as expected.

Greetings, Thomas

**EDIT: Updated the commits to have the right e-mail address** 
**EDIT2: Signed CLA** 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1444)
<!-- Reviewable:end -->
