### PR TITLE
Security improvements on IAM policies

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -14,6 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// TODO: We have a couple different code paths until with do lifecycles, and
+// TODO: when we have a cluster or refactor some s3 code.  The only code that
+// TODO: is not shared by the different path is the s3 / state store stuff
+
+// TODO: We may want to look at https://aws.amazon.com/blogs/security/how-to-help-lock-down-a-users-amazon-ec2-capabilities-to-a-single-vpc/
+// TODO: But that gets complicated fast.  I would like to lock the policy down to a single VPC.
+
 package iam
 
 import (
@@ -48,6 +55,7 @@ func (p *IAMPolicy) AsJSON() (string, error) {
 }
 
 type IAMStatementEffect string
+type IAMSid string
 
 const IAMStatementEffectAllow IAMStatementEffect = "Allow"
 const IAMStatementEffectDeny IAMStatementEffect = "Deny"
@@ -56,6 +64,7 @@ type IAMStatement struct {
 	Effect   IAMStatementEffect
 	Action   stringorslice.StringOrSlice
 	Resource stringorslice.StringOrSlice
+	Sid      IAMSid
 }
 
 func (l *IAMStatement) Equal(r *IAMStatement) bool {
@@ -72,14 +81,23 @@ func (l *IAMStatement) Equal(r *IAMStatement) bool {
 }
 
 type IAMPolicyBuilder struct {
-	Cluster      *api.Cluster
-	Role         api.InstanceGroupRole
-	Region       string
-	HostedZoneID string
+	Cluster               *api.Cluster
+	ClusterName           string
+	Role                  api.InstanceGroupRole
+	Region                string
+	HostedZoneID          string
+	S3Bucket              string
+	ResourceARN           *string
+	CreateECRPerms        bool
+	CreateNetworkingPerms bool
+	CloudFormationPerms   bool
+	CreatePolicyPerms     bool
+	KMSKeys               []string
 }
 
+// BuildAWSIAMPolicy generates the IAM policies for a bastion, node or master
 func (b *IAMPolicyBuilder) BuildAWSIAMPolicy() (*IAMPolicy, error) {
-	wildcard := stringorslice.Slice([]string{"*"})
+	resource := createResource(b)
 
 	iamPrefix := b.IAMPrefix()
 
@@ -91,65 +109,30 @@ func (b *IAMPolicyBuilder) BuildAWSIAMPolicy() (*IAMPolicy, error) {
 	if b.Role == api.InstanceGroupRoleBastion {
 		p.Statement = append(p.Statement, &IAMStatement{
 			// We grant a trivial (?) permission (DescribeRegions), because empty policies are not allowed
+			Sid:      "kopsK8sBastion",
 			Effect:   IAMStatementEffectAllow,
 			Action:   stringorslice.Slice([]string{"ec2:DescribeRegions"}),
-			Resource: wildcard,
+			Resource: resource,
 		})
 
 		return p, nil
 	}
 
 	if b.Role == api.InstanceGroupRoleNode {
-		p.Statement = append(p.Statement, &IAMStatement{
-			Effect:   IAMStatementEffectAllow,
-			Action:   stringorslice.Slice([]string{"ec2:Describe*"}),
-			Resource: wildcard,
-		})
-
+		addNodeEC2Policies(p, resource)
 	}
 
-	{
-		// We provide ECR access on the nodes (naturally), but we also provide access on the master.
-		// We shouldn't be running lots of pods on the master, but it is perfectly reasonable to run
-		// a private logging pod or similar.
-		p.Statement = append(p.Statement, &IAMStatement{
-			Effect: IAMStatementEffectAllow,
-			Action: stringorslice.Of(
-				"ecr:GetAuthorizationToken",
-				"ecr:BatchCheckLayerAvailability",
-				"ecr:GetDownloadUrlForLayer",
-				"ecr:GetRepositoryPolicy",
-				"ecr:DescribeRepositories",
-				"ecr:ListImages",
-				"ecr:BatchGetImage",
-			),
-			Resource: wildcard,
-		})
-	}
+	addECRPermissions(p)
 
 	if b.Role == api.InstanceGroupRoleMaster {
-		p.Statement = append(p.Statement, &IAMStatement{
-			Effect:   IAMStatementEffectAllow,
-			Action:   stringorslice.Slice([]string{"ec2:*"}),
-			Resource: wildcard,
-		})
 
-		p.Statement = append(p.Statement, &IAMStatement{
-			Effect:   IAMStatementEffectAllow,
-			Action:   stringorslice.Slice([]string{"elasticloadbalancing:*"}),
-			Resource: wildcard,
-		})
+		addMasterEC2Policies(p, resource)
 
-		p.Statement = append(p.Statement, &IAMStatement{
-			Effect: IAMStatementEffectAllow,
-			Action: stringorslice.Of(
-				"autoscaling:DescribeAutoScalingGroups",
-				"autoscaling:DescribeAutoScalingInstances",
-				"autoscaling:SetDesiredCapacity",
-				"autoscaling:TerminateInstanceInAutoScalingGroup",
-			),
-			Resource: wildcard,
-		})
+		addMasterELBPolicies(p, resource)
+
+		addMasterASPolicies(p, resource)
+
+		addCertIAMPolicies(p, resource)
 
 		// Restrict the KMS permissions to only the keys that are being used
 		kmsKeyIDs := sets.NewString()
@@ -162,28 +145,13 @@ func (b *IAMPolicyBuilder) BuildAWSIAMPolicy() (*IAMPolicy, error) {
 		}
 
 		if kmsKeyIDs.Len() > 0 {
-			p.Statement = append(p.Statement, &IAMStatement{
-				Effect: IAMStatementEffectAllow,
-				Action: stringorslice.Of(
-					"kms:Encrypt",
-					"kms:Decrypt",
-					"kms:ReEncrypt*",
-					"kms:GenerateDataKey*",
-					"kms:DescribeKey",
-					"kms:CreateGrant",
-					"kms:ListGrants",
-					"kms:RevokeGrant",
-				),
-				Resource: stringorslice.Slice(kmsKeyIDs.List()),
-			})
+			addKMSIAMPolicies(p, stringorslice.Slice(kmsKeyIDs.List()))
+		}
+
+		if b.HostedZoneID != "" {
+			addRoute53Permissions(p, b.HostedZoneID)
 		}
 	}
-
-	if b.HostedZoneID != "" {
-		addRoute53Permissions(p, b.HostedZoneID)
-	}
-	// dns-controller currently assumes it can list the hosted zones, even when using gossip
-	addRoute53ListHostedZonesPermission(p)
 
 	// For S3 IAM permissions, we grant permissions to subtrees.  So find the parents;
 	// we don't need to grant mypath and mypath/child.
@@ -236,8 +204,12 @@ func (b *IAMPolicyBuilder) BuildAWSIAMPolicy() (*IAMPolicy, error) {
 			iamS3Path = strings.TrimSuffix(iamS3Path, "/")
 
 			p.Statement = append(p.Statement, &IAMStatement{
+				Sid:    "kopsK8sStateStoreAccess",
 				Effect: IAMStatementEffectAllow,
-				Action: stringorslice.Slice([]string{"s3:*"}),
+				Action: stringorslice.Of(
+					"s3:GetObject",
+					"s3:ListObject",
+				),
 				Resource: stringorslice.Of(
 					iamPrefix+":s3:::"+iamS3Path,
 					iamPrefix+":s3:::"+iamS3Path+"/*",
@@ -245,6 +217,7 @@ func (b *IAMPolicyBuilder) BuildAWSIAMPolicy() (*IAMPolicy, error) {
 			})
 
 			p.Statement = append(p.Statement, &IAMStatement{
+				Sid:    "kopsK8sStateStoreAccessList",
 				Effect: IAMStatementEffectAllow,
 				Action: stringorslice.Of("s3:GetBucketLocation", "s3:ListBucket"),
 				Resource: stringorslice.Slice([]string{
@@ -263,24 +236,42 @@ func (b *IAMPolicyBuilder) BuildAWSIAMPolicy() (*IAMPolicy, error) {
 	return p, nil
 }
 
-func addRoute53Permissions(p *IAMPolicy, hostedZoneID string) {
-	// Remove /hostedzone/ prefix (if present)
-	hostedZoneID = strings.TrimPrefix(hostedZoneID, "/")
-	hostedZoneID = strings.TrimPrefix(hostedZoneID, "hostedzone/")
+// BuildAWSIAMPolicyNode generates a custom policy for a Kubernetes master.
+func (b *IAMPolicyBuilder) BuildAWSIAMPolicyMaster() (*IAMPolicy, error) {
 
-	p.Statement = append(p.Statement, &IAMStatement{
-		Effect: IAMStatementEffectAllow,
-		Action: stringorslice.Of("route53:ChangeResourceRecordSets",
-			"route53:ListResourceRecordSets",
-			"route53:GetHostedZone"),
-		Resource: stringorslice.Slice([]string{"arn:aws:route53:::hostedzone/" + hostedZoneID}),
-	})
+	resource := createResource(b)
 
-	p.Statement = append(p.Statement, &IAMStatement{
-		Effect:   IAMStatementEffectAllow,
-		Action:   stringorslice.Slice([]string{"route53:GetChange"}),
-		Resource: stringorslice.Slice([]string{"arn:aws:route53:::change/*"}),
-	})
+	p := &IAMPolicy{
+		Version: IAMPolicyDefaultVersion,
+	}
+
+	addMasterEC2Policies(p, resource)
+
+	addMasterELBPolicies(p, resource)
+
+	addMasterASPolicies(p, resource)
+
+	addCertIAMPolicies(p, resource)
+
+	b.addIAMCustomPolicies(p, resource)
+
+	if b.KMSKeys != nil && len(b.KMSKeys) != 0 {
+		addKMSIAMPolicies(p, stringorslice.Slice(b.KMSKeys))
+	}
+
+	// We provide ECR access on the nodes (naturally), but we also provide access on the master.
+	// We shouldn't be running lots of pods on the master, but it is perfectly reasonable to run
+	// a private logging pod or similar.
+	if b.CreateECRPerms {
+		addECRPermissions(p)
+	}
+
+	if b.HostedZoneID != "" {
+		addRoute53Permissions(p, b.HostedZoneID)
+	}
+
+	return p, nil
+
 }
 
 func addRoute53ListHostedZonesPermission(p *IAMPolicy) {
@@ -290,6 +281,245 @@ func addRoute53ListHostedZonesPermission(p *IAMPolicy) {
 		Action:   stringorslice.Slice([]string{"route53:ListHostedZones"}),
 		Resource: wildcard,
 	})
+}
+
+// BuildAWSIAMPolicyNode generates a custom policy for a Kubernetes node.
+func (b *IAMPolicyBuilder) BuildAWSIAMPolicyNode() (*IAMPolicy, error) {
+	resource := createResource(b)
+
+	p := &IAMPolicy{
+		Version: IAMPolicyDefaultVersion,
+	}
+
+	if b.CreateECRPerms {
+		addECRPermissions(p)
+	}
+
+	addNodeEC2Policies(p, resource)
+
+	b.addIAMCustomPolicies(p, resource)
+
+	return p, nil
+
+}
+
+// BuildAWSIAMPolicyInstaller generates an installer/admin policy that can be used to execute kops.
+// This method is used to create an example user for users who want a specific user for kops.
+func (b *IAMPolicyBuilder) BuildAWSIAMPolicyInstaller() (*IAMPolicy, error) {
+
+	resource := createResource(b)
+	iamPrefix := b.IAMPrefix()
+
+	p := &IAMPolicy{
+		Version: IAMPolicyDefaultVersion,
+	}
+	if b.CreateNetworkingPerms {
+		p.Statement = append(p.Statement, &IAMStatement{
+			Sid:    "kopsAdminVpcNetworking",
+			Effect: IAMStatementEffectAllow,
+			Action: stringorslice.Of(
+				"ec2:AllocateAddress",
+				"ec2:AssociateAddress",
+				"ec2:AssociateDhcpOptions",
+				"ec2:AssociateRouteTable",
+				"ec2:AttachInternetGateway",
+				"ec2:CreateDhcpOptions",
+				"ec2:CreateInternetGateway",
+				"ec2:CreateNatGateway",
+				"ec2:CreateRoute",
+				"ec2:CreateRouteTable",
+				"ec2:CreateSubnet",
+				"ec2:CreateVpc",
+				"ec2:DeleteDhcpOptions",
+				"ec2:DeleteInternetGateway",
+				"ec2:DeleteNatGateway",
+				"ec2:DeleteRoute",
+				"ec2:DeleteRouteTable",
+				"ec2:DetachInternetGateway",
+				"ec2:DisassociateRouteTable",
+				"ec2:ModifyVpcAttribute",
+				"ec2:ReplaceRoute",
+			),
+			Resource: resource,
+		})
+	}
+
+	// ec2
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:    "kopsAdminEc2",
+		Effect: IAMStatementEffectAllow,
+		Action: stringorslice.Of(
+			"ec2:AttachVolume",
+			"ec2:AuthorizeSecurityGroupEgress",
+			"ec2:AuthorizeSecurityGroupIngress",
+			"ec2:CreateSecurityGroup",
+			"ec2:CreateTags",
+			"ec2:CreateVolume",
+			"ec2:DeleteKeyPair",
+			"ec2:DeleteSecurityGroup",
+			"ec2:DeleteTags",
+			"ec2:DeleteVolume",
+			"ec2:DescribeAddresses",
+			"ec2:DescribeAvailabilityZones",
+			"ec2:DescribeDhcpOptions",
+			"ec2:DescribeHosts",
+			"ec2:DescribeImages",
+			"ec2:DescribeImageAttributes",
+			"ec2:DescribeInstances",
+			"ec2:DescribeInternetGateways",
+			"ec2:DescribeKeyPairs",
+			"ec2:DescribeNatGateways",
+			"ec2:DescribeRegions",
+			"ec2:DescribeRouteTables",
+			"ec2:DescribeSecurityGroups",
+			"ec2:DescribeSubnets",
+			"ec2:DescribeTags",
+			"ec2:DescribeVolumes",
+			"ec2:DescribeVpcAttribute",
+			"ec2:DescribeVpc",
+			"ec2:DescribeVpcs",
+			"ec2:DetachVolume",
+			"ec2:ImportKeyPair",
+			"ec2:RevokeSecurityGroupEgress",
+			"ec2:RevokeSecurityGroupIngress",
+			"ec2:StopInstances",
+			"ec2:TerminateInstances",
+		),
+		Resource: resource,
+	})
+
+	// elasticloadbalancing
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:    "kopsAdminElb",
+		Effect: IAMStatementEffectAllow,
+		Action: stringorslice.Of(
+			"elasticloadbalancing:AddTags",
+			"elasticloadbalancing:ApplySec*",
+			"elasticloadbalancing:ConfigureHealthCheck",
+			"elasticloadbalancing:CreateLoadBalancer",
+			"elasticloadbalancing:CreateLoadBalancerListeners",
+			"elasticloadbalancing:DescribeLoadBalancers",
+			"elasticloadbalancing:DescribeTags",
+			"elasticloadbalancing:DeleteLoadBalancer",
+			"elasticloadbalancing:DescribeLoadBalancerAttributes",
+			"elasticloadbalancing:ModifyLoadBalancerAttributes",
+			"elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+			"elasticloadbalancing:RemoveTags",
+			"elasticloadbalancing:SetSecurityGroups",
+		),
+		Resource: resource,
+	})
+
+	// autoscaling
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:    "kopsAdminAsg",
+		Effect: IAMStatementEffectAllow,
+		Action: stringorslice.Of(
+			"autoscaling:AttachInstances",
+			"autoscaling:AttachLoadBalancers",
+			"autoscaling:CreateAutoScalingGroup",
+			"autoscaling:CreateLaunchConfiguration",
+			"autoscaling:CreateOrUpdateTags",
+			"autoscaling:DeleteAutoScalingGroup",
+			"autoscaling:DeleteLaunchConfiguration",
+			"autoscaling:DeleteTags",
+			"autoscaling:Describe*",
+			"autoscaling:SetDesiredCapacity",
+			"autoscaling:TerminateInstanceInAutoScalingGroup",
+			"autoscaling:UpdateAutoScalingGroup",
+		),
+		Resource: resource,
+	})
+
+	if b.CloudFormationPerms {
+		p.Statement = append(p.Statement, &IAMStatement{
+			Sid:    "kopsAdminCF",
+			Effect: IAMStatementEffectAllow,
+			Action: stringorslice.Of(
+				"cloudformation:*",
+			),
+			Resource: resource,
+		})
+	}
+
+	// Installer does not need role policy information if reusing policies
+	if b.CreatePolicyPerms {
+		p.Statement = append(p.Statement, &IAMStatement{
+			Sid:    "kopsAdminRolePolicies",
+			Effect: IAMStatementEffectAllow,
+			Action: stringorslice.Of(
+				"iam:DeleteRolePolicy",
+				"iam:PutRolePolicy",
+			),
+			Resource: resource,
+		})
+	}
+
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:    "kopsAdminIAM",
+		Effect: IAMStatementEffectAllow,
+		Action: stringorslice.Of(
+			"iam:AddRoleToInstanceProfile",
+			"iam:CreateInstanceProfile",
+			"iam:CreateRole",
+			"iam:DeleteInstanceProfile",
+			"iam:DeleteRole",
+			"iam:GetRole",
+			"iam:GetRolePolicy",
+			"iam:GetInstanceProfile",
+			"iam:ListInstanceProfiles",
+			"iam:ListRolePolicies",
+			"iam:ListRoles",
+			"iam:ListInstanceProfiles",
+			"iam:PassRole",
+			"iam:RemoveRoleFromInstanceProfile",
+			"iam:UpdateAssumeRolePolicy",
+		),
+		Resource: resource,
+	})
+
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:    "kopsAdminKMS",
+		Effect: IAMStatementEffectAllow,
+		Action: stringorslice.Of(
+			"kms:Encrypt",
+			"kms:Decrypt",
+			"kms:ReEncrypt*",
+			"kms:GenerateDataKey*",
+			"kms:DescribeKey",
+			"kms:CreateGrant",
+			"kms:ListGrants",
+			"kms:RevokeGrant",
+		),
+		Resource: resource,
+	})
+
+	if b.HostedZoneID != "" {
+		addRoute53Permissions(p, b.HostedZoneID)
+	}
+
+	// dns-controller currently assumes it can list the hosted zones, even when using gossip
+	addRoute53ListHostedZonesPermission(p)
+
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:    "kopsAdminStatestoreAccess",
+		Effect: IAMStatementEffectAllow,
+		Action: stringorslice.Of(
+			"s3:PutObject",
+			"s3:CreateBucket",
+			"s3:DeleteBucket",
+			"s3:DeleteObject",
+			"s3:GetObject",
+			"s3:GetBucketLocation",
+			"s3:ListBucket",
+		),
+		Resource: stringorslice.Of(
+			iamPrefix+":s3:::"+b.S3Bucket,
+			iamPrefix+":s3:::"+b.S3Bucket+"/*",
+		),
+	})
+
+	return p, nil
 }
 
 // IAMPrefix returns the prefix for AWS ARNs in the current region, for use with IAM
