### PR TITLE
Increase conntrack table size using sysctl

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -17,9 +17,10 @@ limitations under the License.
 package model
 
 import (
+	"strings"
+
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
-	"strings"
 )
 
 // SysctlBuilder set up our sysctls
@@ -93,6 +94,10 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 
 			"# Increase size of file handles and inode cache",
 			"fs.file-max = 2097152",
+			"",
+
+			"# Increase size of conntrack table size to avoid poor iptables performance",
+			"net.netfilter.nf_conntrack_max = 1000000",
 			"",
 		)
 	}


### PR DESCRIPTION
default:
```
core@ip-172-20-125-180 ~ $ sysctl net.netfilter.nf_conntrack_max
net.netfilter.nf_conntrack_max = 131072
```

http://docs.projectcalico.org/v2.0/usage/configuration/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1828)
<!-- Reviewable:end -->
