### PR TITLE
Remove printf from delete cluster

### DIFF
--- a/upup/pkg/kutil/delete_cluster.go
+++ b/upup/pkg/kutil/delete_cluster.go
@@ -1418,7 +1418,7 @@ func FindNatGateways(cloud fi.Cloud, routeTableIds sets.String) ([]*ResourceTrac
 				for _, route := range rt.Routes {
 					if route.NatGatewayId != nil {
 						natGatewayIds.Insert(*route.NatGatewayId)
-						fmt.Printf("inserting %s to be deleted\n", *route.NatGatewayId)
+						glog.Infof("inserting %s to be deleted\n", *route.NatGatewayId)
 					}
 				}
 			}


### PR DESCRIPTION
This was breaking toolbox dump

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/1990)
<!-- Reviewable:end -->
