### PR TITLE
Tag 1.5.2-beta.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ifndef VERSION
   # We expect that if you are uploading nodeup/protokube, you will set
   # VERSION (along with S3_BUCKET), either directly or by setting CI=1
   ifndef CI
-    VERSION=1.5.1
+    VERSION=1.5.2-beta.1
   else
     VERSION := git-${GITSHA}
   endif


### PR DESCRIPTION
The CoreOS changes need a new nodeup; easiest way is probably to tag a
beta of the next release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1905)
<!-- Reviewable:end -->
