### PR TITLE
Provide iam policy for autoscaler addon

### DIFF
--- a/addons/cluster-autoscaler/v1.4.0.yaml
+++ b/addons/cluster-autoscaler/v1.4.0.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         k8s-app: cluster-autoscaler
+      annotations:
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated", "value":"master"}]'
     spec:
         containers:
           - name: cluster-autoscaler
@@ -40,3 +42,5 @@ spec:
           - name: ssl-certs
             hostPath:
               path: {{SSL_CERT_PATH}}
+        nodeSelector:
+          kubernetes.io/role: master

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -140,6 +140,17 @@ func (b *IAMPolicyBuilder) BuildAWSIAMPolicy() (*IAMPolicy, error) {
 			Resource: []string{"*"},
 		})
 
+		p.Statement = append(p.Statement, &IAMStatement{
+			Effect: IAMStatementEffectAllow,
+			Action: []string{
+				"autoscaling:DescribeAutoScalingGroups",
+				"autoscaling:DescribeAutoScalingInstances",
+				"autoscaling:SetDesiredCapacity",
+				"autoscaling:TerminateInstanceInAutoScalingGroup",
+			},
+			Resource: []string{"*"},
+		})
+
 		// Restrict the KMS permissions to only the keys that are being used
 		kmsKeyIDs := sets.NewString()
 		for _, e := range b.Cluster.Spec.EtcdClusters {


### PR DESCRIPTION
close: #1573
Add autoscaler [required permissions](https://github.com/kubernetes/contrib/tree/master/cluster-autoscaler/cloudprovider/aws) in the master policy and schedule the addon in masters

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1620)
<!-- Reviewable:end -->