@@ -303,6 +533,38 @@ func (b *IAMPolicyBuilder) IAMPrefix() string {
 	default:
 		return "arn:aws"
 	}
+}
+
+func (b *IAMPolicyBuilder) addIAMCustomPolicies(p *IAMPolicy, resource stringorslice.StringOrSlice) {
+
+	// For S3 IAM permissions, we grant permissions to subtrees.  So find the parents;
+	// we don't need to grant mypath and mypath/child.
+
+	iamPrefix := b.IAMPrefix()
+
+	bucket := iamPrefix + ":s3:::" + b.S3Bucket + "/" + b.ClusterName
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:    "kopsK8sStatestoreAccessBucket",
+		Effect: IAMStatementEffectAllow,
+		Action: stringorslice.Of(
+			"s3:GetBucket",
+			"s3:ListBucket",
+		),
+		Resource: stringorslice.Of(
+			bucket,
+			bucket+"/*",
+		),
+	})
+
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:    "KopsK8sStatestoreAccessGet",
+		Effect: IAMStatementEffectAllow,
+		Action: stringorslice.Of("s3:GetBucketLocation", "s3:ListBucket"),
+		Resource: stringorslice.Slice([]string{
+			iamPrefix + ":s3:::" + b.S3Bucket,
+		}),
+	})
+
 }
 
 type IAMPolicyResource struct {
@@ -339,9 +601,207 @@ func (b *IAMPolicyResource) Open() (io.Reader, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error building IAM policy: %v", err)
 	}
-	json, err := policy.AsJSON()
+	j, err := policy.AsJSON()
 	if err != nil {
 		return nil, fmt.Errorf("error building IAM policy: %v", err)
 	}
-	return bytes.NewReader([]byte(json)), nil
+	return bytes.NewReader([]byte(j)), nil
+}
+
+func addECRPermissions(p *IAMPolicy) {
+	// TODO - I think we can just have GetAuthorizationToken here, as we are not
+	// TODO - making any API calls except for GetAuthorizationToken.
+
+	// We provide ECR access on the nodes (naturally), but we also provide access on the master.
+	// We shouldn't be running lots of pods on the master, but it is perfectly reasonable to run
+	// a private logging pod or similar.
+	// At this point we allow all regions with ECR, since ECR is region specific.
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:    "kopsK8sECR",
+		Effect: IAMStatementEffectAllow,
+		Action: stringorslice.Of(
+			"ecr:GetAuthorizationToken",
+			"ecr:BatchCheckLayerAvailability",
+			"ecr:GetDownloadUrlForLayer",
+			"ecr:GetRepositoryPolicy",
+			"ecr:DescribeRepositories",
+			"ecr:ListImages",
+			"ecr:BatchGetImage",
+		),
+		Resource: stringorslice.Slice([]string{"*"}),
+	})
+}
+
+func addRoute53Permissions(p *IAMPolicy, hostedZoneID string) {
+
+	// TODO we should test if we are in China, and not just return
+	// TODO no Route53 in China
+
+	// Remove /hostedzone/ prefix (if present)
+	hostedZoneID = strings.TrimPrefix(hostedZoneID, "/")
+	hostedZoneID = strings.TrimPrefix(hostedZoneID, "hostedzone/")
+
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:    "kopsK8sRoute53Change",
+		Effect: IAMStatementEffectAllow,
+		Action: stringorslice.Of("route53:ChangeResourceRecordSets",
+			"route53:ListResourceRecordSets",
+			"route53:GetHostedZone"),
+		Resource: stringorslice.Slice([]string{"arn:aws:route53:::hostedzone/" + hostedZoneID}),
+	})
+
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:      "kopsK8sRoute53GetChanges",
+		Effect:   IAMStatementEffectAllow,
+		Action:   stringorslice.Slice([]string{"route53:GetChange"}),
+		Resource: stringorslice.Slice([]string{"arn:aws:route53:::change/*"}),
+	})
+
+	wildcard := stringorslice.Slice([]string{"*"})
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:      "kopsK8sRoute53ListZones",
+		Effect:   IAMStatementEffectAllow,
+		Action:   stringorslice.Slice([]string{"route53:ListHostedZones"}),
+		Resource: wildcard,
+	})
+}
+
+func addKMSIAMPolicies(p *IAMPolicy, resource stringorslice.StringOrSlice) {
+
+	// TODO should we add conditions?
+	//	"Condition": {
+	//	    "StringEquals": {
+	//	      "kms:ViaService": [
+	//	        "ec2.us-west-2.amazonaws.com",
+	//	      ]
+	//	    }
+	//	  }
+
+	// I removed these perms and testing is fine with encrypted volumes
+	//			"kms:ListGrants",
+	//			"kms:RevokeGrant",
+
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:    "kopsK8sKMSEncryptedVolumes",
+		Effect: IAMStatementEffectAllow,
+		Action: stringorslice.Of(
+			"kms:Encrypt",
+			"kms:Decrypt",
+			"kms:ReEncrypt*",
+			"kms:GenerateDataKey*",
+			"kms:DescribeKey",
+			"kms:CreateGrant",
+		),
+		Resource: resource,
+	})
+}
+
+func addNodeEC2Policies(p *IAMPolicy, resource stringorslice.StringOrSlice) {
+
+	// protokube makes a describe instance call
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:      "kopsK8sNodeEC2Perms",
+		Effect:   IAMStatementEffectAllow,
+		Action:   stringorslice.Slice([]string{"ec2:DescribeInstances"}),
+		Resource: resource,
+	})
+}
+
+func addMasterEC2Policies(p *IAMPolicy, resource stringorslice.StringOrSlice) {
+
+	// comments are which cloudprovider code file makes the call
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:    "kopsK8sMasterEC2Perms",
+		Effect: IAMStatementEffectAllow,
+		Action: stringorslice.Of(
+			"ec2:AttachVolume",                  // aws.go
+			"ec2:AuthorizeSecurityGroupIngress", // aws.go
+			"ec2:CreateTags",                    // tag.go
+			"ec2:CreateVolume",                  // aws.go
+			"ec2:CreateRoute",                   // aws.go
+			"ec2:CreateSecurityGroup",           // aws.go
+			"ec2:DeleteSecurityGroup",           // aws.go
+			"ec2:DeleteRoute",                   // aws.go
+			"ec2:DeleteVolume",                  // aws.go
+			"ec2:DescribeInstances",             // aws.go
+			"ec2:DescribeRouteTables",           // aws.go
+			"ec2:DescribeSubnets",               // aws.go
+			"ec2:DescribeSecurityGroups",        // aws.go
+			"ec2:DescribeVolumes",               // aws.go
+			"ec2:DetachVolume",                  // aws.go
+			"ec2:ModifyInstanceAttribute",       // aws.go
+			"ec2:RevokeSecurityGroupIngress",    // aws.go
+		),
+		Resource: resource,
+	})
+
+}
+
+func addMasterELBPolicies(p *IAMPolicy, resource stringorslice.StringOrSlice) {
+
+	// comments are which cloudprovider code file makes the call
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:    "kopsElbPerms",
+		Effect: IAMStatementEffectAllow,
+		Action: stringorslice.Of(
+			"elasticloadbalancing:AttachLoadBalancerToSubnets",             // aws_loadbalanacer.go
+			"elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",       // aws_loadbalanacer.go
+			"elasticloadbalancing:CreateLoadBalancer",                      // aws_loadbalanacer.go
+			"elasticloadbalancing:CreateLoadBalancerPolicy",                // aws_loadbalanacer.go
+			"elasticloadbalancing:CreateLoadBalancerListeners",             // aws_loadbalanacer.go
+			"elasticloadbalancing:ConfigureHealthCheck",                    // aws_loadbalanacer.go
+			"elasticloadbalancing:DeleteLoadBalancer",                      // aws.go
+			"elasticloadbalancing:DeleteLoadBalancerListeners",             // aws_loadbalanacer.go
+			"elasticloadbalancing:DescribeLoadBalancers",                   // aws.go
+			"elasticloadbalancing:DescribeLoadBalancerAttributes",          // aws.go
+			"elasticloadbalancing:DetachLoadBalancerFromSubnets",           // aws_loadbalancer.go
+			"elasticloadbalancing:DeregisterInstancesFromLoadBalancer",     // aws_loadbalanacer.go
+			"elasticloadbalancing:ModifyLoadBalancerAttributes",            // aws_loadbalanacer.go
+			"elasticloadbalancing:RegisterInstancesWithLoadBalancer",       // aws_loadbalanacer.go
+			"elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer", // aws_loadbalanacer.go
+		),
+		Resource: resource,
+	})
+}
+
+func addMasterASPolicies(p *IAMPolicy, resource stringorslice.StringOrSlice) {
+	// comments are which cloudprovider / autoscaler code file makes the call
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:    "kopsMasterASPerms",
+		Effect: IAMStatementEffectAllow,
+		Action: stringorslice.Of(
+			"autoscaling:DescribeAutoScalingGroups",           // aws_instancegroups.go
+			"autoscaling:GetAsgForInstance",                   // aws_manager.go
+			"autoscaling:SetDesiredCapacity",                  // aws_manager.go
+			"autoscaling:TerminateInstanceInAutoScalingGroup", // aws_manager.go
+			"autoscaling:UpdateAutoScalingGroup",              // aws_instancegroups.go
+		),
+		Resource: resource,
+	})
+}
+
+func addCertIAMPolicies(p *IAMPolicy, resource stringorslice.StringOrSlice) {
+	// This is needed if we are using iam ssl certs
+	// on ELBs
+	// TODO need to test this
+	p.Statement = append(p.Statement, &IAMStatement{
+		Sid:    "kopsMasterCertIAMPerms",
+		Effect: IAMStatementEffectAllow,
+		Action: stringorslice.Of(
+			"iam:ListServerCertificates",
+			"iam:GetServerCertificate",
+		),
+		Resource: resource,
+	})
+
+}
+
+func createResource(b *IAMPolicyBuilder) stringorslice.StringOrSlice {
+	var resource stringorslice.StringOrSlice
+	if b.ResourceARN != nil {
+		resource = stringorslice.Slice([]string{*b.ResourceARN})
+	} else {
+		resource = stringorslice.Slice([]string{"*"})
+	}
+	return resource
 }

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -33,16 +33,18 @@ func TestRoundTrip(t *testing.T) {
 				Effect:   IAMStatementEffectAllow,
 				Action:   stringorslice.Of("ec2:DescribeRegions"),
 				Resource: stringorslice.Of("*"),
+				Sid:      "foo",
 			},
