### PR TITLE
Alias replace -> apply and add deprecation notice to replace

### DIFF
--- a/cmd/kops/apply.go
+++ b/cmd/kops/apply.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+	"k8s.io/kops/cmd/kops/util"
+
+	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/util/i18n"
+)
+
+var (
+	apply_long = templates.LongDesc(i18n.T(`
+		Apply a cluster resource specification by filename or stdin.`))
+
+	apply_example = templates.Examples(i18n.T(`
+		# Apply a cluster resource specification using a file.
+		kops apply -f my-cluster.yaml
+		`))
+
+	apply_short = i18n.T(`Apply a cluster resource specification.`)
+)
+
+func NewCmdApply(f *util.Factory, out io.Writer) *cobra.Command {
+	options := &ReplaceOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "apply -f FILENAME",
+		Short:   apply_short,
+		Long:    apply_long,
+		Example: apply_example,
+		Run: func(cmd *cobra.Command, args []string) {
+			if cmdutil.IsFilenameEmpty(options.Filenames) {
+				cmd.Help()
+				return
+			}
+
+			cmdutil.CheckErr(RunReplace(f, cmd, out, options))
+		},
+	}
+
+	ConfigureReplaceCmd(cmd, options)
+
+	return cmd
+}

--- a/cmd/kops/replace.go
+++ b/cmd/kops/replace.go
@@ -36,9 +36,12 @@ import (
 
 var (
 	replace_long = templates.LongDesc(i18n.T(`
-		Replace a resource specification by filename or stdin.`))
+		DEPRECATED - Replace a resource specification by filename or stdin.`))
 
 	replace_example = templates.Examples(i18n.T(`
+		# THIS COMMAND HAS BEEN DEPRECATED.
+		# Please use kops apply instead.
+		
 		# Replace a cluster specification using a file
 		kops replace -f my-cluster.yaml
 		`))
@@ -54,7 +57,7 @@ func NewCmdReplace(f *util.Factory, out io.Writer) *cobra.Command {
 	options := &ReplaceOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "replace -f FILENAME",
+		Use:     "replace -f FILENAME (DEPRECATED in favor of apply)",
 		Short:   replace_short,
 		Long:    replace_long,
 		Example: replace_example,
@@ -68,10 +71,15 @@ func NewCmdReplace(f *util.Factory, out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVarP(&options.Filenames, "filename", "f", options.Filenames, "A list of one or more files separated by a comma.")
-	cmd.MarkFlagRequired("filename")
+	ConfigureReplaceCmd(cmd, options)
 
 	return cmd
+}
+
+func ConfigureReplaceCmd(cmd *cobra.Command, options *ReplaceOptions) {
+	// Shared with the apply command
+	cmd.Flags().StringSliceVarP(&options.Filenames, "filename", "f", options.Filenames, "A list of one or more files separated by a comma.")
+	cmd.MarkFlagRequired("filename")
 }
 
 func RunReplace(f *util.Factory, cmd *cobra.Command, out io.Writer, c *ReplaceOptions) error {

--- a/docs/cli/kops_replace.md
+++ b/docs/cli/kops_replace.md
@@ -5,15 +5,18 @@ Replace cluster resources.
 ### Synopsis
 
 
-Replace a resource specification by filename or stdin.
+DEPRECATED - Replace a resource specification by filename or stdin.
 
 ```
-kops replace -f FILENAME
+kops replace -f FILENAME (DEPRECATED in favor of apply)
 ```
 
 ### Examples
 
 ```
+  # THIS COMMAND HAS BEEN DEPRECATED.
+  # Please use kops apply instead.
+  
   # Replace a cluster specification using a file
   kops replace -f my-cluster.yaml
 ```


### PR DESCRIPTION
[As discussed here.](https://github.com/kubernetes/kops/issues/2603#issuecomment-302885788)

The idea is to rename the `replace` command to `apply`, to closer match `kubectl` and lower mental overhead.

I implemented an alias to the `replace` command and marked the `replace` command as deprecated in the CLI help and docs. I don't expect this PR to pass without any discussion, I'm just hoping this PR will speed up and focus the discussion.

(It also includes a bit of documentation that was in `master` but had not been generated, I don't quite understand how that got through CI.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2618)
<!-- Reviewable:end -->
