### PR TITLE
bumping go version to 1.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ go:
   #- 1.5  go test arguments are different in 1.5 :-(
   #- 1.6 issues with OSX release, and 1.7 is required now by core
   - 1.7
+  - 1.8
   - tip
 
 go_import_path: k8s.io/kops

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ GCS_URL=$(GCS_LOCATION:gs://%=https://storage.googleapis.com/%)
 LATEST_FILE?=latest-ci.txt
 GOPATH_1ST=$(shell echo ${GOPATH} | cut -d : -f 1)
 UNIQUE:=$(shell date +%s)
-GOVERSION=1.7.5
+GOVERSION=1.8.1
 
 # See http://stackoverflow.com/questions/18136918/how-to-get-current-relative-directory-of-your-makefile
 MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))


### PR DESCRIPTION
Using go 1.8.1 in Travis build and container build.  Core is now running 1.8.1, we might as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2445)
<!-- Reviewable:end -->
