### PR TITLE
missing DisableSecurityGroupIngress from api files

### DIFF
--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -668,6 +668,8 @@ type CloudConfiguration struct {
 	Multizone          *bool   `json:"multizone,omitempty"`
 	NodeTags           *string `json:"nodeTags,omitempty"`
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
+	// AWS cloud-config options
+	DisableSecurityGroupIngress *bool `json:"disableSecurityGroupIngress,omitempty"`
 
 	// vSphere cloud-config specs
 	VSphereUsername      *string `json:"vSphereUsername,omitempty"`

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -304,6 +304,7 @@ func autoConvert_v1alpha1_CloudConfiguration_To_kops_CloudConfiguration(in *Clou
 	out.Multizone = in.Multizone
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
+	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
 	out.VSphereUsername = in.VSphereUsername
 	out.VSpherePassword = in.VSpherePassword
 	out.VSphereServer = in.VSphereServer
@@ -322,6 +323,7 @@ func autoConvert_kops_CloudConfiguration_To_v1alpha1_CloudConfiguration(in *kops
 	out.Multizone = in.Multizone
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
+	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
 	out.VSphereUsername = in.VSphereUsername
 	out.VSpherePassword = in.VSpherePassword
 	out.VSphereServer = in.VSphereServer

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -297,6 +297,8 @@ type CloudConfiguration struct {
 	Multizone          *bool   `json:"multizone,omitempty"`
 	NodeTags           *string `json:"nodeTags,omitempty"`
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
+	// AWS cloud-config options
+	DisableSecurityGroupIngress *bool `json:"disableSecurityGroupIngress,omitempty"`
 
 	// vSphere cloud-config specs
 	VSphereUsername      *string `json:"vSphereUsername,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -330,6 +330,7 @@ func autoConvert_v1alpha2_CloudConfiguration_To_kops_CloudConfiguration(in *Clou
 	out.Multizone = in.Multizone
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
+	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
 	out.VSphereUsername = in.VSphereUsername
 	out.VSpherePassword = in.VSpherePassword
 	out.VSphereServer = in.VSphereServer
@@ -348,6 +349,7 @@ func autoConvert_kops_CloudConfiguration_To_v1alpha2_CloudConfiguration(in *kops
 	out.Multizone = in.Multizone
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
+	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
 	out.VSphereUsername = in.VSphereUsername
 	out.VSpherePassword = in.VSpherePassword
 	out.VSphereServer = in.VSphereServer


### PR DESCRIPTION
For some reason:

```
	DisableSecurityGroupIngress *bool `json:"disableSecurityGroupIngress,omitempty"`
```

Was lost in space.

```
./hack/make-apimachinery.sh
/Users/clove/Workspace/bin/conversion-gen --skip-unsafe=true --input-dirs k8s.io/kops/pkg/apis/kops/v1alpha1 --v=0  --output-file-base=zz_generated.conversion
E0426 11:14:26.498266   24369 conversion.go:574] Warning: could not find nor generate a final Conversion function for k8s.io/kops/pkg/apis/kops.CloudConfiguration -> k8s.io/kops/pkg/apis/kops/v1alpha1.CloudConfiguration
E0426 11:14:26.501081   24369 conversion.go:575]   the following fields need manual conversion:
E0426 11:14:26.501090   24369 conversion.go:577]       - DisableSecurityGroupIngress
/Users/clove/Workspace/bin/conversion-gen --skip-unsafe=true --input-dirs k8s.io/kops/pkg/apis/kops/v1alpha2 --v=0  --output-file-base=zz_generated.conversion
E0426 11:14:29.334137   24372 conversion.go:574] Warning: could not find nor generate a final Conversion function for k8s.io/kops/pkg/apis/kops.CloudConfiguration -> k8s.io/kops/pkg/apis/kops/v1alpha2.CloudConfiguration
E0426 11:14:29.335776   24372 conversion.go:575]   the following fields need manual conversion:
E0426 11:14:29.335784   24372 conversion.go:577]       - DisableSecurityGroupIngress
/Users/clove/Workspace/bin/defaulter-gen --input-dirs k8s.io/kops/pkg/apis/kops/v1alpha1 --v=0  --output-file-base=zz_generated.defaults
/Users/clove/Workspace/bin/defaulter-gen --input-dirs k8s.io/kops/pkg/apis/kops/v1alpha2 --v=0  --output-file-base=zz_generated.defaults
#go install github.com/ugorji/go/codec/codecgen
# codecgen works only if invoked from directory where the file is located.
#cd pkg/apis/kops/v1alpha2/ && ~/k8s/bin/codecgen -d 1234 -o types.generated.go instancegroup.go cluster.go federation.go
#cd pkg/apis/kops/v1alpha1/ && ~/k8s/bin/codecgen -d 1234 -o types.generated.go instancegroup.go cluster.go federation.go
#cd pkg/apis/kops/ && ~/k8s/bin/codecgen -d 1234 -o types.generated.go instancegroup.go cluster.go federation.go
```

Is the error I was getting.  I will search to see if we have an issue open to check apimachinery during the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2442)
<!-- Reviewable:end -->
