### PR TITLE
Allow node -> master on tcp 10255

### DIFF
--- a/pkg/model/firewall.go
+++ b/pkg/model/firewall.go
@@ -18,11 +18,12 @@ package model
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/golang/glog"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
-	"strconv"
 )
 
 type Protocol int
@@ -106,6 +107,9 @@ func (b *FirewallModelBuilder) applyNodeToMasterAllowSpecificPorts(c *fi.ModelBu
 
 	// allow cadvisor
 	tcpPorts = append(tcpPorts, 4194)
+
+	// kubelet read-only used by heapster
+	tcpPorts = append(tcpPorts, 10255)
 
 	if b.Cluster.Spec.Networking != nil {
 		if b.Cluster.Spec.Networking.Kopeio != nil {


### PR DESCRIPTION
This port serves the read-only kubelet api and is required by heapster

Fixes https://github.com/kubernetes/kops/issues/1821

Looks like this also has been fixed by https://github.com/kubernetes/kops/pull/1971, but I think it can't hurt to have the port added to `applyNodeToMasterAllowSpecificPorts` once kops switches back to per port white listening

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1973)
<!-- Reviewable:end -->
