### PR TITLE
Update run_in_existing_vpc.md note for tagging shared subnets

### DIFF
--- a/docs/run_in_existing_vpc.md
+++ b/docs/run_in_existing_vpc.md
@@ -114,6 +114,8 @@ kops update cluster ${CLUSTER_NAME}
 kops update cluster ${CLUSTER_NAME} --yes
 ```
 
+If you run in AWS private topology with shared subnets, and you would like Kubernetes to provision resources in these shared subnets, you must create tags on them with Key=value `KubernetesCluster=<clustername>`. This is important, for example, if your `utility` subnets are shared, you will not be able to launch any services that create Elastic Load Balancers (ELBs).
+
 ### Shared NAT Gateways
 
 On AWS in private [topology](docs/topology.md), `kops` creates one NAT Gateway (NGW) per AZ. If your shared VPC is already set up with an NGW in the subnet that `kops` deploys private resources to, it is possible to specify the ID and have `kops`/`kubernetes` use it.


### PR DESCRIPTION
So Kubernetes is able to use them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1615)
<!-- Reviewable:end -->
