### PR TITLE
Use explicit tag management in network tasks

### DIFF
--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -29,7 +29,9 @@ import (
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/model/components"
+	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
+	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 )
 
 var UseLegacyELBName = featureflag.New("UseLegacyELBName", featureflag.Bool(false))
@@ -187,6 +189,27 @@ func (m *KopsModelContext) CloudTagsForInstanceGroup(ig *kops.InstanceGroup) (ma
 	}
 
 	return labels, nil
+}
+
+// CloudTags computes the tags to apply to a normal cloud resource with the specified name
+func (m *KopsModelContext) CloudTags(name string, shared bool) map[string]string {
+	tags := make(map[string]string)
+
+	switch fi.CloudProviderID(m.Cluster.Spec.CloudProvider) {
+	case fi.CloudProviderAWS:
+		tags[awsup.TagClusterName] = m.Cluster.ObjectMeta.Name
+		if name != "" {
+			tags["Name"] = name
+		}
+
+		if shared {
+			tags["kubernetes.io/cluster/"+m.Cluster.ObjectMeta.Name] = "shared"
+		} else {
+			tags["kubernetes.io/cluster/"+m.Cluster.ObjectMeta.Name] = "owned"
+		}
+
+	}
+	return tags
 }
 
 func (m *KopsModelContext) UsesBastionDns() bool {

--- a/tests/integration/complex/kubernetes.tf
+++ b/tests/integration/complex/kubernetes.tf
@@ -342,8 +342,9 @@ resource "aws_subnet" "us-test-1a-complex-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "complex.example.com"
-    Name              = "us-test-1a.complex.example.com"
+    KubernetesCluster                           = "complex.example.com"
+    Name                                        = "us-test-1a.complex.example.com"
+    "kubernetes.io/cluster/complex.example.com" = "owned"
   }
 }
 
@@ -353,8 +354,9 @@ resource "aws_vpc" "complex-example-com" {
   enable_dns_support   = true
 
   tags = {
-    KubernetesCluster = "complex.example.com"
-    Name              = "complex.example.com"
+    KubernetesCluster                           = "complex.example.com"
+    Name                                        = "complex.example.com"
+    "kubernetes.io/cluster/complex.example.com" = "owned"
   }
 }
 

--- a/tests/integration/ha/kubernetes.tf
+++ b/tests/integration/ha/kubernetes.tf
@@ -512,8 +512,9 @@ resource "aws_subnet" "us-test-1a-ha-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "ha.example.com"
-    Name              = "us-test-1a.ha.example.com"
+    KubernetesCluster                      = "ha.example.com"
+    Name                                   = "us-test-1a.ha.example.com"
+    "kubernetes.io/cluster/ha.example.com" = "owned"
   }
 }
 
@@ -523,8 +524,9 @@ resource "aws_subnet" "us-test-1b-ha-example-com" {
   availability_zone = "us-test-1b"
 
   tags = {
-    KubernetesCluster = "ha.example.com"
-    Name              = "us-test-1b.ha.example.com"
+    KubernetesCluster                      = "ha.example.com"
+    Name                                   = "us-test-1b.ha.example.com"
+    "kubernetes.io/cluster/ha.example.com" = "owned"
   }
 }
 
@@ -534,8 +536,9 @@ resource "aws_subnet" "us-test-1c-ha-example-com" {
   availability_zone = "us-test-1c"
 
   tags = {
-    KubernetesCluster = "ha.example.com"
-    Name              = "us-test-1c.ha.example.com"
+    KubernetesCluster                      = "ha.example.com"
+    Name                                   = "us-test-1c.ha.example.com"
+    "kubernetes.io/cluster/ha.example.com" = "owned"
   }
 }
 
@@ -545,8 +548,9 @@ resource "aws_vpc" "ha-example-com" {
   enable_dns_support   = true
 
   tags = {
-    KubernetesCluster = "ha.example.com"
-    Name              = "ha.example.com"
+    KubernetesCluster                      = "ha.example.com"
+    Name                                   = "ha.example.com"
+    "kubernetes.io/cluster/ha.example.com" = "owned"
   }
 }
 

