### PR TITLE
Add kube-dns configmap

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/v1.6.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/v1.6.0.yaml.template
@@ -229,3 +229,11 @@ spec:
   - name: dns-tcp
     port: 53
     protocol: TCP
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-dns
+  namespace: kube-system


### PR DESCRIPTION
Optional volume mounting is not supported until we have kubectl 1.6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2037)
<!-- Reviewable:end -->
