### PR TITLE
Attach additional IAM policies to same role

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
@@ -128,7 +128,7 @@ func (_ *IAMRolePolicy) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *IAMRoleP
 	if doPut {
 		request := &iam.PutRolePolicyInput{}
 		request.PolicyDocument = aws.String(policy)
-		request.RoleName = e.Name
+		request.RoleName = e.Role.Name
 		request.PolicyName = e.Name
 
 		_, err = t.Cloud.IAM().PutRolePolicy(request)

--- a/upup/pkg/kutil/delete_cluster.go
+++ b/upup/pkg/kutil/delete_cluster.go
@@ -1941,9 +1941,6 @@ func ListIAMRoles(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error
 	remove["masters."+clusterName] = true
 	remove["nodes."+clusterName] = true
 	remove["bastions."+clusterName] = true
-	remove["additional.nodes."+clusterName] = true
-	remove["additional.masters."+clusterName] = true
-	remove["additional.bastions."+clusterName] = true
 
 	var roles []*iam.Role
 	// Find roles matching remove map
@@ -2022,9 +2019,6 @@ func ListIAMInstanceProfiles(cloud fi.Cloud, clusterName string) ([]*ResourceTra
 	remove["masters."+clusterName] = true
 	remove["nodes."+clusterName] = true
 	remove["bastions."+clusterName] = true
-	remove["additional.nodes."+clusterName] = true
-	remove["additional.masters."+clusterName] = true
-	remove["additional.bastions."+clusterName] = true
 
 	var profiles []*iam.InstanceProfile
 


### PR DESCRIPTION
Rather than creating a second role, we can attach the policy to the existing
role.  This is an "inline" policy in the AWS IAM console.

Issue #1642
Issue #1631

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1707)
<!-- Reviewable:end -->
