### PR TITLE
Run Weave Net in Guaranteed Quality of Service

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/v1.9.0.yaml
+++ b/upup/models/cloudup/resources/addons/networking.weave/v1.9.0.yaml
@@ -50,12 +50,20 @@ spec:
               mountPath: /host/var/lib/dbus
           resources:
             requests:
-              cpu: 10m
+              cpu: 100m
+              memory: 200Mi
+            limits:
+              cpu: 100m
+              memory: 200Mi
         - name: weave-npc
           image: weaveworks/weave-npc:1.9.0
           resources:
             requests:
-              cpu: 10m
+              cpu: 100m
+              memory: 200Mi
+            limits:
+              cpu: 100m
+              memory: 200Mi
           securityContext:
             privileged: true
       restartPolicy: Always

--- a/upup/models/cloudup/resources/addons/networking.weave/v1.9.0.yaml
+++ b/upup/models/cloudup/resources/addons/networking.weave/v1.9.0.yaml
@@ -26,7 +26,7 @@ spec:
       hostPID: true
       containers:
         - name: weave
-          image: weaveworks/weave-kube:1.8.2
+          image: weaveworks/weave-kube:1.9.0
           command:
             - /home/weave/launch.sh
           livenessProbe:
@@ -41,16 +41,18 @@ spec:
             - name: weavedb
               mountPath: /weavedb
             - name: cni-bin
-              mountPath: /opt
+              mountPath: /host/opt
             - name: cni-bin2
-              mountPath: /host_home
+              mountPath: /host/home
             - name: cni-conf
-              mountPath: /etc
+              mountPath: /host/etc
+            - name: dbus
+              mountPath: /host/var/lib/dbus
           resources:
             requests:
               cpu: 10m
         - name: weave-npc
-          image: weaveworks/weave-npc:1.8.2
+          image: weaveworks/weave-npc:1.9.0
           resources:
             requests:
               cpu: 10m
@@ -69,3 +71,6 @@ spec:
         - name: cni-conf
           hostPath:
             path: /etc
+        - name: dbus
+          hostPath:
+            path: /var/lib/dbus

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -175,7 +175,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Weave != nil {
 		key := "networking.weave"
-		version := "1.8.2"
+		version := "1.9.0"
 
 		// TODO: Create configuration object for cni providers (maybe create it but orphan it)?
 		location := key + "/v" + version + ".yaml"


### PR DESCRIPTION
Per [the resource QOS doc](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-qos.md) we want to set the `limits` and `requests` to the same value in order to run with `Guaranteed` QOS.  It is super-pointless for Kubernetes to evict the network pod in favour of anything else.

100milli-cpus and 200MB RAM should be OK for most clusters, but will be too high to fit on small nodes (particularly on master).  There doesn't seem to be a clean way out of that; would you consider having a "small node" config as an option?

At the other end of the scale, there must be some number of nodes and pods which makes the memory usage go above 200MB.

Note this branch includes the commits from #1893 to bump the version - I did it this way to avoid creating a manual merge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1894)
<!-- Reviewable:end -->
