### PR TITLE
Bump Weave Net version to 1.9.0

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/v1.9.0.yaml
+++ b/upup/models/cloudup/resources/addons/networking.weave/v1.9.0.yaml
@@ -26,7 +26,7 @@ spec:
       hostPID: true
       containers:
         - name: weave
-          image: weaveworks/weave-kube:1.8.2
+          image: weaveworks/weave-kube:1.9.0
           command:
             - /home/weave/launch.sh
           livenessProbe:
@@ -41,16 +41,18 @@ spec:
             - name: weavedb
               mountPath: /weavedb
             - name: cni-bin
-              mountPath: /opt
+              mountPath: /host/opt
             - name: cni-bin2
-              mountPath: /host_home
+              mountPath: /host/home
             - name: cni-conf
-              mountPath: /etc
+              mountPath: /host/etc
+            - name: dbus
+              mountPath: /host/var/lib/dbus
           resources:
             requests:
               cpu: 10m
         - name: weave-npc
-          image: weaveworks/weave-npc:1.8.2
+          image: weaveworks/weave-npc:1.9.0
           resources:
             requests:
               cpu: 10m
@@ -69,3 +71,6 @@ spec:
         - name: cni-conf
           hostPath:
             path: /etc
+        - name: dbus
+          hostPath:
+            path: /var/lib/dbus

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -175,7 +175,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Weave != nil {
 		key := "networking.weave"
-		version := "1.8.2"
+		version := "1.9.0"
 
 		// TODO: Create configuration object for cni providers (maybe create it but orphan it)?
 		location := key + "/v" + version + ".yaml"


### PR DESCRIPTION
Weave Net Version 1.9 has optional IPSec encryption, is built for ARM as well as AMD64, and fixes quite a few issues.
Release notes https://github.com/weaveworks/weave/releases/tag/v1.9.0

I followed #1250 for the version number changes; the volume-mount changes are required by internal changes in Weave Net

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1893)
<!-- Reviewable:end -->
