### PR TITLE
Fix CNI bin & conf paths

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -83,13 +83,17 @@ func (c *NodeupModelContext) PathSrvSshproxy() string {
 	}
 }
 
-func (c *NodeupModelContext) NetworkPluginDir() string {
+func (c *NodeupModelContext) CNIBinDir() string {
 	switch c.Distribution {
 	case distros.DistributionContainerOS:
 		return "/home/kubernetes/bin/"
 	default:
 		return "/opt/cni/bin/"
 	}
+}
+
+func (c *NodeupModelContext) CNIConfDir() string {
+	return "/etc/cni/net.d/"
 }
 
 func (c *NodeupModelContext) buildPKIKubeconfig(id string) (string, error) {

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -94,7 +94,7 @@ func (b *KubeletBuilder) Build(c *fi.ModelBuilderContext) error {
 
 	if b.UsesCNI {
 		t := &nodetasks.File{
-			Path: "/etc/cni/net.d/",
+			Path: b.CNIConfDir(),
 			Type: nodetasks.FileType_Directory,
 		}
 		c.AddTask(t)
@@ -135,7 +135,10 @@ func (b *KubeletBuilder) buildSystemdEnvironmentFile(kubeletConfig *kops.Kubelet
 		flags += " --cloud-config=" + CloudConfigFilePath
 	}
 
-	flags += " --network-plugin-dir=" + b.NetworkPluginDir()
+	if b.UsesCNI {
+		flags += " --cni-bin-dir=" + b.CNIBinDir()
+		flags += " --cni-conf-dir=" + b.CNIConfDir()
+	}
 
 	sysconfig := "DAEMON_ARGS=\"" + flags + "\"\n"
 

--- a/nodeup/pkg/model/network.go
+++ b/nodeup/pkg/model/network.go
@@ -55,7 +55,7 @@ func (b *NetworkBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 
 	for _, assetName := range assetNames {
-		if err := b.addAsset(c, assetName); err != nil {
+		if err := b.addCNIBinAsset(c, assetName); err != nil {
 			return err
 		}
 	}
@@ -63,7 +63,7 @@ func (b *NetworkBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-func (b *NetworkBuilder) addAsset(c *fi.ModelBuilderContext, assetName string) error {
+func (b *NetworkBuilder) addCNIBinAsset(c *fi.ModelBuilderContext, assetName string) error {
 	assetPath := ""
 	asset, err := b.Assets.Find(assetName, assetPath)
 	if err != nil {
@@ -74,7 +74,7 @@ func (b *NetworkBuilder) addAsset(c *fi.ModelBuilderContext, assetName string) e
 	}
 
 	t := &nodetasks.File{
-		Path:     filepath.Join(b.NetworkPluginDir(), assetName),
+		Path:     filepath.Join(b.CNIBinDir(), assetName),
 		Contents: asset,
 		Type:     nodetasks.FileType_File,
 		Mode:     s("0755"),

--- a/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
@@ -1,4 +1,4 @@
 contents: |
-  DAEMON_ARGS="--feature-gates=AllowExtTrafficLocalEndpoints=false,ExperimentalCriticalPodAnnotation=true --node-labels=kubernetes.io/role=node,node-role.kubernetes.io/node= --network-plugin-dir=/opt/cni/bin/"
+  DAEMON_ARGS="--feature-gates=AllowExtTrafficLocalEndpoints=false,ExperimentalCriticalPodAnnotation=true --node-labels=kubernetes.io/role=node,node-role.kubernetes.io/node="
 path: /etc/sysconfig/kubelet
 type: file


### PR DESCRIPTION
Stop using the networking-plugin-dir flag, and replace with the
cni-bin-dir and cni-conf-dir flags, set appropriately.

Thanks for spotting @prachetasp

Issue #2267

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2282)
<!-- Reviewable:end -->
