### PR TITLE
WIP:  fix for ELB name collisions

### DIFF
--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/model/components"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
+	"k8s.io/kubernetes/pkg/util/rand"
 )
 
 type KopsModelContext struct {
@@ -55,9 +56,9 @@ func (m *KopsModelContext) GetELBName32(prefix string) (string, error) {
 	} else {
 		returnString = fmt.Sprintf("%s-%s", prefix, c)
 	}
-	if len(returnString) > 32 {
-		returnString = returnString[:32]
-	}
+
+	r := rand.String(6)
+	returnString = fmt.Sprintf("%.25s-%.6s", returnString, r)
 	return returnString, nil
 }
 


### PR DESCRIPTION
This is meant to address: https://github.com/kubernetes/kops/issues/1899

@kris-nova @chrislovecnm @yissachar: Let me know your thoughts on this. 

~~The only problem I'm running into is with the integration-test framework, which doesn't like non-determinism in names. For example, in TestPrivateCanal, I need to figure out how to get the generated name for the ELBs in to the expected kubernetes.tf file. I'm inclined to make the expected file a template and insert the generated name, but don't see an easy way to retrieve the generated name in the first place.~~

Edit: Feedback from @justinsb and @chrislovecnm from March 3 office hours:
- [ ] need to ensure we don't rename existing ELBs during updates
- [ ] use truncated hash instead of random strings. We want names deterministic.
- [ ] don't truncate names unless they exceed the 32 char limit.

To ensure backwards compatibility, I think we'll have to update the ELB Find() method to look for both truncated (eg api-foo) names, as well as whatever convention we settle on for this PR. When a result is found with the former, we'd also have to compare the KubernetesCluster tag, to confirm whether it is, in fact, the ELB we're looking for. Are there any uses cases that would miss?


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2019)
<!-- Reviewable:end -->
