### PR TITLE
Change int to int32 in API

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -45,7 +45,7 @@ type CreateClusterOptions struct {
 	MasterZones       string
 	NodeSize          string
 	MasterSize        string
-	NodeCount         int
+	NodeCount         int32
 	Project           string
 	KubernetesVersion string
 	OutDir            string
@@ -129,7 +129,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&options.VPCID, "vpc", options.VPCID, "Set to use a shared VPC")
 	cmd.Flags().StringVar(&options.NetworkCIDR, "network-cidr", options.NetworkCIDR, "Set to override the default network CIDR")
 
-	cmd.Flags().IntVar(&options.NodeCount, "node-count", options.NodeCount, "Set the number of nodes")
+	cmd.Flags().Int32Var(&options.NodeCount, "node-count", options.NodeCount, "Set the number of nodes")
 
 	cmd.Flags().StringVar(&options.Image, "image", options.Image, "Image to use")
 
@@ -273,8 +273,8 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 				g := &api.InstanceGroup{}
 				g.Spec.Role = api.InstanceGroupRoleMaster
 				g.Spec.Subnets = []string{subnet.Name}
-				g.Spec.MinSize = fi.Int(1)
-				g.Spec.MaxSize = fi.Int(1)
+				g.Spec.MinSize = fi.Int32(1)
+				g.Spec.MaxSize = fi.Int32(1)
 				g.ObjectMeta.Name = "master-" + subnet.Name // Subsequent masters (if we support that) could be <zone>-1, <zone>-2
 				instanceGroups = append(instanceGroups, g)
 				masters = append(masters, g)
@@ -290,8 +290,8 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 				g := &api.InstanceGroup{}
 				g.Spec.Role = api.InstanceGroupRoleMaster
 				g.Spec.Subnets = []string{subnetName}
-				g.Spec.MinSize = fi.Int(1)
-				g.Spec.MaxSize = fi.Int(1)
+				g.Spec.MinSize = fi.Int32(1)
+				g.Spec.MaxSize = fi.Int32(1)
 				g.ObjectMeta.Name = "master-" + subnetName
 				instanceGroups = append(instanceGroups, g)
 				masters = append(masters, g)
@@ -379,8 +379,8 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 
 	if c.NodeCount != 0 {
 		for _, group := range nodes {
-			group.Spec.MinSize = fi.Int(c.NodeCount)
-			group.Spec.MaxSize = fi.Int(c.NodeCount)
+			group.Spec.MinSize = fi.Int32(c.NodeCount)
+			group.Spec.MaxSize = fi.Int32(c.NodeCount)
 		}
 	}
 

--- a/cmd/kops/get_instancegroups.go
+++ b/cmd/kops/get_instancegroups.go
@@ -113,10 +113,10 @@ func (c *GetInstanceGroupsCmd) Run(args []string) error {
 			return strings.Join(c.Spec.Subnets, ",")
 		})
 		t.AddColumn("MIN", func(c *api.InstanceGroup) string {
-			return intPointerToString(c.Spec.MinSize)
+			return int32PointerToString(c.Spec.MinSize)
 		})
 		t.AddColumn("MAX", func(c *api.InstanceGroup) string {
-			return intPointerToString(c.Spec.MaxSize)
+			return int32PointerToString(c.Spec.MaxSize)
 		})
 		return t.Render(instancegroups, os.Stdout, "NAME", "ROLE", "MACHINETYPE", "MIN", "MAX", "SUBNETS")
 
@@ -144,9 +144,9 @@ func (c *GetInstanceGroupsCmd) Run(args []string) error {
 	return nil
 }
 
