### PR TITLE
Remove requirement to define SSH and K8S API Access CIDRs

### DIFF
--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -267,18 +267,6 @@ func ValidateCluster(c *kops.Cluster, strict bool) error {
 		}
 	}
 
-	// AdminAccess
-	if strict && len(c.Spec.SSHAccess) == 0 {
-		// TODO: We may want to allow this
-		return fmt.Errorf("SSHAccess not configured")
-	}
-
-	// AdminAccess
-	if strict && len(c.Spec.KubernetesAPIAccess) == 0 {
-		// TODO: We may want to allow this (maybe)
-		return fmt.Errorf("KubernetesAPIAccess not configured")
-	}
-
 	// KubeProxy
 	if c.Spec.KubeProxy != nil {
 		kubeProxyPath := specPath.Child("KubeProxy")


### PR DESCRIPTION
For security reasons, we'd like to be able to create a cluster using kops that does not have any routes for SSH or the K8S API defined by default. This allows us to connect to the cluster solely through a VPN that provides more security than a CIDR restriction.

Currently, kops requires at least one CIDR to be defined for both SSH and K8S API access. However, it already displays a warning if either of these values aren't defined. This PR removes this requirement in order to enable the aforementioned use case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2111)
<!-- Reviewable:end -->
