### PR TITLE
Remove deprecated secrets commands per #2519

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,6 @@
 
 all: kops
 
-.PHONY: channels examples
-
 DOCKER_REGISTRY?=gcr.io/must-override
 S3_BUCKET?=s3://must-override/
 GCS_LOCATION?=gs://must-override
@@ -76,38 +74,47 @@ ifndef SHASUMCMD
   $(error "Neither sha1sum nor shasum command is available")
 endif
 
+.PHONY: kops
 kops: kops-gobindata
 	go install ${EXTRA_BUILDFLAGS} -ldflags "-X k8s.io/kops.Version=${VERSION} -X k8s.io/kops.GitVersion=${GITSHA} ${EXTRA_LDFLAGS}" k8s.io/kops/cmd/kops/...
 
+.PHONY: gobindata-tools
 gobindata-tool:
 	go build ${EXTRA_BUILDFLAGS} -ldflags "${EXTRA_LDFLAGS}" -o ${GOPATH_1ST}/bin/go-bindata k8s.io/kops/vendor/github.com/jteeuwen/go-bindata/go-bindata
 
+.PHONY: kops-gobindata
 kops-gobindata: gobindata-tool
 	cd ${GOPATH_1ST}/src/k8s.io/kops; ${GOPATH_1ST}/bin/go-bindata -o upup/models/bindata.go -pkg models -ignore="\\.DS_Store" -ignore="bindata\\.go" -ignore="vfs\\.go" -prefix upup/models/ upup/models/...
 	cd ${GOPATH_1ST}/src/k8s.io/kops; ${GOPATH_1ST}/bin/go-bindata -o federation/model/bindata.go -pkg model -ignore="\\.DS_Store" -ignore="bindata\\.go" -prefix federation/model/ federation/model/...
 
 # Build in a docker container with golang 1.X
 # Used to test we have not broken 1.X
+.PHONY: check-builds-in-go15:
 check-builds-in-go15:
 	docker run -v ${GOPATH_1ST}/src/k8s.io/kops:/go/src/k8s.io/kops golang:1.5 make -f /go/src/k8s.io/kops/Makefile kops
 
+.PHONY: check-builds-in-go16
 check-builds-in-go16:
 	docker run -v ${GOPATH_1ST}/src/k8s.io/kops:/go/src/k8s.io/kops golang:1.6 make -f /go/src/k8s.io/kops/Makefile kops
 
+.PHONY: check-builds-in-go17
 check-builds-in-go17:
 	docker run -v ${GOPATH_1ST}/src/k8s.io/kops:/go/src/k8s.io/kops golang:1.7 make -f /go/src/k8s.io/kops/Makefile kops
 
+.PHONY: codegen
 codegen: kops-gobindata
 	go install k8s.io/kops/upup/tools/generators/...
 	PATH=${GOPATH_1ST}/bin:${PATH} go generate k8s.io/kops/upup/pkg/fi/cloudup/awstasks
 	PATH=${GOPATH_1ST}/bin:${PATH} go generate k8s.io/kops/upup/pkg/fi/cloudup/gcetasks
 	PATH=${GOPATH_1ST}/bin:${PATH} go generate k8s.io/kops/upup/pkg/fi/fitasks
 
+.PHONY: protobuf
 protobuf: protokube/pkg/gossip/mesh/mesh.pb.go
 
 protokube/pkg/gossip/mesh/mesh.pb.go: protokube/pkg/gossip/mesh/mesh.proto
 	cd ${GOPATH_1ST}/src; protoc --gofast_out=. k8s.io/kops/protokube/pkg/gossip/mesh/mesh.proto
 
+.PHONY: test
 test:
 	go test k8s.io/kops/pkg/... -args -v=1 -logtostderr
 	go test k8s.io/kops/nodeup/pkg/... -args -v=1 -logtostderr
@@ -120,32 +127,36 @@ test:
 	go test k8s.io/kops/channels/... -args -v=1 -logtostderr
 	go test k8s.io/kops/util/... -args -v=1 -logtostderr
 
+.PHONY: crossbuild-nodeup
 crossbuild-nodeup:
 	mkdir -p .build/dist/
 	GOOS=linux GOARCH=amd64 go build -a ${EXTRA_BUILDFLAGS} -o .build/dist/linux/amd64/nodeup -ldflags "${EXTRA_LDFLAGS} -X k8s.io/kops.Version=${VERSION} -X k8s.io/kops.GitVersion=${GITSHA}" k8s.io/kops/cmd/nodeup
 
+.PHONY: crossbuild-nodeup-in-docker
 crossbuild-nodeup-in-docker:
 	docker pull golang:${GOVERSION} # Keep golang image up to date
 	docker run --name=nodeup-build-${UNIQUE} -e STATIC_BUILD=yes -e VERSION=${VERSION} -v ${MAKEDIR}:/go/src/k8s.io/kops golang:${GOVERSION} make -f /go/src/k8s.io/kops/Makefile crossbuild-nodeup
 	docker cp nodeup-build-${UNIQUE}:/go/.build .
 
