### PR TITLE
Update the terraform generator to use the value "role" instead of "roles" for the aws_iam_instance_profile resource

### DIFF
--- a/tests/integration/complex/kubernetes.tf
+++ b/tests/integration/complex/kubernetes.tf
@@ -165,7 +165,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-complex-example-c
   }
 
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/complex/kubernetes.tf
+++ b/tests/integration/complex/kubernetes.tf
@@ -104,12 +104,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-complex-example-com" {
 
 resource "aws_iam_instance_profile" "masters-complex-example-com" {
   name  = "masters.complex.example.com"
-  roles = ["${aws_iam_role.masters-complex-example-com.name}"]
+  role  = "${aws_iam_role.masters-complex-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-complex-example-com" {
   name  = "nodes.complex.example.com"
-  roles = ["${aws_iam_role.nodes-complex-example-com.name}"]
+  role  = "${aws_iam_role.nodes-complex-example-com.name}"
 }
 
 resource "aws_iam_role" "masters-complex-example-com" {

--- a/tests/integration/complex/kubernetes.tf
+++ b/tests/integration/complex/kubernetes.tf
@@ -103,12 +103,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-complex-example-com" {
 }
 
 resource "aws_iam_instance_profile" "masters-complex-example-com" {
-  name  = "masters.complex.example.com"
+  name = "masters.complex.example.com"
   role = "${aws_iam_role.masters-complex-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-complex-example-com" {
-  name  = "nodes.complex.example.com"
+  name = "nodes.complex.example.com"
   role = "${aws_iam_role.nodes-complex-example-com.name}"
 }
 
@@ -165,7 +165,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-complex-example-c
   }
 
   ephemeral_block_device = {
-    device_name  = "/dev/sdc"
+    device_name = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/complex/kubernetes.tf
+++ b/tests/integration/complex/kubernetes.tf
@@ -104,12 +104,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-complex-example-com" {
 
 resource "aws_iam_instance_profile" "masters-complex-example-com" {
   name  = "masters.complex.example.com"
-  role  = "${aws_iam_role.masters-complex-example-com.name}"
+  role = "${aws_iam_role.masters-complex-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-complex-example-com" {
   name  = "nodes.complex.example.com"
-  role  = "${aws_iam_role.nodes-complex-example-com.name}"
+  role = "${aws_iam_role.nodes-complex-example-com.name}"
 }
 
 resource "aws_iam_role" "masters-complex-example-com" {

--- a/tests/integration/ha/kubernetes.tf
+++ b/tests/integration/ha/kubernetes.tf
@@ -212,12 +212,12 @@ resource "aws_ebs_volume" "c-etcd-main-ha-example-com" {
 
 resource "aws_iam_instance_profile" "masters-ha-example-com" {
   name  = "masters.ha.example.com"
-  roles = ["${aws_iam_role.masters-ha-example-com.name}"]
+  role  = "${aws_iam_role.masters-ha-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-ha-example-com" {
   name  = "nodes.ha.example.com"
-  roles = ["${aws_iam_role.nodes-ha-example-com.name}"]
+  role  = "${aws_iam_role.nodes-ha-example-com.name}"
 }
 
 resource "aws_iam_role" "masters-ha-example-com" {

--- a/tests/integration/ha/kubernetes.tf
+++ b/tests/integration/ha/kubernetes.tf
@@ -273,7 +273,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-ha-example-com" {
   }
 
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 
@@ -299,7 +299,7 @@ resource "aws_launch_configuration" "master-us-test-1b-masters-ha-example-com" {
   }
 
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 
@@ -325,7 +325,7 @@ resource "aws_launch_configuration" "master-us-test-1c-masters-ha-example-com" {
   }
 
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/ha/kubernetes.tf
+++ b/tests/integration/ha/kubernetes.tf
@@ -212,12 +212,12 @@ resource "aws_ebs_volume" "c-etcd-main-ha-example-com" {
 
 resource "aws_iam_instance_profile" "masters-ha-example-com" {
   name  = "masters.ha.example.com"
-  role  = "${aws_iam_role.masters-ha-example-com.name}"
+  role = "${aws_iam_role.masters-ha-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-ha-example-com" {
   name  = "nodes.ha.example.com"
-  role  = "${aws_iam_role.nodes-ha-example-com.name}"
+  role = "${aws_iam_role.nodes-ha-example-com.name}"
 }
 
 resource "aws_iam_role" "masters-ha-example-com" {

--- a/tests/integration/ha/kubernetes.tf
+++ b/tests/integration/ha/kubernetes.tf
@@ -211,12 +211,12 @@ resource "aws_ebs_volume" "c-etcd-main-ha-example-com" {
 }
 
 resource "aws_iam_instance_profile" "masters-ha-example-com" {
-  name  = "masters.ha.example.com"
+  name = "masters.ha.example.com"
   role = "${aws_iam_role.masters-ha-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-ha-example-com" {
-  name  = "nodes.ha.example.com"
+  name = "nodes.ha.example.com"
   role = "${aws_iam_role.nodes-ha-example-com.name}"
 }
 
@@ -273,7 +273,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-ha-example-com" {
   }
 
   ephemeral_block_device = {
-    device_name  = "/dev/sdc"
+    device_name = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 
@@ -299,7 +299,7 @@ resource "aws_launch_configuration" "master-us-test-1b-masters-ha-example-com" {
   }
 
   ephemeral_block_device = {
-    device_name  = "/dev/sdc"
+    device_name = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 
@@ -325,7 +325,7 @@ resource "aws_launch_configuration" "master-us-test-1c-masters-ha-example-com" {
   }
 
   ephemeral_block_device = {
-    device_name  = "/dev/sdc"
+    device_name = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/minimal-141/kubernetes.tf
+++ b/tests/integration/minimal-141/kubernetes.tf
@@ -104,12 +104,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-141-example-com" {
 
 resource "aws_iam_instance_profile" "masters-minimal-141-example-com" {
   name  = "masters.minimal-141.example.com"
-  role  = "${aws_iam_role.masters-minimal-141-example-com.name}"
+  role = "${aws_iam_role.masters-minimal-141-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-minimal-141-example-com" {
   name  = "nodes.minimal-141.example.com"
-  role  = "${aws_iam_role.nodes-minimal-141-example-com.name}"
+  role = "${aws_iam_role.nodes-minimal-141-example-com.name}"
 }
 
 resource "aws_iam_role" "masters-minimal-141-example-com" {

--- a/tests/integration/minimal-141/kubernetes.tf
+++ b/tests/integration/minimal-141/kubernetes.tf
@@ -165,7 +165,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-minimal-141-examp
   }
 
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/minimal-141/kubernetes.tf
+++ b/tests/integration/minimal-141/kubernetes.tf
@@ -104,12 +104,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-141-example-com" {
 
 resource "aws_iam_instance_profile" "masters-minimal-141-example-com" {
   name  = "masters.minimal-141.example.com"
-  roles = ["${aws_iam_role.masters-minimal-141-example-com.name}"]
+  role  = "${aws_iam_role.masters-minimal-141-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-minimal-141-example-com" {
   name  = "nodes.minimal-141.example.com"
-  roles = ["${aws_iam_role.nodes-minimal-141-example-com.name}"]
+  role  = "${aws_iam_role.nodes-minimal-141-example-com.name}"
 }
 
 resource "aws_iam_role" "masters-minimal-141-example-com" {

--- a/tests/integration/minimal-141/kubernetes.tf
+++ b/tests/integration/minimal-141/kubernetes.tf
@@ -103,12 +103,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-141-example-com" {
 }
 
 resource "aws_iam_instance_profile" "masters-minimal-141-example-com" {
-  name  = "masters.minimal-141.example.com"
+  name = "masters.minimal-141.example.com"
   role = "${aws_iam_role.masters-minimal-141-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-minimal-141-example-com" {
-  name  = "nodes.minimal-141.example.com"
+  name = "nodes.minimal-141.example.com"
   role = "${aws_iam_role.nodes-minimal-141-example-com.name}"
 }
 
@@ -165,7 +165,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-minimal-141-examp
   }
 
   ephemeral_block_device = {
-    device_name  = "/dev/sdc"
+    device_name = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/minimal/kubernetes.tf
+++ b/tests/integration/minimal/kubernetes.tf
@@ -104,12 +104,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
 
 resource "aws_iam_instance_profile" "masters-minimal-example-com" {
   name  = "masters.minimal.example.com"
-  role  = "${aws_iam_role.masters-minimal-example-com.name}"
+  role = "${aws_iam_role.masters-minimal-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-minimal-example-com" {
   name  = "nodes.minimal.example.com"
-  role  = "${aws_iam_role.nodes-minimal-example-com.name}"
+  role = "${aws_iam_role.nodes-minimal-example-com.name}"
 }
 
 resource "aws_iam_role" "masters-minimal-example-com" {

--- a/tests/integration/minimal/kubernetes.tf
+++ b/tests/integration/minimal/kubernetes.tf
@@ -103,12 +103,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
 }
 
 resource "aws_iam_instance_profile" "masters-minimal-example-com" {
-  name  = "masters.minimal.example.com"
+  name = "masters.minimal.example.com"
   role = "${aws_iam_role.masters-minimal-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-minimal-example-com" {
-  name  = "nodes.minimal.example.com"
+  name = "nodes.minimal.example.com"
   role = "${aws_iam_role.nodes-minimal-example-com.name}"
 }
 
@@ -165,7 +165,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-minimal-example-c
   }
 
   ephemeral_block_device = {
-    device_name  = "/dev/sdc"
+    device_name = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/minimal/kubernetes.tf
+++ b/tests/integration/minimal/kubernetes.tf
@@ -104,12 +104,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
 
 resource "aws_iam_instance_profile" "masters-minimal-example-com" {
   name  = "masters.minimal.example.com"
-  roles = ["${aws_iam_role.masters-minimal-example-com.name}"]
+  role  = "${aws_iam_role.masters-minimal-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-minimal-example-com" {
   name  = "nodes.minimal.example.com"
-  roles = ["${aws_iam_role.nodes-minimal-example-com.name}"]
+  role  = "${aws_iam_role.nodes-minimal-example-com.name}"
 }
 
 resource "aws_iam_role" "masters-minimal-example-com" {

--- a/tests/integration/minimal/kubernetes.tf
+++ b/tests/integration/minimal/kubernetes.tf
@@ -165,7 +165,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-minimal-example-c
   }
 
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/privatecalico/kubernetes.tf
+++ b/tests/integration/privatecalico/kubernetes.tf
@@ -206,17 +206,17 @@ resource "aws_elb" "bastion-privatecalico-example-com" {
 
 resource "aws_iam_instance_profile" "bastions-privatecalico-example-com" {
   name  = "bastions.privatecalico.example.com"
-  roles = ["${aws_iam_role.bastions-privatecalico-example-com.name}"]
+  role  = "${aws_iam_role.bastions-privatecalico-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privatecalico-example-com" {
   name  = "masters.privatecalico.example.com"
-  roles = ["${aws_iam_role.masters-privatecalico-example-com.name}"]
+  role  = "${aws_iam_role.masters-privatecalico-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privatecalico-example-com" {
   name  = "nodes.privatecalico.example.com"
-  roles = ["${aws_iam_role.nodes-privatecalico-example-com.name}"]
+  role  = "${aws_iam_role.nodes-privatecalico-example-com.name}"
 }
 
 resource "aws_iam_role" "bastions-privatecalico-example-com" {

--- a/tests/integration/privatecalico/kubernetes.tf
+++ b/tests/integration/privatecalico/kubernetes.tf
@@ -303,7 +303,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privatecalico-exa
   }
 
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/privatecalico/kubernetes.tf
+++ b/tests/integration/privatecalico/kubernetes.tf
@@ -205,17 +205,17 @@ resource "aws_elb" "bastion-privatecalico-example-com" {
 }
 
 resource "aws_iam_instance_profile" "bastions-privatecalico-example-com" {
-  name  = "bastions.privatecalico.example.com"
+  name = "bastions.privatecalico.example.com"
   role = "${aws_iam_role.bastions-privatecalico-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privatecalico-example-com" {
-  name  = "masters.privatecalico.example.com"
+  name = "masters.privatecalico.example.com"
   role = "${aws_iam_role.masters-privatecalico-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privatecalico-example-com" {
-  name  = "nodes.privatecalico.example.com"
+  name = "nodes.privatecalico.example.com"
   role = "${aws_iam_role.nodes-privatecalico-example-com.name}"
 }
 
@@ -303,7 +303,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privatecalico-exa
   }
 
   ephemeral_block_device = {
-    device_name  = "/dev/sdc"
+    device_name = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/privatecalico/kubernetes.tf
+++ b/tests/integration/privatecalico/kubernetes.tf
@@ -206,17 +206,17 @@ resource "aws_elb" "bastion-privatecalico-example-com" {
 
 resource "aws_iam_instance_profile" "bastions-privatecalico-example-com" {
   name  = "bastions.privatecalico.example.com"
-  role  = "${aws_iam_role.bastions-privatecalico-example-com.name}"
+  role = "${aws_iam_role.bastions-privatecalico-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privatecalico-example-com" {
   name  = "masters.privatecalico.example.com"
-  role  = "${aws_iam_role.masters-privatecalico-example-com.name}"
+  role = "${aws_iam_role.masters-privatecalico-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privatecalico-example-com" {
   name  = "nodes.privatecalico.example.com"
-  role  = "${aws_iam_role.nodes-privatecalico-example-com.name}"
+  role = "${aws_iam_role.nodes-privatecalico-example-com.name}"
 }
 
 resource "aws_iam_role" "bastions-privatecalico-example-com" {

--- a/tests/integration/privatecanal/kubernetes.tf
+++ b/tests/integration/privatecanal/kubernetes.tf
@@ -206,17 +206,17 @@ resource "aws_elb" "bastion-privatecanal-example-com" {
 
 resource "aws_iam_instance_profile" "bastions-privatecanal-example-com" {
   name  = "bastions.privatecanal.example.com"
-  roles = ["${aws_iam_role.bastions-privatecanal-example-com.name}"]
+  role  = "${aws_iam_role.bastions-privatecanal-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privatecanal-example-com" {
   name  = "masters.privatecanal.example.com"
-  roles = ["${aws_iam_role.masters-privatecanal-example-com.name}"]
+  role  = "${aws_iam_role.masters-privatecanal-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privatecanal-example-com" {
   name  = "nodes.privatecanal.example.com"
-  roles = ["${aws_iam_role.nodes-privatecanal-example-com.name}"]
+  role  = "${aws_iam_role.nodes-privatecanal-example-com.name}"
 }
 
 resource "aws_iam_role" "bastions-privatecanal-example-com" {

--- a/tests/integration/privatecanal/kubernetes.tf
+++ b/tests/integration/privatecanal/kubernetes.tf
@@ -205,17 +205,17 @@ resource "aws_elb" "bastion-privatecanal-example-com" {
 }
 
 resource "aws_iam_instance_profile" "bastions-privatecanal-example-com" {
-  name  = "bastions.privatecanal.example.com"
+  name = "bastions.privatecanal.example.com"
   role = "${aws_iam_role.bastions-privatecanal-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privatecanal-example-com" {
-  name  = "masters.privatecanal.example.com"
+  name = "masters.privatecanal.example.com"
   role = "${aws_iam_role.masters-privatecanal-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privatecanal-example-com" {
-  name  = "nodes.privatecanal.example.com"
+  name = "nodes.privatecanal.example.com"
   role = "${aws_iam_role.nodes-privatecanal-example-com.name}"
 }
 
@@ -303,7 +303,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privatecanal-exam
   }
 
   ephemeral_block_device = {
-    device_name  = "/dev/sdc"
+    device_name = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/privatecanal/kubernetes.tf
+++ b/tests/integration/privatecanal/kubernetes.tf
@@ -206,17 +206,17 @@ resource "aws_elb" "bastion-privatecanal-example-com" {
 
 resource "aws_iam_instance_profile" "bastions-privatecanal-example-com" {
   name  = "bastions.privatecanal.example.com"
-  role  = "${aws_iam_role.bastions-privatecanal-example-com.name}"
+  role = "${aws_iam_role.bastions-privatecanal-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privatecanal-example-com" {
   name  = "masters.privatecanal.example.com"
-  role  = "${aws_iam_role.masters-privatecanal-example-com.name}"
+  role = "${aws_iam_role.masters-privatecanal-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privatecanal-example-com" {
   name  = "nodes.privatecanal.example.com"
-  role  = "${aws_iam_role.nodes-privatecanal-example-com.name}"
+  role = "${aws_iam_role.nodes-privatecanal-example-com.name}"
 }
 
 resource "aws_iam_role" "bastions-privatecanal-example-com" {

--- a/tests/integration/privatecanal/kubernetes.tf
+++ b/tests/integration/privatecanal/kubernetes.tf
@@ -303,7 +303,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privatecanal-exam
   }
 
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/privatedns1/kubernetes.tf
+++ b/tests/integration/privatedns1/kubernetes.tf
@@ -206,17 +206,17 @@ resource "aws_elb" "bastion-privatedns1-example-com" {
 
 resource "aws_iam_instance_profile" "bastions-privatedns1-example-com" {
   name  = "bastions.privatedns1.example.com"
-  roles = ["${aws_iam_role.bastions-privatedns1-example-com.name}"]
+  role  = "${aws_iam_role.bastions-privatedns1-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privatedns1-example-com" {
   name  = "masters.privatedns1.example.com"
-  roles = ["${aws_iam_role.masters-privatedns1-example-com.name}"]
+  role  = "${aws_iam_role.masters-privatedns1-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privatedns1-example-com" {
   name  = "nodes.privatedns1.example.com"
-  roles = ["${aws_iam_role.nodes-privatedns1-example-com.name}"]
+  role  = "${aws_iam_role.nodes-privatedns1-example-com.name}"
 }
 
 resource "aws_iam_role" "bastions-privatedns1-example-com" {

--- a/tests/integration/privatedns1/kubernetes.tf
+++ b/tests/integration/privatedns1/kubernetes.tf
@@ -206,17 +206,17 @@ resource "aws_elb" "bastion-privatedns1-example-com" {
 
 resource "aws_iam_instance_profile" "bastions-privatedns1-example-com" {
   name  = "bastions.privatedns1.example.com"
-  role  = "${aws_iam_role.bastions-privatedns1-example-com.name}"
+  role = "${aws_iam_role.bastions-privatedns1-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privatedns1-example-com" {
   name  = "masters.privatedns1.example.com"
-  role  = "${aws_iam_role.masters-privatedns1-example-com.name}"
+  role = "${aws_iam_role.masters-privatedns1-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privatedns1-example-com" {
   name  = "nodes.privatedns1.example.com"
-  role  = "${aws_iam_role.nodes-privatedns1-example-com.name}"
+  role = "${aws_iam_role.nodes-privatedns1-example-com.name}"
 }
 
 resource "aws_iam_role" "bastions-privatedns1-example-com" {

--- a/tests/integration/privatedns1/kubernetes.tf
+++ b/tests/integration/privatedns1/kubernetes.tf
@@ -205,17 +205,17 @@ resource "aws_elb" "bastion-privatedns1-example-com" {
 }
 
 resource "aws_iam_instance_profile" "bastions-privatedns1-example-com" {
-  name  = "bastions.privatedns1.example.com"
+  name = "bastions.privatedns1.example.com"
   role = "${aws_iam_role.bastions-privatedns1-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privatedns1-example-com" {
-  name  = "masters.privatedns1.example.com"
+  name = "masters.privatedns1.example.com"
   role = "${aws_iam_role.masters-privatedns1-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privatedns1-example-com" {
-  name  = "nodes.privatedns1.example.com"
+  name = "nodes.privatedns1.example.com"
   role = "${aws_iam_role.nodes-privatedns1-example-com.name}"
 }
 
@@ -303,7 +303,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privatedns1-examp
   }
 
   ephemeral_block_device = {
-    device_name  = "/dev/sdc"
+    device_name = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/privatedns1/kubernetes.tf
+++ b/tests/integration/privatedns1/kubernetes.tf
@@ -303,7 +303,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privatedns1-examp
   }
 
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/privatedns2/kubernetes.tf
+++ b/tests/integration/privatedns2/kubernetes.tf
@@ -206,17 +206,17 @@ resource "aws_elb" "bastion-privatedns2-example-com" {
 
 resource "aws_iam_instance_profile" "bastions-privatedns2-example-com" {
   name  = "bastions.privatedns2.example.com"
-  roles = ["${aws_iam_role.bastions-privatedns2-example-com.name}"]
+  role  = "${aws_iam_role.bastions-privatedns2-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privatedns2-example-com" {
   name  = "masters.privatedns2.example.com"
-  roles = ["${aws_iam_role.masters-privatedns2-example-com.name}"]
+  role  = "${aws_iam_role.masters-privatedns2-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privatedns2-example-com" {
   name  = "nodes.privatedns2.example.com"
-  roles = ["${aws_iam_role.nodes-privatedns2-example-com.name}"]
+  role  = "${aws_iam_role.nodes-privatedns2-example-com.name}"
 }
 
 resource "aws_iam_role" "bastions-privatedns2-example-com" {

--- a/tests/integration/privatedns2/kubernetes.tf
+++ b/tests/integration/privatedns2/kubernetes.tf
@@ -205,17 +205,17 @@ resource "aws_elb" "bastion-privatedns2-example-com" {
 }
 
 resource "aws_iam_instance_profile" "bastions-privatedns2-example-com" {
-  name  = "bastions.privatedns2.example.com"
+  name = "bastions.privatedns2.example.com"
   role = "${aws_iam_role.bastions-privatedns2-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privatedns2-example-com" {
-  name  = "masters.privatedns2.example.com"
+  name = "masters.privatedns2.example.com"
   role = "${aws_iam_role.masters-privatedns2-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privatedns2-example-com" {
-  name  = "nodes.privatedns2.example.com"
+  name = "nodes.privatedns2.example.com"
   role = "${aws_iam_role.nodes-privatedns2-example-com.name}"
 }
 
@@ -294,7 +294,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privatedns2-examp
   }
 
   ephemeral_block_device = {
-    device_name  = "/dev/sdc"
+    device_name = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/privatedns2/kubernetes.tf
+++ b/tests/integration/privatedns2/kubernetes.tf
@@ -206,17 +206,17 @@ resource "aws_elb" "bastion-privatedns2-example-com" {
 
 resource "aws_iam_instance_profile" "bastions-privatedns2-example-com" {
   name  = "bastions.privatedns2.example.com"
-  role  = "${aws_iam_role.bastions-privatedns2-example-com.name}"
+  role = "${aws_iam_role.bastions-privatedns2-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privatedns2-example-com" {
   name  = "masters.privatedns2.example.com"
-  role  = "${aws_iam_role.masters-privatedns2-example-com.name}"
+  role = "${aws_iam_role.masters-privatedns2-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privatedns2-example-com" {
   name  = "nodes.privatedns2.example.com"
-  role  = "${aws_iam_role.nodes-privatedns2-example-com.name}"
+  role = "${aws_iam_role.nodes-privatedns2-example-com.name}"
 }
 
 resource "aws_iam_role" "bastions-privatedns2-example-com" {

--- a/tests/integration/privatedns2/kubernetes.tf
+++ b/tests/integration/privatedns2/kubernetes.tf
@@ -294,7 +294,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privatedns2-examp
   }
 
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/privateflannel/kubernetes.tf
+++ b/tests/integration/privateflannel/kubernetes.tf
@@ -303,7 +303,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privateflannel-ex
   }
 
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/privateflannel/kubernetes.tf
+++ b/tests/integration/privateflannel/kubernetes.tf
@@ -205,17 +205,17 @@ resource "aws_elb" "bastion-privateflannel-example-com" {
 }
 
 resource "aws_iam_instance_profile" "bastions-privateflannel-example-com" {
-  name  = "bastions.privateflannel.example.com"
+  name = "bastions.privateflannel.example.com"
   role = "${aws_iam_role.bastions-privateflannel-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privateflannel-example-com" {
-  name  = "masters.privateflannel.example.com"
+  name = "masters.privateflannel.example.com"
   role = "${aws_iam_role.masters-privateflannel-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privateflannel-example-com" {
-  name  = "nodes.privateflannel.example.com"
+  name = "nodes.privateflannel.example.com"
   role = "${aws_iam_role.nodes-privateflannel-example-com.name}"
 }
 
@@ -303,7 +303,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privateflannel-ex
   }
 
   ephemeral_block_device = {
-    device_name  = "/dev/sdc"
+    device_name = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/privateflannel/kubernetes.tf
+++ b/tests/integration/privateflannel/kubernetes.tf
@@ -206,17 +206,17 @@ resource "aws_elb" "bastion-privateflannel-example-com" {
 
 resource "aws_iam_instance_profile" "bastions-privateflannel-example-com" {
   name  = "bastions.privateflannel.example.com"
-  role  = "${aws_iam_role.bastions-privateflannel-example-com.name}"
+  role = "${aws_iam_role.bastions-privateflannel-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privateflannel-example-com" {
   name  = "masters.privateflannel.example.com"
-  role  = "${aws_iam_role.masters-privateflannel-example-com.name}"
+  role = "${aws_iam_role.masters-privateflannel-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privateflannel-example-com" {
   name  = "nodes.privateflannel.example.com"
-  role  = "${aws_iam_role.nodes-privateflannel-example-com.name}"
+  role = "${aws_iam_role.nodes-privateflannel-example-com.name}"
 }
 
 resource "aws_iam_role" "bastions-privateflannel-example-com" {

--- a/tests/integration/privateflannel/kubernetes.tf
+++ b/tests/integration/privateflannel/kubernetes.tf
@@ -206,17 +206,17 @@ resource "aws_elb" "bastion-privateflannel-example-com" {
 
 resource "aws_iam_instance_profile" "bastions-privateflannel-example-com" {
   name  = "bastions.privateflannel.example.com"
-  roles = ["${aws_iam_role.bastions-privateflannel-example-com.name}"]
+  role  = "${aws_iam_role.bastions-privateflannel-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privateflannel-example-com" {
   name  = "masters.privateflannel.example.com"
-  roles = ["${aws_iam_role.masters-privateflannel-example-com.name}"]
+  role  = "${aws_iam_role.masters-privateflannel-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privateflannel-example-com" {
   name  = "nodes.privateflannel.example.com"
-  roles = ["${aws_iam_role.nodes-privateflannel-example-com.name}"]
+  role  = "${aws_iam_role.nodes-privateflannel-example-com.name}"
 }
 
 resource "aws_iam_role" "bastions-privateflannel-example-com" {

--- a/tests/integration/privatekopeio/kubernetes.tf
+++ b/tests/integration/privatekopeio/kubernetes.tf
@@ -201,17 +201,17 @@ resource "aws_elb" "bastion-privatekopeio-example-com" {
 }
 
 resource "aws_iam_instance_profile" "bastions-privatekopeio-example-com" {
-  name  = "bastions.privatekopeio.example.com"
+  name = "bastions.privatekopeio.example.com"
   role = "${aws_iam_role.bastions-privatekopeio-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privatekopeio-example-com" {
-  name  = "masters.privatekopeio.example.com"
+  name = "masters.privatekopeio.example.com"
   role = "${aws_iam_role.masters-privatekopeio-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privatekopeio-example-com" {
-  name  = "nodes.privatekopeio.example.com"
+  name = "nodes.privatekopeio.example.com"
   role = "${aws_iam_role.nodes-privatekopeio-example-com.name}"
 }
 
@@ -299,7 +299,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privatekopeio-exa
   }
 
   ephemeral_block_device = {
-    device_name  = "/dev/sdc"
+    device_name = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/privatekopeio/kubernetes.tf
+++ b/tests/integration/privatekopeio/kubernetes.tf
@@ -202,17 +202,17 @@ resource "aws_elb" "bastion-privatekopeio-example-com" {
 
 resource "aws_iam_instance_profile" "bastions-privatekopeio-example-com" {
   name  = "bastions.privatekopeio.example.com"
-  role  = "${aws_iam_role.bastions-privatekopeio-example-com.name}"
+  role = "${aws_iam_role.bastions-privatekopeio-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privatekopeio-example-com" {
   name  = "masters.privatekopeio.example.com"
-  role  = "${aws_iam_role.masters-privatekopeio-example-com.name}"
+  role = "${aws_iam_role.masters-privatekopeio-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privatekopeio-example-com" {
   name  = "nodes.privatekopeio.example.com"
-  role  = "${aws_iam_role.nodes-privatekopeio-example-com.name}"
+  role = "${aws_iam_role.nodes-privatekopeio-example-com.name}"
 }
 
 resource "aws_iam_role" "bastions-privatekopeio-example-com" {

--- a/tests/integration/privatekopeio/kubernetes.tf
+++ b/tests/integration/privatekopeio/kubernetes.tf
@@ -202,17 +202,17 @@ resource "aws_elb" "bastion-privatekopeio-example-com" {
 
 resource "aws_iam_instance_profile" "bastions-privatekopeio-example-com" {
   name  = "bastions.privatekopeio.example.com"
-  roles = ["${aws_iam_role.bastions-privatekopeio-example-com.name}"]
+  role  = "${aws_iam_role.bastions-privatekopeio-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privatekopeio-example-com" {
   name  = "masters.privatekopeio.example.com"
-  roles = ["${aws_iam_role.masters-privatekopeio-example-com.name}"]
+  role  = "${aws_iam_role.masters-privatekopeio-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privatekopeio-example-com" {
   name  = "nodes.privatekopeio.example.com"
-  roles = ["${aws_iam_role.nodes-privatekopeio-example-com.name}"]
+  role  = "${aws_iam_role.nodes-privatekopeio-example-com.name}"
 }
 
 resource "aws_iam_role" "bastions-privatekopeio-example-com" {

--- a/tests/integration/privatekopeio/kubernetes.tf
+++ b/tests/integration/privatekopeio/kubernetes.tf
@@ -299,7 +299,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privatekopeio-exa
   }
 
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/privateweave/kubernetes.tf
+++ b/tests/integration/privateweave/kubernetes.tf
@@ -206,17 +206,17 @@ resource "aws_elb" "bastion-privateweave-example-com" {
 
 resource "aws_iam_instance_profile" "bastions-privateweave-example-com" {
   name  = "bastions.privateweave.example.com"
-  role  = "${aws_iam_role.bastions-privateweave-example-com.name}"
+  role = "${aws_iam_role.bastions-privateweave-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privateweave-example-com" {
   name  = "masters.privateweave.example.com"
-  role  = "${aws_iam_role.masters-privateweave-example-com.name}"
+  role = "${aws_iam_role.masters-privateweave-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privateweave-example-com" {
   name  = "nodes.privateweave.example.com"
-  role  = "${aws_iam_role.nodes-privateweave-example-com.name}"
+  role = "${aws_iam_role.nodes-privateweave-example-com.name}"
 }
 
 resource "aws_iam_role" "bastions-privateweave-example-com" {

--- a/tests/integration/privateweave/kubernetes.tf
+++ b/tests/integration/privateweave/kubernetes.tf
@@ -205,17 +205,17 @@ resource "aws_elb" "bastion-privateweave-example-com" {
 }
 
 resource "aws_iam_instance_profile" "bastions-privateweave-example-com" {
-  name  = "bastions.privateweave.example.com"
+  name = "bastions.privateweave.example.com"
   role = "${aws_iam_role.bastions-privateweave-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privateweave-example-com" {
-  name  = "masters.privateweave.example.com"
+  name = "masters.privateweave.example.com"
   role = "${aws_iam_role.masters-privateweave-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privateweave-example-com" {
-  name  = "nodes.privateweave.example.com"
+  name = "nodes.privateweave.example.com"
   role = "${aws_iam_role.nodes-privateweave-example-com.name}"
 }
 
@@ -303,7 +303,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privateweave-exam
   }
 
   ephemeral_block_device = {
-    device_name  = "/dev/sdc"
+    device_name = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/tests/integration/privateweave/kubernetes.tf
+++ b/tests/integration/privateweave/kubernetes.tf
@@ -206,17 +206,17 @@ resource "aws_elb" "bastion-privateweave-example-com" {
 
 resource "aws_iam_instance_profile" "bastions-privateweave-example-com" {
   name  = "bastions.privateweave.example.com"
-  roles = ["${aws_iam_role.bastions-privateweave-example-com.name}"]
+  role  = "${aws_iam_role.bastions-privateweave-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "masters-privateweave-example-com" {
   name  = "masters.privateweave.example.com"
-  roles = ["${aws_iam_role.masters-privateweave-example-com.name}"]
+  role  = "${aws_iam_role.masters-privateweave-example-com.name}"
 }
 
 resource "aws_iam_instance_profile" "nodes-privateweave-example-com" {
   name  = "nodes.privateweave.example.com"
-  roles = ["${aws_iam_role.nodes-privateweave-example-com.name}"]
+  role  = "${aws_iam_role.nodes-privateweave-example-com.name}"
 }
 
 resource "aws_iam_role" "bastions-privateweave-example-com" {

--- a/tests/integration/privateweave/kubernetes.tf
+++ b/tests/integration/privateweave/kubernetes.tf
@@ -303,7 +303,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privateweave-exam
   }
 
   ephemeral_block_device = {
-    device_name = "/dev/sdc"
+    device_name  = "/dev/sdc"
     virtual_name = "ephemeral0"
   }
 

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
@@ -110,13 +110,13 @@ func (_ *IAMInstanceProfileRole) RenderAWS(t *awsup.AWSAPITarget, a, e, changes 
 
 type terraformIAMInstanceProfile struct {
 	Name  *string              `json:"name"`
-	Roles []*terraform.Literal `json:"roles"`
+	Role  *terraform.Literal   `json:"role"`
 }
 
 func (_ *IAMInstanceProfileRole) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *IAMInstanceProfileRole) error {
 	tf := &terraformIAMInstanceProfile{
 		Name:  e.InstanceProfile.Name,
-		Roles: []*terraform.Literal{e.Role.TerraformLink()},
+		Role:  e.Role.TerraformLink(),
 	}
 
 	return t.RenderResource("aws_iam_instance_profile", *e.InstanceProfile.Name, tf)

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
@@ -109,14 +109,14 @@ func (_ *IAMInstanceProfileRole) RenderAWS(t *awsup.AWSAPITarget, a, e, changes 
 }
 
 type terraformIAMInstanceProfile struct {
-	Name  *string              `json:"name"`
-	Role  *terraform.Literal   `json:"role"`
+	Name *string            `json:"name"`
+	Role *terraform.Literal `json:"role"`
 }
 
 func (_ *IAMInstanceProfileRole) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *IAMInstanceProfileRole) error {
 	tf := &terraformIAMInstanceProfile{
-		Name:  e.InstanceProfile.Name,
-		Role:  e.Role.TerraformLink(),
+		Name: e.InstanceProfile.Name,
+		Role: e.Role.TerraformLink(),
 	}
 
 	return t.RenderResource("aws_iam_instance_profile", *e.InstanceProfile.Name, tf)


### PR DESCRIPTION
the `aws_iam_instance_profile` terraform resource only allows a single role to be applied. Using `"roles"` instead of `"role"` as a value for this resource is currently throwing terraform deprecation warnings.

Ive updated the code to reflect this change and terraform is no longer throwing warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2424)
<!-- Reviewable:end -->
