### PR TITLE
kops nodeLables - additional documentation to clarify how nodeLables work in AWS

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -7,7 +7,12 @@ There are two main types of labels that kops can create:
 
 Both are specified at the InstanceGroup level.
 
-A nice use for CloudLabels is to specify [AWS cost allocation tags](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html)
+A nice use for CloudLabels is to specify [AWS cost allocation tags](http://docs.aws.amazon
+.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html).
+
+A good use for nodeLables is to implement [nodeSelector labels](https://kubernetes
+.io/docs/concepts/configuration/assign-pod-node/#step-two-add-a-nodeselector-field-to-your-pod-configuration) that 
+survive [AWS EC2 auto scaling groups](https://aws.amazon.com/autoscaling/) replacing unhealthy or unreachable instances.
 
 An example:
 
@@ -28,3 +33,6 @@ Note that keys and values are strings, so you need quotes around values that YAM
  would otherwise treat as numbers or booleans.
 
 To apply changes, you'll need to do a `kops update cluster` and then likely a `kops rolling-update cluster`
+
+Note for AWS if `kops rolling-update cluster --instance-group nodes` returns "No rolling-update required." you'll need 
+to manually terminate the EC2 node for the auto scaling group to propagate the new labels. 


### PR DESCRIPTION
kops nodeLables - additional documentation to clarify how nodeLables work in AWS and a work around for kops rolling-update not recognizing any required changes in AWS.

A good use for nodeLables is to implement [nodeSelector labels](https://kubernetes
.io/docs/concepts/configuration/assign-pod-node/#step-two-add-a-nodeselector-field-to-your-pod-configuration) that survive 
[AWS EC2 auto scaling groups](https://aws.amazon.com/autoscaling/) replacing unhealthy or unreachable instances.

Note for AWS if `kops rolling-update cluster --instance-group nodes` returns "No rolling-update required." you'll need to 
manually terminate the EC2 node for the auto scaling group to propagate the new labels.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2365)
<!-- Reviewable:end -->
