### PR TITLE
Add required terraform version declaration

### DIFF
--- a/tests/integration/complex/kubernetes.tf
+++ b/tests/integration/complex/kubernetes.tf
@@ -390,3 +390,7 @@ resource "aws_vpc_dhcp_options_association" "complex-example-com" {
   vpc_id          = "${aws_vpc.complex-example-com.id}"
   dhcp_options_id = "${aws_vpc_dhcp_options.complex-example-com.id}"
 }
+
+terraform = {
+  required_version = ">= 0.9.3"
+}

--- a/tests/integration/ha/kubernetes.tf
+++ b/tests/integration/ha/kubernetes.tf
@@ -584,3 +584,7 @@ resource "aws_vpc_dhcp_options_association" "ha-example-com" {
   vpc_id          = "${aws_vpc.ha-example-com.id}"
   dhcp_options_id = "${aws_vpc_dhcp_options.ha-example-com.id}"
 }
+
+terraform = {
+  required_version = ">= 0.9.3"
+}

--- a/tests/integration/minimal-141/kubernetes.tf
+++ b/tests/integration/minimal-141/kubernetes.tf
@@ -390,3 +390,7 @@ resource "aws_vpc_dhcp_options_association" "minimal-141-example-com" {
   vpc_id          = "${aws_vpc.minimal-141-example-com.id}"
   dhcp_options_id = "${aws_vpc_dhcp_options.minimal-141-example-com.id}"
 }
+
+terraform = {
+  required_version = ">= 0.9.3"
+}

--- a/tests/integration/minimal/kubernetes.tf
+++ b/tests/integration/minimal/kubernetes.tf
@@ -390,3 +390,7 @@ resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
   vpc_id          = "${aws_vpc.minimal-example-com.id}"
   dhcp_options_id = "${aws_vpc_dhcp_options.minimal-example-com.id}"
 }
+
+terraform = {
+  required_version = ">= 0.9.3"
+}

--- a/tests/integration/privatecalico/kubernetes.tf
+++ b/tests/integration/privatecalico/kubernetes.tf
@@ -682,3 +682,7 @@ resource "aws_vpc_dhcp_options_association" "privatecalico-example-com" {
   vpc_id          = "${aws_vpc.privatecalico-example-com.id}"
   dhcp_options_id = "${aws_vpc_dhcp_options.privatecalico-example-com.id}"
 }
+
+terraform = {
+  required_version = ">= 0.9.3"
+}

--- a/tests/integration/privatecanal/kubernetes.tf
+++ b/tests/integration/privatecanal/kubernetes.tf
@@ -673,3 +673,7 @@ resource "aws_vpc_dhcp_options_association" "privatecanal-example-com" {
   vpc_id          = "${aws_vpc.privatecanal-example-com.id}"
   dhcp_options_id = "${aws_vpc_dhcp_options.privatecanal-example-com.id}"
 }
+
+terraform = {
+  required_version = ">= 0.9.3"
+}

--- a/tests/integration/privatedns1/kubernetes.tf
+++ b/tests/integration/privatedns1/kubernetes.tf
@@ -678,3 +678,7 @@ resource "aws_vpc_dhcp_options_association" "privatedns1-example-com" {
   vpc_id          = "${aws_vpc.privatedns1-example-com.id}"
   dhcp_options_id = "${aws_vpc_dhcp_options.privatedns1-example-com.id}"
 }
+
+terraform = {
+  required_version = ">= 0.9.3"
+}

--- a/tests/integration/privatedns2/kubernetes.tf
+++ b/tests/integration/privatedns2/kubernetes.tf
@@ -637,3 +637,7 @@ resource "aws_subnet" "utility-us-test-1a-privatedns2-example-com" {
     "kubernetes.io/cluster/privatedns2.example.com" = "owned"
   }
 }
+
+terraform = {
+  required_version = ">= 0.9.3"
+}

--- a/tests/integration/privateflannel/kubernetes.tf
+++ b/tests/integration/privateflannel/kubernetes.tf
@@ -673,3 +673,7 @@ resource "aws_vpc_dhcp_options_association" "privateflannel-example-com" {
   vpc_id          = "${aws_vpc.privateflannel-example-com.id}"
   dhcp_options_id = "${aws_vpc_dhcp_options.privateflannel-example-com.id}"
 }
+
+terraform = {
+  required_version = ">= 0.9.3"
+}

--- a/tests/integration/privatekopeio/kubernetes.tf
+++ b/tests/integration/privatekopeio/kubernetes.tf
@@ -664,3 +664,7 @@ resource "aws_vpc_dhcp_options_association" "privatekopeio-example-com" {
   vpc_id          = "${aws_vpc.privatekopeio-example-com.id}"
   dhcp_options_id = "${aws_vpc_dhcp_options.privatekopeio-example-com.id}"
 }
+
+terraform = {
+  required_version = ">= 0.9.3"
+}

--- a/tests/integration/privateweave/kubernetes.tf
+++ b/tests/integration/privateweave/kubernetes.tf
@@ -673,3 +673,7 @@ resource "aws_vpc_dhcp_options_association" "privateweave-example-com" {
   vpc_id          = "${aws_vpc.privateweave-example-com.id}"
   dhcp_options_id = "${aws_vpc_dhcp_options.privateweave-example-com.id}"
 }
+
+terraform = {
+  required_version = ">= 0.9.3"
+}

--- a/upup/pkg/fi/cloudup/terraform/hcl_printer.go
+++ b/upup/pkg/fi/cloudup/terraform/hcl_printer.go
@@ -109,6 +109,10 @@ func hclPrint(node ast.Node) ([]byte, error) {
 	s = strings.Replace(s, "(\\\"", "(\"", -1)
 	s = strings.Replace(s, "\\\")", "\")", -1)
 
+	// We don't need to escape > or <
+	s = strings.Replace(s, "\\u003c", "<", -1)
+	s = strings.Replace(s, "\\u003e", ">", -1)
+
 	if featureflag.SkipTerraformFormat.Enabled() {
 		glog.Infof("feature-flag SkipTerraformFormat was set; skipping terraform format")
 		return []byte(s), nil

--- a/upup/pkg/fi/cloudup/terraform/target.go
+++ b/upup/pkg/fi/cloudup/terraform/target.go
@@ -213,7 +213,12 @@ func (t *TerraformTarget) Finish(taskMap map[string]fi.Task) error {
 		outputVariables[tfName] = tfVar
 	}
 
+	// See https://github.com/kubernetes/kops/pull/2424 for why we require 0.9.3
+	terraformConfiguration := make(map[string]interface{})
+	terraformConfiguration["required_version"] = ">= 0.9.3"
+
 	data := make(map[string]interface{})
+	data["terraform"] = terraformConfiguration
 	data["resource"] = resourcesByType
 	if len(providersByName) != 0 {
 		data["provider"] = providersByName


### PR DESCRIPTION
Terraform is changing its schema, and we probably want to encourage
users to use the newer terraform versions anyway.

See #2424

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2569)
<!-- Reviewable:end -->
