### PR TITLE
Creates a testuser when it should create kops

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -61,7 +61,7 @@ arn:aws:iam::aws:policy/AmazonVPCFullAccess"
 
 for arn in $arns; do aws iam attach-group-policy --policy-arn "$arn" --group-name kops; done
 
-aws iam create-user --user-name testuser
+aws iam create-user --user-name kops
 
 aws iam add-user-to-group --user-name kops --group-name kops
 


### PR DESCRIPTION
I believe that the aws tutorial has a typo. Surely you are meant to create the `kops` user which you use in the next line rather than `testuser`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1800)
<!-- Reviewable:end -->