-			JSON: "{\"Effect\":\"Allow\",\"Action\":\"ec2:DescribeRegions\",\"Resource\":\"*\"}",
+			JSON: "{\"Effect\":\"Allow\",\"Action\":\"ec2:DescribeRegions\",\"Resource\":\"*\",\"Sid\":\"foo\"}",
 		},
 		{
 			IAM: &IAMStatement{
 				Effect:   IAMStatementEffectDeny,
 				Action:   stringorslice.Of("ec2:DescribeRegions", "ec2:DescribeInstances"),
 				Resource: stringorslice.Of("a", "b"),
+				Sid:      "foo",
 			},
-			JSON: "{\"Effect\":\"Deny\",\"Action\":[\"ec2:DescribeRegions\",\"ec2:DescribeInstances\"],\"Resource\":[\"a\",\"b\"]}",
+			JSON: "{\"Effect\":\"Deny\",\"Action\":[\"ec2:DescribeRegions\",\"ec2:DescribeInstances\"],\"Resource\":[\"a\",\"b\"],\"Sid\":\"foo\"}",
 		},
 	}
 	for _, g := range grid {

--- a/tests/integration/minimal/cloudformation.json
+++ b/tests/integration/minimal/cloudformation.json
@@ -547,37 +547,83 @@
               "Effect": "Allow",
               "Resource": [
                 "*"
-              ]
+              ],
+              "Sid": "kopsK8sECR"
             },
             {
               "Action": [
-                "ec2:*"
+                "ec2:AttachVolume",
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:CreateTags",
+                "ec2:CreateVolume",
+                "ec2:CreateRoute",
+                "ec2:CreateSecurityGroup",
+                "ec2:DeleteSecurityGroup",
+                "ec2:DeleteRoute",
+                "ec2:DeleteVolume",
+                "ec2:DescribeInstances",
+                "ec2:DescribeRouteTables",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeVolumes",
+                "ec2:DetachVolume",
+                "ec2:ModifyInstanceAttribute",
+                "ec2:RevokeSecurityGroupIngress"
               ],
               "Effect": "Allow",
               "Resource": [
                 "*"
-              ]
+              ],
+              "Sid": "kopsK8sMasterEC2Perms"
             },
             {
               "Action": [
-                "elasticloadbalancing:*"
+                "elasticloadbalancing:AttachLoadBalancerToSubnets",
+                "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateLoadBalancerPolicy",
+                "elasticloadbalancing:CreateLoadBalancerListeners",
+                "elasticloadbalancing:ConfigureHealthCheck",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:DeleteLoadBalancerListeners",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DetachLoadBalancerFromSubnets",
+                "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+                "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
               ],
               "Effect": "Allow",
               "Resource": [
                 "*"
-              ]
+              ],
+              "Sid": "kopsElbPerms"
             },
             {
               "Action": [
                 "autoscaling:DescribeAutoScalingGroups",
-                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:GetAsgForInstance",
                 "autoscaling:SetDesiredCapacity",
-                "autoscaling:TerminateInstanceInAutoScalingGroup"
+                "autoscaling:TerminateInstanceInAutoScalingGroup",
+                "autoscaling:UpdateAutoScalingGroup"
               ],
               "Effect": "Allow",
               "Resource": [
                 "*"
-              ]
+              ],
+              "Sid": "kopsMasterASPerms"
+            },
+            {
+              "Action": [
+                "iam:ListServerCertificates",
+                "iam:GetServerCertificate"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ],
+              "Sid": "kopsMasterCertIAMPerms"
             },
             {
               "Action": [
@@ -588,7 +634,8 @@
               "Effect": "Allow",
               "Resource": [
                 "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
-              ]
+              ],
+              "Sid": "kopsK8sRoute53Change"
             },
             {
               "Action": [
@@ -597,7 +644,8 @@
               "Effect": "Allow",
               "Resource": [
                 "arn:aws:route53:::change/*"
-              ]
+              ],
+              "Sid": "kopsK8sRoute53GetChanges"
             },
             {
               "Action": [
@@ -606,7 +654,8 @@
               "Effect": "Allow",
               "Resource": [
                 "*"
-              ]
+              ],
+              "Sid": "kopsK8sRoute53ListZones"
             }
           ],
           "Version": "2012-10-17"
