### PR TITLE
Add critical pod annotations to kopeio networking

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kope.io/k8s-1.6.yaml
+++ b/upup/models/cloudup/resources/addons/networking.kope.io/k8s-1.6.yaml
@@ -12,6 +12,8 @@ spec:
       labels:
         name: kopeio-networking-agent
         role.kubernetes.io/networking: "1"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostPID: true
       hostIPC: true

--- a/upup/models/cloudup/resources/addons/networking.kope.io/pre-k8s-1.6.yaml
+++ b/upup/models/cloudup/resources/addons/networking.kope.io/pre-k8s-1.6.yaml
@@ -12,6 +12,8 @@ spec:
       labels:
         name: kopeio-networking-agent
         role.kubernetes.io/networking: "1"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostPID: true
       hostIPC: true


### PR DESCRIPTION
Should prevent eviction, which would (best case) stop us discovering new
nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2544)
<!-- Reviewable:end -->
