### PR TITLE
Added instance role as terraform output

### DIFF
--- a/pkg/model/iam.go
+++ b/pkg/model/iam.go
@@ -75,6 +75,7 @@ func (b *IAMModelBuilder) Build(c *fi.ModelBuilderContext) error {
 
 			iamRole = &awstasks.IAMRole{
 				Name:               s(name),
+				RoleType:           s(b.InstanceGroupTypeName(role)),
 				RolePolicyDocument: fi.WrapResource(rolePolicy),
 			}
 			c.AddTask(iamRole)

--- a/pkg/model/names.go
+++ b/pkg/model/names.go
@@ -27,13 +27,10 @@ func (b *KopsModelContext) SecurityGroupName(role kops.InstanceGroupRole) string
 	switch role {
 	case kops.InstanceGroupRoleBastion:
 		return "bastion." + b.ClusterName()
-
 	case kops.InstanceGroupRoleNode:
 		return "nodes." + b.ClusterName()
-
 	case kops.InstanceGroupRoleMaster:
 		return "masters." + b.ClusterName()
-
 	default:
 		glog.Fatalf("unknown role: %v", role)
 		return ""
@@ -100,23 +97,22 @@ func (b *KopsModelContext) NameForDNSZone() string {
 }
 
 func (b *KopsModelContext) IAMName(role kops.InstanceGroupRole) string {
-	var name string
+	return b.InstanceGroupTypeName(role) + "s." + b.ClusterName()
+}
 
+func (b *KopsModelContext) InstanceGroupTypeName(role kops.InstanceGroupRole) string {
 	switch role {
 	case kops.InstanceGroupRoleMaster:
-		name = "masters." + b.ClusterName()
-
+		return "master"
 	case kops.InstanceGroupRoleBastion:
-		name = "bastions." + b.ClusterName()
-
+		return "bastion"
 	case kops.InstanceGroupRoleNode:
-		name = "nodes." + b.ClusterName()
+		return "node"
 
 	default:
 		glog.Fatalf("unknown InstanceGroup Role: %q", role)
+		return ""
 	}
-
-	return name
 }
 
 func (b *KopsModelContext) LinkToIAMInstanceProfile(ig *kops.InstanceGroup) *awstasks.IAMInstanceProfile {

--- a/tests/integration/complex/kubernetes.tf
+++ b/tests/integration/complex/kubernetes.tf
@@ -6,12 +6,28 @@ output "master_security_group_ids" {
   value = ["${aws_security_group.masters-complex-example-com.id}"]
 }
 
+output "masters_role_arn" {
+  value = "${aws_iam_role.masters-complex-example-com.arn}"
+}
+
+output "masters_role_name" {
+  value = "${aws_iam_role.masters-complex-example-com.name}"
+}
+
 output "node_security_group_ids" {
   value = ["${aws_security_group.nodes-complex-example-com.id}", "sg-exampleid3", "sg-exampleid4"]
 }
 
 output "node_subnet_ids" {
   value = ["${aws_subnet.us-test-1a-complex-example-com.id}"]
+}
+
+output "nodes_role_arn" {
+  value = "${aws_iam_role.nodes-complex-example-com.arn}"
+}
+
+output "nodes_role_name" {
+  value = "${aws_iam_role.nodes-complex-example-com.name}"
 }
 
 output "region" {

--- a/tests/integration/ha/kubernetes.tf
+++ b/tests/integration/ha/kubernetes.tf
@@ -6,12 +6,28 @@ output "master_security_group_ids" {
   value = ["${aws_security_group.masters-ha-example-com.id}"]
 }
 
+output "masters_role_arn" {
+  value = "${aws_iam_role.masters-ha-example-com.arn}"
+}
+
+output "masters_role_name" {
+  value = "${aws_iam_role.masters-ha-example-com.name}"
+}
+
 output "node_security_group_ids" {
   value = ["${aws_security_group.nodes-ha-example-com.id}"]
 }
 
 output "node_subnet_ids" {
   value = ["${aws_subnet.us-test-1a-ha-example-com.id}", "${aws_subnet.us-test-1b-ha-example-com.id}", "${aws_subnet.us-test-1c-ha-example-com.id}"]
+}
+
+output "nodes_role_arn" {
+  value = "${aws_iam_role.nodes-ha-example-com.arn}"
+}
+
+output "nodes_role_name" {
+  value = "${aws_iam_role.nodes-ha-example-com.name}"
 }
 
 output "region" {

--- a/tests/integration/minimal-141/kubernetes.tf
+++ b/tests/integration/minimal-141/kubernetes.tf
@@ -6,12 +6,28 @@ output "master_security_group_ids" {
   value = ["${aws_security_group.masters-minimal-141-example-com.id}"]
 }
 
+output "masters_role_arn" {
+  value = "${aws_iam_role.masters-minimal-141-example-com.arn}"
+}
+
+output "masters_role_name" {
+  value = "${aws_iam_role.masters-minimal-141-example-com.name}"
+}
+
 output "node_security_group_ids" {
   value = ["${aws_security_group.nodes-minimal-141-example-com.id}"]
 }
 
 output "node_subnet_ids" {
   value = ["${aws_subnet.us-test-1a-minimal-141-example-com.id}"]
+}
+
+output "nodes_role_arn" {
+  value = "${aws_iam_role.nodes-minimal-141-example-com.arn}"
+}
+
+output "nodes_role_name" {
+  value = "${aws_iam_role.nodes-minimal-141-example-com.name}"
 }
 
 output "region" {

--- a/tests/integration/minimal/kubernetes.tf
+++ b/tests/integration/minimal/kubernetes.tf
@@ -6,12 +6,28 @@ output "master_security_group_ids" {
   value = ["${aws_security_group.masters-minimal-example-com.id}"]
 }
 
+output "masters_role_arn" {
+  value = "${aws_iam_role.masters-minimal-example-com.arn}"
+}
+
+output "masters_role_name" {
+  value = "${aws_iam_role.masters-minimal-example-com.name}"
+}
+
 output "node_security_group_ids" {
   value = ["${aws_security_group.nodes-minimal-example-com.id}"]
 }
 
 output "node_subnet_ids" {
   value = ["${aws_subnet.us-test-1a-minimal-example-com.id}"]
+}
+
+output "nodes_role_arn" {
+  value = "${aws_iam_role.nodes-minimal-example-com.arn}"
+}
+
+output "nodes_role_name" {
+  value = "${aws_iam_role.nodes-minimal-example-com.name}"
 }
 
 output "region" {

--- a/tests/integration/privatecalico/kubernetes.tf
+++ b/tests/integration/privatecalico/kubernetes.tf
@@ -2,6 +2,14 @@ output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-privatecalico-example-com.id}"]
 }
 
+output "bastions_role_arn" {
+  value = "${aws_iam_role.bastions-privatecalico-example-com.arn}"
+}
+
+output "bastions_role_name" {
+  value = "${aws_iam_role.bastions-privatecalico-example-com.name}"
+}
+
 output "cluster_name" {
   value = "privatecalico.example.com"
 }
@@ -10,12 +18,28 @@ output "master_security_group_ids" {
   value = ["${aws_security_group.masters-privatecalico-example-com.id}"]
 }
 
+output "masters_role_arn" {
+  value = "${aws_iam_role.masters-privatecalico-example-com.arn}"
+}
+
+output "masters_role_name" {
+  value = "${aws_iam_role.masters-privatecalico-example-com.name}"
+}
+
 output "node_security_group_ids" {
   value = ["${aws_security_group.nodes-privatecalico-example-com.id}"]
 }
 
 output "node_subnet_ids" {
   value = ["${aws_subnet.us-test-1a-privatecalico-example-com.id}"]
+}
+
+output "nodes_role_arn" {
+  value = "${aws_iam_role.nodes-privatecalico-example-com.arn}"
+}
+
+output "nodes_role_name" {
+  value = "${aws_iam_role.nodes-privatecalico-example-com.name}"
 }
 
 output "region" {

--- a/tests/integration/privatecanal/kubernetes.tf
+++ b/tests/integration/privatecanal/kubernetes.tf
@@ -2,6 +2,14 @@ output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-privatecanal-example-com.id}"]
 }
 
+output "bastions_role_arn" {
+  value = "${aws_iam_role.bastions-privatecanal-example-com.arn}"
+}
+
+output "bastions_role_name" {
+  value = "${aws_iam_role.bastions-privatecanal-example-com.name}"
+}
+
 output "cluster_name" {
   value = "privatecanal.example.com"
 }
@@ -10,12 +18,28 @@ output "master_security_group_ids" {
   value = ["${aws_security_group.masters-privatecanal-example-com.id}"]
 }
 
+output "masters_role_arn" {
+  value = "${aws_iam_role.masters-privatecanal-example-com.arn}"
+}
+
+output "masters_role_name" {
+  value = "${aws_iam_role.masters-privatecanal-example-com.name}"
+}
+
 output "node_security_group_ids" {
   value = ["${aws_security_group.nodes-privatecanal-example-com.id}"]
 }
 
 output "node_subnet_ids" {
   value = ["${aws_subnet.us-test-1a-privatecanal-example-com.id}"]
+}
+
+output "nodes_role_arn" {
+  value = "${aws_iam_role.nodes-privatecanal-example-com.arn}"
+}
+
+output "nodes_role_name" {
+  value = "${aws_iam_role.nodes-privatecanal-example-com.name}"
 }
 
 output "region" {

--- a/tests/integration/privatedns1/kubernetes.tf
+++ b/tests/integration/privatedns1/kubernetes.tf
@@ -2,6 +2,14 @@ output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-privatedns1-example-com.id}"]
 }
 
+output "bastions_role_arn" {
+  value = "${aws_iam_role.bastions-privatedns1-example-com.arn}"
+}
+
+output "bastions_role_name" {
+  value = "${aws_iam_role.bastions-privatedns1-example-com.name}"
+}
+
 output "cluster_name" {
   value = "privatedns1.example.com"
 }
@@ -10,12 +18,28 @@ output "master_security_group_ids" {
   value = ["${aws_security_group.masters-privatedns1-example-com.id}"]
 }
 
+output "masters_role_arn" {
+  value = "${aws_iam_role.masters-privatedns1-example-com.arn}"
+}
+
+output "masters_role_name" {
+  value = "${aws_iam_role.masters-privatedns1-example-com.name}"
+}
+
 output "node_security_group_ids" {
   value = ["${aws_security_group.nodes-privatedns1-example-com.id}"]
 }
 
 output "node_subnet_ids" {
   value = ["${aws_subnet.us-test-1a-privatedns1-example-com.id}"]
+}
+
+output "nodes_role_arn" {
+  value = "${aws_iam_role.nodes-privatedns1-example-com.arn}"
+}
+
+output "nodes_role_name" {
+  value = "${aws_iam_role.nodes-privatedns1-example-com.name}"
 }
 
 output "region" {

--- a/tests/integration/privatedns2/kubernetes.tf
+++ b/tests/integration/privatedns2/kubernetes.tf
@@ -2,6 +2,14 @@ output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-privatedns2-example-com.id}"]
 }
 
+output "bastions_role_arn" {
+  value = "${aws_iam_role.bastions-privatedns2-example-com.arn}"
+}
+
+output "bastions_role_name" {
+  value = "${aws_iam_role.bastions-privatedns2-example-com.name}"
+}
+
 output "cluster_name" {
   value = "privatedns2.example.com"
 }
@@ -10,12 +18,28 @@ output "master_security_group_ids" {
   value = ["${aws_security_group.masters-privatedns2-example-com.id}"]
 }
 
+output "masters_role_arn" {
+  value = "${aws_iam_role.masters-privatedns2-example-com.arn}"
+}
+
+output "masters_role_name" {
+  value = "${aws_iam_role.masters-privatedns2-example-com.name}"
+}
+
 output "node_security_group_ids" {
   value = ["${aws_security_group.nodes-privatedns2-example-com.id}"]
 }
 
 output "node_subnet_ids" {
   value = ["${aws_subnet.us-test-1a-privatedns2-example-com.id}"]
+}
+
+output "nodes_role_arn" {
+  value = "${aws_iam_role.nodes-privatedns2-example-com.arn}"
+}
+
+output "nodes_role_name" {
+  value = "${aws_iam_role.nodes-privatedns2-example-com.name}"
 }
 
 output "region" {

--- a/tests/integration/privateflannel/kubernetes.tf
+++ b/tests/integration/privateflannel/kubernetes.tf
@@ -2,6 +2,14 @@ output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-privateflannel-example-com.id}"]
 }
 
+output "bastions_role_arn" {
+  value = "${aws_iam_role.bastions-privateflannel-example-com.arn}"
+}
+
+output "bastions_role_name" {
+  value = "${aws_iam_role.bastions-privateflannel-example-com.name}"
+}
+
 output "cluster_name" {
   value = "privateflannel.example.com"
 }
@@ -10,12 +18,28 @@ output "master_security_group_ids" {
   value = ["${aws_security_group.masters-privateflannel-example-com.id}"]
 }
 
+output "masters_role_arn" {
+  value = "${aws_iam_role.masters-privateflannel-example-com.arn}"
+}
+
+output "masters_role_name" {
+  value = "${aws_iam_role.masters-privateflannel-example-com.name}"
+}
+
 output "node_security_group_ids" {
   value = ["${aws_security_group.nodes-privateflannel-example-com.id}"]
 }
 
 output "node_subnet_ids" {
   value = ["${aws_subnet.us-test-1a-privateflannel-example-com.id}"]
+}
+
+output "nodes_role_arn" {
+  value = "${aws_iam_role.nodes-privateflannel-example-com.arn}"
+}
+
+output "nodes_role_name" {
+  value = "${aws_iam_role.nodes-privateflannel-example-com.name}"
 }
 
 output "region" {

--- a/tests/integration/privatekopeio/kubernetes.tf
+++ b/tests/integration/privatekopeio/kubernetes.tf
@@ -2,6 +2,14 @@ output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-privatekopeio-example-com.id}"]
 }
 
