### PR TITLE
Record git version of what we're building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))
 # Keep in sync with upup/models/cloudup/resources/addons/dns-controller/
 DNS_CONTROLLER_TAG=1.5.0
 
+GITSHA := $(shell cd ${GOPATH_1ST}/src/k8s.io/kops; git describe --always)
+
 ifndef VERSION
   # To keep both CI and end-users building from source happy,
   # we expect that CI sets CI=1.
@@ -45,11 +47,10 @@ ifndef VERSION
   ifndef CI
     VERSION=1.5.0-alpha3
   else
-    VERSION := git-$(shell git describe --always)
+    VERSION := git-${GITSHA}
   endif
 endif
 
-GITSHA := $(shell git describe --always)
 
 # Go exports:
 


### PR DESCRIPTION
If we're running from a different directory (most commonly a checkout
into src/github.com/kubernetes/kops), the git sha would be the sha of
the working directory, but then we always build by name.

Fix by changing to the correct directory first.

Fix #1057

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1581)
<!-- Reviewable:end -->
