### PR TITLE
Check sha1sum command exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,12 @@ ifdef STATIC_BUILD
   EXTRA_LDFLAGS=-s
 endif
 
+SHASUMCMD := $(shell sha1sum --help 2> /dev/null)
+
+ifndef SHASUMCMD
+	$(error "sha1sum command is not available")
+endif
+
 kops: kops-gobindata
 	go install ${EXTRA_BUILDFLAGS} -ldflags "-X k8s.io/kops.Version=${VERSION} -X k8s.io/kops.GitVersion=${GITSHA} ${EXTRA_LDFLAGS}" k8s.io/kops/cmd/kops/...
 


### PR DESCRIPTION
In osx there is no `sha1sum` command.
Using the script `dev-build.sh` leads to empty `.sha1` files and timeout installing the cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1814)
<!-- Reviewable:end -->