+output "bastions_role_arn" {
+  value = "${aws_iam_role.bastions-privatekopeio-example-com.arn}"
+}
+
+output "bastions_role_name" {
+  value = "${aws_iam_role.bastions-privatekopeio-example-com.name}"
+}
+
 output "cluster_name" {
   value = "privatekopeio.example.com"
 }
@@ -10,12 +18,28 @@ output "master_security_group_ids" {
   value = ["${aws_security_group.masters-privatekopeio-example-com.id}"]
 }
 
+output "masters_role_arn" {
+  value = "${aws_iam_role.masters-privatekopeio-example-com.arn}"
+}
+
+output "masters_role_name" {
+  value = "${aws_iam_role.masters-privatekopeio-example-com.name}"
+}
+
 output "node_security_group_ids" {
   value = ["${aws_security_group.nodes-privatekopeio-example-com.id}"]
 }
 
 output "node_subnet_ids" {
   value = ["${aws_subnet.us-test-1a-privatekopeio-example-com.id}"]
+}
+
+output "nodes_role_arn" {
+  value = "${aws_iam_role.nodes-privatekopeio-example-com.arn}"
+}
+
+output "nodes_role_name" {
+  value = "${aws_iam_role.nodes-privatekopeio-example-com.name}"
 }
 
 output "region" {

--- a/tests/integration/privateweave/kubernetes.tf
+++ b/tests/integration/privateweave/kubernetes.tf
@@ -2,6 +2,14 @@ output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-privateweave-example-com.id}"]
 }
 
