### PR TITLE
Fix bash commands on "Set up IAM user" section in aws docs.

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -52,12 +52,13 @@ You can create the kops IAM user from the command line using the following:
 ```bash
 aws iam create-group --group-name kops
 
-export arns="
+arns=(
 arn:aws:iam::aws:policy/AmazonEC2FullAccess
 arn:aws:iam::aws:policy/AmazonRoute53FullAccess
 arn:aws:iam::aws:policy/AmazonS3FullAccess
 arn:aws:iam::aws:policy/IAMFullAccess
-arn:aws:iam::aws:policy/AmazonVPCFullAccess"
+arn:aws:iam::aws:policy/AmazonVPCFullAccess
+)
 
 for arn in $arns; do aws iam attach-group-policy --policy-arn "$arn" --group-name kops; done
 


### PR DESCRIPTION
Hello there.

I was following [setting-up-a-kops-iam-user](https://github.com/kubernetes/kops/blob/master/docs/aws.md#setting-up-a-kops-iam-user) for create kops user.

But it doesn't work, so I fixed commands properly.

Thanks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2355)
<!-- Reviewable:end -->
