### PR TITLE
Drop DNS message to V(2)

### DIFF
--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -232,7 +232,7 @@ func (c *populateClusterSpec) run() error {
 		if err != nil {
 			return fmt.Errorf("error determining default DNS zone: %v", err)
 		}
-		glog.Infof("Defaulting DNS zone to: %s", dnsZone)
+		glog.V(2).Infof("Defaulting DNS zone to: %s", dnsZone)
 		cluster.Spec.DNSZone = dnsZone
 	}
 	tags, err := buildCloudupTags(cluster)


### PR DESCRIPTION
It is getting logged twice, and it just doesn't seem particularly
important anyway.

Issue #1679

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1689)
<!-- Reviewable:end -->
