### PR TITLE
Update stable channel for kops 1.5.0, k8s 1.4.8

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -1,8 +1,29 @@
 spec:
   images:
+    # We put the "legacy" version first, for kops versions that don't support versions ( < 1.5.0 )
     - name: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
       providerID: aws
+      kubernetesVersion: ">=1.4.0 <1.5.0"
+    - name: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+      providerID: aws
+      kubernetesVersion: ">=1.5.0"
   cluster:
-    kubernetesVersion: v1.4.7
+    kubernetesVersion: v1.4.8
     networking:
       kubenet: {}
+  kubernetesVersions:
+  - range: ">=1.5.0"
+    recommendedVersion: 1.5.2
+    requiredVersion: 1.5.1
+  - range: "<1.5.0"
+    recommendedVersion: 1.4.8
+    requiredVersion: 1.4.2
+  kopsVersions:
+  - range: ">=1.5.0-alpha1"
+    recommendedVersion: 1.5.0
+    #requiredVersion: 1.5.0
+    kubernetesVersion: 1.5.2
+  - range: "<1.5.0"
+    recommendedVersion: 1.4.4
+    #requiredVersion: 1.4.4
+    kubernetesVersion: 1.4.8


### PR DESCRIPTION
This should not impact kops 1.4 users:

* The first image is the 1.4 image
* The cluster.kubernetesVersion is 1.4.8
* kops 1.4 will not read kubernetesVersion nor kopsVersion

We do bump the recommended k8s to 1.4.8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1799)
<!-- Reviewable:end -->