-func intPointerToString(v *int) string {
+func int32PointerToString(v *int32) string {
 	if v == nil {
 		return "-"
 	}
-	return strconv.Itoa(*v)
+	return strconv.Itoa(int(*v))
 }

--- a/cmd/kops/validate_cluster.go
+++ b/cmd/kops/validate_cluster.go
@@ -125,10 +125,10 @@ func RunValidateCluster(f *util.Factory, cmd *cobra.Command, args []string, out 
 		return strings.Join(c.Spec.Subnets, ",")
 	})
 	t.AddColumn("MIN", func(c api.InstanceGroup) string {
-		return intPointerToString(c.Spec.MinSize)
+		return int32PointerToString(c.Spec.MinSize)
 	})
 	t.AddColumn("MAX", func(c api.InstanceGroup) string {
-		return intPointerToString(c.Spec.MaxSize)
+		return int32PointerToString(c.Spec.MaxSize)
 	})
 
 	fmt.Fprintln(out, "INSTANCE GROUPS")

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -295,7 +295,7 @@ type EtcdMemberSpec struct {
 	InstanceGroup *string `json:"instanceGroup,omitempty"`
 
 	VolumeType      *string `json:"volumeType,omitempty"`
-	VolumeSize      *int    `json:"volumeSize,omitempty"`
+	VolumeSize      *int32  `json:"volumeSize,omitempty"`
 	KmsKeyId        *string `json:"kmsKeyId,omitempty"`
 	EncryptedVolume *bool   `json:"encryptedVolume,omitempty"`
 }

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -19,7 +19,7 @@ package kops
 type KubeletConfigSpec struct {
 	APIServers string `json:"apiServers,omitempty" flag:"api-servers"`
 
-	LogLevel *int `json:"logLevel,omitempty" flag:"v"`
+	LogLevel *int32 `json:"logLevel,omitempty" flag:"v"`
 
 	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
 
@@ -301,7 +301,7 @@ type KubeProxyConfig struct {
 	// TODO: Better type ?
 	CPURequest string `json:"cpuRequest,omitempty"` // e.g. "20m"
 
-	LogLevel int `json:"logLevel,omitempty" flag:"v"`
+	LogLevel int32 `json:"logLevel,omitempty" flag:"v"`
 
 	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
 
@@ -358,10 +358,10 @@ type KubeAPIServerConfig struct {
 	PathSrvSshproxy   string `json:"pathSrvSshproxy,omitempty"`
 	Image             string `json:"image,omitempty"`
 
-	LogLevel int `json:"logLevel,omitempty" flag:"v"`
+	LogLevel int32 `json:"logLevel,omitempty" flag:"v"`
 
 	CloudProvider         string   `json:"cloudProvider,omitempty" flag:"cloud-provider"`
-	SecurePort            int      `json:"securePort,omitempty" flag:"secure-port"`
+	SecurePort            int32    `json:"securePort,omitempty" flag:"secure-port"`
 	Address               string   `json:"address,omitempty" flag:"address"`
 	EtcdServers           []string `json:"etcdServers,omitempty" flag:"etcd-servers"`
 	EtcdServersOverrides  []string `json:"etcdServersOverrides,omitempty" flag:"etcd-servers-overrides"`
@@ -373,7 +373,7 @@ type KubeAPIServerConfig struct {
 	TLSPrivateKeyFile     string   `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
 	TokenAuthFile         string   `json:"tokenAuthFile,omitempty" flag:"token-auth-file"`
 	AllowPrivileged       *bool    `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
-	APIServerCount        *int     `json:"apiServerCount,omitempty" flag:"apiserver-count"`
+	APIServerCount        *int32   `json:"apiServerCount,omitempty" flag:"apiserver-count"`
 	// keys and values in RuntimeConfig are parsed into the `--runtime-config` parameter
 	// for KubeAPIServer, concatenated with commas. ex: `--runtime-config=key1=value1,key2=value2`.
 	// Use this to enable alpha resources on kube-apiserver
@@ -388,7 +388,7 @@ type KubeAPIServerConfig struct {
 
 type KubeControllerManagerConfig struct {
 	Master   string `json:"master,omitempty" flag:"master"`
-	LogLevel int    `json:"logLevel,omitempty" flag:"v"`
+	LogLevel int32  `json:"logLevel,omitempty" flag:"v"`
 
 	ServiceAccountPrivateKeyFile string `json:"serviceAccountPrivateKeyFile,omitempty" flag:"service-account-private-key-file"`
 
@@ -537,7 +537,7 @@ type KubeControllerManagerConfig struct {
 
 type KubeSchedulerConfig struct {
 	Master   string `json:"master,omitempty" flag:"master"`
-	LogLevel int    `json:"logLevel,omitempty" flag:"v"`
+	LogLevel int32  `json:"logLevel,omitempty" flag:"v"`
 
 	Image string `json:"image,omitempty"`
 

--- a/pkg/apis/kops/dockerconfig.go
+++ b/pkg/apis/kops/dockerconfig.go
@@ -31,7 +31,7 @@ type DockerConfig struct {
 	Storage *string `json:"storage,omitempty" flag:"storage-driver"`
 
 	InsecureRegistry *string `json:"insecureRegistry,omitempty" flag:"insecure-registry"`
-	MTU              *int    `json:"mtu,omitempty" flag:"mtu"`
+	MTU              *int32  `json:"mtu,omitempty" flag:"mtu"`
 
 	// The version of docker to install
 	// Be careful if changing this; not all docker versions are validated, and they will break in bad ways.

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -59,15 +59,15 @@ type InstanceGroupSpec struct {
 	Role InstanceGroupRole `json:"role,omitempty"`
 
 	Image   string `json:"image,omitempty"`
-	MinSize *int   `json:"minSize,omitempty"`
-	MaxSize *int   `json:"maxSize,omitempty"`
+	MinSize *int32 `json:"minSize,omitempty"`
+	MaxSize *int32 `json:"maxSize,omitempty"`
 	//NodeInstancePrefix string `json:",omitempty"`
 	//NodeLabels         string `json:",omitempty"`
 	MachineType string `json:"machineType,omitempty"`
 	//NodeTag            string `json:",omitempty"`
 
 	// RootVolumeSize is the size of the EBS root volume to use, in GB
-	RootVolumeSize *int `json:"rootVolumeSize,omitempty"`
+	RootVolumeSize *int32 `json:"rootVolumeSize,omitempty"`
 	// RootVolumeType is the type of the EBS root volume to use (e.g. gp2)
 	RootVolumeType *string `json:"rootVolumeType,omitempty"`
 

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -289,7 +289,7 @@ type EtcdMemberSpec struct {
 	Zone *string `json:"zone,omitempty"`
 
 	VolumeType      *string `json:"volumeType,omitempty"`
-	VolumeSize      *int    `json:"volumeSize,omitempty"`
+	VolumeSize      *int32  `json:"volumeSize,omitempty"`
 	KmsKeyId        *string `json:"kmsKeyId,omitempty"`
 	EncryptedVolume *bool   `json:"encryptedVolume,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -19,7 +19,7 @@ package v1alpha1
 type KubeletConfigSpec struct {
 	APIServers string `json:"apiServers,omitempty" flag:"api-servers"`
 
-	LogLevel *int `json:"logLevel,omitempty" flag:"v"`
+	LogLevel *int32 `json:"logLevel,omitempty" flag:"v"`
 
 	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
 
@@ -301,7 +301,7 @@ type KubeProxyConfig struct {
 	// TODO: Better type ?
 	CPURequest string `json:"cpuRequest,omitempty"` // e.g. "20m"
 
-	LogLevel int `json:"logLevel,omitempty" flag:"v"`
+	LogLevel int32 `json:"logLevel,omitempty" flag:"v"`
 
 	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
 
@@ -358,10 +358,10 @@ type KubeAPIServerConfig struct {
 	PathSrvSshproxy   string `json:"pathSrvSshproxy,omitempty"`
 	Image             string `json:"image,omitempty"`
 
-	LogLevel int `json:"logLevel,omitempty" flag:"v"`
+	LogLevel int32 `json:"logLevel,omitempty" flag:"v"`
 
 	CloudProvider         string            `json:"cloudProvider,omitempty" flag:"cloud-provider"`
-	SecurePort            int               `json:"securePort,omitempty" flag:"secure-port"`
+	SecurePort            int32             `json:"securePort,omitempty" flag:"secure-port"`
 	Address               string            `json:"address,omitempty" flag:"address"`
 	EtcdServers           []string          `json:"etcdServers,omitempty" flag:"etcd-servers"`
 	EtcdServersOverrides  []string          `json:"etcdServersOverrides,omitempty" flag:"etcd-servers-overrides"`
@@ -373,7 +373,7 @@ type KubeAPIServerConfig struct {
 	TLSPrivateKeyFile     string            `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
 	TokenAuthFile         string            `json:"tokenAuthFile,omitempty" flag:"token-auth-file"`
 	AllowPrivileged       *bool             `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
-	APIServerCount        *int              `json:"apiServerCount,omitempty" flag:"apiserver-count"`
+	APIServerCount        *int32            `json:"apiServerCount,omitempty" flag:"apiserver-count"`
 	RuntimeConfig         map[string]string `json:"runtimeConfig,omitempty" flag:"runtime-config"`
 
 	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"anonymous-auth"`
@@ -385,7 +385,7 @@ type KubeAPIServerConfig struct {
 
 type KubeControllerManagerConfig struct {
 	Master   string `json:"master,omitempty" flag:"master"`
-	LogLevel int    `json:"logLevel,omitempty" flag:"v"`
+	LogLevel int32  `json:"logLevel,omitempty" flag:"v"`
 
 	ServiceAccountPrivateKeyFile string `json:"serviceAccountPrivateKeyFile,omitempty" flag:"service-account-private-key-file"`
 
@@ -534,7 +534,7 @@ type KubeControllerManagerConfig struct {
 
 type KubeSchedulerConfig struct {
 	Master   string `json:"master,omitempty" flag:"master"`
-	LogLevel int    `json:"logLevel,omitempty" flag:"v"`
+	LogLevel int32  `json:"logLevel,omitempty" flag:"v"`
 
 	Image string `json:"image,omitempty"`
 

--- a/pkg/apis/kops/v1alpha1/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha1/dockerconfig.go
@@ -27,7 +27,7 @@ type DockerConfig struct {
 	Storage *string `json:"storage,omitempty" flag:"storage-driver"`
 
 	InsecureRegistry *string `json:"insecureRegistry,omitempty" flag:"insecure-registry"`
-	MTU              *int    `json:"mtu,omitempty" flag:"mtu"`
+	MTU              *int32  `json:"mtu,omitempty" flag:"mtu"`
 
 	// The version of docker to install
 	// Be careful if changing this; not all docker versions are validated, and they will break in bad ways.

--- a/pkg/apis/kops/v1alpha1/instancegroup.go
+++ b/pkg/apis/kops/v1alpha1/instancegroup.go
@@ -49,15 +49,15 @@ type InstanceGroupSpec struct {
 	Role InstanceGroupRole `json:"role,omitempty"`
 
 	Image   string `json:"image,omitempty"`
-	MinSize *int   `json:"minSize,omitempty"`
-	MaxSize *int   `json:"maxSize,omitempty"`
+	MinSize *int32 `json:"minSize,omitempty"`
+	MaxSize *int32 `json:"maxSize,omitempty"`
 	//NodeInstancePrefix string `json:",omitempty"`
 	//NodeLabels         string `json:",omitempty"`
 	MachineType string `json:"machineType,omitempty"`
 	//NodeTag            string `json:",omitempty"`
 
 	// RootVolumeSize is the size of the EBS root volume to use, in GB
-	RootVolumeSize *int `json:"rootVolumeSize,omitempty"`
+	RootVolumeSize *int32 `json:"rootVolumeSize,omitempty"`
 	// RootVolumeType is the type of the EBS root volume to use (e.g. gp2)
 	RootVolumeType *string `json:"rootVolumeType,omitempty"`
 

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -201,7 +201,7 @@ type EtcdMemberSpec struct {
 	InstanceGroup *string `json:"instanceGroup,omitempty"`
 
 	VolumeType      *string `json:"volumeType,omitempty"`
-	VolumeSize      *int    `json:"volumeSize,omitempty"`
+	VolumeSize      *int32  `json:"volumeSize,omitempty"`
 	KmsKeyId        *string `json:"kmsKeyId,omitempty"`
 	EncryptedVolume *bool   `json:"encryptedVolume,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -19,7 +19,7 @@ package v1alpha2
 type KubeletConfigSpec struct {
 	APIServers string `json:"apiServers,omitempty" flag:"api-servers"`
 
-	LogLevel *int `json:"logLevel,omitempty" flag:"v"`
+	LogLevel *int32 `json:"logLevel,omitempty" flag:"v"`
 
 	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
 
@@ -100,7 +100,7 @@ type KubeProxyConfig struct {
 	// TODO: Better type ?
 	CPURequest string `json:"cpuRequest,omitempty"` // e.g. "20m"
 
-	LogLevel int `json:"logLevel,omitempty" flag:"v"`
+	LogLevel int32 `json:"logLevel,omitempty" flag:"v"`
 
 	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
 
@@ -113,10 +113,10 @@ type KubeAPIServerConfig struct {
 	PathSrvSshproxy   string `json:"pathSrvSshproxy,omitempty"`
 	Image             string `json:"image,omitempty"`
 
-	LogLevel int `json:"logLevel,omitempty" flag:"v"`
+	LogLevel int32 `json:"logLevel,omitempty" flag:"v"`
 
 	CloudProvider         string   `json:"cloudProvider,omitempty" flag:"cloud-provider"`
-	SecurePort            int      `json:"securePort,omitempty" flag:"secure-port"`
+	SecurePort            int32    `json:"securePort,omitempty" flag:"secure-port"`
 	Address               string   `json:"address,omitempty" flag:"address"`
 	EtcdServers           []string `json:"etcdServers,omitempty" flag:"etcd-servers"`
 	EtcdServersOverrides  []string `json:"etcdServersOverrides,omitempty" flag:"etcd-servers-overrides"`
@@ -128,7 +128,7 @@ type KubeAPIServerConfig struct {
 	TLSPrivateKeyFile     string   `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
 	TokenAuthFile         string   `json:"tokenAuthFile,omitempty" flag:"token-auth-file"`
 	AllowPrivileged       *bool    `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
-	APIServerCount        *int     `json:"apiServerCount,omitempty" flag:"apiserver-count"`
+	APIServerCount        *int32   `json:"apiServerCount,omitempty" flag:"apiserver-count"`
 	// keys and values in RuntimeConfig are parsed into the `--runtime-config` parameter
 	// for KubeAPIServer, concatenated with commas. ex: `--runtime-config=key1=value1,key2=value2`.
 	// Use this to enable alpha resources on kube-apiserver
@@ -143,7 +143,7 @@ type KubeAPIServerConfig struct {
 
 type KubeControllerManagerConfig struct {
 	Master   string `json:"master,omitempty" flag:"master"`
-	LogLevel int    `json:"logLevel,omitempty" flag:"v"`
+	LogLevel int32  `json:"logLevel,omitempty" flag:"v"`
 
 	ServiceAccountPrivateKeyFile string `json:"serviceAccountPrivateKeyFile,omitempty" flag:"service-account-private-key-file"`
 
@@ -174,7 +174,7 @@ type KubeControllerManagerConfig struct {
 
 type KubeSchedulerConfig struct {
 	Master   string `json:"master,omitempty" flag:"master"`
-	LogLevel int    `json:"logLevel,omitempty" flag:"v"`
+	LogLevel int32  `json:"logLevel,omitempty" flag:"v"`
 
 	Image string `json:"image,omitempty"`
 

--- a/pkg/apis/kops/v1alpha2/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha2/dockerconfig.go
@@ -27,7 +27,7 @@ type DockerConfig struct {
 	Storage *string `json:"storage,omitempty" flag:"storage-driver"`
 
 	InsecureRegistry *string `json:"insecureRegistry,omitempty" flag:"insecure-registry"`
-	MTU              *int    `json:"mtu,omitempty" flag:"mtu"`
+	MTU              *int32  `json:"mtu,omitempty" flag:"mtu"`
 
 	// The version of docker to install
 	// Be careful if changing this; not all docker versions are validated, and they will break in bad ways.

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -56,15 +56,15 @@ type InstanceGroupSpec struct {
 	Role InstanceGroupRole `json:"role,omitempty"`
 
 	Image   string `json:"image,omitempty"`
-	MinSize *int   `json:"minSize,omitempty"`
-	MaxSize *int   `json:"maxSize,omitempty"`
+	MinSize *int32 `json:"minSize,omitempty"`
+	MaxSize *int32 `json:"maxSize,omitempty"`
 	//NodeInstancePrefix string `json:",omitempty"`
 	//NodeLabels         string `json:",omitempty"`
 	MachineType string `json:"machineType,omitempty"`
 	//NodeTag            string `json:",omitempty"`
 
 	// RootVolumeSize is the size of the EBS root volume to use, in GB
-	RootVolumeSize *int `json:"rootVolumeSize,omitempty"`
+	RootVolumeSize *int32 `json:"rootVolumeSize,omitempty"`
 	// RootVolumeType is the type of the EBS root volume to use (e.g. gp2)
 	RootVolumeType *string `json:"rootVolumeType,omitempty"`
 

--- a/pkg/model/autoscalinggroup.go
+++ b/pkg/model/autoscalinggroup.go
@@ -50,7 +50,7 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		// LaunchConfiguration
 		var launchConfiguration *awstasks.LaunchConfiguration
 		{
-			volumeSize := int64(fi.IntValue(ig.Spec.RootVolumeSize))
+			volumeSize := fi.Int32Value(ig.Spec.RootVolumeSize)
 			if volumeSize == 0 {
 				volumeSize = DefaultVolumeSize
 			}
@@ -69,7 +69,7 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 				ImageID:            s(ig.Spec.Image),
 				InstanceType:       s(ig.Spec.MachineType),
 
-				RootVolumeSize: i64(volumeSize),
+				RootVolumeSize: i64(int64(volumeSize)),
 				RootVolumeType: s(volumeType),
 			}
 
@@ -146,10 +146,10 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 				LaunchConfiguration: launchConfiguration,
 			}
 
-			minSize := 1
-			maxSize := 1
+			minSize := int32(1)
+			maxSize := int32(1)
 			if ig.Spec.MinSize != nil {
-				minSize = *ig.Spec.MinSize
+				minSize = fi.Int32Value(ig.Spec.MinSize)
 			} else if ig.Spec.Role == kops.InstanceGroupRoleNode {
 				minSize = 2
 			}

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -41,7 +41,7 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 		if count == 0 {
 			return fmt.Errorf("no instance groups found")
 		}
-		options.KubeAPIServer.APIServerCount = fi.Int(count)
+		options.KubeAPIServer.APIServerCount = fi.Int32(int32(count))
 	}
 
 	if options.KubeAPIServer.StorageBackend == nil {

--- a/pkg/model/convenience.go
+++ b/pkg/model/convenience.go
@@ -27,3 +27,8 @@ func s(v string) *string {
 func i64(v int64) *int64 {
 	return fi.Int64(v)
 }
+
+// i32 is a helper that builds a *int32 from an int32 value
+func i32(v int32) *int32 {
+	return fi.Int32(v)
+}

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -67,7 +67,7 @@ func (b *MasterVolumeBuilder) Build(c *fi.ModelBuilderContext) error {
 				return fmt.Errorf("Subnet %q did not specify a zone", subnet.Name)
 			}
 
-			volumeSize := int64(fi.IntValue(m.VolumeSize))
+			volumeSize := int64(fi.Int32Value(m.VolumeSize))
 			if volumeSize == 0 {
 				volumeSize = DefaultEtcdVolumeSize
 			}

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/pkg/api/v1"
 	k8s_clientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 )
@@ -57,9 +58,9 @@ func ValidateCluster(clusterName string, instanceGroupList *kops.InstanceGroupLi
 		ig := &instanceGroupList.Items[i]
 		instanceGroups = append(instanceGroups, ig)
 		if ig.Spec.Role == kops.InstanceGroupRoleMaster {
-			validationCluster.MastersCount += *ig.Spec.MinSize
+			validationCluster.MastersCount += int(fi.Int32Value(ig.Spec.MinSize))
 		} else if ig.Spec.Role == kops.InstanceGroupRoleNode {
-			validationCluster.NodesCount += *ig.Spec.MinSize
+			validationCluster.NodesCount += int(fi.Int32Value(ig.Spec.MinSize))
 		}
 	}
 
@@ -134,14 +135,12 @@ func validateTheNodes(clusterName string, validationCluster *ValidationCluster) 
 	}
 
 	validationCluster.MastersReady = true
-	if len(validationCluster.MastersNotReadyArray) != 0 || validationCluster.MastersCount !=
-		len(validationCluster.MastersReadyArray) {
+	if len(validationCluster.MastersNotReadyArray) != 0 || validationCluster.MastersCount != len(validationCluster.MastersReadyArray) {
 		validationCluster.MastersReady = false
 	}
 
 	validationCluster.NodesReady = true
-	if len(validationCluster.NodesNotReadyArray) != 0 || validationCluster.NodesCount !=
-		len(validationCluster.NodesReadyArray) {
+	if len(validationCluster.NodesNotReadyArray) != 0 || validationCluster.NodesCount != len(validationCluster.NodesReadyArray) {
 		validationCluster.NodesReady = false
 	}
 

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -57,30 +57,30 @@ func PopulateInstanceGroupSpec(cluster *api.Cluster, input *api.InstanceGroup, c
 			ig.Spec.MachineType = defaultMasterMachineType(cluster)
 		}
 		if ig.Spec.MinSize == nil {
-			ig.Spec.MinSize = fi.Int(1)
+			ig.Spec.MinSize = fi.Int32(1)
 		}
 		if ig.Spec.MaxSize == nil {
-			ig.Spec.MaxSize = fi.Int(1)
+			ig.Spec.MaxSize = fi.Int32(1)
 		}
 	} else if ig.Spec.Role == api.InstanceGroupRoleBastion {
 		if ig.Spec.MachineType == "" {
 			ig.Spec.MachineType = defaultBastionMachineType(cluster)
 		}
 		if ig.Spec.MinSize == nil {
-			ig.Spec.MinSize = fi.Int(1)
+			ig.Spec.MinSize = fi.Int32(1)
 		}
 		if ig.Spec.MaxSize == nil {
-			ig.Spec.MaxSize = fi.Int(1)
+			ig.Spec.MaxSize = fi.Int32(1)
 		}
 	} else {
 		if ig.Spec.MachineType == "" {
 			ig.Spec.MachineType = defaultNodeMachineType(cluster)
 		}
 		if ig.Spec.MinSize == nil {
-			ig.Spec.MinSize = fi.Int(2)
+			ig.Spec.MinSize = fi.Int32(2)
 		}
 		if ig.Spec.MaxSize == nil {
-			ig.Spec.MaxSize = fi.Int(2)
+			ig.Spec.MaxSize = fi.Int32(2)
 		}
 	}
 

--- a/upup/pkg/fi/cloudup/populatecluster_test.go
+++ b/upup/pkg/fi/cloudup/populatecluster_test.go
@@ -92,7 +92,7 @@ func TestPopulateCluster_Default_NoError(t *testing.T) {
 func TestPopulateCluster_Docker_Spec(t *testing.T) {
 	c := buildMinimalCluster()
 	c.Spec.Docker = &api.DockerConfig{
-		MTU:              fi.Int(5678),
+		MTU:              fi.Int32(5678),
 		InsecureRegistry: fi.String("myregistry.com:1234"),
 	}
 
@@ -108,7 +108,7 @@ func TestPopulateCluster_Docker_Spec(t *testing.T) {
 		t.Fatalf("Unexpected error from PopulateCluster: %v", err)
 	}
 
-	if fi.IntValue(full.Spec.Docker.MTU) != 5678 {
+	if fi.Int32Value(full.Spec.Docker.MTU) != 5678 {
 		t.Fatalf("Unexpected Docker MTU: %v", full.Spec.Docker.MTU)
 	}
 
@@ -370,8 +370,8 @@ func TestPopulateCluster_APIServerCount(t *testing.T) {
 		t.Fatalf("error during build: %v", err)
 	}
 
-	if fi.IntValue(full.Spec.KubeAPIServer.APIServerCount) != 3 {
-		t.Fatalf("Unexpected APIServerCount: %v", fi.IntValue(full.Spec.KubeAPIServer.APIServerCount))
+	if fi.Int32Value(full.Spec.KubeAPIServer.APIServerCount) != 3 {
+		t.Fatalf("Unexpected APIServerCount: %v", fi.Int32Value(full.Spec.KubeAPIServer.APIServerCount))
 	}
 }
 

--- a/upup/pkg/fi/nodeup/protokube_flags.go
+++ b/upup/pkg/fi/nodeup/protokube_flags.go
@@ -17,9 +17,9 @@ limitations under the License.
 package nodeup
 
 type ProtokubeFlags struct {
-	Master        *bool `json:"master,omitempty" flag:"master"`
-	Containerized *bool `json:"containerized,omitempty" flag:"containerized"`
-	LogLevel      *int  `json:"logLevel,omitempty" flag:"v"`
+	Master        *bool  `json:"master,omitempty" flag:"master"`
+	Containerized *bool  `json:"containerized,omitempty" flag:"containerized"`
+	LogLevel      *int32 `json:"logLevel,omitempty" flag:"v"`
 
 	DNSProvider *string `json:"dnsProvider,omitempty" flag:"dns"`
 

--- a/upup/pkg/fi/nodeup/template_functions.go
+++ b/upup/pkg/fi/nodeup/template_functions.go
@@ -276,7 +276,7 @@ func (t *templateFunctions) ProtokubeFlags() *ProtokubeFlags {
 		f.Channels = t.nodeupConfig.Channels
 	}
 
-	f.LogLevel = fi.Int(4)
+	f.LogLevel = fi.Int32(4)
 	f.Containerized = fi.Bool(true)
 
 	zone := t.cluster.Spec.DNSZone

--- a/upup/pkg/fi/values.go
+++ b/upup/pkg/fi/values.go
@@ -53,11 +53,11 @@ func BoolValue(v *bool) bool {
 	return *v
 }
 
-func Int(v int) *int {
+func Int32(v int32) *int32 {
 	return &v
 }
 
-func IntValue(v *int) int {
+func Int32Value(v *int32) int32 {
 	if v == nil {
 		return 0
 	}

--- a/upup/pkg/kutil/import_cluster.go
+++ b/upup/pkg/kutil/import_cluster.go
@@ -134,8 +134,8 @@ func (x *ImportCluster) ImportAWSCluster() error {
 
 	masterGroup := &api.InstanceGroup{}
 	masterGroup.Spec.Role = api.InstanceGroupRoleMaster
-	masterGroup.Spec.MinSize = fi.Int(1)
-	masterGroup.Spec.MaxSize = fi.Int(1)
+	masterGroup.Spec.MinSize = fi.Int32(1)
+	masterGroup.Spec.MaxSize = fi.Int32(1)
 
 	masterGroup.Spec.MachineType = aws.StringValue(masterInstance.InstanceType)
 
@@ -294,17 +294,17 @@ func (x *ImportCluster) ImportAWSCluster() error {
 		if len(groups) == 1 {
 			glog.Warningf("Multiple Autoscaling groups found")
 		}
-		minSize := 0
-		maxSize := 0
+		minSize := int32(0)
+		maxSize := int32(0)
 		for _, group := range groups {
-			minSize += int(aws.Int64Value(group.MinSize))
-			maxSize += int(aws.Int64Value(group.MaxSize))
+			minSize += int32(aws.Int64Value(group.MinSize))
+			maxSize += int32(aws.Int64Value(group.MaxSize))
 		}
 		if minSize != 0 {
-			nodeGroup.Spec.MinSize = fi.Int(minSize)
+			nodeGroup.Spec.MinSize = fi.Int32(minSize)
 		}
 		if maxSize != 0 {
-			nodeGroup.Spec.MaxSize = fi.Int(maxSize)
+			nodeGroup.Spec.MaxSize = fi.Int32(maxSize)
 		}
 
 		// Determine the machine type
@@ -700,7 +700,7 @@ func (u *UserDataConfiguration) ParseBool(key string) *bool {
 	return fi.Bool(false)
 }
 
-func (u *UserDataConfiguration) ParseInt(key string) (*int, error) {
+func (u *UserDataConfiguration) ParseInt64(key string) (*int64, error) {
 	s := u.Settings[key]
 	if s == "" {
 		return nil, nil
@@ -711,7 +711,7 @@ func (u *UserDataConfiguration) ParseInt(key string) (*int, error) {
 		return nil, fmt.Errorf("error parsing key %q=%q", key, s)
 	}
 
-	return fi.Int(int(n)), nil
+	return fi.Int64(n), nil
 }
 
 func (u *UserDataConfiguration) ParseCert(key string) (*fi.Certificate, error) {

--- a/upup/pkg/kutil/import_cluster.go
+++ b/upup/pkg/kutil/import_cluster.go
@@ -700,20 +700,6 @@ func (u *UserDataConfiguration) ParseBool(key string) *bool {
 	return fi.Bool(false)
 }
 
-func (u *UserDataConfiguration) ParseInt64(key string) (*int64, error) {
-	s := u.Settings[key]
-	if s == "" {
-		return nil, nil
-	}
-
-	n, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing key %q=%q", key, s)
-	}
-
-	return fi.Int64(n), nil
-}
-
 func (u *UserDataConfiguration) ParseCert(key string) (*fi.Certificate, error) {
 	s := u.Settings[key]
 	if s == "" {


### PR DESCRIPTION
We shouldn't be using the variable-sized int in the API

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1483)
<!-- Reviewable:end -->
