### PR TITLE
Add support for adjusting ELB idle timeout for apiserver

### DIFF
--- a/docs/bastion.md
+++ b/docs/bastion.md
@@ -49,7 +49,7 @@ If you do not want the bastion instance group created at all, simply drop the `-
 
 ### Using a public CNAME to access your bastion
 
-By default the bastion instance group will create a public CNAME alias that will point to the bastion ELB. 
+By default the bastion instance group will create a public CNAME alias that will point to the bastion ELB.
 
 The default bastion name is `bastion.$NAME` as in
 
@@ -105,7 +105,7 @@ spec:
       idleTimeoutSeconds: 1200
 ```
 
-Where the maximum value is 1200 seconds (20 minutes) allowed by AWS. [More information](http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-idle-timeout.html)
+Where the maximum value is 3600 seconds (60 minutes) allowed by AWS. For more information see [configuring idle timeouts](http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-idle-timeout.html).
 
 ### Using the bastion
 
@@ -113,7 +113,7 @@ Once your cluster is setup and you need to SSH into the bastion you can access a
 
 ```bash
 # Verify you have an SSH agent running. This should match whatever you built your cluster with.
-ssh-add -l 
+ssh-add -l
 # If you need to add an agent
 ssh-add path/to/public/key
 

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -24,11 +24,15 @@ spec:
 When configuring a LoadBalancer, you can also choose to have a public ELB or an internal (VPC only) ELB.  The `type`
 field should be `Public` or `Internal`.
 
+Additionally, you can increase idle timeout of the load balancer by setting its `idleTimeoutSeconds`. The default idle timeout is 5 minutes, with a maximum of 1200 seconds (20 minutes) being allowed by AWS.
+For more information see [configuring idle timeouts](http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-idle-timeout.html).
+
 ```yaml
 spec:
   api:
     loadBalancer:
       type: Public
+      idleTimeoutSeconds: 300
 ```
 
 ### sshAccess

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -24,7 +24,7 @@ spec:
 When configuring a LoadBalancer, you can also choose to have a public ELB or an internal (VPC only) ELB.  The `type`
 field should be `Public` or `Internal`.
 
-Additionally, you can increase idle timeout of the load balancer by setting its `idleTimeoutSeconds`. The default idle timeout is 5 minutes, with a maximum of 1200 seconds (20 minutes) being allowed by AWS.
+Additionally, you can increase idle timeout of the load balancer by setting its `idleTimeoutSeconds`. The default idle timeout is 5 minutes, with a maximum of 3600 seconds (60 minutes) being allowed by AWS.
 For more information see [configuring idle timeouts](http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-idle-timeout.html).
 
 ```yaml
@@ -67,7 +67,7 @@ ID of a subnet to share in an existing VPC.
 #### egress
 The resource identifier (ID) of something in your existing VPC that you would like to use as "egress" to the outside world.
 
