### PR TITLE
Add the ingress permission to the dns-controller

### DIFF
--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.6.yaml.template
@@ -72,6 +72,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - "extensions"
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
 
 ---
 


### PR DESCRIPTION
This is so that if users enable ingress records, it will still work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2244)
<!-- Reviewable:end -->
