### PR TITLE
Upgrade kubectl embedded in protokube to 1.6.0

### DIFF
--- a/images/protokube-builder/onbuild.sh
+++ b/images/protokube-builder/onbuild.sh
@@ -34,5 +34,5 @@ cp /go/bin/channels /src/.build/artifacts/
 
 # channels uses protokube
 cd /src/.build/artifacts/
-curl -O https://storage.googleapis.com/kubernetes-release/release/v1.5.1/bin/linux/amd64/kubectl
+curl -O https://storage.googleapis.com/kubernetes-release/release/v1.6.0-beta.1/bin/linux/amd64/kubectl
 chmod +x kubectl

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/v1.6.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/v1.6.0.yaml.template
@@ -228,11 +228,3 @@ spec:
   - name: dns-tcp
     port: 53
     protocol: TCP
-
----
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kube-dns
-  namespace: kube-system


### PR DESCRIPTION
Also revert #2037

This was causing tests to fail.  The dns manifest is only used on 1.6
and above.  This PR should _not_ be cherry-picked to a release branch,
at least not until kubectl is verified stable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2055)
<!-- Reviewable:end -->
