### PR TITLE
Only block etcd port from node -> master

### DIFF
--- a/tests/integration/minimal-141/kubernetes.tf
+++ b/tests/integration/minimal-141/kubernetes.tf
@@ -267,22 +267,31 @@ resource "aws_security_group_rule" "node-egress" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
-resource "aws_security_group_rule" "node-to-master-tcp-4194" {
+resource "aws_security_group_rule" "node-to-master-tcp-1-4000" {
   type                     = "ingress"
   security_group_id        = "${aws_security_group.masters-minimal-141-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-minimal-141-example-com.id}"
-  from_port                = 4194
-  to_port                  = 4194
+  from_port                = 1
+  to_port                  = 4000
   protocol                 = "tcp"
 }
 
-resource "aws_security_group_rule" "node-to-master-tcp-443" {
+resource "aws_security_group_rule" "node-to-master-tcp-4003-65535" {
   type                     = "ingress"
   security_group_id        = "${aws_security_group.masters-minimal-141-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-minimal-141-example-com.id}"
-  from_port                = 443
-  to_port                  = 443
+  from_port                = 4003
+  to_port                  = 65535
   protocol                 = "tcp"
+}
+
+resource "aws_security_group_rule" "node-to-master-udp-1-65535" {
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-minimal-141-example-com.id}"
+  source_security_group_id = "${aws_security_group.nodes-minimal-141-example-com.id}"
+  from_port                = 1
+  to_port                  = 65535
+  protocol                 = "udp"
 }
 
 resource "aws_security_group_rule" "ssh-external-to-master-0-0-0-0--0" {

--- a/tests/integration/minimal/cloudformation.json
+++ b/tests/integration/minimal/cloudformation.json
@@ -266,7 +266,7 @@
         "CidrIp": "0.0.0.0/0"
       }
     },
-    "AWSEC2SecurityGroupIngressnodetomastertcp4194": {
+    "AWSEC2SecurityGroupIngressnodetomastertcp14000": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
         "GroupId": {
@@ -275,12 +275,12 @@
         "SourceSecurityGroupId": {
           "Ref": "AWSEC2SecurityGroupnodesminimalexamplecom"
         },
-        "FromPort": 4194,
-        "ToPort": 4194,
+        "FromPort": 1,
+        "ToPort": 4000,
         "IpProtocol": "tcp"
       }
     },