@@ -626,12 +675,13 @@
           "Statement": [
             {
               "Action": [
-                "ec2:Describe*"
+                "ec2:DescribeInstances"
               ],
               "Effect": "Allow",
               "Resource": [
                 "*"
-              ]
+              ],
+              "Sid": "kopsK8sNodeEC2Perms"
             },
             {
               "Action": [
@@ -646,36 +696,8 @@
               "Effect": "Allow",
               "Resource": [
                 "*"
-              ]
-            },
-            {
-              "Action": [
-                "route53:ChangeResourceRecordSets",
-                "route53:ListResourceRecordSets",
-                "route53:GetHostedZone"
               ],
-              "Effect": "Allow",
-              "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
-              ]
-            },
-            {
-              "Action": [
-                "route53:GetChange"
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                "arn:aws:route53:::change/*"
-              ]
-            },
-            {
-              "Action": [
-                "route53:ListHostedZones"
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                "*"
-              ]
+              "Sid": "kopsK8sECR"
             }
           ],
           "Version": "2012-10-17"


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kops/issues/1103

This PR continues the work on https://github.com/kubernetes/kops/issues/1873 for an end user to have the capability to create specific policies that will be used by kops.  

### Capability

Custom IAM policies can be a complicated, and maintaining those policies create technical debt.  To automate the maintenance of these policies, kops can now create its own fine grain IAM policies.

The current IAM policies have been given a much shorter hair cut.  Permissions such as `ec2:*` and `s3:*` no longer exist.  Also, the nodes had Route53 permissions, which they should not have.  The node permissions are now very limited.

### TODO

- [X] create admin policy for running kops
- [x] create admin policy for running kops in a provided VPC
- [x] create master policy
- [x] create node policy
- [x] test k8s policies
- [x] documentation
- [x] testing and more testing
- [x] update unit tests

## Testing

I have tested the following different installs with 1.6.3.

1. EBS PV and PVC creation
1. ELB - used the go guestbook
1. Encrypted volumes
1. HA public kubenet
1. HA private weave
1. Single master public kubenet

I have not tested ECR, but I have not changed those permissions.  I have not tested the new IAM permissions for working with SSL certs and ELBs, as I do not have an SSL cert with AWS.

E2E is happy as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2497)
<!-- Reviewable:end -->
