### PR TITLE
kube-dns autoscaler: set min replicas to 2

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/v1.5.1.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/v1.5.1.yaml.template
@@ -46,7 +46,7 @@ spec:
           - --target=Deployment/kube-dns
           # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
           # If using small nodes, "nodesPerReplica" should dominate.
-          - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"min":1}}
+          - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"min":2}}
           - --logtostderr=true
           - --v=2
 

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -85,7 +85,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	{
 		key := "kube-dns.addons.k8s.io"
-		version := "1.5.0"
+		version := "1.5.1"
 
 		location := key + "/v" + version + ".yaml"
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
@@ -9,11 +9,11 @@ spec:
     selector:
       k8s-addon: core.addons.k8s.io
     version: 1.4.0
-  - manifest: kube-dns.addons.k8s.io/v1.5.0.yaml
+  - manifest: kube-dns.addons.k8s.io/v1.5.1.yaml
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.5.0
+    version: 1.5.1
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
     name: limit-range.addons.k8s.io
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -9,11 +9,11 @@ spec:
     selector:
       k8s-addon: core.addons.k8s.io
     version: 1.4.0
-  - manifest: kube-dns.addons.k8s.io/v1.5.0.yaml
+  - manifest: kube-dns.addons.k8s.io/v1.5.1.yaml
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.5.0
+    version: 1.5.1
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
     name: limit-range.addons.k8s.io
     selector:


### PR DESCRIPTION
Issue https://github.com/kubernetes/kubernetes/issues/40063

Having a single pod would be a single point of failure.  Multiple pods
should be spread across AZs & nodes by k8s automatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1592)
<!-- Reviewable:end -->
