### PR TITLE
Use instance group subnets instead of topology type

### DIFF
--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"k8s.io/kops/upup/pkg/fi/utils"
 	"k8s.io/kops/upup/pkg/kutil"
+	k8sapi "k8s.io/kubernetes/pkg/api"
 	"os"
 	"strings"
 	"time"
@@ -147,6 +148,17 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 		glog.Infof("Using SSH public key: %v\n", c.SSHPublicKey)
 	}
 
+	var instanceGroups []*kops.InstanceGroup
+	{
+		list, err := clientset.InstanceGroups(cluster.ObjectMeta.Name).List(k8sapi.ListOptions{})
+		if err != nil {
+			return err
+		}
+		for i := range list.Items {
+			instanceGroups = append(instanceGroups, &list.Items[i])
+		}
+	}
+
 	applyCmd := &cloudup.ApplyClusterCmd{
 		Cluster:         cluster,
 		Models:          strings.Split(c.Models, ","),
@@ -155,6 +167,7 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 		OutDir:          c.OutDir,
 		DryRun:          isDryrun,
 		MaxTaskDuration: c.MaxTaskDuration,
+		InstanceGroups:  instanceGroups,
 	}
 
 	err = applyCmd.Run()
@@ -222,7 +235,7 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 			}
 			fmt.Fprintf(sb, "Suggestions:\n")
 			fmt.Fprintf(sb, " * list nodes: kubectl get nodes --show-labels\n")
