### PR TITLE
Remove additional IAM policies that have been removed

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
@@ -110,6 +110,11 @@ func (_ *IAMRolePolicy) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *IAMRoleP
 		glog.V(2).Infof("Deleting role policy %s/%s", aws.StringValue(e.Role.Name), aws.StringValue(e.Name))
 		_, err = t.Cloud.IAM().DeleteRolePolicy(request)
 		if err != nil {
+			if awsup.AWSErrorCode(err) == "NoSuchEntity" {
+				// Already deleted
+				glog.V(2).Infof("Got NoSuchEntity deleting role policy %s/%s; assuming does not exist", aws.StringValue(e.Role.Name), aws.StringValue(e.Name))
+				return nil
+			}
 			return fmt.Errorf("error deleting IAMRolePolicy: %v", err)
 		}
 		return nil

--- a/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
@@ -32,9 +32,12 @@ import (
 
 //go:generate fitask -type=IAMRolePolicy
 type IAMRolePolicy struct {
-	ID             *string
-	Name           *string
-	Role           *IAMRole
+	ID   *string
+	Name *string
+	Role *IAMRole
+
+	// The PolicyDocument to create as an inline policy.
+	// If the PolicyDocument is empty, the policy will be removed.
 	PolicyDocument *fi.ResourceHolder
 }
 
@@ -97,6 +100,21 @@ func (_ *IAMRolePolicy) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *IAMRoleP
 		return fmt.Errorf("error rendering PolicyDocument: %v", err)
 	}
 
+	if policy == "" {
+		// A deletion
+
+		request := &iam.DeleteRolePolicyInput{}
+		request.RoleName = e.Role.Name
+		request.PolicyName = e.Name
+
+		glog.V(2).Infof("Deleting role policy %s/%s", aws.StringValue(e.Role.Name), aws.StringValue(e.Name))
+		_, err = t.Cloud.IAM().DeleteRolePolicy(request)
+		if err != nil {
+			return fmt.Errorf("error deleting IAMRolePolicy: %v", err)
+		}
+		return nil
+	}
+
 	doPut := false
 
 	if a == nil {
@@ -148,6 +166,17 @@ type terraformIAMRolePolicy struct {
 }
 
 func (_ *IAMRolePolicy) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *IAMRolePolicy) error {
+	{
+		policyString, err := e.PolicyDocument.AsString()
+		if err != nil {
+			return fmt.Errorf("error rendering PolicyDocument: %v", err)
+		}
+		if policyString == "" {
+			// A deletion; we simply don't render; terraform will observe the removal
+			return nil
+		}
+	}
+
 	policy, err := t.AddFile("aws_iam_role_policy", *e.Name, "policy", e.PolicyDocument)
 	if err != nil {
 		return fmt.Errorf("error rendering PolicyDocument: %v", err)


### PR DESCRIPTION
This uses an explicit deletion approach, where we set the policy to empty,
and use that to signal that the policy should be deleted.  This is
acceptable because IAM policies can't be empty anyway.

We probably should use a tag-based "garbage-collection" approach, but IAM
objects can't be tagged, so we're pretty much always going to be doing
something name based.

Fix #1642

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1720)
<!-- Reviewable:end -->
