### PR TITLE
Fix error for invalid vfs paths

### DIFF
--- a/util/pkg/vfs/context.go
+++ b/util/pkg/vfs/context.go
@@ -204,15 +204,15 @@ func RetryWithBackoff(backoff wait.Backoff, condition func() (bool, error)) (boo
 func (c *VFSContext) buildS3Path(p string) (*S3Path, error) {
 	u, err := url.Parse(p)
 	if err != nil {
-		return nil, fmt.Errorf("invalid s3 path: %q", err)
+		return nil, fmt.Errorf("invalid s3 path: %q", p)
 	}
 	if u.Scheme != "s3" {
-		return nil, fmt.Errorf("invalid s3 path: %q", err)
+		return nil, fmt.Errorf("invalid s3 path: %q", p)
 	}
 
 	bucket := strings.TrimSuffix(u.Host, "/")
 	if bucket == "" {
-		return nil, fmt.Errorf("invalid s3 path: %q", err)
+		return nil, fmt.Errorf("invalid s3 path: %q", p)
 	}
 
 	s3path := newS3Path(c.s3Context, bucket, u.Path)
@@ -242,11 +242,11 @@ func (c *VFSContext) ResetMemfsContext(clusterReadable bool) {
 func (c *VFSContext) buildGCSPath(p string) (*GSPath, error) {
 	u, err := url.Parse(p)
 	if err != nil {
-		return nil, fmt.Errorf("invalid google cloud storage path: %q", err)
+		return nil, fmt.Errorf("invalid google cloud storage path: %q", p)
 	}
 
 	if u.Scheme != "gs" {
-		return nil, fmt.Errorf("invalid google cloud storage path: %q", err)
+		return nil, fmt.Errorf("invalid google cloud storage path: %q", p)
 	}
 
 	bucket := strings.TrimSuffix(u.Host, "/")


### PR DESCRIPTION
We should be printing the path when it fails validation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2113)
<!-- Reviewable:end -->
