### PR TITLE
Add --headroom flag for rolling updates

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/elb"
@@ -66,7 +67,7 @@ type AWSCloud interface {
 	EC2() ec2iface.EC2API
 	IAM() *iam.IAM
 	ELB() *elb.ELB
-	Autoscaling() *autoscaling.AutoScaling
+	Autoscaling() autoscalingiface.AutoScalingAPI
 	Route53() route53iface.Route53API
 
 	// TODO: Document and rationalize these tags/filters methods
@@ -671,7 +672,7 @@ func (c *awsCloudImplementation) ELB() *elb.ELB {
 	return c.elb
 }
 
-func (c *awsCloudImplementation) Autoscaling() *autoscaling.AutoScaling {
+func (c *awsCloudImplementation) Autoscaling() autoscalingiface.AutoScalingAPI {
 	return c.autoscaling
 }
 

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -19,7 +19,7 @@ package awsup
 import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/elb"
@@ -66,6 +66,7 @@ func BuildMockAWSCloud(region string, zoneLetters string) *MockAWSCloud {
 
 type MockCloud struct {
 	MockEC2     ec2iface.EC2API
+	MockAutoscaling     autoscalingiface.AutoScalingAPI
 	MockRoute53 route53iface.Route53API
 }
 
@@ -166,9 +167,8 @@ func (c *MockAWSCloud) ELB() *elb.ELB {
 	return nil
 }
 
-func (c *MockAWSCloud) Autoscaling() *autoscaling.AutoScaling {
-	glog.Fatalf("MockAWSCloud Autoscaling not implemented")
-	return nil
+func (c *MockAWSCloud) Autoscaling() autoscalingiface.AutoScalingAPI {
+	return c.MockAutoscaling
 }
 
 func (c *MockAWSCloud) Route53() route53iface.Route53API {


### PR DESCRIPTION
Adds the ability to add extra nodes into cluster when performing rolling updates. I still think kops needs more elaborate rolling updates but I think this is a good start. 

If someone could point me in the right direction on where to add tests for this that would be great :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1774)
<!-- Reviewable:end -->
