### PR TITLE
cleanup delete cluster

### DIFF
--- a/upup/pkg/kutil/delete_cluster.go
+++ b/upup/pkg/kutil/delete_cluster.go
@@ -951,6 +951,7 @@ func ListSubnets(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error)
 			}
 			if sharedNgwIds.Has(id) {
 				// If we find this NGW in our list of shared NGWs, skip it (don't delete!)
+				glog.V(2).Infof("Won't delete shared NAT gateway %q", id)
 				continue
 			}
 


### PR DESCRIPTION
Don't try to delete an ElasticIP before deleting the attached NAT
gateway.

Optimize the queries we make when finding subnets for deletion.

Issue #1604

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1617)
<!-- Reviewable:end -->
