### PR TITLE
Don't delete cloudformation stacks

### DIFF
--- a/upup/pkg/kutil/cluster_resources.go
+++ b/upup/pkg/kutil/cluster_resources.go
@@ -57,7 +57,8 @@ func (c *AwsCluster) ListResources() (map[string]*ResourceTracker, error) {
 	listFunctions := []listFn{
 
 		// CloudFormation
-		ListCloudFormationStacks,
+		// Note - temporarily disabled while we figure out how to filter these
+		// ListCloudFormationStacks,
 
 		// EC2
 		ListInstances,


### PR DESCRIPTION
Until we can figure out how to filter them to just our cluster, we can't
delete them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1989)
<!-- Reviewable:end -->