--- a/tests/integration/minimal-141/kubernetes.tf
+++ b/tests/integration/minimal-141/kubernetes.tf
@@ -342,8 +342,9 @@ resource "aws_subnet" "us-test-1a-minimal-141-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "minimal-141.example.com"
-    Name              = "us-test-1a.minimal-141.example.com"
+    KubernetesCluster                               = "minimal-141.example.com"
+    Name                                            = "us-test-1a.minimal-141.example.com"
+    "kubernetes.io/cluster/minimal-141.example.com" = "owned"
   }
 }
 
@@ -353,8 +354,9 @@ resource "aws_vpc" "minimal-141-example-com" {
   enable_dns_support   = true
 
   tags = {
-    KubernetesCluster = "minimal-141.example.com"
-    Name              = "minimal-141.example.com"
+    KubernetesCluster                               = "minimal-141.example.com"
+    Name                                            = "minimal-141.example.com"
+    "kubernetes.io/cluster/minimal-141.example.com" = "owned"
   }
 }
 

--- a/tests/integration/minimal/cloudformation.json
+++ b/tests/integration/minimal/cloudformation.json
@@ -397,6 +397,10 @@
           {
             "Key": "Name",
             "Value": "us-test-1a.minimal.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/minimal.example.com",
+            "Value": "owned"
           }
         ]
       }
@@ -437,6 +441,10 @@
           {
             "Key": "Name",
             "Value": "minimal.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/minimal.example.com",
+            "Value": "owned"
           }
         ]
       }

--- a/tests/integration/minimal/kubernetes.tf
+++ b/tests/integration/minimal/kubernetes.tf
@@ -342,8 +342,9 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "minimal.example.com"
-    Name              = "us-test-1a.minimal.example.com"
+    KubernetesCluster                           = "minimal.example.com"
+    Name                                        = "us-test-1a.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
 }
 
@@ -353,8 +354,9 @@ resource "aws_vpc" "minimal-example-com" {
   enable_dns_support   = true
 
   tags = {
-    KubernetesCluster = "minimal.example.com"
-    Name              = "minimal.example.com"
+    KubernetesCluster                           = "minimal.example.com"
+    Name                                        = "minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
 }
 

--- a/tests/integration/privatecalico/kubernetes.tf
+++ b/tests/integration/privatecalico/kubernetes.tf
@@ -614,8 +614,9 @@ resource "aws_subnet" "us-test-1a-privatecalico-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "privatecalico.example.com"
-    Name              = "us-test-1a.privatecalico.example.com"
+    KubernetesCluster                                 = "privatecalico.example.com"
+    Name                                              = "us-test-1a.privatecalico.example.com"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
   }
 }
 
@@ -625,8 +626,9 @@ resource "aws_subnet" "utility-us-test-1a-privatecalico-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "privatecalico.example.com"
-    Name              = "utility-us-test-1a.privatecalico.example.com"
+    KubernetesCluster                                 = "privatecalico.example.com"
+    Name                                              = "utility-us-test-1a.privatecalico.example.com"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
   }
 }
 
@@ -636,8 +638,9 @@ resource "aws_vpc" "privatecalico-example-com" {
   enable_dns_support   = true
 
   tags = {
-    KubernetesCluster = "privatecalico.example.com"
-    Name              = "privatecalico.example.com"
+    KubernetesCluster                                 = "privatecalico.example.com"
+    Name                                              = "privatecalico.example.com"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
   }
 }
 

--- a/tests/integration/privatecanal/kubernetes.tf
+++ b/tests/integration/privatecanal/kubernetes.tf
@@ -605,8 +605,9 @@ resource "aws_subnet" "us-test-1a-privatecanal-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "privatecanal.example.com"
-    Name              = "us-test-1a.privatecanal.example.com"
+    KubernetesCluster                                = "privatecanal.example.com"
+    Name                                             = "us-test-1a.privatecanal.example.com"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
   }
 }
 
@@ -616,8 +617,9 @@ resource "aws_subnet" "utility-us-test-1a-privatecanal-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "privatecanal.example.com"
-    Name              = "utility-us-test-1a.privatecanal.example.com"
+    KubernetesCluster                                = "privatecanal.example.com"
+    Name                                             = "utility-us-test-1a.privatecanal.example.com"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
   }
 }
 
