### PR TITLE
Fix GCE disk dependency bug

### DIFF
--- a/upup/pkg/kutil/delete_cluster_gce.go
+++ b/upup/pkg/kutil/delete_cluster_gce.go
@@ -399,7 +399,7 @@ func (d *clusterDiscoveryGCE) listGCEDisks() ([]*ResourceTracker, error) {
 		}
 
 		for _, u := range t.Users {
-			tracker.blocked = append(tracker.blocked, typeInstance+":"+gce.LastComponent(u))
+			tracker.blocked = append(tracker.blocked, typeInstance+":"+t.Zone+"/"+gce.LastComponent(u))
 		}
 
 		glog.V(4).Infof("Found resource: %s", t.SelfLink)


### PR DESCRIPTION
When we refer to blockers of the disk resource, we use `type:Name` and not `type:ID`. The ID of GCE instances is `zone/instance-name` not `instance-name`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2262)
<!-- Reviewable:end -->
