### PR TITLE
Channel manifest should be version aware

### DIFF
--- a/hack/.packages
+++ b/hack/.packages
@@ -41,6 +41,7 @@ k8s.io/kops/pkg/validation
 k8s.io/kops/protokube/cmd/protokube
 k8s.io/kops/protokube/pkg/protokube
 k8s.io/kops/protokube/tests/integration/build_etcd_manifest
+k8s.io/kops/tests/integration/channel
 k8s.io/kops/tests/integration/conversion
 k8s.io/kops/upup/models
 k8s.io/kops/upup/pkg/fi

--- a/permalinks/README.md
+++ b/permalinks/README.md
@@ -1,0 +1,3 @@
+This directory contains docs that add contextual help to error messages.
+
+The links are baked into kops, and thus we cannot rename or move these files (at least not quickly).

--- a/permalinks/upgrade_k8s.md
+++ b/permalinks/upgrade_k8s.md
@@ -1,0 +1,5 @@
+# Kubernetes Upgrade Recommended
+
+You are running a version of kubernetes that we recommend upgrading.
+
+Please see the [instructions for how to upgrade kubernetes](https://github.com/kubernetes/kops/blob/master/docs/upgrade.md)

--- a/permalinks/upgrade_kops.md
+++ b/permalinks/upgrade_kops.md
@@ -1,0 +1,5 @@
+# Kops Upgrade Recommended
+
+You are running a version of kops that we recommend upgrading.
+
+The latest releases are available from [Github Releases](https://github.com/kubernetes/kops/releases)

--- a/tests/integration/channel/integration_test.go
+++ b/tests/integration/channel/integration_test.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/blang/semver"
+	"io/ioutil"
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/upup/pkg/fi"
+	"path"
+	"testing"
+)
+
+// TestKopsUpgrades tests the version logic for kops versions
+func TestKopsUpgrades(t *testing.T) {
+	srcDir := "simple"
+	sourcePath := path.Join(srcDir, "channel.yaml")
+	sourceBytes, err := ioutil.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
+	}
+
+	channel, err := kops.ParseChannel(sourceBytes)
+	if err != nil {
+		t.Fatalf("failed to parse channel: %v", err)
+	}
+
+	grid := []struct {
+		KopsVersion      string
+		ExpectedUpgrade  string
+		ExpectedRequired bool
+		ExpectedError    bool
+	}{
+		{
+			KopsVersion:      "1.4.4",
+			ExpectedUpgrade:  "1.4.5",
+			ExpectedRequired: true,
+		},
+		{
+			KopsVersion:     "1.4.5",
+			ExpectedUpgrade: "",
+		},
+		{
+			KopsVersion:      "1.5.0-alpha4",
+			ExpectedUpgrade:  "1.5.0-beta1",
+			ExpectedRequired: true,
+		},
+		{
+			KopsVersion:     "1.5.0-beta1",
+			ExpectedUpgrade: "",
+		},
+		{
+			KopsVersion:     "1.5.0-beta2",
+			ExpectedUpgrade: "",
+		},
+		{
+			KopsVersion:      "1.5.0",
+			ExpectedUpgrade:  "1.5.1",
+			ExpectedRequired: false,
+		},
+		{
+			KopsVersion:     "1.5.1",
+			ExpectedUpgrade: "",
+		},
+	}
+	for _, g := range grid {
+		kopsVersion := semver.MustParse(g.KopsVersion)
+
+		versionInfo := kops.FindVersionInfo(channel.Spec.KopsVersions, kopsVersion)
+		if versionInfo == nil {
+			t.Errorf("unable to find version information for kops version %q in channel", kopsVersion)
+			continue
+		}
+
+		actual, err := kops.FindRecommendedUpgrade(versionInfo, kopsVersion)
+		if g.ExpectedError {
+			if err == nil {
+				t.Errorf("expected error from FindRecommendedUpgrade(%q)", g.KopsVersion)
+				continue
+			}
+		} else {
+			if err != nil {
+				t.Errorf("unexpected error from FindRecommendedUpgrade(%q): %v", g.KopsVersion, err)
+				continue
+			}
+		}
+		if actual != g.ExpectedUpgrade {
+			t.Errorf("unexpected result from IsUpgradeRequired(%q): expected=%q, actual=%q", g.KopsVersion, g.ExpectedUpgrade, actual)
+			continue
+		}
+
+		required, err := kops.IsUpgradeRequired(versionInfo, kopsVersion)
+		if err != nil {
+			t.Errorf("unexpected error from IsUpgradeRequired(%q)", g.KopsVersion, err)
+			continue
+		}
+		if required != g.ExpectedRequired {
+			t.Errorf("unexpected result from IsUpgradeRequired(%q): expected=%t, actual=%t", g.KopsVersion, g.ExpectedRequired, required)
+			continue
+		}
+	}
+}
+
+// TestKubernetesUpgrades tests the version logic kubernetes kops versions
+func TestKubernetesUpgrades(t *testing.T) {
+	srcDir := "simple"
+	sourcePath := path.Join(srcDir, "channel.yaml")
+	sourceBytes, err := ioutil.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
+	}
+
+	channel, err := kops.ParseChannel(sourceBytes)
+	if err != nil {
+		t.Fatalf("failed to parse channel: %v", err)
+	}
+
+	grid := []struct {
+		KubernetesVersion string
+		ExpectedUpgrade   string
+		ExpectedRequired  bool
+		ExpectedError     bool
+	}{
+		{
+			KubernetesVersion: "1.4.0",
+			ExpectedUpgrade:   "1.4.8",
+			ExpectedRequired:  true,
+		},
+		{
+			KubernetesVersion: "1.4.1",
+			ExpectedUpgrade:   "1.4.8",
+			ExpectedRequired:  true,
+		},
+		{
+			KubernetesVersion: "1.4.2",
+			ExpectedUpgrade:   "1.4.8",
+		},
+		{
+			KubernetesVersion: "1.4.4",
+			ExpectedUpgrade:   "1.4.8",
+		},
+		{
+			KubernetesVersion: "1.4.8",
+			ExpectedUpgrade:   "",
+		},
+		{
+			KubernetesVersion: "1.5.0",
+			ExpectedUpgrade:   "1.5.2",
+			ExpectedRequired:  true,
+		},
+		{
+			KubernetesVersion: "1.5.1",
+			ExpectedUpgrade:   "1.5.2",
+		},
+		{
+			KubernetesVersion: "1.5.2",
+			ExpectedUpgrade:   "",
+		},
+	}
+	for _, g := range grid {
+		kubernetesVersion := semver.MustParse(g.KubernetesVersion)
+
+		versionInfo := kops.FindVersionInfo(channel.Spec.KubernetesVersions, kubernetesVersion)
+		if versionInfo == nil {
+			t.Errorf("unable to find version information for kubernetes version %q in channel", kubernetesVersion)
+			continue
+		}
+
+		actual, err := kops.FindRecommendedUpgrade(versionInfo, kubernetesVersion)
+		if g.ExpectedError {
+			if err == nil {
+				t.Errorf("expected error from FindRecommendedUpgrade(%q)", g.KubernetesVersion)
+				continue
+			}
+		} else {
+			if err != nil {
+				t.Errorf("unexpected error from FindRecommendedUpgrade(%q): %v", g.KubernetesVersion, err)
+				continue
+			}
+		}
+		if actual != g.ExpectedUpgrade {
+			t.Errorf("unexpected result from IsUpgradeRequired(%q): expected=%q, actual=%q", g.KubernetesVersion, g.ExpectedUpgrade, actual)
+			continue
+		}
+
+		required, err := kops.IsUpgradeRequired(versionInfo, kubernetesVersion)
+		if err != nil {
+			t.Errorf("unexpected error from IsUpgradeRequired(%q)", g.KubernetesVersion, err)
+			continue
+		}
+		if required != g.ExpectedRequired {
+			t.Errorf("unexpected result from IsUpgradeRequired(%q): expected=%t, actual=%t", g.KubernetesVersion, g.ExpectedRequired, required)
+			continue
+		}
+	}
+}
+
+// TestFindImage tests the version-based image finding
+func TestFindImage(t *testing.T) {
+	srcDir := "simple"
+	sourcePath := path.Join(srcDir, "channel.yaml")
+	sourceBytes, err := ioutil.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
+	}
+
+	channel, err := kops.ParseChannel(sourceBytes)
+	if err != nil {
+		t.Fatalf("failed to parse channel: %v", err)
+	}
+
+	grid := []struct {
+		KubernetesVersion string
+		ExpectedImage     string
+	}{
+		{
+			KubernetesVersion: "1.4.4",
+			ExpectedImage:     "kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21",
+		},
+		{
+			KubernetesVersion: "1.5.1",
+			ExpectedImage:     "kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09",
+		},
+	}
+	for _, g := range grid {
+		kubernetesVersion := semver.MustParse(g.KubernetesVersion)
+
+		image := channel.FindImage(fi.CloudProviderAWS, kubernetesVersion)
+		name := ""
+		if image != nil {
+			name = image.Name
+		}
+		if name != g.ExpectedImage {
+			t.Errorf("unexpected image from FindImage(%q): expected=%q, actual=%q", g.KubernetesVersion, g.ExpectedImage, name)
+		}
+	}
+}

