### PR TITLE
Reuse the public key if it exists

### DIFF
--- a/upup/pkg/fi/ca.go
+++ b/upup/pkg/fi/ca.go
@@ -103,10 +103,20 @@ type Keystore interface {
 	// (if the certificate is found but not keypair, that is not an error: only the cert will be returned)
 	FindKeypair(name string) (*Certificate, *PrivateKey, error)
 
-	CreateKeypair(name string, template *x509.Certificate) (*Certificate, *PrivateKey, error)
+	CreateKeypair(name string, template *x509.Certificate, privateKey *PrivateKey) (*Certificate, error)
 
 	// Store the keypair
 	StoreKeypair(id string, cert *Certificate, privateKey *PrivateKey) error
+}
+
+func GeneratePrivateKey() (*PrivateKey, error) {
+	rsaKey, err := rsa.GenerateKey(crypto_rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("error generating RSA private key: %v", err)
+	}
+
+	privateKey := &PrivateKey{Key: rsaKey}
+	return privateKey, nil
 }
 
 type CAStore interface {

--- a/upup/pkg/fi/k8sapi/k8s_keystore.go
+++ b/upup/pkg/fi/k8sapi/k8s_keystore.go
@@ -17,8 +17,6 @@ limitations under the License.
 package k8sapi
 
 import (
-	crypto_rand "crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
 	"github.com/golang/glog"
@@ -107,22 +105,16 @@ func (c *KubernetesKeystore) FindKeypair(id string) (*fi.Certificate, *fi.Privat
 	return keypair.Certificate, keypair.PrivateKey, nil
 }
 
-func (c *KubernetesKeystore) CreateKeypair(id string, template *x509.Certificate) (*fi.Certificate, *fi.PrivateKey, error) {
+func (c *KubernetesKeystore) CreateKeypair(id string, template *x509.Certificate, privateKey *fi.PrivateKey) (*fi.Certificate, error) {
 	t := time.Now().UnixNano()
 	serial := fi.BuildPKISerial(t)
 
-	rsaKey, err := rsa.GenerateKey(crypto_rand.Reader, 2048)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error generating RSA private key: %v", err)
-	}
-
-	privateKey := &fi.PrivateKey{Key: rsaKey}
 	cert, err := c.issueCert(id, serial, privateKey, template)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return cert, privateKey, nil
+	return cert, nil
 }
 
 func (c *KubernetesKeystore) StoreKeypair(id string, cert *fi.Certificate, privateKey *fi.PrivateKey) error {

--- a/upup/pkg/fi/vfs_castore.go
+++ b/upup/pkg/fi/vfs_castore.go
@@ -607,22 +607,15 @@ func (c *VFSCAStore) PrivateKey(id string) (*PrivateKey, error) {
 
 }
 
-func (c *VFSCAStore) CreateKeypair(id string, template *x509.Certificate) (*Certificate, *PrivateKey, error) {
+func (c *VFSCAStore) CreateKeypair(id string, template *x509.Certificate, privateKey *PrivateKey) (*Certificate, error) {
 	serial := c.buildSerial()
-
-	rsaKey, err := rsa.GenerateKey(crypto_rand.Reader, 2048)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error generating RSA private key: %v", err)
-	}
-
-	privateKey := &PrivateKey{Key: rsaKey}
 
 	cert, err := c.IssueCert(id, serial, privateKey, template)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return cert, privateKey, nil
+	return cert, nil
 }
 
 func (c *VFSCAStore) storePrivateKey(privateKey *PrivateKey, p vfs.Path) error {


### PR DESCRIPTION
This avoids breaking all the service account signatures if a minor
change is made to the certs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2247)
<!-- Reviewable:end -->
