### PR TITLE
When base64 encoding you must use single quotes

### DIFF
--- a/vendor/k8s.io/kubernetes/docs/user-guide/kubectl-cheatsheet.md
+++ b/vendor/k8s.io/kubernetes/docs/user-guide/kubectl-cheatsheet.md
@@ -50,8 +50,8 @@ metadata:
   name: mysecret
 type: Opaque
 data:
-  password: $(echo "s33msi4" | base64)
-  username: $(echo "jane" | base64)
+  password: $(echo 's33msi4' | base64)
+  username: $(echo 'jane' | base64)
 EOF
 
 # TODO: kubectl-explain example


### PR DESCRIPTION
Changed the example base64 secret encoding on the fly to use single quotes instead of double quotes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2277)
<!-- Reviewable:end -->
