### PR TITLE
Add p2 instances

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/machine_types.go
+++ b/upup/pkg/fi/cloudup/awsup/machine_types.go
@@ -481,7 +481,7 @@ var MachineTypes []AWSMachineTypeInfo = []AWSMachineTypeInfo{
 		Cores:          64,
 		EphemeralDisks: nil,
 	},
-	
+
 	// p2 family
 	{
 		Name:           "p2.xlarge",

--- a/upup/pkg/fi/cloudup/awsup/machine_types.go
+++ b/upup/pkg/fi/cloudup/awsup/machine_types.go
@@ -481,4 +481,27 @@ var MachineTypes []AWSMachineTypeInfo = []AWSMachineTypeInfo{
 		Cores:          64,
 		EphemeralDisks: nil,
 	},
+	
+	// p2 family
+	{
+		Name:           "p2.xlarge",
+		MemoryGB:       61,
+		ECU:            12,
+		Cores:          4,
+		EphemeralDisks: nil,
+	},
+	{
+		Name:           "p2.8xlarge",
+		MemoryGB:       488,
+		ECU:            94,
+		Cores:          32,
+		EphemeralDisks: nil,
+	},
+	{
+		Name:           "p2.16xlarge",
+		MemoryGB:       732,
+		ECU:            188,
+		Cores:          64,
+		EphemeralDisks: nil,
+	},
 }


### PR DESCRIPTION
Add AWS P2 instances introduced in Sep 2016. ECU info obtained from http://www.ec2instances.info/?filter=p2&region=us-west-2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1646)
<!-- Reviewable:end -->
