### PR TITLE
Fix channel version recommendations

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -28,8 +28,8 @@ spec:
   - range: ">=1.5.0-alpha1"
     recommendedVersion: 1.5.1
     #requiredVersion: 1.5.1
-    kubernetesVersion: 1.5.4
+    kubernetesVersion: 1.5.6
   - range: "<1.5.0"
     recommendedVersion: 1.4.4
     #requiredVersion: 1.4.4
-    kubernetesVersion: 1.4.9
+    kubernetesVersion: 1.4.12

--- a/channels/stable
+++ b/channels/stable
@@ -24,7 +24,7 @@ spec:
   - range: ">=1.5.0-alpha1"
     recommendedVersion: 1.5.1
     #requiredVersion: 1.5.1
-    kubernetesVersion: 1.5.2
+    kubernetesVersion: 1.5.4
   - range: "<1.5.0"
     recommendedVersion: 1.4.4
     #requiredVersion: 1.4.4

--- a/tests/integration/channel/integration_test.go
+++ b/tests/integration/channel/integration_test.go
@@ -304,6 +304,87 @@ func TestOrdering(t *testing.T) {
 	}
 }
 
+// TestChannelsSelfConsistent tests the channels have version recommendations that are consistent
+// i.e. we don't recommend 1.5.2 and then recommend upgrading it to 1.5.4
+func TestChannelsSelfConsistent(t *testing.T) {
+
+	grid := []struct {
+		KopsVersion               string
+		Channel                   string
+		ExpectedKubernetesVersion string
+	}{
+		{
+			KopsVersion: "1.4.4",
+			Channel:     "alpha",
+		},
+		{
+			KopsVersion: "1.4.4",
+			Channel:     "stable",
+		},
+		{
+			KopsVersion: "1.5.3",
+			Channel:     "alpha",
+		},
+		{
+			KopsVersion: "1.5.3",
+			Channel:     "stable",
+		},
+		{
+			KopsVersion: "1.6.0-beta.1",
+			Channel:     "alpha",
+		},
+		{
+			KopsVersion: "1.6.0-beta.1",
+			Channel:     "stable",
+		},
+		{
+			KopsVersion: "1.7.0",
+			Channel:     "alpha",
+		},
+		{
+			KopsVersion: "1.7.0",
+			Channel:     "stable",
+		},
+	}
+	for _, g := range grid {
+		srcDir := "../../../channels/"
+		sourcePath := path.Join(srcDir, g.Channel)
+		sourceBytes, err := ioutil.ReadFile(sourcePath)
+		if err != nil {
+			t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
+		}
+
+		channel, err := kops.ParseChannel(sourceBytes)
+		if err != nil {
+			t.Fatalf("failed to parse channel %s: %v", g.Channel, err)
+		}
+
+		kubernetesVersion := kops.RecommendedKubernetesVersion(channel, g.KopsVersion)
+
+		if kubernetesVersion == nil {
+			t.Errorf("RecommendedKubernetesVersion returned nil for %s/%q", g.Channel, kubernetesVersion)
+			continue
+		}
+
+		versionInfo := kops.FindKubernetesVersionSpec(channel.Spec.KubernetesVersions, *kubernetesVersion)
+		if versionInfo == nil {
+			t.Errorf("FindKubernetesVersionSpec did not find version for %s/%q", g.Channel, *kubernetesVersion)
+			continue
+		}
+
+		recommended, err := versionInfo.FindRecommendedUpgrade(*kubernetesVersion)
+		if err != nil {
+			t.Errorf("FindRecommendedUpgrade have error for %s/%q: %v", g.Channel, *kubernetesVersion, err)
+			continue
+		}
+
+		if recommended != nil {
+			t.Errorf("Kops recommended kubernetesVersion is %q, but then k8s recommended kubernetesVersion is %q (%s)", *kubernetesVersion, *recommended, g.Channel)
+			continue
+		}
+	}
+}
+
 func semverString(sv *semver.Version) string {
 	if sv == nil {
 		return ""


### PR DESCRIPTION
We were recommending 1.5.2 based on the kops version, but then 1.5.4
based on that k8s version.

Fix & add a test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2513)
<!-- Reviewable:end -->
