### PR TITLE
Checking that cobra docs are generated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,11 @@ verify-gofmt:
 verify-packages:
 	hack/verify-packages.sh
 
-ci: govet verify-gofmt kops nodeup-gocode examples test verify-boilerplate verify-packages
+.PHONY: verify-gendocs
+verify-gendocs: kops
+	hack/verify-gendocs.sh
+
+ci: govet verify-gofmt verify-boilerplate verify-packages kops verify-gendocs nodeup-gocode examples test
 	echo "Done!"
 
 # --------------------------------------------------

--- a/hack/verify-gendocs.sh
+++ b/hack/verify-gendocs.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. $(dirname "${BASH_SOURCE}")/common.sh
+
+TMP_DOCS="${KUBE_ROOT}/.build/docs"
+rm -rf $TMP_DOCS
+mkdir -p $TMP_DOCS
+
+command -v uname >/dev/null 2>&1 || { echo >&2 "uname must be installed. Aborting."; exit 1; }
+OS=$(uname -s)
+
+platform=""
+if [[ $OS == "Darwin" ]]; then
+	platform="darwin/amd64/"	
+else 
+	platform="linux/amd64/"	
+fi
+
+locations=(
+  "${GOPATH}/bin/kops"
+  "${KUBE_ROOT}/.build/dist/${platform}/kops"
+)
+# List most recently-updated location.
+BIN=$( (ls -t "${locations[@]}" 2>/dev/null || true) | head -1 )
+
+command -v $BIN >/dev/null 2>&1 || { echo >&2 "kops must be installed. Please run make.  Aborting."; exit 1; }
+
+KOPS_STATE_STORE= $BIN genhelpdocs --out $TMP_DOCS
+
+if [[ "$(diff $TMP_DOCS ${KUBE_ROOT}/docs/cli)" != "" ]]; then
+	  echo "List of generated docs doesn't match a freshly built list. Please run the command make gen-cli-docs."
+	  exit 1
+fi


### PR DESCRIPTION
Closed https://github.com/kubernetes/kops/pull/2028 since I am pushing this in from a different repo.

This adds a script that checks that the cobra generated documents are up to date.  The make target is used by Travis CI.

This should fail CI, because https://github.com/kubernetes/kops/pull/2402 need to be merged first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2403)
<!-- Reviewable:end -->
