### PR TITLE
Tag 1.6.0-beta.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ GOVERSION=1.8.1
 MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))
 
 # Keep in sync with upup/models/cloudup/resources/addons/dns-controller/
-DNS_CONTROLLER_TAG=1.6.0
+DNS_CONTROLLER_TAG=1.6.1
 
-KOPS_RELEASE_VERSION=1.6.0-alpha.2
-KOPS_CI_VERSION=1.6.0-alpha.3
+KOPS_RELEASE_VERSION=1.6.0-beta.1
+KOPS_CI_VERSION=1.6.0-beta.2
 
 GITSHA := $(shell cd ${GOPATH_1ST}/src/k8s.io/kops; git describe --always)
 

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.6.yaml.template
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.6.0
+    version: v1.6.1
 spec:
   replicas: 1
   selector:
@@ -17,7 +17,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.6.0
+        version: v1.6.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         # For 1.6, we keep the old tolerations in case of a downgrade to 1.5
@@ -33,7 +33,7 @@ spec:
       serviceAccount: dns-controller
       containers:
       - name: dns-controller
-        image: kope/dns-controller:1.6.0
+        image: kope/dns-controller:1.6.1
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/pre-k8s-1.6.yaml.template
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.6.0
+    version: v1.6.1
 spec:
   replicas: 1
   selector:
@@ -17,7 +17,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.6.0
+        version: v1.6.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key": "dedicated", "value": "master"}]'
@@ -28,7 +28,7 @@ spec:
       hostNetwork: true
       containers:
       - name: dns-controller
-        image: {{ DnsControllerImage }}:1.6.0
+        image: {{ DnsControllerImage }}:1.6.1
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -139,7 +139,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	{
 		key := "dns-controller.addons.k8s.io"
-		version := "1.6.1-alpha.2"
+		version := "1.6.1"
 
 		{
 			location := key + "/pre-k8s-1.6.yaml"


### PR DESCRIPTION
Bumping dns-controller also to 1.6.1, for the gossip DNS support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2478)
<!-- Reviewable:end -->
