### PR TITLE
Add bastion creation doc

### DIFF
--- a/docs/bastion.md
+++ b/docs/bastion.md
@@ -15,6 +15,11 @@ To enable a bastion instance group, a user will need to set the `--bastion` flag
 kops create cluster --topology private --networking $provider --bastion $NAME
 ```
 
+To add a bastion instance group to a pre-existing cluster, create a new instance group with the `--role Bastion` flag and one or more subnets (e.g. `utility-us-east-2a,utility-us-east-2b`). 
+```yaml
+kops create instancegroup --role Bastion --subnet $SUBNET
+```
+
 ### Configure the bastion instance group
 
 You can edit the bastion instance group to make changes. By default the name of the bastion instance group will be `bastions` and you can specify the name of the cluster with `--name` as in:


### PR DESCRIPTION
Originally I was confused why you could only add a bastion server at cluster creation but then I figured you could just create a new instance group with role Bastion. I figured this could be helpful for others.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2607)
<!-- Reviewable:end -->
