### PR TITLE
Recommend a k8s version based on each kops version

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -20,8 +20,10 @@ spec:
     requiredVersion: 1.4.2
   kopsVersions:
   - range: ">=1.5.0-alpha1"
-    recommendedVersion: 1.5.0-beta1
-    #requiredVersion: 1.5.0-beta1
+    recommendedVersion: 1.5.0-beta2
+    #requiredVersion: 1.5.0-beta2
+    kubernetesVersion: 1.5.2
   - range: "<1.5.0"
     recommendedVersion: 1.4.4
     #requiredVersion: 1.4.4
+    kubernetesVersion: 1.4.8

--- a/channels/pkg/channels/channel_version.go
+++ b/channels/pkg/channels/channel_version.go
@@ -96,12 +96,12 @@ func (c *ChannelVersion) Replaces(existing *ChannelVersion) bool {
 		if c.Version == nil {
 			return false
 		}
-		cVersion, err := semver.Parse(*c.Version)
+		cVersion, err := semver.ParseTolerant(*c.Version)
 		if err != nil {
 			glog.Warningf("error parsing version %q; will ignore this version", *c.Version)
 			return false
 		}
-		existingVersion, err := semver.Parse(*existing.Version)
+		existingVersion, err := semver.ParseTolerant(*existing.Version)
 		if err != nil {
 			glog.Warningf("error parsing existing version %q", *existing.Version)
 			return true

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -272,7 +272,7 @@ func (b *DockerBuilder) Build(c *fi.ModelBuilderContext) error {
 		}
 	}
 
-	dockerSemver, err := semver.Parse(dockerVersion)
+	dockerSemver, err := semver.ParseTolerant(dockerVersion)
 	if err != nil {
 		return fmt.Errorf("error parsing docker version %q as semver: %v", dockerVersion, err)
 	}

--- a/tests/integration/channel/integration_test.go
+++ b/tests/integration/channel/integration_test.go
@@ -80,13 +80,13 @@ func TestKopsUpgrades(t *testing.T) {
 	for _, g := range grid {
 		kopsVersion := semver.MustParse(g.KopsVersion)
 
-		versionInfo := kops.FindVersionInfo(channel.Spec.KopsVersions, kopsVersion)
+		versionInfo := kops.FindKopsVersionSpec(channel.Spec.KopsVersions, kopsVersion)
 		if versionInfo == nil {
 			t.Errorf("unable to find version information for kops version %q in channel", kopsVersion)
 			continue
 		}
 
-		actual, err := kops.FindRecommendedUpgrade(versionInfo, kopsVersion)
+		actual, err := versionInfo.FindRecommendedUpgrade(kopsVersion)
 		if g.ExpectedError {
 			if err == nil {
 				t.Errorf("expected error from FindRecommendedUpgrade(%q)", g.KopsVersion)
@@ -98,12 +98,12 @@ func TestKopsUpgrades(t *testing.T) {
 				continue
 			}
 		}
-		if actual != g.ExpectedUpgrade {
+		if semverString(actual) != g.ExpectedUpgrade {
 			t.Errorf("unexpected result from IsUpgradeRequired(%q): expected=%q, actual=%q", g.KopsVersion, g.ExpectedUpgrade, actual)
 			continue
 		}
 
-		required, err := kops.IsUpgradeRequired(versionInfo, kopsVersion)
+		required, err := versionInfo.IsUpgradeRequired(kopsVersion)
 		if err != nil {
 			t.Errorf("unexpected error from IsUpgradeRequired(%q)", g.KopsVersion, err)
 			continue
@@ -174,13 +174,13 @@ func TestKubernetesUpgrades(t *testing.T) {
 	for _, g := range grid {
 		kubernetesVersion := semver.MustParse(g.KubernetesVersion)
 
-		versionInfo := kops.FindVersionInfo(channel.Spec.KubernetesVersions, kubernetesVersion)
+		versionInfo := kops.FindKubernetesVersionSpec(channel.Spec.KubernetesVersions, kubernetesVersion)
 		if versionInfo == nil {
 			t.Errorf("unable to find version information for kubernetes version %q in channel", kubernetesVersion)
 			continue
 		}
 
-		actual, err := kops.FindRecommendedUpgrade(versionInfo, kubernetesVersion)
+		actual, err := versionInfo.FindRecommendedUpgrade(kubernetesVersion)
 		if g.ExpectedError {
 			if err == nil {
 				t.Errorf("expected error from FindRecommendedUpgrade(%q)", g.KubernetesVersion)
@@ -192,12 +192,12 @@ func TestKubernetesUpgrades(t *testing.T) {
 				continue
 			}
 		}
-		if actual != g.ExpectedUpgrade {
+		if semverString(actual) != g.ExpectedUpgrade {
 			t.Errorf("unexpected result from IsUpgradeRequired(%q): expected=%q, actual=%q", g.KubernetesVersion, g.ExpectedUpgrade, actual)
 			continue
 		}
 
-		required, err := kops.IsUpgradeRequired(versionInfo, kubernetesVersion)
+		required, err := versionInfo.IsUpgradeRequired(kubernetesVersion)
 		if err != nil {
 			t.Errorf("unexpected error from IsUpgradeRequired(%q)", g.KubernetesVersion, err)
 			continue
@@ -248,4 +248,11 @@ func TestFindImage(t *testing.T) {
 			t.Errorf("unexpected image from FindImage(%q): expected=%q, actual=%q", g.KubernetesVersion, g.ExpectedImage, name)
 		}
 	}
+}
+
+func semverString(sv *semver.Version) string {
+	if sv == nil {
+		return ""
+	}
+	return sv.String()
 }

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -623,38 +623,38 @@ func (c *ApplyClusterCmd) upgradeSpecs() error {
 
 // validateKopsVersion ensures that kops meet the version requirements / recommendations in the channel
 func (c *ApplyClusterCmd) validateKopsVersion() error {
-	kopsVersion, err := semver.Parse(kops.Version)
+	kopsVersion, err := semver.ParseTolerant(kops.Version)
 	if err != nil {
 		glog.Warningf("unable to parse kops version %q", kops.Version)
 		// Not a hard-error
 		return nil
 	}
 
-	versionInfo := api.FindVersionInfo(c.channel.Spec.KopsVersions, kopsVersion)
+	versionInfo := api.FindKopsVersionSpec(c.channel.Spec.KopsVersions, kopsVersion)
 	if versionInfo == nil {
 		glog.Warningf("unable to find version information for kops version %q in channel", kopsVersion)
 		// Not a hard-error
 		return nil
 	}
 
-	recommended, err := api.FindRecommendedUpgrade(versionInfo, kopsVersion)
+	recommended, err := versionInfo.FindRecommendedUpgrade(kopsVersion)
 	if err != nil {
 		glog.Warningf("unable to parse version recommendation for kops version %q in channel", kopsVersion)
 	}
 
-	required, err := api.IsUpgradeRequired(versionInfo, kopsVersion)
+	required, err := versionInfo.IsUpgradeRequired(kopsVersion)
 	if err != nil {
 		glog.Warningf("unable to parse version requirement for kops version %q in channel", kopsVersion)
 	}
 
-	if recommended != "" && !required {
+	if recommended != nil && !required {
 		fmt.Printf("\n")
 		fmt.Printf(starline)
 		fmt.Printf("\n")
 		fmt.Printf("A new kops version is available: %s\n", recommended)
 		fmt.Printf("\n")
 		fmt.Printf("Upgrading is recommended\n")
-		fmt.Printf("More information: %s\n", buildPermalink("upgrade_kops", recommended))
+		fmt.Printf("More information: %s\n", buildPermalink("upgrade_kops", recommended.String()))
 		fmt.Printf("\n")
 		fmt.Printf(starline)
 		fmt.Printf("\n")
@@ -662,18 +662,17 @@ func (c *ApplyClusterCmd) validateKopsVersion() error {
 		fmt.Printf("\n")
 		fmt.Printf(starline)
 		fmt.Printf("\n")
-		if recommended != "" {
+		if recommended != nil {
 			fmt.Printf("A new kops version is available: %s\n", recommended)
 		}
 		fmt.Printf("\n")
 		fmt.Printf("This version of kops is no longer supported; upgrading is required\n")
 		fmt.Printf("(you can bypass this check by exporting KOPS_RUN_OBSOLETE_VERSION)\n")
 		fmt.Printf("\n")
-		fmt.Printf("More information: %s\n", buildPermalink("upgrade_kops", recommended))
+		fmt.Printf("More information: %s\n", buildPermalink("upgrade_kops", recommended.String()))
 		fmt.Printf("\n")
 		fmt.Printf(starline)
 		fmt.Printf("\n")
-
 	}
 
 	if required {
@@ -697,31 +696,31 @@ func (c *ApplyClusterCmd) validateKubernetesVersion() error {
 	// TODO: make util.ParseKubernetesVersion not return a pointer
 	kubernetesVersion := *parsed
 
-	versionInfo := api.FindVersionInfo(c.channel.Spec.KubernetesVersions, kubernetesVersion)
+	versionInfo := api.FindKubernetesVersionSpec(c.channel.Spec.KubernetesVersions, kubernetesVersion)
 	if versionInfo == nil {
 		glog.Warningf("unable to find version information for kubernetes version %q in channel", kubernetesVersion)
 		// Not a hard-error
 		return nil
 	}
 
-	recommended, err := api.FindRecommendedUpgrade(versionInfo, kubernetesVersion)
+	recommended, err := versionInfo.FindRecommendedUpgrade(kubernetesVersion)
 	if err != nil {
 		glog.Warningf("unable to parse version recommendation for kubernetes version %q in channel", kubernetesVersion)
 	}
 
-	required, err := api.IsUpgradeRequired(versionInfo, kubernetesVersion)
+	required, err := versionInfo.IsUpgradeRequired(kubernetesVersion)
 	if err != nil {
 		glog.Warningf("unable to parse version requirement for kubernetes version %q in channel", kubernetesVersion)
 	}
 
-	if recommended != "" && !required {
+	if recommended != nil && !required {
 		fmt.Printf("\n")
 		fmt.Printf(starline)
 		fmt.Printf("\n")
 		fmt.Printf("A new kubernetes version is available: %s\n", recommended)
 		fmt.Printf("Upgrading is recommended (try kops upgrade cluster)\n")
 		fmt.Printf("\n")
-		fmt.Printf("More information: %s\n", buildPermalink("upgrade_k8s", recommended))
+		fmt.Printf("More information: %s\n", buildPermalink("upgrade_k8s", recommended.String()))
 		fmt.Printf("\n")
 		fmt.Printf(starline)
 		fmt.Printf("\n")
@@ -729,14 +728,14 @@ func (c *ApplyClusterCmd) validateKubernetesVersion() error {
 		fmt.Printf("\n")
 		fmt.Printf(starline)
 		fmt.Printf("\n")
-		if recommended != "" {
+		if recommended != nil {
 			fmt.Printf("A new kubernetes version is available: %s\n", recommended)
 		}
 		fmt.Printf("\n")
 		fmt.Printf("This version of kubernetes is no longer supported; upgrading is required\n")
 		fmt.Printf("(you can bypass this check by exporting KOPS_RUN_OBSOLETE_VERSION)\n")
 		fmt.Printf("\n")
-		fmt.Printf("More information: %s\n", buildPermalink("upgrade_k8s", recommended))
+		fmt.Printf("More information: %s\n", buildPermalink("upgrade_k8s", recommended.String()))
 		fmt.Printf("\n")
 		fmt.Printf(starline)
 		fmt.Printf("\n")

--- a/upup/pkg/fi/cloudup/defaults.go
+++ b/upup/pkg/fi/cloudup/defaults.go
@@ -91,8 +91,9 @@ func ensureKubernetesVersion(c *kops.Cluster) error {
 			if err != nil {
 				return err
 			}
-			if channel.Spec.Cluster.KubernetesVersion != "" {
-				c.Spec.KubernetesVersion = channel.Spec.Cluster.KubernetesVersion
+			kubernetesVersion := kops.RecommendedKubernetesVersion(channel)
+			if kubernetesVersion != nil {
+				c.Spec.KubernetesVersion = kubernetesVersion.String()
 			}
 		}
 	}

--- a/upup/pkg/kutil/convert_kubeup_cluster.go
+++ b/upup/pkg/kutil/convert_kubeup_cluster.go
@@ -86,8 +86,11 @@ func (x *ConvertKubeupCluster) Upgrade() error {
 	}
 
 	// Set KubernetesVersion from channel
-	if x.Channel != nil && x.Channel.Spec.Cluster != nil && x.Channel.Spec.Cluster.KubernetesVersion != "" {
-		cluster.Spec.KubernetesVersion = x.Channel.Spec.Cluster.KubernetesVersion
+	if x.Channel != nil {
+		kubernetesVersion := api.RecommendedKubernetesVersion(x.Channel)
+		if kubernetesVersion != nil {
+			cluster.Spec.KubernetesVersion = kubernetesVersion.String()
+		}
 	}
 
 	err = cloudup.PerformAssignments(cluster)


### PR DESCRIPTION
So the flow is that we recommend (or strongly recommend) a new kops
version when one is required for a new version, and then the new kops
version will recommend (or strongly recommend) a new k8s version.

We don't have a notion of multiple recommended k8s versions per kops
version - that is what channels are for.

Users are always free to disregard updates, even "required" ones by
setting a flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1790)
<!-- Reviewable:end -->
