### PR TITLE
bumping Calico versions to 2.0.1

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/v2.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/v2.0.yaml.template
@@ -77,7 +77,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v1.0.0
+          image: calico/node:v1.0.1
           resources:
             requests:
               cpu: 10m
@@ -189,7 +189,7 @@ spec:
       hostNetwork: true
       containers:
         - name: calico-policy-controller
-          image: calico/kube-policy-controller:v0.5.1
+          image: calico/kube-policy-controller:v0.5.2
           resources:
             requests:
               cpu: 10m
@@ -237,7 +237,7 @@ spec:
       containers:
         # Writes basic configuration to datastore.
         - name: configure-calico
-          image: calico/ctl:v1.0.0
+          image: calico/ctl:v1.0.1
           args:
           - apply
           - -f


### PR DESCRIPTION
Calico 2.0.1 was released with some bug fixes, bumping to appropriate versions.

For more information, see the 2.0.1 Release notes here.
http://docs.projectcalico.org/v2.0/releases/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1630)
<!-- Reviewable:end -->
