### PR TITLE
Move cluster delete files to pkg/resources

### DIFF
--- a/cmd/kops/delete_cluster.go
+++ b/cmd/kops/delete_cluster.go
@@ -27,10 +27,10 @@ import (
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/registry"
 	"k8s.io/kops/pkg/kubeconfig"
+	"k8s.io/kops/pkg/resources"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
-	"k8s.io/kops/upup/pkg/kutil"
 	"k8s.io/kops/util/pkg/tables"
 	"k8s.io/kops/util/pkg/vfs"
 )
@@ -122,32 +122,32 @@ func RunDeleteCluster(f *util.Factory, out io.Writer, options *DeleteClusterOpti
 		}
 
 		// Todo lets make this smart enough to detect the cloud and switch on the ClusterResources interface
-		d := &kutil.AwsCluster{}
+		d := &resources.AwsCluster{}
 		d.ClusterName = clusterName
 		d.Cloud = cloud
 
-		resources, err := d.ListResources()
+		clusterResources, err := d.ListResources()
 		if err != nil {
 			return err
 		}
 
-		if len(resources) == 0 {
+		if len(clusterResources) == 0 {
 			fmt.Fprintf(out, "No cloud resources to delete\n")
 		} else {
 			wouldDeleteCloudResources = true
 
 			t := &tables.Table{}
-			t.AddColumn("TYPE", func(r *kutil.ResourceTracker) string {
+			t.AddColumn("TYPE", func(r *resources.ResourceTracker) string {
 				return r.Type
 			})
-			t.AddColumn("ID", func(r *kutil.ResourceTracker) string {
+			t.AddColumn("ID", func(r *resources.ResourceTracker) string {
 				return r.ID
 			})
-			t.AddColumn("NAME", func(r *kutil.ResourceTracker) string {
+			t.AddColumn("NAME", func(r *resources.ResourceTracker) string {
 				return r.Name
 			})
-			var l []*kutil.ResourceTracker
-			for _, v := range resources {
+			var l []*resources.ResourceTracker
+			for _, v := range clusterResources {
 				l = append(l, v)
 			}
 
@@ -162,7 +162,7 @@ func RunDeleteCluster(f *util.Factory, out io.Writer, options *DeleteClusterOpti
 
 			fmt.Fprintf(out, "\n")
 
-			err = d.DeleteResources(resources)
+			err = d.DeleteResources(clusterResources)
 			if err != nil {
 				return err
 			}

--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -24,8 +24,8 @@ import (
 	"io"
 	"k8s.io/kops/cmd/kops/util"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/resources"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
-	"k8s.io/kops/upup/pkg/kutil"
 )
 
 type ToolboxDumpOptions struct {
@@ -91,7 +91,7 @@ func RunToolboxDump(f *util.Factory, out io.Writer, options *ToolboxDumpOptions)
 	}
 
 	// Todo lets make this smart enough to detect the cloud and switch on the ClusterResources interface
-	d := &kutil.AwsCluster{}
+	d := &resources.AwsCluster{}
 	d.ClusterName = options.ClusterName
 	d.Cloud = cloud
 

--- a/hack/.packages
+++ b/hack/.packages
@@ -46,6 +46,7 @@ k8s.io/kops/pkg/model/components
 k8s.io/kops/pkg/model/gcemodel
 k8s.io/kops/pkg/model/iam
 k8s.io/kops/pkg/model/resources
+k8s.io/kops/pkg/resources
 k8s.io/kops/pkg/systemd
 k8s.io/kops/pkg/util/stringorslice
 k8s.io/kops/pkg/validation

--- a/pkg/resources/cluster_resources.go
+++ b/pkg/resources/cluster_resources.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kutil
+package resources
 
 import (
 	"fmt"

--- a/pkg/resources/delete_cluster.go
+++ b/pkg/resources/delete_cluster.go
@@ -14,16 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kutil
+package resources
 
 import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
 	"fmt"
-	"io"
-	"strings"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -32,10 +29,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/golang/glog"
-
+	"io"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"strings"
+	"sync"
+	"time"
 )
 
 const (
@@ -137,6 +137,155 @@ func addUntaggedRouteTables(cloud awsup.AWSCloud, clusterName string, resources 
 	}
 
 	return nil
+}
+
+func (c *AwsCluster) DeleteResources(resources map[string]*ResourceTracker) error {
+	depMap := make(map[string][]string)
+
+	done := make(map[string]*ResourceTracker)
+
+	var mutex sync.Mutex
+
+	for k, t := range resources {
+		for _, block := range t.blocks {
+			depMap[block] = append(depMap[block], k)
+		}
+
+		for _, blocked := range t.blocked {
+			depMap[k] = append(depMap[k], blocked)
+		}
+
+		if t.done {
+			done[k] = t
+		}
+	}
+
+	glog.V(2).Infof("Dependencies")
+	for k, v := range depMap {
+		glog.V(2).Infof("\t%s\t%v", k, v)
+	}
+
+	iterationsWithNoProgress := 0
+	for {
+		// TODO: Some form of default ordering based on types?
+
+		failed := make(map[string]*ResourceTracker)
+
+		for {
+			phase := make(map[string]*ResourceTracker)
+
+			for k, r := range resources {
+				if _, d := done[k]; d {
+					continue
+				}
+
+				if _, d := failed[k]; d {
+					// Only attempt each resource once per pass
+					continue
+				}
+
+				ready := true
+				for _, dep := range depMap[k] {
+					if _, d := done[dep]; !d {
+						glog.V(4).Infof("dependency %q of %q not deleted; skipping", dep, k)
+						ready = false
+					}
+				}
+				if !ready {
+					continue
+				}
+
+				phase[k] = r
+			}
+
+			if len(phase) == 0 {
+				break
+			}
+
+			groups := make(map[string][]*ResourceTracker)
+			for k, t := range phase {
+				groupKey := t.groupKey
+				if groupKey == "" {
+					groupKey = "_" + k
+				}
+				groups[groupKey] = append(groups[groupKey], t)
+			}
+
+			var wg sync.WaitGroup
+			for _, trackers := range groups {
+				wg.Add(1)
+
+				go func(trackers []*ResourceTracker) {
+					mutex.Lock()
+					for _, t := range trackers {
+						k := t.Type + ":" + t.ID
+						failed[k] = t
+					}
+					mutex.Unlock()
+
+					defer wg.Done()
+
+					human := trackers[0].Type + ":" + trackers[0].ID
+
+					var err error
+					if trackers[0].groupDeleter != nil {
+						err = trackers[0].groupDeleter(c.Cloud, trackers)
+					} else {
+						if len(trackers) != 1 {
+							glog.Fatalf("found group without groupKey")
+						}
+						err = trackers[0].deleter(c.Cloud, trackers[0])
+					}
+					if err != nil {
+						mutex.Lock()
+						if IsDependencyViolation(err) {
+							fmt.Printf("%s\tstill has dependencies, will retry\n", human)
+							glog.V(4).Infof("API call made when had dependency: %s", human)
+						} else {
+							fmt.Printf("%s\terror deleting resource, will retry: %v\n", human, err)
+						}
+						for _, t := range trackers {
+							k := t.Type + ":" + t.ID
+							failed[k] = t
+						}
+						mutex.Unlock()
+					} else {
+						mutex.Lock()
+						fmt.Printf("%s\tok\n", human)
+
+						iterationsWithNoProgress = 0
+						for _, t := range trackers {
+							k := t.Type + ":" + t.ID
+							delete(failed, k)
+							done[k] = t
+						}
+						mutex.Unlock()
+					}
+				}(trackers)
+			}
+			wg.Wait()
+		}
+
+		if len(resources) == len(done) {
+			return nil
+		}
+
+		fmt.Printf("Not all resources deleted; waiting before reattempting deletion\n")
+		for k := range resources {
+			if _, d := done[k]; d {
+				continue
+			}
+
+			fmt.Printf("\t%s\n", k)
+		}
+
+		iterationsWithNoProgress++
+		if iterationsWithNoProgress > 42 {
+			return fmt.Errorf("Not making progress deleting resources; giving up")
+		}
+
+		time.Sleep(10 * time.Second)
+	}
 }
 
 func matchesAsgTags(tags map[string]string, actual []*autoscaling.TagDescription) bool {

--- a/pkg/resources/delete_cluster_gce.go
+++ b/pkg/resources/delete_cluster_gce.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kutil
+package resources
 
 import (
 	"context"

--- a/pkg/resources/deletecluster_test.go
+++ b/pkg/resources/deletecluster_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kutil
+package resources
 
 import (
 	"reflect"

--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/golang/glog"
+	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+)
+
+// findAutoscalingGroups finds autoscaling groups matching the specified tags
+// This isn't entirely trivial because autoscaling doesn't let us filter with as much precision as we would like
+func findAutoscalingGroups(cloud awsup.AWSCloud, tags map[string]string) ([]*autoscaling.Group, error) {
+	var asgs []*autoscaling.Group
+
+	glog.V(2).Infof("Listing all Autoscaling groups matching cluster tags")
+	var asgNames []*string
+	{
+		var asFilters []*autoscaling.Filter
+		for _, v := range tags {
+			// Not an exact match, but likely the best we can do
+			asFilters = append(asFilters, &autoscaling.Filter{
+				Name:   aws.String("value"),
+				Values: []*string{aws.String(v)},
+			})
+		}
+		request := &autoscaling.DescribeTagsInput{
+			Filters: asFilters,
+		}
+
+		err := cloud.Autoscaling().DescribeTagsPages(request, func(p *autoscaling.DescribeTagsOutput, lastPage bool) bool {
+			for _, t := range p.Tags {
+				switch *t.ResourceType {
+				case "auto-scaling-group":
+					asgNames = append(asgNames, t.ResourceId)
+				default:
+					glog.Warningf("Unknown resource type: %v", *t.ResourceType)
+
+				}
+			}
+			return true
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error listing autoscaling cluster tags: %v", err)
+		}
+	}
+
+	if len(asgNames) != 0 {
+		request := &autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: asgNames,
+		}
+		err := cloud.Autoscaling().DescribeAutoScalingGroupsPages(request, func(p *autoscaling.DescribeAutoScalingGroupsOutput, lastPage bool) bool {
+			for _, asg := range p.AutoScalingGroups {
+				if !matchesAsgTags(tags, asg.Tags) {
+					// We used an inexact filter above
+					continue
+				}
+				// Check for "Delete in progress" (the only use of .Status)
+				if asg.Status != nil {
+					glog.Warningf("Skipping ASG %v (which matches tags): %v", *asg.AutoScalingGroupARN, *asg.Status)
+					continue
+				}
+				asgs = append(asgs, asg)
+			}
+			return true
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error listing autoscaling groups: %v", err)
+		}
+
+	}
+
+	return asgs, nil
+}
+
+func findAutoscalingLaunchConfiguration(cloud awsup.AWSCloud, name string) (*autoscaling.LaunchConfiguration, error) {
+	glog.V(2).Infof("Retrieving Autoscaling LaunchConfigurations %q", name)
+
+	var results []*autoscaling.LaunchConfiguration
+
+	request := &autoscaling.DescribeLaunchConfigurationsInput{
+		LaunchConfigurationNames: []*string{&name},
+	}
+	err := cloud.Autoscaling().DescribeLaunchConfigurationsPages(request, func(p *autoscaling.DescribeLaunchConfigurationsOutput, lastPage bool) bool {
+		for _, t := range p.LaunchConfigurations {
+			results = append(results, t)
+		}
+		return true
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error listing autoscaling LaunchConfigurations: %v", err)
+	}
+
+	if len(results) == 0 {
+		return nil, nil
+	}
+	if len(results) != 1 {
+		return nil, fmt.Errorf("Found multiple LaunchConfigurations with name %q", name)
+	}
+	return results[0], nil
+}


### PR DESCRIPTION
I'd like to generalize the cluster delete code so it can be pluggable with other cloud providers. Before doing that I wanted to move it to a package that made more sense. Related issue: https://github.com/kubernetes/kops/issues/2310. 

This PR only moves the contents of the file, you'll notice that `upup/pkg/kutil/delete_cluster.go` was not deleted since some code in `convert_kubeup_cluster.go` depends on it. I'm not sure when kubeup conversion to kops can be deprecated but seems like a possibility in the near future. Until then some of the code in `upup/pkg/kutil/delete_cluster.go` is duplicated in `pkg/resources` 😭 

There will be future PRs coming to refactor/clean up `pkg/resources`.

cc @kris-nova

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2328)
<!-- Reviewable:end -->
