### PR TITLE
Updated machine_types.go for i3 instances

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/machine_types.go
+++ b/upup/pkg/fi/cloudup/awsup/machine_types.go
@@ -396,6 +396,50 @@ var MachineTypes []AWSMachineTypeInfo = []AWSMachineTypeInfo{
 		EphemeralDisks: []int{800, 800, 800, 800, 800, 800, 800, 800},
 	},
 
+	// i3 family
+	{
+		Name:           "i3.large",
+		MemoryGB:       15.25,
+		ECU:            9,
+		Cores:          2,
+		EphemeralDisks: []int{475},
+	},
+	{
+		Name:           "i3.xlarge",
+		MemoryGB:       30.5,
+		ECU:            14,
+		Cores:          4,
+		EphemeralDisks: []int{950},
+	},
+	{
+		Name:           "i3.2xlarge",
+		MemoryGB:       61,
+		ECU:            27,
+		Cores:          8,
+		EphemeralDisks: []int{1900},
+	},
+	{
+		Name:           "i3.4xlarge",
+		MemoryGB:       122,
+		ECU:            53,
+		Cores:          16,
+		EphemeralDisks: []int{1900, 1900},
+	},
+	{
+		Name:           "i3.8xlarge",
+		MemoryGB:       244,
+		ECU:            104,
+		Cores:          32,
+		EphemeralDisks: []int{1900, 1900, 1900, 1900},
+	},
+	{
+		Name:           "i3.16xlarge",
+		MemoryGB:       488,
+		ECU:            208,
+		Cores:          64,
+		EphemeralDisks: []int{1900, 1900, 1900, 1900, 1900, 1900, 1900, 1900},
+	},
+
 	// r3 family
 	{
 		Name:           "r3.large",


### PR DESCRIPTION
Closes #2006.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2007)
<!-- Reviewable:end -->
