### PR TITLE
Fix segfault in apply_channel

### DIFF
--- a/channels/cmd/channels/apply_channel.go
+++ b/channels/cmd/channels/apply_channel.go
@@ -175,10 +175,13 @@ func (c *ApplyChannelCmd) Run(args []string) error {
 		if err != nil {
 			return fmt.Errorf("error updating %q: %v", needUpdate.Name, err)
 		}
-		if update.NewVersion.Version != nil {
-			fmt.Printf("Updated %q to %d\n", update.Name, *update.NewVersion)
-		} else {
-			fmt.Printf("Updated %q\n", update.Name)
+		// Could have been a concurrent request
+		if update != nil {
+			if update.NewVersion.Version != nil {
+				fmt.Printf("Updated %q to %d\n", update.Name, *update.NewVersion)
+			} else {
+				fmt.Printf("Updated %q\n", update.Name)
+			}
 		}
 	}
 


### PR DESCRIPTION
If a parallel master concurrently applied an update, update may be nil,
and we might raise a segafault.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1534)
<!-- Reviewable:end -->
