### PR TITLE
[GCE] Only apply dns changes if records were removed

### DIFF
--- a/upup/pkg/kutil/delete_cluster_gce.go
+++ b/upup/pkg/kutil/delete_cluster_gce.go
@@ -787,7 +787,6 @@ func (d *clusterDiscoveryGCE) deleteDNSZone(cloud fi.Cloud, r *ResourceTracker) 
 	}
 
 	changeset := rrs.StartChangeset()
-
 	for _, record := range records {
 		if record.Type() != "A" {
 			continue
@@ -810,6 +809,10 @@ func (d *clusterDiscoveryGCE) deleteDNSZone(cloud fi.Cloud, r *ResourceTracker) 
 		}
 
 		changeset.Remove(record)
+	}
+
+	if changeset.IsEmpty() {
+		return nil
 	}
 
 	err = changeset.Apply()


### PR DESCRIPTION
Fixing a minor bug from https://github.com/kubernetes/kops/pull/2187 where running delete on GCE DNS records twice will retry until timeout. 

cc @justinsb

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2218)
<!-- Reviewable:end -->
