### PR TITLE
invalid tags field in aws_route53_zone_association terraform resource

### DIFF
--- a/tests/integration/privatedns1/kubernetes.tf
+++ b/tests/integration/privatedns1/kubernetes.tf
@@ -366,11 +366,6 @@ resource "aws_route53_record" "api-privatedns1-example-com" {
 resource "aws_route53_zone_association" "internal-example-com" {
   zone_id = "/hostedzone/Z2AFAKE1ZON3NO"
   vpc_id  = "${aws_vpc.privatedns1-example-com.id}"
-
-  tags = {
-    KubernetesCluster = "privatedns1.example.com"
-    Name              = "internal.example.com"
-  }
 }
 
 resource "aws_route_table" "private-us-test-1a-privatedns1-example-com" {

--- a/upup/pkg/fi/cloudup/awstasks/dnszone.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnszone.go
@@ -222,7 +222,6 @@ func (_ *DNSZone) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *DNSZone) error
 type terraformRoute53ZoneAssociation struct {
 	ZoneID    *terraform.Literal   `json:"zone_id"`
 	VPCID     *terraform.Literal   `json:"vpc_id"`
-	Tags      map[string]string    `json:"tags,omitempty"`
 	Lifecycle *terraform.Lifecycle `json:"lifecycle,omitempty"`
 }
 
@@ -268,7 +267,6 @@ func (_ *DNSZone) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *D
 				tf := &terraformRoute53ZoneAssociation{
 					ZoneID: terraform.LiteralFromStringValue(*e.ZoneID),
 					VPCID:  e.PrivateVPC.TerraformLink(),
-					Tags:   cloud.BuildTags(e.Name),
 				}
 				return t.RenderResource("aws_route53_zone_association", *e.Name, tf)
 			}


### PR DESCRIPTION
with apologies: terraform vomits on the tags field. I'm not sure how I missed this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2322)
<!-- Reviewable:end -->
