### PR TITLE
create cluster: take correct k8s version

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	"k8s.io/kops"
 	"k8s.io/kops/cmd/kops/util"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/registry"
@@ -228,6 +229,11 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 
 	if channel.Spec.Cluster != nil {
 		cluster.Spec = *channel.Spec.Cluster
+
+		kubernetesVersion := api.RecommendedKubernetesVersion(channel, kops.Version)
+		if kubernetesVersion != nil {
+			cluster.Spec.KubernetesVersion = kubernetesVersion.String()
+		}
 	}
 	cluster.Spec.Channel = c.Channel
 

--- a/cmd/kops/upgrade_cluster.go
+++ b/cmd/kops/upgrade_cluster.go
@@ -23,6 +23,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	"k8s.io/kops"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/apis/kops/validation"
@@ -140,7 +141,7 @@ func (c *UpgradeClusterCmd) Run(args []string) error {
 		}
 	}
 
-	proposedKubernetesVersion := api.RecommendedKubernetesVersion(channel)
+	proposedKubernetesVersion := api.RecommendedKubernetesVersion(channel, kops.Version)
 
 	// We won't propose a downgrade
 	// TODO: What if a kubernetes version is bad?

--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"github.com/blang/semver"
 	"github.com/golang/glog"
-	"k8s.io/kops"
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/util/pkg/vfs"
@@ -276,8 +275,7 @@ func (c *Channel) FindImage(provider fi.CloudProviderID, kubernetesVersion semve
 	return matches[0]
 }
 
-func RecommendedKubernetesVersion(c *Channel) *semver.Version {
-	kopsVersionString := kops.Version
+func RecommendedKubernetesVersion(c *Channel, kopsVersionString string) *semver.Version {
 	kopsVersion, err := semver.ParseTolerant(kopsVersionString)
 	if err != nil {
 		glog.Warningf("unable to parse kops version %q", kopsVersionString)

--- a/tests/integration/channel/simple/channel.yaml
+++ b/tests/integration/channel/simple/channel.yaml
@@ -22,10 +22,12 @@ spec:
   - range: ">=1.5.0"
     recommendedVersion: 1.5.1
     requiredVersion: 1.5.0
+    kubernetesVersion: 1.5.2
   - range: ">=1.5.0-alpha1"
     recommendedVersion: 1.5.0-beta1
     requiredVersion: 1.5.0-beta1
+    kubernetesVersion: 1.5.0
   - range: "<1.5.0"
     recommendedVersion: 1.4.5
     requiredVersion: 1.4.5
-
+    kubernetesVersion: 1.4.8

--- a/upup/pkg/fi/cloudup/defaults.go
+++ b/upup/pkg/fi/cloudup/defaults.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/util/pkg/vfs"
 	"strings"
+
+	kopsversion "k8s.io/kops"
 )
 
 // PerformAssignments populates values that are required and immutable
@@ -91,10 +93,15 @@ func ensureKubernetesVersion(c *kops.Cluster) error {
 			if err != nil {
 				return err
 			}
-			kubernetesVersion := kops.RecommendedKubernetesVersion(channel)
+			kubernetesVersion := kops.RecommendedKubernetesVersion(channel, kopsversion.Version)
 			if kubernetesVersion != nil {
 				c.Spec.KubernetesVersion = kubernetesVersion.String()
+				glog.Infof("Using KubernetesVersion %q from channel %q", c.Spec.KubernetesVersion, c.Spec.Channel)
+			} else {
+				glog.Warningf("Cannot determine recommended kubernetes version from channel %q", c.Spec.Channel)
 			}
+		} else {
+			glog.Warningf("Channel is not set; cannot determine KubernetesVersion from channel")
 		}
 	}
 

--- a/upup/pkg/kutil/convert_kubeup_cluster.go
+++ b/upup/pkg/kutil/convert_kubeup_cluster.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/glog"
+	"k8s.io/kops"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/registry"
 	"k8s.io/kops/pkg/client/simple"
@@ -87,7 +88,7 @@ func (x *ConvertKubeupCluster) Upgrade() error {
 
 	// Set KubernetesVersion from channel
 	if x.Channel != nil {
-		kubernetesVersion := api.RecommendedKubernetesVersion(x.Channel)
+		kubernetesVersion := api.RecommendedKubernetesVersion(x.Channel, kops.Version)
 		if kubernetesVersion != nil {
 			cluster.Spec.KubernetesVersion = kubernetesVersion.String()
 		}


### PR DESCRIPTION
We were not overriding the cluster version, even when a kubernetes
version could be determined from the direct specifications.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1802)
<!-- Reviewable:end -->
