### PR TITLE
Update cluster spec to explain why public ngw is in private subnet spec.

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -61,9 +61,9 @@ spec:
 ID of a subnet to share in an existing VPC.
 
 #### egress
-The resource identifier (ID) of something in your existing VPC that you would like to use as "egress" to the outside world. This feature was originally envisioned to allow re-use of NAT Gateways. In this case, the correct usageis as follows.
+The resource identifier (ID) of something in your existing VPC that you would like to use as "egress" to the outside world.
 
-
+This feature was originally envisioned to allow re-use of NAT Gateways. In this case, the usage is as follows. Although NAT gateways are "public"-facing resources, in the Cluster spec, you must specify them in the private subnet section. One way to think about this is that you are specifying "egress", which is the default route out from this private subnet. 
 
 ```
 spec:


### PR DESCRIPTION
Addresses and closes #1623 .  I was getting feedback on slack with folks wondering if there was a mistake in the docs because the Nat gateway, a "public" resource was listed in "private" subnet. 

Hopefully this helps clarify. If it doesn't, let's work on it!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1652)
<!-- Reviewable:end -->
