### PR TITLE
Specify KubernetesVersion in create cluster test

### DIFF
--- a/tests/integration/create_cluster/ha/options.yaml
+++ b/tests/integration/create_cluster/ha/options.yaml
@@ -8,3 +8,4 @@ MasterZones:
 - us-test-1b
 - us-test-1c
 Cloud: aws
+KubernetesVersion: v1.4.8

--- a/tests/integration/create_cluster/ha_shared_zones/options.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/options.yaml
@@ -4,3 +4,4 @@ Zones:
 - us-test-1b
 MasterCount: 5
 Cloud: aws
+KubernetesVersion: v1.4.8

--- a/tests/integration/create_cluster/minimal/options.yaml
+++ b/tests/integration/create_cluster/minimal/options.yaml
@@ -2,3 +2,4 @@ ClusterName: minimal.example.com
 Zones:
 - us-test-1a
 Cloud: aws
+KubernetesVersion: v1.4.8

--- a/tests/integration/create_cluster/ngwspecified/options.yaml
+++ b/tests/integration/create_cluster/ngwspecified/options.yaml
@@ -6,3 +6,4 @@ Topology: private
 Networking: kopeio-vxlan
 Bastion: true
 Egress: nat-09123456
+KubernetesVersion: v1.4.8

--- a/tests/integration/create_cluster/private/options.yaml
+++ b/tests/integration/create_cluster/private/options.yaml
@@ -11,3 +11,4 @@ NodeSecurityGroups:
 MasterSecurityGroups:
 - sg-exampleid3
 - sg-exampleid4
+KubernetesVersion: v1.4.8


### PR DESCRIPTION
We probably should use a canned channel, but in the interim this is
probably the best option, otherwise every time we update the stable
channel we break the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1804)
<!-- Reviewable:end -->
