### PR TITLE
Add a warning that egress is not appropriate for public subnets

### DIFF
--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -327,6 +327,9 @@ func ValidateCluster(c *kops.Cluster, strict bool) error {
 			if s.Egress != "" && !strings.HasPrefix(s.Egress, "nat-") {
 				return fmt.Errorf("egress must be of type NAT Gateway")
 			}
+			if s.Egress != "" && !(s.Type == "Private") {
+				return fmt.Errorf("egress can only be specified for Private subnets")
+			}
 		}
 	}
 


### PR DESCRIPTION
Feedback from folks that have been trying to use the egress identifier. It just fails with a notice. 

Without this very minor patch, the egress gets saved in cluster spec so it looks like it may do something, but it doesn't.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1822)
<!-- Reviewable:end -->
