### PR TITLE
Implemented a Git hook for the CI tests and related installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,10 @@ protobuf: protokube/pkg/gossip/mesh/mesh.pb.go
 protokube/pkg/gossip/mesh/mesh.pb.go: protokube/pkg/gossip/mesh/mesh.proto
 	cd ${GOPATH_1ST}/src; protoc --gofast_out=. k8s.io/kops/protokube/pkg/gossip/mesh/mesh.proto
 
+.PHONY: hooks
+hooks: # Install Git hooks
+	cp hack/pre-commit.sh .git/hooks/pre-commit
+
 .PHONY: test
 test: # Run tests locally
 	go test k8s.io/kops/pkg/... -args -v=1 -logtostderr

--- a/hack/pre-commit.sh
+++ b/hack/pre-commit.sh
@@ -1,0 +1,16 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/sh -eu
+make ci


### PR DESCRIPTION
I implemented a Git hook for the CI tests and related installer Makefile target. This is so I don't forget to run the tests, and so others don't have to look up to the `git-hooks` manpage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2561)
<!-- Reviewable:end -->
