### PR TITLE
Skip DNSName lookup if Zone not created

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/dnsname.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname.go
@@ -42,6 +42,11 @@ type DNSName struct {
 func (e *DNSName) Find(c *fi.Context) (*DNSName, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
+	if e.Zone == nil || e.Zone.ZoneID == nil {
+		glog.V(4).Infof("Zone / ZoneID not found for %s, skipping Find", fi.StringValue(e.Name))
+		return nil, nil
+	}
+
 	findName := fi.StringValue(e.Name)
 	if findName == "" {
 		return nil, nil


### PR DESCRIPTION
If the DNSZone is not yet created, it can't have any names, so Find must
early-exit.

Fix #1654

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1660)
<!-- Reviewable:end -->
