### PR TITLE
Fix documentation for setting up the DNS.

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -121,7 +121,7 @@ ID=$(uuidgen) && aws route53 create-hosted-zone --name subdomain.example.com --c
 
 ```bash
 # Note: This example assumes you have jq installed locally.
-aws route53 list-hosted-zones | jq '.HostedZones[] | select(.Name=="subdomain.example.com.") | .Id'
+aws route53 list-hosted-zones | jq '.HostedZones[] | select(.Name=="example.com.") | .Id'
 ```
 
 * Create a new JSON file with your values (`subdomain.json`)


### PR DESCRIPTION
The example was supposed to look up the *parent* and not the *subdomain*.
Updating the subdomain with the ns servers we just pulled from it would not make sense.

I with this change, I was able to successfully follow along.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2183)
<!-- Reviewable:end -->
