### PR TITLE
Added documentation on downloading the kops spec config file

### DIFF
--- a/docs/download_config.md
+++ b/docs/download_config.md
@@ -1,0 +1,41 @@
+# Download kops config spec file
+KOPS operates off of a config spec file that is generated during the create phase.  It is uploaded to the amazon s3 bucket that is passed in during create.
+
+If you download the config spec file on a running cluster that is configured the way you like it, you can just pass that config spec file in to the create command and have kops create the cluster for you , `kops create -f spec_file` in a completely unattended manor.
+
+## How to download the config spec file.
+Let's say you create your cluster with the following configuration options:
+
+```
+declare -x KOPS_STATE_STORE=s3://k8s-us-west
+declare -x CLOUD=aws
+declare -x ZONE="us-west-1a"
+declare -x MASTER_ZONES="us-west-1a"
+declare -x NAME=westtest.c.foo.com
+declare -x K8S_VERSION=1.4.6
+declare -x NETWORKCIDER="10.240.0.0/16"
+declare -x MASTER_SIZE="t2.medium"
+declare -x WORKER_SIZE="t2.large"
+```
+Next you call the kops command to create the cluster in your terminal:
+
+```
+  kops create cluster $NAME       \
+    --cloud=$CLOUD                      \
+    --zones="$ZONE"                     \
+    --kubernetes-version=$K8S_VERSION   \
+    --master-zones="$MASTER_ZONES"       \
+    --node-count=3                      \
+    --node-size="$WORKER_SIZE"          \
+    --master-size="$MASTER_SIZE"        \
+    --network-cidr=${NETWORKCIDER}      \
+    --dns-zone=ZVO7KL181S5AP \
+    --ssh-public-key=/Users/foo/.ssh/lab_no_password.pub
+```
+
+Your spec file will be located in your s3 bucket, in the location `s3://k8s-us-west/$NAME/config`.  Using the above as an example the config file is located at `s3://k8s-us-west/westtest.c.foo.com/config`
+
+To download this file via the aws cli you can use the aws s3 copy command.  Using the above cluster as an example the command would be
+
+`aws s3 cp $KOPS_STATE_STORE/$NAME/config ~/a_fun_name_you_will_remember.yml`  
+

--- a/docs/download_config.md
+++ b/docs/download_config.md
@@ -3,7 +3,8 @@ KOPS operates off of a config spec file that is generated during the create phas
 
 If you download the config spec file on a running cluster that is configured the way you like it, you can just pass that config spec file in to the create command and have kops create the cluster for you , `kops create -f spec_file` in a completely unattended manor.
 
-## How to download the config spec file.
+## How to download the config spec file. ( 2 possible ways )
+
 Let's say you create your cluster with the following configuration options:
 
 ```
@@ -33,9 +34,18 @@ Next you call the kops command to create the cluster in your terminal:
     --ssh-public-key=/Users/foo/.ssh/lab_no_password.pub
 ```
 
+### Method One - Kops command
+
+You can simply use the kops command `kops get cluster -o yaml > a_fun_name_you_will_remember.yml`
+
+Note: for the above command to work the cluster NAME and the KOPS_STATE_STORE will have to be exported in your environment.
+
+### Method Two - Manual method directly from s3
+
 Your spec file will be located in your s3 bucket, in the location `s3://k8s-us-west/$NAME/config`.  Using the above as an example the config file is located at `s3://k8s-us-west/westtest.c.foo.com/config`
 
 To download this file via the aws cli you can use the aws s3 copy command.  Using the above cluster as an example the command would be
 
-`aws s3 cp $KOPS_STATE_STORE/$NAME/config ~/a_fun_name_you_will_remember.yml`  
+`aws s3 cp $KOPS_STATE_STORE/$NAME/config ~/a_fun_name_you_will_remember.yml`
+
 


### PR DESCRIPTION
@kris-nova 
I wrote a quick little page on pulling the KOPS config spec down from the AWS s3 bucket.  Feel free to word smith it however you think is best.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1887)
<!-- Reviewable:end -->
