### PR TITLE
Improve error logging

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/logging_retryer.go
+++ b/upup/pkg/fi/cloudup/awsup/logging_retryer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awsup
 
 import (
+	"fmt"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/golang/glog"
@@ -47,7 +48,15 @@ func (l LoggingRetryer) RetryRules(r *request.Request) time.Duration {
 	}
 	methodDescription := service + "/" + name
 
-	glog.Infof("Retryable error %d (%s) from %s - will retry after delay of %v", r.HTTPResponse.StatusCode, r.HTTPResponse.Status, methodDescription, duration)
+	var errorDescription string
+	if r.Error != nil {
+		// We could check aws error Code & Message, but we expect them to be in the string
+		errorDescription = fmt.Sprintf("%v", r.Error)
+	} else {
+		errorDescription = fmt.Sprintf("%d %s", r.HTTPResponse.StatusCode, r.HTTPResponse.Status)
+	}
+
+	glog.Infof("Retryable error (%s) from %s - will retry after delay of %v", errorDescription, methodDescription, duration)
 
 	return duration
 }


### PR DESCRIPTION
We've had reports where something has gone wrong (misconfigured zone?)
but AWS is in a retry loop, and we don't get the full error until
timeout.

Log more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1658)
<!-- Reviewable:end -->
