### PR TITLE
Fix outdated arg in dns-horizontal-autoscaler

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/v1.6.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/v1.6.0.yaml.template
@@ -41,12 +41,11 @@ spec:
           - /cluster-proportional-autoscaler
           - --namespace=kube-system
           - --configmap=kube-dns-autoscaler
-          - --mode=linear
           # Should keep target in sync with cluster/addons/dns/kubedns-controller.yaml.base
           - --target=Deployment/kube-dns
           # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
           # If using small nodes, "nodesPerReplica" should dominate.
-          - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"min":2}}
+          - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
           - --logtostderr=true
           - --v=2
 


### PR DESCRIPTION
From kubernetes/kubernetes#42461. Removes the deprecated flag for dns-horizontal-autoscaler.

@justinsb @bowei

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2044)
<!-- Reviewable:end -->
