### PR TITLE
dns-controller: include namespace in keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GOVERSION=1.7.4
 MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))
 
 # Keep in sync with upup/models/cloudup/resources/addons/dns-controller/
-DNS_CONTROLLER_TAG=1.5.1
+DNS_CONTROLLER_TAG=1.5.2
 
 GITSHA := $(shell cd ${GOPATH_1ST}/src/k8s.io/kops; git describe --always)
 
@@ -214,13 +214,13 @@ nodeup-dist:
 	(sha1sum .build/dist/nodeup | cut -d' ' -f1) > .build/dist/nodeup.sha1
 
 dns-controller-gocode:
-	go install k8s.io/kops/dns-controller/cmd/dns-controller
+	go install -ldflags "${EXTRA_LDFLAGS} -X main.BuildVersion=${DNS_CONTROLLER_TAG}" k8s.io/kops/dns-controller/cmd/dns-controller
 
 dns-controller-builder-image:
 	docker build -t dns-controller-builder images/dns-controller-builder
 
 dns-controller-build-in-docker: dns-controller-builder-image
-	docker run -t -e VERSION=${VERSION} -v `pwd`:/src dns-controller-builder /onbuild.sh
+	docker run -t -v `pwd`:/src dns-controller-builder /onbuild.sh
 
 dns-controller-image: dns-controller-build-in-docker
 	docker build -t ${DOCKER_REGISTRY}/dns-controller:${DNS_CONTROLLER_TAG}  -f images/dns-controller/Dockerfile .

--- a/dns-controller/cmd/dns-controller/main.go
+++ b/dns-controller/cmd/dns-controller/main.go
@@ -18,6 +18,9 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"os"
+
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 	"k8s.io/kops/dns-controller/pkg/dns"
@@ -26,7 +29,6 @@ import (
 	client "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/core/v1"
 	client_extensions "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/extensions/v1beta1"
 	kubectl_util "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	"os"
 
 	_ "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/aws/route53"
 	_ "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns"
@@ -34,9 +36,14 @@ import (
 
 var (
 	flags = pflag.NewFlagSet("", pflag.ExitOnError)
+
+	// value overwritten during build. This can be used to resolve issues.
+	BuildVersion = "0.1"
 )
 
 func main() {
+	fmt.Printf("dns-controller version %s\n", BuildVersion)
+
 	dnsProviderId := "aws-route53"
 	flags.StringVar(&dnsProviderId, "dns", dnsProviderId, "DNS provider we should use (aws-route53, google-clouddns)")
 

--- a/dns-controller/pkg/watchers/ingresscontroller.go
+++ b/dns-controller/pkg/watchers/ingresscontroller.go
@@ -110,7 +110,7 @@ func (c *IngressController) runWatcher(stopCh <-chan struct{}) {
 					c.updateIngressRecords(ingress)
 
 				case watch.Deleted:
-					c.scope.Replace(ingress.Name, nil)
+					c.scope.Replace(ingress.Namespace+"/"+ingress.Name, nil)
 
 				default:
 					glog.Warningf("Unknown event type: %v", event.Type)
@@ -167,5 +167,5 @@ func (c *IngressController) updateIngressRecords(ingress *v1beta1.Ingress) {
 		}
 	}
 
-	c.scope.Replace(ingress.Name, records)
+	c.scope.Replace(ingress.Namespace+"/"+ingress.Name, records)
 }

--- a/dns-controller/pkg/watchers/nodecontroller.go
+++ b/dns-controller/pkg/watchers/nodecontroller.go
@@ -112,7 +112,7 @@ func (c *NodeController) runWatcher(stopCh <-chan struct{}) {
 					c.updateNodeRecords(node)
 
 				case watch.Deleted:
-					c.scope.Replace(node.Name, nil)
+					c.scope.Replace( /* no namespace for nodes */ node.Name, nil)
 				}
 			}
 		}
@@ -236,5 +236,5 @@ func (c *NodeController) updateNodeRecords(node *v1.Node) {
 		}
 	}
 
-	c.scope.Replace(node.Name, records)
+	c.scope.Replace( /* no namespace for nodes */ node.Name, records)
 }

--- a/dns-controller/pkg/watchers/podcontroller.go
+++ b/dns-controller/pkg/watchers/podcontroller.go
@@ -110,7 +110,7 @@ func (c *PodController) runWatcher(stopCh <-chan struct{}) {
 					c.updatePodRecords(pod)
 
 				case watch.Deleted:
-					c.scope.Replace(pod.Name, nil)
+					c.scope.Replace(pod.Namespace+"/"+pod.Name, nil)
 
 				default:
 					glog.Warningf("Unknown event type: %v", event.Type)
@@ -191,5 +191,5 @@ func (c *PodController) updatePodRecords(pod *v1.Pod) {
 		glog.V(4).Infof("Pod %q did not have %s label", pod.Name, AnnotationNameDnsInternal)
 	}
 
-	c.scope.Replace(pod.Name, records)
+	c.scope.Replace(pod.Namespace+"/"+pod.Name, records)
 }

--- a/dns-controller/pkg/watchers/servicecontroller.go
+++ b/dns-controller/pkg/watchers/servicecontroller.go
@@ -111,7 +111,7 @@ func (c *ServiceController) runWatcher(stopCh <-chan struct{}) {
 					c.updateServiceRecords(service)
 
 				case watch.Deleted:
-					c.scope.Replace(service.Name, nil)
+					c.scope.Replace(service.Namespace+"/"+service.Name, nil)
 
 				default:
 					glog.Warningf("Unknown event type: %v", event.Type)
@@ -205,5 +205,5 @@ func (c *ServiceController) updateServiceRecords(service *v1.Service) {
 		glog.V(8).Infof("Service %s/%s did not have %s annotation", service.Namespace, service.Name, AnnotationNameDnsExternal)
 	}
 
-	c.scope.Replace(service.Name, records)
+	c.scope.Replace(service.Namespace+"/"+service.Name, records)
 }


### PR DESCRIPTION
Avoids collisions when two services are named the same (for example).

Fix #1788

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1923)
<!-- Reviewable:end -->
