### PR TITLE
Updating CNI version for k8s 1.6

### DIFF
--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -222,7 +222,12 @@ func (c *ApplyClusterCmd) Run() error {
 		}
 
 		if usesCNI(cluster) {
-			cniAsset, cniAssetHashString := findCNIAssets(cluster)
+			cniAsset, cniAssetHashString, err := findCNIAssets(cluster)
+
+			if err != nil {
+				return err
+			}
+
 			c.Assets = append(c.Assets, cniAssetHashString+"@"+cniAsset)
 		}
 

--- a/upup/pkg/fi/cloudup/networking.go
+++ b/upup/pkg/fi/cloudup/networking.go
@@ -17,9 +17,13 @@ limitations under the License.
 package cloudup
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/blang/semver"
 	"github.com/golang/glog"
 	api "k8s.io/kops/pkg/apis/kops"
-	"os"
+	"k8s.io/kops/pkg/apis/kops/util"
 )
 
 func usesCNI(c *api.Cluster) bool {
@@ -78,19 +82,40 @@ func usesCNI(c *api.Cluster) bool {
 // https://github.com/kubernetes/kops/issues/724
 // https://github.com/kubernetes/kops/issues/626
 // https://github.com/kubernetes/kubernetes/issues/30338
+
 const (
-	defaultCNIAsset           = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz"
-	defaultCNIAssetHashString = "19d49f7b2b99cd2493d5ae0ace896c64e289ccbb"
-	ENV_VAR_CNI_VERSION_URL   = "CNI_VERSION_URL"
+	// 1.5.x k8s uses release 07a8a28637e97b22eb8dfe710eeae1344f69d16e
+	defaultCNIAssetK8s1_5           = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz"
+	defaultCNIAssetHashStringK8s1_5 = "19d49f7b2b99cd2493d5ae0ace896c64e289ccbb"
+
+	// 1.6.x k8s uses release 0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff
+	defaultCNIAssetK8s1_6           = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz"
+	defaultCNIAssetHashStringK8s1_6 = "1d9788b0f5420e1a219aad2cb8681823fc515e7c"
+
+	// Environment variable for overriding CNI url
+	ENV_VAR_CNI_VERSION_URL = "CNI_VERSION_URL"
 )
 
-func findCNIAssets(c *api.Cluster) (string, string) {
+func findCNIAssets(c *api.Cluster) (string, string, error) {
 
 	if cniVersionURL := os.Getenv(ENV_VAR_CNI_VERSION_URL); cniVersionURL != "" {
 		glog.Infof("Using CNI asset version %q, as set in %s", cniVersionURL, ENV_VAR_CNI_VERSION_URL)
-		return cniVersionURL, ""
+		return cniVersionURL, "", nil
 	}
 
-	glog.V(2).Infof("Adding default CNI asset: %s", defaultCNIAsset)
-	return defaultCNIAsset, defaultCNIAssetHashString
+	sv, err := util.ParseKubernetesVersion(c.Spec.KubernetesVersion)
+	if err != nil {
+		return "", "", fmt.Errorf("Failed to lookup kubernetes version: %v", err)
+	}
+
+	sv.Pre = nil
+	sv.Build = nil
+
+	if sv.GTE(semver.Version{Major: 1, Minor: 6, Patch: 0, Pre: nil, Build: nil}) {
+		glog.V(2).Infof("Adding default CNI asset: %s", defaultCNIAssetK8s1_6)
+		return defaultCNIAssetK8s1_6, defaultCNIAssetHashStringK8s1_6, nil
+	}
+
+	glog.V(2).Infof("Adding default CNI asset: %s", defaultCNIAssetK8s1_5)
+	return defaultCNIAssetK8s1_5, defaultCNIAssetHashStringK8s1_5, nil
 }

--- a/upup/pkg/fi/cloudup/networking_test.go
+++ b/upup/pkg/fi/cloudup/networking_test.go
@@ -31,7 +31,11 @@ func Test_FindCNIAssetFromEnvironmentVariable(t *testing.T) {
 	}()
 
 	cluster := &api.Cluster{}
-	cniAsset, cniAssetHashString := findCNIAssets(cluster)
+	cniAsset, cniAssetHashString, err := findCNIAssets(cluster)
+
+	if err != nil {
+		t.Errorf("Unable to parse k8s version %s", err)
+	}
 
 	if cniAsset != desiredCNIVersion {
 		t.Errorf("Expected CNI version from Environment variable %q, but got %q instead", desiredCNIVersion, cniAsset)
@@ -42,17 +46,42 @@ func Test_FindCNIAssetFromEnvironmentVariable(t *testing.T) {
 	}
 }
 
-func Test_FindCNIAssetDefaultValue(t *testing.T) {
+func Test_FindCNIAssetDefaultValue1_6(t *testing.T) {
 
-	cluster := &api.Cluster{}
-	cniAsset, cniAssetHashString := findCNIAssets(cluster)
+	cluster := &api.Cluster{Spec: api.ClusterSpec{}}
+	cluster.Spec.KubernetesVersion = "v1.6.2"
+	cniAsset, cniAssetHashString, err := findCNIAssets(cluster)
 
-	if cniAsset != defaultCNIAsset {
-		t.Errorf("Expected default CNI version %q and got %q", defaultCNIAsset, cniAsset)
+	if err != nil {
+		t.Errorf("Unable to parse k8s version %s", err)
 	}
 
-	if cniAssetHashString != defaultCNIAssetHashString {
-		t.Errorf("Expected default CNI Version Hash String %q and got %q", defaultCNIAssetHashString, cniAssetHashString)
+	if cniAsset != defaultCNIAssetK8s1_6 {
+		t.Errorf("Expected default CNI version %q and got %q", defaultCNIAssetK8s1_5, cniAsset)
+	}
+
+	if cniAssetHashString != defaultCNIAssetHashStringK8s1_6 {
+		t.Errorf("Expected default CNI Version Hash String %q and got %q", defaultCNIAssetHashStringK8s1_5, cniAssetHashString)
+	}
+
+}
+
+func Test_FindCNIAssetDefaultValue1_5(t *testing.T) {
+
+	cluster := &api.Cluster{Spec: api.ClusterSpec{}}
+	cluster.Spec.KubernetesVersion = "v1.5.12"
+	cniAsset, cniAssetHashString, err := findCNIAssets(cluster)
+
+	if err != nil {
+		t.Errorf("Unable to parse k8s version %s", err)
+	}
+
+	if cniAsset != defaultCNIAssetK8s1_5 {
+		t.Errorf("Expected default CNI version %q and got %q", defaultCNIAssetK8s1_5, cniAsset)
+	}
+
+	if cniAssetHashString != defaultCNIAssetHashStringK8s1_5 {
+		t.Errorf("Expected default CNI Version Hash String %q and got %q", defaultCNIAssetHashStringK8s1_5, cniAssetHashString)
 	}
 
 }


### PR DESCRIPTION
New CNI version, we need it for the 1.6 kops release

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2408)
<!-- Reviewable:end -->
