### PR TITLE
Added "cloud-labels" to ebs volumes

### DIFF
--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -106,6 +106,12 @@ func (b *MasterVolumeBuilder) addAWSVolume(c *fi.ModelBuilderContext, name strin
 
 	// The tags are how protokube knows to mount the volume and use it for etcd
 	tags := make(map[string]string)
+
+	// Apply all user defined labels on the volumes
+	for k, v := range b.Cluster.Spec.CloudLabels {
+		tags[k] = v
+	}
+
 	//tags[awsup.TagClusterName] = b.C.cluster.Name
 	// This is the configuration of the etcd cluster
 	tags[awsup.TagNameEtcdClusterPrefix+etcd.Name] = m.Name + "/" + strings.Join(allMembers, ",")

--- a/tests/integration/complex/in-v1alpha2.yaml
+++ b/tests/integration/complex/in-v1alpha2.yaml
@@ -8,6 +8,9 @@ spec:
   - 0.0.0.0/0
   channel: stable
   cloudProvider: aws
+  cloudLabels:
+    Owner: John Doe
+    foo/bar: fib+baz
   configBase: memfs://clusters.example.com/complex.example.com
   etcdClusters:
   - etcdMembers:

--- a/tests/integration/complex/kubernetes.tf
+++ b/tests/integration/complex/kubernetes.tf
@@ -58,6 +58,18 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-complex-example-com"
   }
 
   tag = {
+    key                 = "Owner"
+    value               = "John Doe"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "foo/bar"
+    value               = "fib+baz"
+    propagate_at_launch = true
+  }
+
+  tag = {
     key                 = "k8s.io/role/master"
     value               = "1"
     propagate_at_launch = true
@@ -84,6 +96,18 @@ resource "aws_autoscaling_group" "nodes-complex-example-com" {
   }
 
   tag = {
+    key                 = "Owner"
+    value               = "John Doe"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "foo/bar"
+    value               = "fib+baz"
+    propagate_at_launch = true
+  }
+
+  tag = {
     key                 = "k8s.io/role/node"
     value               = "1"
     propagate_at_launch = true
@@ -99,6 +123,8 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-complex-example-com" {
   tags = {
     KubernetesCluster    = "complex.example.com"
     Name                 = "us-test-1a.etcd-events.complex.example.com"
+    Owner                = "John Doe"
+    "foo/bar"            = "fib+baz"
     "k8s.io/etcd/events" = "us-test-1a/us-test-1a"
     "k8s.io/role/master" = "1"
   }
@@ -113,6 +139,8 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-complex-example-com" {
   tags = {
     KubernetesCluster    = "complex.example.com"
     Name                 = "us-test-1a.etcd-main.complex.example.com"
+    Owner                = "John Doe"
+    "foo/bar"            = "fib+baz"
     "k8s.io/etcd/main"   = "us-test-1a/us-test-1a"
     "k8s.io/role/master" = "1"
   }


### PR DESCRIPTION
I added the cloud-labels on the ebs volumes, since thoses labels don't affect the kubernetes behaviors and can be used for things like billing categorization this is a little plus :) and it makes it easier to control the output terraform.

>There is no test for that part, I should maybe have added some.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2527)
<!-- Reviewable:end -->
