### PR TITLE
Add feature: Custom IAM Roles

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -51,6 +51,8 @@ type CreateClusterOptions struct {
 	MasterSize           string
 	MasterCount          int32
 	NodeCount            int32
+	MasterIAMRole        string
+	NodeIAMRole          string
 	Project              string
 	KubernetesVersion    string
 	OutDir               string
@@ -146,6 +148,10 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&options.NodeSize, "node-size", options.NodeSize, "Set instance size for nodes")
 
 	cmd.Flags().StringVar(&options.MasterSize, "master-size", options.MasterSize, "Set instance size for masters")
+
+	cmd.Flags().StringVar(&options.NodeIAMRole, "node-iam-role", options.NodeIAMRole, "Set IAM role for nodes")
+
+	cmd.Flags().StringVar(&options.MasterIAMRole, "master-iam-role", options.MasterIAMRole, "Set IAM role for masters")
 
 	cmd.Flags().StringVar(&options.VPCID, "vpc", options.VPCID, "Set to use a shared VPC")
 	cmd.Flags().StringVar(&options.NetworkCIDR, "network-cidr", options.NetworkCIDR, "Set to override the default network CIDR")
@@ -465,6 +471,19 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 			group.Spec.MachineType = c.MasterSize
 		}
 	}
+
+	var customIamRoles map[string]string
+	customIamRoles = make(map[string]string)
+
+	if c.MasterIAMRole != "" {
+		customIamRoles["Master"] = c.MasterIAMRole
+	}
+
+	if c.NodeIAMRole != "" {
+		customIamRoles["Node"] = c.NodeIAMRole
+	}
+
+	cluster.Spec.RoleCustomIamRoles = customIamRoles
 
 	if c.DNSZone != "" {
 		cluster.Spec.DNSZone = c.DNSZone

--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -18,16 +18,17 @@ package main
 
 import (
 	"bytes"
-	"github.com/golang/glog"
 	"io/ioutil"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kops/cmd/kops/util"
-	"k8s.io/kops/pkg/apis/kops"
-	"k8s.io/kops/pkg/diff"
 	"path"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/golang/glog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kops/cmd/kops/util"
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/diff"
 )
 
 var MagicTimestamp = metav1.Time{Time: time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC)}
