### PR TITLE
Update Project Calico from 2.0.2 to 2.1.1

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/v2.1.1.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/v2.1.1.yaml.template
@@ -77,7 +77,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v1.0.2
+          image: calico/node:v1.1.1
           resources:
             requests:
               cpu: 10m
@@ -116,7 +116,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v1.5.6
+          image: calico/cni:v1.6.1
           resources:
             requests:
               cpu: 10m
@@ -189,7 +189,7 @@ spec:
       hostNetwork: true
       containers:
         - name: calico-policy-controller
-          image: calico/kube-policy-controller:v0.5.2
+          image: calico/kube-policy-controller:v0.5.4
           resources:
             requests:
               cpu: 10m
@@ -237,7 +237,7 @@ spec:
       containers:
         # Writes basic configuration to datastore.
         - name: configure-calico
-          image: calico/ctl:v1.0.2
+          image: calico/ctl:v1.1.1
           args:
           - apply
           - -f

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -243,7 +243,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Calico != nil {
 		key := "networking.projectcalico.org"
-		version := "2.0.2"
+		version := "2.1.1"
 
 		// TODO: Create configuration object for cni providers (maybe create it but orphan it)?
 		location := key + "/v" + version + ".yaml"


### PR DESCRIPTION
This should fix #2273. This update also allows us to run Calico in native L3 instead without a subnet in the future; the work needed is captured here:
#2066

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2286)
<!-- Reviewable:end -->
