### PR TITLE
Remove docs regarding manual IAM modification

### DIFF
--- a/docs/etcd_volume_encryption.md
+++ b/docs/etcd_volume_encryption.md
@@ -63,17 +63,3 @@ kops update cluster ${CLUSTER_NAME}
 # Review changes before applying
 kops update cluster ${CLUSTER_NAME} --yes
 ```
-
-At this point you must edit the Key Users list to add the `masters` role. 
-This has to be done before the master(s) attempt to to mount the volumes. 
-You should have at least a several minute window between the `masters` role being created by kops and the master(s) 
-mounting the volume, but if you somehow miss this window, you can just delete the master(s) and the ASG will kick in 
-and once new masters start up they should be able to mount successfully.
-
-Adding the `masters` role to the Key Users group via the AWS Console:
-
-1. Navigate to the IAM page
-2. Click on `Encryption keys` on the left sidebar
-3. Select the KMS key that you are using to encrypt the etcd volumes
-4. Scroll down to Key Users and click Add
-5. Select the `masters.<your.domain>` role and click Attach


### PR DESCRIPTION
Testing reveals that this step is not required. This makes sense, since we already add the KMS IAM permissions when `encryptedVolumes` is specified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1866)
<!-- Reviewable:end -->
