### PR TITLE
Revert "Deploys dns-controller with default ingress setting (--watch-ingress=true)"

### DIFF
--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -131,9 +131,7 @@ func (tf *TemplateFunctions) DnsControllerArgv() ([]string, error) {
 
 	argv = append(argv, "/usr/bin/dns-controller")
 
-	// Default dns-controller behavior --watch-ingress=true
-	// Turning on as per: https://github.com/kubernetes/kops/issues/551#issuecomment-275981949
-	// argv = append(argv, "--watch-ingress=false")
+	argv = append(argv, "--watch-ingress=false")
 
 	switch fi.CloudProviderID(tf.cluster.Spec.CloudProvider) {
 	case fi.CloudProviderAWS:


### PR DESCRIPTION
This reverts commit 8c13903ab748567390138cfead667bc376e9fc0c.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2560)
<!-- Reviewable:end -->
