### PR TITLE
Add the -o flag to 1.6 dnsmasq startup.

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -162,6 +162,7 @@ spec:
         - -restartDnsmasq=true
         - --
         - -k
+        - -o
         - --cache-size=1000
         - --log-facility=-
         - --server=/{{ KubeDNS.Domain }}/127.0.0.1#10053


### PR DESCRIPTION
Fixes #2546 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2547)
<!-- Reviewable:end -->
