### PR TITLE
Update stable & alpha channel to 1.5.1

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -20,8 +20,8 @@ spec:
     requiredVersion: 1.4.2
   kopsVersions:
   - range: ">=1.5.0-alpha1"
-    recommendedVersion: 1.5.0-beta2
-    #requiredVersion: 1.5.0-beta2
+    recommendedVersion: 1.5.1
+    #requiredVersion: 1.5.1
     kubernetesVersion: 1.5.2
   - range: "<1.5.0"
     recommendedVersion: 1.4.4

--- a/channels/stable
+++ b/channels/stable
@@ -20,8 +20,8 @@ spec:
     requiredVersion: 1.4.2
   kopsVersions:
   - range: ">=1.5.0-alpha1"
-    recommendedVersion: 1.5.0
-    #requiredVersion: 1.5.0
+    recommendedVersion: 1.5.1
+    #requiredVersion: 1.5.1
     kubernetesVersion: 1.5.2
   - range: "<1.5.0"
     recommendedVersion: 1.4.4


### PR DESCRIPTION
This will only affect the kops 1.5.x line, and it is only a
recommendation at the current time.