### PR TITLE
Relax DNS requirements on shared VPCs

### DIFF
--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -37,6 +37,7 @@ func Bool(b bool) *bool {
 
 // DNSPreCreate controls whether we pre-create DNS records.
 var DNSPreCreate = New("DNSPreCreate", Bool(true))
+var VPCSkipEnableDNSSupport = New("VPCSkipEnableDNSSupport", Bool(true))
 
 var flags = make(map[string]*FeatureFlag)
 var flagsMutex sync.Mutex

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -18,8 +18,10 @@ package model
 
 import (
 	"fmt"
+	"github.com/blang/semver"
 	"github.com/golang/glog"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/util"
 	"strings"
 )
 
@@ -188,5 +190,35 @@ func (m *KopsModelContext) UsePrivateDNS() bool {
 		}
 	}
 
+	return false
+}
+
+// KubernetesVersion parses the semver version of kubernetes, from the cluster spec
+func (c *KopsModelContext) KubernetesVersion() (semver.Version, error) {
+	kubernetesVersion := c.Cluster.Spec.KubernetesVersion
+
+	if kubernetesVersion == "" {
+		return semver.Version{}, fmt.Errorf("KubernetesVersion is required")
+	}
+
+	sv, err := util.ParseKubernetesVersion(kubernetesVersion)
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("unable to determine kubernetes version from %q", kubernetesVersion)
+	}
+
+	return *sv, nil
+}
+
+// VersionGTE is a simplified semver comparison
+func VersionGTE(version semver.Version, major uint64, minor uint64) bool {
+	if version.Major > major {
+		return true
+	}
+	if version.Major > major {
+		return true
+	}
+	if version.Major == major && version.Minor >= minor {
+		return true
+	}
 	return false
 }

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -195,6 +195,8 @@ func (m *KopsModelContext) UsePrivateDNS() bool {
 
 // KubernetesVersion parses the semver version of kubernetes, from the cluster spec
 func (c *KopsModelContext) KubernetesVersion() (semver.Version, error) {
+	// TODO: Remove copy-pasting c.f. https://github.com/kubernetes/kops/blob/master/pkg/model/components/context.go#L32
+
 	kubernetesVersion := c.Cluster.Spec.KubernetesVersion
 
 	if kubernetesVersion == "" {
@@ -211,9 +213,6 @@ func (c *KopsModelContext) KubernetesVersion() (semver.Version, error) {
 
 // VersionGTE is a simplified semver comparison
 func VersionGTE(version semver.Version, major uint64, minor uint64) bool {
-	if version.Major > major {
-		return true
-	}
 	if version.Major > major {
 		return true
 	}


### PR DESCRIPTION
Don't require EnableDNSHostnames on a shared VPC in >= 1.5.0

Create a feature flag for tolerating EnableDNSSupport=false.

Issue #786

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1673)
<!-- Reviewable:end -->
