### PR TITLE
Implement --filename option for kops delete

### DIFF
--- a/docs/cli/kops_delete.md
+++ b/docs/cli/kops_delete.md
@@ -1,11 +1,21 @@
 ## kops delete
 
-delete clusters
+Deletes a resource by filename or stdin
 
 ### Synopsis
 
+Delete clusters or instancegroups by filename or stdin
 
-Delete clusters
+```
+kops delete -f FILENAME [--yes]
+```
+
+### Options
+
+```
+  -f, --filename stringSlice   Filename to use to delete the resource
+  -y, --yes                    Specify --yes to delete the resource
+```
 
 ### Options inherited from parent commands
 
@@ -27,4 +37,3 @@ Delete clusters
 * [kops delete cluster](kops_delete_cluster.md)	 - Delete cluster
 * [kops delete instancegroup](kops_delete_instancegroup.md)	 - Delete instancegroup
 * [kops delete secret](kops_delete_secret.md)	 - Delete secret
-


### PR DESCRIPTION
Works for both clusters and instancegroups. Mostly inspired from the code in the kops create command.

I am wondering if I should implement the ``--yes`` option. If we want to be close to the kubectl behaviour, maybe not.

This is totally untested for now.

Fixes #2071

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2240)
<!-- Reviewable:end -->
