### PR TITLE
Fixes 2502: unset default value of state flag when docs are generated

### DIFF
--- a/cmd/kops/gen_help_docs.go
+++ b/cmd/kops/gen_help_docs.go
@@ -50,8 +50,10 @@ func init() {
 
 func (c *GenHelpDocsCmd) Run() error {
 	rootCommand.cobraCommand.DisableAutoGenTag = true
-	rootCommand.RegistryPath = ""
-	err := doc.GenMarkdownTree(rootCommand.cobraCommand, c.OutDir)
 
-	return err
+	// unset KOPS_STATE_STORE from default value
+	for _, c := range rootCommand.cobraCommand.Commands() {
+		c.Flag("state").DefValue = ""
+	}
+	return doc.GenMarkdownTree(rootCommand.cobraCommand, c.OutDir)
 }


### PR DESCRIPTION
Needed to overwrite default value to avoid KOPS_STATE_STORE output in docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2555)
<!-- Reviewable:end -->
