### PR TITLE
fix cloudup: Apply Terraform formatting to TF files

### DIFF
--- a/tests/integration/minimal-141/kubernetes.tf
+++ b/tests/integration/minimal-141/kubernetes.tf
@@ -1,57 +1,64 @@
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-141-example-com" {
-  name = "master-us-test-1a.masters.minimal-141.example.com"
+  name                 = "master-us-test-1a.masters.minimal-141.example.com"
   launch_configuration = "${aws_launch_configuration.master-us-test-1a-masters-minimal-141-example-com.id}"
-  max_size = 1
-  min_size = 1
-  vpc_zone_identifier = ["${aws_subnet.us-test-1a-minimal-141-example-com.id}"]
+  max_size             = 1
+  min_size             = 1
+  vpc_zone_identifier  = ["${aws_subnet.us-test-1a-minimal-141-example-com.id}"]
+
   tag = {
-    key = "KubernetesCluster"
-    value = "minimal-141.example.com"
+    key                 = "KubernetesCluster"
+    value               = "minimal-141.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "Name"
-    value = "master-us-test-1a.masters.minimal-141.example.com"
+    key                 = "Name"
+    value               = "master-us-test-1a.masters.minimal-141.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "k8s.io/role/master"
-    value = "1"
+    key                 = "k8s.io/role/master"
+    value               = "1"
     propagate_at_launch = true
   }
 }
 
 resource "aws_autoscaling_group" "nodes-minimal-141-example-com" {
-  name = "nodes.minimal-141.example.com"
+  name                 = "nodes.minimal-141.example.com"
   launch_configuration = "${aws_launch_configuration.nodes-minimal-141-example-com.id}"
-  max_size = 2
-  min_size = 2
-  vpc_zone_identifier = ["${aws_subnet.us-test-1a-minimal-141-example-com.id}"]
+  max_size             = 2
+  min_size             = 2
+  vpc_zone_identifier  = ["${aws_subnet.us-test-1a-minimal-141-example-com.id}"]
+
   tag = {
-    key = "KubernetesCluster"
-    value = "minimal-141.example.com"
+    key                 = "KubernetesCluster"
+    value               = "minimal-141.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "Name"
-    value = "nodes.minimal-141.example.com"
+    key                 = "Name"
+    value               = "nodes.minimal-141.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "k8s.io/role/node"
-    value = "1"
+    key                 = "k8s.io/role/node"
+    value               = "1"
     propagate_at_launch = true
   }
 }
 
 resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-141-example-com" {
   availability_zone = "us-test-1a"
-  size = 20
-  type = "gp2"
-  encrypted = false
+  size              = 20
+  type              = "gp2"
+  encrypted         = false
+
   tags = {
-    KubernetesCluster = "minimal-141.example.com"
-    Name = "us-test-1a.etcd-events.minimal-141.example.com"
+    KubernetesCluster    = "minimal-141.example.com"
+    Name                 = "us-test-1a.etcd-events.minimal-141.example.com"
     "k8s.io/etcd/events" = "us-test-1a/us-test-1a"
     "k8s.io/role/master" = "1"
   }
@@ -59,263 +66,276 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-141-example-com" {
 
 resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-141-example-com" {
   availability_zone = "us-test-1a"
-  size = 20
-  type = "gp2"
-  encrypted = false
+  size              = 20
+  type              = "gp2"
+  encrypted         = false
+
   tags = {
-    KubernetesCluster = "minimal-141.example.com"
-    Name = "us-test-1a.etcd-main.minimal-141.example.com"
-    "k8s.io/etcd/main" = "us-test-1a/us-test-1a"
+    KubernetesCluster    = "minimal-141.example.com"
+    Name                 = "us-test-1a.etcd-main.minimal-141.example.com"
+    "k8s.io/etcd/main"   = "us-test-1a/us-test-1a"
     "k8s.io/role/master" = "1"
   }
 }
 
 resource "aws_iam_instance_profile" "masters-minimal-141-example-com" {
-  name = "masters.minimal-141.example.com"
+  name  = "masters.minimal-141.example.com"
   roles = ["${aws_iam_role.masters-minimal-141-example-com.name}"]
 }
 
 resource "aws_iam_instance_profile" "nodes-minimal-141-example-com" {
-  name = "nodes.minimal-141.example.com"
+  name  = "nodes.minimal-141.example.com"
   roles = ["${aws_iam_role.nodes-minimal-141-example-com.name}"]
 }
 
 resource "aws_iam_role" "masters-minimal-141-example-com" {
-  name = "masters.minimal-141.example.com"
+  name               = "masters.minimal-141.example.com"
   assume_role_policy = "${file("${path.module}/data/aws_iam_role_masters.minimal-141.example.com_policy")}"
 }
 
 resource "aws_iam_role" "nodes-minimal-141-example-com" {
-  name = "nodes.minimal-141.example.com"
+  name               = "nodes.minimal-141.example.com"
   assume_role_policy = "${file("${path.module}/data/aws_iam_role_nodes.minimal-141.example.com_policy")}"
 }
 
 resource "aws_iam_role_policy" "masters-minimal-141-example-com" {
-  name = "masters.minimal-141.example.com"
-  role = "${aws_iam_role.masters-minimal-141-example-com.name}"
+  name   = "masters.minimal-141.example.com"
+  role   = "${aws_iam_role.masters-minimal-141-example-com.name}"
   policy = "${file("${path.module}/data/aws_iam_role_policy_masters.minimal-141.example.com_policy")}"
 }
 
 resource "aws_iam_role_policy" "nodes-minimal-141-example-com" {
-  name = "nodes.minimal-141.example.com"
-  role = "${aws_iam_role.nodes-minimal-141-example-com.name}"
+  name   = "nodes.minimal-141.example.com"
+  role   = "${aws_iam_role.nodes-minimal-141-example-com.name}"
   policy = "${file("${path.module}/data/aws_iam_role_policy_nodes.minimal-141.example.com_policy")}"
 }
 
 resource "aws_internet_gateway" "minimal-141-example-com" {
   vpc_id = "${aws_vpc.minimal-141-example-com.id}"
+
   tags = {
     KubernetesCluster = "minimal-141.example.com"
-    Name = "minimal-141.example.com"
+    Name              = "minimal-141.example.com"
   }
 }
 
 resource "aws_key_pair" "kubernetes-minimal-141-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