@@ -627,8 +629,9 @@ resource "aws_vpc" "privatecanal-example-com" {
   enable_dns_support   = true
 
   tags = {
-    KubernetesCluster = "privatecanal.example.com"
-    Name              = "privatecanal.example.com"
+    KubernetesCluster                                = "privatecanal.example.com"
+    Name                                             = "privatecanal.example.com"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
   }
 }
 

--- a/tests/integration/privatedns1/kubernetes.tf
+++ b/tests/integration/privatedns1/kubernetes.tf
@@ -610,8 +610,9 @@ resource "aws_subnet" "us-test-1a-privatedns1-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "privatedns1.example.com"
-    Name              = "us-test-1a.privatedns1.example.com"
+    KubernetesCluster                               = "privatedns1.example.com"
+    Name                                            = "us-test-1a.privatedns1.example.com"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
 
@@ -621,8 +622,9 @@ resource "aws_subnet" "utility-us-test-1a-privatedns1-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "privatedns1.example.com"
-    Name              = "utility-us-test-1a.privatedns1.example.com"
+    KubernetesCluster                               = "privatedns1.example.com"
+    Name                                            = "utility-us-test-1a.privatedns1.example.com"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
 
@@ -632,8 +634,9 @@ resource "aws_vpc" "privatedns1-example-com" {
   enable_dns_support   = true
 
   tags = {
-    KubernetesCluster = "privatedns1.example.com"
-    Name              = "privatedns1.example.com"
+    KubernetesCluster                               = "privatedns1.example.com"
+    Name                                            = "privatedns1.example.com"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
 

--- a/tests/integration/privatedns2/kubernetes.tf
+++ b/tests/integration/privatedns2/kubernetes.tf
@@ -596,8 +596,9 @@ resource "aws_subnet" "us-test-1a-privatedns2-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "privatedns2.example.com"
-    Name              = "us-test-1a.privatedns2.example.com"
+    KubernetesCluster                               = "privatedns2.example.com"
+    Name                                            = "us-test-1a.privatedns2.example.com"
+    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
   }
 }
 
@@ -607,7 +608,8 @@ resource "aws_subnet" "utility-us-test-1a-privatedns2-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "privatedns2.example.com"
-    Name              = "utility-us-test-1a.privatedns2.example.com"
+    KubernetesCluster                               = "privatedns2.example.com"
+    Name                                            = "utility-us-test-1a.privatedns2.example.com"
+    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
   }
 }

--- a/tests/integration/privateflannel/kubernetes.tf
+++ b/tests/integration/privateflannel/kubernetes.tf
@@ -605,8 +605,9 @@ resource "aws_subnet" "us-test-1a-privateflannel-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "privateflannel.example.com"
-    Name              = "us-test-1a.privateflannel.example.com"
+    KubernetesCluster                                  = "privateflannel.example.com"
+    Name                                               = "us-test-1a.privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
   }
 }
 
@@ -616,8 +617,9 @@ resource "aws_subnet" "utility-us-test-1a-privateflannel-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "privateflannel.example.com"
-    Name              = "utility-us-test-1a.privateflannel.example.com"
+    KubernetesCluster                                  = "privateflannel.example.com"
+    Name                                               = "utility-us-test-1a.privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
   }
 }
 
@@ -627,8 +629,9 @@ resource "aws_vpc" "privateflannel-example-com" {
   enable_dns_support   = true
 
   tags = {
-    KubernetesCluster = "privateflannel.example.com"
-    Name              = "privateflannel.example.com"
+    KubernetesCluster                                  = "privateflannel.example.com"
+    Name                                               = "privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
   }
 }
 

--- a/tests/integration/privatekopeio/kubernetes.tf
+++ b/tests/integration/privatekopeio/kubernetes.tf
@@ -596,8 +596,9 @@ resource "aws_subnet" "us-test-1a-privatekopeio-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "privatekopeio.example.com"
-    Name              = "us-test-1a.privatekopeio.example.com"
+    KubernetesCluster                                 = "privatekopeio.example.com"
+    Name                                              = "us-test-1a.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
   }
 }
 
@@ -607,8 +608,9 @@ resource "aws_subnet" "utility-us-test-1a-privatekopeio-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "privatekopeio.example.com"
-    Name              = "utility-us-test-1a.privatekopeio.example.com"
+    KubernetesCluster                                 = "privatekopeio.example.com"
+    Name                                              = "utility-us-test-1a.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
   }
 }
 
