### PR TITLE
logging-elasticsearch: version label mismatched

### DIFF
--- a/addons/logging-elasticsearch/v1.5.0.yaml
+++ b/addons/logging-elasticsearch/v1.5.0.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         k8s-app: fluentd-es
         kubernetes.io/cluster-service: "true"
-        version: v1.20
+        version: v1.22
     spec:
       containers:
       - name: fluentd-es


### PR DESCRIPTION
Version was bumped to v0.22, but only updated one one of the two labels. I left a comment on this in the original PR, but it was never fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2473)
<!-- Reviewable:end -->