+output "bastions_role_arn" {
+  value = "${aws_iam_role.bastions-privateweave-example-com.arn}"
+}
+
+output "bastions_role_name" {
+  value = "${aws_iam_role.bastions-privateweave-example-com.name}"
+}
+
 output "cluster_name" {
   value = "privateweave.example.com"
 }
@@ -10,12 +18,28 @@ output "master_security_group_ids" {
   value = ["${aws_security_group.masters-privateweave-example-com.id}"]
 }
 
+output "masters_role_arn" {
+  value = "${aws_iam_role.masters-privateweave-example-com.arn}"
+}
+
+output "masters_role_name" {
+  value = "${aws_iam_role.masters-privateweave-example-com.name}"
+}
+
 output "node_security_group_ids" {
   value = ["${aws_security_group.nodes-privateweave-example-com.id}"]
 }
 
 output "node_subnet_ids" {
   value = ["${aws_subnet.us-test-1a-privateweave-example-com.id}"]
+}
+
+output "nodes_role_arn" {
+  value = "${aws_iam_role.nodes-privateweave-example-com.arn}"
+}
+
+output "nodes_role_name" {
+  value = "${aws_iam_role.nodes-privateweave-example-com.name}"
 }
 
 output "region" {

--- a/upup/pkg/fi/cloudup/awstasks/iamrole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrole.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"encoding/json"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -37,6 +38,7 @@ import (
 type IAMRole struct {
 	ID                 *string
 	Name               *string
+	RoleType           *string
 	RolePolicyDocument *fi.ResourceHolder // "inline" IAM policy
 }
 
@@ -193,6 +195,9 @@ func (_ *IAMRole) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *I
 		Name:             e.Name,
 		AssumeRolePolicy: policy,
 	}
+
+	t.AddOutputVariable(*e.RoleType+"s_role_arn", terraform.LiteralProperty("aws_iam_role", *e.Name, "arn"))
+	t.AddOutputVariable(*e.RoleType+"s_role_name", e.TerraformLink())
 
 	return t.RenderResource("aws_iam_role", *e.Name, tf)
 }


### PR DESCRIPTION
Added:
- Instance role name
- Instance role arn

as terraform outputs, this can then be references later on to
use as sts:assume role, created after this one

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2508)
<!-- Reviewable:end -->
