### PR TITLE
update route53-mapper readme and addon catalog

### DIFF
--- a/addons/route53-mapper/README.md
+++ b/addons/route53-mapper/README.md
@@ -14,9 +14,7 @@ The project is created by wearemolecule, and maintained at
 ### Deploy To Cluster
 
 ```
-# Version 1.2.0
-# https://github.com/wearemolecule/route53-kubernetes/tree/v1.2.0
-$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/route53-mapper/v1.2.0.yml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/route53-mapper/v1.3.0.yml
 ```
 
 **Important:**

--- a/addons/route53-mapper/addon.yml
+++ b/addons/route53-mapper/addon.yml
@@ -7,3 +7,7 @@ spec:
       selector:
         k8s-addon: route53-mapper.addons.k8s.io
       manifest: v1.2.0.yaml
+    - version: 1.3.0
+      selector:
+        k8s-addon: route53-mapper.addons.k8s.io
+      manifest: v1.3.0.yaml


### PR DESCRIPTION
adds missing version to addon.yml and updates the readme with latest version of the plugin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2364)
<!-- Reviewable:end -->
