### PR TITLE
Fix weave daemonset labels to be backwards compatible

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml
@@ -53,12 +53,14 @@ metadata:
   name: weave-net
   namespace: kube-system
   labels:
+    name: weave-net
     role.kubernetes.io/networking: "1"
 spec:
   template:
     metadata:
       labels:
         name: weave-net
+        role.kubernetes.io/networking: "1"
     spec:
       hostNetwork: true
       hostPID: true

--- a/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml
+++ b/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml
@@ -4,12 +4,14 @@ metadata:
   name: weave-net
   namespace: kube-system
   labels:
+    name: weave-net
     role.kubernetes.io/networking: "1"
 spec:
   template:
     metadata:
       labels:
         name: weave-net
+        role.kubernetes.io/networking: "1"
       annotations:
         scheduler.alpha.kubernetes.io/tolerations: |
           [


### PR DESCRIPTION
Otherwise the kops 1.5 -> kops 1.6 upgrade was failing with:

The DaemonSet "weave-net" is invalid: spec.template.metadata.labels:
Invalid value: {"name":"weave-net"}: `selector` does not match template
`labels`

Fix #2345

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2353)
<!-- Reviewable:end -->
