### PR TITLE
SecurityGroupRule: Avoid spurious warnings when SourceGroup not found

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -336,6 +336,12 @@ func (e *SecurityGroup) FindDeletions(c *fi.Context) ([]fi.Deletion, error) {
 			if !ok {
 				continue
 			}
+
+			if er.SourceGroup != nil && er.SourceGroup.ID == nil {
+				glog.V(4).Infof("Deletion skipping find of SecurityGroupRule %s, because SourceGroup was not found", fi.StringValue(er.Name))
+				return nil, nil
+			}
+
 			if er.matches(permission) {
 				found = true
 			}

--- a/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
@@ -53,6 +53,11 @@ func (e *SecurityGroupRule) Find(c *fi.Context) (*SecurityGroupRule, error) {
 		return nil, nil
 	}
 
+	if e.SourceGroup != nil && e.SourceGroup.ID == nil {
+		glog.V(4).Infof("Skipping find of SecurityGroupRule %s, because SourceGroup was not found", fi.StringValue(e.Name))
+		return nil, nil
+	}
+
 	request := &ec2.DescribeSecurityGroupsInput{
 		Filters: []*ec2.Filter{
 			awsup.NewEC2Filter("group-id", *e.SecurityGroup.ID),


### PR DESCRIPTION
We were warning on a Find operation, which just isn't right - we can
just skip the find.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1659)
<!-- Reviewable:end -->