-  key_name = "kubernetes.minimal-141.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
+  key_name   = "kubernetes.minimal-141.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = "${file("${path.module}/data/aws_key_pair_kubernetes.minimal-141.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")}"
 }
 
 resource "aws_launch_configuration" "master-us-test-1a-masters-minimal-141-example-com" {
-  name_prefix = "master-us-test-1a.masters.minimal-141.example.com-"
-  image_id = "ami-12345678"
-  instance_type = "m3.medium"
-  key_name = "${aws_key_pair.kubernetes-minimal-141-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
-  iam_instance_profile = "${aws_iam_instance_profile.masters-minimal-141-example-com.id}"
-  security_groups = ["${aws_security_group.masters-minimal-141-example-com.id}"]
+  name_prefix                 = "master-us-test-1a.masters.minimal-141.example.com-"
+  image_id                    = "ami-12345678"
+  instance_type               = "m3.medium"
+  key_name                    = "${aws_key_pair.kubernetes-minimal-141-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
+  iam_instance_profile        = "${aws_iam_instance_profile.masters-minimal-141-example-com.id}"
+  security_groups             = ["${aws_security_group.masters-minimal-141-example-com.id}"]
   associate_public_ip_address = true
-  user_data = "${file("${path.module}/data/aws_launch_configuration_master-us-test-1a.masters.minimal-141.example.com_user_data")}"
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_master-us-test-1a.masters.minimal-141.example.com_user_data")}"
+
   root_block_device = {
-    volume_type = "gp2"
-    volume_size = 20
+    volume_type           = "gp2"
+    volume_size           = 20
     delete_on_termination = true
   }
+
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
+
   lifecycle = {
     create_before_destroy = true
   }
 }
 
 resource "aws_launch_configuration" "nodes-minimal-141-example-com" {
-  name_prefix = "nodes.minimal-141.example.com-"
-  image_id = "ami-12345678"
-  instance_type = "t2.medium"
-  key_name = "${aws_key_pair.kubernetes-minimal-141-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
-  iam_instance_profile = "${aws_iam_instance_profile.nodes-minimal-141-example-com.id}"
-  security_groups = ["${aws_security_group.nodes-minimal-141-example-com.id}"]
+  name_prefix                 = "nodes.minimal-141.example.com-"
+  image_id                    = "ami-12345678"
+  instance_type               = "t2.medium"
+  key_name                    = "${aws_key_pair.kubernetes-minimal-141-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
+  iam_instance_profile        = "${aws_iam_instance_profile.nodes-minimal-141-example-com.id}"
+  security_groups             = ["${aws_security_group.nodes-minimal-141-example-com.id}"]
   associate_public_ip_address = true
-  user_data = "${file("${path.module}/data/aws_launch_configuration_nodes.minimal-141.example.com_user_data")}"
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_nodes.minimal-141.example.com_user_data")}"
+
   root_block_device = {
-    volume_type = "gp2"
-    volume_size = 20
+    volume_type           = "gp2"
+    volume_size           = 20
     delete_on_termination = true
   }
+
   lifecycle = {
     create_before_destroy = true
   }
 }
 
 resource "aws_route" "0-0-0-0--0" {
-  route_table_id = "${aws_route_table.minimal-141-example-com.id}"
+  route_table_id         = "${aws_route_table.minimal-141-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id = "${aws_internet_gateway.minimal-141-example-com.id}"
+  gateway_id             = "${aws_internet_gateway.minimal-141-example-com.id}"
 }
 
 resource "aws_route_table" "minimal-141-example-com" {
   vpc_id = "${aws_vpc.minimal-141-example-com.id}"
+
   tags = {
     KubernetesCluster = "minimal-141.example.com"
-    Name = "minimal-141.example.com"
+    Name              = "minimal-141.example.com"
   }
 }
 
 resource "aws_route_table_association" "us-test-1a-minimal-141-example-com" {
-  subnet_id = "${aws_subnet.us-test-1a-minimal-141-example-com.id}"
+  subnet_id      = "${aws_subnet.us-test-1a-minimal-141-example-com.id}"
   route_table_id = "${aws_route_table.minimal-141-example-com.id}"
 }
 
 resource "aws_security_group" "masters-minimal-141-example-com" {
-  name = "masters.minimal-141.example.com"
-  vpc_id = "${aws_vpc.minimal-141-example-com.id}"
+  name        = "masters.minimal-141.example.com"
+  vpc_id      = "${aws_vpc.minimal-141-example-com.id}"
   description = "Security group for masters"
+
   tags = {
     KubernetesCluster = "minimal-141.example.com"
-    Name = "masters.minimal-141.example.com"
+    Name              = "masters.minimal-141.example.com"
   }
 }
 
 resource "aws_security_group" "nodes-minimal-141-example-com" {
-  name = "nodes.minimal-141.example.com"
-  vpc_id = "${aws_vpc.minimal-141-example-com.id}"
+  name        = "nodes.minimal-141.example.com"
+  vpc_id      = "${aws_vpc.minimal-141-example-com.id}"
   description = "Security group for nodes"
+
   tags = {
     KubernetesCluster = "minimal-141.example.com"
-    Name = "nodes.minimal-141.example.com"
+    Name              = "nodes.minimal-141.example.com"
   }
 }
 
 resource "aws_security_group_rule" "all-master-to-master" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-minimal-141-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-minimal-141-example-com.id}"
   source_security_group_id = "${aws_security_group.masters-minimal-141-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
 }
 
 resource "aws_security_group_rule" "all-master-to-node" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.nodes-minimal-141-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.nodes-minimal-141-example-com.id}"
   source_security_group_id = "${aws_security_group.masters-minimal-141-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
 }
 
 resource "aws_security_group_rule" "all-node-to-node" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.nodes-minimal-141-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.nodes-minimal-141-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-minimal-141-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
 }
 
 resource "aws_security_group_rule" "https-external-to-master-0-0-0-0--0" {
-  type = "ingress"
+  type              = "ingress"
   security_group_id = "${aws_security_group.masters-minimal-141-example-com.id}"
-  from_port = 443
-  to_port = 443
-  protocol = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "master-egress" {
-  type = "egress"
+  type              = "egress"
   security_group_id = "${aws_security_group.masters-minimal-141-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "node-egress" {
-  type = "egress"
+  type              = "egress"
   security_group_id = "${aws_security_group.nodes-minimal-141-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "node-to-master-tcp-4194" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-minimal-141-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-minimal-141-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-minimal-141-example-com.id}"
-  from_port = 4194
-  to_port = 4194
-  protocol = "tcp"
+  from_port                = 4194
+  to_port                  = 4194
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "node-to-master-tcp-443" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-minimal-141-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-minimal-141-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-minimal-141-example-com.id}"
-  from_port = 443
-  to_port = 443
-  protocol = "tcp"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "ssh-external-to-master-0-0-0-0--0" {
-  type = "ingress"
+  type              = "ingress"
   security_group_id = "${aws_security_group.masters-minimal-141-example-com.id}"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "ssh-external-to-node-0-0-0-0--0" {
-  type = "ingress"
+  type              = "ingress"
   security_group_id = "${aws_security_group.nodes-minimal-141-example-com.id}"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_subnet" "us-test-1a-minimal-141-example-com" {
-  vpc_id = "${aws_vpc.minimal-141-example-com.id}"
-  cidr_block = "172.20.32.0/19"
+  vpc_id            = "${aws_vpc.minimal-141-example-com.id}"
+  cidr_block        = "172.20.32.0/19"
   availability_zone = "us-test-1a"
+
   tags = {
     KubernetesCluster = "minimal-141.example.com"
-    Name = "us-test-1a.minimal-141.example.com"
+    Name              = "us-test-1a.minimal-141.example.com"
   }
 }
 
 resource "aws_vpc" "minimal-141-example-com" {
-  cidr_block = "172.20.0.0/16"
+  cidr_block           = "172.20.0.0/16"
   enable_dns_hostnames = true
-  enable_dns_support = true
+  enable_dns_support   = true
+
   tags = {
     KubernetesCluster = "minimal-141.example.com"
-    Name = "minimal-141.example.com"
+    Name              = "minimal-141.example.com"
   }
 }
 
 resource "aws_vpc_dhcp_options" "minimal-141-example-com" {
-  domain_name = "us-test-1.compute.internal"
+  domain_name         = "us-test-1.compute.internal"
   domain_name_servers = ["AmazonProvidedDNS"]
+
   tags = {
     KubernetesCluster = "minimal-141.example.com"
-    Name = "minimal-141.example.com"
+    Name              = "minimal-141.example.com"
   }
 }
 
 resource "aws_vpc_dhcp_options_association" "minimal-141-example-com" {
-  vpc_id = "${aws_vpc.minimal-141-example-com.id}"
+  vpc_id          = "${aws_vpc.minimal-141-example-com.id}"
   dhcp_options_id = "${aws_vpc_dhcp_options.minimal-141-example-com.id}"
 }

--- a/tests/integration/minimal/kubernetes.tf
+++ b/tests/integration/minimal/kubernetes.tf
@@ -1,57 +1,64 @@
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com" {
-  name = "master-us-test-1a.masters.minimal.example.com"
+  name                 = "master-us-test-1a.masters.minimal.example.com"
   launch_configuration = "${aws_launch_configuration.master-us-test-1a-masters-minimal-example-com.id}"
-  max_size = 1
-  min_size = 1
-  vpc_zone_identifier = ["${aws_subnet.us-test-1a-minimal-example-com.id}"]
+  max_size             = 1
+  min_size             = 1
+  vpc_zone_identifier  = ["${aws_subnet.us-test-1a-minimal-example-com.id}"]
+
   tag = {
-    key = "KubernetesCluster"
-    value = "minimal.example.com"
+    key                 = "KubernetesCluster"
+    value               = "minimal.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "Name"
-    value = "master-us-test-1a.masters.minimal.example.com"
+    key                 = "Name"
+    value               = "master-us-test-1a.masters.minimal.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "k8s.io/role/master"
-    value = "1"
+    key                 = "k8s.io/role/master"
+    value               = "1"
     propagate_at_launch = true
   }
 }
 
 resource "aws_autoscaling_group" "nodes-minimal-example-com" {
-  name = "nodes.minimal.example.com"
+  name                 = "nodes.minimal.example.com"
   launch_configuration = "${aws_launch_configuration.nodes-minimal-example-com.id}"
-  max_size = 2
-  min_size = 2
-  vpc_zone_identifier = ["${aws_subnet.us-test-1a-minimal-example-com.id}"]
+  max_size             = 2
+  min_size             = 2
+  vpc_zone_identifier  = ["${aws_subnet.us-test-1a-minimal-example-com.id}"]
+
   tag = {
-    key = "KubernetesCluster"
-    value = "minimal.example.com"
+    key                 = "KubernetesCluster"
+    value               = "minimal.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "Name"
-    value = "nodes.minimal.example.com"
+    key                 = "Name"
+    value               = "nodes.minimal.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "k8s.io/role/node"
-    value = "1"
+    key                 = "k8s.io/role/node"
+    value               = "1"
     propagate_at_launch = true
   }
 }
 
 resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-example-com" {
   availability_zone = "us-test-1a"
-  size = 20
-  type = "gp2"
-  encrypted = false
+  size              = 20
+  type              = "gp2"
+  encrypted         = false
+
   tags = {
-    KubernetesCluster = "minimal.example.com"
-    Name = "us-test-1a.etcd-events.minimal.example.com"
+    KubernetesCluster    = "minimal.example.com"
+    Name                 = "us-test-1a.etcd-events.minimal.example.com"
     "k8s.io/etcd/events" = "us-test-1a/us-test-1a"
     "k8s.io/role/master" = "1"
   }
@@ -59,263 +66,276 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-example-com" {
 
 resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
   availability_zone = "us-test-1a"
-  size = 20
-  type = "gp2"
-  encrypted = false
+  size              = 20
+  type              = "gp2"
+  encrypted         = false
+
   tags = {
-    KubernetesCluster = "minimal.example.com"
-    Name = "us-test-1a.etcd-main.minimal.example.com"
-    "k8s.io/etcd/main" = "us-test-1a/us-test-1a"
+    KubernetesCluster    = "minimal.example.com"
+    Name                 = "us-test-1a.etcd-main.minimal.example.com"
+    "k8s.io/etcd/main"   = "us-test-1a/us-test-1a"
     "k8s.io/role/master" = "1"
   }
 }
 
 resource "aws_iam_instance_profile" "masters-minimal-example-com" {
-  name = "masters.minimal.example.com"
+  name  = "masters.minimal.example.com"
   roles = ["${aws_iam_role.masters-minimal-example-com.name}"]
 }
 
 resource "aws_iam_instance_profile" "nodes-minimal-example-com" {
-  name = "nodes.minimal.example.com"
+  name  = "nodes.minimal.example.com"
   roles = ["${aws_iam_role.nodes-minimal-example-com.name}"]
 }
 
 resource "aws_iam_role" "masters-minimal-example-com" {
-  name = "masters.minimal.example.com"
+  name               = "masters.minimal.example.com"
   assume_role_policy = "${file("${path.module}/data/aws_iam_role_masters.minimal.example.com_policy")}"
 }
 
 resource "aws_iam_role" "nodes-minimal-example-com" {
-  name = "nodes.minimal.example.com"
+  name               = "nodes.minimal.example.com"
   assume_role_policy = "${file("${path.module}/data/aws_iam_role_nodes.minimal.example.com_policy")}"
 }
 
 resource "aws_iam_role_policy" "masters-minimal-example-com" {
-  name = "masters.minimal.example.com"
-  role = "${aws_iam_role.masters-minimal-example-com.name}"
+  name   = "masters.minimal.example.com"
+  role   = "${aws_iam_role.masters-minimal-example-com.name}"
   policy = "${file("${path.module}/data/aws_iam_role_policy_masters.minimal.example.com_policy")}"
 }
 
 resource "aws_iam_role_policy" "nodes-minimal-example-com" {
-  name = "nodes.minimal.example.com"
-  role = "${aws_iam_role.nodes-minimal-example-com.name}"
+  name   = "nodes.minimal.example.com"
+  role   = "${aws_iam_role.nodes-minimal-example-com.name}"
   policy = "${file("${path.module}/data/aws_iam_role_policy_nodes.minimal.example.com_policy")}"
 }
 
 resource "aws_internet_gateway" "minimal-example-com" {
   vpc_id = "${aws_vpc.minimal-example-com.id}"
+
   tags = {
     KubernetesCluster = "minimal.example.com"
-    Name = "minimal.example.com"
+    Name              = "minimal.example.com"
   }
 }
 
 resource "aws_key_pair" "kubernetes-minimal-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