-			if cluster.Spec.Topology.Masters == kops.TopologyPublic {
+			if !usesBastion(instanceGroups) {
 				fmt.Fprintf(sb, " * ssh to the master: ssh -i ~/.ssh/id_rsa admin@%s\n", cluster.Spec.MasterPublicName)
 			} else {
 				fmt.Fprintf(sb, " * ssh to the bastion: ssh -i ~/.ssh/id_rsa admin@%s\n", cluster.Spec.MasterPublicName)
@@ -238,6 +251,16 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 	}
 
 	return nil
+}
+
+func usesBastion(instanceGroups []*kops.InstanceGroup) bool {
+	for _, ig := range instanceGroups {
+		if ig.Spec.Role == kops.InstanceGroupRoleBastion {
+			return true
+		}
+	}
+
+	return false
 }
 
 func hasKubecfg(contextName string) (bool, error) {

--- a/pkg/model/autoscalinggroup.go
+++ b/pkg/model/autoscalinggroup.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"fmt"
+	"github.com/golang/glog"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/model/resources"
 	"k8s.io/kops/upup/pkg/fi"
@@ -88,48 +89,45 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			}
 
 			{
+				// TODO: Wrapper / helper class to analyze clusters
+				subnetMap := make(map[string]*kops.ClusterSubnetSpec)
+				for i := range b.Cluster.Spec.Subnets {
+					subnet := &b.Cluster.Spec.Subnets[i]
+					subnetMap[subnet.Name] = subnet
+				}
+
+				var subnetType kops.SubnetType
+				for _, subnetName := range ig.Spec.Subnets {
+					subnet := subnetMap[subnetName]
+					if subnet == nil {
+						return fmt.Errorf("InstanceGroup %q uses subnet %q that does not exist", ig.ObjectMeta.Name, subnetName)
+					}
+					if subnetType != "" && subnetType != subnet.Type {
+						return fmt.Errorf("InstanceGroup %q cannot be in subnets of different Type", ig.ObjectMeta.Name)
+					}
+					subnetType = subnet.Type
+				}
+
 				associatePublicIP := true
-				switch ig.Spec.Role {
-				case kops.InstanceGroupRoleMaster:
-					switch b.Cluster.Spec.Topology.Masters {
-					case kops.TopologyPrivate:
-						associatePublicIP = false
-						// TODO: what if AssociatePublicIP is set
-
-					case kops.TopologyPublic:
-						associatePublicIP = true
-						if ig.Spec.AssociatePublicIP != nil {
-							associatePublicIP = *ig.Spec.AssociatePublicIP
-						}
-
-					default:
-						return fmt.Errorf("unhandled master topology %q", b.Cluster.Spec.Topology.Masters)
-					}
-
-				case kops.InstanceGroupRoleNode:
-					switch b.Cluster.Spec.Topology.Nodes {
-					case kops.TopologyPrivate:
-						associatePublicIP = false
-						// TODO: We probably should honor AssociatePublicIP
-
-					case kops.TopologyPublic:
-						associatePublicIP = true
-						if ig.Spec.AssociatePublicIP != nil {
-							associatePublicIP = *ig.Spec.AssociatePublicIP
-						}
-
-					default:
-						return fmt.Errorf("unhandled master topology %q", b.Cluster.Spec.Topology.Masters)
-					}
-
-				case kops.InstanceGroupRoleBastion:
+				switch subnetType {
+				case kops.SubnetTypePublic, kops.SubnetTypeUtility:
 					associatePublicIP = true
 					if ig.Spec.AssociatePublicIP != nil {
 						associatePublicIP = *ig.Spec.AssociatePublicIP
 					}
 
+				case kops.SubnetTypePrivate:
+					associatePublicIP = false
+					if ig.Spec.AssociatePublicIP != nil {
+						// This isn't meaningful - private subnets can't have public ip
+						//associatePublicIP = *ig.Spec.AssociatePublicIP
+						if *ig.Spec.AssociatePublicIP {
+							glog.Warningf("Ignoring private InstanceGroup %q with AssociatePublicIP=true", ig.ObjectMeta.Name)
+						}
+					}
+
 				default:
-					return fmt.Errorf("Unknown instance group role %q", ig.Spec.Role)
+					return fmt.Errorf("unknown subnet type %q", subnetType)
 				}
 				t.AssociatePublicIP = &associatePublicIP
 			}

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -156,6 +156,16 @@ func (m *KopsModelContext) UsesBastionDns() bool {
 	return false
 }
 
+func (m *KopsModelContext) UsesSSHBastion() bool {
+	for _, ig := range m.InstanceGroups {
+		if ig.Spec.Role == kops.InstanceGroupRoleBastion {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (m *KopsModelContext) UseLoadBalancerForAPI() bool {
 	if m.Cluster.Spec.API == nil {
 		return false

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -90,6 +90,7 @@ func PopulateInstanceGroupSpec(cluster *api.Cluster, input *api.InstanceGroup, c
 	}
 
 	if ig.Spec.AssociatePublicIP == nil {
+		// TODO: Only if a Public IG
 		ig.Spec.AssociatePublicIP = fi.Bool(true)
 	}
 

--- a/upup/pkg/fi/cloudup/tagbuilder.go
+++ b/upup/pkg/fi/cloudup/tagbuilder.go
@@ -55,18 +55,6 @@ func buildCloudupTags(cluster *api.Cluster) (sets.String, error) {
 		return nil, fmt.Errorf("No networking mode set")
 	}
 
-	// Network Topologies
-	if cluster.Spec.Topology == nil {
-		return nil, fmt.Errorf("missing topology spec")
-	}
-	if cluster.Spec.Topology.Masters == api.TopologyPublic && cluster.Spec.Topology.Nodes == api.TopologyPublic {
-		tags.Insert("_topology_public")
-	} else if cluster.Spec.Topology.Masters == api.TopologyPrivate && cluster.Spec.Topology.Nodes == api.TopologyPrivate {
-		tags.Insert("_topology_private")
-	} else {
-		return nil, fmt.Errorf("Unable to parse topology. Unsupported topology configuration. Masters and nodes must match!")
-	}
-
 	switch cluster.Spec.CloudProvider {
 	case "gce":
 		{


### PR DESCRIPTION
It looks like we can infer this from the instance group types, keeping
topology as an argument to `kops create cluster`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1527)
<!-- Reviewable:end -->
