### PR TITLE
Allow InstanceGroups to override Kubelet config

### DIFF
--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -18,6 +18,7 @@ package kops
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/meta/v1"
@@ -89,6 +90,9 @@ type InstanceGroupSpec struct {
 
 	// NodeLabels indicates the kubernetes labels for nodes in this group
 	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
+
+	// Kubelet overrides kubelet config from the ClusterSpec
+	Kubelet *KubeletConfigSpec `json:"kubelet,omitempty"`
 }
 
 // PerformAssignmentsInstanceGroups populates InstanceGroups with default values

--- a/pkg/apis/kops/kubeletconfig.go
+++ b/pkg/apis/kops/kubeletconfig.go
@@ -56,5 +56,9 @@ func BuildKubeletConfigSpec(cluster *Cluster, instanceGroup *InstanceGroup) (*Ku
 		c.NodeLabels[k] = v
 	}
 
+	if instanceGroup.Spec.Kubelet != nil {
+		utils.JsonMergeStruct(c, instanceGroup.Spec.Kubelet)
+	}
+
 	return c, nil
 }

--- a/pkg/apis/kops/kubeletconfig_test.go
+++ b/pkg/apis/kops/kubeletconfig_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kops
+
+import (
+	"testing"
+)
+
+func Test_InstanceGroupKubeletMerge(t *testing.T) {
+	var cluster = &Cluster{}
+	cluster.Spec.Kubelet = &KubeletConfigSpec{}
+	cluster.Spec.Kubelet.NvidiaGPUs = 0
+
+	var instanceGroup = &InstanceGroup{}
+	instanceGroup.Spec.Kubelet = &KubeletConfigSpec{}
+	instanceGroup.Spec.Kubelet.NvidiaGPUs = 1
+
+	var mergedKubeletSpec, err = BuildKubeletConfigSpec(cluster, instanceGroup)
+	if err != nil {
+		t.Error(err)
+	}
+	if mergedKubeletSpec == nil {
+		t.Error("Returned nil kubelet spec")
+	}
+
+	if mergedKubeletSpec.NvidiaGPUs != instanceGroup.Spec.Kubelet.NvidiaGPUs {
+		t.Errorf("InstanceGroup kubelet value (%d) should be reflected in merged output", instanceGroup.Spec.Kubelet.NvidiaGPUs)
+	}
+}


### PR DESCRIPTION
This allows the option of altering kubelet `DAEMON_ARGS` on a per-InstanceGroup basis. The core use case is currently the ability to maintain an InstanceGroup with `nvidiaGPUs` enabled without requiring the whole cluster to meet that requirement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1931)
<!-- Reviewable:end -->
