### PR TITLE
Update protokube to make tainting optional

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kops/nodeup/pkg/distros"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/flagbuilder"
 	"k8s.io/kops/pkg/kubeconfig"
 	"k8s.io/kops/pkg/systemd"

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -132,6 +132,8 @@ type ProtokubeFlags struct {
 
 	DNSInternalSuffix *string `json:"dnsInternalSuffix,omitempty" flag:"dns-internal-suffix"`
 	Cloud             *string `json:"cloud,omitempty" flag:"cloud"`
+
+	ApplyTaints *bool `json:"applyTaints,omitempty" flag:"apply-taints"`
 }
 
 // ProtokubeFlags returns the flags object for protokube
@@ -177,6 +179,10 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) *ProtokubeF
 	}
 
 	f.DNSInternalSuffix = fi.String(".internal." + t.Cluster.ObjectMeta.Name)
+
+	if k8sVersion.Major == 1 && k8sVersion.Minor <= 5 {
+		f.ApplyTaints = fi.Bool(true)
+	}
 
 	return f
 }

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -213,8 +213,6 @@ type ClusterSpec struct {
 	//KubeProxyTestArgs             string `json:",omitempty"`
 	//KubeProxyTestLogLevel         string `json:",omitempty"`
 
-	//NodeUp                        *NodeUpConfig `json:",omitempty"`
-
 	//// Masters is the configuration for each master in the cluster
 	//Masters []*MasterConfig `json:",omitempty"`
 
@@ -318,16 +316,6 @@ type ClusterSubnetSpec struct {
 
 	Type SubnetType `json:"type,omitempty"`
 }
-
-//type NodeUpConfig struct {
-//	Source     string `json:",omitempty"`
-//	SourceHash string `json:",omitempty"`
-//
-//	Tags       []string `json:",omitempty"`
-//
-//	// Assets that NodeUp should use.  This is a "search-path" for resolving dependencies.
-//	Assets     []string `json:",omitempty"`
-//}
 
 // FillDefaults populates default values.
 // This is different from PerformAssignments, because these values are changeable, and thus we don't need to

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -271,8 +271,10 @@ type KubeletConfigSpec struct {
 	//// nodeIP is IP address of the node. If set, kubelet will use this IP
 	//// address for the node.
 	//NodeIP string `json:"nodeIP,omitempty"`
+
 	// nodeLabels to add when registering the node in the cluster.
 	NodeLabels map[string]string `json:"nodeLabels,omitempty" flag:"node-labels"`
+
 	// nonMasqueradeCIDR configures masquerading: traffic to IPs outside this range will use IP masquerade.
 	NonMasqueradeCIDR string `json:"nonMasqueradeCIDR,omitempty" flag:"non-masquerade-cidr"`
 

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -214,8 +214,6 @@ type ClusterSpec struct {
 	//KubeProxyTestArgs             string `json:",omitempty"`
 	//KubeProxyTestLogLevel         string `json:",omitempty"`
 
-	//NodeUp                        *NodeUpConfig `json:",omitempty"`
-
 	// EtcdClusters stores the configuration for each cluster
 	EtcdClusters []*EtcdClusterSpec `json:"etcdClusters,omitempty"`
 

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -270,8 +270,10 @@ type KubeletConfigSpec struct {
 	//// nodeIP is IP address of the node. If set, kubelet will use this IP
 	//// address for the node.
 	//NodeIP string `json:"nodeIP,omitempty"`
+
 	// nodeLabels to add when registering the node in the cluster.
 	NodeLabels map[string]string `json:"nodeLabels,omitempty" flag:"node-labels"`
+
 	// nonMasqueradeCIDR configures masquerading: traffic to IPs outside this range will use IP masquerade.
 	NonMasqueradeCIDR string `json:"nonMasqueradeCIDR,omitempty" flag:"non-masquerade-cidr"`
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -99,8 +99,10 @@ type KubeletConfigSpec struct {
 	// registerSchedulable tells the kubelet to register the node as
 	// schedulable. No-op if register-node is false.
 	RegisterSchedulable *bool `json:"registerSchedulable,omitempty" flag:"register-schedulable"`
+
 	// nodeLabels to add when registering the node in the cluster.
 	NodeLabels map[string]string `json:"nodeLabels,omitempty" flag:"node-labels"`
+
 	// nonMasqueradeCIDR configures masquerading: traffic to IPs outside this range will use IP masquerade.
 	NonMasqueradeCIDR string `json:"nonMasqueradeCIDR,omitempty" flag:"non-masquerade-cidr"`
 

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -61,6 +61,9 @@ func run() error {
 	master := false
 	flag.BoolVar(&master, "master", master, "Act as master")
 
+	applyTaints := false
+	flag.BoolVar(&applyTaints, "apply-taints", applyTaints, "Apply taints to nodes based on the role")
+
 	containerized := false
 	flag.BoolVar(&containerized, "containerized", containerized, "Set if we are running containerized.")
 
@@ -203,6 +206,7 @@ func run() error {
 
 	k := &protokube.KubeBoot{
 		Master:            master,
+		ApplyTaints:       applyTaints,
 		InternalDNSSuffix: dnsInternalSuffix,
 		InternalIP:        internalIP,
 		//MasterID          : fromVolume

--- a/protokube/pkg/protokube/kube_boot.go
+++ b/protokube/pkg/protokube/kube_boot.go
@@ -32,6 +32,10 @@ type KubeBoot struct {
 	//MasterID          int
 	//EtcdClusters      []*EtcdClusterSpec
 
+	// ApplyTaints controls whether we set taints based on the master label
+	// This should not be needed in k8s 1.6, because kubelet has the --taint flag
+	ApplyTaints bool
+
 	volumeMounter   *VolumeMountController
 	etcdControllers map[string]*EtcdController
 
@@ -112,7 +116,7 @@ func (k *KubeBoot) syncOnce() error {
 		glog.V(4).Infof("Not in role master; won't scan for volumes")
 	}
 
-	if k.Master {
+	if k.Master && k.ApplyTaints {
 		if err := ApplyMasterTaints(k.Kubernetes); err != nil {
 			glog.Warningf("error updating master taints: %v", err)
 		}


### PR DESCRIPTION
As of 1.6, kubelet can apply the taints, so we don't need to do it in
protokube.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2192)
<!-- Reviewable:end -->
