### PR TITLE
Calico 2.0.2 released, updating kops manifest

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/v2.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/v2.0.yaml.template
@@ -77,7 +77,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v1.0.1
+          image: calico/node:v1.0.2
           resources:
             requests:
               cpu: 10m
@@ -116,7 +116,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v1.5.5
+          image: calico/cni:v1.5.6
           resources:
             requests:
               cpu: 10m
@@ -237,7 +237,7 @@ spec:
       containers:
         # Writes basic configuration to datastore.
         - name: configure-calico
-          image: calico/ctl:v1.0.1
+          image: calico/ctl:v1.0.2
           args:
           - apply
           - -f


### PR DESCRIPTION
Calico has released 2.0.2 with some good bug fixes in it, more info can be found [here](http://docs.projectcalico.org/v2.0/releases/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1753)
<!-- Reviewable:end -->
