### PR TITLE
kubelet cgroup-root should be / for k8s 1.6

### DIFF
--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -17,10 +17,11 @@ limitations under the License.
 package components
 
 import (
+	"strings"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/loader"
-	"strings"
 )
 
 // KubeletOptionsBuilder adds options for kubelets
@@ -121,7 +122,7 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 
 	if cloudProvider == fi.CloudProviderAWS {
 		clusterSpec.Kubelet.CloudProvider = "aws"
-		clusterSpec.Kubelet.CgroupRoot = "docker"
+		clusterSpec.Kubelet.CgroupRoot = "/"
 
 		// Use the hostname from the AWS metadata service
 		clusterSpec.Kubelet.HostnameOverride = "@aws"


### PR DESCRIPTION
sig-node is deploying a new cgroup hierarchy to support per pod cgroups and enforcement of node alloctable.  to support that, the pods should not be a children of the container runtime.

see: https://github.com/kubernetes/kubernetes/pull/41349

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1944)
<!-- Reviewable:end -->
