### PR TITLE
Add Route53 Mapper Addon

### DIFF
--- a/addons/route53-mapper/README.md
+++ b/addons/route53-mapper/README.md
@@ -1,0 +1,64 @@
+# Route53 Mapping Service
+
+This is a Kubernetes service that polls services (in all namespaces) that are
+configured with the label `dns=route53` and adds the appropriate alias to the
+domain specified by the annotation `domainName=sub.mydomain.io`. Multiple
+domains and top level domains are also supported:
+`domainName=.mydomain.io,sub1.mydomain.io,sub2.mydomain.io`.
+
+## Usage
+
+### Deploy To Cluster
+
+```
+# Version 1.2.0
+# https://github.com/wearemolecule/route53-kubernetes/tree/v1.2.0
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/monitoring-standalone/v1.2.0.yaml
+```
+
+### Service Configuration
+
+Add the `dns: route53` label and your target DNS entry in a `domainName`
+annotation. Example below:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-awesome-app
+  labels:
+    app: my-awesome-app
+    dns: route53
+  annotations:
+    domainName: "test.mydomain.tld"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: |-
+      arn:aws:acm:us-east-1:659153740712:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+spec:
+  selector:
+    app: my-awesome-app
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+    - name: https
+      port: 443
+      protocol: TCP
+  type: LoadBalancer
+```
+
+An `A` record for `test.mydomain.tld` will be created as an alias to the ELB
+that is configured by Kuberntes (see `service.beta.kubernetes.io/aws-load-
+balancer` annotations). This assumes that a hosted zone exists in Route53 for
+`mydomain.tld`. Any record that previously existed for that dns record will be
+updated.
+
+### Caveats
+
+[Molecule Software][1] **DON'T currently sign their docker images**. So, please
+use their images at your own risk.
+
+[1]: https://github.com/wearemolecule
+
+

--- a/addons/route53-mapper/addon.yml
+++ b/addons/route53-mapper/addon.yml
@@ -1,0 +1,9 @@
+kind: Addons
+metadata:
+  name: route53-mapper
+spec:
+  addons:
+    - version: 1.2.0
+      selector:
+        k8s-addon: route53-mapper.addons.k8s.io
+      manifest: v1.2.0.yaml

--- a/addons/route53-mapper/v1.2.0.yml
+++ b/addons/route53-mapper/v1.2.0.yml
@@ -1,0 +1,22 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: route53-mapper
+  namespace: kube-system
+  labels:
+    app: route53-mapper
+    k8s-addon: route53-mapper.addons.k8s.io
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: route53-mapper
+  template:
+    metadata:
+      labels:
+        app: route53-mapper
+    spec:
+      containers:
+        - image: quay.io/molecule/route53-kubernetes:v1.2.0
+          name: route53-mapper

--- a/addons/route53-mapper/v1.2.0.yml
+++ b/addons/route53-mapper/v1.2.0.yml
@@ -16,7 +16,11 @@ spec:
     metadata:
       labels:
         app: route53-mapper
+      annotations:
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated", "value":"master"}]'
     spec:
+      nodeSelector:
+        kubernetes.io/role: master
       containers:
         - image: quay.io/molecule/route53-kubernetes:v1.2.0
           name: route53-mapper

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -35,3 +35,12 @@ Install using:
 ```
 kubectl create -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/monitoring-standalone/v1.2.0.yaml
 ```
+
+### Route53 Mapper
+
+Automates creation and updating of entries on Route53 with `A` records pointing
+to ELB-backed `LoadBalancer` services created by Kubernetes. Install using:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/monitoring-standalone/v1.2.0.yaml
+```


### PR DESCRIPTION
Once deployed to cluster, just add the `dns: route53` label and your target DNS entry in a `domainName` annotation on your ELB-backed `Service`. Example below:

```yaml
apiVersion: v1
kind: Service
metadata:
  name: my-awesome-app
  labels:
    app: my-awesome-app
    dns: route53
  annotations:
    domainName: "test.mydomain.tld"
    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: |-
      arn:aws:acm:us-east-1:659153740712:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
spec:
  selector:
    app: my-awesome-app
  ports:
    - name: http
      port: 80
      protocol: TCP
    - name: https
      port: 443
      protocol: TCP
  type: LoadBalancer
```

An `A` record for `test.mydomain.tld` will be created as an alias to the ELB that is configured by Kuberntes (see `service.beta.kubernetes.io/aws-load-balancer` annotations). This assumes that a hosted zone exists in Route53 for`mydomain.tld`. Any record that previously existed for that DNS record will be updated.

Required permissions already exist on the master. See:

* ELB - [pkg/model/iam/iam_builder.go#L137-L141][1]
* Route53 - [pkg/model/iam/iam_builder.go#L131-L135][2]

[1]: https://github.com/kubernetes/kops/blob/b147b0f0e211792bf5b70e7d76d892b2646b5b32/pkg/model/iam/iam_builder.go#L137-L141
[2]: https://github.com/kubernetes/kops/blob/b147b0f0e211792bf5b70e7d76d892b2646b5b32/pkg/model/iam/iam_builder.go#L131-L135

Ps: I added a little security note in the `README`. What do you guys think about that concern?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1864)
<!-- Reviewable:end -->