### PR TITLE
Set nf_conntrack_max in kubeproxy

### DIFF
--- a/nodeup/pkg/model/kubeproxy.go
+++ b/nodeup/pkg/model/kubeproxy.go
@@ -125,7 +125,7 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 	}
 
 	image := c.Image
-	cmd := "echo -998 > /proc/$$$/oom_score_adj && kube-proxy --kubeconfig=/var/lib/kube-proxy/kubeconfig --resource-container=\"\" "
+	cmd := "echo -998 > /proc/$$$/oom_score_adj && kube-proxy --kubeconfig=/var/lib/kube-proxy/kubeconfig --conntrack-max-per-core=131072 --resource-container=\"\" "
 	cmd += flags
 	// TODO: tee or similar so we get logs in kubectl logs
 	cmd += " 1>>/var/log/kube-proxy.log 2>&1"

--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -95,10 +95,6 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"# Increase size of file handles and inode cache",
 			"fs.file-max = 2097152",
 			"",
-
-			"# Increase size of conntrack table size to avoid poor iptables performance",
-			"net.netfilter.nf_conntrack_max = 1000000",
-			"",
 		)
 	}
 


### PR DESCRIPTION
[kube-proxy sets some sysctls](https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-proxy/app/options/options.go#L91-L95) when it starts which overrides [any sysctls we set during node bootstrap](https://github.com/kubernetes/kops/blob/master/nodeup/pkg/model/sysctls.go#L99-L101).

Here are logs from kube-proxy on v1.6.0
```
I0329 01:29:47.024208       5 healthcheck.go:119] Initializing kube-proxy health checker
I0329 01:29:47.137848       5 conntrack.go:81] Set sysctl 'net/netfilter/nf_conntrack_max' to 131072
I0329 01:29:47.138410       5 conntrack.go:66] Setting conntrack hashsize to 32768
I0329 01:29:47.138850       5 conntrack.go:81] Set sysctl 'net/netfilter/nf_conntrack_tcp_timeout_established' to 86400
I0329 01:29:47.138834       5 proxier.go:490] Adding new service "default/kubernetes:https" at 100.64.0.1:443/TCP
I0329 01:29:47.138906       5 conntrack.go:81] Set sysctl 'net/netfilter/nf_conntrack_tcp_timeout_close_wait' to 3600
```

```
andrewsykim@nodes-xx23 /var/log $ cat /proc/sys/net/netfilter/nf_conntrack_max
131072
```

I've updated kube-proxy to set nf_conntrack_max based on # of cores on the node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2223)
<!-- Reviewable:end -->