-  key_name = "kubernetes.minimal.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
+  key_name   = "kubernetes.minimal.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = "${file("${path.module}/data/aws_key_pair_kubernetes.minimal.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")}"
 }
 
 resource "aws_launch_configuration" "master-us-test-1a-masters-minimal-example-com" {
-  name_prefix = "master-us-test-1a.masters.minimal.example.com-"
-  image_id = "ami-12345678"
-  instance_type = "m3.medium"
-  key_name = "${aws_key_pair.kubernetes-minimal-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
-  iam_instance_profile = "${aws_iam_instance_profile.masters-minimal-example-com.id}"
-  security_groups = ["${aws_security_group.masters-minimal-example-com.id}"]
+  name_prefix                 = "master-us-test-1a.masters.minimal.example.com-"
+  image_id                    = "ami-12345678"
+  instance_type               = "m3.medium"
+  key_name                    = "${aws_key_pair.kubernetes-minimal-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
+  iam_instance_profile        = "${aws_iam_instance_profile.masters-minimal-example-com.id}"
+  security_groups             = ["${aws_security_group.masters-minimal-example-com.id}"]
   associate_public_ip_address = true
-  user_data = "${file("${path.module}/data/aws_launch_configuration_master-us-test-1a.masters.minimal.example.com_user_data")}"
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_master-us-test-1a.masters.minimal.example.com_user_data")}"
+
   root_block_device = {
-    volume_type = "gp2"
-    volume_size = 20
+    volume_type           = "gp2"
+    volume_size           = 20
     delete_on_termination = true
   }
+
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
+
   lifecycle = {
     create_before_destroy = true
   }
 }
 
 resource "aws_launch_configuration" "nodes-minimal-example-com" {
-  name_prefix = "nodes.minimal.example.com-"
-  image_id = "ami-12345678"
-  instance_type = "t2.medium"
-  key_name = "${aws_key_pair.kubernetes-minimal-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
-  iam_instance_profile = "${aws_iam_instance_profile.nodes-minimal-example-com.id}"
-  security_groups = ["${aws_security_group.nodes-minimal-example-com.id}"]
+  name_prefix                 = "nodes.minimal.example.com-"
+  image_id                    = "ami-12345678"
+  instance_type               = "t2.medium"
+  key_name                    = "${aws_key_pair.kubernetes-minimal-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
+  iam_instance_profile        = "${aws_iam_instance_profile.nodes-minimal-example-com.id}"
+  security_groups             = ["${aws_security_group.nodes-minimal-example-com.id}"]
   associate_public_ip_address = true
-  user_data = "${file("${path.module}/data/aws_launch_configuration_nodes.minimal.example.com_user_data")}"
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_nodes.minimal.example.com_user_data")}"
+
   root_block_device = {
-    volume_type = "gp2"
-    volume_size = 20
+    volume_type           = "gp2"
+    volume_size           = 20
     delete_on_termination = true
   }
+
   lifecycle = {
     create_before_destroy = true
   }
 }
 
 resource "aws_route" "0-0-0-0--0" {
-  route_table_id = "${aws_route_table.minimal-example-com.id}"
+  route_table_id         = "${aws_route_table.minimal-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id = "${aws_internet_gateway.minimal-example-com.id}"
+  gateway_id             = "${aws_internet_gateway.minimal-example-com.id}"
 }
 
 resource "aws_route_table" "minimal-example-com" {
   vpc_id = "${aws_vpc.minimal-example-com.id}"
+
   tags = {
     KubernetesCluster = "minimal.example.com"
-    Name = "minimal.example.com"
+    Name              = "minimal.example.com"
   }
 }
 
 resource "aws_route_table_association" "us-test-1a-minimal-example-com" {
-  subnet_id = "${aws_subnet.us-test-1a-minimal-example-com.id}"
+  subnet_id      = "${aws_subnet.us-test-1a-minimal-example-com.id}"
   route_table_id = "${aws_route_table.minimal-example-com.id}"
 }
 
 resource "aws_security_group" "masters-minimal-example-com" {
-  name = "masters.minimal.example.com"
-  vpc_id = "${aws_vpc.minimal-example-com.id}"
+  name        = "masters.minimal.example.com"
+  vpc_id      = "${aws_vpc.minimal-example-com.id}"
   description = "Security group for masters"
+
   tags = {
     KubernetesCluster = "minimal.example.com"
-    Name = "masters.minimal.example.com"
+    Name              = "masters.minimal.example.com"
   }
 }
 
 resource "aws_security_group" "nodes-minimal-example-com" {
-  name = "nodes.minimal.example.com"
-  vpc_id = "${aws_vpc.minimal-example-com.id}"
+  name        = "nodes.minimal.example.com"
+  vpc_id      = "${aws_vpc.minimal-example-com.id}"
   description = "Security group for nodes"
+
   tags = {
     KubernetesCluster = "minimal.example.com"
-    Name = "nodes.minimal.example.com"
+    Name              = "nodes.minimal.example.com"
   }
 }
 
 resource "aws_security_group_rule" "all-master-to-master" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-minimal-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-minimal-example-com.id}"
   source_security_group_id = "${aws_security_group.masters-minimal-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
 }
 
 resource "aws_security_group_rule" "all-master-to-node" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.nodes-minimal-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.nodes-minimal-example-com.id}"
   source_security_group_id = "${aws_security_group.masters-minimal-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
 }
 
 resource "aws_security_group_rule" "all-node-to-node" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.nodes-minimal-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.nodes-minimal-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-minimal-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
 }
 
 resource "aws_security_group_rule" "https-external-to-master-0-0-0-0--0" {
-  type = "ingress"
+  type              = "ingress"
   security_group_id = "${aws_security_group.masters-minimal-example-com.id}"
-  from_port = 443
-  to_port = 443
-  protocol = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "master-egress" {
-  type = "egress"
+  type              = "egress"
   security_group_id = "${aws_security_group.masters-minimal-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "node-egress" {
-  type = "egress"
+  type              = "egress"
   security_group_id = "${aws_security_group.nodes-minimal-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "node-to-master-tcp-4194" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-minimal-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-minimal-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-minimal-example-com.id}"
-  from_port = 4194
-  to_port = 4194
-  protocol = "tcp"
+  from_port                = 4194
+  to_port                  = 4194
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "node-to-master-tcp-443" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-minimal-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-minimal-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-minimal-example-com.id}"
-  from_port = 443
-  to_port = 443
-  protocol = "tcp"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "ssh-external-to-master-0-0-0-0--0" {
-  type = "ingress"
+  type              = "ingress"
   security_group_id = "${aws_security_group.masters-minimal-example-com.id}"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "ssh-external-to-node-0-0-0-0--0" {
-  type = "ingress"
+  type              = "ingress"
   security_group_id = "${aws_security_group.nodes-minimal-example-com.id}"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_subnet" "us-test-1a-minimal-example-com" {
-  vpc_id = "${aws_vpc.minimal-example-com.id}"
-  cidr_block = "172.20.32.0/19"
+  vpc_id            = "${aws_vpc.minimal-example-com.id}"
+  cidr_block        = "172.20.32.0/19"
   availability_zone = "us-test-1a"
+
   tags = {
     KubernetesCluster = "minimal.example.com"
-    Name = "us-test-1a.minimal.example.com"
+    Name              = "us-test-1a.minimal.example.com"
   }
 }
 
 resource "aws_vpc" "minimal-example-com" {
-  cidr_block = "172.20.0.0/16"
+  cidr_block           = "172.20.0.0/16"
   enable_dns_hostnames = true
-  enable_dns_support = true
+  enable_dns_support   = true
+
   tags = {
     KubernetesCluster = "minimal.example.com"
-    Name = "minimal.example.com"
+    Name              = "minimal.example.com"
   }
 }
 
 resource "aws_vpc_dhcp_options" "minimal-example-com" {
-  domain_name = "us-test-1.compute.internal"
+  domain_name         = "us-test-1.compute.internal"
   domain_name_servers = ["AmazonProvidedDNS"]
+
   tags = {
     KubernetesCluster = "minimal.example.com"
-    Name = "minimal.example.com"
+    Name              = "minimal.example.com"
   }
 }
 
 resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
-  vpc_id = "${aws_vpc.minimal-example-com.id}"
+  vpc_id          = "${aws_vpc.minimal-example-com.id}"
   dhcp_options_id = "${aws_vpc_dhcp_options.minimal-example-com.id}"
 }

--- a/tests/integration/privatecalico/kubernetes.tf
+++ b/tests/integration/privatecalico/kubernetes.tf
@@ -1,90 +1,100 @@
 resource "aws_autoscaling_attachment" "bastion-privatecalico-example-com" {
-  elb = "${aws_elb.bastion-privatecalico-example-com.id}"
+  elb                    = "${aws_elb.bastion-privatecalico-example-com.id}"
   autoscaling_group_name = "${aws_autoscaling_group.bastion-privatecalico-example-com.id}"
 }
 
 resource "aws_autoscaling_attachment" "master-us-test-1a-masters-privatecalico-example-com" {
-  elb = "${aws_elb.api-privatecalico-example-com.id}"
+  elb                    = "${aws_elb.api-privatecalico-example-com.id}"
   autoscaling_group_name = "${aws_autoscaling_group.master-us-test-1a-masters-privatecalico-example-com.id}"
 }
 
 resource "aws_autoscaling_group" "bastion-privatecalico-example-com" {
-  name = "bastion.privatecalico.example.com"
+  name                 = "bastion.privatecalico.example.com"
   launch_configuration = "${aws_launch_configuration.bastion-privatecalico-example-com.id}"
-  max_size = 1
-  min_size = 1
-  vpc_zone_identifier = ["${aws_subnet.utility-us-test-1a-privatecalico-example-com.id}"]
+  max_size             = 1
+  min_size             = 1
+  vpc_zone_identifier  = ["${aws_subnet.utility-us-test-1a-privatecalico-example-com.id}"]
+
   tag = {
-    key = "KubernetesCluster"
-    value = "privatecalico.example.com"
+    key                 = "KubernetesCluster"
+    value               = "privatecalico.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "Name"
-    value = "bastion.privatecalico.example.com"
+    key                 = "Name"
+    value               = "bastion.privatecalico.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "k8s.io/role/bastion"
-    value = "1"
+    key                 = "k8s.io/role/bastion"
+    value               = "1"
     propagate_at_launch = true
   }
 }
 
 resource "aws_autoscaling_group" "master-us-test-1a-masters-privatecalico-example-com" {
-  name = "master-us-test-1a.masters.privatecalico.example.com"
+  name                 = "master-us-test-1a.masters.privatecalico.example.com"
   launch_configuration = "${aws_launch_configuration.master-us-test-1a-masters-privatecalico-example-com.id}"
-  max_size = 1
-  min_size = 1
-  vpc_zone_identifier = ["${aws_subnet.us-test-1a-privatecalico-example-com.id}"]
+  max_size             = 1
+  min_size             = 1
+  vpc_zone_identifier  = ["${aws_subnet.us-test-1a-privatecalico-example-com.id}"]
+
   tag = {
-    key = "KubernetesCluster"
-    value = "privatecalico.example.com"
+    key                 = "KubernetesCluster"
+    value               = "privatecalico.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "Name"
-    value = "master-us-test-1a.masters.privatecalico.example.com"
+    key                 = "Name"
+    value               = "master-us-test-1a.masters.privatecalico.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "k8s.io/role/master"
-    value = "1"
+    key                 = "k8s.io/role/master"
+    value               = "1"
     propagate_at_launch = true
   }
 }
 
 resource "aws_autoscaling_group" "nodes-privatecalico-example-com" {
-  name = "nodes.privatecalico.example.com"
+  name                 = "nodes.privatecalico.example.com"
   launch_configuration = "${aws_launch_configuration.nodes-privatecalico-example-com.id}"
-  max_size = 2
-  min_size = 2
-  vpc_zone_identifier = ["${aws_subnet.us-test-1a-privatecalico-example-com.id}"]
+  max_size             = 2
+  min_size             = 2
+  vpc_zone_identifier  = ["${aws_subnet.us-test-1a-privatecalico-example-com.id}"]
+
   tag = {
-    key = "KubernetesCluster"
-    value = "privatecalico.example.com"
+    key                 = "KubernetesCluster"
+    value               = "privatecalico.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "Name"
-    value = "nodes.privatecalico.example.com"
+    key                 = "Name"
+    value               = "nodes.privatecalico.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "k8s.io/role/node"
-    value = "1"
+    key                 = "k8s.io/role/node"
+    value               = "1"
     propagate_at_launch = true
   }
 }
 
 resource "aws_ebs_volume" "us-test-1a-etcd-events-privatecalico-example-com" {
   availability_zone = "us-test-1a"
-  size = 20
-  type = "gp2"
-  encrypted = false
+  size              = 20
+  type              = "gp2"
+  encrypted         = false
+
   tags = {
-    KubernetesCluster = "privatecalico.example.com"
-    Name = "us-test-1a.etcd-events.privatecalico.example.com"
+    KubernetesCluster    = "privatecalico.example.com"
+    Name                 = "us-test-1a.etcd-events.privatecalico.example.com"
     "k8s.io/etcd/events" = "us-test-1a/us-test-1a"
     "k8s.io/role/master" = "1"
   }
@@ -92,13 +102,14 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-privatecalico-example-com" {
 
 resource "aws_ebs_volume" "us-test-1a-etcd-main-privatecalico-example-com" {
   availability_zone = "us-test-1a"
-  size = 20
-  type = "gp2"
-  encrypted = false
+  size              = 20
+  type              = "gp2"
+  encrypted         = false
+
   tags = {
-    KubernetesCluster = "privatecalico.example.com"
-    Name = "us-test-1a.etcd-main.privatecalico.example.com"
-    "k8s.io/etcd/main" = "us-test-1a/us-test-1a"
+    KubernetesCluster    = "privatecalico.example.com"
+    Name                 = "us-test-1a.etcd-main.privatecalico.example.com"
+    "k8s.io/etcd/main"   = "us-test-1a/us-test-1a"
     "k8s.io/role/master" = "1"
   }
 }
@@ -109,167 +120,184 @@ resource "aws_eip" "us-test-1a-privatecalico-example-com" {
 
 resource "aws_elb" "api-privatecalico-example-com" {
   name = "api-privatecalico"
+
   listener = {
-    instance_port = 443
+    instance_port     = 443
     instance_protocol = "TCP"
-    lb_port = 443
-    lb_protocol = "TCP"
+    lb_port           = 443
+    lb_protocol       = "TCP"
   }
+
   security_groups = ["${aws_security_group.api-elb-privatecalico-example-com.id}"]
-  subnets = ["${aws_subnet.utility-us-test-1a-privatecalico-example-com.id}"]
+  subnets         = ["${aws_subnet.utility-us-test-1a-privatecalico-example-com.id}"]
+
   health_check = {
-    target = "TCP:443"
-    healthy_threshold = 2
+    target              = "TCP:443"
+    healthy_threshold   = 2
     unhealthy_threshold = 2
-    interval = 10
-    timeout = 5
+    interval            = 10
+    timeout             = 5
   }
+
   tags = {
     KubernetesCluster = "privatecalico.example.com"
-    Name = "api.privatecalico.example.com"
+    Name              = "api.privatecalico.example.com"
   }
 }
 
 resource "aws_elb" "bastion-privatecalico-example-com" {
   name = "bastion-privatecalico"
+
   listener = {
-    instance_port = 22
+    instance_port     = 22
     instance_protocol = "TCP"
-    lb_port = 22
-    lb_protocol = "TCP"
+    lb_port           = 22
+    lb_protocol       = "TCP"
   }
+
   security_groups = ["${aws_security_group.bastion-elb-privatecalico-example-com.id}"]
-  subnets = ["${aws_subnet.utility-us-test-1a-privatecalico-example-com.id}"]
+  subnets         = ["${aws_subnet.utility-us-test-1a-privatecalico-example-com.id}"]
+
   health_check = {
-    target = "TCP:22"
-    healthy_threshold = 2
+    target              = "TCP:22"
+    healthy_threshold   = 2
     unhealthy_threshold = 2
-    interval = 10
-    timeout = 5
+    interval            = 10
+    timeout             = 5
   }
+
   idle_timeout = 300
+
   tags = {
     KubernetesCluster = "privatecalico.example.com"
-    Name = "bastion.privatecalico.example.com"
+    Name              = "bastion.privatecalico.example.com"
   }
 }
 
 resource "aws_iam_instance_profile" "bastions-privatecalico-example-com" {
-  name = "bastions.privatecalico.example.com"
+  name  = "bastions.privatecalico.example.com"
   roles = ["${aws_iam_role.bastions-privatecalico-example-com.name}"]
 }
 
 resource "aws_iam_instance_profile" "masters-privatecalico-example-com" {
-  name = "masters.privatecalico.example.com"
+  name  = "masters.privatecalico.example.com"
   roles = ["${aws_iam_role.masters-privatecalico-example-com.name}"]
 }
 
 resource "aws_iam_instance_profile" "nodes-privatecalico-example-com" {
-  name = "nodes.privatecalico.example.com"
+  name  = "nodes.privatecalico.example.com"
   roles = ["${aws_iam_role.nodes-privatecalico-example-com.name}"]
 }
 
 resource "aws_iam_role" "bastions-privatecalico-example-com" {
-  name = "bastions.privatecalico.example.com"
+  name               = "bastions.privatecalico.example.com"
   assume_role_policy = "${file("${path.module}/data/aws_iam_role_bastions.privatecalico.example.com_policy")}"
 }
 
 resource "aws_iam_role" "masters-privatecalico-example-com" {
-  name = "masters.privatecalico.example.com"
+  name               = "masters.privatecalico.example.com"
   assume_role_policy = "${file("${path.module}/data/aws_iam_role_masters.privatecalico.example.com_policy")}"
 }
 
 resource "aws_iam_role" "nodes-privatecalico-example-com" {
-  name = "nodes.privatecalico.example.com"
+  name               = "nodes.privatecalico.example.com"
   assume_role_policy = "${file("${path.module}/data/aws_iam_role_nodes.privatecalico.example.com_policy")}"
 }
 
 resource "aws_iam_role_policy" "bastions-privatecalico-example-com" {
-  name = "bastions.privatecalico.example.com"
-  role = "${aws_iam_role.bastions-privatecalico-example-com.name}"
+  name   = "bastions.privatecalico.example.com"
+  role   = "${aws_iam_role.bastions-privatecalico-example-com.name}"
   policy = "${file("${path.module}/data/aws_iam_role_policy_bastions.privatecalico.example.com_policy")}"
 }
 
 resource "aws_iam_role_policy" "masters-privatecalico-example-com" {
-  name = "masters.privatecalico.example.com"
-  role = "${aws_iam_role.masters-privatecalico-example-com.name}"
+  name   = "masters.privatecalico.example.com"
+  role   = "${aws_iam_role.masters-privatecalico-example-com.name}"
   policy = "${file("${path.module}/data/aws_iam_role_policy_masters.privatecalico.example.com_policy")}"
 }
 
 resource "aws_iam_role_policy" "nodes-privatecalico-example-com" {
-  name = "nodes.privatecalico.example.com"
-  role = "${aws_iam_role.nodes-privatecalico-example-com.name}"
+  name   = "nodes.privatecalico.example.com"
+  role   = "${aws_iam_role.nodes-privatecalico-example-com.name}"
   policy = "${file("${path.module}/data/aws_iam_role_policy_nodes.privatecalico.example.com_policy")}"
 }
 
 resource "aws_internet_gateway" "privatecalico-example-com" {
   vpc_id = "${aws_vpc.privatecalico-example-com.id}"
+
   tags = {
     KubernetesCluster = "privatecalico.example.com"
-    Name = "privatecalico.example.com"
+    Name              = "privatecalico.example.com"
   }
 }
 
 resource "aws_key_pair" "kubernetes-privatecalico-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
-  key_name = "kubernetes.privatecalico.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
+  key_name   = "kubernetes.privatecalico.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = "${file("${path.module}/data/aws_key_pair_kubernetes.privatecalico.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")}"
 }
 
 resource "aws_launch_configuration" "bastion-privatecalico-example-com" {
-  name_prefix = "bastion.privatecalico.example.com-"
-  image_id = "ami-12345678"
-  instance_type = "t2.micro"
-  key_name = "${aws_key_pair.kubernetes-privatecalico-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
-  iam_instance_profile = "${aws_iam_instance_profile.bastions-privatecalico-example-com.id}"
-  security_groups = ["${aws_security_group.bastion-privatecalico-example-com.id}"]
+  name_prefix                 = "bastion.privatecalico.example.com-"
+  image_id                    = "ami-12345678"
+  instance_type               = "t2.micro"
+  key_name                    = "${aws_key_pair.kubernetes-privatecalico-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
+  iam_instance_profile        = "${aws_iam_instance_profile.bastions-privatecalico-example-com.id}"
+  security_groups             = ["${aws_security_group.bastion-privatecalico-example-com.id}"]
   associate_public_ip_address = true
+
   root_block_device = {
-    volume_type = "gp2"
-    volume_size = 20
+    volume_type           = "gp2"
+    volume_size           = 20
     delete_on_termination = true
   }
+
   lifecycle = {
     create_before_destroy = true
   }
 }
 
 resource "aws_launch_configuration" "master-us-test-1a-masters-privatecalico-example-com" {
-  name_prefix = "master-us-test-1a.masters.privatecalico.example.com-"
-  image_id = "ami-12345678"
-  instance_type = "m3.medium"
-  key_name = "${aws_key_pair.kubernetes-privatecalico-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
-  iam_instance_profile = "${aws_iam_instance_profile.masters-privatecalico-example-com.id}"
-  security_groups = ["${aws_security_group.masters-privatecalico-example-com.id}"]
+  name_prefix                 = "master-us-test-1a.masters.privatecalico.example.com-"
+  image_id                    = "ami-12345678"
+  instance_type               = "m3.medium"
+  key_name                    = "${aws_key_pair.kubernetes-privatecalico-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
+  iam_instance_profile        = "${aws_iam_instance_profile.masters-privatecalico-example-com.id}"
+  security_groups             = ["${aws_security_group.masters-privatecalico-example-com.id}"]
   associate_public_ip_address = false
-  user_data = "${file("${path.module}/data/aws_launch_configuration_master-us-test-1a.masters.privatecalico.example.com_user_data")}"
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_master-us-test-1a.masters.privatecalico.example.com_user_data")}"
+
   root_block_device = {
-    volume_type = "gp2"
-    volume_size = 20
+    volume_type           = "gp2"
+    volume_size           = 20
     delete_on_termination = true
   }
+
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
+
   lifecycle = {
     create_before_destroy = true
   }
 }
 
 resource "aws_launch_configuration" "nodes-privatecalico-example-com" {
-  name_prefix = "nodes.privatecalico.example.com-"
-  image_id = "ami-12345678"
-  instance_type = "t2.medium"
-  key_name = "${aws_key_pair.kubernetes-privatecalico-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
-  iam_instance_profile = "${aws_iam_instance_profile.nodes-privatecalico-example-com.id}"
-  security_groups = ["${aws_security_group.nodes-privatecalico-example-com.id}"]
+  name_prefix                 = "nodes.privatecalico.example.com-"
+  image_id                    = "ami-12345678"
+  instance_type               = "t2.medium"
+  key_name                    = "${aws_key_pair.kubernetes-privatecalico-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
+  iam_instance_profile        = "${aws_iam_instance_profile.nodes-privatecalico-example-com.id}"
+  security_groups             = ["${aws_security_group.nodes-privatecalico-example-com.id}"]
   associate_public_ip_address = false
-  user_data = "${file("${path.module}/data/aws_launch_configuration_nodes.privatecalico.example.com_user_data")}"
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_nodes.privatecalico.example.com_user_data")}"
+
   root_block_device = {
-    volume_type = "gp2"
-    volume_size = 20
+    volume_type           = "gp2"
+    volume_size           = 20
     delete_on_termination = true
   }
+
   lifecycle = {
     create_before_destroy = true
   }
@@ -277,319 +305,332 @@ resource "aws_launch_configuration" "nodes-privatecalico-example-com" {
 
 resource "aws_nat_gateway" "us-test-1a-privatecalico-example-com" {
   allocation_id = "${aws_eip.us-test-1a-privatecalico-example-com.id}"
-  subnet_id = "${aws_subnet.utility-us-test-1a-privatecalico-example-com.id}"
+  subnet_id     = "${aws_subnet.utility-us-test-1a-privatecalico-example-com.id}"
 }
 
 resource "aws_route" "0-0-0-0--0" {
-  route_table_id = "${aws_route_table.privatecalico-example-com.id}"
+  route_table_id         = "${aws_route_table.privatecalico-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id = "${aws_internet_gateway.privatecalico-example-com.id}"
+  gateway_id             = "${aws_internet_gateway.privatecalico-example-com.id}"
 }
 
 resource "aws_route" "private-us-test-1a-0-0-0-0--0" {
-  route_table_id = "${aws_route_table.private-us-test-1a-privatecalico-example-com.id}"
+  route_table_id         = "${aws_route_table.private-us-test-1a-privatecalico-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id = "${aws_nat_gateway.us-test-1a-privatecalico-example-com.id}"
+  nat_gateway_id         = "${aws_nat_gateway.us-test-1a-privatecalico-example-com.id}"
 }
 
 resource "aws_route53_record" "api-privatecalico-example-com" {
   name = "api.privatecalico.example.com"
   type = "A"
+
   alias = {
-    name = "${aws_elb.api-privatecalico-example-com.dns_name}"
-    zone_id = "${aws_elb.api-privatecalico-example-com.zone_id}"
+    name                   = "${aws_elb.api-privatecalico-example-com.dns_name}"
+    zone_id                = "${aws_elb.api-privatecalico-example-com.zone_id}"
     evaluate_target_health = false
   }
+
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
 resource "aws_route_table" "private-us-test-1a-privatecalico-example-com" {
   vpc_id = "${aws_vpc.privatecalico-example-com.id}"
+
   tags = {
     KubernetesCluster = "privatecalico.example.com"
-    Name = "private-us-test-1a.privatecalico.example.com"
+    Name              = "private-us-test-1a.privatecalico.example.com"
   }
 }
 
 resource "aws_route_table" "privatecalico-example-com" {
   vpc_id = "${aws_vpc.privatecalico-example-com.id}"
+
   tags = {
     KubernetesCluster = "privatecalico.example.com"
-    Name = "privatecalico.example.com"
+    Name              = "privatecalico.example.com"
   }
 }
 
 resource "aws_route_table_association" "private-us-test-1a-privatecalico-example-com" {
-  subnet_id = "${aws_subnet.us-test-1a-privatecalico-example-com.id}"
+  subnet_id      = "${aws_subnet.us-test-1a-privatecalico-example-com.id}"
   route_table_id = "${aws_route_table.private-us-test-1a-privatecalico-example-com.id}"
 }
 
 resource "aws_route_table_association" "utility-us-test-1a-privatecalico-example-com" {
-  subnet_id = "${aws_subnet.utility-us-test-1a-privatecalico-example-com.id}"
+  subnet_id      = "${aws_subnet.utility-us-test-1a-privatecalico-example-com.id}"
   route_table_id = "${aws_route_table.privatecalico-example-com.id}"
 }
 
 resource "aws_security_group" "api-elb-privatecalico-example-com" {
-  name = "api-elb.privatecalico.example.com"
-  vpc_id = "${aws_vpc.privatecalico-example-com.id}"
+  name        = "api-elb.privatecalico.example.com"
+  vpc_id      = "${aws_vpc.privatecalico-example-com.id}"
   description = "Security group for api ELB"
+
   tags = {
     KubernetesCluster = "privatecalico.example.com"
-    Name = "api-elb.privatecalico.example.com"
+    Name              = "api-elb.privatecalico.example.com"
   }
 }
 
 resource "aws_security_group" "bastion-elb-privatecalico-example-com" {
-  name = "bastion-elb.privatecalico.example.com"
-  vpc_id = "${aws_vpc.privatecalico-example-com.id}"
+  name        = "bastion-elb.privatecalico.example.com"
+  vpc_id      = "${aws_vpc.privatecalico-example-com.id}"
   description = "Security group for bastion ELB"
+
   tags = {
     KubernetesCluster = "privatecalico.example.com"
-    Name = "bastion-elb.privatecalico.example.com"
+    Name              = "bastion-elb.privatecalico.example.com"
   }
 }
 
 resource "aws_security_group" "bastion-privatecalico-example-com" {
-  name = "bastion.privatecalico.example.com"
-  vpc_id = "${aws_vpc.privatecalico-example-com.id}"
+  name        = "bastion.privatecalico.example.com"
+  vpc_id      = "${aws_vpc.privatecalico-example-com.id}"
   description = "Security group for bastion"
+
   tags = {
     KubernetesCluster = "privatecalico.example.com"
-    Name = "bastion.privatecalico.example.com"
+    Name              = "bastion.privatecalico.example.com"
   }
 }
 
 resource "aws_security_group" "masters-privatecalico-example-com" {
-  name = "masters.privatecalico.example.com"
-  vpc_id = "${aws_vpc.privatecalico-example-com.id}"
+  name        = "masters.privatecalico.example.com"
+  vpc_id      = "${aws_vpc.privatecalico-example-com.id}"
   description = "Security group for masters"
+
   tags = {
     KubernetesCluster = "privatecalico.example.com"
-    Name = "masters.privatecalico.example.com"
+    Name              = "masters.privatecalico.example.com"
   }
 }
 
 resource "aws_security_group" "nodes-privatecalico-example-com" {
-  name = "nodes.privatecalico.example.com"
-  vpc_id = "${aws_vpc.privatecalico-example-com.id}"
+  name        = "nodes.privatecalico.example.com"
+  vpc_id      = "${aws_vpc.privatecalico-example-com.id}"
   description = "Security group for nodes"
+
   tags = {
     KubernetesCluster = "privatecalico.example.com"
-    Name = "nodes.privatecalico.example.com"
+    Name              = "nodes.privatecalico.example.com"
   }
 }
 
 resource "aws_security_group_rule" "all-master-to-master" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-privatecalico-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privatecalico-example-com.id}"
   source_security_group_id = "${aws_security_group.masters-privatecalico-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
 }
 
 resource "aws_security_group_rule" "all-master-to-node" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.nodes-privatecalico-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.nodes-privatecalico-example-com.id}"
   source_security_group_id = "${aws_security_group.masters-privatecalico-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
 }
 
 resource "aws_security_group_rule" "all-node-to-node" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.nodes-privatecalico-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.nodes-privatecalico-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privatecalico-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
 }
 
 resource "aws_security_group_rule" "api-elb-egress" {
-  type = "egress"
+  type              = "egress"
   security_group_id = "${aws_security_group.api-elb-privatecalico-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "bastion-egress" {
-  type = "egress"
+  type              = "egress"
   security_group_id = "${aws_security_group.bastion-privatecalico-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "bastion-elb-egress" {
-  type = "egress"
+  type              = "egress"
   security_group_id = "${aws_security_group.bastion-elb-privatecalico-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "bastion-to-master-ssh" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-privatecalico-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privatecalico-example-com.id}"
   source_security_group_id = "${aws_security_group.bastion-privatecalico-example-com.id}"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
+  from_port                = 22
+  to_port                  = 22
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "bastion-to-node-ssh" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.nodes-privatecalico-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.nodes-privatecalico-example-com.id}"
   source_security_group_id = "${aws_security_group.bastion-privatecalico-example-com.id}"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
