### PR TITLE
Fix 1.6.0 validation

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -19,7 +19,7 @@ package kops
 import metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 
 type KubeletConfigSpec struct {
-	// not used for clusters version 1.6 and later
+	// not used for clusters version 1.6 and later - flag removed
 	APIServers string `json:"apiServers,omitempty" flag:"api-servers"`
 
 	// kubeconfigPath is the path to the kubeconfig file with authorization

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -37,6 +37,21 @@ func ValidateCluster(c *kops.Cluster, strict bool) error {
 
 	specPath := field.NewPath("Cluster").Child("Spec")
 
+	// kubernetesRelease is the version with only major & minor fields
+	var kubernetesRelease semver.Version
+
+	// KubernetesVersion
+	if c.Spec.KubernetesVersion == "" {
+		return field.Required(specField.Child("KubernetesVersion"), "")
+	} else {
+		sv, err := util.ParseKubernetesVersion(c.Spec.KubernetesVersion)
+		if err != nil {
+			return field.Invalid(specField.Child("KubernetesVersion"), c.Spec.KubernetesVersion, "unable to determine kubernetes version")
+		}
+
+		kubernetesRelease = semver.Version{Major: sv.Major, Minor: sv.Minor}
+	}
+
 	if c.ObjectMeta.Name == "" {
 		return field.Required(field.NewPath("Name"), "Cluster Name is required (e.g. --name=mycluster.myzone.com)")
 	}
@@ -281,9 +296,20 @@ func ValidateCluster(c *kops.Cluster, strict bool) error {
 	if c.Spec.Kubelet != nil {
 		kubeletPath := specPath.Child("Kubelet")
 
-		if strict && c.Spec.Kubelet.APIServers == "" {
-			return field.Required(kubeletPath.Child("APIServers"), "")
+		if kubernetesRelease.GTE(semver.MustParse("1.6.0")) {
+			// Flag removed in 1.6
+			if c.Spec.Kubelet.APIServers != "" {
+				return field.Invalid(
+					kubeletPath.Child("APIServers"),
+					c.Spec.Kubelet.APIServers,
+					"api-servers flag was removed in 1.6")
+			}
+		} else {
+			if strict && c.Spec.Kubelet.APIServers == "" {
+				return field.Required(kubeletPath.Child("APIServers"), "")
+			}
 		}
+
 		if c.Spec.Kubelet.APIServers != "" && !isValidAPIServersURL(c.Spec.Kubelet.APIServers) {
 			return field.Invalid(kubeletPath.Child("APIServers"), c.Spec.Kubelet.APIServers, "Not a valid APIServer URL")
 		}
@@ -293,9 +319,20 @@ func ValidateCluster(c *kops.Cluster, strict bool) error {
 	if c.Spec.MasterKubelet != nil {
 		masterKubeletPath := specPath.Child("MasterKubelet")
 
-		if strict && c.Spec.MasterKubelet.APIServers == "" {
-			return field.Required(masterKubeletPath.Child("APIServers"), "")
+		if kubernetesRelease.GTE(semver.MustParse("1.6.0")) {
+			// Flag removed in 1.6
+			if c.Spec.MasterKubelet.APIServers != "" {
+				return field.Invalid(
+					masterKubeletPath.Child("APIServers"),
+					c.Spec.MasterKubelet.APIServers,
+					"api-servers flag was removed in 1.6")
+			}
+		} else {
+			if strict && c.Spec.MasterKubelet.APIServers == "" {
+				return field.Required(masterKubeletPath.Child("APIServers"), "")
+			}
 		}
+
 		if c.Spec.MasterKubelet.APIServers != "" && !isValidAPIServersURL(c.Spec.MasterKubelet.APIServers) {
 			return field.Invalid(masterKubeletPath.Child("APIServers"), c.Spec.MasterKubelet.APIServers, "Not a valid APIServer URL")
 		}
@@ -366,21 +403,9 @@ func ValidateCluster(c *kops.Cluster, strict bool) error {
 		}
 	}
 
-	// KubernetesVersion
-	if c.Spec.KubernetesVersion == "" {
-		if strict {
-			return field.Required(specField.Child("KubernetesVersion"), "")
-		}
-	} else {
-		sv, err := util.ParseKubernetesVersion(c.Spec.KubernetesVersion)
-		if err != nil {
-			return field.Invalid(specField.Child("KubernetesVersion"), c.Spec.KubernetesVersion, "unable to determine kubernetes version")
-		}
-
-		if sv.GTE(semver.Version{Major: 1, Minor: 4}) {
-			if c.Spec.Networking != nil && c.Spec.Networking.Classic != nil {
-				return field.Invalid(specField.Child("Networking"), "classic", "classic networking is not supported with kubernetes versions 1.4 and later")
-			}
+	if kubernetesRelease.GTE(semver.MustParse("1.4.0")) {
+		if c.Spec.Networking != nil && c.Spec.Networking.Classic != nil {
+			return field.Invalid(specField.Child("Networking"), "classic", "classic networking is not supported with kubernetes versions 1.4 and later")
 		}
 	}
 

--- a/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
@@ -28,7 +28,7 @@ spec:
     - name: c
       zone: us-test-1c
     name: events
-  kubernetesVersion: v1.4.8
+  kubernetesVersion: v1.6.0-alpha.3
   masterPublicName: api.ha.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -57,7 +57,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -75,7 +75,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -93,7 +93,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1c
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -111,7 +111,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -28,7 +28,7 @@ spec:
     name: events
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.4.8
+  kubernetesVersion: v1.6.0-alpha.3
   masterPublicName: api.ha.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -65,7 +65,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -83,7 +83,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -101,7 +101,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1c
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -119,7 +119,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/ha/options.yaml
+++ b/tests/integration/create_cluster/ha/options.yaml
@@ -8,4 +8,4 @@ MasterZones:
 - us-test-1b
 - us-test-1c
 Cloud: aws
-KubernetesVersion: v1.4.8
+KubernetesVersion: v1.6.0-alpha.3


### PR DESCRIPTION
We were requiring API servers, but the apiserver flag is removed from
1.6.