### PR TITLE
Better validate CIDRs - provide some hints on failure

### DIFF
--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -250,22 +250,10 @@ func ValidateCluster(c *kops.Cluster, strict bool) error {
 	if strict && len(c.Spec.SSHAccess) == 0 {
 		return fmt.Errorf("SSHAccess not configured")
 	}
-	for _, cidr := range c.Spec.SSHAccess {
-		_, _, err := net.ParseCIDR(cidr)
-		if err != nil {
-			return fmt.Errorf("SSHAccess rule %q could not be parsed (invalid CIDR)", cidr)
-		}
-	}
 
 	// AdminAccess
 	if strict && len(c.Spec.KubernetesAPIAccess) == 0 {
 		return fmt.Errorf("KubernetesAPIAccess not configured")
-	}
-	for _, cidr := range c.Spec.KubernetesAPIAccess {
-		_, _, err := net.ParseCIDR(cidr)
-		if err != nil {
-			return fmt.Errorf("KubernetesAPIAccess rule %q could not be parsed (invalid CIDR)", cidr)
-		}
 	}
 
 	// KubeProxy

--- a/upup/pkg/fi/cloudup/deepvalidate_test.go
+++ b/upup/pkg/fi/cloudup/deepvalidate_test.go
@@ -107,7 +107,7 @@ func TestDeepValidate_DuplicateZones(t *testing.T) {
 	var groups []*api.InstanceGroup
 	groups = append(groups, buildMinimalMasterInstanceGroup("dup1"))
 	groups = append(groups, buildMinimalNodeInstanceGroup("dup1"))
-	expectErrorFromDeepValidate(t, c, groups, "Subnets with duplicate name \"dup1\" found")
+	expectErrorFromDeepValidate(t, c, groups, "subnets with duplicate name \"dup1\" found")
 }
 
 func TestDeepValidate_ExtraMasterZone(t *testing.T) {


### PR DESCRIPTION
With this:

`kops create cluster ... --admin-access 12.34.56.78`

gives

spec.sshAccess[0]: Invalid value: "12.34.56.78": Could not be parsed as
a CIDR (did you mean "12.34.56.78/32")

Fix #1595

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1619)
<!-- Reviewable:end -->
