### PR TITLE
Sanitize docker tag consistently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ ifndef VERSION
 endif
 
 # + is valid in semver, but not in docker tags. Fixup CI versions.
+# Note that this mirrors the logic in DefaultProtokubeImageName
 PROTOKUBE_TAG := $(subst +,-,${VERSION})
 
 # Go exports:

--- a/version.go
+++ b/version.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package kops
 
+import "strings"
+
 // This should be replaced by the makefile
 var Version = "1.5.0"
 
@@ -24,5 +26,8 @@ var GitVersion = ""
 
 // DefaultProtokubeImageName is the name of the protokube image, as we would pass to "docker run"
 func DefaultProtokubeImageName() string {
-	return "protokube:" + Version
+	// + is valid in semver, but not in docker tags.
+	// Note that this mirrors the logic in the makefile for PROTOKUBE_TAG.
+	dockerTag := strings.Replace(Version, "+", "-", -1)
+	return "protokube:" + dockerTag
 }


### PR DESCRIPTION
We need to use the same logic in the Makefile when we build the image,
and in kops when we reference the image.