-    "AWSEC2SecurityGroupIngressnodetomastertcp443": {
+    "AWSEC2SecurityGroupIngressnodetomastertcp400365535": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
         "GroupId": {
@@ -289,9 +289,23 @@
         "SourceSecurityGroupId": {
           "Ref": "AWSEC2SecurityGroupnodesminimalexamplecom"
         },
-        "FromPort": 443,
-        "ToPort": 443,
+        "FromPort": 4003,
+        "ToPort": 65535,
         "IpProtocol": "tcp"
+      }
+    },
+    "AWSEC2SecurityGroupIngressnodetomasterudp165535": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmastersminimalexamplecom"
+        },
+        "SourceSecurityGroupId": {
+          "Ref": "AWSEC2SecurityGroupnodesminimalexamplecom"
+        },
+        "FromPort": 1,
+        "ToPort": 65535,
+        "IpProtocol": "udp"
       }
     },
     "AWSEC2SecurityGroupIngresssshexternaltomaster00000": {

--- a/tests/integration/minimal/kubernetes.tf
+++ b/tests/integration/minimal/kubernetes.tf
@@ -267,22 +267,31 @@ resource "aws_security_group_rule" "node-egress" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
-resource "aws_security_group_rule" "node-to-master-tcp-4194" {
+resource "aws_security_group_rule" "node-to-master-tcp-1-4000" {
   type                     = "ingress"
   security_group_id        = "${aws_security_group.masters-minimal-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-minimal-example-com.id}"
-  from_port                = 4194
-  to_port                  = 4194
+  from_port                = 1
+  to_port                  = 4000
   protocol                 = "tcp"
 }
 
-resource "aws_security_group_rule" "node-to-master-tcp-443" {
+resource "aws_security_group_rule" "node-to-master-tcp-4003-65535" {
   type                     = "ingress"
   security_group_id        = "${aws_security_group.masters-minimal-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-minimal-example-com.id}"
-  from_port                = 443
-  to_port                  = 443
+  from_port                = 4003
+  to_port                  = 65535
   protocol                 = "tcp"
+}
+
+resource "aws_security_group_rule" "node-to-master-udp-1-65535" {
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-minimal-example-com.id}"
+  source_security_group_id = "${aws_security_group.nodes-minimal-example-com.id}"
+  from_port                = 1
+  to_port                  = 65535
+  protocol                 = "udp"
 }
 
 resource "aws_security_group_rule" "ssh-external-to-master-0-0-0-0--0" {

--- a/tests/integration/privatecalico/kubernetes.tf
+++ b/tests/integration/privatecalico/kubernetes.tf
@@ -535,40 +535,31 @@ resource "aws_security_group_rule" "node-to-master-protocol-ipip" {
   protocol                 = "4"
 }
 
-resource "aws_security_group_rule" "node-to-master-tcp-179" {
+resource "aws_security_group_rule" "node-to-master-tcp-1-4001" {
   type                     = "ingress"
   security_group_id        = "${aws_security_group.masters-privatecalico-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privatecalico-example-com.id}"
-  from_port                = 179
-  to_port                  = 179
-  protocol                 = "tcp"
-}
-
-resource "aws_security_group_rule" "node-to-master-tcp-4001" {
-  type                     = "ingress"
-  security_group_id        = "${aws_security_group.masters-privatecalico-example-com.id}"
-  source_security_group_id = "${aws_security_group.nodes-privatecalico-example-com.id}"
-  from_port                = 4001
+  from_port                = 1
   to_port                  = 4001
   protocol                 = "tcp"
 }
 
-resource "aws_security_group_rule" "node-to-master-tcp-4194" {
+resource "aws_security_group_rule" "node-to-master-tcp-4003-65535" {
   type                     = "ingress"
   security_group_id        = "${aws_security_group.masters-privatecalico-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privatecalico-example-com.id}"
-  from_port                = 4194
-  to_port                  = 4194
+  from_port                = 4003
+  to_port                  = 65535
   protocol                 = "tcp"
 }
 
-resource "aws_security_group_rule" "node-to-master-tcp-443" {
+resource "aws_security_group_rule" "node-to-master-udp-1-65535" {
   type                     = "ingress"
   security_group_id        = "${aws_security_group.masters-privatecalico-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privatecalico-example-com.id}"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
+  from_port                = 1
+  to_port                  = 65535
+  protocol                 = "udp"
 }
 
 resource "aws_security_group_rule" "ssh-elb-to-bastion" {

--- a/tests/integration/privatecanal/kubernetes.tf
+++ b/tests/integration/privatecanal/kubernetes.tf
@@ -526,22 +526,31 @@ resource "aws_security_group_rule" "node-egress" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
-resource "aws_security_group_rule" "node-to-master-tcp-4194" {
+resource "aws_security_group_rule" "node-to-master-tcp-1-4000" {
   type                     = "ingress"
   security_group_id        = "${aws_security_group.masters-privatecanal-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privatecanal-example-com.id}"
-  from_port                = 4194
-  to_port                  = 4194
+  from_port                = 1
+  to_port                  = 4000
   protocol                 = "tcp"
 }
 
-resource "aws_security_group_rule" "node-to-master-tcp-443" {
+resource "aws_security_group_rule" "node-to-master-tcp-4003-65535" {
   type                     = "ingress"
   security_group_id        = "${aws_security_group.masters-privatecanal-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privatecanal-example-com.id}"
-  from_port                = 443
-  to_port                  = 443
+  from_port                = 4003
+  to_port                  = 65535
   protocol                 = "tcp"
+}
+
+resource "aws_security_group_rule" "node-to-master-udp-1-65535" {
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.masters-privatecanal-example-com.id}"
+  source_security_group_id = "${aws_security_group.nodes-privatecanal-example-com.id}"
+  from_port                = 1
+  to_port                  = 65535
+  protocol                 = "udp"
 }
 
 resource "aws_security_group_rule" "ssh-elb-to-bastion" {

--- a/tests/integration/privateflannel/kubernetes.tf
+++ b/tests/integration/privateflannel/kubernetes.tf
@@ -526,30 +526,30 @@ resource "aws_security_group_rule" "node-egress" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
-resource "aws_security_group_rule" "node-to-master-tcp-4194" {
+resource "aws_security_group_rule" "node-to-master-tcp-1-4000" {
   type                     = "ingress"
   security_group_id        = "${aws_security_group.masters-privateflannel-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privateflannel-example-com.id}"
-  from_port                = 4194
-  to_port                  = 4194
+  from_port                = 1
+  to_port                  = 4000
   protocol                 = "tcp"
 }
 
-resource "aws_security_group_rule" "node-to-master-tcp-443" {
+resource "aws_security_group_rule" "node-to-master-tcp-4003-65535" {
   type                     = "ingress"
   security_group_id        = "${aws_security_group.masters-privateflannel-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privateflannel-example-com.id}"
-  from_port                = 443
-  to_port                  = 443
+  from_port                = 4003
+  to_port                  = 65535
   protocol                 = "tcp"
 }
 
-resource "aws_security_group_rule" "node-to-master-udp-8285" {
+resource "aws_security_group_rule" "node-to-master-udp-1-65535" {
   type                     = "ingress"
   security_group_id        = "${aws_security_group.masters-privateflannel-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privateflannel-example-com.id}"
-  from_port                = 8285
-  to_port                  = 8285
+  from_port                = 1
+  to_port                  = 65535
   protocol                 = "udp"
 }
 

--- a/tests/integration/privateweave/kubernetes.tf
+++ b/tests/integration/privateweave/kubernetes.tf
@@ -526,48 +526,30 @@ resource "aws_security_group_rule" "node-egress" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
-resource "aws_security_group_rule" "node-to-master-tcp-4194" {
+resource "aws_security_group_rule" "node-to-master-tcp-1-4000" {
   type                     = "ingress"
   security_group_id        = "${aws_security_group.masters-privateweave-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privateweave-example-com.id}"
-  from_port                = 4194
-  to_port                  = 4194
+  from_port                = 1
+  to_port                  = 4000
   protocol                 = "tcp"
 }
 
-resource "aws_security_group_rule" "node-to-master-tcp-443" {
+resource "aws_security_group_rule" "node-to-master-tcp-4003-65535" {
   type                     = "ingress"
   security_group_id        = "${aws_security_group.masters-privateweave-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privateweave-example-com.id}"
-  from_port                = 443
-  to_port                  = 443
+  from_port                = 4003
+  to_port                  = 65535
   protocol                 = "tcp"
 }
 
-resource "aws_security_group_rule" "node-to-master-tcp-6783" {
+resource "aws_security_group_rule" "node-to-master-udp-1-65535" {
   type                     = "ingress"
   security_group_id        = "${aws_security_group.masters-privateweave-example-com.id}"
   source_security_group_id = "${aws_security_group.nodes-privateweave-example-com.id}"
-  from_port                = 6783
-  to_port                  = 6783
-  protocol                 = "tcp"
-}
-
-resource "aws_security_group_rule" "node-to-master-udp-6783" {
-  type                     = "ingress"
-  security_group_id        = "${aws_security_group.masters-privateweave-example-com.id}"
-  source_security_group_id = "${aws_security_group.nodes-privateweave-example-com.id}"
-  from_port                = 6783
-  to_port                  = 6783
-  protocol                 = "udp"
-}
-
-resource "aws_security_group_rule" "node-to-master-udp-6784" {
-  type                     = "ingress"
-  security_group_id        = "${aws_security_group.masters-privateweave-example-com.id}"
-  source_security_group_id = "${aws_security_group.nodes-privateweave-example-com.id}"
-  from_port                = 6784
-  to_port                  = 6784
+  from_port                = 1
+  to_port                  = 65535
   protocol                 = "udp"
 }
 


### PR DESCRIPTION
Just block specific traffic from node -> master, rather than allowing all ports.

We _should_ block per port (this is less secure)... but:
 * It causes e2e tests to break
 * Users expect to be able to reach pods
 * If we are running an overlay, we allow all ports anyway

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1971)
<!-- Reviewable:end -->
