### PR TITLE
[Fixes #2506] Adds CoreOS SSH username as `core` in docs

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -44,7 +44,7 @@ The tooling used to build these images is open source:
   used for building the kernel.
 
 The latest image name is kept in the [stable channel manifest](https://github.com/kubernetes/kops/blob/master/channels/stable),
-but an example is `kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21`.  This means to look for an image published 
+but an example is `kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21`.  This means to look for an image published
 by `kope.io`, (which is a well-known alias to account `383156758163`), with the name
 `k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21`.  By using a name instead of an AMI, we can reference an image
 irrespective of the region in which it is located.
@@ -101,5 +101,4 @@ The following steps are known:
 * CoreOS AMIs can be found using `aws ec2 describe-images --region=us-east-1 --owner=595879546273 --filters Name=virtualization-type,Values=hvm`
 * You can specify the name using the `coreos.com` owner alias, for example `coreos.com/CoreOS-stable-1235.9.0-hvm`
 
-
-
+> Note: SSH username will be `core`

--- a/docs/security.md
+++ b/docs/security.md
@@ -11,6 +11,8 @@ the private key corresponding to the public key in `kops get secrets --type sshp
 creating a new cluster, the SSH public key can be specified with the `--ssh-public-key` option, and it
 defaults to `~/.ssh/id_rsa.pub`.
 
+> Note: In CoreOS, SSH username will be `core`.
+
 To change the SSH public key on an existing cluster:
 
 * `kops delete secret --name <clustername> sshpublickey admin`


### PR DESCRIPTION
Signed-off-by: Jaipradeesh Janarthanan <jaipradeesh@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2526)
<!-- Reviewable:end -->
