### PR TITLE
Fixed typos: clusteres -> cluster

### DIFF
--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -95,7 +95,7 @@ func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 		Short: "Rolling update a cluster",
 		Long: `Rolling update a cluster instance groups.
 
-This command updates a kubernetes cluseter to match the cloud, and kops specifications.
+This command updates a kubernetes cluster to match the cloud, and kops specifications.
 
 To perform rolling update, you need to update the cloud resources first with "kops update cluster"
 

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -7,7 +7,7 @@ Rolling update a cluster
 
 Rolling update a cluster instance groups.
 
-This command updates a kubernetes cluseter to match the cloud, and kops specifications.
+This command updates a kubernetes cluster to match the cloud, and kops specifications.
 
 To perform rolling update, you need to update the cloud resources first with "kops update cluster"
 


### PR DESCRIPTION
Just a simple typo fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2305)
<!-- Reviewable:end -->
