### PR TITLE
Add Eviction flags

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -21,7 +21,7 @@ import metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 type KubeletConfigSpec struct {
 	APIServers string `json:"apiServers,omitempty" flag:"api-servers"`
 
-	LogLevel *int32 `json:"logLevel,omitempty" flag:"v"`
+	LogLevel *int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
 
 	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
 
@@ -219,7 +219,7 @@ type KubeletConfigSpec struct {
 	MaxPods *int32 `json:"maxPods,omitempty" flag:"max-pods"`
 
 	// nvidiaGPUs is the number of NVIDIA GPU devices on this node.
-	NvidiaGPUs int32 `json:"nvidiaGPUs,omitempty" flag:"experimental-nvidia-gpus"`
+	NvidiaGPUs int32 `json:"nvidiaGPUs,omitempty" flag:"experimental-nvidia-gpus" flag-empty:"0"`
 
 	//// dockerExecHandlerName is the handler to use when executing a command
 	//// in a container. Valid values are 'native' and 'nsenter'. Defaults to
@@ -274,16 +274,6 @@ type KubeletConfigSpec struct {
 	// enable gathering custom metrics.
 	EnableCustomMetrics *bool `json:"enableCustomMetrics,omitempty" flag:"enable-custom-metrics"`
 
-	//// Comma-delimited list of hard eviction expressions.  For example, 'memory.available<300Mi'.
-	//EvictionHard string `json:"evictionHard,omitempty"`
-	//// Comma-delimited list of soft eviction expressions.  For example, 'memory.available<300Mi'.
-	//EvictionSoft string `json:"evictionSoft,omitempty"`
-	//// Comma-delimeted list of grace periods for each soft eviction signal.  For example, 'memory.available=30s'.
-	//EvictionSoftGracePeriod string `json:"evictionSoftGracePeriod,omitempty"`
-	//// Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.
-	//EvictionPressureTransitionPeriod unversioned.Duration `json:"evictionPressureTransitionPeriod,omitempty"`
-	//// Maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.
-	//EvictionMaxPodGracePeriod int32 `json:"evictionMaxPodGracePeriod,omitempty"`
 	//// Maximum number of pods per core. Cannot exceed MaxPods
 	//PodsPerCore int32 `json:"podsPerCore"`
 	//// enableControllerAttachDetach enables the Attach/Detach controller to
@@ -308,6 +298,19 @@ type KubeletConfigSpec struct {
 	// before the terminated pod garbage collector starts deleting terminated pods.
 	// If <= 0, the terminated pod garbage collector is disabled.
 	TerminatedPodGCThreshold *int32 `json:"terminatedPodGCThreshold,omitempty" flag:"terminated-pod-gc-threshold"`
+
+	// Comma-delimited list of hard eviction expressions.  For example, 'memory.available<300Mi'.
+	EvictionHard *string `json:"evictionHard,omitempty" flag:"eviction-hard"`
+	// Comma-delimited list of soft eviction expressions.  For example, 'memory.available<300Mi'.
+	EvictionSoft string `json:"evictionSoft,omitempty" flag:"eviction-soft"`
+	// Comma-delimited list of grace periods for each soft eviction signal.  For example, 'memory.available=30s'.
+	EvictionSoftGracePeriod string `json:"evictionSoftGracePeriod,omitempty" flag:"eviction-soft-grace-period"`
+	// Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.
+	EvictionPressureTransitionPeriod metav1.Duration `json:"evictionPressureTransitionPeriod,omitempty" flag:"eviction-pressure-transition-period" flag-empty:"0"`
+	// Maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.
+	EvictionMaxPodGracePeriod int32 `json:"evictionMaxPodGracePeriod,omitempty" flag:"eviction-max-pod-grace-period" flag-empty:"0"`
+	// Comma-delimited list of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.
+	EvictionMinimumReclaim string `json:"evictionMinimumReclaim,omitempty" flag:"eviction-minimum-reclaim"`
 }
 
 type KubeProxyConfig struct {
@@ -420,7 +423,7 @@ type KubeAPIServerConfig struct {
 
 type KubeControllerManagerConfig struct {
 	Master   string `json:"master,omitempty" flag:"master"`
-	LogLevel int32  `json:"logLevel,omitempty" flag:"v"`
+	LogLevel int32  `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
 
 	ServiceAccountPrivateKeyFile string `json:"serviceAccountPrivateKeyFile,omitempty" flag:"service-account-private-key-file"`
 

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -306,7 +306,7 @@ type KubeletConfigSpec struct {
 	// Comma-delimited list of grace periods for each soft eviction signal.  For example, 'memory.available=30s'.
 	EvictionSoftGracePeriod string `json:"evictionSoftGracePeriod,omitempty" flag:"eviction-soft-grace-period"`
 	// Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.
-	EvictionPressureTransitionPeriod metav1.Duration `json:"evictionPressureTransitionPeriod,omitempty" flag:"eviction-pressure-transition-period" flag-empty:"0"`
+	EvictionPressureTransitionPeriod metav1.Duration `json:"evictionPressureTransitionPeriod,omitempty" flag:"eviction-pressure-transition-period" flag-empty:"0s"`
 	// Maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.
 	EvictionMaxPodGracePeriod int32 `json:"evictionMaxPodGracePeriod,omitempty" flag:"eviction-max-pod-grace-period" flag-empty:"0"`
 	// Comma-delimited list of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -273,16 +273,6 @@ type KubeletConfigSpec struct {
 	// enable gathering custom metrics.
 	EnableCustomMetrics *bool `json:"enableCustomMetrics,omitempty" flag:"enable-custom-metrics"`
 
-	//// Comma-delimited list of hard eviction expressions.  For example, 'memory.available<300Mi'.
-	//EvictionHard string `json:"evictionHard,omitempty"`
-	//// Comma-delimited list of soft eviction expressions.  For example, 'memory.available<300Mi'.
-	//EvictionSoft string `json:"evictionSoft,omitempty"`
-	//// Comma-delimeted list of grace periods for each soft eviction signal.  For example, 'memory.available=30s'.
-	//EvictionSoftGracePeriod string `json:"evictionSoftGracePeriod,omitempty"`
-	//// Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.
-	//EvictionPressureTransitionPeriod unversioned.Duration `json:"evictionPressureTransitionPeriod,omitempty"`
-	//// Maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.
-	//EvictionMaxPodGracePeriod int32 `json:"evictionMaxPodGracePeriod,omitempty"`
 	//// Maximum number of pods per core. Cannot exceed MaxPods
 	//PodsPerCore int32 `json:"podsPerCore"`
 	//// enableControllerAttachDetach enables the Attach/Detach controller to
@@ -307,6 +297,19 @@ type KubeletConfigSpec struct {
 	// before the terminated pod garbage collector starts deleting terminated pods.
 	// If <= 0, the terminated pod garbage collector is disabled.
 	TerminatedPodGCThreshold *int32 `json:"terminatedPodGCThreshold,omitempty" flag:"terminated-pod-gc-threshold"`
+
+	// Comma-delimited list of hard eviction expressions.  For example, 'memory.available<300Mi'.
+	EvictionHard *string `json:"evictionHard,omitempty" flag:"eviction-hard"`
+	// Comma-delimited list of soft eviction expressions.  For example, 'memory.available<300Mi'.
+	EvictionSoft string `json:"evictionSoft,omitempty" flag:"eviction-soft"`
+	// Comma-delimited list of grace periods for each soft eviction signal.  For example, 'memory.available=30s'.
+	EvictionSoftGracePeriod string `json:"evictionSoftGracePeriod,omitempty" flag:"eviction-soft-grace-period"`
+	// Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.
+	EvictionPressureTransitionPeriod metav1.Duration `json:"evictionPressureTransitionPeriod,omitempty" flag:"eviction-pressure-transition-period"`
+	// Maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.
+	EvictionMaxPodGracePeriod int32 `json:"evictionMaxPodGracePeriod,omitempty" flag:"eviction-max-pod-grace-period"`
+	// Comma-delimited list of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.
+	EvictionMinimumReclaim string `json:"evictionMinimumReclaim,omitempty" flag:"eviction-minimum-reclaim"`
 }
 
 type KubeProxyConfig struct {

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1188,6 +1188,12 @@ func autoConvert_v1alpha1_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.ImageGCHighThresholdPercent = in.ImageGCHighThresholdPercent
 	out.ImageGCLowThresholdPercent = in.ImageGCLowThresholdPercent
 	out.TerminatedPodGCThreshold = in.TerminatedPodGCThreshold
+	out.EvictionHard = in.EvictionHard
+	out.EvictionSoft = in.EvictionSoft
+	out.EvictionSoftGracePeriod = in.EvictionSoftGracePeriod
+	out.EvictionPressureTransitionPeriod = in.EvictionPressureTransitionPeriod
+	out.EvictionMaxPodGracePeriod = in.EvictionMaxPodGracePeriod
+	out.EvictionMinimumReclaim = in.EvictionMinimumReclaim
 	return nil
 }
 
@@ -1225,6 +1231,12 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha1_KubeletConfigSpec(in *kops.K
 	out.ImageGCHighThresholdPercent = in.ImageGCHighThresholdPercent
 	out.ImageGCLowThresholdPercent = in.ImageGCLowThresholdPercent
 	out.TerminatedPodGCThreshold = in.TerminatedPodGCThreshold
+	out.EvictionHard = in.EvictionHard
+	out.EvictionSoft = in.EvictionSoft
+	out.EvictionSoftGracePeriod = in.EvictionSoftGracePeriod
+	out.EvictionPressureTransitionPeriod = in.EvictionPressureTransitionPeriod
+	out.EvictionMaxPodGracePeriod = in.EvictionMaxPodGracePeriod
+	out.EvictionMinimumReclaim = in.EvictionMinimumReclaim
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -118,6 +118,19 @@ type KubeletConfigSpec struct {
 	// before the terminated pod garbage collector starts deleting terminated pods.
 	// If <= 0, the terminated pod garbage collector is disabled.
 	TerminatedPodGCThreshold *int32 `json:"terminatedPodGCThreshold,omitempty" flag:"terminated-pod-gc-threshold"`
+
+	// Comma-delimited list of hard eviction expressions.  For example, 'memory.available<300Mi'.
+	EvictionHard *string `json:"evictionHard,omitempty" flag:"eviction-hard"`
+	// Comma-delimited list of soft eviction expressions.  For example, 'memory.available<300Mi'.
+	EvictionSoft string `json:"evictionSoft,omitempty" flag:"eviction-soft"`
+	// Comma-delimited list of grace periods for each soft eviction signal.  For example, 'memory.available=30s'.
+	EvictionSoftGracePeriod string `json:"evictionSoftGracePeriod,omitempty" flag:"eviction-soft-grace-period"`
+	// Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.
+	EvictionPressureTransitionPeriod metav1.Duration `json:"evictionPressureTransitionPeriod,omitempty" flag:"eviction-pressure-transition-period"`
+	// Maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.
+	EvictionMaxPodGracePeriod int32 `json:"evictionMaxPodGracePeriod,omitempty" flag:"eviction-max-pod-grace-period"`
+	// Comma-delimited list of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.
+	EvictionMinimumReclaim string `json:"evictionMinimumReclaim,omitempty" flag:"eviction-minimum-reclaim"`
 }
 
 type KubeProxyConfig struct {

--- a/pkg/flagbuilder/build_flags.go
+++ b/pkg/flagbuilder/build_flags.go
@@ -114,6 +114,14 @@ func BuildFlags(options interface{}) (string, error) {
 
 		case metav1.Duration:
 			vString := v.Duration.String()
+
+			// See https://github.com/kubernetes/kubernetes/issues/40783
+			// Go renders a time.Duration to `0` in <= 1.6, and `0s` in >= 1.7
+			// We force it to be `0s`, regardless of value
+			if vString == "0" {
+				vString = "0s"
+			}
+
 			if vString != flagEmpty {
 				flag = fmt.Sprintf("--%s=%s", flagName, vString)
 			}

--- a/pkg/flagbuilder/buildflags_test.go
+++ b/pkg/flagbuilder/buildflags_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagbuilder
+
+import (
+	"k8s.io/kops/pkg/apis/kops"
+	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
+	"testing"
+	"time"
+)
+
+func TestBuildKCMFlags(t *testing.T) {
+	kcm := &kops.KubeControllerManagerConfig{
+		AttachDetachReconcileSyncPeriod: &metav1.Duration{Duration: time.Minute},
+	}
+	actual, err := BuildFlags(kcm)
+	if err != nil {
+		t.Fatalf("error from BuildFlags: %v", err)
+	}
+	expected := "--attach-detach-reconcile-sync-period=1m0s"
+	if actual != expected {
+		t.Fatalf("unexpected flags.  actual=%q expected=%q", actual, expected)
+	}
+}
+
+func TestKubeletConfigSpec(t *testing.T) {
+	grid := []struct {
+		Config   interface{}
+		Expected string
+	}{
+		{
+			Config: &kops.KubeletConfigSpec{
+				APIServers: "https://example.com",
+			},
+			Expected: "--api-servers=https://example.com",
+		},
+		{
+			Config:   &kops.KubeletConfigSpec{},
+			Expected: "",
+		},
+	}
+
+	for _, test := range grid {
+		actual, err := BuildFlags(test.Config)
+		if err != nil {
+			t.Errorf("error from BuildFlags: %v", err)
+			continue
+		}
+
+		if actual != test.Expected {
+			t.Errorf("unexpected flags.  actual=%q expected=%q", actual, test.Expected)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
Otherwise we were not evicting based on low inodes

Also add the notion of a flag-default, so we can pass fewer spurious
flags, and get closer to the component model

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1740)
<!-- Reviewable:end -->
