### PR TITLE
Use versioned taint annotations

### DIFF
--- a/protokube/pkg/protokube/tainter.go
+++ b/protokube/pkg/protokube/tainter.go
@@ -56,7 +56,7 @@ func ApplyMasterTaints(kubeContext *KubernetesContext) error {
 		return fmt.Errorf("error querying nodes: %v", err)
 	}
 
-	taint := []api.Taint{{Key: "dedicated", Value: "master", Effect: "NoSchedule"}}
+	taint := []v1.Taint{{Key: "dedicated", Value: "master", Effect: "NoSchedule"}}
 	taintJSON, err := json.Marshal(taint)
 	if err != nil {
 		return fmt.Errorf("error serializing taint: %v", err)
@@ -65,7 +65,7 @@ func ApplyMasterTaints(kubeContext *KubernetesContext) error {
 	for i := range nodes.Items {
 		node := &nodes.Items[i]
 
-		nodeTaintJSON := node.Annotations[api.TaintsAnnotationKey]
+		nodeTaintJSON := node.Annotations[v1.TaintsAnnotationKey]
 		if nodeTaintJSON != "" {
 			if nodeTaintJSON != string(taintJSON) {
 				glog.Infof("Node %q had unexpected taint: %v", node.Name, nodeTaintJSON)
@@ -74,7 +74,7 @@ func ApplyMasterTaints(kubeContext *KubernetesContext) error {
 		}
 
 		nodePatchMetadata := &nodePatchMetadata{
-			Annotations: map[string]string{api.TaintsAnnotationKey: string(taintJSON)},
+			Annotations: map[string]string{v1.TaintsAnnotationKey: string(taintJSON)},
 		}
 		unschedulable := false
 		nodePatchSpec := &nodePatchSpec{


### PR DESCRIPTION
The json annotations were removed from the unversioned types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1466)
<!-- Reviewable:end -->
