### PR TITLE
fixed trying to match NatGateway via RouteTable log

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -190,7 +190,7 @@ func findNatGatewayById(cloud awsup.AWSCloud, id *string) (*ec2.NatGateway, erro
 func findNatGatewayFromRouteTable(cloud awsup.AWSCloud, routeTable *RouteTable) (*ec2.NatGateway, error) {
 	// Find via route on private route table
 	if routeTable.ID != nil {
-		glog.V(2).Infof("trying to match NatGateway via RouteTable %s", routeTable.ID)
+		glog.V(2).Infof("trying to match NatGateway via RouteTable %s", *routeTable.ID)
 		rt, err := routeTable.findEc2RouteTable(cloud)
 		if err != nil {
 			return nil, fmt.Errorf("error finding associated RouteTable to NatGateway: %v", err)


### PR DESCRIPTION
Log is showing things like:

```
trying to match NatGateway via RouteTable %!s(*string=0xc420d0da08)
```

instead of the route table id.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2472)
<!-- Reviewable:end -->
