### PR TITLE
Fix route53 mapper addon URL in docs

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -42,5 +42,5 @@ Automates creation and updating of entries on Route53 with `A` records pointing
 to ELB-backed `LoadBalancer` services created by Kubernetes. Install using:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/monitoring-standalone/v1.2.0.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/route53-mapper/v1.2.0.yml
 ```


### PR DESCRIPTION
Just fixing a slight error in the docs -- the URL for the route53 mapper yaml file was incorrect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2042)
<!-- Reviewable:end -->
