### PR TITLE
Deploys dns-controller with --watch-ingress=true

### DIFF
--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -131,7 +131,9 @@ func (tf *TemplateFunctions) DnsControllerArgv() ([]string, error) {
 
 	argv = append(argv, "/usr/bin/dns-controller")
 
-	argv = append(argv, "--watch-ingress=false")
+	// Default dns-controller behavior --watch-ingress=true
+	// Turning on as per: https://github.com/kubernetes/kops/issues/551#issuecomment-275981949
+	// argv = append(argv, "--watch-ingress=false")
 
 	switch fi.CloudProviderID(tf.cluster.Spec.CloudProvider) {
 	case fi.CloudProviderAWS:


### PR DESCRIPTION
Flips the default watch-ingress on dns-controller to true.

Closes #1413, #2360 and #551

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2468)
<!-- Reviewable:end -->
