### PR TITLE
Fix circular dependency in file node task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ push-aws-dry: push
 
 push-gce-run: push
 	ssh ${TARGET} sudo cp /tmp/nodeup /home/kubernetes/bin/nodeup
-	ssh ${TARGET} sudo SKIP_PACKAGE_UPDATE=1 /home/kubernetes/bin/nodeup --conf=/var/cache/kubernetes-install/kube_env.yaml --v=8
+	ssh ${TARGET} sudo SKIP_PACKAGE_UPDATE=1 /home/kubernetes/bin/nodeup --conf=/var/lib/toolbox/kubernetes-install/kube_env.yaml --v=8
 
 # -t is for CentOS http://unix.stackexchange.com/questions/122616/why-do-i-need-a-tty-to-run-sudo-if-i-can-sudo-without-a-password
 push-aws-run: push

--- a/upup/pkg/fi/nodeup/nodetasks/file.go
+++ b/upup/pkg/fi/nodeup/nodetasks/file.go
@@ -107,6 +107,11 @@ func (f *File) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 			if !strings.HasSuffix(dirPath, "/") {
 				dirPath += "/"
 			}
+
+			if f.Path == dirPath {
+				continue
+			}
+
 			if strings.HasPrefix(f.Path, dirPath) {
 				deps = append(deps, v)
 			}


### PR DESCRIPTION
Fixes a circular dependency that was introduced in https://github.com/kubernetes/kops/commit/b9204e9911554bece7c283ac102987f957581d5e. 

I was getting 
```
F0328 02:19:55.165532   24083 command.go:277] error running tasks: Unable to execute tasks (circular dependency): File//etc/cni/net.d/, Service/protokube.service, Service/kubelet.service, Service/kubernetes-iptables-setup.service
make: *** [push-gce-run] Error 1
```
When trying to run kops on GCE with `--networking=calico`.

Haven't tested on AWS yet, but seems like it would break AWS as well. 

cc @justinsb

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2201)
<!-- Reviewable:end -->