+.PHONY: crossbuild
 crossbuild:
 	mkdir -p .build/dist/
 	GOOS=darwin GOARCH=amd64 go build -a ${EXTRA_BUILDFLAGS} -o .build/dist/darwin/amd64/kops -ldflags "${EXTRA_LDFLAGS} -X k8s.io/kops.Version=${VERSION} -X k8s.io/kops.GitVersion=${GITSHA}" k8s.io/kops/cmd/kops
 	GOOS=linux GOARCH=amd64 go build -a ${EXTRA_BUILDFLAGS} -o .build/dist/linux/amd64/kops -ldflags "${EXTRA_LDFLAGS} -X k8s.io/kops.Version=${VERSION} -X k8s.io/kops.GitVersion=${GITSHA}" k8s.io/kops/cmd/kops
 
-
-
+.PHONY: crossbuild-in-docker
 crossbuild-in-docker:
 	docker pull golang:${GOVERSION} # Keep golang image up to date
 	docker run --name=kops-build-${UNIQUE} -e STATIC_BUILD=yes -e VERSION=${VERSION} -v ${MAKEDIR}:/go/src/k8s.io/kops golang:${GOVERSION} make -f /go/src/k8s.io/kops/Makefile crossbuild
 	docker cp kops-build-${UNIQUE}:/go/.build .
 
+.PHONY: kops-dist
 kops-dist: crossbuild-in-docker
 	mkdir -p .build/dist/
 	(${SHASUMCMD} .build/dist/darwin/amd64/kops | cut -d' ' -f1) > .build/dist/darwin/amd64/kops.sha1
 	(${SHASUMCMD} .build/dist/linux/amd64/kops | cut -d' ' -f1) > .build/dist/linux/amd64/kops.sha1
 
+.PHONY: version-dist
 version-dist: nodeup-dist kops-dist protokube-export utils-dist
 	rm -rf .build/upload
 	mkdir -p .build/upload/kops/${VERSION}/linux/amd64/
@@ -163,6 +174,7 @@ version-dist: nodeup-dist kops-dist protokube-export utils-dist
 	cp .build/dist/linux/amd64/utils.tar.gz .build/upload/kops/${VERSION}/linux/amd64/utils.tar.gz
 	cp .build/dist/linux/amd64/utils.tar.gz.sha1 .build/upload/kops/${VERSION}/linux/amd64/utils.tar.gz.sha1
 
+.PHONY: vsphere-version-dist
 vsphere-version-dist: nodeup-dist protokube-export
 	rm -rf .build/upload
 	mkdir -p .build/upload/kops/${VERSION}/linux/amd64/
@@ -181,14 +193,17 @@ vsphere-version-dist: nodeup-dist protokube-export
 	cp .build/dist/darwin/amd64/kops .build/upload/kops/${VERSION}/darwin/amd64/kops
 	cp .build/dist/darwin/amd64/kops.sha1 .build/upload/kops/${VERSION}/darwin/amd64/kops.sha1
 
+.PHONY: upload
 upload: kops version-dist
 	aws s3 sync --acl public-read .build/upload/ ${S3_BUCKET}
 
