### PR TITLE
use --kubeconfig on kubelet instead of --api-servers in post 1.6 clusters

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -186,6 +186,12 @@ func (b *KubeletBuilder) buildKubeconfig() (string, error) {
 		return "", fmt.Errorf("error encoding CA certificate: %v", err)
 	}
 
+	if b.IsMaster {
+		cluster.Server = "http://127.0.0.1:8080"
+	} else {
+		cluster.Server = "https://" + b.Cluster.Spec.MasterInternalName
+	}
+
 	config := &kubeconfig.KubectlConfig{
 		ApiVersion: "v1",
 		Kind:       "Config",

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -19,7 +19,14 @@ package kops
 import metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 
 type KubeletConfigSpec struct {
+	// not used for clusters version 1.6 and later
 	APIServers string `json:"apiServers,omitempty" flag:"api-servers"`
+
+	// kubeconfigPath is the path to the kubeconfig file with authorization
+	// information and API server location
+	// kops will only use this for clusters version 1.6 and later
+	KubeconfigPath    string `json:"kubeconfigPath,omitempty" flag:"kubeconfig"`
+	RequireKubeconfig *bool  `json:"requireKubeconfig,omitempty" flag:"require-kubeconfig"`
 
 	LogLevel *int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
 

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -19,7 +19,14 @@ package v1alpha1
 import metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 
 type KubeletConfigSpec struct {
+	// not used for clusters version 1.6 and later
 	APIServers string `json:"apiServers,omitempty" flag:"api-servers"`
+
+	// kubeconfigPath is the path to the kubeconfig file with authorization
+	// information and API server location
+	// kops will only use this for clusters version 1.6 and later
+	KubeconfigPath    string `json:"kubeconfigPath,omitempty" flag:"kubeconfig"`
+	RequireKubeconfig *bool  `json:"requireKubeconfig,omitempty" flag:"require-kubeconfig"`
 
 	LogLevel *int32 `json:"logLevel,omitempty" flag:"v"`
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -19,7 +19,14 @@ package v1alpha2
 import metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 
 type KubeletConfigSpec struct {
+	// not used for clusters version 1.6 and later
 	APIServers string `json:"apiServers,omitempty" flag:"api-servers"`
+
+	// kubeconfigPath is the path to the kubeconfig file with authorization
+	// information and API server location
+	// kops will only use this for clusters version 1.6 and later
+	KubeconfigPath    string `json:"kubeconfigPath,omitempty" flag:"kubeconfig"`
+	RequireKubeconfig *bool  `json:"requireKubeconfig,omitempty" flag:"require-kubeconfig"`
 
 	LogLevel *int32 `json:"logLevel,omitempty" flag:"v"`
 


### PR DESCRIPTION
`--api-servers` will be removed in 1.6 if https://github.com/kubernetes/kubernetes/pull/40050 goes in. The flag has been deprecated for 2 versions and over-complicates toggling standalone mode. API server locations should be provided via the kubeconfig file instead.

This also sets `--require-kubeconfig=true` when `--kubeconfig` is used, in case https://github.com/kubernetes/kubernetes/pull/40050 doesn't go in (since we are so close to the freeze). Due to an edge case (https://github.com/kubernetes/kubernetes/pull/40050#issuecomment-276569990) `--require-kubeconfig=true` must be set along with `--kubeconfig` in pre-40050 clusters for things to work properly. 