### PR TITLE
Alert user when edited YAML fields have not been added

### DIFF
--- a/cmd/kops/edit_cluster.go
+++ b/cmd/kops/edit_cluster.go
@@ -29,7 +29,9 @@ import (
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/registry"
 	"k8s.io/kops/pkg/apis/kops/validation"
+	"k8s.io/kops/pkg/diff"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
+	"k8s.io/kops/upup/pkg/fi/utils"
 	k8sapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util/editor"
 )
@@ -153,6 +155,30 @@ func RunEditCluster(f *util.Factory, cmd *cobra.Command, args []string, out io.W
 	err = registry.WriteConfigDeprecated(configBase.Join(registry.PathClusterCompleted), fullCluster)
 	if err != nil {
 		return fmt.Errorf("error writing completed cluster spec: %v", err)
+	}
+
+	// Convert the cluster back to YAML for comparison purposes
+	newYaml, err := api.ToVersionedYaml(newCluster)
+	if err != nil {
+		return err
+	}
+
+	// Marshal the edited YAML to a map; this will prevent bad diffs due to sorting
+	var editedYamlObj map[string]interface{}
+	err = utils.YamlUnmarshal([]byte(edited), &editedYamlObj)
+	if err != nil {
+		return err
+	}
+
+	// Convert the object back to YAML so that we can compare it to the cluster YAML
+	editedYaml, err := utils.YamlMarshal(editedYamlObj)
+	if err != nil {
+		return err
+	}
+
+	if !bytes.Equal(editedYaml, newYaml) {
+		discardedChanges := diff.FormatDiff(string(editedYaml), string(newYaml))
+		fmt.Fprintln(os.Stderr, "Not all edits were applied:\n"+discardedChanges)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #123 

As discussed with @justinsb I first took a look to see if `kubectl` handled this situation. From my testing it doesn't do anything better than `kops` currently - simply prints out the edit was skipped (in general kubectl edit needs some UX improvement, see [kubernetes#26050](https://github.com/kubernetes/kubernetes/issues/26050), so until they come up with a nice approach I think we're fine to blaze our own trail).

The approach I took here was to do the following:

1. Take the raw edited YAML and convert to map (this step normalizes the data and prevents us from false diffing)
2. Take the map and convert it back to a YAML string
3. Take the cluster object and convert it to a YAML string
4. Compare the edited YAML string to the cluster YAML string. If there are any differences, print the diff and warn the user that edits weren't applied

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1772)
<!-- Reviewable:end -->
