### PR TITLE
update to latest version of calico release

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.6.yaml.template
@@ -83,7 +83,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v1.1.3
+          image: calico/node:v1.2.1
           resources:
             requests:
               cpu: 10m
@@ -122,7 +122,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v1.8.0
+          image: calico/cni:v1.8.3
           resources:
             requests:
               cpu: 10m
@@ -198,7 +198,7 @@ spec:
         operator: Exists
       containers:
         - name: calico-policy-controller
-          image: calico/kube-policy-controller:v0.5.4
+          image: calico/kube-policy-controller:v0.6.0
           resources:
             requests:
               cpu: 10m
@@ -249,7 +249,7 @@ spec:
       containers:
         # Writes basic configuration to datastore.
         - name: configure-calico
-          image: calico/ctl:v1.1.3
+          image: calico/ctl:v1.2.1
           args:
           - apply
           - -f


### PR DESCRIPTION
Update to the latest release of the calico containers used. see #2589

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2595)
<!-- Reviewable:end -->
