### PR TITLE
Fix terraform render for addtl security groups

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
@@ -367,6 +367,10 @@ func (_ *LaunchConfiguration) RenderTerraform(t *terraform.TerraformTarget, a, e
 	for _, sg := range e.SecurityGroups {
 		tf.SecurityGroups = append(tf.SecurityGroups, sg.TerraformLink())
 	}
+
+	for _, sg := range e.AdditionalSecurityGroupIDs {
+		tf.SecurityGroups = append(tf.SecurityGroups, terraform.LiteralFromStringValue(sg))
+	}
 	tf.AssociatePublicIpAddress = e.AssociatePublicIP
 
 	{


### PR DESCRIPTION
The update in #1444 didn't add the security groups to terraform meaning
if you did a `kops --target terraform` you only got the standard
security group.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1854)
<!-- Reviewable:end -->
