### PR TITLE
Set default master size for ap-northeast-2

### DIFF
--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -43,9 +43,10 @@ const (
 
 var masterMachineTypeExceptions = map[string]string{
 	// Some regions do not (currently) support the m3 family; the c4 large is the cheapest non-burstable instance
-	"us-east-2":    "c4.large",
-	"ca-central-1": "c4.large",
-	"eu-west-2":    "c4.large",
+	"us-east-2":      "c4.large",
+	"ca-central-1":   "c4.large",
+	"eu-west-2":      "c4.large",
+	"ap-northeast-2": "c4.large",
 }
 
 var awsDedicatedInstanceExceptions = map[string]bool{


### PR DESCRIPTION
The ap-northeast-2 region doesn't support the m3 family; a c4.large is
the cheapest non-burstable instance.

Please refer to the issue #1455.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2349)
<!-- Reviewable:end -->
