### PR TITLE
create -f now does --yes

### DIFF
--- a/cmd/kops/get_instancegroups.go
+++ b/cmd/kops/get_instancegroups.go
@@ -87,7 +87,7 @@ func RunGetInstanceGroups(options *GetInstanceGroupsOptions, args []string) erro
 
 	cluster, err := clientset.GetCluster(clusterName)
 	if err != nil {
-		return fmt.Errorf("error fetching cluster %q: %v", cluster, err)
+		return fmt.Errorf("error fetching cluster %q: %v", clusterName, err)
 	}
 
 	list, err := clientset.InstanceGroupsFor(cluster).List(metav1.ListOptions{})

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -101,11 +101,11 @@ func NewCmdUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&options.Yes, "yes", options.Yes, "Actually create cloud resources")
-	cmd.Flags().StringVar(&options.Target, "target", options.Target, "Target - direct, terraform, cloudformation")
-	cmd.Flags().StringVar(&options.Models, "model", options.Models, "Models to apply (separate multiple models with commas)")
-	cmd.Flags().StringVar(&options.SSHPublicKey, "ssh-public-key", options.SSHPublicKey, "SSH public key to use (deprecated: use kops create secret instead)")
-	cmd.Flags().StringVar(&options.OutDir, "out", options.OutDir, "Path to write any local output")
+	cmd.Flags().BoolVarP(&options.Yes, "yes", "y", options.Yes, "Actually create cloud resources")
+	cmd.Flags().StringVarP(&options.Target, "target", "t", options.Target, "Target - direct, terraform, cloudformation")
+	cmd.Flags().StringVarP(&options.Models, "model", "m", options.Models, "Models to apply (separate multiple models with commas)")
+	cmd.Flags().StringVarP(&options.SSHPublicKey, "ssh-public-key", "i", options.SSHPublicKey, "SSH public key to use (deprecated: use kops create secret instead)")
+	cmd.Flags().StringVarP(&options.OutDir, "out", "o", options.OutDir, "Path to write any local output")
 	cmd.Flags().BoolVar(&options.CreateKubecfg, "create-kube-config", options.CreateKubecfg, "Will control automatically creating the kube config file on your local filesystem")
 	return cmd
 }
@@ -126,15 +126,7 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 		targetName = cloudup.TargetDryRun
 	}
 
-	if c.OutDir == "" {
-		if c.Target == cloudup.TargetTerraform {
-			c.OutDir = "out/terraform"
-		} else if c.Target == cloudup.TargetCloudformation {
-			c.OutDir = "out/cloudformation"
-		} else {
-			c.OutDir = "out"
-		}
-	}
+	c.OutDir = setOutDir(c.OutDir, c.Target)
 
 	cluster, err := GetCluster(f, clusterName)
 	if err != nil {

--- a/docs/cli/kops_create.md
+++ b/docs/cli/kops_create.md
@@ -21,8 +21,16 @@ kops create -f FILENAME
 ### Examples
 
 ```
-  # Create a cluster using a cluser spec file
+  # Create a cluster using a cluster spec file.
+  # The cluster will not be fully created until "kops update" is executed.
   kops create -f my-cluster.yaml
+  
+  # Immediately create a cluster using a cluster spec file.
+  kops create -y -f my-cluster.yaml
+  
+  # Create a cluster using a cluster spec file .
+  # Create terraform files for cluster and use a specific ssh key
+  kops create -y -f my-cluster.yaml -i ~/.ssh/mykey.pub -o myfolder -t terraform
   
   # Create a cluster in AWS
   kops create cluster --name=kubernetes-cluster.example.com \
@@ -42,7 +50,12 @@ kops create -f FILENAME
 ### Options
 
 ```
-  -f, --filename stringSlice   Filename to use to create the resource
+  -f, --filename stringSlice    Filename to use to create the resource
+  -m, --model string            Models to apply (separate multiple models with commas) (default "config,proto,cloudup")
+  -o, --out string              Path to write any local output
+  -i, --ssh-public-key string   SSH public key to use (default "~/.ssh/id_rsa.pub")
+  -t, --target string           Target - direct, terraform, cloudformation (default "direct")
+  -y, --yes                     Specify --yes to immediately create the cluster
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -24,11 +24,11 @@ kops update cluster
 
 ```
       --create-kube-config      Will control automatically creating the kube config file on your local filesystem (default true)
-      --model string            Models to apply (separate multiple models with commas) (default "config,proto,cloudup")
-      --out string              Path to write any local output
-      --ssh-public-key string   SSH public key to use (deprecated: use kops create secret instead)
-      --target string           Target - direct, terraform, cloudformation (default "direct")
-      --yes                     Actually create cloud resources
+  -m, --model string            Models to apply (separate multiple models with commas) (default "config,proto,cloudup")
+  -o, --out string              Path to write any local output
+  -i, --ssh-public-key string   SSH public key to use (deprecated: use kops create secret instead)
+  -t, --target string           Target - direct, terraform, cloudformation (default "direct")
+  -y, --yes                     Actually create cloud resources
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kops/issues/1995 

User is able to now set target, ssh key, output dir, and yes with `kops create -f`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2612)
<!-- Reviewable:end -->
