### PR TITLE
Fix omitEmpty tag: only omitempty is valid

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -291,7 +291,7 @@ type KubeletConfigSpec struct {
 	// networkPluginMTU is the MTU to be passed to the network plugin,
 	// and overrides the default MTU for cases where it cannot be automatically
 	// computed (such as IPSEC).
-	NetworkPluginMTU *int32 `json:"networkPluginMTU,omitEmpty" flag:"network-plugin-mtu"`
+	NetworkPluginMTU *int32 `json:"networkPluginMTU,omitempty" flag:"network-plugin-mtu"`
 
 	// imageGCHighThresholdPercent is the percent of disk usage after which
 	// image garbage collection is always run.


### PR DESCRIPTION
Although actually omitEmpty appears to be recognized, although it is not
"traditional".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2205)
<!-- Reviewable:end -->