@@ -618,8 +620,9 @@ resource "aws_vpc" "privatekopeio-example-com" {
   enable_dns_support   = true
 
   tags = {
-    KubernetesCluster = "privatekopeio.example.com"
-    Name              = "privatekopeio.example.com"
+    KubernetesCluster                                 = "privatekopeio.example.com"
+    Name                                              = "privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
   }
 }
 

--- a/tests/integration/privateweave/kubernetes.tf
+++ b/tests/integration/privateweave/kubernetes.tf
@@ -605,8 +605,9 @@ resource "aws_subnet" "us-test-1a-privateweave-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "privateweave.example.com"
-    Name              = "us-test-1a.privateweave.example.com"
+    KubernetesCluster                                = "privateweave.example.com"
+    Name                                             = "us-test-1a.privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
   }
 }
 
@@ -616,8 +617,9 @@ resource "aws_subnet" "utility-us-test-1a-privateweave-example-com" {
   availability_zone = "us-test-1a"
 
   tags = {
-    KubernetesCluster = "privateweave.example.com"
-    Name              = "utility-us-test-1a.privateweave.example.com"
+    KubernetesCluster                                = "privateweave.example.com"
+    Name                                             = "utility-us-test-1a.privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
   }
 }
 
@@ -627,8 +629,9 @@ resource "aws_vpc" "privateweave-example-com" {
   enable_dns_support   = true
 
   tags = {
-    KubernetesCluster = "privateweave.example.com"
-    Name              = "privateweave.example.com"
+    KubernetesCluster                                = "privateweave.example.com"
+    Name                                             = "privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
   }
 }
 

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip_test.go
@@ -40,11 +40,13 @@ func TestElasticIPCreate(t *testing.T) {
 		vpc1 := &VPC{
 			Name: s("vpc1"),
 			CIDR: s("172.20.0.0/16"),
+			Tags: map[string]string{"Name": "vpc1"},
 		}
 		subnet1 := &Subnet{
 			Name: s("subnet1"),
 			VPC:  vpc1,
 			CIDR: s("172.20.1.0/24"),
+			Tags: map[string]string{"Name": "subnet1"},
 		}
 		eip1 := &ElasticIP{
 			Name:        s("eip1"),

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup_test.go
@@ -102,6 +102,7 @@ func TestSecurityGroupCreate(t *testing.T) {
 		vpc1 := &VPC{
 			Name: s("vpc1"),
 			CIDR: s("172.20.0.0/16"),
+			Tags: map[string]string{"Name": "vpc1"},
 		}
 		sg1 := &SecurityGroup{
 			Name:        s("sg1"),

--- a/upup/pkg/fi/cloudup/awstasks/tags.go
+++ b/upup/pkg/fi/cloudup/awstasks/tags.go
@@ -40,3 +40,21 @@ func findNameTag(tags []*ec2.Tag) *string {
 	}
 	return nil
 }
+
+// intersectTags returns the tags of interest from a specified list of AWS tags;
+// because we only add tags, this set of tags of interest is the tags that occur in the desired seet.
+func intersectTags(tags []*ec2.Tag, desired map[string]string) map[string]string {
+	if tags == nil {
+		return nil
+	}
+	actual := make(map[string]string)
+	for _, t := range tags {
+		k := aws.StringValue(t.Key)
+		v := aws.StringValue(t.Value)
+
+		if _, found := desired[k]; found {
+			actual[k] = v
+		}
+	}
+	return actual
+}

--- a/upup/pkg/fi/cloudup/awstasks/vpc_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc_test.go
@@ -36,6 +36,7 @@ func TestVPCCreate(t *testing.T) {
 		vpc1 := &VPC{
 			Name: s("vpc1"),
 			CIDR: s("172.21.0.0/16"),
+			Tags: map[string]string{"Name": "vpc1"},
 		}
 		return map[string]fi.Task{
 			"vpc1": vpc1,


### PR DESCRIPTION
This lets us use the new shared cluster tags, for shared networking
objects - in particular subnets.

We continue to add the existing tags also, for compatability.  When we
add direct management of shared networks, we will likely address that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2474)
<!-- Reviewable:end -->
