### PR TITLE
Make Weave MTU configurable and configure jumbo frame support for new clusters on AWS

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -101,6 +101,19 @@ Daemonset installation for K8s 1.4.x or 1.5.x.
 $ kubectl create -f https://git.io/weave-kube
 ```
 
+### Configuring Weave MTU
+
+The Weave MTU is configurable by editing the cluster and setting `mtu` option in the weave configuration.
+AWS VPCs support jumbo frames, so on cluster creation kops sets the weave MTU to 8912 bytes (9001 minus overhead).
+
+```
+spec:
+  networking:
+    weave:
+      mtu: 8912
+```
+
+
 ### Calico Example for CNI and Network Policy
 
 #### Installing Calico on a new Cluster

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -54,6 +54,7 @@ type KopeioNetworkingSpec struct {
 
 // Weave declares that we want Weave networking
 type WeaveNetworkingSpec struct {
+	MTU *int32 `json:"mtu,omitempty"`
 }
 
 // Flannel declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -54,6 +54,7 @@ type KopeioNetworkingSpec struct {
 
 // Weave declares that we want Weave networking
 type WeaveNetworkingSpec struct {
+	MTU *int32 `json:"mtu,omitempty"`
 }
 
 // Flannel declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1765,6 +1765,7 @@ func Convert_kops_RBACAuthorizationSpec_To_v1alpha1_RBACAuthorizationSpec(in *ko
 }
 
 func autoConvert_v1alpha1_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveNetworkingSpec, out *kops.WeaveNetworkingSpec, s conversion.Scope) error {
+	out.MTU = in.MTU
 	return nil
 }
 
@@ -1773,6 +1774,7 @@ func Convert_v1alpha1_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveN
 }
 
 func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha1_WeaveNetworkingSpec(in *kops.WeaveNetworkingSpec, out *WeaveNetworkingSpec, s conversion.Scope) error {
+	out.MTU = in.MTU
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -54,6 +54,7 @@ type KopeioNetworkingSpec struct {
 
 // Weave declares that we want Weave networking
 type WeaveNetworkingSpec struct {
+	MTU *int32 `json:"mtu,omitempty"`
 }
 
 // Flannel declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1919,6 +1919,7 @@ func Convert_kops_TopologySpec_To_v1alpha2_TopologySpec(in *kops.TopologySpec, o
 }
 
 func autoConvert_v1alpha2_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveNetworkingSpec, out *kops.WeaveNetworkingSpec, s conversion.Scope) error {
+	out.MTU = in.MTU
 	return nil
 }
 
@@ -1927,6 +1928,7 @@ func Convert_v1alpha2_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveN
 }
 
 func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha2_WeaveNetworkingSpec(in *kops.WeaveNetworkingSpec, out *WeaveNetworkingSpec, s conversion.Scope) error {
+	out.MTU = in.MTU
 	return nil
 }
 

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
@@ -97,6 +97,11 @@ spec:
             limits:
               cpu: 100m
               memory: 200Mi
+          {{if .Networking.Weave.MTU }}
+          env:
+            - name: WEAVE_MTU
+              value: "{{ .Networking.Weave.MTU }}"
+          {{end}}
         - name: weave-npc
           image: weaveworks/weave-npc:1.9.4
           resources:

--- a/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
@@ -58,6 +58,11 @@ spec:
             limits:
               cpu: 100m
               memory: 200Mi
+          {{if .Networking.Weave.MTU }}
+          env:
+            - name: WEAVE_MTU
+              value: "{{ .Networking.Weave.MTU }}"
+          {{end}}
         - name: weave-npc
           image: weaveworks/weave-npc:1.9.4
           resources:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -241,7 +241,9 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Weave != nil {
 		key := "networking.weave"
-		version := "1.9.4"
+
+		// 1.9.5-kops.1 = 1.9.4 with WEAVE_MTU configured
+		version := "1.9.5-kops.1"
 
 		{
 			location := key + "/pre-k8s-1.6.yaml"


### PR DESCRIPTION
Pull request for #2600 to make MTU configurable and to set a good default value.

From the discussion in #1171 it looks like nonMasqueradeCIDR is meant for the overlay CIDR, so I added that to the configuration as well.

New config looks like:

```
spec:
  networking:
    weave:
      mtu: 8912
```

I tested the following scenarios with this change:
- Editing an existing cluster and adding `mtu: 8912`, then running update cluster. The ManagedFile for weave was updated as expected, however I am not sure what the process would be to actually get the settings rolled out.
- Creating a new cluster with command line flags (it sets `mtu: 8912` as expected)
- Creating a new cluster with `kops create -f mycluster.yml` based on https://github.com/kubernetes/kops/blob/master/tests/integration/privateweave/in-v1alpha2.yaml with minor edits

Todo:
- Update docs

Let me know if there's anything else I need to do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2613)
<!-- Reviewable:end -->
