### PR TITLE
Dockerfile revived and lightened

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,57 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.5
+
+ARG GO_VERSION=1.8.1
+
+# KOPS_GITISH: Modify to build at an explicit tag/gitish
+ARG KOPS_GITISH=release
+
+# KUBECTL_SOURCE: Change to kubernetes-dev/ci for CI
+ARG KUBECTL_SOURCE=kubernetes-release/release
+
+# KUBECTL_TRACK: Currently latest from KUBECTL_SOURCE. Change to latest-1.3.txt, etc. if desired.
+ARG KUBECTL_TRACK=stable.txt
+
+ARG KUBECTL_ARCH=linux/amd64
+
+RUN set -ex && \
+        apk add --no-cache --virtual build-dependencies curl jq git bash gcc musl-dev openssl go make && \
+        apk add  --no-cache vim ca-certificates &&\
+        \
+        export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
+        curl -L https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar zx -C /usr/local && \
+        cd /usr/local/go/src && \
+        ./make.bash && \
+        mkdir -p /go && \
+        export GOPATH=/go && \
+        \
+        go get -d k8s.io/kops && \
+        cd ${GOPATH}/src/k8s.io/kops/ && \
+        git checkout ${KOPS_GITISH} && \
+        make SHASUMCMD=0 && \
+        mv ${GOPATH}/bin/kops /usr/bin/. && \
+        \
+        KUBECTL_VERSION=$(curl -SsL --retry 5 "https://storage.googleapis.com/${KUBECTL_SOURCE}/${KUBECTL_TRACK}") && \
+        curl -SsL --retry 5 "https://storage.googleapis.com/${KUBECTL_SOURCE}/${KUBECTL_VERSION}/bin/${KUBECTL_ARCH}/kubectl" > /usr/bin/kubectl && \
+        chmod +x /usr/bin/kubectl &&\
+        \
+        rm -rf /go /usr/local/go && \
+        apk del build-dependencies && \
+        rm -rf /var/cache/apk/* && \
+        \
+        echo "=== Built kops at ${KOPS_GITISH}, fetched kubectl ${KUBECTL_VERSION} ==="
+
+ENTRYPOINT ["/usr/bin/kops"]

--- a/docker/Dockerfile-light
+++ b/docker/Dockerfile-light
@@ -1,0 +1,34 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.5
+
+# KUBECTL_SOURCE: Change to kubernetes-dev/ci for CI
+ARG KUBECTL_SOURCE=kubernetes-release/release
+
+# KUBECTL_TRACK: Currently latest from KUBECTL_SOURCE. Change to latest-1.3.txt, etc. if desired.
+ARG KUBECTL_TRACK=stable.txt
+
+ARG KUBECTL_ARCH=linux/amd64
+
+RUN apk add --no-cache --update ca-certificates vim curl jq && \
+    KOPS_URL=$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | jq -r ".assets[] | select(.name == \"kops-linux-amd64\") | .browser_download_url") && \
+    curl -SsL --retry 5 "${KOPS_URL}" > /usr/local/bin/kops && \
+    chmod +x /usr/local/bin/kops && \
+    KUBECTL_VERSION=$(curl -SsL --retry 5 "https://storage.googleapis.com/${KUBECTL_SOURCE}/${KUBECTL_TRACK}") && \
+    curl -SsL --retry 5 "https://storage.googleapis.com/${KUBECTL_SOURCE}/${KUBECTL_VERSION}/bin/${KUBECTL_ARCH}/kubectl" > /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl &&\
+    apk del curl jq
+
+ENTRYPOINT ["/usr/local/bin/kops"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,27 @@
+# Running Kops in Docker
+
+The Dockerfile here is offered primarily as a way to build continuous
+integration versions of `kops` until we figure out how we want to
+release/package it.
+
+To use it, e.g. (assumes your `$HOME` is correct and that `$KOPS_STATE_STORE` is correct):
+```shell
+$ docker build -t kops .
+$ KOPS="docker run -v $HOME/.aws:/root/.aws:ro -v $HOME/.ssh:/root/.ssh:ro -v $HOME/.kube:/root/.kube -it kops --state=$KOPS_STATE_STORE"
+```
+
+This creates a shell variable that runs the `kops` container with `~/.aws` mounted in (for AWS credentials), `~/.ssh` mounted in (for SSH keys, for AWS specifically), and `~/.kube` mounted in (so `kubectl` can add newly created clusters).
+
+After this, you can just use `$KOPS` where you would generally use `kops`, e.g. `$KOPS get cluster`.
+
+#### Choose branch/release to build.
+By default, the current release branch is built.  To build using a specific tag or commit, add the flag `--build-arg KOPS_GITISH=<tag/branch/sha>` to `docker build`, e.g. `docker build --build-arg KOPS_GITISH=release-1.6 -t kops .`
+
+#### Light Version
+The light version downloads the latest release binaries of kops from [Github Releases](https://github.com/kubernetes/kops/releases).
+
+To build the lighter version:
+```shell
+$ docker build -t kops:light -f Dockerfile-light .
+$ KOPS="docker run -v $HOME/.aws:/root/.aws:ro -v $HOME/.ssh:/root/.ssh:ro -v $HOME/.kube:/root/.kube -it kops:light --state=$KOPS_STATE_STORE"
+  ```


### PR DESCRIPTION
This is to return the Dockerfile for kops that was added in #314 and removed in #475.  It addresses #1687.  I also created a _light_ version that simply installs the latest released `kops` binary and the latest stable `kubectl`.

Also updated readme.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1727)
<!-- Reviewable:end -->