+  from_port                = 22
+  to_port                  = 22
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "https-api-elb-0-0-0-0--0" {
-  type = "ingress"
+  type              = "ingress"
   security_group_id = "${aws_security_group.api-elb-privatecalico-example-com.id}"
-  from_port = 443
-  to_port = 443
-  protocol = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "https-elb-to-master" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-privatecalico-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privatecalico-example-com.id}"
   source_security_group_id = "${aws_security_group.api-elb-privatecalico-example-com.id}"
-  from_port = 443
-  to_port = 443
-  protocol = "tcp"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "master-egress" {
-  type = "egress"
+  type              = "egress"
   security_group_id = "${aws_security_group.masters-privatecalico-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "node-egress" {
-  type = "egress"
+  type              = "egress"
   security_group_id = "${aws_security_group.nodes-privatecalico-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "node-to-master-protocol-ipip" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-privatecalico-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privatecalico-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privatecalico-example-com.id}"
-  from_port = 0
-  to_port = 65535
-  protocol = "4"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "4"
 }
 
 resource "aws_security_group_rule" "node-to-master-tcp-179" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-privatecalico-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privatecalico-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privatecalico-example-com.id}"
-  from_port = 179
-  to_port = 179
-  protocol = "tcp"
+  from_port                = 179
+  to_port                  = 179
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "node-to-master-tcp-4001" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-privatecalico-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privatecalico-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privatecalico-example-com.id}"
-  from_port = 4001
-  to_port = 4001
-  protocol = "tcp"
+  from_port                = 4001
+  to_port                  = 4001
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "node-to-master-tcp-4194" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-privatecalico-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privatecalico-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privatecalico-example-com.id}"
-  from_port = 4194
-  to_port = 4194
-  protocol = "tcp"
+  from_port                = 4194
+  to_port                  = 4194
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "node-to-master-tcp-443" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-privatecalico-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privatecalico-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privatecalico-example-com.id}"
-  from_port = 443
-  to_port = 443
-  protocol = "tcp"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "ssh-elb-to-bastion" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.bastion-privatecalico-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.bastion-privatecalico-example-com.id}"
   source_security_group_id = "${aws_security_group.bastion-elb-privatecalico-example-com.id}"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
