### PR TITLE
Fix phrasing of kubectl context message

### DIFF
--- a/upup/pkg/kutil/kubecfg_builder.go
+++ b/upup/pkg/kutil/kubecfg_builder.go
@@ -185,7 +185,7 @@ func (c *KubeconfigBuilder) WriteKubecfg() error {
 		}
 	}
 	fmt.Printf("Wrote config for %s to %q\n", c.Context, c.KubeconfigPath)
-	fmt.Printf("Kops has changed your kubectl context to %s\n", c.Context)
+	fmt.Printf("Kops has set your kubectl context to %s\n", c.Context)
 	return nil
 }
 


### PR DESCRIPTION
Per @yissachar's suggestion.

Issue #1676

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1690)
<!-- Reviewable:end -->
