### PR TITLE
Add api-loadbalancer option to cli set public or internal loadbalancer

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -796,7 +796,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 			case "internal":
 				cluster.Spec.API.LoadBalancer.Type = api.LoadBalancerTypeInternal
 			default:
-				return fmt.Errorf("unkown api-loadbalancer type: %q", c.APILoadbalancer)
+				return fmt.Errorf("unknown api-loadbalancer type: %q", c.APILoadbalancer)
 			}
 		}
 	}

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -99,6 +99,9 @@ type CreateClusterOptions struct {
 	MasterTenancy string
 	NodeTenancy   string
 
+	// Specify API loadbalancer as public or internal
+	APILoadbalancer string
+
 	// vSphere options
 	VSphereServer        string
 	VSphereDatacenter    string
@@ -269,6 +272,8 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	// Master and Node Tenancy
 	cmd.Flags().StringVar(&options.MasterTenancy, "master-tenancy", options.MasterTenancy, "The tenancy of the master group on AWS. Can either be default or dedicated.")
 	cmd.Flags().StringVar(&options.NodeTenancy, "node-tenancy", options.NodeTenancy, "The tenancy of the node group on AWS. Can be either default or dedicated.")
+
+	cmd.Flags().StringVar(&options.APILoadbalancer, "api-loadbalancer", options.APILoadbalancer, "Sets the API loadbalancer to either 'public' or 'internal'")
 
 	if featureflag.VSphereCloudProvider.Enabled() {
 		// vSphere flags
@@ -766,19 +771,34 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		cluster.Spec.API = &api.AccessSpec{}
 	}
 	if cluster.Spec.API.IsEmpty() {
-		switch cluster.Spec.Topology.Masters {
-		case api.TopologyPublic:
-			cluster.Spec.API.DNS = &api.DNSAccessSpec{}
-
-		case api.TopologyPrivate:
+		if c.APILoadbalancer != "" {
 			cluster.Spec.API.LoadBalancer = &api.LoadBalancerAccessSpec{}
+		} else {
+			switch cluster.Spec.Topology.Masters {
+			case api.TopologyPublic:
+				cluster.Spec.API.DNS = &api.DNSAccessSpec{}
 
-		default:
-			return fmt.Errorf("unknown master topology type: %q", cluster.Spec.Topology.Masters)
+			case api.TopologyPrivate:
+				cluster.Spec.API.LoadBalancer = &api.LoadBalancerAccessSpec{}
+
+			default:
+				return fmt.Errorf("unknown master topology type: %q", cluster.Spec.Topology.Masters)
+			}
 		}
 	}
 	if cluster.Spec.API.LoadBalancer != nil && cluster.Spec.API.LoadBalancer.Type == "" {
-		cluster.Spec.API.LoadBalancer.Type = api.LoadBalancerTypePublic
+		if c.APILoadbalancer == "" {
+			cluster.Spec.API.LoadBalancer.Type = api.LoadBalancerTypePublic
+		} else {
+			switch c.APILoadbalancer {
+			case "public":
+				cluster.Spec.API.LoadBalancer.Type = api.LoadBalancerTypePublic
+			case "internal":
+				cluster.Spec.API.LoadBalancer.Type = api.LoadBalancerTypeInternal
+			default:
+				return fmt.Errorf("unkown api-loadbalancer type: %q", c.APILoadbalancer)
+			}
+		}
 	}
 
 	sshPublicKeys := make(map[string][]byte)

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -5,7 +5,7 @@ Create a Kubernetes cluster.
 ### Synopsis
 
 
-Create a kubernetes cluster using command line flags. This command creates cloud based resources such as networks and virtual machine. Once the infrastructure is in place Kubernetes is installed on the virtual machines. 
+Create a kubernetes cluster using command line flags. This command creates cloud based resources such as networks and virtual machine. Once the infrastructure is in place Kubernetes is installed on the virtual machines.
 
 These operations are done in parrellel and rely on eventual consitency.
 
@@ -20,11 +20,11 @@ kops create cluster
   kops create cluster --name=kubernetes-cluster.example.com \
   --state=s3://kops-state-1234 --zones=eu-west-1a \
   --node-count=2
-  
+
   # Create a cluster in AWS that has HA masters.  This cluster
   # will be setup with an internal networking in a private VPC.
   # A bastion instance will be setup to provide instance access.
-  
+
   export NODE_SIZE=${NODE_SIZE:-m4.large}
   export MASTER_SIZE=${MASTER_SIZE:-m4.large}
   export ZONES=${ZONES:-"us-east-1d,us-east-1b,us-east-1c"}
@@ -39,13 +39,13 @@ kops create cluster
   --topology private \
   --bastion="true" \
   --yes
-  
+
   # Create cluster in GCE.
   # This is an alpha feature.
   export KOPS_STATE_STORE="gs://mybucket-kops"
   export ZONES=${MASTER_ZONES:-"us-east1-b,us-east1-c,us-east1-d"}
   export KOPS_FEATURE_FLAGS=AlphaAllowGCE
-  
+
   kops create cluster kubernetes-k8s-gce.example.com
   --zones $ZONES \
   --master-zones $ZONES \
@@ -59,7 +59,7 @@ kops create cluster
 
 ```
       --admin-access stringSlice             Restrict access to admin endpoints (SSH, HTTPS) to this CIDR.  If not set, access will not be restricted by IP. (default [0.0.0.0/0])
-      --api-loadbalancer string              Sets the API loadbalancer to either 'public' or 'internal'
+      --api-loadbalancer-type string         Sets the API loadbalancer to either 'public' or 'internal'
       --associate-public-ip                  Specify --associate-public-ip=[true|false] to enable/disable association of public IP for master ASG and nodes. Default is 'true'.
       --authorization string                 Authorization mode to use: AlwaysAllow or RBAC (default "AlwaysAllow")
       --bastion                              Pass the --bastion flag to enable a bastion instance group. Only applies to private topology.
@@ -110,4 +110,3 @@ kops create cluster
 
 ### SEE ALSO
 * [kops create](kops_create.md)	 - Create a resource by command line, filename or stdin.
-

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -5,7 +5,7 @@ Create a Kubernetes cluster.
 ### Synopsis
 
 
-Create a kubernetes cluster using command line flags. This command creates cloud based resources such as networks and virtual machine. Once the infrastructure is in place Kubernetes is installed on the virtual machines.
+Create a kubernetes cluster using command line flags. This command creates cloud based resources such as networks and virtual machine. Once the infrastructure is in place Kubernetes is installed on the virtual machines. 
 
 These operations are done in parrellel and rely on eventual consitency.
 
@@ -20,11 +20,11 @@ kops create cluster
   kops create cluster --name=kubernetes-cluster.example.com \
   --state=s3://kops-state-1234 --zones=eu-west-1a \
   --node-count=2
-
+  
   # Create a cluster in AWS that has HA masters.  This cluster
   # will be setup with an internal networking in a private VPC.
   # A bastion instance will be setup to provide instance access.
-
+  
   export NODE_SIZE=${NODE_SIZE:-m4.large}
   export MASTER_SIZE=${MASTER_SIZE:-m4.large}
   export ZONES=${ZONES:-"us-east-1d,us-east-1b,us-east-1c"}
@@ -39,13 +39,13 @@ kops create cluster
   --topology private \
   --bastion="true" \
   --yes
-
+  
   # Create cluster in GCE.
   # This is an alpha feature.
   export KOPS_STATE_STORE="gs://mybucket-kops"
   export ZONES=${MASTER_ZONES:-"us-east1-b,us-east1-c,us-east1-d"}
   export KOPS_FEATURE_FLAGS=AlphaAllowGCE
-
+  
   kops create cluster kubernetes-k8s-gce.example.com
   --zones $ZONES \
   --master-zones $ZONES \
@@ -59,7 +59,7 @@ kops create cluster
 
 ```
       --admin-access stringSlice             Restrict access to admin endpoints (SSH, HTTPS) to this CIDR.  If not set, access will not be restricted by IP. (default [0.0.0.0/0])
-      --api-loadbalancer-type string         Sets the API loadbalancer to either 'public' or 'internal'
+      --api-loadbalancer-type string         Sets the API loadbalancer type to either 'public' or 'internal'
       --associate-public-ip                  Specify --associate-public-ip=[true|false] to enable/disable association of public IP for master ASG and nodes. Default is 'true'.
       --authorization string                 Authorization mode to use: AlwaysAllow or RBAC (default "AlwaysAllow")
       --bastion                              Pass the --bastion flag to enable a bastion instance group. Only applies to private topology.
@@ -110,3 +110,4 @@ kops create cluster
 
 ### SEE ALSO
 * [kops create](kops_create.md)	 - Create a resource by command line, filename or stdin.
+

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -59,6 +59,7 @@ kops create cluster
 
 ```
       --admin-access stringSlice             Restrict access to admin endpoints (SSH, HTTPS) to this CIDR.  If not set, access will not be restricted by IP. (default [0.0.0.0/0])
+      --api-loadbalancer string              Sets the API loadbalancer to either 'public' or 'internal'
       --associate-public-ip                  Specify --associate-public-ip=[true|false] to enable/disable association of public IP for master ASG and nodes. Default is 'true'.
       --authorization string                 Authorization mode to use: AlwaysAllow or RBAC (default "AlwaysAllow")
       --bastion                              Pass the --bastion flag to enable a bastion instance group. Only applies to private topology.


### PR DESCRIPTION
I found the updates proposed in https://github.com/kubernetes/kops/pull/2456 very helpful and thought it'd be helpful to set this from the command line. I image we're trying to limit the number of flags on `kops cluster create` but considering we allow changing the topology, changing the api server loadbalancer to public or internal seems to make things much easier for people like me who only expose ingress endpoints publicly.  

I'm not super familiar with the code so I'm open to any changes or naming ideas but hope others can find this as useful as I!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2559)
<!-- Reviewable:end -->
