### PR TITLE
create encrypted weave network fixes #1880

### DIFF
--- a/channels/pkg/api/channel.go
+++ b/channels/pkg/api/channel.go
@@ -58,4 +58,7 @@ type AddonSpec struct {
 	// version of the software we are packaging.  But we always want to reinstall when we
 	// switch kubernetes versions.
 	Id string `json:"id,omitempty"`
+
+	// Instead of Manifest define Yamldata
+	Yamldata *string `json:"yamldata,omitempty"`
 }

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -79,6 +79,7 @@ kops create cluster
       --master-zones stringSlice             Zones in which to run masters (must be an odd number)
       --model string                         Models to apply (separate multiple models with commas) (default "config,proto,cloudup")
       --network-cidr string                  Set to override the default network CIDR
+      --network-encrypt                      Weave network support encryption between nodes. Password stored in etcd as k8s secret weave-pass.
       --networking string                    Networking mode to use.  kubenet (default), classic, external, kopeio-vxlan (or kopeio), weave, flannel, calico, canal. (default "kubenet")
       --node-count int32                     Set the number of nodes
       --node-security-groups stringSlice     Add precreated additional security groups to nodes.

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -10,7 +10,7 @@ Kubernetes Operations (kops) currently supports 4 networking modes:
 ### kops Default Networking
 
 Kubernetes Operations (kops) uses `kubenet` networking by default. This sets up networking on AWS using VPC
-networking, where the  master allocates a /24 CIDR to each Node, drawing from the Node network.  
+networking, where the  master allocates a /24 CIDR to each Node, drawing from the Node network.
 Using `kubenet` mode routes for  each node are then configured in the AWS VPC routing tables.
 
 One important limitation when using `kubenet` networking is that an AWS routing table cannot have more than
