### PR TITLE
Support tenancy field in terraform output

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
@@ -339,6 +339,7 @@ type terraformLaunchConfiguration struct {
 	EphemeralBlockDevice     []*terraformBlockDevice `json:"ephemeral_block_device,omitempty"`
 	Lifecycle                *terraform.Lifecycle    `json:"lifecycle,omitempty"`
 	SpotPrice                *string                 `json:"spot_price,omitempty"`
+	PlacementTenancy         *string                 `json:"placement_tenancy,omitempty"`
 }
 
 type terraformBlockDevice struct {
@@ -371,6 +372,10 @@ func (_ *LaunchConfiguration) RenderTerraform(t *terraform.TerraformTarget, a, e
 
 	if e.SpotPrice != "" {
 		tf.SpotPrice = aws.String(e.SpotPrice)
+	}
+
+	if e.Tenancy != nil {
+		tf.PlacementTenancy = e.Tenancy
 	}
 
 	if e.SSHKey != nil {


### PR DESCRIPTION
This PR updates Terraform LaunchConfiguration output to include placement_tenancy. This is necessary to support the tenancy changes added in #2155 

I tested this with tenancy equal to 'default', 'dedicated' and without the instancegroup tenancy field set. Worked correctly for all values.

Not sure if there is a unit test that needs to be added to this. Perhaps you could point me in the right direction there as I am new to Go and kops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2249)
<!-- Reviewable:end -->
