### PR TITLE
Added kops get for all elements in a cluster

### DIFF
--- a/cmd/kops/get.go
+++ b/cmd/kops/get.go
@@ -56,7 +56,8 @@ var (
 )
 
 type GetOptions struct {
-	output string
+	output      string
+	clusterName string
 }
 
 const (


### PR DESCRIPTION
This work is based on https://github.com/kubernetes/kops/pull/2311, the PR provides the capability to do `kops get --name my-cluster.com -o yaml`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2592)
<!-- Reviewable:end -->
