### PR TITLE
Replace kubernetes.com with example.com

### DIFF
--- a/docs/advanced_create.md
+++ b/docs/advanced_create.md
@@ -7,7 +7,7 @@ kops create cluster \
     --node-count 3 \
     --zones us-west-2a,us-west-2b,us-west-2c \
     --master-zones us-west-2a,us-west-2b,us-west-2c \
-    --dns-zone kubernetes.com \
+    --dns-zone example.com \
     --node-size t2.medium \
     --master-size t2.medium \
     --node-security-groups sg-12345678 \

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -103,7 +103,7 @@ of a domain you host in Route53.  This requires creating a second hosted zone
 in route53, and then setting up route delegation to the new zone.
 
 In this example you own `example.com` and your records for Kubernetes would
-look like `etcd-us-east-1c.internal.clustername.kubernetes.example.com`
+look like `etcd-us-east-1c.internal.clustername.subdomain.example.com`
 
 This is copying the NS servers of your **SUBDOMAIN** up to the **PARENT**
 domain in Route53.  To do this you should:
@@ -119,7 +119,7 @@ ID=$(uuidgen) && aws route53 create-hosted-zone --name subdomain.example.com --c
 
 ```bash
 # Note: This example assumes you have jq installed locally.
-aws route53 list-hosted-zones | jq '.HostedZones[] | select(.Name=="example.com.") | .Id'
+aws route53 list-hosted-zones | jq '.HostedZones[] | select(.Name=="subdomain.example.com.") | .Id'
 ```
 
 * Create a new JSON file with your values (`subdomain.json`)
@@ -164,7 +164,7 @@ aws route53 change-resource-record-sets \
  --change-batch file://subdomain.json
 ```
 
-Now traffic to `*.example.com` will be routed to the correct subdomain hosted zone in Route53.
+Now traffic to `*.subdomain.example.com` will be routed to the correct subdomain hosted zone in Route53.
 
 ### Scenario 2: Setting up Route53 for a domain purchased with another registrar
 
@@ -184,7 +184,7 @@ for some of these instructions.
   this you can also [get the values](ns.md))
 
 ```bash
-ID=$(uuidgen) && aws route53 create-hosted-zone --name subdomain.kubernetes.com --caller-reference $ID | jq .DelegationSet.NameServers
+ID=$(uuidgen) && aws route53 create-hosted-zone --name subdomain.example.com --caller-reference $ID | jq .DelegationSet.NameServers
 ```
 
 * You will now go to your registrars page and log in. You will need to create a

--- a/docs/bastion.md
+++ b/docs/bastion.md
@@ -54,7 +54,7 @@ By default the bastion instance group will create a public CNAME alias that will
 The default bastion name is `bastion.$NAME` as in
 
 ```yaml
-bastion.example.kubernetes.com
+bastion.mycluster.example.com
 ```
 
 Unless a user is using `--dns-zone` which will inherently use the `basion-$ZONE` syntax.
@@ -65,7 +65,7 @@ You can define a custom bastion CNAME by editing the main cluster config `kops e
 spec:
   topology:
     bastion:
-      bastionPublicName: bastion.example.kubernetes.com
+      bastionPublicName: bastion.mycluster.example.com
 ```
 
 ### Using SSH agent to access your bastion

--- a/docs/ns.md
+++ b/docs/ns.md
@@ -3,7 +3,7 @@
  - Note your hosted zone ID
 
 ```bash
-aws route53 list-hosted-zones | jq '.HostedZones[] | select(.Name=="subdomain.kubernetes.com.") | .Id' 
+aws route53 list-hosted-zones | jq '.HostedZones[] | select(.Name=="subdomain.example.com.") | .Id'
 
 ```
 


### PR DESCRIPTION
We should be using example.com in our docs.

Fix #2058

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2114)
<!-- Reviewable:end -->