-This feature was originally envisioned to allow re-use of NAT Gateways. In this case, the usage is as follows. Although NAT gateways are "public"-facing resources, in the Cluster spec, you must specify them in the private subnet section. One way to think about this is that you are specifying "egress", which is the default route out from this private subnet. 
+This feature was originally envisioned to allow re-use of NAT Gateways. In this case, the usage is as follows. Although NAT gateways are "public"-facing resources, in the Cluster spec, you must specify them in the private subnet section. One way to think about this is that you are specifying "egress", which is the default route out from this private subnet.
 
 ```
 spec:

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -260,7 +260,8 @@ const (
 )
 
 type LoadBalancerAccessSpec struct {
-	Type LoadBalancerType `json:"type,omitempty"`
+	Type               LoadBalancerType `json:"type,omitempty"`
+	IdleTimeoutSeconds *int64           `json:"idleTimeoutSeconds,omitempty"`
 }
 
 type KubeDNSConfig struct {

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -258,7 +258,8 @@ const (
 )
 
 type LoadBalancerAccessSpec struct {
-	Type LoadBalancerType `json:"type,omitempty"`
+	Type               LoadBalancerType `json:"type,omitempty"`
+	IdleTimeoutSeconds *int64           `json:"idleTimeoutSeconds,omitempty"`
 }
 
 type KubeDNSConfig struct {

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1318,6 +1318,7 @@ func Convert_kops_LeaderElectionConfiguration_To_v1alpha1_LeaderElectionConfigur
 
 func autoConvert_v1alpha1_LoadBalancerAccessSpec_To_kops_LoadBalancerAccessSpec(in *LoadBalancerAccessSpec, out *kops.LoadBalancerAccessSpec, s conversion.Scope) error {
 	out.Type = kops.LoadBalancerType(in.Type)
+	out.IdleTimeoutSeconds = in.IdleTimeoutSeconds
 	return nil
 }
 
@@ -1327,6 +1328,7 @@ func Convert_v1alpha1_LoadBalancerAccessSpec_To_kops_LoadBalancerAccessSpec(in *
 
 func autoConvert_kops_LoadBalancerAccessSpec_To_v1alpha1_LoadBalancerAccessSpec(in *kops.LoadBalancerAccessSpec, out *LoadBalancerAccessSpec, s conversion.Scope) error {
 	out.Type = LoadBalancerType(in.Type)
+	out.IdleTimeoutSeconds = in.IdleTimeoutSeconds
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -178,7 +178,8 @@ const (
 )
 
 type LoadBalancerAccessSpec struct {
-	Type LoadBalancerType `json:"type,omitempty"`
+	Type               LoadBalancerType `json:"type,omitempty"`
+	IdleTimeoutSeconds *int64           `json:"idleTimeoutSeconds,omitempty"`
 }
 
 type KubeDNSConfig struct {

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1416,6 +1416,7 @@ func Convert_kops_LeaderElectionConfiguration_To_v1alpha2_LeaderElectionConfigur
 
 func autoConvert_v1alpha2_LoadBalancerAccessSpec_To_kops_LoadBalancerAccessSpec(in *LoadBalancerAccessSpec, out *kops.LoadBalancerAccessSpec, s conversion.Scope) error {
 	out.Type = kops.LoadBalancerType(in.Type)
+	out.IdleTimeoutSeconds = in.IdleTimeoutSeconds
 	return nil
 }
 
@@ -1425,6 +1426,7 @@ func Convert_v1alpha2_LoadBalancerAccessSpec_To_kops_LoadBalancerAccessSpec(in *
 
 func autoConvert_kops_LoadBalancerAccessSpec_To_v1alpha2_LoadBalancerAccessSpec(in *kops.LoadBalancerAccessSpec, out *LoadBalancerAccessSpec, s conversion.Scope) error {
 	out.Type = LoadBalancerType(in.Type)
+	out.IdleTimeoutSeconds = in.IdleTimeoutSeconds
 	return nil
 }
 

--- a/tests/integration/privatecalico/kubernetes.tf
+++ b/tests/integration/privatecalico/kubernetes.tf
@@ -139,6 +139,8 @@ resource "aws_elb" "api-privatecalico-example-com" {
     timeout             = 5
   }
 
+  idle_timeout = 300
+
   tags = {
     KubernetesCluster = "privatecalico.example.com"
     Name              = "api.privatecalico.example.com"

--- a/tests/integration/privatecanal/kubernetes.tf
+++ b/tests/integration/privatecanal/kubernetes.tf
@@ -139,6 +139,8 @@ resource "aws_elb" "api-privatecanal-example-com" {
     timeout             = 5
   }
 
+  idle_timeout = 300
+
   tags = {
     KubernetesCluster = "privatecanal.example.com"
     Name              = "api.privatecanal.example.com"

--- a/tests/integration/privateflannel/kubernetes.tf
+++ b/tests/integration/privateflannel/kubernetes.tf
@@ -139,6 +139,8 @@ resource "aws_elb" "api-privateflannel-example-com" {
     timeout             = 5
   }
 
+  idle_timeout = 300
+
   tags = {
     KubernetesCluster = "privateflannel.example.com"
     Name              = "api.privateflannel.example.com"

--- a/tests/integration/privateweave/kubernetes.tf
+++ b/tests/integration/privateweave/kubernetes.tf
@@ -139,6 +139,8 @@ resource "aws_elb" "api-privateweave-example-com" {
     timeout             = 5
   }
 
+  idle_timeout = 300
+
   tags = {
     KubernetesCluster = "privateweave.example.com"
     Name              = "api.privateweave.example.com"


### PR DESCRIPTION
Addresses https://github.com/kubernetes/kops/issues/1883 by adding an `idleTimeoutSeconds` to the `api.loadBalancer` in the cluster spec:
```yaml
spec:
  api:
    loadBalancer:
      type: Public
      idleTimeoutSeconds: 600 # I'd like it a bit longer than the default
```

The default timeout value is 5 minutes, and can be adjusted by editing the cluster spec.

* [x] Add documentation
* [x] Ensure tests pass locally

P.S. First time contributor, let me know if I've missed something.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1886)
<!-- Reviewable:end -->
