### PR TITLE
Resolve DNS Hosted Zone ID while building IAM policy

### DIFF
--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -33,6 +33,7 @@ type KopsModelContext struct {
 	Cluster *kops.Cluster
 
 	Region         string
+	HostedZoneID   string // used to set up route53 IAM policy
 	InstanceGroups []*kops.InstanceGroup
 
 	SSHPublicKeys [][]byte

--- a/pkg/model/iam.go
+++ b/pkg/model/iam.go
@@ -157,9 +157,10 @@ func (b *IAMModelBuilder) Build(c *fi.ModelBuilderContext) error {
 // buildAWSIAMPolicy produces the AWS IAM policy for the given role
 func (b *IAMModelBuilder) buildAWSIAMPolicy(role kops.InstanceGroupRole) (string, error) {
 	pb := &iam.IAMPolicyBuilder{
-		Cluster: b.Cluster,
-		Role:    role,
-		Region:  b.Region,
+		Cluster:      b.Cluster,
+		Role:         role,
+		Region:       b.Region,
+		HostedZoneID: b.HostedZoneID,
 	}
 
 	policy, err := pb.BuildAWSIAMPolicy()

--- a/tests/integration/minimal/cloudformation.json
+++ b/tests/integration/minimal/cloudformation.json
@@ -552,6 +552,27 @@
             },
             {
               "Action": [
+                "elasticloadbalancing:*"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:SetDesiredCapacity",
+                "autoscaling:TerminateInstanceInAutoScalingGroup"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
                 "route53:ChangeResourceRecordSets",
                 "route53:ListResourceRecordSets",
                 "route53:GetHostedZone"
@@ -573,27 +594,6 @@
             {
               "Action": [
                 "route53:ListHostedZones"
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                "*"
-              ]
-            },
-            {
-              "Action": [
-                "elasticloadbalancing:*"
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                "*"
-              ]
-            },
-            {
-              "Action": [
-                "autoscaling:DescribeAutoScalingGroups",
-                "autoscaling:DescribeAutoScalingInstances",
-                "autoscaling:SetDesiredCapacity",
-                "autoscaling:TerminateInstanceInAutoScalingGroup"
               ],
               "Effect": "Allow",
               "Resource": [
@@ -627,6 +627,21 @@
             },
             {
               "Action": [
+                "ecr:GetAuthorizationToken",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:GetRepositoryPolicy",
+                "ecr:DescribeRepositories",
+                "ecr:ListImages",
+                "ecr:BatchGetImage"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
                 "route53:ChangeResourceRecordSets",
                 "route53:ListResourceRecordSets",
                 "route53:GetHostedZone"
@@ -648,21 +663,6 @@
             {
               "Action": [
                 "route53:ListHostedZones"
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                "*"
-              ]
-            },
-            {
-              "Action": [
-                "ecr:GetAuthorizationToken",
-                "ecr:BatchCheckLayerAvailability",
-                "ecr:GetDownloadUrlForLayer",
-                "ecr:GetRepositoryPolicy",
-                "ecr:DescribeRepositories",
-                "ecr:ListImages",
-                "ecr:BatchGetImage"
               ],
               "Effect": "Allow",
               "Resource": [

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -346,6 +346,11 @@ func (c *ApplyClusterCmd) Run() error {
 	if err != nil {
 		return err
 	}
+	dnszone, err := findZone(cluster, cloud)
+	if err != nil {
+		return err
+	}
+	modelContext.HostedZoneID = dnszone.ID()
 
 	clusterTags, err := buildCloudupTags(cluster)
 	if err != nil {


### PR DESCRIPTION
Fixes #1949 by resolving DNS Zone prior to running IAM builder.

Also small refactor to remove code duplication (thanks @yissachar )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1969)
<!-- Reviewable:end -->
