### PR TITLE
Unset KOPS_STATE_STORE when calling genhelpdocs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ gcs-publish-ci: gcs-upload
 	gsutil -h "Cache-Control:private, max-age=0, no-transform" cp .build/upload/${LATEST_FILE} ${GCS_LOCATION}
 
 gen-cli-docs:
-	@kops genhelpdocs --out docs/cli
+	KOPS_STATE_STORE= kops genhelpdocs --out docs/cli
 
 # Will always push a linux-based build up to the server
 push: crossbuild-nodeup


### PR DESCRIPTION
Fix #1365

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1499)
<!-- Reviewable:end -->