+  from_port                = 22
+  to_port                  = 22
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "ssh-external-to-bastion-elb-0-0-0-0--0" {
-  type = "ingress"
+  type              = "ingress"
   security_group_id = "${aws_security_group.bastion-elb-privatecalico-example-com.id}"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_subnet" "us-test-1a-privatecalico-example-com" {
-  vpc_id = "${aws_vpc.privatecalico-example-com.id}"
-  cidr_block = "172.20.32.0/19"
+  vpc_id            = "${aws_vpc.privatecalico-example-com.id}"
+  cidr_block        = "172.20.32.0/19"
   availability_zone = "us-test-1a"
+
   tags = {
     KubernetesCluster = "privatecalico.example.com"
-    Name = "us-test-1a.privatecalico.example.com"
+    Name              = "us-test-1a.privatecalico.example.com"
   }
 }
 
 resource "aws_subnet" "utility-us-test-1a-privatecalico-example-com" {
-  vpc_id = "${aws_vpc.privatecalico-example-com.id}"
-  cidr_block = "172.20.4.0/22"
+  vpc_id            = "${aws_vpc.privatecalico-example-com.id}"
+  cidr_block        = "172.20.4.0/22"
   availability_zone = "us-test-1a"
+
   tags = {
     KubernetesCluster = "privatecalico.example.com"
-    Name = "utility-us-test-1a.privatecalico.example.com"
+    Name              = "utility-us-test-1a.privatecalico.example.com"
   }
 }
 
 resource "aws_vpc" "privatecalico-example-com" {
-  cidr_block = "172.20.0.0/16"
+  cidr_block           = "172.20.0.0/16"
   enable_dns_hostnames = true
-  enable_dns_support = true
+  enable_dns_support   = true
+
   tags = {
     KubernetesCluster = "privatecalico.example.com"
-    Name = "privatecalico.example.com"
+    Name              = "privatecalico.example.com"
   }
 }
 
 resource "aws_vpc_dhcp_options" "privatecalico-example-com" {
-  domain_name = "us-test-1.compute.internal"
+  domain_name         = "us-test-1.compute.internal"
   domain_name_servers = ["AmazonProvidedDNS"]
+
   tags = {
     KubernetesCluster = "privatecalico.example.com"
-    Name = "privatecalico.example.com"
+    Name              = "privatecalico.example.com"
   }
 }
 
 resource "aws_vpc_dhcp_options_association" "privatecalico-example-com" {
-  vpc_id = "${aws_vpc.privatecalico-example-com.id}"
+  vpc_id          = "${aws_vpc.privatecalico-example-com.id}"
   dhcp_options_id = "${aws_vpc_dhcp_options.privatecalico-example-com.id}"
 }

