### PR TITLE
Fix minor issue in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ endif
 SHASUMCMD := $(shell sha1sum --help 2> /dev/null)
 
 ifndef SHASUMCMD
-	$(error "sha1sum command is not available")
+  $(error "sha1sum command is not available")
 endif
 
 kops: kops-gobindata


### PR DESCRIPTION
Fix minor build issue related to detecting existence of
sha1sum command - this has to be preceded by whitespace and not TAB
so $(error) macro won't be treated as command.
`Makefile:70: *** commands commence before first target.  Stop.`

This obsoletes #1838 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1852)
<!-- Reviewable:end -->
