### PR TITLE
service task: consider changes to the systemd manifest itself

### DIFF
--- a/upup/pkg/fi/nodeup/nodetasks/service.go
+++ b/upup/pkg/fi/nodeup/nodetasks/service.go
@@ -295,6 +295,9 @@ func (_ *Service) RenderLocal(t *local.LocalTarget, a, e, changes *Service) erro
 				return err
 			}
 
+			// Include the systemd unit file itself
+			dependencies = append(dependencies, path.Join(systemdSystemPath, serviceName))
+
 			var newest time.Time
 			for _, dependency := range dependencies {
 				stat, err := os.Stat(dependency)


### PR DESCRIPTION
We do smart service restarting: we restart the service if a dependency
changed after the running service.  However, we were not considering the
service manifest itself in the calculation, which was an error.

The bug only exposed itself though when we downloaded and updated
docker, e.g. when running k8s 1.5 with a 1.4 image.  We would write the
env file early (no dependencies), then we would download docker and
install it, and then we would write the service manifest.  But if docker
had been started during this interval (e.g. by protokube), then we would
see that docker had been started after the dependencies (the env file),
and not restart it.  When we consider the manifest file also, things
work as intended.

Fix #1731

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2102)
<!-- Reviewable:end -->
