### PR TITLE
dns-controller: skip over duplicate records

### DIFF
--- a/dns-controller/cmd/dns-controller/main.go
+++ b/dns-controller/cmd/dns-controller/main.go
@@ -43,6 +43,9 @@ var (
 func main() {
 	fmt.Printf("dns-controller version %s\n", BuildVersion)
 
+	// Be sure to get the glog flags
+	glog.Flush()
+
 	dnsProviderId := "aws-route53"
 	flags.StringVar(&dnsProviderId, "dns", dnsProviderId, "DNS provider we should use (aws-route53, google-clouddns)")
 
@@ -56,6 +59,8 @@ func main() {
 	flag.CommandLine.Parse([]string{})
 
 	flag.Set("logtostderr", "true")
+
+	flags.AddGoFlagSet(flag.CommandLine)
 
 	flags.Parse(os.Args)
 


### PR DESCRIPTION
Route53 considers this an error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2203)
<!-- Reviewable:end -->
