### PR TITLE
tweak to log level

### DIFF
--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -87,7 +87,7 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 	// We disable the insecure port from 1.6 onwards
 	if b.IsKubernetesGTE("1.6") {
 		c.InsecurePort = 0
-		glog.Warning("Enabling apiserver insecure port, for healthchecks (issue #43784)")
+		glog.V(4).Infof("Enabling apiserver insecure port, for healthchecks (issue #43784)")
 		c.InsecurePort = 8080
 	} else {
 		c.InsecurePort = 8080


### PR DESCRIPTION
This API log warning really is not a warning for a user and could be confusing.  It frankly is just annoying.  Lowering level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2611)
<!-- Reviewable:end -->
