### PR TITLE
dns-controller optimizations

### DIFF
--- a/dns-controller/pkg/dns/dnscache.go
+++ b/dns-controller/pkg/dns/dnscache.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dns
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+)
+
+// dnsCache is a wrapper around the DNS provider, adding some caching
+type dnsCache struct {
+	// zones is the DNS provider
+	zonesProvider dnsprovider.Zones
+
+	// mutex protects the following mutable state
+	mutex sync.Mutex
+
+	cachedZones          []dnsprovider.Zone
+	cachedZonesTimestamp int64
+}
+
+func newDNSCache(provider dnsprovider.Interface) (*dnsCache, error) {
+	zonesProvider, ok := provider.Zones()
+	if !ok {
+		return nil, fmt.Errorf("DNS provider does not support zones")
+	}
+
+	return &dnsCache{
+		zonesProvider: zonesProvider,
+	}, nil
+}
+
+// nanoTime is a stand-in until we get a monotonic clock
+func nanoTime() int64 {
+	return time.Now().UnixNano()
+}
+
+// ListZones returns the zones, using a cached copy if validity has not yet expired.
+// This is not a cheap call with a large number of hosted zones, hence the caching.
+func (d *dnsCache) ListZones(validity time.Duration) ([]dnsprovider.Zone, error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	now := nanoTime()
+
+	if d.cachedZones != nil {
+		if (d.cachedZonesTimestamp + validity.Nanoseconds()) > now {
+			return d.cachedZones, nil
+		} else {
+			glog.V(2).Infof("querying all DNS zones (cache expired)")
+		}
+	} else {
+		glog.V(2).Infof("querying all DNS zones (no cached results)")
+	}
+
+	zones, err := d.zonesProvider.List()
+	if err != nil {
+		return nil, fmt.Errorf("error querying for DNS zones: %v", err)
+	}
+
+	d.cachedZones = zones
+	d.cachedZonesTimestamp = now
+
+	return zones, nil
+}

--- a/dns-controller/pkg/dns/record.go
+++ b/dns-controller/pkg/dns/record.go
@@ -44,3 +44,15 @@ type Record struct {
 func AliasForNodesInRole(role, roleType string) string {
 	return "node/role=" + role + "/" + roleType
 }
+
+func (r *Record) String() string {
+	s := "Record:[Type=" + string(r.RecordType) + ",FQDN=" + r.FQDN + ",Value=" + r.Value
+
+	if r.AliasTarget {
+		s += ",AliasTarget"
+	}
+
+	s += "]"
+
+	return s
+}

--- a/upup/pkg/fi/cloudup/dns.go
+++ b/upup/pkg/fi/cloudup/dns.go
@@ -144,6 +144,8 @@ func precreateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
 		return fmt.Errorf("error getting DNS resource records for %q", zone.Name())
 	}
 
+	// TODO: We should change the filter to be a suffix match instead
+	//records, err := rrs.List("", "")
 	records, err := rrs.List()
 	if err != nil {
 		return fmt.Errorf("error listing DNS resource records for %q: %v", zone.Name(), err)


### PR DESCRIPTION
* Cache list of zones
* Combine DNS changesets
* If we have to list records for a zone, cache them in the dns operation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1494)
<!-- Reviewable:end -->
