### PR TITLE
recommend using matching kops to kube versions docs

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -4,7 +4,7 @@ Upgrading Kubernetes is easy with kops. The cluster spec contains a `KubernetesV
 
 The `kops upgrade` command also automates checking for and applying updates.
 
-It is recommended to run the latest version of Kops to ensure compatibility with the target KubernetesVersion. When applying a Kubernetes minor version upgrade (e.g. `v1.5.3` to `v1.6.0`), you should confirm that the target KubernetesVersion is compatible with [current Kops release](https://github.com/kubernetes/kops/releases).
+It is recommended to run the latest version of Kops to ensure compatibility with the target KubernetesVersion. When applying a Kubernetes minor version upgrade (e.g. `v1.5.3` to `v1.6.0`), you should confirm that the target KubernetesVersion is compatible with the [current Kops release](https://github.com/kubernetes/kops/releases).
 
 Note: if you want to upgrade from a `kube-up` installation, please see the instructions for [how to upgrade kubernetes installed with kube-up](cluster_upgrades_and_migrations.md).
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -10,6 +10,7 @@ Note: if you want to upgrade from a `kube-up` installation, please see the instr
 
 * `kops edit cluster $NAME`
 * set the KubernetesVersion to the target version (e.g. `v1.3.5`)
+* ensure you are using the matching Kops version (e.g. Kubernetes `v1.5.3` and Kops `v1.5.3`)
 * `kops update cluster $NAME` to preview, then `kops update cluster $NAME --yes`
 * `kops rolling-update cluster $NAME` to preview, then `kops rolling-update cluster $NAME --yes`
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -4,13 +4,14 @@ Upgrading Kubernetes is easy with kops. The cluster spec contains a `KubernetesV
 
 The `kops upgrade` command also automates checking for and applying updates.
 
+It is recommended to run the latest version of Kops to ensure compatibility with the target KubernetesVersion. When applying a Kubernetes minor version upgrade (e.g. `v1.5.3` to `v1.6.0`), you should confirm that the target KubernetesVersion is compatible with [current Kops release](https://github.com/kubernetes/kops/releases).
+
 Note: if you want to upgrade from a `kube-up` installation, please see the instructions for [how to upgrade kubernetes installed with kube-up](cluster_upgrades_and_migrations.md).
 
 ### Manual update
 
 * `kops edit cluster $NAME`
 * set the KubernetesVersion to the target version (e.g. `v1.3.5`)
-* ensure you are using the matching Kops version (e.g. Kubernetes `v1.5.3` and Kops `v1.5.3`)
 * `kops update cluster $NAME` to preview, then `kops update cluster $NAME --yes`
 * `kops rolling-update cluster $NAME` to preview, then `kops rolling-update cluster $NAME --yes`
 


### PR DESCRIPTION
```release-note
NONE
```

after attempting a cluster update from 1.5.3 to 1.6.0, I was informed that Kops version had to match KubernetesVersion. I think this would be a helpful heads up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2228)
<!-- Reviewable:end -->