--- a/tests/integration/channel/simple/channel.yaml
+++ b/tests/integration/channel/simple/channel.yaml
@@ -1,0 +1,30 @@
+spec:
+  images:
+    - name: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+      providerID: aws
+      kubernetesVersion: ">=1.4.0 <1.5.0"
+    - name: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+      providerID: aws
+      kubernetesVersion: ">=1.5.0"
+  cluster:
+    kubernetesVersion: v1.4.7
+    networking:
+      kubenet: {}
+  kubernetesVersions:
+  - range: ">=1.5.0"
+    recommendedVersion: 1.5.2
+    requiredVersion: 1.5.1
+  - range: "<1.5.0"
+    recommendedVersion: 1.4.8
+    requiredVersion: 1.4.2
+  kopsVersions:
+  - range: ">=1.5.0"
+    recommendedVersion: 1.5.1
+    requiredVersion: 1.5.0
+  - range: ">=1.5.0-alpha1"
+    recommendedVersion: 1.5.0-beta1
+    requiredVersion: 1.5.0-beta1
+  - range: "<1.5.0"
+    recommendedVersion: 1.4.5
+    requiredVersion: 1.4.5
+


### PR DESCRIPTION
* We can target AMIs to kubernetes versions
* We can recommend / force a kops upgrade
* We can recommend / force a kubernetes upgrade

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1625)
<!-- Reviewable:end -->