--- a/tests/integration/privateweave/kubernetes.tf
+++ b/tests/integration/privateweave/kubernetes.tf
@@ -1,90 +1,100 @@
 resource "aws_autoscaling_attachment" "bastion-privateweave-example-com" {
-  elb = "${aws_elb.bastion-privateweave-example-com.id}"
+  elb                    = "${aws_elb.bastion-privateweave-example-com.id}"
   autoscaling_group_name = "${aws_autoscaling_group.bastion-privateweave-example-com.id}"
 }
 
 resource "aws_autoscaling_attachment" "master-us-test-1a-masters-privateweave-example-com" {
-  elb = "${aws_elb.api-privateweave-example-com.id}"
+  elb                    = "${aws_elb.api-privateweave-example-com.id}"
   autoscaling_group_name = "${aws_autoscaling_group.master-us-test-1a-masters-privateweave-example-com.id}"
 }
 
 resource "aws_autoscaling_group" "bastion-privateweave-example-com" {
-  name = "bastion.privateweave.example.com"
+  name                 = "bastion.privateweave.example.com"
   launch_configuration = "${aws_launch_configuration.bastion-privateweave-example-com.id}"
-  max_size = 1
-  min_size = 1
-  vpc_zone_identifier = ["${aws_subnet.utility-us-test-1a-privateweave-example-com.id}"]
+  max_size             = 1
+  min_size             = 1
+  vpc_zone_identifier  = ["${aws_subnet.utility-us-test-1a-privateweave-example-com.id}"]
+
   tag = {
-    key = "KubernetesCluster"
-    value = "privateweave.example.com"
+    key                 = "KubernetesCluster"
+    value               = "privateweave.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "Name"
-    value = "bastion.privateweave.example.com"
+    key                 = "Name"
+    value               = "bastion.privateweave.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "k8s.io/role/bastion"
-    value = "1"
+    key                 = "k8s.io/role/bastion"
+    value               = "1"
     propagate_at_launch = true
   }
 }
 
 resource "aws_autoscaling_group" "master-us-test-1a-masters-privateweave-example-com" {
-  name = "master-us-test-1a.masters.privateweave.example.com"
+  name                 = "master-us-test-1a.masters.privateweave.example.com"
   launch_configuration = "${aws_launch_configuration.master-us-test-1a-masters-privateweave-example-com.id}"
-  max_size = 1
-  min_size = 1
-  vpc_zone_identifier = ["${aws_subnet.us-test-1a-privateweave-example-com.id}"]
+  max_size             = 1
+  min_size             = 1
+  vpc_zone_identifier  = ["${aws_subnet.us-test-1a-privateweave-example-com.id}"]
+
   tag = {
-    key = "KubernetesCluster"
-    value = "privateweave.example.com"
+    key                 = "KubernetesCluster"
+    value               = "privateweave.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "Name"
-    value = "master-us-test-1a.masters.privateweave.example.com"
+    key                 = "Name"
+    value               = "master-us-test-1a.masters.privateweave.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "k8s.io/role/master"
-    value = "1"
+    key                 = "k8s.io/role/master"
+    value               = "1"
     propagate_at_launch = true
   }
 }
 
 resource "aws_autoscaling_group" "nodes-privateweave-example-com" {
-  name = "nodes.privateweave.example.com"
+  name                 = "nodes.privateweave.example.com"
   launch_configuration = "${aws_launch_configuration.nodes-privateweave-example-com.id}"
-  max_size = 2
-  min_size = 2
-  vpc_zone_identifier = ["${aws_subnet.us-test-1a-privateweave-example-com.id}"]
+  max_size             = 2
+  min_size             = 2
+  vpc_zone_identifier  = ["${aws_subnet.us-test-1a-privateweave-example-com.id}"]
+
   tag = {
-    key = "KubernetesCluster"
-    value = "privateweave.example.com"
+    key                 = "KubernetesCluster"
+    value               = "privateweave.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "Name"
-    value = "nodes.privateweave.example.com"
+    key                 = "Name"
+    value               = "nodes.privateweave.example.com"
     propagate_at_launch = true
   }
+
   tag = {
-    key = "k8s.io/role/node"
-    value = "1"
+    key                 = "k8s.io/role/node"
+    value               = "1"
     propagate_at_launch = true
   }
 }
 
 resource "aws_ebs_volume" "us-test-1a-etcd-events-privateweave-example-com" {
   availability_zone = "us-test-1a"
-  size = 20
-  type = "gp2"
-  encrypted = false
+  size              = 20
+  type              = "gp2"
+  encrypted         = false
+
   tags = {
-    KubernetesCluster = "privateweave.example.com"
-    Name = "us-test-1a.etcd-events.privateweave.example.com"
+    KubernetesCluster    = "privateweave.example.com"
+    Name                 = "us-test-1a.etcd-events.privateweave.example.com"
     "k8s.io/etcd/events" = "us-test-1a/us-test-1a"
     "k8s.io/role/master" = "1"
   }
@@ -92,13 +102,14 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-privateweave-example-com" {
 
 resource "aws_ebs_volume" "us-test-1a-etcd-main-privateweave-example-com" {
   availability_zone = "us-test-1a"
-  size = 20
-  type = "gp2"
-  encrypted = false
+  size              = 20
+  type              = "gp2"
+  encrypted         = false
+
   tags = {
-    KubernetesCluster = "privateweave.example.com"
-    Name = "us-test-1a.etcd-main.privateweave.example.com"
-    "k8s.io/etcd/main" = "us-test-1a/us-test-1a"
+    KubernetesCluster    = "privateweave.example.com"
+    Name                 = "us-test-1a.etcd-main.privateweave.example.com"
+    "k8s.io/etcd/main"   = "us-test-1a/us-test-1a"
     "k8s.io/role/master" = "1"
   }
 }
@@ -109,167 +120,184 @@ resource "aws_eip" "us-test-1a-privateweave-example-com" {
 
 resource "aws_elb" "api-privateweave-example-com" {
   name = "api-privateweave"
+
   listener = {
-    instance_port = 443
+    instance_port     = 443
     instance_protocol = "TCP"
-    lb_port = 443
-    lb_protocol = "TCP"
+    lb_port           = 443
+    lb_protocol       = "TCP"
   }
+
   security_groups = ["${aws_security_group.api-elb-privateweave-example-com.id}"]
-  subnets = ["${aws_subnet.utility-us-test-1a-privateweave-example-com.id}"]
+  subnets         = ["${aws_subnet.utility-us-test-1a-privateweave-example-com.id}"]
+
   health_check = {
-    target = "TCP:443"
-    healthy_threshold = 2
+    target              = "TCP:443"
+    healthy_threshold   = 2
     unhealthy_threshold = 2
-    interval = 10
-    timeout = 5
+    interval            = 10
+    timeout             = 5
   }
+
   tags = {
     KubernetesCluster = "privateweave.example.com"
-    Name = "api.privateweave.example.com"
+    Name              = "api.privateweave.example.com"
   }
 }
 
 resource "aws_elb" "bastion-privateweave-example-com" {
   name = "bastion-privateweave"
+
   listener = {
-    instance_port = 22
+    instance_port     = 22
     instance_protocol = "TCP"
-    lb_port = 22
-    lb_protocol = "TCP"
+    lb_port           = 22
+    lb_protocol       = "TCP"
   }
+
   security_groups = ["${aws_security_group.bastion-elb-privateweave-example-com.id}"]
-  subnets = ["${aws_subnet.utility-us-test-1a-privateweave-example-com.id}"]
+  subnets         = ["${aws_subnet.utility-us-test-1a-privateweave-example-com.id}"]
+
   health_check = {
-    target = "TCP:22"
-    healthy_threshold = 2
+    target              = "TCP:22"
+    healthy_threshold   = 2
     unhealthy_threshold = 2
-    interval = 10
-    timeout = 5
+    interval            = 10
+    timeout             = 5
   }
+
   idle_timeout = 300
+
   tags = {
     KubernetesCluster = "privateweave.example.com"
-    Name = "bastion.privateweave.example.com"
+    Name              = "bastion.privateweave.example.com"
   }
 }
 
 resource "aws_iam_instance_profile" "bastions-privateweave-example-com" {
-  name = "bastions.privateweave.example.com"
+  name  = "bastions.privateweave.example.com"
   roles = ["${aws_iam_role.bastions-privateweave-example-com.name}"]
 }
 
 resource "aws_iam_instance_profile" "masters-privateweave-example-com" {
-  name = "masters.privateweave.example.com"
+  name  = "masters.privateweave.example.com"
   roles = ["${aws_iam_role.masters-privateweave-example-com.name}"]
 }
 
 resource "aws_iam_instance_profile" "nodes-privateweave-example-com" {
-  name = "nodes.privateweave.example.com"
+  name  = "nodes.privateweave.example.com"
   roles = ["${aws_iam_role.nodes-privateweave-example-com.name}"]
 }
 
 resource "aws_iam_role" "bastions-privateweave-example-com" {
-  name = "bastions.privateweave.example.com"
+  name               = "bastions.privateweave.example.com"
   assume_role_policy = "${file("${path.module}/data/aws_iam_role_bastions.privateweave.example.com_policy")}"
 }
 
 resource "aws_iam_role" "masters-privateweave-example-com" {
-  name = "masters.privateweave.example.com"
+  name               = "masters.privateweave.example.com"
   assume_role_policy = "${file("${path.module}/data/aws_iam_role_masters.privateweave.example.com_policy")}"
 }
 
 resource "aws_iam_role" "nodes-privateweave-example-com" {
-  name = "nodes.privateweave.example.com"
+  name               = "nodes.privateweave.example.com"
   assume_role_policy = "${file("${path.module}/data/aws_iam_role_nodes.privateweave.example.com_policy")}"
 }
 
 resource "aws_iam_role_policy" "bastions-privateweave-example-com" {
-  name = "bastions.privateweave.example.com"
-  role = "${aws_iam_role.bastions-privateweave-example-com.name}"
+  name   = "bastions.privateweave.example.com"
+  role   = "${aws_iam_role.bastions-privateweave-example-com.name}"
   policy = "${file("${path.module}/data/aws_iam_role_policy_bastions.privateweave.example.com_policy")}"
 }
 
 resource "aws_iam_role_policy" "masters-privateweave-example-com" {
-  name = "masters.privateweave.example.com"
-  role = "${aws_iam_role.masters-privateweave-example-com.name}"
+  name   = "masters.privateweave.example.com"
+  role   = "${aws_iam_role.masters-privateweave-example-com.name}"
   policy = "${file("${path.module}/data/aws_iam_role_policy_masters.privateweave.example.com_policy")}"
 }
 
 resource "aws_iam_role_policy" "nodes-privateweave-example-com" {
-  name = "nodes.privateweave.example.com"
-  role = "${aws_iam_role.nodes-privateweave-example-com.name}"
+  name   = "nodes.privateweave.example.com"
+  role   = "${aws_iam_role.nodes-privateweave-example-com.name}"
   policy = "${file("${path.module}/data/aws_iam_role_policy_nodes.privateweave.example.com_policy")}"
 }
 
 resource "aws_internet_gateway" "privateweave-example-com" {
   vpc_id = "${aws_vpc.privateweave-example-com.id}"
+
   tags = {
     KubernetesCluster = "privateweave.example.com"
-    Name = "privateweave.example.com"
+    Name              = "privateweave.example.com"
   }
 }
 
 resource "aws_key_pair" "kubernetes-privateweave-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
-  key_name = "kubernetes.privateweave.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
+  key_name   = "kubernetes.privateweave.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = "${file("${path.module}/data/aws_key_pair_kubernetes.privateweave.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")}"
 }
 
 resource "aws_launch_configuration" "bastion-privateweave-example-com" {
-  name_prefix = "bastion.privateweave.example.com-"
-  image_id = "ami-12345678"
-  instance_type = "t2.micro"
-  key_name = "${aws_key_pair.kubernetes-privateweave-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
-  iam_instance_profile = "${aws_iam_instance_profile.bastions-privateweave-example-com.id}"
-  security_groups = ["${aws_security_group.bastion-privateweave-example-com.id}"]
+  name_prefix                 = "bastion.privateweave.example.com-"
+  image_id                    = "ami-12345678"
+  instance_type               = "t2.micro"
+  key_name                    = "${aws_key_pair.kubernetes-privateweave-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
+  iam_instance_profile        = "${aws_iam_instance_profile.bastions-privateweave-example-com.id}"
+  security_groups             = ["${aws_security_group.bastion-privateweave-example-com.id}"]
   associate_public_ip_address = true
+
   root_block_device = {
-    volume_type = "gp2"
-    volume_size = 20
+    volume_type           = "gp2"
+    volume_size           = 20
     delete_on_termination = true
   }
+
   lifecycle = {
     create_before_destroy = true
   }
 }
 
 resource "aws_launch_configuration" "master-us-test-1a-masters-privateweave-example-com" {
-  name_prefix = "master-us-test-1a.masters.privateweave.example.com-"
-  image_id = "ami-12345678"
-  instance_type = "m3.medium"
-  key_name = "${aws_key_pair.kubernetes-privateweave-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
-  iam_instance_profile = "${aws_iam_instance_profile.masters-privateweave-example-com.id}"
-  security_groups = ["${aws_security_group.masters-privateweave-example-com.id}"]
+  name_prefix                 = "master-us-test-1a.masters.privateweave.example.com-"
+  image_id                    = "ami-12345678"
+  instance_type               = "m3.medium"
+  key_name                    = "${aws_key_pair.kubernetes-privateweave-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
+  iam_instance_profile        = "${aws_iam_instance_profile.masters-privateweave-example-com.id}"
+  security_groups             = ["${aws_security_group.masters-privateweave-example-com.id}"]
   associate_public_ip_address = false
-  user_data = "${file("${path.module}/data/aws_launch_configuration_master-us-test-1a.masters.privateweave.example.com_user_data")}"
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_master-us-test-1a.masters.privateweave.example.com_user_data")}"
+
   root_block_device = {
-    volume_type = "gp2"
-    volume_size = 20
+    volume_type           = "gp2"
+    volume_size           = 20
     delete_on_termination = true
   }
+
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
+
   lifecycle = {
     create_before_destroy = true
   }
 }
 
 resource "aws_launch_configuration" "nodes-privateweave-example-com" {
-  name_prefix = "nodes.privateweave.example.com-"
-  image_id = "ami-12345678"
-  instance_type = "t2.medium"
-  key_name = "${aws_key_pair.kubernetes-privateweave-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
-  iam_instance_profile = "${aws_iam_instance_profile.nodes-privateweave-example-com.id}"
-  security_groups = ["${aws_security_group.nodes-privateweave-example-com.id}"]
+  name_prefix                 = "nodes.privateweave.example.com-"
+  image_id                    = "ami-12345678"
+  instance_type               = "t2.medium"
+  key_name                    = "${aws_key_pair.kubernetes-privateweave-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
+  iam_instance_profile        = "${aws_iam_instance_profile.nodes-privateweave-example-com.id}"
+  security_groups             = ["${aws_security_group.nodes-privateweave-example-com.id}"]
   associate_public_ip_address = false
-  user_data = "${file("${path.module}/data/aws_launch_configuration_nodes.privateweave.example.com_user_data")}"
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_nodes.privateweave.example.com_user_data")}"
+
   root_block_device = {
-    volume_type = "gp2"
-    volume_size = 20
+    volume_type           = "gp2"
+    volume_size           = 20
     delete_on_termination = true
   }
+
   lifecycle = {
     create_before_destroy = true
   }
@@ -277,319 +305,332 @@ resource "aws_launch_configuration" "nodes-privateweave-example-com" {
 
 resource "aws_nat_gateway" "us-test-1a-privateweave-example-com" {
   allocation_id = "${aws_eip.us-test-1a-privateweave-example-com.id}"
-  subnet_id = "${aws_subnet.utility-us-test-1a-privateweave-example-com.id}"
+  subnet_id     = "${aws_subnet.utility-us-test-1a-privateweave-example-com.id}"
 }
 
 resource "aws_route" "0-0-0-0--0" {
-  route_table_id = "${aws_route_table.privateweave-example-com.id}"
+  route_table_id         = "${aws_route_table.privateweave-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id = "${aws_internet_gateway.privateweave-example-com.id}"
+  gateway_id             = "${aws_internet_gateway.privateweave-example-com.id}"
 }
 
 resource "aws_route" "private-us-test-1a-0-0-0-0--0" {
-  route_table_id = "${aws_route_table.private-us-test-1a-privateweave-example-com.id}"
+  route_table_id         = "${aws_route_table.private-us-test-1a-privateweave-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id = "${aws_nat_gateway.us-test-1a-privateweave-example-com.id}"
+  nat_gateway_id         = "${aws_nat_gateway.us-test-1a-privateweave-example-com.id}"
 }
 
 resource "aws_route53_record" "api-privateweave-example-com" {
   name = "api.privateweave.example.com"
   type = "A"
+
   alias = {
-    name = "${aws_elb.api-privateweave-example-com.dns_name}"
-    zone_id = "${aws_elb.api-privateweave-example-com.zone_id}"
+    name                   = "${aws_elb.api-privateweave-example-com.dns_name}"
+    zone_id                = "${aws_elb.api-privateweave-example-com.zone_id}"
     evaluate_target_health = false
   }
+
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
 resource "aws_route_table" "private-us-test-1a-privateweave-example-com" {
   vpc_id = "${aws_vpc.privateweave-example-com.id}"
+
   tags = {
     KubernetesCluster = "privateweave.example.com"
-    Name = "private-us-test-1a.privateweave.example.com"
+    Name              = "private-us-test-1a.privateweave.example.com"
   }
 }
 
 resource "aws_route_table" "privateweave-example-com" {
   vpc_id = "${aws_vpc.privateweave-example-com.id}"
+
   tags = {
     KubernetesCluster = "privateweave.example.com"
-    Name = "privateweave.example.com"
+    Name              = "privateweave.example.com"
   }
 }
 
 resource "aws_route_table_association" "private-us-test-1a-privateweave-example-com" {
-  subnet_id = "${aws_subnet.us-test-1a-privateweave-example-com.id}"
+  subnet_id      = "${aws_subnet.us-test-1a-privateweave-example-com.id}"
   route_table_id = "${aws_route_table.private-us-test-1a-privateweave-example-com.id}"
 }
 
 resource "aws_route_table_association" "utility-us-test-1a-privateweave-example-com" {
-  subnet_id = "${aws_subnet.utility-us-test-1a-privateweave-example-com.id}"
+  subnet_id      = "${aws_subnet.utility-us-test-1a-privateweave-example-com.id}"
   route_table_id = "${aws_route_table.privateweave-example-com.id}"
 }
 
 resource "aws_security_group" "api-elb-privateweave-example-com" {
-  name = "api-elb.privateweave.example.com"
-  vpc_id = "${aws_vpc.privateweave-example-com.id}"
+  name        = "api-elb.privateweave.example.com"
+  vpc_id      = "${aws_vpc.privateweave-example-com.id}"
   description = "Security group for api ELB"
+
   tags = {
     KubernetesCluster = "privateweave.example.com"
-    Name = "api-elb.privateweave.example.com"
+    Name              = "api-elb.privateweave.example.com"
   }
 }
 
 resource "aws_security_group" "bastion-elb-privateweave-example-com" {
-  name = "bastion-elb.privateweave.example.com"
-  vpc_id = "${aws_vpc.privateweave-example-com.id}"
+  name        = "bastion-elb.privateweave.example.com"
+  vpc_id      = "${aws_vpc.privateweave-example-com.id}"
   description = "Security group for bastion ELB"
+
   tags = {
     KubernetesCluster = "privateweave.example.com"
-    Name = "bastion-elb.privateweave.example.com"
+    Name              = "bastion-elb.privateweave.example.com"
   }
 }
 
 resource "aws_security_group" "bastion-privateweave-example-com" {
-  name = "bastion.privateweave.example.com"
-  vpc_id = "${aws_vpc.privateweave-example-com.id}"
+  name        = "bastion.privateweave.example.com"
+  vpc_id      = "${aws_vpc.privateweave-example-com.id}"
   description = "Security group for bastion"
+
   tags = {
     KubernetesCluster = "privateweave.example.com"
-    Name = "bastion.privateweave.example.com"
+    Name              = "bastion.privateweave.example.com"
   }
 }
 
 resource "aws_security_group" "masters-privateweave-example-com" {
-  name = "masters.privateweave.example.com"
-  vpc_id = "${aws_vpc.privateweave-example-com.id}"
+  name        = "masters.privateweave.example.com"
+  vpc_id      = "${aws_vpc.privateweave-example-com.id}"
   description = "Security group for masters"
+
   tags = {
     KubernetesCluster = "privateweave.example.com"
-    Name = "masters.privateweave.example.com"
+    Name              = "masters.privateweave.example.com"
   }
 }
 
 resource "aws_security_group" "nodes-privateweave-example-com" {
-  name = "nodes.privateweave.example.com"
-  vpc_id = "${aws_vpc.privateweave-example-com.id}"
+  name        = "nodes.privateweave.example.com"
+  vpc_id      = "${aws_vpc.privateweave-example-com.id}"
   description = "Security group for nodes"
+
   tags = {
     KubernetesCluster = "privateweave.example.com"
-    Name = "nodes.privateweave.example.com"
+    Name              = "nodes.privateweave.example.com"
   }
 }
 
 resource "aws_security_group_rule" "all-master-to-master" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-privateweave-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privateweave-example-com.id}"
   source_security_group_id = "${aws_security_group.masters-privateweave-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
 }
 
 resource "aws_security_group_rule" "all-master-to-node" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.nodes-privateweave-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.nodes-privateweave-example-com.id}"
   source_security_group_id = "${aws_security_group.masters-privateweave-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
 }
 
 resource "aws_security_group_rule" "all-node-to-node" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.nodes-privateweave-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.nodes-privateweave-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privateweave-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
 }
 
 resource "aws_security_group_rule" "api-elb-egress" {
-  type = "egress"
+  type              = "egress"
   security_group_id = "${aws_security_group.api-elb-privateweave-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "bastion-egress" {
-  type = "egress"
+  type              = "egress"
   security_group_id = "${aws_security_group.bastion-privateweave-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "bastion-elb-egress" {
-  type = "egress"
+  type              = "egress"
   security_group_id = "${aws_security_group.bastion-elb-privateweave-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "bastion-to-master-ssh" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-privateweave-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privateweave-example-com.id}"
   source_security_group_id = "${aws_security_group.bastion-privateweave-example-com.id}"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
+  from_port                = 22
+  to_port                  = 22
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "bastion-to-node-ssh" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.nodes-privateweave-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.nodes-privateweave-example-com.id}"
   source_security_group_id = "${aws_security_group.bastion-privateweave-example-com.id}"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
