### PR TITLE
Change how tolerations are defined in cluster-autoscaler.yaml for k8s 1.6

### DIFF
--- a/addons/cluster-autoscaler/v1.4.0.yaml
+++ b/addons/cluster-autoscaler/v1.4.0.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         k8s-app: cluster-autoscaler
       annotations:
+         # For 1.6, we keep the old tolerations in case of a downgrade to 1.5
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated", "value":"master"}]'
     spec:
         containers:
@@ -43,4 +44,7 @@ spec:
             hostPath:
               path: {{SSL_CERT_PATH}}
         nodeSelector:
-          kubernetes.io/role: master
+          node-role.kubernetes.io/master: ""
+        tolerations:
+          - key: "node-role.kubernetes.io/master"
+            effect: NoSchedule


### PR DESCRIPTION
Set the tolerations as a field since annotated tolerations are pretty much ignored by the scheduler now in 1.6. Also, change the nodeSelector field.

And... I'm not sure if this is backwards compatible with Kubernetes 1.5, and what should be the right approach for making that happen is. Guidance would be appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2288)
<!-- Reviewable:end -->
