### PR TITLE
VPCSkipEnableDNSSupport: Fix flag default value

### DIFF
--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -37,7 +37,9 @@ func Bool(b bool) *bool {
 
 // DNSPreCreate controls whether we pre-create DNS records.
 var DNSPreCreate = New("DNSPreCreate", Bool(true))
-var VPCSkipEnableDNSSupport = New("VPCSkipEnableDNSSupport", Bool(true))
+
+// VPCSkipEnableDNSSupport if set will make that a VPC does not need DNSSupport enabled
+var VPCSkipEnableDNSSupport = New("VPCSkipEnableDNSSupport", Bool(false))
 
 var flags = make(map[string]*FeatureFlag)
 var flagsMutex sync.Mutex


### PR DESCRIPTION
I should have defaulted this flag to false - we're not yet sure if it is
safe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1713)
<!-- Reviewable:end -->
