### PR TITLE
tweaking makefile so that KOPS_STATE_STORE is not in the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ gcs-publish-ci: gcs-upload
 	gsutil -h "Cache-Control:private, max-age=0, no-transform" cp .build/upload/${LATEST_FILE} ${GCS_LOCATION}
 
 gen-cli-docs: kops
-	@kops genhelpdocs --out docs/cli
+	KOPS_STATE_STORE= kops genhelpdocs --out docs/cli
 
 # Will always push a linux-based build up to the server
 push: crossbuild-nodeup
@@ -340,7 +340,7 @@ verify-packages:
 
 .PHONY: verify-gendocs
 verify-gendocs: kops
-	hack/verify-gendocs.sh
+	KOPS_STATE_STORE= hack/verify-gendocs.sh
 
 # verify-gendocs will call kops target
 # verify-package has to be after verify-gendoc, because with .gitignore for federation bindata


### PR DESCRIPTION
This PR is related to https://github.com/kubernetes/kops/issues/2502

With the new docs check feature in the kops build we need to ensure that the KOPS_STATE_STORE is unset.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2503)
<!-- Reviewable:end -->
