### PR TITLE
Rolling Update Unit Tests

### DIFF
--- a/cloudmock/aws/mockautoscaling/unimplemented.go
+++ b/cloudmock/aws/mockautoscaling/unimplemented.go
@@ -23,562 +23,557 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 )
 
-func AttachInstancesRequest(*autoscaling.AttachInstancesInput) (*request.Request, *autoscaling.AttachInstancesOutput) {
+func (m *MockAutoscaling) AttachInstancesRequest(*autoscaling.AttachInstancesInput) (*request.Request, *autoscaling.AttachInstancesOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func AttachLoadBalancerTargetGroupsRequest(*autoscaling.AttachLoadBalancerTargetGroupsInput) (*request.Request, *autoscaling.AttachLoadBalancerTargetGroupsOutput) {
+func (m *MockAutoscaling) AttachLoadBalancerTargetGroupsRequest(*autoscaling.AttachLoadBalancerTargetGroupsInput) (*request.Request, *autoscaling.AttachLoadBalancerTargetGroupsOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func AttachLoadBalancerTargetGroups(*autoscaling.AttachLoadBalancerTargetGroupsInput) (*autoscaling.AttachLoadBalancerTargetGroupsOutput, error) {
+func (m *MockAutoscaling) AttachLoadBalancerTargetGroups(*autoscaling.AttachLoadBalancerTargetGroupsInput) (*autoscaling.AttachLoadBalancerTargetGroupsOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func AttachLoadBalancersRequest(*autoscaling.AttachLoadBalancersInput) (*request.Request, *autoscaling.AttachLoadBalancersOutput) {
+func (m *MockAutoscaling) AttachLoadBalancersRequest(*autoscaling.AttachLoadBalancersInput) (*request.Request, *autoscaling.AttachLoadBalancersOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func AttachLoadBalancers(*autoscaling.AttachLoadBalancersInput) (*autoscaling.AttachLoadBalancersOutput, error) {
+func (m *MockAutoscaling) AttachLoadBalancers(*autoscaling.AttachLoadBalancersInput) (*autoscaling.AttachLoadBalancersOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func CompleteLifecycleActionRequest(*autoscaling.CompleteLifecycleActionInput) (*request.Request, *autoscaling.CompleteLifecycleActionOutput) {
+func (m *MockAutoscaling) CompleteLifecycleActionRequest(*autoscaling.CompleteLifecycleActionInput) (*request.Request, *autoscaling.CompleteLifecycleActionOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func CompleteLifecycleAction(*autoscaling.CompleteLifecycleActionInput) (*autoscaling.CompleteLifecycleActionOutput, error) {
+func (m *MockAutoscaling) CompleteLifecycleAction(*autoscaling.CompleteLifecycleActionInput) (*autoscaling.CompleteLifecycleActionOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func CreateAutoScalingGroupRequest(*autoscaling.CreateAutoScalingGroupInput) (*request.Request, *autoscaling.CreateAutoScalingGroupOutput) {
+func (m *MockAutoscaling) CreateAutoScalingGroupRequest(*autoscaling.CreateAutoScalingGroupInput) (*request.Request, *autoscaling.CreateAutoScalingGroupOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func CreateLaunchConfigurationRequest(*autoscaling.CreateLaunchConfigurationInput) (*request.Request, *autoscaling.CreateLaunchConfigurationOutput) {
+func (m *MockAutoscaling) CreateLaunchConfigurationRequest(*autoscaling.CreateLaunchConfigurationInput) (*request.Request, *autoscaling.CreateLaunchConfigurationOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func CreateLaunchConfiguration(*autoscaling.CreateLaunchConfigurationInput) (*autoscaling.CreateLaunchConfigurationOutput, error) {
+func (m *MockAutoscaling) CreateLaunchConfiguration(*autoscaling.CreateLaunchConfigurationInput) (*autoscaling.CreateLaunchConfigurationOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func CreateOrUpdateTagsRequest(*autoscaling.CreateOrUpdateTagsInput) (*request.Request, *autoscaling.CreateOrUpdateTagsOutput) {
+func (m *MockAutoscaling) CreateOrUpdateTagsRequest(*autoscaling.CreateOrUpdateTagsInput) (*request.Request, *autoscaling.CreateOrUpdateTagsOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func CreateOrUpdateTags(*autoscaling.CreateOrUpdateTagsInput) (*autoscaling.CreateOrUpdateTagsOutput, error) {
+func (m *MockAutoscaling) CreateOrUpdateTags(*autoscaling.CreateOrUpdateTagsInput) (*autoscaling.CreateOrUpdateTagsOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DeleteAutoScalingGroupRequest(*autoscaling.DeleteAutoScalingGroupInput) (*request.Request, *autoscaling.DeleteAutoScalingGroupOutput) {
+func (m *MockAutoscaling) DeleteAutoScalingGroupRequest(*autoscaling.DeleteAutoScalingGroupInput) (*request.Request, *autoscaling.DeleteAutoScalingGroupOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DeleteAutoScalingGroup(*autoscaling.DeleteAutoScalingGroupInput) (*autoscaling.DeleteAutoScalingGroupOutput, error) {
+func (m *MockAutoscaling) DeleteAutoScalingGroup(*autoscaling.DeleteAutoScalingGroupInput) (*autoscaling.DeleteAutoScalingGroupOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DeleteLaunchConfigurationRequest(*autoscaling.DeleteLaunchConfigurationInput) (*request.Request, *autoscaling.DeleteLaunchConfigurationOutput) {
+func (m *MockAutoscaling) DeleteLaunchConfigurationRequest(*autoscaling.DeleteLaunchConfigurationInput) (*request.Request, *autoscaling.DeleteLaunchConfigurationOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DeleteLaunchConfiguration(*autoscaling.DeleteLaunchConfigurationInput) (*autoscaling.DeleteLaunchConfigurationOutput, error) {
+func (m *MockAutoscaling) DeleteLaunchConfiguration(*autoscaling.DeleteLaunchConfigurationInput) (*autoscaling.DeleteLaunchConfigurationOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DeleteLifecycleHookRequest(*autoscaling.DeleteLifecycleHookInput) (*request.Request, *autoscaling.DeleteLifecycleHookOutput) {
+func (m *MockAutoscaling) DeleteLifecycleHookRequest(*autoscaling.DeleteLifecycleHookInput) (*request.Request, *autoscaling.DeleteLifecycleHookOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DeleteLifecycleHook(*autoscaling.DeleteLifecycleHookInput) (*autoscaling.DeleteLifecycleHookOutput, error) {
+func (m *MockAutoscaling) DeleteLifecycleHook(*autoscaling.DeleteLifecycleHookInput) (*autoscaling.DeleteLifecycleHookOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DeleteNotificationConfigurationRequest(*autoscaling.DeleteNotificationConfigurationInput) (*request.Request, *autoscaling.DeleteNotificationConfigurationOutput) {
+func (m *MockAutoscaling) DeleteNotificationConfigurationRequest(*autoscaling.DeleteNotificationConfigurationInput) (*request.Request, *autoscaling.DeleteNotificationConfigurationOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DeleteNotificationConfiguration(*autoscaling.DeleteNotificationConfigurationInput) (*autoscaling.DeleteNotificationConfigurationOutput, error) {
+func (m *MockAutoscaling) DeleteNotificationConfiguration(*autoscaling.DeleteNotificationConfigurationInput) (*autoscaling.DeleteNotificationConfigurationOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DeletePolicyRequest(*autoscaling.DeletePolicyInput) (*request.Request, *autoscaling.DeletePolicyOutput) {
+func (m *MockAutoscaling) DeletePolicyRequest(*autoscaling.DeletePolicyInput) (*request.Request, *autoscaling.DeletePolicyOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DeletePolicy(*autoscaling.DeletePolicyInput) (*autoscaling.DeletePolicyOutput, error) {
+func (m *MockAutoscaling) DeletePolicy(*autoscaling.DeletePolicyInput) (*autoscaling.DeletePolicyOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DeleteScheduledActionRequest(*autoscaling.DeleteScheduledActionInput) (*request.Request, *autoscaling.DeleteScheduledActionOutput) {
+func (m *MockAutoscaling) DeleteScheduledActionRequest(*autoscaling.DeleteScheduledActionInput) (*request.Request, *autoscaling.DeleteScheduledActionOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DeleteScheduledAction(*autoscaling.DeleteScheduledActionInput) (*autoscaling.DeleteScheduledActionOutput, error) {
+func (m *MockAutoscaling) DeleteScheduledAction(*autoscaling.DeleteScheduledActionInput) (*autoscaling.DeleteScheduledActionOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DeleteTagsRequest(*autoscaling.DeleteTagsInput) (*request.Request, *autoscaling.DeleteTagsOutput) {
+func (m *MockAutoscaling) DeleteTagsRequest(*autoscaling.DeleteTagsInput) (*request.Request, *autoscaling.DeleteTagsOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DeleteTags(*autoscaling.DeleteTagsInput) (*autoscaling.DeleteTagsOutput, error) {
+func (m *MockAutoscaling) DeleteTags(*autoscaling.DeleteTagsInput) (*autoscaling.DeleteTagsOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeAccountLimitsRequest(*autoscaling.DescribeAccountLimitsInput) (*request.Request, *autoscaling.DescribeAccountLimitsOutput) {
+func (m *MockAutoscaling) DescribeAccountLimitsRequest(*autoscaling.DescribeAccountLimitsInput) (*request.Request, *autoscaling.DescribeAccountLimitsOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeAccountLimits(*autoscaling.DescribeAccountLimitsInput) (*autoscaling.DescribeAccountLimitsOutput, error) {
+func (m *MockAutoscaling) DescribeAccountLimits(*autoscaling.DescribeAccountLimitsInput) (*autoscaling.DescribeAccountLimitsOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeAdjustmentTypesRequest(*autoscaling.DescribeAdjustmentTypesInput) (*request.Request, *autoscaling.DescribeAdjustmentTypesOutput) {
+func (m *MockAutoscaling) DescribeAdjustmentTypesRequest(*autoscaling.DescribeAdjustmentTypesInput) (*request.Request, *autoscaling.DescribeAdjustmentTypesOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeAdjustmentTypes(*autoscaling.DescribeAdjustmentTypesInput) (*autoscaling.DescribeAdjustmentTypesOutput, error) {
+func (m *MockAutoscaling) DescribeAdjustmentTypes(*autoscaling.DescribeAdjustmentTypesInput) (*autoscaling.DescribeAdjustmentTypesOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeAutoScalingGroupsRequest(*autoscaling.DescribeAutoScalingGroupsInput) (*request.Request, *autoscaling.DescribeAutoScalingGroupsOutput) {
+func (m *MockAutoscaling) DescribeAutoScalingGroupsRequest(*autoscaling.DescribeAutoScalingGroupsInput) (*request.Request, *autoscaling.DescribeAutoScalingGroupsOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeAutoScalingGroups(*autoscaling.DescribeAutoScalingGroupsInput) (*autoscaling.DescribeAutoScalingGroupsOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DescribeAutoScalingGroupsPages(*autoscaling.DescribeAutoScalingGroupsInput, func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool) error {
+func (m *MockAutoscaling) DescribeAutoScalingGroupsPages(*autoscaling.DescribeAutoScalingGroupsInput, func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool) error {
 	log.Fatal("Not implemented")
 	return nil
 }
 
-func DescribeAutoScalingInstancesRequest(*autoscaling.DescribeAutoScalingInstancesInput) (*request.Request, *autoscaling.DescribeAutoScalingInstancesOutput) {
+func (m *MockAutoscaling) DescribeAutoScalingInstancesRequest(*autoscaling.DescribeAutoScalingInstancesInput) (*request.Request, *autoscaling.DescribeAutoScalingInstancesOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeAutoScalingInstances(*autoscaling.DescribeAutoScalingInstancesInput) (*autoscaling.DescribeAutoScalingInstancesOutput, error) {
+func (m *MockAutoscaling) DescribeAutoScalingInstances(*autoscaling.DescribeAutoScalingInstancesInput) (*autoscaling.DescribeAutoScalingInstancesOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeAutoScalingInstancesPages(*autoscaling.DescribeAutoScalingInstancesInput, func(*autoscaling.DescribeAutoScalingInstancesOutput, bool) bool) error {
-	log.Fatal("Not implemented")
-	return nil
-}
-
-func DescribeAutoScalingNotificationTypesRequest(*autoscaling.DescribeAutoScalingNotificationTypesInput) (*request.Request, *autoscaling.DescribeAutoScalingNotificationTypesOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DescribeAutoScalingNotificationTypes(*autoscaling.DescribeAutoScalingNotificationTypesInput) (*autoscaling.DescribeAutoScalingNotificationTypesOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DescribeLaunchConfigurationsRequest(*autoscaling.DescribeLaunchConfigurationsInput) (*request.Request, *autoscaling.DescribeLaunchConfigurationsOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DescribeLaunchConfigurations(*autoscaling.DescribeLaunchConfigurationsInput) (*autoscaling.DescribeLaunchConfigurationsOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DescribeLaunchConfigurationsPages(*autoscaling.DescribeLaunchConfigurationsInput, func(*autoscaling.DescribeLaunchConfigurationsOutput, bool) bool) error {
+func (m *MockAutoscaling) DescribeAutoScalingInstancesPages(*autoscaling.DescribeAutoScalingInstancesInput, func(*autoscaling.DescribeAutoScalingInstancesOutput, bool) bool) error {
 	log.Fatal("Not implemented")
 	return nil
 }
 
-func DescribeLifecycleHookTypesRequest(*autoscaling.DescribeLifecycleHookTypesInput) (*request.Request, *autoscaling.DescribeLifecycleHookTypesOutput) {
+func (m *MockAutoscaling) DescribeAutoScalingNotificationTypesRequest(*autoscaling.DescribeAutoScalingNotificationTypesInput) (*request.Request, *autoscaling.DescribeAutoScalingNotificationTypesOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeLifecycleHookTypes(*autoscaling.DescribeLifecycleHookTypesInput) (*autoscaling.DescribeLifecycleHookTypesOutput, error) {
+func (m *MockAutoscaling) DescribeAutoScalingNotificationTypes(*autoscaling.DescribeAutoScalingNotificationTypesInput) (*autoscaling.DescribeAutoScalingNotificationTypesOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeLifecycleHooksRequest(*autoscaling.DescribeLifecycleHooksInput) (*request.Request, *autoscaling.DescribeLifecycleHooksOutput) {
+func (m *MockAutoscaling) DescribeLaunchConfigurationsRequest(*autoscaling.DescribeLaunchConfigurationsInput) (*request.Request, *autoscaling.DescribeLaunchConfigurationsOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeLifecycleHooks(*autoscaling.DescribeLifecycleHooksInput) (*autoscaling.DescribeLifecycleHooksOutput, error) {
+func (m *MockAutoscaling) DescribeLaunchConfigurations(*autoscaling.DescribeLaunchConfigurationsInput) (*autoscaling.DescribeLaunchConfigurationsOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeLoadBalancerTargetGroupsRequest(*autoscaling.DescribeLoadBalancerTargetGroupsInput) (*request.Request, *autoscaling.DescribeLoadBalancerTargetGroupsOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DescribeLoadBalancerTargetGroups(*autoscaling.DescribeLoadBalancerTargetGroupsInput) (*autoscaling.DescribeLoadBalancerTargetGroupsOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DescribeLoadBalancersRequest(*autoscaling.DescribeLoadBalancersInput) (*request.Request, *autoscaling.DescribeLoadBalancersOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DescribeLoadBalancers(*autoscaling.DescribeLoadBalancersInput) (*autoscaling.DescribeLoadBalancersOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DescribeMetricCollectionTypesRequest(*autoscaling.DescribeMetricCollectionTypesInput) (*request.Request, *autoscaling.DescribeMetricCollectionTypesOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DescribeMetricCollectionTypes(*autoscaling.DescribeMetricCollectionTypesInput) (*autoscaling.DescribeMetricCollectionTypesOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DescribeNotificationConfigurationsRequest(*autoscaling.DescribeNotificationConfigurationsInput) (*request.Request, *autoscaling.DescribeNotificationConfigurationsOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DescribeNotificationConfigurations(*autoscaling.DescribeNotificationConfigurationsInput) (*autoscaling.DescribeNotificationConfigurationsOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DescribeNotificationConfigurationsPages(*autoscaling.DescribeNotificationConfigurationsInput, func(*autoscaling.DescribeNotificationConfigurationsOutput, bool) bool) error {
+func (m *MockAutoscaling) DescribeLaunchConfigurationsPages(*autoscaling.DescribeLaunchConfigurationsInput, func(*autoscaling.DescribeLaunchConfigurationsOutput, bool) bool) error {
 	log.Fatal("Not implemented")
 	return nil
 }
 
-func DescribePoliciesRequest(*autoscaling.DescribePoliciesInput) (*request.Request, *autoscaling.DescribePoliciesOutput) {
+func (m *MockAutoscaling) DescribeLifecycleHookTypesRequest(*autoscaling.DescribeLifecycleHookTypesInput) (*request.Request, *autoscaling.DescribeLifecycleHookTypesOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribePolicies(*autoscaling.DescribePoliciesInput) (*autoscaling.DescribePoliciesOutput, error) {
+func (m *MockAutoscaling) DescribeLifecycleHookTypes(*autoscaling.DescribeLifecycleHookTypesInput) (*autoscaling.DescribeLifecycleHookTypesOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribePoliciesPages(*autoscaling.DescribePoliciesInput, func(*autoscaling.DescribePoliciesOutput, bool) bool) error {
+func (m *MockAutoscaling) DescribeLifecycleHooksRequest(*autoscaling.DescribeLifecycleHooksInput) (*request.Request, *autoscaling.DescribeLifecycleHooksOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DescribeLifecycleHooks(*autoscaling.DescribeLifecycleHooksInput) (*autoscaling.DescribeLifecycleHooksOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DescribeLoadBalancerTargetGroupsRequest(*autoscaling.DescribeLoadBalancerTargetGroupsInput) (*request.Request, *autoscaling.DescribeLoadBalancerTargetGroupsOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DescribeLoadBalancerTargetGroups(*autoscaling.DescribeLoadBalancerTargetGroupsInput) (*autoscaling.DescribeLoadBalancerTargetGroupsOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DescribeLoadBalancersRequest(*autoscaling.DescribeLoadBalancersInput) (*request.Request, *autoscaling.DescribeLoadBalancersOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DescribeLoadBalancers(*autoscaling.DescribeLoadBalancersInput) (*autoscaling.DescribeLoadBalancersOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DescribeMetricCollectionTypesRequest(*autoscaling.DescribeMetricCollectionTypesInput) (*request.Request, *autoscaling.DescribeMetricCollectionTypesOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DescribeMetricCollectionTypes(*autoscaling.DescribeMetricCollectionTypesInput) (*autoscaling.DescribeMetricCollectionTypesOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DescribeNotificationConfigurationsRequest(*autoscaling.DescribeNotificationConfigurationsInput) (*request.Request, *autoscaling.DescribeNotificationConfigurationsOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DescribeNotificationConfigurations(*autoscaling.DescribeNotificationConfigurationsInput) (*autoscaling.DescribeNotificationConfigurationsOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DescribeNotificationConfigurationsPages(*autoscaling.DescribeNotificationConfigurationsInput, func(*autoscaling.DescribeNotificationConfigurationsOutput, bool) bool) error {
 	log.Fatal("Not implemented")
 	return nil
 }
 
-func DescribeScalingActivitiesRequest(*autoscaling.DescribeScalingActivitiesInput) (*request.Request, *autoscaling.DescribeScalingActivitiesOutput) {
+func (m *MockAutoscaling) DescribePoliciesRequest(*autoscaling.DescribePoliciesInput) (*request.Request, *autoscaling.DescribePoliciesOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeScalingActivities(*autoscaling.DescribeScalingActivitiesInput) (*autoscaling.DescribeScalingActivitiesOutput, error) {
+func (m *MockAutoscaling) DescribePolicies(*autoscaling.DescribePoliciesInput) (*autoscaling.DescribePoliciesOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeScalingActivitiesPages(*autoscaling.DescribeScalingActivitiesInput, func(*autoscaling.DescribeScalingActivitiesOutput, bool) bool) error {
+func (m *MockAutoscaling) DescribePoliciesPages(*autoscaling.DescribePoliciesInput, func(*autoscaling.DescribePoliciesOutput, bool) bool) error {
 	log.Fatal("Not implemented")
 	return nil
 }
 
-func DescribeScalingProcessTypesRequest(*autoscaling.DescribeScalingProcessTypesInput) (*request.Request, *autoscaling.DescribeScalingProcessTypesOutput) {
+func (m *MockAutoscaling) DescribeScalingActivitiesRequest(*autoscaling.DescribeScalingActivitiesInput) (*request.Request, *autoscaling.DescribeScalingActivitiesOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeScalingProcessTypes(*autoscaling.DescribeScalingProcessTypesInput) (*autoscaling.DescribeScalingProcessTypesOutput, error) {
+func (m *MockAutoscaling) DescribeScalingActivities(*autoscaling.DescribeScalingActivitiesInput) (*autoscaling.DescribeScalingActivitiesOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeScheduledActionsRequest(*autoscaling.DescribeScheduledActionsInput) (*request.Request, *autoscaling.DescribeScheduledActionsOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DescribeScheduledActions(*autoscaling.DescribeScheduledActionsInput) (*autoscaling.DescribeScheduledActionsOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DescribeScheduledActionsPages(*autoscaling.DescribeScheduledActionsInput, func(*autoscaling.DescribeScheduledActionsOutput, bool) bool) error {
+func (m *MockAutoscaling) DescribeScalingActivitiesPages(*autoscaling.DescribeScalingActivitiesInput, func(*autoscaling.DescribeScalingActivitiesOutput, bool) bool) error {
 	log.Fatal("Not implemented")
 	return nil
 }
 
-func DescribeTagsRequest(*autoscaling.DescribeTagsInput) (*request.Request, *autoscaling.DescribeTagsOutput) {
+func (m *MockAutoscaling) DescribeScalingProcessTypesRequest(*autoscaling.DescribeScalingProcessTypesInput) (*request.Request, *autoscaling.DescribeScalingProcessTypesOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeTags(*autoscaling.DescribeTagsInput) (*autoscaling.DescribeTagsOutput, error) {
+func (m *MockAutoscaling) DescribeScalingProcessTypes(*autoscaling.DescribeScalingProcessTypesInput) (*autoscaling.DescribeScalingProcessTypesOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeTagsPages(*autoscaling.DescribeTagsInput, func(*autoscaling.DescribeTagsOutput, bool) bool) error {
+func (m *MockAutoscaling) DescribeScheduledActionsRequest(*autoscaling.DescribeScheduledActionsInput) (*request.Request, *autoscaling.DescribeScheduledActionsOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DescribeScheduledActions(*autoscaling.DescribeScheduledActionsInput) (*autoscaling.DescribeScheduledActionsOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DescribeScheduledActionsPages(*autoscaling.DescribeScheduledActionsInput, func(*autoscaling.DescribeScheduledActionsOutput, bool) bool) error {
 	log.Fatal("Not implemented")
 	return nil
 }
 
-func DescribeTerminationPolicyTypesRequest(*autoscaling.DescribeTerminationPolicyTypesInput) (*request.Request, *autoscaling.DescribeTerminationPolicyTypesOutput) {
+func (m *MockAutoscaling) DescribeTagsRequest(*autoscaling.DescribeTagsInput) (*request.Request, *autoscaling.DescribeTagsOutput) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DescribeTerminationPolicyTypes(*autoscaling.DescribeTerminationPolicyTypesInput) (*autoscaling.DescribeTerminationPolicyTypesOutput, error) {
+func (m *MockAutoscaling) DescribeTags(*autoscaling.DescribeTagsInput) (*autoscaling.DescribeTagsOutput, error) {
 	log.Fatal("Not implemented")
 	return nil, nil
 }
 
-func DetachInstancesRequest(*autoscaling.DetachInstancesInput) (*request.Request, *autoscaling.DetachInstancesOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DetachInstances(*autoscaling.DetachInstancesInput) (*autoscaling.DetachInstancesOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DetachLoadBalancerTargetGroupsRequest(*autoscaling.DetachLoadBalancerTargetGroupsInput) (*request.Request, *autoscaling.DetachLoadBalancerTargetGroupsOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DetachLoadBalancerTargetGroups(*autoscaling.DetachLoadBalancerTargetGroupsInput) (*autoscaling.DetachLoadBalancerTargetGroupsOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DetachLoadBalancersRequest(*autoscaling.DetachLoadBalancersInput) (*request.Request, *autoscaling.DetachLoadBalancersOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DetachLoadBalancers(*autoscaling.DetachLoadBalancersInput) (*autoscaling.DetachLoadBalancersOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DisableMetricsCollectionRequest(*autoscaling.DisableMetricsCollectionInput) (*request.Request, *autoscaling.DisableMetricsCollectionOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func DisableMetricsCollection(*autoscaling.DisableMetricsCollectionInput) (*autoscaling.DisableMetricsCollectionOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func EnableMetricsCollectionRequest(*autoscaling.EnableMetricsCollectionInput) (*request.Request, *autoscaling.EnableMetricsCollectionOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func EnableMetricsCollection(*autoscaling.EnableMetricsCollectionInput) (*autoscaling.EnableMetricsCollectionOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func EnterStandbyRequest(*autoscaling.EnterStandbyInput) (*request.Request, *autoscaling.EnterStandbyOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func EnterStandby(*autoscaling.EnterStandbyInput) (*autoscaling.EnterStandbyOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func ExecutePolicyRequest(*autoscaling.ExecutePolicyInput) (*request.Request, *autoscaling.ExecutePolicyOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func ExecutePolicy(*autoscaling.ExecutePolicyInput) (*autoscaling.ExecutePolicyOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func ExitStandbyRequest(*autoscaling.ExitStandbyInput) (*request.Request, *autoscaling.ExitStandbyOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func ExitStandby(*autoscaling.ExitStandbyInput) (*autoscaling.ExitStandbyOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func PutLifecycleHookRequest(*autoscaling.PutLifecycleHookInput) (*request.Request, *autoscaling.PutLifecycleHookOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func PutLifecycleHook(*autoscaling.PutLifecycleHookInput) (*autoscaling.PutLifecycleHookOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func PutNotificationConfigurationRequest(*autoscaling.PutNotificationConfigurationInput) (*request.Request, *autoscaling.PutNotificationConfigurationOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func PutNotificationConfiguration(*autoscaling.PutNotificationConfigurationInput) (*autoscaling.PutNotificationConfigurationOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func PutScalingPolicyRequest(*autoscaling.PutScalingPolicyInput) (*request.Request, *autoscaling.PutScalingPolicyOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func PutScalingPolicy(*autoscaling.PutScalingPolicyInput) (*autoscaling.PutScalingPolicyOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func PutScheduledUpdateGroupActionRequest(*autoscaling.PutScheduledUpdateGroupActionInput) (*request.Request, *autoscaling.PutScheduledUpdateGroupActionOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func PutScheduledUpdateGroupAction(*autoscaling.PutScheduledUpdateGroupActionInput) (*autoscaling.PutScheduledUpdateGroupActionOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func RecordLifecycleActionHeartbeatRequest(*autoscaling.RecordLifecycleActionHeartbeatInput) (*request.Request, *autoscaling.RecordLifecycleActionHeartbeatOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func RecordLifecycleActionHeartbeat(*autoscaling.RecordLifecycleActionHeartbeatInput) (*autoscaling.RecordLifecycleActionHeartbeatOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func ResumeProcessesRequest(*autoscaling.ScalingProcessQuery) (*request.Request, *autoscaling.ResumeProcessesOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func ResumeProcesses(*autoscaling.ScalingProcessQuery) (*autoscaling.ResumeProcessesOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func SetDesiredCapacityRequest(*autoscaling.SetDesiredCapacityInput) (*request.Request, *autoscaling.SetDesiredCapacityOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func SetDesiredCapacity(*autoscaling.SetDesiredCapacityInput) (*autoscaling.SetDesiredCapacityOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func SetInstanceHealthRequest(*autoscaling.SetInstanceHealthInput) (*request.Request, *autoscaling.SetInstanceHealthOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func SetInstanceHealth(*autoscaling.SetInstanceHealthInput) (*autoscaling.SetInstanceHealthOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func SetInstanceProtectionRequest(*autoscaling.SetInstanceProtectionInput) (*request.Request, *autoscaling.SetInstanceProtectionOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func SetInstanceProtection(*autoscaling.SetInstanceProtectionInput) (*autoscaling.SetInstanceProtectionOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func SuspendProcessesRequest(*autoscaling.ScalingProcessQuery) (*request.Request, *autoscaling.SuspendProcessesOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func SuspendProcesses(*autoscaling.ScalingProcessQuery) (*autoscaling.SuspendProcessesOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func TerminateInstanceInAutoScalingGroupRequest(*autoscaling.TerminateInstanceInAutoScalingGroupInput) (*request.Request, *autoscaling.TerminateInstanceInAutoScalingGroupOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func UpdateAutoScalingGroupRequest(*autoscaling.UpdateAutoScalingGroupInput) (*request.Request, *autoscaling.UpdateAutoScalingGroupOutput) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func UpdateAutoScalingGroup(*autoscaling.UpdateAutoScalingGroupInput) (*autoscaling.UpdateAutoScalingGroupOutput, error) {
-	log.Fatal("Not implemented")
-	return nil, nil
-}
-
-func WaitUntilGroupExists(*autoscaling.DescribeAutoScalingGroupsInput) error {
+func (m *MockAutoscaling) DescribeTagsPages(*autoscaling.DescribeTagsInput, func(*autoscaling.DescribeTagsOutput, bool) bool) error {
 	log.Fatal("Not implemented")
 	return nil
 }
 
-func WaitUntilGroupInService(*autoscaling.DescribeAutoScalingGroupsInput) error {
+func (m *MockAutoscaling) DescribeTerminationPolicyTypesRequest(*autoscaling.DescribeTerminationPolicyTypesInput) (*request.Request, *autoscaling.DescribeTerminationPolicyTypesOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DescribeTerminationPolicyTypes(*autoscaling.DescribeTerminationPolicyTypesInput) (*autoscaling.DescribeTerminationPolicyTypesOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DetachInstancesRequest(*autoscaling.DetachInstancesInput) (*request.Request, *autoscaling.DetachInstancesOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DetachInstances(*autoscaling.DetachInstancesInput) (*autoscaling.DetachInstancesOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DetachLoadBalancerTargetGroupsRequest(*autoscaling.DetachLoadBalancerTargetGroupsInput) (*request.Request, *autoscaling.DetachLoadBalancerTargetGroupsOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DetachLoadBalancerTargetGroups(*autoscaling.DetachLoadBalancerTargetGroupsInput) (*autoscaling.DetachLoadBalancerTargetGroupsOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DetachLoadBalancersRequest(*autoscaling.DetachLoadBalancersInput) (*request.Request, *autoscaling.DetachLoadBalancersOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DetachLoadBalancers(*autoscaling.DetachLoadBalancersInput) (*autoscaling.DetachLoadBalancersOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DisableMetricsCollectionRequest(*autoscaling.DisableMetricsCollectionInput) (*request.Request, *autoscaling.DisableMetricsCollectionOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) DisableMetricsCollection(*autoscaling.DisableMetricsCollectionInput) (*autoscaling.DisableMetricsCollectionOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) EnableMetricsCollectionRequest(*autoscaling.EnableMetricsCollectionInput) (*request.Request, *autoscaling.EnableMetricsCollectionOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) EnableMetricsCollection(*autoscaling.EnableMetricsCollectionInput) (*autoscaling.EnableMetricsCollectionOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) EnterStandbyRequest(*autoscaling.EnterStandbyInput) (*request.Request, *autoscaling.EnterStandbyOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) EnterStandby(*autoscaling.EnterStandbyInput) (*autoscaling.EnterStandbyOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) ExecutePolicyRequest(*autoscaling.ExecutePolicyInput) (*request.Request, *autoscaling.ExecutePolicyOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) ExecutePolicy(*autoscaling.ExecutePolicyInput) (*autoscaling.ExecutePolicyOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) ExitStandbyRequest(*autoscaling.ExitStandbyInput) (*request.Request, *autoscaling.ExitStandbyOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) ExitStandby(*autoscaling.ExitStandbyInput) (*autoscaling.ExitStandbyOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) PutLifecycleHookRequest(*autoscaling.PutLifecycleHookInput) (*request.Request, *autoscaling.PutLifecycleHookOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) PutLifecycleHook(*autoscaling.PutLifecycleHookInput) (*autoscaling.PutLifecycleHookOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) PutNotificationConfigurationRequest(*autoscaling.PutNotificationConfigurationInput) (*request.Request, *autoscaling.PutNotificationConfigurationOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) PutNotificationConfiguration(*autoscaling.PutNotificationConfigurationInput) (*autoscaling.PutNotificationConfigurationOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) PutScalingPolicyRequest(*autoscaling.PutScalingPolicyInput) (*request.Request, *autoscaling.PutScalingPolicyOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) PutScalingPolicy(*autoscaling.PutScalingPolicyInput) (*autoscaling.PutScalingPolicyOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) PutScheduledUpdateGroupActionRequest(*autoscaling.PutScheduledUpdateGroupActionInput) (*request.Request, *autoscaling.PutScheduledUpdateGroupActionOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) PutScheduledUpdateGroupAction(*autoscaling.PutScheduledUpdateGroupActionInput) (*autoscaling.PutScheduledUpdateGroupActionOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) RecordLifecycleActionHeartbeatRequest(*autoscaling.RecordLifecycleActionHeartbeatInput) (*request.Request, *autoscaling.RecordLifecycleActionHeartbeatOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) RecordLifecycleActionHeartbeat(*autoscaling.RecordLifecycleActionHeartbeatInput) (*autoscaling.RecordLifecycleActionHeartbeatOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) ResumeProcessesRequest(*autoscaling.ScalingProcessQuery) (*request.Request, *autoscaling.ResumeProcessesOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) ResumeProcesses(*autoscaling.ScalingProcessQuery) (*autoscaling.ResumeProcessesOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) SetDesiredCapacityRequest(*autoscaling.SetDesiredCapacityInput) (*request.Request, *autoscaling.SetDesiredCapacityOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) SetDesiredCapacity(*autoscaling.SetDesiredCapacityInput) (*autoscaling.SetDesiredCapacityOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) SetInstanceHealthRequest(*autoscaling.SetInstanceHealthInput) (*request.Request, *autoscaling.SetInstanceHealthOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) SetInstanceHealth(*autoscaling.SetInstanceHealthInput) (*autoscaling.SetInstanceHealthOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) SetInstanceProtectionRequest(*autoscaling.SetInstanceProtectionInput) (*request.Request, *autoscaling.SetInstanceProtectionOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) SetInstanceProtection(*autoscaling.SetInstanceProtectionInput) (*autoscaling.SetInstanceProtectionOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) SuspendProcessesRequest(*autoscaling.ScalingProcessQuery) (*request.Request, *autoscaling.SuspendProcessesOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) SuspendProcesses(*autoscaling.ScalingProcessQuery) (*autoscaling.SuspendProcessesOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) TerminateInstanceInAutoScalingGroupRequest(*autoscaling.TerminateInstanceInAutoScalingGroupInput) (*request.Request, *autoscaling.TerminateInstanceInAutoScalingGroupOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) UpdateAutoScalingGroupRequest(*autoscaling.UpdateAutoScalingGroupInput) (*request.Request, *autoscaling.UpdateAutoScalingGroupOutput) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) UpdateAutoScalingGroup(*autoscaling.UpdateAutoScalingGroupInput) (*autoscaling.UpdateAutoScalingGroupOutput, error) {
+	log.Fatal("Not implemented")
+	return nil, nil
+}
+
+func (m *MockAutoscaling) WaitUntilGroupExists(*autoscaling.DescribeAutoScalingGroupsInput) error {
 	log.Fatal("Not implemented")
 	return nil
 }
 
-func WaitUntilGroupNotExists(*autoscaling.DescribeAutoScalingGroupsInput) error {
+func (m *MockAutoscaling) WaitUntilGroupInService(*autoscaling.DescribeAutoScalingGroupsInput) error {
+	log.Fatal("Not implemented")
+	return nil
+}
+
+func (m *MockAutoscaling) WaitUntilGroupNotExists(*autoscaling.DescribeAutoScalingGroupsInput) error {
 	log.Fatal("Not implemented")
 	return nil
 }

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
@@ -76,7 +77,7 @@ type AWSCloud interface {
 	EC2() ec2iface.EC2API
 	IAM() *iam.IAM
 	ELB() *elb.ELB
-	Autoscaling() *autoscaling.AutoScaling
+	Autoscaling() autoscalingiface.AutoScalingAPI
 	Route53() route53iface.Route53API
 
 	// TODO: Document and rationalize these tags/filters methods
@@ -700,7 +701,7 @@ func (c *awsCloudImplementation) ELB() *elb.ELB {
 	return c.elb
 }
 
-func (c *awsCloudImplementation) Autoscaling() *autoscaling.AutoScaling {
+func (c *awsCloudImplementation) Autoscaling() autoscalingiface.AutoScalingAPI {
 	return c.autoscaling
 }
 

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -19,7 +19,7 @@ package awsup
 import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
@@ -66,6 +66,7 @@ func BuildMockAWSCloud(region string, zoneLetters string) *MockAWSCloud {
 }
 
 type MockCloud struct {
+	MockAutoscaling    autoscalingiface.AutoScalingAPI
 	MockCloudFormation *cloudformation.CloudFormation
 	MockEC2            ec2iface.EC2API
 	MockRoute53        route53iface.Route53API
@@ -175,9 +176,11 @@ func (c *MockAWSCloud) ELB() *elb.ELB {
 	return nil
 }
 
-func (c *MockAWSCloud) Autoscaling() *autoscaling.AutoScaling {
-	glog.Fatalf("MockAWSCloud Autoscaling not implemented")
-	return nil
+func (c *MockAWSCloud) Autoscaling() autoscalingiface.AutoScalingAPI {
+	if c.MockAutoscaling == nil {
+		glog.Fatalf("MockAWSCloud Autoscaling not implemented")
+	}
+	return c.MockAutoscaling
 }
 
 func (c *MockAWSCloud) Route53() route53iface.Route53API {

--- a/upup/pkg/kutil/rollingupdate_cluster.go
+++ b/upup/pkg/kutil/rollingupdate_cluster.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
@@ -116,9 +115,8 @@ func FindCloudInstanceGroups(cloud fi.Cloud, cluster *api.Cluster, instancegroup
 	return groups, nil
 }
 
-// RollingUpdateDrainValidate performs a rolling update on a K8s Cluster.
+// RollingUpdate performs a rolling update on a K8s Cluster.
 func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*CloudInstanceGroup, instanceGroups *api.InstanceGroupList) error {
-
 	if len(groups) == 0 {
 		glog.Infof("Cloud Instance Group length is zero. Not doing a rolling-update.")
 		return nil
@@ -451,10 +449,12 @@ func (n *CloudInstanceGroup) DeleteAWSInstance(u *CloudInstanceGroupInstance, in
 		glog.Infof("Stopping instance %q, in AWS ASG %q.", instanceId, n.ASGName)
 	}
 
-	request := &ec2.TerminateInstancesInput{
-		InstanceIds: []*string{u.ASGInstance.InstanceId},
+	request := &autoscaling.TerminateInstanceInAutoScalingGroupInput{
+		InstanceId:                     u.ASGInstance.InstanceId,
+		ShouldDecrementDesiredCapacity: aws.Bool(false),
 	}
-	if _, err := c.EC2().TerminateInstances(request); err != nil {
+
+	if _, err := c.Autoscaling().TerminateInstanceInAutoScalingGroup(request); err != nil {
 		if nodeName != "" {
 			return fmt.Errorf("error deleting instance %q, node %q: %v", instanceId, nodeName, err)
 		}

--- a/upup/pkg/kutil/rollingupdate_cluster_test.go
+++ b/upup/pkg/kutil/rollingupdate_cluster_test.go
@@ -1,0 +1,760 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+
+	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/kops/cloudmock/aws/mockautoscaling"
+	kopsapi "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+)
+
+func setUpCloud(c *RollingUpdateCluster) {
+	cloud := c.Cloud.(awsup.AWSCloud)
+	cloud.Autoscaling().CreateAutoScalingGroup(&autoscaling.CreateAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String("node-1"),
+		MinSize:              aws.Int64(1),
+		MaxSize:              aws.Int64(5),
+	})
+
+	cloud.Autoscaling().AttachInstances(&autoscaling.AttachInstancesInput{
+		AutoScalingGroupName: aws.String("node-1"),
+		InstanceIds:          []*string{aws.String("node-1a"), aws.String("node-1b")},
+	})
+
+	cloud.Autoscaling().CreateAutoScalingGroup(&autoscaling.CreateAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String("node-2"),
+		MinSize:              aws.Int64(1),
+		MaxSize:              aws.Int64(5),
+	})
+
+	cloud.Autoscaling().AttachInstances(&autoscaling.AttachInstancesInput{
+		AutoScalingGroupName: aws.String("node-2"),
+		InstanceIds:          []*string{aws.String("node-2a"), aws.String("node-2b")},
+	})
+
+	cloud.Autoscaling().CreateAutoScalingGroup(&autoscaling.CreateAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String("master-1"),
+		MinSize:              aws.Int64(1),
+		MaxSize:              aws.Int64(5),
+	})
+
+	cloud.Autoscaling().AttachInstances(&autoscaling.AttachInstancesInput{
+		AutoScalingGroupName: aws.String("master-1"),
+		InstanceIds:          []*string{aws.String("master-1a")},
+	})
+
+	cloud.Autoscaling().CreateAutoScalingGroup(&autoscaling.CreateAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String("bastion-1"),
+		MinSize:              aws.Int64(1),
+		MaxSize:              aws.Int64(5),
+	})
+
+	cloud.Autoscaling().AttachInstances(&autoscaling.AttachInstancesInput{
+		AutoScalingGroupName: aws.String("bastion-1"),
+		InstanceIds:          []*string{aws.String("bastion-1a")},
+	})
+}
+
+func TestRollingUpdateAllNeedUpdate(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+
+	mockcloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
+	mockcloud.MockAutoscaling = &mockautoscaling.MockAutoscaling{}
+
+	c := &RollingUpdateCluster{
+		Cloud:           mockcloud,
+		MasterInterval:  1 * time.Millisecond,
+		NodeInterval:    1 * time.Millisecond,
+		BastionInterval: 1 * time.Millisecond,
+		Force:           false,
+		K8sClient:       k8sClient,
+	}
+
+	cloud := c.Cloud.(awsup.AWSCloud)
+	setUpCloud(c)
+
+	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+	groups := make(map[string]*CloudInstanceGroup)
+	groups["node-1"] = &CloudInstanceGroup{
+		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[0].AutoScalingGroupName),
+		asg:     asgGroups.AutoScalingGroups[0],
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "node-1",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleNode,
+			},
+		},
+		Ready: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-1a"),
+				},
+				Node: &v1.Node{},
+			},
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-1b"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+		NeedUpdate: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-1a"),
+				},
+				Node: &v1.Node{},
+			},
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-1b"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+	}
+
+	groups["node-2"] = &CloudInstanceGroup{
+		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[1].AutoScalingGroupName),
+		asg:     asgGroups.AutoScalingGroups[1],
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "node-2",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleNode,
+			},
+		},
+		Ready: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-2a"),
+				},
+				Node: &v1.Node{},
+			},
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-2b"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+		NeedUpdate: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-2a"),
+				},
+				Node: &v1.Node{},
+			},
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-2b"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+	}
+
+	groups["master-1"] = &CloudInstanceGroup{
+		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[2].AutoScalingGroupName),
+		asg:     asgGroups.AutoScalingGroups[2],
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "master-1",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleMaster,
+			},
+		},
+		Ready: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("master-1a"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+		NeedUpdate: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("master-1a"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+	}
+
+	groups["bastion-1"] = &CloudInstanceGroup{
+		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[3].AutoScalingGroupName),
+		asg:     asgGroups.AutoScalingGroups[3],
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "bastion-1",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleBastion,
+			},
+		},
+		Ready: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("bastion-1a"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+		NeedUpdate: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("bastion-1a"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+	}
+
+	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	if err != nil {
+		t.Errorf("Error on rolling update: %v", err)
+	}
+
+	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) > 0 {
+			t.Error("Not all instances terminated")
+		}
+	}
+}
+
+func TestRollingUpdateNoneNeedUpdate(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+
+	mockcloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
+	mockcloud.MockAutoscaling = &mockautoscaling.MockAutoscaling{}
+
+	c := &RollingUpdateCluster{
+		Cloud:           mockcloud,
+		MasterInterval:  1 * time.Millisecond,
+		NodeInterval:    1 * time.Millisecond,
+		BastionInterval: 1 * time.Millisecond,
+		Force:           false,
+		K8sClient:       k8sClient,
+	}
+
+	cloud := c.Cloud.(awsup.AWSCloud)
+	setUpCloud(c)
+
+	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+
+	groups := make(map[string]*CloudInstanceGroup)
+	groups["node-1"] = &CloudInstanceGroup{
+		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[0].AutoScalingGroupName),
+		asg:     asgGroups.AutoScalingGroups[0],
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "node-1",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleNode,
+			},
+		},
+		Ready: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-1a"),
+				},
+				Node: &v1.Node{},
+			},
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-1b"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+	}
+
+	groups["node-2"] = &CloudInstanceGroup{
+		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[1].AutoScalingGroupName),
+		asg:     asgGroups.AutoScalingGroups[1],
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "node-2",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleNode,
+			},
+		},
+		Ready: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-2a"),
+				},
+				Node: &v1.Node{},
+			},
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-2b"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+	}
+
+	groups["master-1"] = &CloudInstanceGroup{
+		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[2].AutoScalingGroupName),
+		asg:     asgGroups.AutoScalingGroups[2],
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "master-1",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleMaster,
+			},
+		},
+		Ready: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("master-1a"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+	}
+
+	groups["bastion-1"] = &CloudInstanceGroup{
+		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[3].AutoScalingGroupName),
+		asg:     asgGroups.AutoScalingGroups[3],
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "bastion-1",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleBastion,
+			},
+		},
+		Ready: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("bastion-1a"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+	}
+
+	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	if err != nil {
+		t.Errorf("Error on rolling update: %v", err)
+	}
+
+	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("node-1")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) != 2 {
+			t.Errorf("Expected 2 instances got: %v", len(group.Instances))
+		}
+	}
+
+	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("node-2")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) != 2 {
+			t.Errorf("Expected 2 instances got: %v", len(group.Instances))
+		}
+	}
+
+	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("master-1")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) != 1 {
+			t.Errorf("Expected 1 instances got: %v", len(group.Instances))
+		}
+	}
+
+	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("bastion-1")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) != 1 {
+			t.Errorf("Expected 1 instances got: %v", len(group.Instances))
+		}
+	}
+}
+
+func TestRollingUpdateNoneNeedUpdateWithForce(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+
+	mockcloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
+	mockcloud.MockAutoscaling = &mockautoscaling.MockAutoscaling{}
+
+	c := &RollingUpdateCluster{
+		Cloud:           mockcloud,
+		MasterInterval:  1 * time.Millisecond,
+		NodeInterval:    1 * time.Millisecond,
+		BastionInterval: 1 * time.Millisecond,
+		Force:           true,
+		K8sClient:       k8sClient,
+	}
+	cloud := c.Cloud.(awsup.AWSCloud)
+	setUpCloud(c)
+
+	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+
+	groups := make(map[string]*CloudInstanceGroup)
+	groups["node-1"] = &CloudInstanceGroup{
+		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[0].AutoScalingGroupName),
+		asg:     asgGroups.AutoScalingGroups[0],
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "node-1",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleNode,
+			},
+		},
+		Ready: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-1a"),
+				},
+				Node: &v1.Node{},
+			},
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-1b"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+	}
+
+	groups["node-2"] = &CloudInstanceGroup{
+		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[1].AutoScalingGroupName),
+		asg:     asgGroups.AutoScalingGroups[1],
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "node-2",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleNode,
+			},
+		},
+		Ready: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-2a"),
+				},
+				Node: &v1.Node{},
+			},
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-2b"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+	}
+
+	groups["master-1"] = &CloudInstanceGroup{
+		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[2].AutoScalingGroupName),
+		asg:     asgGroups.AutoScalingGroups[2],
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "master-1",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleMaster,
+			},
+		},
+		Ready: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("master-1a"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+	}
+
+	groups["bastion-1"] = &CloudInstanceGroup{
+		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[3].AutoScalingGroupName),
+		asg:     asgGroups.AutoScalingGroups[3],
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "bastion-1",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleBastion,
+			},
+		},
+		Ready: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("bastion-1a"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+	}
+
+	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	if err != nil {
+		t.Errorf("Error on rolling update: %v", err)
+	}
+
+	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) > 0 {
+			t.Error("Not all instances terminated")
+		}
+	}
+}
+
+func TestRollingUpdateEmptyGroup(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+
+	mockcloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
+	mockcloud.MockAutoscaling = &mockautoscaling.MockAutoscaling{}
+
+	c := &RollingUpdateCluster{
+		Cloud:           mockcloud,
+		MasterInterval:  1 * time.Millisecond,
+		NodeInterval:    1 * time.Millisecond,
+		BastionInterval: 1 * time.Millisecond,
+		K8sClient:       k8sClient,
+		Force:           false,
+	}
+	cloud := c.Cloud.(awsup.AWSCloud)
+	setUpCloud(c)
+
+	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+	groups := make(map[string]*CloudInstanceGroup)
+
+	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	if err != nil {
+		t.Errorf("Error on rolling update: %v", err)
+	}
+
+	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("node-1")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) != 2 {
+			t.Errorf("Expected 2 instances got: %v", len(group.Instances))
+		}
+	}
+
+	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("node-2")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) != 2 {
+			t.Errorf("Expected 2 instances got: %v", len(group.Instances))
+		}
+	}
+
+	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("master-1")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) != 1 {
+			t.Errorf("Expected 1 instances got: %v", len(group.Instances))
+		}
+	}
+
+	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("bastion-1")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) != 1 {
+			t.Errorf("Expected 1 instances got: %v", len(group.Instances))
+		}
+	}
+}
+
+func TestRollingUpdateUnknownRole(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+
+	mockcloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
+	mockcloud.MockAutoscaling = &mockautoscaling.MockAutoscaling{}
+
+	c := &RollingUpdateCluster{
+		Cloud:           mockcloud,
+		MasterInterval:  1 * time.Millisecond,
+		NodeInterval:    1 * time.Millisecond,
+		BastionInterval: 1 * time.Millisecond,
+		Force:           false,
+		K8sClient:       k8sClient,
+	}
+	cloud := c.Cloud.(awsup.AWSCloud)
+	setUpCloud(c)
+
+	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+
+	groups := make(map[string]*CloudInstanceGroup)
+	groups["node-1"] = &CloudInstanceGroup{
+		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[0].AutoScalingGroupName),
+		asg:     asgGroups.AutoScalingGroups[0],
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "node-1",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: "Unknown",
+			},
+		},
+		Ready: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-1a"),
+				},
+				Node: &v1.Node{},
+			},
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-1b"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+	}
+
+	groups["node-2"] = &CloudInstanceGroup{
+		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[1].AutoScalingGroupName),
+		asg:     asgGroups.AutoScalingGroups[1],
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "node-2",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleNode,
+			},
+		},
+		Ready: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-2a"),
+				},
+				Node: &v1.Node{},
+			},
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("node-2b"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+	}
+
+	groups["master-1"] = &CloudInstanceGroup{
+		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[2].AutoScalingGroupName),
+		asg:     asgGroups.AutoScalingGroups[2],
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "master-1",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleMaster,
+			},
+		},
+		Ready: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("master-1a"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+	}
+
+	groups["bastion-1"] = &CloudInstanceGroup{
+		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[3].AutoScalingGroupName),
+		asg:     asgGroups.AutoScalingGroups[3],
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "bastion-1",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleBastion,
+			},
+		},
+		Ready: []*CloudInstanceGroupInstance{
+			{
+				ASGInstance: &autoscaling.Instance{
+					InstanceId: aws.String("bastion-1a"),
+				},
+				Node: &v1.Node{},
+			},
+		},
+	}
+
+	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	if err == nil {
+		t.Errorf("Error expected on rolling update: %v", err)
+	}
+
+	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("node-1")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) != 2 {
+			t.Errorf("Expected 2 instances got: %v", len(group.Instances))
+		}
+	}
+
+	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("node-2")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) != 2 {
+			t.Errorf("Expected 2 instances got: %v", len(group.Instances))
+		}
+	}
+
+	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("master-1")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) != 1 {
+			t.Errorf("Expected 1 instances got: %v", len(group.Instances))
+		}
+	}
+
+	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("bastion-1")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) != 1 {
+			t.Errorf("Expected 1 instances got: %v", len(group.Instances))
+		}
+	}
+}


### PR DESCRIPTION
Addresses https://github.com/kubernetes/kops/issues/1761 and should help with https://github.com/kubernetes/kops/pull/1134.

I'm not sure how portable it would be with @chrislovecnm's PR. Stuck on how we would mock the validate/drain logic.  We could record the # of drains the fake client did, but the validation part assumes that the cloud provider replaced any terminated nodes (right?). Alternatively we can assume validation always passes (since it has its own unit tests) and just make sure the # of drains and  terminated instances line up.

Anyways, wanted to put my progress up for the time being. If it blocks progress on the other PR I'm open to wait for it to go in and modify tests afterwards 😃

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1875)
<!-- Reviewable:end -->