@@ -36,6 +37,12 @@ var MagicTimestamp = metav1.Time{Time: time.Date(2017, 1, 1, 0, 0, 0, 0, time.UT
 func TestCreateClusterMinimal(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/minimal", "v1alpha1")
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/minimal", "v1alpha2")
+}
+
+// TestCreateClusterCustomIamRole runs kops create cluster custom_iam_role.example.com --zones us-test-1a
+func TestCreateClusterCustomIamRole(t *testing.T) {
+	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/custom_iam_role", "v1alpha1")
+	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/custom_iam_role", "v1alpha2")
 }
 
 // TestCreateClusterHA runs kops create cluster ha.example.com --zones us-test-1a,us-test-1b,us-test-1c --master-zones us-test-1a,us-test-1b,us-test-1c

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -132,6 +132,9 @@ type ClusterSpec struct {
 	//   missing: default policy (currently OS security upgrades that do not require a reboot)
 	UpdatePolicy *string `json:"updatePolicy,omitempty"`
 
+	// Use custom IAM roles for cluster roles
+	RoleCustomIamRoles map[string]string `json:"roleCustomIamRoles,omitempty"`
+
 	// Additional policies to add for roles
 	AdditionalPolicies *map[string]string `json:"additionalPolicies,omitempty"`
 

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -18,6 +18,7 @@ package kops
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -133,6 +133,9 @@ type ClusterSpec struct {
 	//   missing: default policy (currently OS security upgrades that do not require a reboot)
 	UpdatePolicy *string `json:"updatePolicy,omitempty"`
 
+	// Use custom IAM roles for cluster roles
+	RoleCustomIamRoles map[string]string `json:"roleCustomIamRoles,omitempty"`
+
 	// Additional policies to add for roles
 	AdditionalPolicies *map[string]string `json:"additionalPolicies,omitempty"`
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -344,6 +344,7 @@ func autoConvert_v1alpha1_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 	// WARNING: in.AdminAccess requires manual conversion: does not exist in peer-type
 	out.IsolateMasters = in.IsolateMasters
 	out.UpdatePolicy = in.UpdatePolicy
+	out.RoleCustomIamRoles = in.RoleCustomIamRoles
 	out.AdditionalPolicies = in.AdditionalPolicies
 	if in.EtcdClusters != nil {
 		in, out := &in.EtcdClusters, &out.EtcdClusters
@@ -491,6 +492,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha1_ClusterSpec(in *kops.ClusterSpec, 
 	// WARNING: in.KubernetesAPIAccess requires manual conversion: does not exist in peer-type
 	out.IsolateMasters = in.IsolateMasters
 	out.UpdatePolicy = in.UpdatePolicy
+	out.RoleCustomIamRoles = in.RoleCustomIamRoles
 	out.AdditionalPolicies = in.AdditionalPolicies
 	if in.EtcdClusters != nil {
 		in, out := &in.EtcdClusters, &out.EtcdClusters

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -133,6 +133,9 @@ type ClusterSpec struct {
 	//   missing: default policy (currently OS security upgrades that do not require a reboot)
 	UpdatePolicy *string `json:"updatePolicy,omitempty"`
 
+	// Use custom IAM roles for cluster roles
+	RoleCustomIamRoles map[string]string `json:"roleCustomIamRoles,omitempty"`
+
 	// Additional policies to add for roles
 	AdditionalPolicies *map[string]string `json:"additionalPolicies,omitempty"`
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -380,6 +380,7 @@ func autoConvert_v1alpha2_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 	out.KubernetesAPIAccess = in.KubernetesAPIAccess
 	out.IsolateMasters = in.IsolateMasters
 	out.UpdatePolicy = in.UpdatePolicy
+	out.RoleCustomIamRoles = in.RoleCustomIamRoles
 	out.AdditionalPolicies = in.AdditionalPolicies
 	if in.EtcdClusters != nil {
 		in, out := &in.EtcdClusters, &out.EtcdClusters
@@ -541,6 +542,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, 
 	out.KubernetesAPIAccess = in.KubernetesAPIAccess
 	out.IsolateMasters = in.IsolateMasters
 	out.UpdatePolicy = in.UpdatePolicy
+	out.RoleCustomIamRoles = in.RoleCustomIamRoles
 	out.AdditionalPolicies = in.AdditionalPolicies
 	if in.EtcdClusters != nil {
 		in, out := &in.EtcdClusters, &out.EtcdClusters

--- a/tests/integration/create_cluster/custom_iam_role/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/custom_iam_role/expected-v1alpha1.yaml
@@ -1,0 +1,75 @@
+apiVersion: kops/v1alpha1
+kind: Cluster
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  name: custom-iam-role.example.com
+spec:
+  adminAccess:
+  - 0.0.0.0/0
+  api:
+    dns: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://tests/custom-iam-role.example.com
+  etcdClusters:
+  - etcdMembers:
+    - name: a
+      zone: us-test-1a
+    name: main
+  - etcdMembers:
+    - name: a
+      zone: us-test-1a
+    name: events
+  kubernetesVersion: v1.4.8
+  masterPublicName: api.custom-iam-role.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  roleCustomIamRoles:
+    Master: foo
+    Node: bar
+  topology:
+    dns:
+      type: Public
+    masters: public
+    nodes: public
+  zones:
+  - cidr: 172.20.32.0/19
+    name: us-test-1a
+
+---
+
+apiVersion: kops/v1alpha1
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: custom-iam-role.example.com
+  name: master-us-test-1a
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+  zones:
+  - us-test-1a
+
+---
+
+apiVersion: kops/v1alpha1
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: custom-iam-role.example.com
+  name: nodes
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  machineType: t2.medium
+  maxSize: 2
+  minSize: 2
+  role: Node
+  zones:
+  - us-test-1a

--- a/tests/integration/create_cluster/custom_iam_role/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/custom_iam_role/expected-v1alpha2.yaml
@@ -1,0 +1,79 @@
+apiVersion: kops/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  name: custom-iam-role.example.com
+spec:
+  api:
+    dns: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://tests/custom-iam-role.example.com
+  etcdClusters:
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: a
+    name: main
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: a
+    name: events
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  kubernetesVersion: v1.4.8
+  masterPublicName: api.custom-iam-role.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  roleCustomIamRoles:
+    Master: foo
+    Node: bar
+  sshAccess:
+  - 0.0.0.0/0
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a
+  topology:
+    dns:
+      type: Public
+    masters: public
+    nodes: public
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: custom-iam-role.example.com
+  name: master-us-test-1a
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test-1a
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: custom-iam-role.example.com
+  name: nodes
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  machineType: t2.medium
+  maxSize: 2
+  minSize: 2
+  role: Node
+  subnets:
+  - us-test-1a

--- a/tests/integration/create_cluster/custom_iam_role/options.yaml
+++ b/tests/integration/create_cluster/custom_iam_role/options.yaml
@@ -1,0 +1,7 @@
+ClusterName: custom-iam-role.example.com
+Zones:
+- us-test-1a
+Cloud: aws
+KubernetesVersion: v1.4.8
+MasterIAMRole: foo
+NodeIAMRole: bar

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
@@ -19,7 +19,6 @@ package awstasks
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/golang/glog"
@@ -43,7 +42,6 @@ func (e *IAMInstanceProfileRole) Find(c *fi.Context) (*IAMInstanceProfileRole, e
 		glog.V(2).Infof("Role/RoleID not set")
 		return nil, nil
 	}
-	roleID := *e.Role.ID
 
 	request := &iam.GetInstanceProfileInput{InstanceProfileName: e.InstanceProfile.Name}
 
@@ -60,9 +58,6 @@ func (e *IAMInstanceProfileRole) Find(c *fi.Context) (*IAMInstanceProfileRole, e
 
 	ip := response.InstanceProfile
 	for _, role := range ip.Roles {
-		if aws.StringValue(role.RoleId) != roleID {
-			continue
-		}
 		actual := &IAMInstanceProfileRole{}
 		actual.InstanceProfile = &IAMInstanceProfile{ID: ip.InstanceProfileId, Name: ip.InstanceProfileName}
 		actual.Role = &IAMRole{ID: role.RoleId, Name: role.RoleName}
@@ -86,6 +81,9 @@ func (s *IAMInstanceProfileRole) CheckChanges(a, e, changes *IAMInstanceProfileR
 		}
 		if e.InstanceProfile == nil {
 			return fi.RequiredField("InstanceProfile")
+		}
+		if a.Role != e.Role {
+			return fi.CannotChangeField("Role")
 		}
 	}
 	return nil


### PR DESCRIPTION
This way Cluster IAM roles can be managed externally, either manually,
using cloudformation or any other tool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2139)
<!-- Reviewable:end -->