+  from_port                = 22
+  to_port                  = 22
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "https-api-elb-0-0-0-0--0" {
-  type = "ingress"
+  type              = "ingress"
   security_group_id = "${aws_security_group.api-elb-privateweave-example-com.id}"
-  from_port = 443
-  to_port = 443
-  protocol = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "https-elb-to-master" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-privateweave-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privateweave-example-com.id}"
   source_security_group_id = "${aws_security_group.api-elb-privateweave-example-com.id}"
-  from_port = 443
-  to_port = 443
-  protocol = "tcp"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "master-egress" {
-  type = "egress"
+  type              = "egress"
   security_group_id = "${aws_security_group.masters-privateweave-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "node-egress" {
-  type = "egress"
+  type              = "egress"
   security_group_id = "${aws_security_group.nodes-privateweave-example-com.id}"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "node-to-master-tcp-4194" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-privateweave-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privateweave-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privateweave-example-com.id}"
-  from_port = 4194
-  to_port = 4194
-  protocol = "tcp"
+  from_port                = 4194
+  to_port                  = 4194
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "node-to-master-tcp-443" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-privateweave-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privateweave-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privateweave-example-com.id}"
-  from_port = 443
-  to_port = 443
-  protocol = "tcp"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "node-to-master-tcp-6783" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-privateweave-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privateweave-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privateweave-example-com.id}"
-  from_port = 6783
-  to_port = 6783
-  protocol = "tcp"
+  from_port                = 6783
+  to_port                  = 6783
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "node-to-master-udp-6783" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-privateweave-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privateweave-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privateweave-example-com.id}"
-  from_port = 6783
-  to_port = 6783
-  protocol = "udp"
+  from_port                = 6783
+  to_port                  = 6783
+  protocol                 = "udp"
 }
 
 resource "aws_security_group_rule" "node-to-master-udp-6784" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.masters-privateweave-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privateweave-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privateweave-example-com.id}"
