### PR TITLE
Clarified that --image paramater applies to cluster masters

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -238,7 +238,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().Int32Var(&options.NodeCount, "node-count", options.NodeCount, "Set the number of nodes")
 	cmd.Flags().BoolVar(&options.EncryptEtcdStorage, "encrypt-etcd-storage", options.EncryptEtcdStorage, "Generate key in aws kms and use it for encrypt etcd volumes")
 
-	cmd.Flags().StringVar(&options.Image, "image", options.Image, "Image to use")
+	cmd.Flags().StringVar(&options.Image, "image", options.Image, "Image to use for all instances.")
 
 	cmd.Flags().StringVar(&options.Networking, "networking", "kubenet", "Networking mode to use.  kubenet (default), classic, external, kopeio-vxlan (or kopeio), weave, flannel, calico, canal.")
 

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -69,7 +69,7 @@ kops create cluster
       --dns string                           DNS hosted zone to use: public|private. Default is 'public'. (default "Public")
       --dns-zone string                      DNS hosted zone to use (defaults to longest matching zone)
       --encrypt-etcd-storage                 Generate key in aws kms and use it for encrypt etcd volumes
-      --image string                         Image to use
+      --image string                         Image to use for all instances.
       --kubernetes-version string            Version of kubernetes to run (defaults to version in channel)
       --master-count int32                   Set the number of masters.  Defaults to one master per master-zone
       --master-security-groups stringSlice   Add precreated additional security groups to masters.


### PR DESCRIPTION
Tiny change. I thought it was useful to clarify that the image you provide to `kops create cluster` is for the master(s), as that wasn't obvious to me (I haven't reached the point where I'm running anything I made myself, I guess I'd start doing that with Instance Groups?).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2562)
<!-- Reviewable:end -->
