### PR TITLE
Config is deprecated, use PodManifestPath

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -26,7 +26,7 @@ type KubeletConfigSpec struct {
 	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
 
 	// config is the path to the config file or directory of files
-	Config string `json:"config,omitempty" flag:"config"`
+	PodManifestPath string `json:"podManifestPath,omitempty" flag:"pod-manifest-path"`
 	//// syncFrequency is the max period between synchronizing running
 	//// containers and config
 	//SyncFrequency unversioned.Duration `json:"syncFrequency"`

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -26,7 +26,7 @@ type KubeletConfigSpec struct {
 	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
 
 	// config is the path to the config file or directory of files
-	Config string `json:"config,omitempty" flag:"config"`
+	PodManifestPath string `json:"podManifestPath,omitempty" flag:"pod-manifest-path"`
 	//// syncFrequency is the max period between synchronizing running
 	//// containers and config
 	//SyncFrequency unversioned.Duration `json:"syncFrequency"`

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1159,7 +1159,7 @@ func Convert_kops_KubeSchedulerConfig_To_v1alpha1_KubeSchedulerConfig(in *kops.K
 func autoConvert_v1alpha1_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *KubeletConfigSpec, out *kops.KubeletConfigSpec, s conversion.Scope) error {
 	out.APIServers = in.APIServers
 	out.LogLevel = in.LogLevel
-	out.Config = in.Config
+	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride
 	out.AllowPrivileged = in.AllowPrivileged
 	out.EnableDebuggingHandlers = in.EnableDebuggingHandlers
@@ -1195,7 +1195,7 @@ func Convert_v1alpha1_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *KubeletCon
 func autoConvert_kops_KubeletConfigSpec_To_v1alpha1_KubeletConfigSpec(in *kops.KubeletConfigSpec, out *KubeletConfigSpec, s conversion.Scope) error {
 	out.APIServers = in.APIServers
 	out.LogLevel = in.LogLevel
-	out.Config = in.Config
+	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride
 	out.AllowPrivileged = in.AllowPrivileged
 	out.EnableDebuggingHandlers = in.EnableDebuggingHandlers

--- a/upup/models/config/components/kubelet/kubelet.options
+++ b/upup/models/config/components/kubelet/kubelet.options
@@ -1,6 +1,6 @@
 Kubelet:
   EnableDebuggingHandlers: true
-  Config: /etc/kubernetes/manifests
+  PodManifestPath: /etc/kubernetes/manifests
   AllowPrivileged: true
   LogLevel: 2
   ClusterDNS: {{ WellKnownServiceIP 10 }}


### PR DESCRIPTION
This is in preparation for https://github.com/kubernetes/kubernetes/pull/40048

/cc @zmerlynn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1708)
<!-- Reviewable:end -->
