### PR TITLE
Improve delete cluster process: unset current-context

### DIFF
--- a/cmd/kops/delete_cluster.go
+++ b/cmd/kops/delete_cluster.go
@@ -19,8 +19,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
 	"io"
+
+	"github.com/spf13/cobra"
 	"k8s.io/kops/cmd/kops/util"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/registry"
@@ -180,9 +181,10 @@ func RunDeleteCluster(f *util.Factory, out io.Writer, options *DeleteClusterOpti
 		}
 	}
 
-	b := kutil.NewKubeconfigBuilder()
-	b.Context = cluster.ObjectMeta.Name
-	b.DeleteKubeConfig()
+	err = kutil.DeleteConfig(clusterName)
+	if err != nil {
+		return fmt.Errorf("error deleting kube config: %v", err)
+	}
 
 	fmt.Fprintf(out, "\nCluster deleted\n")
 	return nil

--- a/upup/pkg/kutil/kubecfg_builder.go
+++ b/upup/pkg/kutil/kubecfg_builder.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 )
 
 // KubeconfigBuilder builds a kubecfg file
@@ -58,6 +59,53 @@ func NewKubeconfigBuilder() *KubeconfigBuilder {
 	kubeConfig := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
 	c.KubeconfigPath = c.getKubectlPath(kubeConfig)
 	return c
+}
+
+func DeleteConfig(name string) error {
+	filename := clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
+	config, err := clientcmd.LoadFromFile(filename)
+	if err != nil {
+		return fmt.Errorf("error loading kube config: %v", err)
+	}
+
+	if api.IsConfigEmpty(config) {
+		return fmt.Errorf("kube config is empty")
+	}
+
+	_, ok := config.Clusters[name]
+	if !ok {
+		return fmt.Errorf("cluster %s does not exist", name)
+	}
+	delete(config.Clusters, name)
+
+	_, ok = config.AuthInfos[name]
+	if !ok {
+		return fmt.Errorf("user %s does not exist", name)
+	}
+	delete(config.AuthInfos, name)
+
+	_, ok = config.AuthInfos[fmt.Sprintf("%s-basic-auth", name)]
+	if !ok {
+		return fmt.Errorf("user %s-basic-auth does not exist", name)
+	}
+	delete(config.AuthInfos, fmt.Sprintf("%s-basic-auth", name))
+
+	_, ok = config.Contexts[name]
+	if !ok {
+		return fmt.Errorf("context %s does not exist", name)
+	}
+	delete(config.Contexts, name)
+
+	if config.CurrentContext == name {
+		config.CurrentContext = ""
+	}
+
+	err = clientcmd.WriteToFile(*config, filename)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Create new Rest Client

--- a/upup/pkg/kutil/kubecfg_builder.go
+++ b/upup/pkg/kutil/kubecfg_builder.go
@@ -18,14 +18,15 @@ package kutil
 
 import (
 	"fmt"
-	"github.com/golang/glog"
 	"io/ioutil"
-	"k8s.io/kubernetes/pkg/client/restclient"
-	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	"os"
 	"os/exec"
 	"path"
 	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 )
 
 // KubeconfigBuilder builds a kubecfg file
@@ -194,7 +195,14 @@ func (c *KubeconfigBuilder) DeleteKubeConfig() {
 	c.execKubectl("config", "unset", fmt.Sprintf("users.%s", c.Context))
 	c.execKubectl("config", "unset", fmt.Sprintf("users.%s-basic-auth", c.Context))
 	c.execKubectl("config", "unset", fmt.Sprintf("contexts.%s", c.Context))
-	fmt.Printf("Deleted kubectl config for %s\n", c.Context)
+	config, err := clientcmd.LoadFromFile(c.KubeconfigPath)
+	if err != nil {
+		fmt.Printf("Error reading kube config.")
+	}
+	if config.CurrentContext == c.Context {
+		c.execKubectl("config", "unset", "current-context")
+	}
+	fmt.Printf("Deleted kContextubectl config for %s\n", c.Context)
 }
 
 // get the correct path.  Handle empty and multiple values.

--- a/upup/pkg/kutil/kubecfg_builder.go
+++ b/upup/pkg/kutil/kubecfg_builder.go
@@ -197,12 +197,12 @@ func (c *KubeconfigBuilder) DeleteKubeConfig() {
 	c.execKubectl("config", "unset", fmt.Sprintf("contexts.%s", c.Context))
 	config, err := clientcmd.LoadFromFile(c.KubeconfigPath)
 	if err != nil {
-		fmt.Printf("Error reading kube config.")
+		fmt.Printf("kubectl unset current-context failed: %v", err)
 	}
 	if config.CurrentContext == c.Context {
 		c.execKubectl("config", "unset", "current-context")
 	}
-	fmt.Printf("Deleted kContextubectl config for %s\n", c.Context)
+	fmt.Printf("Deleted kubectl config for %s\n", c.Context)
 }
 
 // get the correct path.  Handle empty and multiple values.


### PR DESCRIPTION
Unset kubectl currect-context if it is the same as the provided cluster name.

This PR addresses issue #1533

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1663)
<!-- Reviewable:end -->
