### PR TITLE
Add --master-count flag, to make it easy to run masters in the same AZ

### DIFF
--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -45,6 +45,12 @@ func TestCreateClusterHA(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/ha", "v1alpha2")
 }
 
+// TestCreateClusterHASharedZones tests kops create cluster when the master count is bigger than the numebr of zones
+func TestCreateClusterHASharedZones(t *testing.T) {
+	// Cannot be expressed in v1alpha1 API:	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/ha_shared_zones", "v1alpha1")
+	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/ha_shared_zones", "v1alpha2")
+}
+
 // TestCreateClusterPrivate runs kops create cluster private.example.com --zones us-test-1a --master-zones us-test-1a
 func TestCreateClusterPrivate(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/private", "v1alpha1")

--- a/cmd/kops/createcluster_test.go
+++ b/cmd/kops/createcluster_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRemoveSharedPrefix(t *testing.T) {
+	grid := []struct {
+		Input  []string
+		Output []string
+	}{
+		{
+			Input:  []string{"a", "b", "c"},
+			Output: []string{"a", "b", "c"},
+		},
+		{
+			Input:  []string{"za", "zb", "zc"},
+			Output: []string{"a", "b", "c"},
+		},
+		{
+			Input:  []string{"zza", "zzb", "zzc"},
+			Output: []string{"a", "b", "c"},
+		},
+		{
+			Input:  []string{"zza", "zzb", ""},
+			Output: []string{"zza", "zzb", ""},
+		},
+		{
+			Input:  []string{"us-test-1a-1", "us-test-1b-1", "us-test-1a-2", "us-test-1b-2", "us-test-1a-3"},
+			Output: []string{"a-1", "b-1", "a-2", "b-2", "a-3"},
+		},
+	}
+	for _, g := range grid {
+		actual := trimCommonPrefix(g.Input)
+		if !reflect.DeepEqual(actual, g.Output) {
+			t.Errorf("unexpected result from %q.  actual=%v, expected=%v", g.Input, actual, g.Output)
+		}
+	}
+}

--- a/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
@@ -13,19 +13,19 @@ spec:
   configBase: memfs://tests/ha.example.com
   etcdClusters:
   - etcdMembers:
-    - name: us-test-1a
+    - name: a
       zone: us-test-1a
-    - name: us-test-1b
+    - name: b
       zone: us-test-1b
-    - name: us-test-1c
+    - name: c
       zone: us-test-1c
     name: main
   - etcdMembers:
-    - name: us-test-1a
+    - name: a
       zone: us-test-1a
-    - name: us-test-1b
+    - name: b
       zone: us-test-1b
-    - name: us-test-1c
+    - name: c
       zone: us-test-1c
     name: events
   kubernetesVersion: v1.4.7

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -11,20 +11,28 @@ spec:
   configBase: memfs://tests/ha.example.com
   etcdClusters:
   - etcdMembers:
-    - instanceGroup: master-us-test-1a
-      name: a
-    - instanceGroup: master-us-test-1b
-      name: b
-    - instanceGroup: master-us-test-1c
-      name: c
+    - instanceGroup: master-us-test-1a-1
+      name: a-1
+    - instanceGroup: master-us-test-1b-1
+      name: b-1
+    - instanceGroup: master-us-test-1a-2
+      name: a-2
+    - instanceGroup: master-us-test-1b-2
+      name: b-2
+    - instanceGroup: master-us-test-1a-3
+      name: a-3
     name: main
   - etcdMembers:
-    - instanceGroup: master-us-test-1a
-      name: a
-    - instanceGroup: master-us-test-1b
-      name: b
-    - instanceGroup: master-us-test-1c
-      name: c
+    - instanceGroup: master-us-test-1a-1
+      name: a-1
+    - instanceGroup: master-us-test-1b-1
+      name: b-1
+    - instanceGroup: master-us-test-1a-2
+      name: a-2
+    - instanceGroup: master-us-test-1b-2
+      name: b-2
+    - instanceGroup: master-us-test-1a-3
+      name: a-3
     name: events
   kubernetesApiAccess:
   - 0.0.0.0/0
@@ -45,10 +53,6 @@ spec:
     name: us-test-1b
     type: Public
     zone: us-test-1b
-  - cidr: 172.20.96.0/19
-    name: us-test-1c
-    type: Public
-    zone: us-test-1c
   topology:
     dns:
       type: Public
@@ -63,7 +67,7 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: ha.example.com
-  name: master-us-test-1a
+  name: master-us-test-1a-1
 spec:
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
   machineType: m3.medium
@@ -81,7 +85,43 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: ha.example.com
-  name: master-us-test-1b
+  name: master-us-test-1a-2
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test-1a
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha.example.com
+  name: master-us-test-1a-3
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test-1a
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha.example.com
+  name: master-us-test-1b-1
 spec:
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
   machineType: m3.medium
@@ -99,7 +139,7 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: ha.example.com
-  name: master-us-test-1c
+  name: master-us-test-1b-2
 spec:
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
   machineType: m3.medium
@@ -107,7 +147,7 @@ spec:
   minSize: 1
   role: Master
   subnets:
-  - us-test-1c
+  - us-test-1b
 
 ---
 
@@ -127,4 +167,3 @@ spec:
   subnets:
   - us-test-1a
   - us-test-1b
-  - us-test-1c

--- a/tests/integration/create_cluster/ha_shared_zones/options.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/options.yaml
@@ -1,0 +1,6 @@
+ClusterName: ha.example.com
+Zones:
+- us-test-1a
+- us-test-1b
+MasterCount: 5
+Cloud: aws

--- a/tests/integration/create_cluster/minimal/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha1.yaml
@@ -13,11 +13,11 @@ spec:
   configBase: memfs://tests/minimal.example.com
   etcdClusters:
   - etcdMembers:
-    - name: us-test-1a
+    - name: a
       zone: us-test-1a
     name: main
   - etcdMembers:
-    - name: us-test-1a
+    - name: a
       zone: us-test-1a
     name: events
   kubernetesVersion: v1.4.7

--- a/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
@@ -12,11 +12,11 @@ spec:
   etcdClusters:
   - etcdMembers:
     - instanceGroup: master-us-test-1a
-      name: us-test-1a
+      name: a
     name: main
   - etcdMembers:
     - instanceGroup: master-us-test-1a
-      name: us-test-1a
+      name: a
     name: events
   kubernetesApiAccess:
   - 0.0.0.0/0

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha1.yaml
@@ -14,11 +14,11 @@ spec:
   configBase: memfs://tests/private.example.com
   etcdClusters:
   - etcdMembers:
-    - name: us-test-1a
+    - name: a
       zone: us-test-1a
     name: main
   - etcdMembers:
-    - name: us-test-1a
+    - name: a
       zone: us-test-1a
     name: events
   kubernetesVersion: v1.4.7

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -13,11 +13,11 @@ spec:
   etcdClusters:
   - etcdMembers:
     - instanceGroup: master-us-test-1a
-      name: us-test-1a
+      name: a
     name: main
   - etcdMembers:
     - instanceGroup: master-us-test-1a
-      name: us-test-1a
+      name: a
     name: events
   kubernetesApiAccess:
   - 0.0.0.0/0

--- a/tests/integration/create_cluster/private/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha1.yaml
@@ -14,11 +14,11 @@ spec:
   configBase: memfs://tests/private.example.com
   etcdClusters:
   - etcdMembers:
-    - name: us-test-1a
+    - name: a
       zone: us-test-1a
     name: main
   - etcdMembers:
-    - name: us-test-1a
+    - name: a
       zone: us-test-1a
     name: events
   kubernetesVersion: v1.4.7

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -13,11 +13,11 @@ spec:
   etcdClusters:
   - etcdMembers:
     - instanceGroup: master-us-test-1a
-      name: us-test-1a
+      name: a
     name: main
   - etcdMembers:
     - instanceGroup: master-us-test-1a
-      name: us-test-1a
+      name: a
     name: events
   kubernetesApiAccess:
   - 0.0.0.0/0


### PR DESCRIPTION
* The master zones are the default set of zones unless explicitly set
* The master count is the number of master zones unless explicitly set
* We then round-robin around the zones
* We append a suffix -1, -2, -3 if there are more masters than zones
* We trim prefixes to keep etcd member names short

Fix #1653

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1710)
<!-- Reviewable:end -->
