### PR TITLE
Adding equal resource requests/limits to flannel for guarenteed QoS

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.flannel/v0.7.0.yaml
+++ b/upup/models/cloudup/resources/addons/networking.flannel/v0.7.0.yaml
@@ -67,6 +67,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
         volumeMounts:
         - name: run
           mountPath: /run
@@ -75,6 +82,13 @@ spec:
       - name: install-cni
         image: quay.io/coreos/flannel:v0.7.0
         command: [ "/bin/sh", "-c", "set -e -x; cp -f /etc/kube-flannel/cni-conf.json /etc/cni/net.d/10-flannel.conf; while true; do sleep 3600; done" ]
+        resources:
+          limits:
+            cpu: 10m
+            memory: 25Mi
+          requests:
+            cpu: 10m
+            memory: 25Mi
         volumeMounts:
         - name: cni
           mountPath: /etc/cni/net.d


### PR DESCRIPTION
Pretty straightforward, [according to docs](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-qos.md) setting the resource limits and requests the same it guarentees QOS for the pod.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2010)
<!-- Reviewable:end -->