+.PHONY: gcs-upload
 gcs-upload: version-dist
 	@echo "== Uploading kops =="
 	gsutil -h "Cache-Control:private, max-age=0, no-transform" -m cp -n -r .build/upload/kops/* ${GCS_LOCATION}
 
 # In CI testing, always upload the CI version.
+.PHONY: gcs-publish-ci
 gcs-publish-ci: VERSION := ${KOPS_CI_VERSION}+${GITSHA}
 gcs-publish-ci: PROTOKUBE_TAG := $(subst +,-,${VERSION})
 gcs-publish-ci: gcs-upload
@@ -197,39 +212,50 @@ gcs-publish-ci: gcs-upload
 	echo "${GCS_URL}/${VERSION}" > .build/upload/${LATEST_FILE}
 	gsutil -h "Cache-Control:private, max-age=0, no-transform" cp .build/upload/${LATEST_FILE} ${GCS_LOCATION}
 
+.PHONY: gen-cli-docs
 gen-cli-docs: kops
 	KOPS_STATE_STORE= kops genhelpdocs --out docs/cli
 
+.PHONY: push
 # Will always push a linux-based build up to the server
 push: crossbuild-nodeup
 	scp -C .build/dist/linux/amd64/nodeup  ${TARGET}:/tmp/
 
+.PHONY: push-gce-dry
 push-gce-dry: push
 	ssh ${TARGET} sudo SKIP_PACKAGE_UPDATE=1 /tmp/nodeup --conf=metadata://gce/config --dryrun --v=8
 
+.PHONY: push-gce-dry
 push-aws-dry: push
 	ssh ${TARGET} sudo SKIP_PACKAGE_UPDATE=1 /tmp/nodeup --conf=/var/cache/kubernetes-install/kube_env.yaml --dryrun --v=8
 
+.PHONY: push-gce-run
 push-gce-run: push
 	ssh ${TARGET} sudo cp /tmp/nodeup /home/kubernetes/bin/nodeup
 	ssh ${TARGET} sudo SKIP_PACKAGE_UPDATE=1 /home/kubernetes/bin/nodeup --conf=/var/lib/toolbox/kubernetes-install/kube_env.yaml --v=8
 
 # -t is for CentOS http://unix.stackexchange.com/questions/122616/why-do-i-need-a-tty-to-run-sudo-if-i-can-sudo-without-a-password
+.PHONY: push-aws-run
 push-aws-run: push
 	ssh -t ${TARGET} sudo SKIP_PACKAGE_UPDATE=1 /tmp/nodeup --conf=/var/cache/kubernetes-install/kube_env.yaml --v=8
 
+.PHONY: protokube-gocode
 protokube-gocode:
 	go install -tags 'peer_name_alternative peer_name_hash' k8s.io/kops/protokube/cmd/protokube
 
+.PHONY: protokube-builder-image
 protokube-builder-image:
 	docker build -t protokube-builder images/protokube-builder
 
+.PHONY: protokube-build-in-docker
 protokube-build-in-docker: protokube-builder-image
 	docker run -t -e VERSION=${VERSION} -v `pwd`:/src protokube-builder /onbuild.sh
 
+.PHONY: protokube-image
 protokube-image: protokube-build-in-docker
 	docker build -t protokube:${PROTOKUBE_TAG} -f images/protokube/Dockerfile .
 
+.PHONY: protokube-export
 protokube-export: protokube-image
 	mkdir -p .build/dist/images
 	docker save protokube:${PROTOKUBE_TAG} > .build/dist/images/protokube.tar
@@ -238,15 +264,19 @@ protokube-export: protokube-image
 
 # protokube-push is no longer used (we upload a docker image tar file to S3 instead),
 # but we're keeping it around in case it is useful for development etc
+.PHONY: protokube-push
 protokube-push: protokube-image
 	docker tag protokube:${PROTOKUBE_TAG} ${DOCKER_REGISTRY}/protokube:${PROTOKUBE_TAG}
 	docker push ${DOCKER_REGISTRY}/protokube:${PROTOKUBE_TAG}
 
+.PHONY: nodeup
 nodeup: nodeup-dist
 
+.PHONY: nodeup-gocode
 nodeup-gocode: kops-gobindata
 	go install ${EXTRA_BUILDFLAGS} -ldflags "${EXTRA_LDFLAGS} -X k8s.io/kops.Version=${VERSION} -X k8s.io/kops.GitVersion=${GITSHA}" k8s.io/kops/cmd/nodeup
 
+.PHONY: nodeup-dist
 nodeup-dist:
 	docker pull golang:${GOVERSION} # Keep golang image up to date
 	docker run --name=nodeup-build-${UNIQUE} -e STATIC_BUILD=yes -e VERSION=${VERSION} -v ${MAKEDIR}:/go/src/k8s.io/kops golang:${GOVERSION} make -f /go/src/k8s.io/kops/Makefile nodeup-gocode
@@ -254,24 +284,30 @@ nodeup-dist:
 	docker cp nodeup-build-${UNIQUE}:/go/bin/nodeup .build/dist/
 	(${SHASUMCMD} .build/dist/nodeup | cut -d' ' -f1) > .build/dist/nodeup.sha1
 
+.PHONY: dns-controller-gocode
 dns-controller-gocode:
 	go install -tags 'peer_name_alternative peer_name_hash' -ldflags "${EXTRA_LDFLAGS} -X main.BuildVersion=${DNS_CONTROLLER_TAG}" k8s.io/kops/dns-controller/cmd/dns-controller
 
+.PHONY: dns-controller-builder-image
 dns-controller-builder-image:
 	docker build -t dns-controller-builder images/dns-controller-builder
 
+.PHONY: dns-controller-build-in-docker
 dns-controller-build-in-docker: dns-controller-builder-image
 	docker run -t -v `pwd`:/src dns-controller-builder /onbuild.sh
 
+.PHONY: dns-controller-image
 dns-controller-image: dns-controller-build-in-docker
 	docker build -t ${DOCKER_REGISTRY}/dns-controller:${DNS_CONTROLLER_TAG}  -f images/dns-controller/Dockerfile .
 
+.PHONY: dns-controller-push
 dns-controller-push: dns-controller-image
 	docker push ${DOCKER_REGISTRY}/dns-controller:${DNS_CONTROLLER_TAG}
 
 # --------------------------------------------------
 # static utils
 
+.PHONY: utils-dist
 utils-dist:
 	docker build -t utils-builder images/utils-builder
 	mkdir -p .build/dist/linux/amd64/
@@ -281,12 +317,14 @@ utils-dist:
 # development targets
 
 # See docs/development/dependencies.md
+.PHONY: copydeps
 copydeps:
 	rsync -avz _vendor/ vendor/ --delete --exclude vendor/  --exclude .git
 	ln -sf kubernetes/staging/src/k8s.io/apimachinery vendor/k8s.io/apimachinery
 	ln -sf kubernetes/staging/src/k8s.io/apiserver vendor/k8s.io/apiserver
 	ln -sf kubernetes/staging/src/k8s.io/client-go vendor/k8s.io/client-go
 
+.PHONY: gofmt
 gofmt:
 	gofmt -w -s channels/
 	gofmt -w -s cloudmock/
@@ -304,12 +342,15 @@ gofmt:
 	gofmt -w -s dns-controller/cmd
 	gofmt -w -s dns-controller/pkg
 
+.PHONY: goimports
 goimports:
 	hack/update-goimports
 
+.PHONY: verify-goimports
 verify-goimports:
 	hack/verify-goimports
 
+.PHONY: govet
 govet:
 	go vet \
 	  k8s.io/kops/cmd/... \
@@ -327,6 +368,7 @@ govet:
 # --------------------------------------------------
 # Continuous integration targets
 
+.PHONY: verify-boilerplate
 verify-boilerplate:
 	hack/verify-boilerplate.sh
 
@@ -345,35 +387,42 @@ verify-gendocs: kops
 # verify-gendocs will call kops target
 # verify-package has to be after verify-gendoc, because with .gitignore for federation bindata
 # it bombs in travis. verify-gendoc generates the bindata file.
+.PHONY: ci
 ci: govet verify-gofmt verify-boilerplate verify-gendocs verify-packages nodeup-gocode examples test 
 	echo "Done!"
 
 # --------------------------------------------------
 # channel tool
 
+.PHONY: channels
 channels: channels-gocode
 
+.PHONY: channels-gocode
 channels-gocode:
 	go install ${EXTRA_BUILDFLAGS} -ldflags "-X k8s.io/kops.Version=${VERSION} ${EXTRA_LDFLAGS}" k8s.io/kops/channels/cmd/channels
 
 # --------------------------------------------------
 # release tasks
 
+.PHONY: release-tag
 release-tag:
 	git tag ${KOPS_RELEASE_VERSION}
 
+.PHONY: release-github
 release-github:
 	shipbot -tag ${KOPS_RELEASE_VERSION} -config .shipbot.yaml
 
 # --------------------------------------------------
 # API / embedding examples
 
+.PHONY: examples
 examples:
 	go install k8s.io/kops/examples/kops-api-example/...
 
 # -----------------------------------------------------
 # api machinery regenerate
 
+.PHONY: apimachinery
 apimachinery:
 	sh -c hack/make-apimachinery.sh
 	${GOPATH}/bin/conversion-gen --skip-unsafe=true --input-dirs k8s.io/kops/pkg/apis/kops/v1alpha1 --v=0  --output-file-base=zz_generated.conversion
@@ -390,9 +439,11 @@ apimachinery:
 # -----------------------------------------------------
 # kops-server
 
+.PHONY: kops-server-docker-compile
 kops-server-docker-compile:
 	GOOS=linux GOARCH=amd64 go build -a ${EXTRA_BUILDFLAGS} -o .build/dist/linux/amd64/kops-server -ldflags "${EXTRA_LDFLAGS} -X k8s.io/kops-server.Version=${VERSION} -X k8s.io/kops-server.GitVersion=${GITSHA}" k8s.io/kops/cmd/kops-server
 
+.PHONY: kops-server-build
 kops-server-build:
 	# Compile the API binary in linux, and copy to local filesystem
 	docker pull golang:${GOVERSION}
@@ -400,5 +451,6 @@ kops-server-build:
 	docker cp kops-server-build-${UNIQUE}:/go/.build .
 	docker build -t ${DOCKER_REGISTRY}/kops-server:latest -f images/kops-server/Dockerfile .
 
+.PHONY: kops-server-push
 kops-server-push: kops-server-build
 	docker push ${DOCKER_REGISTRY}/kops-server:latest


### PR DESCRIPTION
The "secrets" command subtree has previously been deprecated, because "create secrets" was more readable than "secrets create"; the same went for secrets describe, expose and get.

This PR and the related commit removes all these deprecated commands from the CLI and from the documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2521)
<!-- Reviewable:end -->
