### PR TITLE
Adds instructions for developing in Docker

### DIFF
--- a/docs/development/Docker.md
+++ b/docs/development/Docker.md
@@ -1,0 +1,11 @@
+In order to develop inside a Docker container you must mount your local copy of 
+the Kops repo into the container's `GOPATH`. For the offical Golang Docker 
+image this is simply a matter of running the following command:
+
+```bash
+docker run -it -v /path/to/local/kops/repo:/go/src/k8s.io/kops golang bash
+```
+
+You should now be able to test if everything is working by building the project 
+using `make kops` or running the tests with `make test`. In order to simulate 
+the tests ran on the CI server then use the target `make ci`.


### PR DESCRIPTION
When I was working on a PR I did so by running Go inside a Docker container (I very rarely install global packages anymore) and I had a bit of difficulty getting my build to run because I hadn't mounted my source code into the container properly. I've just added a small note to the docs to explain what I did (with help from @chrislovecnm) to get it working although I'm not sure if it should be rolled into an already existing section rather than a new one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2551)
<!-- Reviewable:end -->