@@ -85,6 +85,8 @@ $ kops create cluster \
   --yes \
   --name myclustername.mydns.io
 ```
+
+option `--network-encrypt` will create secret with password and use this password for encrypt weave network between nodes.
 
 Once the cluster is stable, which you can check with a `kubectl cluster-info` command, the next
 step is to install CNI networking. Most of the CNI network providers are

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -54,7 +54,8 @@ type KopeioNetworkingSpec struct {
 
 // Weave declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU *int32 `json:"mtu,omitempty"`
+	Encrypt bool   `json:"encrypted,omitempty"`
+	MTU     *int32 `json:"mtu,omitempty"`
 }
 
 // Flannel declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -54,7 +54,8 @@ type KopeioNetworkingSpec struct {
 
 // Weave declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU *int32 `json:"mtu,omitempty"`
+	Encrypt bool   `json:"encrypted,omitempty"`
+	MTU     *int32 `json:"mtu,omitempty"`
 }
 
 // Flannel declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1767,6 +1767,7 @@ func Convert_kops_RBACAuthorizationSpec_To_v1alpha1_RBACAuthorizationSpec(in *ko
 }
 
 func autoConvert_v1alpha1_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveNetworkingSpec, out *kops.WeaveNetworkingSpec, s conversion.Scope) error {
+	out.Encrypt = in.Encrypt
 	out.MTU = in.MTU
 	return nil
 }
@@ -1776,6 +1777,7 @@ func Convert_v1alpha1_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveN
 }
 
 func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha1_WeaveNetworkingSpec(in *kops.WeaveNetworkingSpec, out *WeaveNetworkingSpec, s conversion.Scope) error {
+	out.Encrypt = in.Encrypt
 	out.MTU = in.MTU
 	return nil
 }

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -54,7 +54,8 @@ type KopeioNetworkingSpec struct {
 
 // Weave declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU *int32 `json:"mtu,omitempty"`
+	Encrypt bool   `json:"encrypted,omitempty"`
+	MTU     *int32 `json:"mtu,omitempty"`
 }
 
 // Flannel declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1921,6 +1921,7 @@ func Convert_kops_TopologySpec_To_v1alpha2_TopologySpec(in *kops.TopologySpec, o
 }
 
 func autoConvert_v1alpha2_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveNetworkingSpec, out *kops.WeaveNetworkingSpec, s conversion.Scope) error {
+	out.Encrypt = in.Encrypt
 	out.MTU = in.MTU
 	return nil
 }
@@ -1930,6 +1931,7 @@ func Convert_v1alpha2_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveN
 }
 
 func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha2_WeaveNetworkingSpec(in *kops.WeaveNetworkingSpec, out *WeaveNetworkingSpec, s conversion.Scope) error {
+	out.Encrypt = in.Encrypt
 	out.MTU = in.MTU
 	return nil
 }

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -17,14 +17,23 @@ limitations under the License.
 package cloudup
 
 import (
+	"bytes"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	channelsapi "k8s.io/kops/channels/pkg/api"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/featureflag"
+	"k8s.io/kops/upup/models"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/fitasks"
 	"k8s.io/kops/upup/pkg/fi/utils"
+	kube_api "k8s.io/kubernetes/pkg/api"
+	kube_api_ext "k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 type BootstrapChannelBuilder struct {
@@ -40,6 +49,7 @@ func (b *BootstrapChannelBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 
 	addonsYAML, err := utils.YamlMarshal(addons)
+
 	if err != nil {
 		return fmt.Errorf("error serializing addons yaml: %v", err)
 	}
@@ -55,12 +65,30 @@ func (b *BootstrapChannelBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 
 	for key, manifest := range manifests {
+		data := func(addons *channelsapi.Addons, key string) string {
+			for _, addon := range addons.Spec.Addons {
+				if *addon.Name == key {
+					if addon.Yamldata != nil {
+						return *addon.Yamldata
+					}
+				}
+			}
+			return ""
+		}
+
+		d := data(addons, key)
 		name := b.cluster.ObjectMeta.Name + "-addons-" + key
-		tasks[name] = &fitasks.ManagedFile{
+		managedfile := &fitasks.ManagedFile{
 			Name:     fi.String(name),
 			Location: fi.String(manifest),
-			Contents: &fi.ResourceHolder{Name: manifest},
+			Contents: &fi.ResourceHolder{
+				Name: manifest,
+			},
 		}
+		if d != "" {
+			managedfile.Contents.Resource = fi.NewStringResource(d)
+		}
+		tasks[name] = managedfile
 	}
 
 	return nil
@@ -283,34 +311,45 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		// 1.9.5-kops.1 = 1.9.4 with WEAVE_MTU configured
 		version := "1.9.5-kops.1"
 
-		{
-			location := key + "/pre-k8s-1.6.yaml"
-			id := "pre-k8s-1.6"
+		if b.cluster.Spec.Networking.Weave.Encrypt {
+			name, weaveLoc, addon := createSecret(key, b)
+			addons.Spec.Addons = append(addons.Spec.Addons, addon)
+			manifests[name] = weaveLoc
 
-			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
-				Name:              fi.String(key),
-				Version:           fi.String(version),
-				Selector:          networkingSelector,
-				Manifest:          fi.String(location),
-				KubernetesVersion: "<1.6.0",
-				Id:                id,
-			})
-			manifests[key+"-"+id] = "addons/" + location
-		}
+			// read weave yaml
+			name, newLocation, addon := modifyWeaveYaml(key, version, b)
+			addons.Spec.Addons = append(addons.Spec.Addons, addon)
+			manifests[name] = newLocation
+		} else {
+			{
+				location := key + "/pre-k8s-1.6.yaml"
+				id := "pre-k8s-1.6"
 
-		{
-			location := key + "/k8s-1.6.yaml"
-			id := "k8s-1.6"
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(version),
+					Selector:          networkingSelector,
+					Manifest:          fi.String(location),
+					KubernetesVersion: "<1.6.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
 
-			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
-				Name:              fi.String(key),
-				Version:           fi.String(version),
-				Selector:          networkingSelector,
-				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.6.0",
-				Id:                id,
-			})
-			manifests[key+"-"+id] = "addons/" + location
+			{
+				location := key + "/k8s-1.6.yaml"
+				id := "k8s-1.6"
+
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(version),
+					Selector:          networkingSelector,
+					Manifest:          fi.String(location),
+					KubernetesVersion: ">=1.6.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
 		}
 	}
 
@@ -422,4 +461,142 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 	}
 
 	return addons, manifests, nil
+}
+
+func buildSecret() (kube_api.Secret, error) {
+	secret, err := fi.CreateSecret()
+	if err != nil {
+		return kube_api.Secret{}, fmt.Errorf("error create secret: %s", err)
+	}
+	secData := make(map[string][]byte)
+	secData["weave-pass"] = []byte(secret.Data)
+	seConfig := kube_api.Secret{
+		Data: secData,
+		Type: kube_api.SecretTypeOpaque,
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "weave-pass",
+			Namespace: "kube-system"}}
+	return seConfig, err
+}
+
+func buildNewEnv() []kube_api.EnvVar {
+	newenv := []kube_api.EnvVar{{
+		Name: "WEAVE_PASSWORD",
+		ValueFrom: &kube_api.EnvVarSource{
+			SecretKeyRef: &kube_api.SecretKeySelector{
+				LocalObjectReference: kube_api.LocalObjectReference{
+					Name: "weave-pass"},
+				Key: "weave-pass"}}}}
+	return newenv
+}
+
+// edit weave yaml
+func BuildWeaveDaemonSet(obj runtime.Object) kube_api_ext.DaemonSet {
+	// assign to all container new env variable
+	weaveConfig := obj.(*kube_api_ext.DaemonSet)
+	containers := make([]kube_api.Container, len(weaveConfig.Spec.Template.Spec.Containers))
+	newenv := buildNewEnv()
+	for i, cont := range weaveConfig.Spec.Template.Spec.Containers {
+		cont.Env = newenv
+		containers[i] = cont
+	}
+	weaveConfig.Spec.Template.Spec.Containers = containers
+	return *weaveConfig
+}
+
+func createSecret(key string, b *BootstrapChannelBuilder) (string, string, *channelsapi.AddonSpec) {
+	_, id, kubernetesVersion := parseK8sVersion(b, key)
+
+	seConfig, _ := buildSecret()
+	info, _ := runtime.SerializerInfoForMediaType(kube_api.Codecs.SupportedMediaTypes(), "application/yaml")
+
+	encoder := kube_api.Codecs.EncoderForVersion(info.Serializer, v1.SchemeGroupVersion)
+	secretData, err := runtime.Encode(encoder, &seConfig)
+	if err != nil {
+		panic(fmt.Errorf("error marshaling secret yaml: %s", err))
+	}
+
+	weaveLoc := "addons/" + key + "/secret.yaml"
+	name := key + "-secret-" + id
+	addon := &channelsapi.AddonSpec{
+		Name:              fi.String(name),
+		Version:           fi.String("0.0.1"),
+		Selector:          map[string]string{"role.kubernetes.io/networking": "1"},
+		Manifest:          fi.String(key + "/secret.yaml"),
+		Yamldata:          fi.String(string(secretData)),
+		KubernetesVersion: kubernetesVersion,
+		Id:                id,
+	}
+	return name, weaveLoc, addon
+
+}
+
+func modifyWeaveYaml(key string, version string, b *BootstrapChannelBuilder) (string, string, *channelsapi.AddonSpec) {
+	location, id, kubernetesVersion := parseK8sVersion(b, key)
+	weave_file := "cloudup/resources/addons/" + location
+	vpath := models.NewAssetPath(weave_file)
+	weavesource, err := vpath.ReadFile()
+	if err != nil {
+		panic(err)
+	}
+	info, _ := runtime.SerializerInfoForMediaType(kube_api.Codecs.SupportedMediaTypes(), "application/yaml")
+	encoder := kube_api.Codecs.EncoderForVersion(info.Serializer, v1beta1.SchemeGroupVersion)
+	delimiter := []byte("\n---\n")
+	sections := bytes.Split(weavesource, delimiter)
+	var newSections []byte
+	for _, section := range sections {
+		obj, err := runtime.Decode(kube_api.Codecs.UniversalDecoder(), section)
+		if err != nil {
+			panic(fmt.Errorf("error parsing file %s obj %s: %v", weavesource, string(section), err))
+		}
+		switch v := obj.(type) {
+		case *kube_api_ext.DaemonSet:
+			weaveconfig := BuildWeaveDaemonSet(obj)
+			weaveData, err := runtime.Encode(encoder, &weaveconfig)
+			if err != nil {
+				panic(fmt.Errorf("error encode file %s obj %v: %v", weavesource, weaveconfig, err))
+			}
+			newSections = append(newSections[:], weaveData[:]...)
+		default:
+			fmt.Printf("not changed %s,\n%v", v, string(section))
+			newSections = append(newSections[:], section[:]...)
+		}
+		newSections = append(newSections[:], delimiter[:]...)
+	}
+
+	newLocation := "addons/" + key + "/k8s-1.6.yaml"
+	name := key + "-" + id
+	addon := &channelsapi.AddonSpec{
+		Name:              fi.String(name),
+		Version:           fi.String(version),
+		Selector:          map[string]string{"role.kubernetes.io/networking": "1"},
+		Manifest:          fi.String(key + "/k8s-1.6.yaml"),
+		Yamldata:          fi.String(string(newSections)),
+		KubernetesVersion: kubernetesVersion,
+		Id:                id,
+	}
+
+	return name, newLocation, addon
+}
+
+func parseK8sVersion(b *BootstrapChannelBuilder, key string) (string, string, string) {
+	var location, id, kubernetesVersion string
+	kv, err := util.ParseKubernetesVersion(b.cluster.Spec.KubernetesVersion)
+	if err != nil {
+		panic(fmt.Errorf("unable to determine kubernetes version from %q", b.cluster.Spec.KubernetesVersion))
+	}
+	switch {
+	case kv.Major == 1 && kv.Minor <= 5:
+		location = key + "/pre-k8s-1.6.yaml"
+		id = "pre-k8s-1.6"
+		kubernetesVersion = "<1.6.0"
+	default:
+		location = key + "/k8s-1.6.yaml"
+		id = "k8s-1.6"
+		kubernetesVersion = ">=1.6.0"
+	}
+	return location, id, kubernetesVersion
 }


### PR DESCRIPTION
there is implemented flag `--network-encrypt` for weave network. when flag is used will created secret(based on struct in k8s api) with password for weave network and added environment variables for weave daemonset(read yaml and add env to containers). fixes #1880

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2276)
<!-- Reviewable:end -->
