### PR TITLE
Proposes standards for grammar for Cobra CLI Docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ gcs-publish-ci: gcs-upload
 	echo "${GCS_URL}/${VERSION}" > .build/upload/${LATEST_FILE}
 	gsutil -h "Cache-Control:private, max-age=0, no-transform" cp .build/upload/${LATEST_FILE} ${GCS_LOCATION}
 
-gen-cli-docs:
+gen-cli-docs: kops
 	@kops genhelpdocs --out docs/cli
 
 # Will always push a linux-based build up to the server

--- a/docs/development/documentation.md
+++ b/docs/development/documentation.md
@@ -4,7 +4,18 @@
 
 `kops` uses cobra for it's CLI implementation. Each command should have the following help fields defined where possible:
 
-* `Short`: single sentence description of command.
-* `Long`: expanded description and usage of the command. The text from the `Short` field should be the first sentence in the `Long` field.
-* `Example`: example(s) of how to use the command. This field is formatted as a code snippet in the docs, so make sure if you have comments
-that these are written as a bash comment (e.g. `# this is a comment`).
+* `Short`: A short statement describing the command in the third person present, starting with a capital letter and ending without a period.
+  * Example: "Edits a cluster"
+
+* `Long`: An expanded description and usage of the command in the third person present tense, starting with a capital letter and ending with a period. The text from the `Short` field should be the first sentence in the `Long` field.
+Example:
+```
+Edits a cluster.
+
+This command changes the cloud specification in the registry.
+
+It does not update the cloud resources, to apply the changes use "kops update cluster".
+```
+
+* `Example`: Example(s) of how to use the command. This field is formatted as a code snippet in the docs, so make sure if you have comments that these are written as a bash comment (e.g. `# this is a comment`).
+


### PR DESCRIPTION
**Proposal:** We need to standardize our UI (which happens to be a CLI) for broader kops adoption. I would be happy to put in some time to help clean these commands up, but I'd like to decide what is correct before changing things back and forth a bunch of times. 

My proposal is one alternative, I'm not married to the exact implementation with respect to tense and layout and anything else, but I'd like to get an implementation that folks are OK with and write it down somewhere. Then it's relatively easy to actually do the work. 

Alongside that, I added `kops` to `gen-cli-docs` target so that you get the latest docs after you've updated your cobra code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2410)
<!-- Reviewable:end -->