-  from_port = 6784
-  to_port = 6784
-  protocol = "udp"
+  from_port                = 6784
+  to_port                  = 6784
+  protocol                 = "udp"
 }
 
 resource "aws_security_group_rule" "ssh-elb-to-bastion" {
-  type = "ingress"
-  security_group_id = "${aws_security_group.bastion-privateweave-example-com.id}"
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.bastion-privateweave-example-com.id}"
   source_security_group_id = "${aws_security_group.bastion-elb-privateweave-example-com.id}"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
+  from_port                = 22
+  to_port                  = 22
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "ssh-external-to-bastion-elb-0-0-0-0--0" {
-  type = "ingress"
+  type              = "ingress"
   security_group_id = "${aws_security_group.bastion-elb-privateweave-example-com.id}"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_subnet" "us-test-1a-privateweave-example-com" {
-  vpc_id = "${aws_vpc.privateweave-example-com.id}"
-  cidr_block = "172.20.32.0/19"
+  vpc_id            = "${aws_vpc.privateweave-example-com.id}"
+  cidr_block        = "172.20.32.0/19"
   availability_zone = "us-test-1a"
+
   tags = {
     KubernetesCluster = "privateweave.example.com"
-    Name = "us-test-1a.privateweave.example.com"
+    Name              = "us-test-1a.privateweave.example.com"
   }
 }
 
 resource "aws_subnet" "utility-us-test-1a-privateweave-example-com" {
-  vpc_id = "${aws_vpc.privateweave-example-com.id}"
-  cidr_block = "172.20.4.0/22"
+  vpc_id            = "${aws_vpc.privateweave-example-com.id}"
+  cidr_block        = "172.20.4.0/22"
   availability_zone = "us-test-1a"
+
   tags = {
     KubernetesCluster = "privateweave.example.com"
-    Name = "utility-us-test-1a.privateweave.example.com"
+    Name              = "utility-us-test-1a.privateweave.example.com"
   }
 }
 
 resource "aws_vpc" "privateweave-example-com" {
-  cidr_block = "172.20.0.0/16"
+  cidr_block           = "172.20.0.0/16"
   enable_dns_hostnames = true
-  enable_dns_support = true
+  enable_dns_support   = true
+
   tags = {
     KubernetesCluster = "privateweave.example.com"
-    Name = "privateweave.example.com"
+    Name              = "privateweave.example.com"
   }
 }
 
 resource "aws_vpc_dhcp_options" "privateweave-example-com" {
-  domain_name = "us-test-1.compute.internal"
+  domain_name         = "us-test-1.compute.internal"
   domain_name_servers = ["AmazonProvidedDNS"]
+
   tags = {
     KubernetesCluster = "privateweave.example.com"
-    Name = "privateweave.example.com"
+    Name              = "privateweave.example.com"
   }
 }
 
 resource "aws_vpc_dhcp_options_association" "privateweave-example-com" {
-  vpc_id = "${aws_vpc.privateweave-example-com.id}"
+  vpc_id          = "${aws_vpc.privateweave-example-com.id}"
   dhcp_options_id = "${aws_vpc_dhcp_options.privateweave-example-com.id}"
 }

--- a/upup/pkg/fi/cloudup/terraform/hcl_printer.go
+++ b/upup/pkg/fi/cloudup/terraform/hcl_printer.go
@@ -99,6 +99,7 @@ func hclPrint(node ast.Node) ([]byte, error) {
 
 	// Remove extra whitespace...
 	s = strings.Replace(s, "\n\n", "\n", -1)
+
 	// ...but leave whitespace between resources
 	s = strings.Replace(s, "}\nresource", "}\n\nresource", -1)
 
@@ -107,5 +108,12 @@ func hclPrint(node ast.Node) ([]byte, error) {
 	s = strings.Replace(s, "(\\\"", "(\"", -1)
 	s = strings.Replace(s, "\\\")", "\")", -1)
 
-	return []byte(s), nil
+	// Apply Terraform style (alignment etc.)
+	formatted, err := hcl_printer.Format([]byte(s))
+
+	if err != nil {
+		return nil, fmt.Errorf("error formatting HCL: %v", err)
+	}
+
+	return formatted, nil
 }


### PR DESCRIPTION
This change runs Terraform code through the hcl_printer's formatter
again after code generation.

For some reason the generation step weaves in spaces between resource
attributes (which kops is already working around), however formatting
has to be applied again in order for alignment to match up.

This fixes #1638

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1651)
<!-- Reviewable:end -->
