### PR TITLE
implementing the capability to self host all assets

### DIFF
--- a/cmd/kops/get.go
+++ b/cmd/kops/get.go
@@ -110,7 +110,7 @@ func NewCmdGet(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.AddCommand(NewCmdGetFederations(f, out, options))
 	cmd.AddCommand(NewCmdGetInstanceGroups(f, out, options))
 	cmd.AddCommand(NewCmdGetSecrets(f, out, options))
-
+	cmd.AddCommand(NewCmdGetInventory(f, out, options))
 	return cmd
 }
 

--- a/cmd/kops/get_inventory.go
+++ b/cmd/kops/get_inventory.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"k8s.io/kops/cmd/kops/util"
+	api "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/client/simple"
+	"k8s.io/kops/upup/pkg/fi/cloudup"
+	"k8s.io/kops/util/pkg/tables"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+	"k8s.io/kubernetes/pkg/util/i18n"
+)
+
+type GetInventoryOptions struct {
+	KubernetesVersion string
+	Channel           string
+	*GetOptions
+	resource.FilenameOptions
+	SSHPublicKey string
+}
+
+func (o *GetInventoryOptions) InitDefaults() {
+	o.Channel = api.DefaultChannel
+	o.output = OutputTable
+	o.Channel = "stable"
+	o.SSHPublicKey = "~/.ssh/id_rsa.pub"
+}
+
+var (
+	get_inventory_long = templates.LongDesc(i18n.T(`
+		Output a list of IoTk - inventory of all things kops.  Bill of materials (BOM) for a kops installation; containers, binaries, etc.`))
+
+	get_inventory_example = templates.Examples(i18n.T(`
+		# Get a inventory list from a YAML file
+		kops get inventory -f k8s.example.com.yaml --state s3://k8s.example.com
+
+		# Get a inventory list from a cluster
+		kops get inventory k8s.example.com --state s3://k8s.example.com
+
+		# Get a inventory list from a cluster as YAML
+		kops get inventory k8s.example.com --state s3://k8s.example.com -o YAML
+
+		`))
+
+	get_inventory_short = i18n.T(`Output a list of IoTk - inventory of all things kops. `)
+	get_inventory_use   = i18n.T("inventory")
+)
+
+// NewCmdGetInventory sets up a new corbra command.
+func NewCmdGetInventory(f *util.Factory, out io.Writer, getOptions *GetOptions) *cobra.Command {
+	options := &GetInventoryOptions{
+		GetOptions: getOptions,
+	}
+	options.InitDefaults()
+
+	cmd := &cobra.Command{
+		Use:     get_inventory_use,
+		Short:   get_inventory_short,
+		Example: get_inventory_example,
+		Long:    get_inventory_long,
+		Run: func(cmd *cobra.Command, args []string) {
+
+			if rootCommand.clusterName != "" && len(options.Filenames) == 0 {
+				options.clusterName = rootCommand.clusterName
+			} else {
+				options.clusterName = ""
+			}
+
+			err := RunToolboxInventory(f, out, options)
+
+			if err != nil {
+				exitWithError(err)
+				return
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.output, "output", "o", options.output, "output format.  One of: yaml, json, table")
+	cmd.Flags().StringVar(&options.Channel, "channel", options.Channel, "Channel for default versions and configuration to use")
+	cmd.Flags().StringVar(&options.KubernetesVersion, "kubernetes-version", options.KubernetesVersion, "Version of kubernetes to run (defaults to version in channel)")
+	cmd.Flags().StringSliceVarP(&options.Filenames, "filename", "f", options.Filenames, "Filename to use to create the resource")
+	return cmd
+}
+
+// RunToolboxInventory executes the business logic to generate a BOM for a kops intallation.
+func RunToolboxInventory(f *util.Factory, out io.Writer, options *GetInventoryOptions) error {
+
+	clientset, err := getClientSet(f)
+	if err != nil {
+		return err
+	}
+
+	extractInventory := &cloudup.ExtractInventory{
+		Clientset:         clientset,
+		FilenameOptions:   options.FilenameOptions,
+		ClusterName:       options.clusterName,
+		KubernetesVersion: options.KubernetesVersion,
+		SSHPublicKey:      options.SSHPublicKey,
+	}
+	a, clusterName, err := extractInventory.ExtractAssets()
+	if err != nil {
+		return fmt.Errorf("Error getting inventory: %v", err)
+	}
+
+	// TODO do we want cluster on the inventory?
+	a.Spec.Cluster = nil
+
+	switch options.output {
+	case OutputTable:
+		fmt.Fprintf(out, "\n\n")
+		fmt.Fprintf(out, "Inventory for cluster %q\n\n", clusterName)
+		fmt.Fprintf(out, "\n")
+
+		fmt.Fprintf(out, "FILES\n\n")
+
+		t := &tables.Table{}
+		t.AddColumn("ASSET", func(i *api.ExecutableFileAsset) string {
+			return i.Location
+		})
+		t.AddColumn("NAME", func(i *api.ExecutableFileAsset) string {
+			return i.Name
+		})
+		if err := t.Render(a.Spec.ExecutableFileAsset, out, "NAME", "ASSET"); err != nil {
+			return err
+		}
+
+		fmt.Fprintf(out, "\n\nCOMPRESSED FILES\n\n")
+
+		t = &tables.Table{}
+		t.AddColumn("ASSET", func(i *api.CompressedFileAsset) string {
+			return i.Location
+		})
+		t.AddColumn("NAME", func(i *api.CompressedFileAsset) string {
+			return i.Name
+		})
+		if err := t.Render(a.Spec.CompressedFileAssets, out, "NAME", "ASSET"); err != nil {
+			return err
+		}
+
+		fmt.Fprintf(out, "\n\nCONTAINERS\n\n")
+		t = &tables.Table{}
+		t.AddColumn("ASSET", func(i *api.ContainerAsset) string {
+			if i.String != "" {
+				return i.String
+			} else if i.Location != "" {
+				return i.Location
+			}
+
+			glog.Errorf("unable to print container asset %q", i)
+
+			return "asset name not set correctly"
+		})
+
+		t.AddColumn("NAME", func(i *api.ContainerAsset) string {
+			return i.Name
+		})
+		if err := t.Render(a.Spec.ContainerAssets, out, "NAME", "ASSET"); err != nil {
+			return err
+		}
+
+		fmt.Fprintf(out, "\n\nHOSTS\n\n")
+		t = &tables.Table{}
+		t.AddColumn("IMAGE", func(i *api.HostAsset) string {
+			return i.Name
+		})
+
+		t.AddColumn("INSTANCE GROUP", func(i *api.HostAsset) string {
+			return i.InstanceGroup
+		})
+		if err := t.Render(a.Spec.HostAssets, out, "INSTANCE GROUP", "IMAGE"); err != nil {
+			return err
+		}
+
+	case OutputJSON:
+		if err := marshalToWriter(a, marshalJSON, out); err != nil {
+			return err
+		}
+
+	case OutputYaml:
+		if err := marshalToWriter(a, marshalYaml, out); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("Unknown output format: %q", options.output)
+	}
+
+	return nil
+
+}
+
+// getClientSet returns a clientset.
+func getClientSet(f *util.Factory) (simple.Clientset, error) {
+	clientset, err := f.Clientset()
+	if err != nil {
+		return nil, fmt.Errorf("unable to load client set %v", err)
+	}
+
+	return clientset, nil
+}

--- a/docs/cli/kops_get.md
+++ b/docs/cli/kops_get.md
@@ -67,5 +67,6 @@ kops get
 * [kops get clusters](kops_get_clusters.md)	 - Get one or many clusters.
 * [kops get federations](kops_get_federations.md)	 - Get federation.
 * [kops get instancegroups](kops_get_instancegroups.md)	 - Get one or many instancegroups
+* [kops get inventory](kops_get_inventory.md)	 - Output a list of IoTk - inventory of all things kops. 
 * [kops get secrets](kops_get_secrets.md)	 - Get one or many secrets.
 

--- a/docs/cli/kops_get_inventory.md
+++ b/docs/cli/kops_get_inventory.md
@@ -1,0 +1,53 @@
+## kops get inventory
+
+Output a list of IoTk - inventory of all things kops. 
+
+### Synopsis
+
+
+Output a list of IoTk - inventory of all things kops.  Bill of materials (BOM) for a kops installation; containers, binaries, etc.
+
+```
+kops get inventory
+```
+
+### Examples
+
+```
+  # Get a inventory list from a YAML file
+  kops get inventory -f k8s.example.com.yaml --state s3://k8s.example.com
+  
+  # Get a inventory list from a cluster
+  kops get inventory k8s.example.com --state s3://k8s.example.com
+  
+  # Get a inventory list from a cluster as YAML
+  kops get inventory k8s.example.com --state s3://k8s.example.com -o YAML
+```
+
+### Options
+
+```
+      --channel string              Channel for default versions and configuration to use (default "stable")
+  -f, --filename stringSlice        Filename to use to create the resource
+      --kubernetes-version string   Version of kubernetes to run (defaults to version in channel)
+  -o, --output string               output format.  One of: yaml, json, table (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --alsologtostderr                  log to standard error as well as files
+      --config string                    config file (default is $HOME/.kops.yaml)
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files (default false)
+      --name string                      Name of cluster
+      --state string                     Location of state storage
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+* [kops get](kops_get.md)	 - Get one or many resources.
+

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/flagbuilder"
+	"k8s.io/kops/pkg/model/components"
 	"k8s.io/kops/pkg/systemd"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
@@ -143,6 +144,17 @@ func (b *KubeletBuilder) buildSystemdEnvironmentFile(kubeletConfig *kops.Kubelet
 	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.Kubenet != nil {
 		// Kubenet is neither CNI nor not-CNI, so we need to pass it `--network-plugin-dir` also
 		flags += " --network-plugin-dir=" + b.CNIBinDir()
+	}
+
+	// If a cluster has a container registry set, flag kubelet to use the pause container from that registry.
+	if b.Cluster.Spec.Assets != nil && b.Cluster.Spec.Assets.ContainerRegistry != nil {
+		// TODO another hardcoded version
+		pause, err := components.GetGoogleImageRegistryContainer(&b.Cluster.Spec, "pause-amd64:3.0")
+
+		if err != nil {
+			return nil, err
+		}
+		flags += " --pod-infra-container-image=" + pause
 	}
 
 	sysconfig := "DAEMON_ARGS=\"" + flags + "\"\n"

--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -79,21 +79,13 @@ type ChannelImageSpec struct {
 
 // LoadChannel loads a Channel object from the specified VFS location
 func LoadChannel(location string) (*Channel, error) {
-	u, err := url.Parse(location)
+
+	resolved, err := ParseChannelLocation(location)
+
 	if err != nil {
-		return nil, fmt.Errorf("invalid channel: %q", location)
+		return nil, fmt.Errorf("unable to parse channel location: %q", location)
 	}
 
-	if !u.IsAbs() {
-		base, err := url.Parse(DefaultChannelBase)
-		if err != nil {
-			return nil, fmt.Errorf("invalid base channel location: %q", DefaultChannelBase)
-		}
-		glog.V(4).Infof("resolving %q against default channel location %q", location, DefaultChannelBase)
-		u = base.ResolveReference(u)
-	}
-
-	resolved := u.String()
 	glog.V(2).Infof("Loading channel from %q", resolved)
 	channelBytes, err := vfs.Context.ReadFile(resolved)
 	if err != nil {
@@ -106,6 +98,26 @@ func LoadChannel(location string) (*Channel, error) {
 	glog.V(4).Infof("Channel contents: %s", string(channelBytes))
 
 	return channel, nil
+}
+
+// ParseChannelLocation returns a valid channel location.
+func ParseChannelLocation(location string) (string, error) {
+
+	u, err := url.Parse(location)
+	if err != nil {
+		return "", fmt.Errorf("invalid channel: %q", location)
+	}
+
+	if !u.IsAbs() {
+		base, err := url.Parse(DefaultChannelBase)
+		if err != nil {
+			return "", fmt.Errorf("invalid base channel location: %q", DefaultChannelBase)
+		}
+		glog.V(4).Infof("resolving %q against default channel location %q", location, DefaultChannelBase)
+		u = base.ResolveReference(u)
+	}
+
+	return u.String(), nil
 }
 
 // ParseChannel parses a Channel object

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -244,6 +244,14 @@ type ClusterSpec struct {
 
 	// Hooks for custom actions e.g. on first installation
 	Hooks []HookSpec `json:"hooks,omitempty"`
+
+	// Alternative locations for files and containers
+	Assets *Assets `json:"assets,omitempty"`
+}
+
+type Assets struct {
+	ContainerRegistry *string `json:"containerRegistry,omitempty"`
+	FileRepository    *string `json:"fileRepository,omitempty"`
 }
 
 type HookSpec struct {

--- a/pkg/apis/kops/inventory.go
+++ b/pkg/apis/kops/inventory.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kops
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Inventory provides a data model for assets that compose a kops installation.
+// This API is a top level API that is only used for Inventory CRUD. Create and
+// read are implemented at this point.
+type Inventory struct {
+	v1.TypeMeta `json:",inline"`
+	ObjectMeta  metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec InventorySpec `json:"spec,omitempty"`
+}
+
+type InventorySpec struct {
+
+	// full cluster
+	Cluster *ClusterSpec `json:"cluster,omitempty"`
+
+	// The file that contains the kops channel
+	// see: https://raw.githubusercontent.com/kubernetes/kops/master/channels/stable
+	ChannelAsset *ChannelAsset `json:"channel,omitempty"`
+
+	// kops version of kops that generated the inventory.  There is an open issue
+	// to track the kops version of a cluster.
+	KopsVersion *string `json:"kopsVersion,omitempty"`
+
+	KubernetesVersion *string `json:"kubernetesVersion,omitempty"`
+
+	// List of executables including such things as nodeup, and all k8s binaries.
+	ExecutableFileAsset []*ExecutableFileAsset `json:"executableFileAssets,omitempty"`
+
+	// Compressed tar balls, for instance, cni package.
+	CompressedFileAssets []*CompressedFileAsset `json:"compressedFileAssets,omitempty"`
+
+	// Containers
+	ContainerAssets []*ContainerAsset `json:"containerAssets,omitempty"`
+
+	// All the contains all of the images from the various instance groups.
+	HostAssets []*HostAsset `json:"hostAsset,omitempty"`
+}
+
+type ChannelAsset struct {
+	Name     string `json:"name"`
+	Location string `json:"location,omitempty"`
+	Version  string `json:"version,omitempty"`
+}
+
+type HostAsset struct {
+	Name          string `json:"name"`
+	Cloud         string `json:"cloud"`
+	Role          string `json:"role"`
+	InstanceGroup string `json:"instanceGroup"`
+}
+
+type ExecutableFileAsset struct {
+	Name     string `json:"name"`
+	Location string `json:"location,omitempty"`
+	Version  string `json:"version,omitempty"`
+	SHA      string `json:"sha,omitempty"`
+}
+
+type CompressedFileAsset struct {
+	Name     string `json:"name"`
+	Location string `json:"location,omitempty"`
+	Version  string `json:"version,omitempty"`
+	SHA      string `json:"sha,omitempty"`
+}
+
+type ContainerAsset struct {
+	String string `json:"string,omitempty"`
+	Name   string `json:"name"`
+	Domain string `json:"domain,omitempty"`
+	Tag    string `json:"tag,omitempty"`
+	Digest string `json:"digest,omitempty"`
+
+	Location string `json:"location,omitempty"`
+	SHA      string `json:"sha,omitempty"`
+	Hash     string `json:"hash,omitempty"`
+}

--- a/pkg/apis/kops/register.go
+++ b/pkg/apis/kops/register.go
@@ -65,6 +65,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&InstanceGroupList{},
 		&Federation{},
 		&FederationList{},
+		&Inventory{},
 	)
 	//metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
@@ -77,5 +78,9 @@ func (obj *InstanceGroup) GetObjectKind() schema.ObjectKind {
 	return &obj.TypeMeta
 }
 func (obj *Federation) GetObjectKind() schema.ObjectKind {
+	return &obj.TypeMeta
+}
+
+func (obj *Inventory) GetObjectKind() schema.ObjectKind {
 	return &obj.TypeMeta
 }

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -735,6 +735,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha1_ClusterSpec(in *kops.ClusterSpec, 
 	} else {
 		out.Hooks = nil
 	}
+	// WARNING: in.Assets requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -164,6 +164,14 @@ type ClusterSpec struct {
 
 	// Hooks for custom actions e.g. on first installation
 	Hooks []HookSpec `json:"hooks,omitempty"`
+
+	// Alternative locations for files and containers
+	Assets *Assets `json:"assets,omitempty"`
+}
+
+type Assets struct {
+	ContainerRegistry *string `json:"containerRegistry,omitempty"`
+	FileRepository    *string `json:"fileRepository,omitempty"`
 }
 
 type HookSpec struct {

--- a/pkg/apis/kops/v1alpha2/inventory.go
+++ b/pkg/apis/kops/v1alpha2/inventory.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Inventory struct {
+	v1.TypeMeta `json:",inline"`
+	ObjectMeta  metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec InventorySpec `json:"spec,omitempty"`
+}
+
+type InventorySpec struct {
+	Cluster              *ClusterSpec           `json:"cluster,omitempty"`
+	ChannelAsset         *ChannelAsset          `json:"channel,omitempty"`
+	KopsVersion          *string                `json:"kopsVersion,omitempty"`
+	KubernetesVersion    *string                `json:"kubernetesVersion,omitempty"`
+	ExecutableFileAsset  []*ExecutableFileAsset `json:"executableFileAssets,omitempty"`
+	CompressedFileAssets []*CompressedFileAsset `json:"compressedFileAssets,omitempty"`
+	ContainerAssets      []*ContainerAsset      `json:"containerAssets,omitempty"`
+	HostAssets           []*HostAsset           `json:"hostAsset,omitempty"`
+}
+
+type ChannelAsset struct {
+	Name     string `json:"name"`
+	Location string `json:"location,omitempty"`
+	Version  string `json:"version,omitempty"`
+}
+
+type HostAsset struct {
+	Name          string `json:"name"`
+	Cloud         string `json:"cloud"`
+	Role          string `json:"role"`
+	InstanceGroup string `json:"instanceGroup"`
+}
+
+type ExecutableFileAsset struct {
+	Name     string `json:"name"`
+	Location string `json:"location,omitempty"`
+	Version  string `json:"version,omitempty"`
+	SHA      string `json:"sha,omitempty"`
+}
+
+type CompressedFileAsset struct {
+	Name     string `json:"name"`
+	Location string `json:"location,omitempty"`
+	Version  string `json:"version,omitempty"`
+	SHA      string `json:"sha,omitempty"`
+}
+
+type ContainerAsset struct {
+	String string `json:"string,omitempty"`
+	Name   string `json:"name"`
+	Domain string `json:"domain,omitempty"`
+	Tag    string `json:"tag,omitempty"`
+	Digest string `json:"digest,omitempty"`
+
+	Location string `json:"location,omitempty"`
+	SHA      string `json:"sha,omitempty"`
+	Hash     string `json:"hash,omitempty"`
+}

--- a/pkg/apis/kops/v1alpha2/register.go
+++ b/pkg/apis/kops/v1alpha2/register.go
@@ -53,6 +53,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&InstanceGroupList{},
 		&Federation{},
 		&FederationList{},
+		&Inventory{},
 	)
 
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
@@ -67,6 +68,9 @@ func (obj *InstanceGroup) GetObjectKind() schema.ObjectKind {
 	return &obj.TypeMeta
 }
 func (obj *Federation) GetObjectKind() schema.ObjectKind {
+	return &obj.TypeMeta
+}
+func (obj *Inventory) GetObjectKind() schema.ObjectKind {
 	return &obj.TypeMeta
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -39,6 +39,8 @@ func RegisterConversions(scheme *runtime.Scheme) error {
 		Convert_kops_AccessSpec_To_v1alpha2_AccessSpec,
 		Convert_v1alpha2_AlwaysAllowAuthorizationSpec_To_kops_AlwaysAllowAuthorizationSpec,
 		Convert_kops_AlwaysAllowAuthorizationSpec_To_v1alpha2_AlwaysAllowAuthorizationSpec,
+		Convert_v1alpha2_Assets_To_kops_Assets,
+		Convert_kops_Assets_To_v1alpha2_Assets,
 		Convert_v1alpha2_AuthorizationSpec_To_kops_AuthorizationSpec,
 		Convert_kops_AuthorizationSpec_To_v1alpha2_AuthorizationSpec,
 		Convert_v1alpha2_BastionSpec_To_kops_BastionSpec,
@@ -49,6 +51,8 @@ func RegisterConversions(scheme *runtime.Scheme) error {
 		Convert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec,
 		Convert_v1alpha2_CanalNetworkingSpec_To_kops_CanalNetworkingSpec,
 		Convert_kops_CanalNetworkingSpec_To_v1alpha2_CanalNetworkingSpec,
+		Convert_v1alpha2_ChannelAsset_To_kops_ChannelAsset,
+		Convert_kops_ChannelAsset_To_v1alpha2_ChannelAsset,
 		Convert_v1alpha2_ClassicNetworkingSpec_To_kops_ClassicNetworkingSpec,
 		Convert_kops_ClassicNetworkingSpec_To_v1alpha2_ClassicNetworkingSpec,
 		Convert_v1alpha2_CloudConfiguration_To_kops_CloudConfiguration,
@@ -61,6 +65,10 @@ func RegisterConversions(scheme *runtime.Scheme) error {
 		Convert_kops_ClusterSpec_To_v1alpha2_ClusterSpec,
 		Convert_v1alpha2_ClusterSubnetSpec_To_kops_ClusterSubnetSpec,
 		Convert_kops_ClusterSubnetSpec_To_v1alpha2_ClusterSubnetSpec,
+		Convert_v1alpha2_CompressedFileAsset_To_kops_CompressedFileAsset,
+		Convert_kops_CompressedFileAsset_To_v1alpha2_CompressedFileAsset,
+		Convert_v1alpha2_ContainerAsset_To_kops_ContainerAsset,
+		Convert_kops_ContainerAsset_To_v1alpha2_ContainerAsset,
 		Convert_v1alpha2_DNSAccessSpec_To_kops_DNSAccessSpec,
 		Convert_kops_DNSAccessSpec_To_v1alpha2_DNSAccessSpec,
 		Convert_v1alpha2_DNSSpec_To_kops_DNSSpec,
@@ -73,6 +81,8 @@ func RegisterConversions(scheme *runtime.Scheme) error {
 		Convert_kops_EtcdMemberSpec_To_v1alpha2_EtcdMemberSpec,
 		Convert_v1alpha2_ExecContainerAction_To_kops_ExecContainerAction,
 		Convert_kops_ExecContainerAction_To_v1alpha2_ExecContainerAction,
+		Convert_v1alpha2_ExecutableFileAsset_To_kops_ExecutableFileAsset,
+		Convert_kops_ExecutableFileAsset_To_v1alpha2_ExecutableFileAsset,
 		Convert_v1alpha2_ExternalNetworkingSpec_To_kops_ExternalNetworkingSpec,
 		Convert_kops_ExternalNetworkingSpec_To_v1alpha2_ExternalNetworkingSpec,
 		Convert_v1alpha2_Federation_To_kops_Federation,
@@ -85,12 +95,18 @@ func RegisterConversions(scheme *runtime.Scheme) error {
 		Convert_kops_FlannelNetworkingSpec_To_v1alpha2_FlannelNetworkingSpec,
 		Convert_v1alpha2_HookSpec_To_kops_HookSpec,
 		Convert_kops_HookSpec_To_v1alpha2_HookSpec,
+		Convert_v1alpha2_HostAsset_To_kops_HostAsset,
+		Convert_kops_HostAsset_To_v1alpha2_HostAsset,
 		Convert_v1alpha2_InstanceGroup_To_kops_InstanceGroup,
 		Convert_kops_InstanceGroup_To_v1alpha2_InstanceGroup,
 		Convert_v1alpha2_InstanceGroupList_To_kops_InstanceGroupList,
 		Convert_kops_InstanceGroupList_To_v1alpha2_InstanceGroupList,
 		Convert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec,
 		Convert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec,
+		Convert_v1alpha2_Inventory_To_kops_Inventory,
+		Convert_kops_Inventory_To_v1alpha2_Inventory,
+		Convert_v1alpha2_InventorySpec_To_kops_InventorySpec,
+		Convert_kops_InventorySpec_To_v1alpha2_InventorySpec,
 		Convert_v1alpha2_KopeioNetworkingSpec_To_kops_KopeioNetworkingSpec,
 		Convert_kops_KopeioNetworkingSpec_To_v1alpha2_KopeioNetworkingSpec,
 		Convert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig,
@@ -188,6 +204,26 @@ func autoConvert_kops_AlwaysAllowAuthorizationSpec_To_v1alpha2_AlwaysAllowAuthor
 
 func Convert_kops_AlwaysAllowAuthorizationSpec_To_v1alpha2_AlwaysAllowAuthorizationSpec(in *kops.AlwaysAllowAuthorizationSpec, out *AlwaysAllowAuthorizationSpec, s conversion.Scope) error {
 	return autoConvert_kops_AlwaysAllowAuthorizationSpec_To_v1alpha2_AlwaysAllowAuthorizationSpec(in, out, s)
+}
+
+func autoConvert_v1alpha2_Assets_To_kops_Assets(in *Assets, out *kops.Assets, s conversion.Scope) error {
+	out.ContainerRegistry = in.ContainerRegistry
+	out.FileRepository = in.FileRepository
+	return nil
+}
+
+func Convert_v1alpha2_Assets_To_kops_Assets(in *Assets, out *kops.Assets, s conversion.Scope) error {
+	return autoConvert_v1alpha2_Assets_To_kops_Assets(in, out, s)
+}
+
+func autoConvert_kops_Assets_To_v1alpha2_Assets(in *kops.Assets, out *Assets, s conversion.Scope) error {
+	out.ContainerRegistry = in.ContainerRegistry
+	out.FileRepository = in.FileRepository
+	return nil
+}
+
+func Convert_kops_Assets_To_v1alpha2_Assets(in *kops.Assets, out *Assets, s conversion.Scope) error {
+	return autoConvert_kops_Assets_To_v1alpha2_Assets(in, out, s)
 }
 
 func autoConvert_v1alpha2_AuthorizationSpec_To_kops_AuthorizationSpec(in *AuthorizationSpec, out *kops.AuthorizationSpec, s conversion.Scope) error {
@@ -310,6 +346,28 @@ func autoConvert_kops_CanalNetworkingSpec_To_v1alpha2_CanalNetworkingSpec(in *ko
 
 func Convert_kops_CanalNetworkingSpec_To_v1alpha2_CanalNetworkingSpec(in *kops.CanalNetworkingSpec, out *CanalNetworkingSpec, s conversion.Scope) error {
 	return autoConvert_kops_CanalNetworkingSpec_To_v1alpha2_CanalNetworkingSpec(in, out, s)
+}
+
+func autoConvert_v1alpha2_ChannelAsset_To_kops_ChannelAsset(in *ChannelAsset, out *kops.ChannelAsset, s conversion.Scope) error {
+	out.Name = in.Name
+	out.Location = in.Location
+	out.Version = in.Version
+	return nil
+}
+
+func Convert_v1alpha2_ChannelAsset_To_kops_ChannelAsset(in *ChannelAsset, out *kops.ChannelAsset, s conversion.Scope) error {
+	return autoConvert_v1alpha2_ChannelAsset_To_kops_ChannelAsset(in, out, s)
+}
+
+func autoConvert_kops_ChannelAsset_To_v1alpha2_ChannelAsset(in *kops.ChannelAsset, out *ChannelAsset, s conversion.Scope) error {
+	out.Name = in.Name
+	out.Location = in.Location
+	out.Version = in.Version
+	return nil
+}
+
+func Convert_kops_ChannelAsset_To_v1alpha2_ChannelAsset(in *kops.ChannelAsset, out *ChannelAsset, s conversion.Scope) error {
+	return autoConvert_kops_ChannelAsset_To_v1alpha2_ChannelAsset(in, out, s)
 }
 
 func autoConvert_v1alpha2_ClassicNetworkingSpec_To_kops_ClassicNetworkingSpec(in *ClassicNetworkingSpec, out *kops.ClassicNetworkingSpec, s conversion.Scope) error {
@@ -604,6 +662,15 @@ func autoConvert_v1alpha2_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 	} else {
 		out.Hooks = nil
 	}
+	if in.Assets != nil {
+		in, out := &in.Assets, &out.Assets
+		*out = new(kops.Assets)
+		if err := Convert_v1alpha2_Assets_To_kops_Assets(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Assets = nil
+	}
 	return nil
 }
 
@@ -785,6 +852,15 @@ func autoConvert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, 
 	} else {
 		out.Hooks = nil
 	}
+	if in.Assets != nil {
+		in, out := &in.Assets, &out.Assets
+		*out = new(Assets)
+		if err := Convert_kops_Assets_To_v1alpha2_Assets(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Assets = nil
+	}
 	return nil
 }
 
@@ -818,6 +894,62 @@ func autoConvert_kops_ClusterSubnetSpec_To_v1alpha2_ClusterSubnetSpec(in *kops.C
 
 func Convert_kops_ClusterSubnetSpec_To_v1alpha2_ClusterSubnetSpec(in *kops.ClusterSubnetSpec, out *ClusterSubnetSpec, s conversion.Scope) error {
 	return autoConvert_kops_ClusterSubnetSpec_To_v1alpha2_ClusterSubnetSpec(in, out, s)
+}
+
+func autoConvert_v1alpha2_CompressedFileAsset_To_kops_CompressedFileAsset(in *CompressedFileAsset, out *kops.CompressedFileAsset, s conversion.Scope) error {
+	out.Name = in.Name
+	out.Location = in.Location
+	out.Version = in.Version
+	out.SHA = in.SHA
+	return nil
+}
+
+func Convert_v1alpha2_CompressedFileAsset_To_kops_CompressedFileAsset(in *CompressedFileAsset, out *kops.CompressedFileAsset, s conversion.Scope) error {
+	return autoConvert_v1alpha2_CompressedFileAsset_To_kops_CompressedFileAsset(in, out, s)
+}
+
+func autoConvert_kops_CompressedFileAsset_To_v1alpha2_CompressedFileAsset(in *kops.CompressedFileAsset, out *CompressedFileAsset, s conversion.Scope) error {
+	out.Name = in.Name
+	out.Location = in.Location
+	out.Version = in.Version
+	out.SHA = in.SHA
+	return nil
+}
+
+func Convert_kops_CompressedFileAsset_To_v1alpha2_CompressedFileAsset(in *kops.CompressedFileAsset, out *CompressedFileAsset, s conversion.Scope) error {
+	return autoConvert_kops_CompressedFileAsset_To_v1alpha2_CompressedFileAsset(in, out, s)
+}
+
+func autoConvert_v1alpha2_ContainerAsset_To_kops_ContainerAsset(in *ContainerAsset, out *kops.ContainerAsset, s conversion.Scope) error {
+	out.String = in.String
+	out.Name = in.Name
+	out.Domain = in.Domain
+	out.Tag = in.Tag
+	out.Digest = in.Digest
+	out.Location = in.Location
+	out.SHA = in.SHA
+	out.Hash = in.Hash
+	return nil
+}
+
+func Convert_v1alpha2_ContainerAsset_To_kops_ContainerAsset(in *ContainerAsset, out *kops.ContainerAsset, s conversion.Scope) error {
+	return autoConvert_v1alpha2_ContainerAsset_To_kops_ContainerAsset(in, out, s)
+}
+
+func autoConvert_kops_ContainerAsset_To_v1alpha2_ContainerAsset(in *kops.ContainerAsset, out *ContainerAsset, s conversion.Scope) error {
+	out.String = in.String
+	out.Name = in.Name
+	out.Domain = in.Domain
+	out.Tag = in.Tag
+	out.Digest = in.Digest
+	out.Location = in.Location
+	out.SHA = in.SHA
+	out.Hash = in.Hash
+	return nil
+}
+
+func Convert_kops_ContainerAsset_To_v1alpha2_ContainerAsset(in *kops.ContainerAsset, out *ContainerAsset, s conversion.Scope) error {
+	return autoConvert_kops_ContainerAsset_To_v1alpha2_ContainerAsset(in, out, s)
 }
 
 func autoConvert_v1alpha2_DNSAccessSpec_To_kops_DNSAccessSpec(in *DNSAccessSpec, out *kops.DNSAccessSpec, s conversion.Scope) error {
@@ -986,6 +1118,30 @@ func Convert_kops_ExecContainerAction_To_v1alpha2_ExecContainerAction(in *kops.E
 	return autoConvert_kops_ExecContainerAction_To_v1alpha2_ExecContainerAction(in, out, s)
 }
 
+func autoConvert_v1alpha2_ExecutableFileAsset_To_kops_ExecutableFileAsset(in *ExecutableFileAsset, out *kops.ExecutableFileAsset, s conversion.Scope) error {
+	out.Name = in.Name
+	out.Location = in.Location
+	out.Version = in.Version
+	out.SHA = in.SHA
+	return nil
+}
+
+func Convert_v1alpha2_ExecutableFileAsset_To_kops_ExecutableFileAsset(in *ExecutableFileAsset, out *kops.ExecutableFileAsset, s conversion.Scope) error {
+	return autoConvert_v1alpha2_ExecutableFileAsset_To_kops_ExecutableFileAsset(in, out, s)
+}
+
+func autoConvert_kops_ExecutableFileAsset_To_v1alpha2_ExecutableFileAsset(in *kops.ExecutableFileAsset, out *ExecutableFileAsset, s conversion.Scope) error {
+	out.Name = in.Name
+	out.Location = in.Location
+	out.Version = in.Version
+	out.SHA = in.SHA
+	return nil
+}
+
+func Convert_kops_ExecutableFileAsset_To_v1alpha2_ExecutableFileAsset(in *kops.ExecutableFileAsset, out *ExecutableFileAsset, s conversion.Scope) error {
+	return autoConvert_kops_ExecutableFileAsset_To_v1alpha2_ExecutableFileAsset(in, out, s)
+}
+
 func autoConvert_v1alpha2_ExternalNetworkingSpec_To_kops_ExternalNetworkingSpec(in *ExternalNetworkingSpec, out *kops.ExternalNetworkingSpec, s conversion.Scope) error {
 	return nil
 }
@@ -1138,6 +1294,30 @@ func Convert_kops_HookSpec_To_v1alpha2_HookSpec(in *kops.HookSpec, out *HookSpec
 	return autoConvert_kops_HookSpec_To_v1alpha2_HookSpec(in, out, s)
 }
 
+func autoConvert_v1alpha2_HostAsset_To_kops_HostAsset(in *HostAsset, out *kops.HostAsset, s conversion.Scope) error {
+	out.Name = in.Name
+	out.Cloud = in.Cloud
+	out.Role = in.Role
+	out.InstanceGroup = in.InstanceGroup
+	return nil
+}
+
+func Convert_v1alpha2_HostAsset_To_kops_HostAsset(in *HostAsset, out *kops.HostAsset, s conversion.Scope) error {
+	return autoConvert_v1alpha2_HostAsset_To_kops_HostAsset(in, out, s)
+}
+
+func autoConvert_kops_HostAsset_To_v1alpha2_HostAsset(in *kops.HostAsset, out *HostAsset, s conversion.Scope) error {
+	out.Name = in.Name
+	out.Cloud = in.Cloud
+	out.Role = in.Role
+	out.InstanceGroup = in.InstanceGroup
+	return nil
+}
+
+func Convert_kops_HostAsset_To_v1alpha2_HostAsset(in *kops.HostAsset, out *HostAsset, s conversion.Scope) error {
+	return autoConvert_kops_HostAsset_To_v1alpha2_HostAsset(in, out, s)
+}
+
 func autoConvert_v1alpha2_InstanceGroup_To_kops_InstanceGroup(in *InstanceGroup, out *kops.InstanceGroup, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	if err := Convert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(&in.Spec, &out.Spec, s); err != nil {
@@ -1264,6 +1444,182 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 
 func Convert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.InstanceGroupSpec, out *InstanceGroupSpec, s conversion.Scope) error {
 	return autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in, out, s)
+}
+
+func autoConvert_v1alpha2_Inventory_To_kops_Inventory(in *Inventory, out *kops.Inventory, s conversion.Scope) error {
+	out.ObjectMeta = in.ObjectMeta
+	if err := Convert_v1alpha2_InventorySpec_To_kops_InventorySpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_v1alpha2_Inventory_To_kops_Inventory(in *Inventory, out *kops.Inventory, s conversion.Scope) error {
+	return autoConvert_v1alpha2_Inventory_To_kops_Inventory(in, out, s)
+}
+
+func autoConvert_kops_Inventory_To_v1alpha2_Inventory(in *kops.Inventory, out *Inventory, s conversion.Scope) error {
+	out.ObjectMeta = in.ObjectMeta
+	if err := Convert_kops_InventorySpec_To_v1alpha2_InventorySpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_kops_Inventory_To_v1alpha2_Inventory(in *kops.Inventory, out *Inventory, s conversion.Scope) error {
+	return autoConvert_kops_Inventory_To_v1alpha2_Inventory(in, out, s)
+}
+
+func autoConvert_v1alpha2_InventorySpec_To_kops_InventorySpec(in *InventorySpec, out *kops.InventorySpec, s conversion.Scope) error {
+	if in.Cluster != nil {
+		in, out := &in.Cluster, &out.Cluster
+		*out = new(kops.ClusterSpec)
+		if err := Convert_v1alpha2_ClusterSpec_To_kops_ClusterSpec(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Cluster = nil
+	}
+	if in.ChannelAsset != nil {
+		in, out := &in.ChannelAsset, &out.ChannelAsset
+		*out = new(kops.ChannelAsset)
+		if err := Convert_v1alpha2_ChannelAsset_To_kops_ChannelAsset(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ChannelAsset = nil
+	}
+	out.KopsVersion = in.KopsVersion
+	out.KubernetesVersion = in.KubernetesVersion
+	if in.ExecutableFileAsset != nil {
+		in, out := &in.ExecutableFileAsset, &out.ExecutableFileAsset
+		*out = make([]*kops.ExecutableFileAsset, len(*in))
+		for i := range *in {
+			// TODO: Inefficient conversion - can we improve it?
+			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.ExecutableFileAsset = nil
+	}
+	if in.CompressedFileAssets != nil {
+		in, out := &in.CompressedFileAssets, &out.CompressedFileAssets
+		*out = make([]*kops.CompressedFileAsset, len(*in))
+		for i := range *in {
+			// TODO: Inefficient conversion - can we improve it?
+			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.CompressedFileAssets = nil
+	}
+	if in.ContainerAssets != nil {
+		in, out := &in.ContainerAssets, &out.ContainerAssets
+		*out = make([]*kops.ContainerAsset, len(*in))
+		for i := range *in {
+			// TODO: Inefficient conversion - can we improve it?
+			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.ContainerAssets = nil
+	}
+	if in.HostAssets != nil {
+		in, out := &in.HostAssets, &out.HostAssets
+		*out = make([]*kops.HostAsset, len(*in))
+		for i := range *in {
+			// TODO: Inefficient conversion - can we improve it?
+			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.HostAssets = nil
+	}
+	return nil
+}
+
+func Convert_v1alpha2_InventorySpec_To_kops_InventorySpec(in *InventorySpec, out *kops.InventorySpec, s conversion.Scope) error {
+	return autoConvert_v1alpha2_InventorySpec_To_kops_InventorySpec(in, out, s)
+}
+
+func autoConvert_kops_InventorySpec_To_v1alpha2_InventorySpec(in *kops.InventorySpec, out *InventorySpec, s conversion.Scope) error {
+	if in.Cluster != nil {
+		in, out := &in.Cluster, &out.Cluster
+		*out = new(ClusterSpec)
+		if err := Convert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Cluster = nil
+	}
+	if in.ChannelAsset != nil {
+		in, out := &in.ChannelAsset, &out.ChannelAsset
+		*out = new(ChannelAsset)
+		if err := Convert_kops_ChannelAsset_To_v1alpha2_ChannelAsset(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ChannelAsset = nil
+	}
+	out.KopsVersion = in.KopsVersion
+	out.KubernetesVersion = in.KubernetesVersion
+	if in.ExecutableFileAsset != nil {
+		in, out := &in.ExecutableFileAsset, &out.ExecutableFileAsset
+		*out = make([]*ExecutableFileAsset, len(*in))
+		for i := range *in {
+			// TODO: Inefficient conversion - can we improve it?
+			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.ExecutableFileAsset = nil
+	}
+	if in.CompressedFileAssets != nil {
+		in, out := &in.CompressedFileAssets, &out.CompressedFileAssets
+		*out = make([]*CompressedFileAsset, len(*in))
+		for i := range *in {
+			// TODO: Inefficient conversion - can we improve it?
+			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.CompressedFileAssets = nil
+	}
+	if in.ContainerAssets != nil {
+		in, out := &in.ContainerAssets, &out.ContainerAssets
+		*out = make([]*ContainerAsset, len(*in))
+		for i := range *in {
+			// TODO: Inefficient conversion - can we improve it?
+			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.ContainerAssets = nil
+	}
+	if in.HostAssets != nil {
+		in, out := &in.HostAssets, &out.HostAssets
+		*out = make([]*HostAsset, len(*in))
+		for i := range *in {
+			// TODO: Inefficient conversion - can we improve it?
+			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.HostAssets = nil
+	}
+	return nil
+}
+
+func Convert_kops_InventorySpec_To_v1alpha2_InventorySpec(in *kops.InventorySpec, out *InventorySpec, s conversion.Scope) error {
+	return autoConvert_kops_InventorySpec_To_v1alpha2_InventorySpec(in, out, s)
 }
 
 func autoConvert_v1alpha2_KopeioNetworkingSpec_To_kops_KopeioNetworkingSpec(in *KopeioNetworkingSpec, out *kops.KopeioNetworkingSpec, s conversion.Scope) error {

--- a/pkg/apis/kops/v1alpha2/zz_generated.defaults.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.defaults.go
@@ -30,6 +30,7 @@ import (
 func RegisterDefaults(scheme *runtime.Scheme) error {
 	scheme.AddTypeDefaultingFunc(&Cluster{}, func(obj interface{}) { SetObjectDefaults_Cluster(obj.(*Cluster)) })
 	scheme.AddTypeDefaultingFunc(&ClusterList{}, func(obj interface{}) { SetObjectDefaults_ClusterList(obj.(*ClusterList)) })
+	scheme.AddTypeDefaultingFunc(&Inventory{}, func(obj interface{}) { SetObjectDefaults_Inventory(obj.(*Inventory)) })
 	return nil
 }
 
@@ -41,5 +42,11 @@ func SetObjectDefaults_ClusterList(in *ClusterList) {
 	for i := range in.Items {
 		a := &in.Items[i]
 		SetObjectDefaults_Cluster(a)
+	}
+}
+
+func SetObjectDefaults_Inventory(in *Inventory) {
+	if in.Spec.Cluster != nil {
+		SetDefaults_ClusterSpec(in.Spec.Cluster)
 	}
 }

--- a/pkg/apis/kops/validation/containers.go
+++ b/pkg/apis/kops/validation/containers.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+// This validation code is utilizing the docker reference funcs which parse and validate docker container
+// syntax.  For instance gci.io/foo/mycontainer:42 passes, while gci.io//foo/mycontainer:42 fails.
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/docker/distribution/reference"
+	"github.com/golang/glog"
+	"k8s.io/kops/pkg/apis/kops"
+	"strings"
+)
+
+// ParseContainer parses s and returns a syntactically valid Reference.
+// If an error was encountered it is returned, along with a nil Reference.
+func ParseContainer(s string) (*kops.ContainerAsset, error) {
+	ref, err := reference.Parse(s)
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse container %q: %v", s, err)
+	}
+
+	asset := &kops.ContainerAsset{}
+	switch r := ref.(type) {
+	case reference.NamedTagged:
+		asset.Tag = r.Tag()
+		asset.Domain, asset.Name = reference.SplitHostname(r)
+	case reference.Canonical:
+		asset.Domain, asset.Name = reference.SplitHostname(r)
+		asset.Digest = r.Digest().String()
+	case reference.Named:
+		asset.Domain, asset.Name = reference.SplitHostname(r)
+	case reference.Tagged:
+		asset.Tag = r.Tag()
+	case reference.Digested:
+		asset.Digest = r.Digest().String()
+	case reference.Reference:
+		asset.String = r.String()
+	default:
+		glog.Errorf("We should not get here")
+	}
+
+	asset.String = ref.String()
+
+	return asset, nil
+
+}
+
+// GetRegistryAsString get the asset container registry as a string if a cluster has an registry.
+func GetRegistryAsString(clusterSpec *kops.ClusterSpec) (string, error) {
+
+	if clusterSpec == nil {
+		return "", fmt.Errorf("unable to parse assets container registry as cluster spec is nil")
+
+	}
+
+	asset, err := GetContainerRegistry(clusterSpec)
+
+	if err != nil {
+		return "", fmt.Errorf("unable to get container registry, asset: %v", err)
+	}
+
+	// registry is not set
+	if asset == nil {
+		return "", nil
+	}
+
+	return getRegistry(asset), nil
+
+}
+
+func getRegistry(asset *kops.ContainerAsset) string {
+
+	if asset == nil {
+		return ""
+	}
+
+	buf := new(bytes.Buffer)
+
+	if asset.Domain != "" {
+		buf.WriteString(asset.Domain)
+		buf.WriteString("/")
+	}
+
+	if asset.Name != "" {
+		buf.WriteString(asset.Name)
+	}
+
+	return buf.String()
+}
+
+func getRepoContainer(registry string, asset *kops.ContainerAsset) (string, error) {
+
+	if asset == nil {
+		return "", fmt.Errorf("asset cannot be nil")
+	}
+	buf := new(bytes.Buffer)
+
+	if registry != "" {
+		buf.WriteString(registry)
+		buf.WriteString("/")
+	} else if asset.Domain != "" {
+		buf.WriteString(asset.Domain)
+		buf.WriteString("/")
+	}
+
+	if asset.Name != "" {
+		buf.WriteString(asset.Name)
+	}
+
+	if asset.Tag != "" {
+		buf.WriteString(":")
+		buf.WriteString(asset.Tag)
+	}
+
+	if asset.Digest != "" {
+		buf.WriteString("@")
+		buf.WriteString(asset.Digest)
+	}
+
+	return buf.String(), nil
+}
+
+// GetContainerRegistry returns a ContainerAsset get the asset container registry if a cluster has an registry.
+func GetContainerRegistry(clusterSpec *kops.ClusterSpec) (*kops.ContainerAsset, error) {
+
+	if clusterSpec == nil {
+		return nil, fmt.Errorf("unable to parse assets container registry as cluster spec is nil")
+
+	}
+
+	if clusterSpec.Assets != nil && clusterSpec.Assets.ContainerRegistry != nil {
+		registry := strings.TrimSuffix(*clusterSpec.Assets.ContainerRegistry, "/")
+		asset, err := ParseContainer(registry)
+
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse assets container registry api value: %v", registry)
+		}
+
+		return asset, nil
+	}
+
+	return nil, nil
+}
+
+// GetContainerAndRegistryAsString returns a full container string if a cluster has an asset container registry.
+func GetContainerAndRegistryAsString(clusterSpec *kops.ClusterSpec, container string) (string, error) {
+
+	if clusterSpec == nil {
+		return "", fmt.Errorf("unable to parse assets container registry as cluster spec is nil")
+
+	}
+
+	registry, err := GetContainerRegistry(clusterSpec)
+
+	if err != nil {
+		return "", err
+	}
+
+	r := getRegistry(registry)
+
+	asset, err := ParseContainer(container)
+
+	if err != nil {
+		return "", err
+	}
+
+	container, err = getRepoContainer(r, asset)
+
+	if err != nil {
+		return "", err
+	}
+
+	return container, nil
+}
+
+// GetContainerAsString returns a full parsed container string.
+func GetContainerAsString(container string) (string, error) {
+	asset, err := ParseContainer(container)
+
+	if err != nil {
+		return "", fmt.Errorf("unable to parse container: %+v: %v", container, err)
+	}
+
+	container, err = getRepoContainer("", asset)
+
+	if err != nil {
+		return "", fmt.Errorf("unable to parse container as asset: %v %v", asset, err)
+	}
+
+	return container, nil
+}

--- a/pkg/model/components/context.go
+++ b/pkg/model/components/context.go
@@ -23,11 +23,18 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/util"
+	"k8s.io/kops/pkg/apis/kops/validation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/util/pkg/vfs"
 	"math/big"
 	"net"
+	"net/url"
 	"strings"
+)
+
+const (
+	GCR_IO      = "gcr.io/google_containers"
+	GCR_STORAGE = "https://storage.googleapis.com/kubernetes-release"
 )
 
 // OptionsContext is the context object for options builders
@@ -120,13 +127,32 @@ func IsBaseURL(kubernetesVersion string) bool {
 
 // Image returns the docker image name for the specified component
 func Image(component string, clusterSpec *kops.ClusterSpec) (string, error) {
+
+	// TODO figure out if we can add a parameter for version as well
+	// TODO https://github.com/kubernetes/kops/pull/2573#discussion_r117329255
+
 	if component == "kube-dns" {
 		// TODO: Once we are shipping different versions, start to use them
-		return "gcr.io/google_containers/kubedns-amd64:1.3", nil
+		i, err := GetGoogleImageRegistryContainer(clusterSpec, "kubedns-amd64:1.3")
+
+		if err != nil {
+			return "", err
+		}
+
+		return i, nil
+
 	}
 
 	if !IsBaseURL(clusterSpec.KubernetesVersion) {
-		return "gcr.io/google_containers/" + component + ":" + "v" + clusterSpec.KubernetesVersion, nil
+		c := component + ":" + "v" + clusterSpec.KubernetesVersion
+		i, err := GetGoogleImageRegistryContainer(clusterSpec, c)
+
+		if err != nil {
+			return "", err
+		}
+
+		return i, nil
+
 	}
 
 	baseURL := clusterSpec.KubernetesVersion
@@ -142,7 +168,102 @@ func Image(component string, clusterSpec *kops.ClusterSpec) (string, error) {
 	tag := strings.TrimSpace(string(b))
 	glog.V(2).Infof("Found tag %q for %q", tag, component)
 
-	return "gcr.io/google_containers/" + component + ":" + tag, nil
+	c := component + ":" + tag
+
+	i, err := GetGoogleImageRegistryContainer(clusterSpec, c)
+
+	if err != nil {
+		return "", err
+	}
+
+	return i, nil
+}
+
+// GetContainer provides a imageName normalized to use a cluster asset container registry if
+// the cluster has a registry.
+func GetContainer(clusterSpec *kops.ClusterSpec, imageName string) (string, error) {
+
+	imageName, err := validation.GetContainerAndRegistryAsString(clusterSpec, imageName)
+
+	if err != nil {
+		glog.Errorf("Unable to get container: %q: %v", imageName, err)
+		return "", fmt.Errorf("unable to parse container %q", imageName)
+	}
+
+	return imageName, nil
+}
+
+// Cached string for the google container registry.  Usually set to `GCR_IO`.
+var googleRepository *string
+
+// GetGoogleImageRegistryContainer returns a container string, it is used for container that are
+// typically hosted in the google registry.
+func GetGoogleImageRegistryContainer(clusterSpec *kops.ClusterSpec, c string) (string, error) {
+
+	c, err := validation.GetContainerAsString(c)
+
+	if err != nil {
+		return "", fmt.Errorf("Unable to get google image based container, container does not validate: %v", err)
+	}
+
+	if googleRepository != nil {
+		return *googleRepository + c, nil
+	}
+
+	repo, err := validation.GetRegistryAsString(clusterSpec)
+
+	if err != nil {
+		return "", fmt.Errorf("Unable to get google image based container: %v", err)
+	}
+
+	if repo != "" {
+		repo = repo + "/"
+	} else {
+		repo = GCR_IO + "/"
+	}
+
+	googleRepository = &repo
+
+	return repo + c, nil
+}
+
+// GetGoogleFileRepositoryURL returns the google file url for binaries typically housed on `GCR_STORAGE`.
+// This function will return the cluster asset file registry normalized url if a file registry is setup.
+func GetGoogleFileRepositoryURL(clusterSpec *kops.ClusterSpec, u string) (string, error) {
+	u = strings.TrimPrefix(u, "/")
+
+	googleUrl := ""
+
+	if clusterSpec.Assets != nil && clusterSpec.Assets.FileRepository != nil {
+		googleUrl = removeSlash(*clusterSpec.Assets.FileRepository) + "/kubernetes-release/" + u
+	}
+
+	if googleUrl == "" {
+		googleUrl = GCR_STORAGE + "/" + u
+	}
+
+	err := validateURL(googleUrl)
+
+	if err != nil {
+		return "", err
+	}
+
+	return googleUrl, err
+
+}
+
+func removeSlash(s string) string {
+	return strings.TrimSuffix(s, "/")
+}
+
+func validateURL(u string) error {
+	_, err := url.ParseRequestURI(u)
+
+	if err != nil {
+		return fmt.Errorf("url is invalid %q", u)
+	}
+
+	return nil
 }
 
 func GCETagForRole(clusterName string, role kops.InstanceGroupRole) string {

--- a/pkg/model/components/context_test.go
+++ b/pkg/model/components/context_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+import (
+	"testing"
+
+	"k8s.io/kops/pkg/apis/kops"
+)
+
+func Test_Build_Google_Containers(t *testing.T) {
+
+	cs := &kops.ClusterSpec{}
+
+	url := "kubedns-amd64:1.3"
+
+	s, err := GetGoogleImageRegistryContainer(cs, url)
+
+	if err != nil {
+		t.Fatalf("incorrect container repo expect: %v", err)
+	}
+
+	base := GCR_IO + "/" + url
+
+	if s != base {
+		t.Fatalf("incorrect container repo expect: %q, got %q", base, s)
+	}
+
+	repo := "quay.io/chrislovecnm"
+	cs = &kops.ClusterSpec{
+		Assets: &kops.Assets{
+			ContainerRegistry: &repo,
+		},
+	}
+
+	googleRepository = nil
+
+	s, err = GetGoogleImageRegistryContainer(cs, url)
+
+	if err != nil {
+		t.Fatalf("incorrect container repo expect: %v", err)
+	}
+
+	base = *cs.Assets.ContainerRegistry + "/" + url
+
+	if s != base {
+		t.Fatalf("incorrect container repo expect: %q, got %q", base, s)
+	}
+
+	googleRepository = nil
+
+	repo = "chrislovecnm"
+	cs = &kops.ClusterSpec{
+		Assets: &kops.Assets{
+			ContainerRegistry: &repo,
+		},
+	}
+
+	googleRepository = nil
+
+	s, err = GetGoogleImageRegistryContainer(cs, url)
+
+	if err != nil {
+		t.Fatalf("incorrect container repo expect: %v", err)
+	}
+
+	base = *cs.Assets.ContainerRegistry + "/" + url
+
+	if s != base {
+		t.Fatalf("incorrect container repo expect: %q, got %q", base, s)
+	}
+
+	googleRepository = nil
+
+	repo = "https://aa/asdf$$^/aa"
+	cs = &kops.ClusterSpec{
+		Assets: &kops.Assets{
+			ContainerRegistry: &repo,
+		},
+	}
+
+	googleRepository = nil
+
+	s, err = GetGoogleImageRegistryContainer(cs, url)
+
+	if err == nil {
+		t.Fatalf("incorrect container failure expected: %v", err)
+	}
+
+	googleRepository = nil
+}
+
+func Test_Build_Google_File_URL(t *testing.T) {
+
+	cs := &kops.ClusterSpec{}
+
+	url := "foo"
+
+	s, err := GetGoogleFileRepositoryURL(cs, url)
+
+	if err != nil {
+		t.Fatalf("unable to parse url %q", url)
+	}
+
+	if s != GCR_STORAGE+"/"+url {
+		t.Fatalf("incorret url %q", s)
+	}
+}

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -42,8 +42,18 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 	clusterSpec.KubeDNS.ServerIP = ip.String()
 	clusterSpec.KubeDNS.Domain = clusterSpec.ClusterDNSDomain
+
+	// TODO another hard coded version
+
+	// Get the container string normalized with assets container registry.
+	container, err := GetGoogleImageRegistryContainer(clusterSpec, "kubedns-amd64:1.3")
+
+	if err != nil {
+		return err
+	}
+
 	// TODO: Once we start shipping more images, start using them
-	clusterSpec.KubeDNS.Image = "gcr.io/google_containers/kubedns-amd64:1.3"
+	clusterSpec.KubeDNS.Image = container
 
 	return nil
 }

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -98,6 +98,10 @@ func run() error {
 	var gossipSecret string
 	flags.StringVar(&gossipSecret, "gossip-secret", gossipSecret, "Secret to use to secure gossip")
 
+	// optional flag to override the location of etcd.  Utilized with cluster asset container registry.
+	var etcdImageSource string
+	flags.StringVar(&etcdImageSource, "etcd-image-source", etcdImageSource, "Etcd Source Container Registry")
+
 	// Trick to avoid 'logging before flag.Parse' warning
 	flag.CommandLine.Parse([]string{})
 
@@ -322,7 +326,8 @@ func run() error {
 
 		Channels: channels,
 
-		Kubernetes: protokube.NewKubernetesContext(),
+		Kubernetes:      protokube.NewKubernetesContext(),
+		EtcdImageSource: etcdImageSource,
 	}
 	k.Init(volumes)
 

--- a/protokube/pkg/protokube/etcd_cluster.go
+++ b/protokube/pkg/protokube/etcd_cluster.go
@@ -54,6 +54,8 @@ type EtcdCluster struct {
 	Spec *EtcdClusterSpec
 
 	VolumeMountPath string
+
+	ImageSource string
 }
 
 func (e *EtcdCluster) String() string {
@@ -92,6 +94,7 @@ func newEtcdController(kubeBoot *KubeBoot, v *Volume, spec *EtcdClusterSpec) (*E
 	cluster.CPURequest = resource.MustParse("100m")
 	cluster.ClientPort = 4001
 	cluster.PeerPort = 2380
+	cluster.ImageSource = kubeBoot.EtcdImageSource
 
 	// We used to build this through text files ... it turns out to just be more complicated than code!
 	switch spec.ClusterKey {

--- a/protokube/pkg/protokube/etcd_manifest.go
+++ b/protokube/pkg/protokube/etcd_manifest.go
@@ -25,6 +25,19 @@ import (
 
 // BuildEtcdManifest creates the pod spec, based on the etcd cluster
 func BuildEtcdManifest(c *EtcdCluster) *v1.Pod {
+
+	// TODO another hardcoded version
+	image := "/etcd:2.2.1"
+	imageRegistry := "gcr.io/google_containers"
+
+	// Test to determine if the container registry has been passed in as a flag.
+	// If so use the provider registry location.
+	if c.ImageSource == "" {
+		image = imageRegistry + image
+	} else {
+		image = strings.TrimSuffix(c.ImageSource, "/") + image
+	}
+
 	pod := &v1.Pod{}
 	pod.APIVersion = "v1"
 	pod.Kind = "Pod"
@@ -40,7 +53,7 @@ func BuildEtcdManifest(c *EtcdCluster) *v1.Pod {
 	{
 		container := v1.Container{
 			Name:  "etcd-container",
-			Image: "gcr.io/google_containers/etcd:2.2.1",
+			Image: image,
 			Resources: v1.ResourceRequirements{
 				Requests: v1.ResourceList{
 					v1.ResourceCPU: c.CPURequest,

--- a/protokube/pkg/protokube/kube_boot.go
+++ b/protokube/pkg/protokube/kube_boot.go
@@ -49,6 +49,9 @@ type KubeBoot struct {
 	Channels []string
 
 	Kubernetes *KubernetesContext
+
+	// Etcd container registry location.
+	EtcdImageSource string
 }
 
 func (k *KubeBoot) Init(volumesProvider Volumes) {

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.6.yaml.template
@@ -33,7 +33,7 @@ spec:
       serviceAccount: dns-controller
       containers:
       - name: dns-controller
-        image: kope/dns-controller:1.6.1
+        image: {{ DnsControllerImage }}
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/pre-k8s-1.6.yaml.template
@@ -28,7 +28,7 @@ spec:
       hostNetwork: true
       containers:
       - name: dns-controller
-        image: {{ DnsControllerImage }}:1.6.1
+        image: {{ DnsControllerImage }}
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: kube-dns-autoscaler
       containers:
       - name: autoscaler
-        image: gcr.io/google_containers/cluster-proportional-autoscaler-{{Arch}}:1.1.1
+        image: {{GetGoogleImageRegistryContainer "cluster-proportional-autoscaler-amd64:1.1.1" }}
         resources:
             requests:
                 cpu: "20m"
@@ -93,7 +93,7 @@ spec:
 
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-{{Arch}}:1.14.1
+        image: {{GetGoogleImageRegistryContainer "k8s-dns-kube-dns-amd64:1.14.1" }}
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -145,7 +145,7 @@ spec:
           mountPath: /kube-dns-config
 
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-{{Arch}}:1.14.1
+        image:  {{GetGoogleImageRegistryContainer "k8s-dns-dnsmasq-nanny-amd64:1.14.1" }}
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -184,7 +184,7 @@ spec:
           mountPath: /etc/k8s/dns/dnsmasq-nanny
 
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.1
+        image: {{GetGoogleImageRegistryContainer "k8s-dns-sidecar-amd64:1.14.1" }}
         livenessProbe:
           httpGet:
             path: /metrics

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: gcr.io/google_containers/cluster-proportional-autoscaler-{{Arch}}:1.0.0
+        image: {{GetGoogleImageRegistryContainer "cluster-proportional-autoscaler-amd64:1.0.0" }}
         resources:
             requests:
                 cpu: "20m"
@@ -83,7 +83,7 @@ spec:
     spec:
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/kubedns-{{Arch}}:1.9
+        image: {{GetGoogleImageRegistryContainer "kubedns-amd64:1.9" }}
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -131,7 +131,7 @@ spec:
           name: metrics
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-{{Arch}}:1.4
+        image: {{GetGoogleImageRegistryContainer "kube-dnsmasq-amd64:1.4" }}
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq
@@ -159,7 +159,7 @@ spec:
             cpu: 150m
             memory: 10Mi
       - name: dnsmasq-metrics
-        image: gcr.io/google_containers/dnsmasq-metrics-{{Arch}}:1.0
+        image: {{GetGoogleImageRegistryContainer "dnsmasq-metrics-amd64:1.0" }}
         livenessProbe:
           httpGet:
             path: /metrics
@@ -180,7 +180,7 @@ spec:
           requests:
             memory: 10Mi
       - name: healthz
-        image: gcr.io/google_containers/exechealthz-{{Arch}}:1.2
+        image: {{GetGoogleImageRegistryContainer "exechealthz-amd64:1.2" }}
         resources:
           limits:
             memory: 50Mi

--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.6.yaml.template
@@ -58,7 +58,7 @@ spec:
         key: node-role.kubernetes.io/master
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.7.1
+        image: {{ GetImage "quay.io/coreos/flannel:v0.7.1" }}
         command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
         securityContext:
           privileged: true
@@ -84,7 +84,7 @@ spec:
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.7.1
+        image: {{ GetImage "quay.io/coreos/flannel:v0.7.1" }}
         command: [ "/bin/sh", "-c", "set -e -x; cp -f /etc/kube-flannel/cni-conf.json /etc/cni/net.d/10-flannel.conf; while true; do sleep 3600; done" ]
         resources:
           limits:

--- a/upup/models/cloudup/resources/addons/networking.flannel/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/pre-k8s-1.6.yaml.template
@@ -54,7 +54,7 @@ spec:
       serviceAccountName: flannel
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.7.1
+        image: {{ GetImage "quay.io/coreos/flannel:v0.7.1" }}
         command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
         securityContext:
           privileged: true
@@ -80,7 +80,7 @@ spec:
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.7.1
+        image: {{ GetImage "quay.io/coreos/flannel:v0.7.1" }}
         command: [ "/bin/sh", "-c", "set -e -x; cp -f /etc/kube-flannel/cni-conf.json /etc/cni/net.d/10-flannel.conf; while true; do sleep 3600; done" ]
         resources:
           limits:

--- a/upup/models/cloudup/resources/addons/networking.kope.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kope.io/k8s-1.6.yaml.template
@@ -28,7 +28,7 @@ spec:
               memory: 100Mi
           securityContext:
             privileged: true
-          image: kopeio/networking-agent:1.0.20170406
+          image: {{ GetImage "kopeio/networking-agent:1.0.20170406" }}
           name: networking-agent
           volumeMounts:
             - name: lib-modules

--- a/upup/models/cloudup/resources/addons/networking.kope.io/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kope.io/pre-k8s-1.6.yaml.template
@@ -28,7 +28,7 @@ spec:
               memory: 100Mi
           securityContext:
             privileged: true
-          image: kopeio/networking-agent:1.0.20170406
+          image: {{ GetImage "kopeio/networking-agent:1.0.20170406" }}
           name: networking-agent
           volumeMounts:
             - name: lib-modules

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.6.yaml.template
@@ -83,7 +83,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v1.2.1
+          image: {{ GetImage "quay.io/calico/node:v1.2.1" }}
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -130,7 +130,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v1.8.3
+          image: {{ GetImage "quay.io/calico/cni:v1.8.3" }}
           command: ["/install-cni.sh"]
           env:
             # The CNI network config to install on each node.
@@ -151,7 +151,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.7.1
+          image: {{ GetImage "quay.io/coreos/flannel:v0.7.1" }}
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/pre-k8s-1.6.yaml.template
@@ -77,7 +77,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v1.2.1
+          image: {{ GetImage "quay.io/calico/node:v1.2.1" }}
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -124,7 +124,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v1.8.3
+          image: {{ GetImage "quay.io/calico/cni:v1.8.3" }}
           command: ["/install-cni.sh"]
           env:
             # The CNI network config to install on each node.
@@ -145,7 +145,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.7.1
+          image: {{ GetImage "quay.io/coreos/flannel:v0.7.1" }}
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.6.yaml.template
@@ -127,7 +127,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v1.2.1
+          image: {{ GetImage "calico/node:v1.2.1" }}
           resources:
             requests:
               cpu: 10m
@@ -167,7 +167,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v1.8.3
+          image: {{ GetImage "calico/cni:v1.8.3" }}
           resources:
             requests:
               cpu: 10m
@@ -243,7 +243,7 @@ spec:
         operator: Exists
       containers:
         - name: calico-policy-controller
-          image: calico/kube-policy-controller:v0.6.0
+          image: {{ GetImage "calico/kube-policy-controller:v0.6.0" }}
           resources:
             requests:
               cpu: 10m

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/pre-k8s-1.6.yaml.template
@@ -70,7 +70,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v1.1.3
+          image: {{ GetImage "calico/node:v1.1.3" }}
           resources:
             requests:
               cpu: 10m
@@ -110,7 +110,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v1.8.0
+          image: {{ GetImage "calico/cni:v1.8.0" }}
           resources:
             requests:
               cpu: 10m
@@ -183,7 +183,7 @@ spec:
       hostNetwork: true
       containers:
         - name: calico-policy-controller
-          image: calico/kube-policy-controller:v0.5.4
+          image: {{ GetImage "calico/kube-policy-controller:v0.5.4" }}
           resources:
             requests:
               cpu: 10m
@@ -203,7 +203,6 @@ spec:
             # kubernetes.default to the correct service clusterIP.
             - name: CONFIGURE_ETC_HOSTS
               value: "true"
-
 {{ if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}
 ---
 # This manifest installs the k8s-ec2-srcdst container, which disables

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
@@ -66,7 +66,7 @@ spec:
       hostPID: true
       containers:
         - name: weave
-          image: weaveworks/weave-kube:1.9.7
+          image: {{ GetImage "weaveworks/weave-kube:1.9.7" }}
           command:
             - /home/weave/launch.sh
           livenessProbe:
@@ -103,7 +103,7 @@ spec:
               value: "{{ .Networking.Weave.MTU }}"
           {{end}}
         - name: weave-npc
-          image: weaveworks/weave-npc:1.9.7
+          image: {{GetImage "weaveworks/weave-npc:1.9.7"}}
           resources:
             requests:
               cpu: 100m

--- a/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
@@ -27,7 +27,7 @@ spec:
       hostPID: true
       containers:
         - name: weave
-          image: weaveworks/weave-kube:1.9.7
+          image: {{GetImage "weaveworks/weave-kube:1.9.7"}}
           command:
             - /home/weave/launch.sh
           livenessProbe:
@@ -64,7 +64,7 @@ spec:
               value: "{{ .Networking.Weave.MTU }}"
           {{end}}
         - name: weave-npc
-          image: weaveworks/weave-npc:1.9.7
+          image: {{GetImage "weaveworks/weave-npc:1.9.7"}}
           resources:
             requests:
               cpu: 100m

--- a/upup/pkg/fi/cloudup/apply_inventory.go
+++ b/upup/pkg/fi/cloudup/apply_inventory.go
@@ -1,0 +1,451 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudup
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/util/sets"
+	api "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/validation"
+
+	api_util "k8s.io/kops/pkg/apis/kops/util"
+
+	"bytes"
+	"io/ioutil"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kops"
+	"k8s.io/kops/pkg/apis/kops/registry"
+	"k8s.io/kops/pkg/apis/kops/v1alpha1"
+	"k8s.io/kops/pkg/apis/nodeup"
+	"k8s.io/kops/pkg/client/simple"
+	"k8s.io/kops/pkg/model/components"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/fitasks"
+	"k8s.io/kops/upup/pkg/fi/utils"
+	"k8s.io/kops/util/pkg/vfs"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+)
+
+type ApplyInventory struct {
+	Cluster             *api.Cluster
+	InstanceGroups      []*api.InstanceGroup
+	NodeUpConfigBuilder func(ig *api.InstanceGroup) (*nodeup.NodeUpConfig, error)
+	BootstrapContainers *sets.String
+	TaskMap             map[string]fi.Task
+	NodeupLocation      string
+}
+
+// BuildInventoryAssets populates the Inventory of a kops Kubernetes cluster.  This func is only
+// accessible when running an ApplyClusterCmd.Run() with a target of TargetInventory.
+func (i *ApplyInventory) BuildInventoryAssets() (*api.Inventory, error) {
+
+	if i.Cluster == nil {
+		return nil, fmt.Errorf("cluster cannot be nil")
+	}
+	if i.InstanceGroups == nil {
+		return nil, fmt.Errorf("instance groups cannot be nil")
+	}
+	if i.NodeUpConfigBuilder == nil {
+		return nil, fmt.Errorf("builder function cannot be nil")
+	}
+
+	inv := &api.Inventory{
+		Spec: api.InventorySpec{
+			CompressedFileAssets: make([]*api.CompressedFileAsset, 0),
+			ContainerAssets:      make([]*api.ContainerAsset, 0),
+			ExecutableFileAsset:  make([]*api.ExecutableFileAsset, 0),
+			HostAssets:           make([]*api.HostAsset, 0),
+			Cluster:              &i.Cluster.Spec,
+			KopsVersion:          &kops.Version,
+		},
+	}
+
+	inventoryBinaryMap := make(map[string]*api.ExecutableFileAsset)
+	inventoryCompressedMap := make(map[string]*api.CompressedFileAsset)
+
+	spec := i.Cluster.Spec
+
+	// nodeup binary
+	inventoryBinaryMap["nodeup"] = &api.ExecutableFileAsset{
+		Location: nodeUpLocation,
+		Name:     "nodeup",
+	}
+
+	// Build Kubernetes Base Containers
+	{
+		etcd, err := components.GetGoogleImageRegistryContainer(&spec, "etcd:2.2.1")
+
+		if err != nil {
+			return nil, err
+		}
+
+		pause, err := components.GetGoogleImageRegistryContainer(&spec, "pause-amd64:3.0")
+
+		if err != nil {
+			return nil, err
+		}
+
+		k8sContainers := map[string]string{
+			spec.KubeAPIServer.Image:         "KubeAPIServer",
+			spec.KubeControllerManager.Image: "KubeControllerManager",
+			spec.KubeProxy.Image:             "KubeProxy",
+			spec.KubeScheduler.Image:         "KubeScheduler",
+			// TODO This value is hardcoded in protokube.
+			etcd:  "Etcd",
+			pause: "pause",
+		}
+
+		for k, v := range k8sContainers {
+			c, err := parseContainer(k, v)
+			if err != nil {
+				return nil, err
+			}
+			inv.Spec.ContainerAssets = append(inv.Spec.ContainerAssets, c)
+		}
+
+	}
+
+	// Build Inventory channel
+	{
+		channelLocation, err := api.ParseChannelLocation(i.Cluster.Spec.Channel)
+
+		if err != nil {
+			return nil, fmt.Errorf("unable to get channel location: %v", err)
+		}
+
+		inv.Spec.ChannelAsset = &api.ChannelAsset{
+			Location: channelLocation,
+		}
+
+		if strings.HasSuffix(channelLocation, "alpha") {
+			inv.Spec.ChannelAsset.Name = "alpha"
+		} else {
+			inv.Spec.ChannelAsset.Name = "stable"
+		}
+	}
+
+	// Build host information and assets created by nodeup.  I choose to parse
+	// the assets to allow dynamic creation and deletion of assets.  Kubernetes assets
+	// are very stable, but these assets are growing in kops.
+	{
+		for _, ig := range i.InstanceGroups {
+			n, err := i.NodeUpConfigBuilder(ig)
+			if err != nil {
+				return nil, fmt.Errorf("unable to render node config: %v", err)
+			}
+
+			host := &api.HostAsset{
+				Name:          ig.Spec.Image,
+				Cloud:         i.Cluster.Spec.CloudProvider,
+				Role:          string(ig.Spec.Role),
+				InstanceGroup: ig.ObjectMeta.Name,
+			}
+
+			inv.Spec.HostAssets = append(inv.Spec.HostAssets, host)
+
+			// binary asset
+			for _, a := range n.Assets {
+
+				asset := strings.Split(a, "@")
+				url := asset[1]
+				name := strings.Split(url, "/")
+				fileName := name[len(name)-1]
+
+				if strings.HasSuffix(fileName, "gz") {
+					inventoryCompressedMap[asset[0]] = &api.CompressedFileAsset{
+						Location: url,
+						Name:     fileName,
+					}
+
+				} else {
+
+					inventoryBinaryMap[asset[0]] = &api.ExecutableFileAsset{
+						Location: url,
+						Name:     fileName,
+						SHA:      url + ".sha",
+					}
+				}
+			}
+		}
+	}
+
+	// protokube
+	{
+		c := &api.ContainerAsset{
+			Name: protokubeImageSource.Name,
+			Tag:  strings.Replace(kops.Version, "+", "-", -1),
+		}
+
+		if protokubeImageSource.Hash != "" {
+			c.Location = protokubeImageSource.Source
+			c.Hash = protokubeImageSource.Hash
+			c.SHA = protokubeImageSource.Source + ".sha"
+		}
+		inv.Spec.ContainerAssets = append(inv.Spec.ContainerAssets, c)
+	}
+
+	// build addons such as CNI providers and dnscontroller
+	{
+
+		sv, err := api_util.ParseKubernetesVersion(spec.KubernetesVersion)
+		if err != nil {
+			return nil, fmt.Errorf("unable to determine kubernetes version from %q", spec.KubernetesVersion)
+		}
+
+		optionsContext := &components.OptionsContext{
+			KubernetesVersion: *sv,
+		}
+
+		isVersionGTE1_6 := optionsContext.IsKubernetesGTE("1.6")
+		isVersionLT1_6 := optionsContext.IsKubernetesLT("1.6")
+
+		v := sv.String()
+		inv.Spec.KubernetesVersion = &v
+
+		// Execute the addons managed file tasks since they do not run until a cluster is updated `kops update cluster --yes`.
+		// Filter the addons by kubernetes version.
+		for _, task := range i.TaskMap {
+			switch m := task.(type) {
+			case *fitasks.ManagedFile:
+
+				pre16 := strings.Contains(*m.Location, "pre-k8s-1.6")
+
+				if pre16 && isVersionGTE1_6 {
+					continue
+				} else if !pre16 && isVersionLT1_6 {
+					continue
+				}
+
+				m.Contents.AsBytes()
+			default:
+
+			}
+
+		}
+
+		for _, b := range i.BootstrapContainers.List() {
+			c, err := validation.ParseContainer(b)
+			if err != nil {
+				return nil, fmt.Errorf("Unable to parse container: %v", err)
+			}
+			inv.Spec.ContainerAssets = append(inv.Spec.ContainerAssets, c)
+		}
+	}
+
+	// Normalize the data.
+
+	// reduce map to a slice
+	for _, value := range inventoryBinaryMap {
+		inv.Spec.ExecutableFileAsset = append(inv.Spec.ExecutableFileAsset, value)
+	}
+
+	// reduce map to a slice
+	for _, value := range inventoryCompressedMap {
+
+		if !strings.HasPrefix(value.Location, "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-") {
+			value.SHA = value.Location + ".sha1"
+		}
+
+		inv.Spec.CompressedFileAssets = append(inv.Spec.CompressedFileAssets, value)
+	}
+
+	glog.V(2).Infof("data %+v", inv)
+
+	return inv, nil
+}
+
+func parseContainer(image string, name string) (*api.ContainerAsset, error) {
+	// List of all containers in the API
+	c, err := validation.ParseContainer(image)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse %s container %q: %v", name, image, err)
+	}
+	if c.Name == "" {
+		c.Name = name
+	}
+	return c, nil
+}
+
+type ExtractInventory struct {
+	Clientset simple.Clientset
+	resource.FilenameOptions
+	ClusterName       string
+	Channel           string
+	KubernetesVersion string
+	SSHPublicKey      string
+}
+
+func (e *ExtractInventory) ExtractAssets() (*api.Inventory, string, error) {
+	var cluster *api.Cluster
+	var ig []*api.InstanceGroup
+	var err error
+
+	if len(e.Filenames) != 0 {
+		cluster, ig, err = e.readFiles()
+		if err != nil {
+			return nil, "", fmt.Errorf("Error loading file(s) %q, %v", e.Filenames, err)
+		}
+
+		e.ClusterName = cluster.ObjectMeta.Name
+	} else if e.ClusterName != "" {
+
+		cluster, err = e.Clientset.Clusters().Get(e.ClusterName)
+
+		if err != nil {
+			return nil, "", fmt.Errorf("Error getting cluster  %q", err)
+		}
+
+		if cluster == nil {
+			return nil, "", fmt.Errorf("cluster not found %q", e.ClusterName)
+		}
+
+	}
+
+	if cluster == nil {
+		return nil, "", fmt.Errorf("error getting cluster")
+	}
+
+	if cluster.Spec.KubernetesVersion == "" {
+		channel, err := api.LoadChannel(e.Channel)
+		if err != nil {
+			return nil, "", fmt.Errorf("Unable to load channel %q", err)
+		}
+		kubernetesVersion := api.RecommendedKubernetesVersion(channel, kops.Version)
+		if kubernetesVersion != nil {
+			cluster.Spec.KubernetesVersion = kubernetesVersion.String()
+			e.KubernetesVersion = cluster.Spec.KubernetesVersion
+		} else {
+
+			return nil, "", fmt.Errorf("Unable to find kubernetes version")
+		}
+
+	}
+
+	// TODO check if the cluster has a key?
+	// TODO how do we get this out of here??
+	// TODO - Reference: https://github.com/kubernetes/kops/issues/2659
+	sshPublicKeys := make(map[string][]byte)
+	if e.SSHPublicKey != "" {
+		e.SSHPublicKey = utils.ExpandPath(e.SSHPublicKey)
+		authorized, err := ioutil.ReadFile(e.SSHPublicKey)
+		if err != nil {
+			return nil, "", fmt.Errorf("error reading SSH key file %q: %v", e.SSHPublicKey, err)
+		}
+		sshPublicKeys[fi.SecretNameSSHPrimary] = authorized
+
+	}
+
+	keyStore, err := registry.KeyStore(cluster)
+	if err != nil {
+		return nil, "", err
+	}
+
+	for k, data := range sshPublicKeys {
+		err = keyStore.AddSSHPublicKey(k, data)
+		if err != nil {
+			return nil, "", fmt.Errorf("error addding SSH public key: %v", err)
+		}
+	}
+
+	applyClusterCmd := &ApplyClusterCmd{
+		Clientset:      e.Clientset,
+		Cluster:        cluster,
+		InstanceGroups: ig,
+		TargetName:     TargetInventory,
+		Models:         []string{"config", "proto", "cloudup"},
+	}
+
+	err = applyClusterCmd.Run()
+
+	if err != nil {
+		return nil, "", fmt.Errorf("error applying cluster build: %v", err)
+	}
+
+	a := applyClusterCmd.Inventory
+
+	clusterExists, err := e.Clientset.Clusters().Get(e.ClusterName)
+
+	// Need to delete tmp ssh key
+	// If we can get ApplyClusterCmd to run w/o ssh key we will not have to create it
+	if err != nil || clusterExists == nil {
+
+		glog.V(2).Infof("Deleting cluster resources for %q", e.ClusterName)
+		configBase, err := registry.ConfigBase(cluster)
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		err = registry.DeleteAllClusterState(configBase)
+		if err != nil {
+			return nil, "", fmt.Errorf("error removing cluster from state store: %v", err)
+		}
+
+	}
+
+	return a, e.ClusterName, nil
+}
+
+// readFiles inputs and marshalls YAML files.
+func (e *ExtractInventory) readFiles() (*api.Cluster, []*api.InstanceGroup, error) {
+
+	codec := api.Codecs.UniversalDecoder(api.SchemeGroupVersion)
+
+	var cluster *api.Cluster
+	var ig []*api.InstanceGroup
+
+	for _, f := range e.Filenames {
+		var sb bytes.Buffer
+		fmt.Fprintf(&sb, "\n")
+
+		contents, err := vfs.Context.ReadFile(f)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error reading file %q: %v", f, err)
+		}
+
+		sections := bytes.Split(contents, []byte("\n---\n"))
+		for _, section := range sections {
+			defaults := &schema.GroupVersionKind{
+				Group:   v1alpha1.SchemeGroupVersion.Group,
+				Version: v1alpha1.SchemeGroupVersion.Version,
+			}
+			o, _, err := codec.Decode(section, defaults, nil)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error parsing file %q: %v", f, err)
+			}
+
+			switch v := o.(type) {
+			case *api.Cluster:
+				err = PerformAssignments(v)
+				if err != nil {
+					return nil, nil, fmt.Errorf("error populating configuration: %v", err)
+				}
+				cluster = v
+			case *api.InstanceGroup:
+				ig = append(ig, v)
+			default:
+				glog.V(8).Infof("Type of object was %T", v)
+			}
+		}
+	}
+
+	return cluster, ig, nil
+}

--- a/upup/pkg/fi/cloudup/networking.go
+++ b/upup/pkg/fi/cloudup/networking.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/glog"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/util"
+	"k8s.io/kops/pkg/model/components"
 )
 
 func usesCNI(c *api.Cluster) bool {
@@ -85,11 +86,11 @@ func usesCNI(c *api.Cluster) bool {
 
 const (
 	// 1.5.x k8s uses release 07a8a28637e97b22eb8dfe710eeae1344f69d16e
-	defaultCNIAssetK8s1_5           = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz"
+	defaultCNIAssetK8s1_5           = "network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz"
 	defaultCNIAssetHashStringK8s1_5 = "19d49f7b2b99cd2493d5ae0ace896c64e289ccbb"
 
 	// 1.6.x k8s uses release 0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff
-	defaultCNIAssetK8s1_6           = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz"
+	defaultCNIAssetK8s1_6           = "network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz"
 	defaultCNIAssetHashStringK8s1_6 = "1d9788b0f5420e1a219aad2cb8681823fc515e7c"
 
 	// Environment variable for overriding CNI url
@@ -113,9 +114,21 @@ func findCNIAssets(c *api.Cluster) (string, string, error) {
 
 	if sv.GTE(semver.Version{Major: 1, Minor: 6, Patch: 0, Pre: nil, Build: nil}) {
 		glog.V(2).Infof("Adding default CNI asset: %s", defaultCNIAssetK8s1_6)
-		return defaultCNIAssetK8s1_6, defaultCNIAssetHashStringK8s1_6, nil
+
+		// Get the file location.  This value can be overridden by using a cluster asset file repository.
+		url, err := components.GetGoogleFileRepositoryURL(&c.Spec, defaultCNIAssetK8s1_6)
+		if err != nil {
+			return "", "", fmt.Errorf("unable to create valid url from %q, %v", defaultCNIAssetK8s1_6, err)
+		}
+		return url, defaultCNIAssetHashStringK8s1_6, nil
 	}
 
 	glog.V(2).Infof("Adding default CNI asset: %s", defaultCNIAssetK8s1_5)
-	return defaultCNIAssetK8s1_5, defaultCNIAssetHashStringK8s1_5, nil
+
+	// Get the file location.  This value can be overridden by using a cluster asset file repository.
+	url, err := components.GetGoogleFileRepositoryURL(&c.Spec, defaultCNIAssetK8s1_5)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to create valid url from %q, %v", defaultCNIAssetK8s1_5, err)
+	}
+	return url, defaultCNIAssetHashStringK8s1_5, nil
 }

--- a/upup/pkg/fi/cloudup/networking_test.go
+++ b/upup/pkg/fi/cloudup/networking_test.go
@@ -18,6 +18,7 @@ package cloudup
 
 import (
 	api "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/model/components"
 	"os"
 	"testing"
 )
@@ -50,18 +51,20 @@ func Test_FindCNIAssetDefaultValue1_6(t *testing.T) {
 
 	cluster := &api.Cluster{Spec: api.ClusterSpec{}}
 	cluster.Spec.KubernetesVersion = "v1.6.2"
+
+	baseUrl := components.GCR_STORAGE
 	cniAsset, cniAssetHashString, err := findCNIAssets(cluster)
 
 	if err != nil {
 		t.Errorf("Unable to parse k8s version %s", err)
 	}
 
-	if cniAsset != defaultCNIAssetK8s1_6 {
-		t.Errorf("Expected default CNI version %q and got %q", defaultCNIAssetK8s1_5, cniAsset)
+	if cniAsset != baseUrl+"/"+defaultCNIAssetK8s1_6 {
+		t.Errorf("Expected default CNI version %q and got %q", baseUrl+"/"+defaultCNIAssetK8s1_6, cniAsset)
 	}
 
 	if cniAssetHashString != defaultCNIAssetHashStringK8s1_6 {
-		t.Errorf("Expected default CNI Version Hash String %q and got %q", defaultCNIAssetHashStringK8s1_5, cniAssetHashString)
+		t.Errorf("Expected default CNI Version Hash String %q and got %q", defaultCNIAssetHashStringK8s1_6, cniAssetHashString)
 	}
 
 }
@@ -71,13 +74,14 @@ func Test_FindCNIAssetDefaultValue1_5(t *testing.T) {
 	cluster := &api.Cluster{Spec: api.ClusterSpec{}}
 	cluster.Spec.KubernetesVersion = "v1.5.12"
 	cniAsset, cniAssetHashString, err := findCNIAssets(cluster)
+	baseUrl := components.GCR_STORAGE
 
 	if err != nil {
 		t.Errorf("Unable to parse k8s version %s", err)
 	}
 
-	if cniAsset != defaultCNIAssetK8s1_5 {
-		t.Errorf("Expected default CNI version %q and got %q", defaultCNIAssetK8s1_5, cniAsset)
+	if cniAsset != baseUrl+"/"+defaultCNIAssetK8s1_5 {
+		t.Errorf("Expected default CNI version %q and got %q", baseUrl+"/"+defaultCNIAssetK8s1_5, cniAsset)
 	}
 
 	if cniAssetHashString != defaultCNIAssetHashStringK8s1_5 {

--- a/upup/pkg/fi/cloudup/target.go
+++ b/upup/pkg/fi/cloudup/target.go
@@ -18,5 +18,6 @@ package cloudup
 
 const TargetDirect = "direct"
 const TargetDryRun = "dryrun"
+const TargetInventory = "inventory"
 const TargetTerraform = "terraform"
 const TargetCloudformation = "cloudformation"

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -30,7 +30,6 @@ package cloudup
 import (
 	"encoding/base64"
 	"fmt"
-	"os"
 	"strings"
 	"text/template"
 
@@ -100,7 +99,6 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap) {
 	// TODO: Only for GCE?
 	dest["EncodeGCELabel"] = gce.EncodeGCELabel
 
-	dest["DnsControllerImage"] = tf.DnsControllerImage
 }
 
 // SharedVPC is a simple helper function which makes the templates for a shared VPC clearer
@@ -170,19 +168,6 @@ func (tf *TemplateFunctions) DnsControllerArgv() ([]string, error) {
 	argv = append(argv, "-v=2")
 
 	return argv, nil
-}
-
-// To use user-defined DNS Controller:
-// 1. DOCKER_REGISTRY=[your docker hub repo] make dns-controller-push
-// 2. export DNSCONTROLLER_IMAGE=[your docker hub repo]
-// 3. make kops and create/apply cluster
-func (tf *TemplateFunctions) DnsControllerImage() (string, error) {
-	image := os.Getenv("DNSCONTROLLER_IMAGE")
-	if image == "" {
-		return "kope/dns-controller", nil
-	} else {
-		return image, nil
-	}
 }
 
 func (tf *TemplateFunctions) ExternalDnsArgv() ([]string, error) {

--- a/upup/pkg/fi/cloudup/urls.go
+++ b/upup/pkg/fi/cloudup/urls.go
@@ -20,26 +20,39 @@ import (
 	"os"
 	"strings"
 
+	"fmt"
 	"github.com/golang/glog"
 	"k8s.io/kops"
+	api "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/validation"
+	"k8s.io/kops/pkg/apis/nodeup"
 )
 
 // baseUrl caches the BaseUrl value
 var baseUrl string
 
 // BaseUrl returns the base url for the distribution of kops - in particular for nodeup & docker images
-func BaseUrl() string {
+func BaseUrl(spec *api.ClusterSpec) string {
 	if baseUrl != "" {
 		// Avoid repeated logging
 		return baseUrl
 	}
 
 	baseUrl = os.Getenv("KOPS_BASE_URL")
-	if baseUrl == "" {
-		baseUrl = "https://kubeupv2.s3.amazonaws.com/kops/" + kops.Version + "/"
-		glog.V(4).Infof("Using default base url: %q", baseUrl)
-	} else {
+	if baseUrl != "" {
 		glog.Warningf("Using base url from KOPS_BASE_URL env var: %q", baseUrl)
+	} else {
+		version := strings.Replace(kops.Version, "+", "%2B", -1)
+		kopsUrl := "/kops/" + version + "/"
+
+		if spec.Assets != nil && spec.Assets.FileRepository != nil {
+			repo := strings.TrimSuffix(*spec.Assets.FileRepository, "/")
+			baseUrl = repo + kopsUrl
+			glog.Warningf("Using custom base url: %q", baseUrl)
+		} else {
+			baseUrl = "https://kubeupv2.s3.amazonaws.com" + kopsUrl
+			glog.V(4).Infof("Using default url: %q", baseUrl)
+		}
 	}
 
 	if !strings.HasSuffix(baseUrl, "/") {
@@ -53,15 +66,15 @@ func BaseUrl() string {
 var nodeUpLocation string
 
 // NodeUpLocation returns the URL where nodeup should be downloaded
-func NodeUpLocation() string {
+func NodeUpLocation(spec *api.ClusterSpec) string {
 	if nodeUpLocation != "" {
 		// Avoid repeated logging
 		return nodeUpLocation
 	}
 	nodeUpLocation = os.Getenv("NODEUP_URL")
 	if nodeUpLocation == "" {
-		nodeUpLocation = BaseUrl() + "linux/amd64/nodeup"
-		glog.V(4).Infof("Using default nodeup location: %q", nodeUpLocation)
+		nodeUpLocation = BaseUrl(spec) + "linux/amd64/nodeup"
+		glog.V(4).Infof("Using default nodeup location set via kops base url: %q", nodeUpLocation)
 	} else {
 		glog.Warningf("Using nodeup location from NODEUP_URL env var: %q", nodeUpLocation)
 	}
@@ -69,22 +82,77 @@ func NodeUpLocation() string {
 }
 
 // protokubeImageSource caches the ProtokubeImageSource value
-var protokubeImageSource string
+var protokubeImageSource *nodeup.Image
 
 // ProtokubeImageSource returns the source for the docker image for protokube.
 // Either a docker name (e.g. gcr.io/protokube:1.4), or a URL (https://...) in which case we download
 // the contents of the url and docker load it
-func ProtokubeImageSource() string {
-	if protokubeImageSource != "" {
-		// Avoid repeated logging
-		return protokubeImageSource
+func ProtokubeImageSource(spec *api.ClusterSpec) (*nodeup.Image, error) {
+
+	protokubeImageSourceEnv := os.Getenv("PROTOKUBE_IMAGE")
+
+	// return cached
+	if protokubeImageSource != nil {
+		return protokubeImageSource, nil
 	}
-	protokubeImageSource = os.Getenv("PROTOKUBE_IMAGE")
-	if protokubeImageSource == "" {
-		protokubeImageSource = BaseUrl() + "images/protokube.tar.gz"
-		glog.V(4).Infof("Using default protokube location: %q", protokubeImageSource)
-	} else {
+
+	var proto string
+	var err error
+
+	// only do this test it the env variable is not set
+	if protokubeImageSourceEnv == "" {
+		// A cluster asset container registry value can the default protokube name.
+		// Use the container registry value.
+		proto, err = validation.GetContainerAndRegistryAsString(spec, kops.DefaultProtokubeImageName())
+		if err != nil {
+			return nil, fmt.Errorf("unable to get protokube container name: %v", err)
+		}
+	}
+
+	if protokubeImageSourceEnv != "" {
+
+		// use env variable
+		hash, err := findHash(protokubeImageSourceEnv)
+		if err != nil {
+			return nil, err
+		}
+
+		protokubeImageSource = &nodeup.Image{
+			Name:   kops.DefaultProtokubeImageName(),
+			Source: protokubeImageSourceEnv,
+			Hash:   hash.Hex(),
+		}
 		glog.Warningf("Using protokube location from PROTOKUBE_IMAGE env var: %q", protokubeImageSource)
+
+	} else if proto != kops.DefaultProtokubeImageName() {
+
+		// Assets.ContainerRegistry is set
+		if err != nil {
+			return nil, err
+		}
+
+		protokubeImageSource = &nodeup.Image{
+			Name:   proto,
+			Source: proto,
+		}
+		glog.Infof("Using protokube location from assets container registry %q", proto)
+	} else {
+
+		//use default from url
+		source := BaseUrl(spec) + "images/protokube.tar.gz"
+		hash, err := findHash(source)
+		if err != nil {
+			return nil, err
+		}
+
+		protokubeImageSource = &nodeup.Image{
+			Name:   kops.DefaultProtokubeImageName(),
+			Source: source,
+			Hash:   hash.Hex(),
+		}
+		glog.V(4).Infof("Using default protokube location set via kops base url: %v", protokubeImageSource)
+
 	}
-	return protokubeImageSource
+
+	return protokubeImageSource, nil
 }

--- a/upup/pkg/fi/cloudup/urls_test.go
+++ b/upup/pkg/fi/cloudup/urls_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudup
+
+import (
+	"fmt"
+	"k8s.io/kops"
+	api "k8s.io/kops/pkg/apis/kops"
+	"testing"
+)
+
+// TODO test env var
+
+func Test_BaseUrl(t *testing.T) {
+	baseUrl = ""
+	c := buildMinimalCluster()
+
+	b := BaseUrl(&c.Spec)
+
+	base := fmt.Sprintf("https://kubeupv2.s3.amazonaws.com/kops/%s/", kops.Version)
+
+	baseUrl = ""
+	if b != base {
+		t.Fatalf("wrong url %q, expected %q", b, base)
+	}
+
+	b = "https://example.com/"
+	f := fmt.Sprintf("%skops/%s/", b, kops.Version)
+	c.Spec.Assets = &api.Assets{
+		FileRepository: &b,
+	}
+
+	baseUrl = ""
+	b = BaseUrl(&c.Spec)
+
+	if b != f {
+		t.Fatalf("wrong url %q, expected %q", b, f)
+	}
+
+}
+
+// TODO test ENV var
+func Test_ProtokubeUrl(t *testing.T) {
+	baseUrl = ""
+	c := buildMinimalCluster()
+
+	b, err := ProtokubeImageSource(&c.Spec)
+
+	if err != nil {
+		t.Fatalf("error building protokube url: %v", err)
+	}
+
+	f := "https://kubeupv2.s3.amazonaws.com/kops/1.5.0/images/protokube.tar.gz"
+
+	if b.Source != f {
+		t.Fatalf("wrong protokube image %q, expected %q", b.Source, f)
+	}
+
+	repo := "quay.io/foo"
+	c.Spec.Assets = &api.Assets{
+		ContainerRegistry: &repo,
+	}
+
+	protokubeImageSource = nil
+
+	b, err = ProtokubeImageSource(&c.Spec)
+
+	if err != nil {
+		t.Fatalf("error building protokube url: %v", err)
+	}
+
+	p := repo + "/protokube:" + kops.Version
+	if b.Source != p {
+		t.Fatalf("wrong url %q, expected %q", b, p)
+	}
+
+}

--- a/upup/pkg/fi/context.go
+++ b/upup/pkg/fi/context.go
@@ -102,6 +102,9 @@ func (c *Context) Render(a, e, changes Task) error {
 	if _, ok := c.Target.(*DryRunTarget); ok {
 		return c.Target.(*DryRunTarget).Render(a, e, changes)
 	}
+	if _, ok := c.Target.(*InventoryTarget); ok {
+		return c.Target.(*InventoryTarget).Render(a, e, changes)
+	}
 
 	v := reflect.ValueOf(e)
 	vType := v.Type()

--- a/upup/pkg/fi/default_methods.go
+++ b/upup/pkg/fi/default_methods.go
@@ -75,8 +75,8 @@ func DefaultDeltaRunMethod(e Task, c *Context) error {
 		for _, deletion := range deletions {
 			if _, ok := c.Target.(*DryRunTarget); ok {
 				err = c.Target.(*DryRunTarget).Delete(deletion)
-			} else if _, ok := c.Target.(*DryRunTarget); ok {
-				err = c.Target.(*DryRunTarget).Delete(deletion)
+			} else if _, ok := c.Target.(*InventoryTarget); ok {
+				err = c.Target.(*InventoryTarget).Delete(deletion)
 			} else {
 				err = deletion.Delete(c.Target)
 			}

--- a/upup/pkg/fi/dryrun_target.go
+++ b/upup/pkg/fi/dryrun_target.go
@@ -295,8 +295,10 @@ func (t *DryRunTarget) PrintReport(taskMap map[string]Task, out io.Writer) error
 					}
 				}
 				fmt.Fprintf(b, "\n")
+
 			}
 		}
+
 	}
 
 	if len(t.deletions) != 0 {

--- a/upup/pkg/fi/inventory_target.go
+++ b/upup/pkg/fi/inventory_target.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fi
+
+import (
+	"reflect"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// InventoryTarget is a special Target that does not execute anything, but instead tracks all changes.
+// By running an InventoryTarget, api.Inventory can be built without any special support from the Tasks.
+type InventoryTarget struct {
+	mutex sync.Mutex
+
+	changes         []*render
+	deletions       []Deletion
+	ContainerAssets *sets.String
+}
+
+var _ Target = &InventoryTarget{}
+
+// NewInventoryTarget creates a new target.
+func NewInventoryTarget() *InventoryTarget {
+	t := &InventoryTarget{
+		ContainerAssets: &sets.String{},
+	}
+	return t
+}
+
+// ProcessDeletions dummy method to process deletes.
+func (t *InventoryTarget) ProcessDeletions() bool {
+	return true
+}
+
+// Render tracks task changes.
+func (t *InventoryTarget) Render(a, e, changes Task) error {
+	valA := reflect.ValueOf(a)
+	aIsNil := valA.IsNil()
+
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	t.changes = append(t.changes, &render{
+		a:       a,
+		aIsNil:  aIsNil,
+		e:       e,
+		changes: changes,
+	})
+	return nil
+}
+
+// Render tracks removes tasks.
+func (t *InventoryTarget) Delete(deletion Deletion) error {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	t.deletions = append(t.deletions, deletion)
+
+	return nil
+}
+
+// RecordContainerAsset is used to record managed file tasks that have a container.
+func (t *InventoryTarget) RecordContainerAsset(container string) error {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	t.ContainerAssets.Insert(container)
+	return nil
+}
+
+// ResetContainerAssets allow for ContainerAsests to be cleared. In order to create
+// the inventory, we first clear the set, and then render the set again.  This is
+// done in order to have the data to filter managed file task by k8s version.
+func (t *InventoryTarget) ResetContainerAssets() error {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	t.ContainerAssets = &sets.String{}
+	return nil
+}
+
+// Finish does not really do anything in this target besides returning nil.
+func (t *InventoryTarget) Finish(taskMap map[string]Task) error {
+	return nil
+}
+
+// HasChanges returns true if any changes would have been made.
+func (t *InventoryTarget) HasChanges() bool {
+	return len(t.changes)+len(t.deletions) != 0
+}

--- a/version.go
+++ b/version.go
@@ -25,6 +25,14 @@ var Version = "1.5.0"
 var GitVersion = ""
 
 // DefaultProtokubeImageName is the name of the protokube image, as we would pass to "docker run"
+func DefaultDnsControllerImageName() string {
+	// + is valid in semver, but not in docker tags.
+	// Note that this mirrors the logic in the makefile for PROTOKUBE_TAG.
+	dockerTag := strings.Replace(Version, "+", "-", -1)
+	return "kope/dns-controller:" + dockerTag
+}
+
+// DefaultProtokubeImageName is the name of the protokube image, as we would pass to "docker run"
 func DefaultProtokubeImageName() string {
 	// + is valid in semver, but not in docker tags.
 	// Note that this mirrors the logic in the makefile for PROTOKUBE_TAG.


### PR DESCRIPTION
This is part of getting us to a point where we can self-host all binaries and containers in a specific docker repository and s3 bucket.

New API values

```
type Assets struct {
	ContainerRegistry *string `json:"containerRegistry,omitempty"`
	FileRepository      *string `json:"fileRepository,omitempty"`
}
```

And a top level API object used for get and create methods with inventory items.
```
type Inventory struct {
	v1.TypeMeta `json:",inline"`
	ObjectMeta  metav1.ObjectMeta `json:"metadata,omitempty"`

	Spec InventorySpec `json:"spec,omitempty"`
}

type InventorySpec struct {
	Cluster              *ClusterSpec           `json:"cluster,omitempty"`
	ChannelAsset         *ChannelAsset          `json:"channel,omitempty"`
	KopsVersion          *string                `json:"kopsVersion,omitempty"`
	KubernetesVersion    *string                `json:"kubernetesVersion,omitempty"`
	ExecutableFileAsset  []*ExecutableFileAsset `json:"executableFileAssets,omitempty"`
	CompressedFileAssets []*CompressedFileAsset `json:"compressedFileAssets,omitempty"`
	ContainerAssets      []*ContainerAsset      `json:"containerAssets,omitempty"`
	HostAssets           []*HostAsset           `json:"hostAsset,omitempty"`
}
```

These API values allow for:

1. define custom base repository for all containers; k8s, protokube, dnscontroller
2. define custom base web location for all binaries; k8s, nodeup, etc
3. `kops inventory get` displays current inventory of cluster

Another PR will come in after this PR which provides `kops inventory create`.  Uploads all items generated by `kops get inventory`.

Design Notes:

1. Choose to add an inventory API struct value to create an interface for outputting inventory data.  Was able to use API machinery to marshall and unmarshal the structs automatically.  Customers will want to use the inventory data to track security issues from external screening systems.
2. apply_cluster.go requires an ssh key in the keystore in s3 to run.  We need to run `kops get inventory` and `kops create inventory` before a cluster exists.  I created a dummy key and then delete it in S3.  Any ideas on how to work around this would be appreciated.
3. apply_inventory.go iterates through the tasks and only selects the correct addons by version.  We could not use the regular apply_cluster.go task iterations because addons are not rendered, and k8s versions are not parsed.
4. Created a new apply_cluster target inventory, because the dry run target outputs to STDOUT.  With `kops get inventory -o yaml` this did not function correctly.


**TODO List**

- [x] Back out Makefile changes
- [x] Test ENV variables
- [x] Test a couple more assets
- [x] Test upload assets
- [x] Clean-up output on `kops get inventory -o table`
- [x] Back out `kops create inventory`
- [x] Testing testing and more testing
- [x] Some more unit tests (that or file an issue for them) https://github.com/kubernetes/kops/issues/2713
- [x] Code level documentation
- [x] File issue about validation
- [x] Put back dnscontroller rendering
- [x] ~~Document how to use assets~~ Going to put in another PR for this.  @robertojrojas is submitted the PR with the upload code, so we need this PR merged, then that PR, and then the docs.
- [X] File issues about current CVEs - since we now have that data https://github.com/kubernetes/kops/issues/2658
- [X] File issue about apply_cluster.go needing a ssh key https://github.com/kubernetes/kops/issues/2659

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2573)
<!-- Reviewable:end -->
