### PR TITLE
New algorithms for rolling-update pre and mid create of instance groups

### DIFF
--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -37,42 +37,64 @@ import (
 	"k8s.io/kops/util/pkg/tables"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	"k8s.io/kubernetes/pkg/util/i18n"
+	"strings"
 )
 
 var (
 	rollingupdate_long = templates.LongDesc(i18n.T(`
-	This command updates a kubernetes cluster to match the cloud, and kops specifications.
+	This command updates a Kubernetes cluster to match the cloud, and kops specifications.
 
-	To perform rolling update, you need to update the cloud resources first with "kops update cluster"
-
-	Note: terraform users will need run the following commands all from the same directory "kops update cluster --target=terraform" then "terraform plan" then "terraform apply"
-	prior to running "kops rolling-update cluster"
+	The Examples below include a series of command for Terraform users.  The workflow includes
+	using Terraform.
 
 	Use export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate" to use beta code that drains the nodes
 	and validates the cluster.  New flags for Drain and Validation operations will be shown when
-	the environment variable is set.`))
+	the environment variable is set.
+
+	Node Replacement Algorithm Alpa Feature
+
+	We are now including three new algorithms that influence node replacement. All masters and bastions
+	are rolled sequentially before the nodes, and this flag does not influence their replacement.  These
+	algorithms utilize the feature flag mentioned above.
+
+	1. "asg" - A node is drained then deleted.  The cloud then replaces the node automatically. (default)
+	2. "pre-create" - All node instance groups are duplicated first; then all old nodes are cordoned.
+	3. "create" - As each node instance group rolls, the instance group is duplicated, then all
+	old nodes are cordoned.
+
+	The second and third options create new instance groups; next, the old nodes are cardoned.
+	The old nodes are drained, and then the instance group(s) is deleted.
+	`))
 
 	rollingupdate_example = templates.Examples(i18n.T(`
+
 		# Roll the currently selected kops cluster
 		kops rolling-update cluster --yes
 
-		# Roll the k8s-cluster.example.com kops cluster
-		# use the new drain an validate functionality
+	        # Update instructions for Terraform users
+	 	kops update cluster --target=terraform
+	 	terraform plan
+	 	terraform apply
+		kops rolling-update cluster --yes
+
+		# Roll the k8s-cluster.example.com kops cluster and use the new drain an validate functionality
 		export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate"
 		kops rolling-update cluster k8s-cluster.example.com --yes \
 		  --fail-on-validate-error="false" \
 		  --master-interval=8m \
 		  --node-interval=8m
 
-
-		# Roll the k8s-cluster.example.com kops cluster
-		# only roll the node instancegroup
-		# use the new drain an validate functionality
+		# Use the pre-create node algorithm. First all new nodes are created
+		# The old nodes are cordon, drained and deleted.
 		export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate"
+		kops rolling-update cluster k8s-cluster.example.com --yes \
+		  --algorithm pre-create
+
+		# Roll the k8s-cluster.example.com kops cluster, and only roll the instancegroup named "foo".
 		kops rolling-update cluster k8s-cluster.example.com --yes \
 		  --fail-on-validate-error="false" \
 		  --node-interval 8m \
-		  --instance-group nodes
+		  --instance-group foo
 		`))
 
 	rollingupdate_short = i18n.T(`Rolling update a cluster.`)
@@ -107,6 +129,8 @@ type RollingUpdateOptions struct {
 	// InstanceGroups is the list of instance groups to rolling-update;
 	// if not specified all instance groups will be updated
 	InstanceGroups []string
+
+	Algorithm string
 }
 
 func (o *RollingUpdateOptions) InitDefaults() {
@@ -123,6 +147,7 @@ func (o *RollingUpdateOptions) InitDefaults() {
 	o.ValidateRetries = 8
 
 	o.DrainInterval = 90 * time.Second
+	o.Algorithm = kutil.ASG_CREATE
 
 }
 
@@ -138,8 +163,8 @@ func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 		Example: rollingupdate_example,
 	}
 
-	cmd.Flags().BoolVar(&options.Yes, "yes", options.Yes, "perform rolling update without confirmation")
-	cmd.Flags().BoolVar(&options.Force, "force", options.Force, "Force rolling update, even if no changes")
+	cmd.Flags().BoolVarP(&options.Yes, "yes", "y", options.Yes, "perform rolling update without confirmation")
+	cmd.Flags().BoolVarP(&options.Force, "force", "f", options.Force, "Force rolling update, even if no changes")
 	cmd.Flags().BoolVar(&options.CloudOnly, "cloudonly", options.CloudOnly, "Perform rolling update without confirming progress with k8s")
 
 	cmd.Flags().DurationVar(&options.MasterInterval, "master-interval", options.MasterInterval, "Time to wait between restarting masters")
@@ -150,8 +175,9 @@ func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	if featureflag.DrainAndValidateRollingUpdate.Enabled() {
 		cmd.Flags().BoolVar(&options.FailOnDrainError, "fail-on-drain-error", true, "The rolling-update will fail if draining a node fails.")
 		cmd.Flags().BoolVar(&options.FailOnValidate, "fail-on-validate-error", true, "The rolling-update will fail if the cluster fails to validate.")
-		cmd.Flags().IntVar(&options.ValidateRetries, "validate-retries", options.ValidateRetries, "The number of times that a node will be validated.  Between validation kops sleeps the master-interval/2 or node-interval/2 duration.")
+		cmd.Flags().IntVar(&options.ValidateRetries, "validate-retries", options.ValidateRetries, "The number of times that a node will be validated.  Validation will sleep the master-interval/2 or node-interval/2 duration.")
 		cmd.Flags().DurationVar(&options.DrainInterval, "drain-interval", options.DrainInterval, "The duration that a rolling-update will wait after the node is drained.")
+		cmd.Flags().StringVarP(&options.Algorithm, "algorithm", "a", options.Algorithm, "When new nodes are created. Supported: "+strings.Join(kutil.AlgorithmTypes.List(), ", ")+".")
 	}
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
@@ -202,6 +228,13 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 
 	if options.ValidateRetries <= 0 {
 		return fmt.Errorf("validate-retries flag cannot be 0 or smaller")
+	}
+
+	if featureflag.DrainAndValidateRollingUpdate.Enabled() {
+		if !kutil.AlgorithmTypes.Has(options.Algorithm) {
+			return fmt.Errorf("Algorithm: %q not known, please use one of: %q", options.Algorithm,
+				strings.Join(kutil.AlgorithmTypes.List(), ", "))
+		}
 	}
 
 	var nodes []v1.Node
@@ -337,8 +370,10 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 	}
 
 	if featureflag.DrainAndValidateRollingUpdate.Enabled() {
-		glog.V(2).Infof("New rolling update with drain and validate enabled.")
+		glog.V(2).Infof("Executing new rolling update with drain and validate enabled.")
+		glog.V(2).Infof("Using %s algorithm to create new nodes.", options.Algorithm)
 	}
+
 	d := &kutil.RollingUpdateCluster{
 		MasterInterval:   options.MasterInterval,
 		NodeInterval:     options.NodeInterval,
@@ -352,6 +387,8 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 		ClusterName:      options.ClusterName,
 		ValidateRetries:  options.ValidateRetries,
 		DrainInterval:    options.DrainInterval,
+		Clientset:        clientset,
+		Algorithm:        options.Algorithm,
 	}
 	return d.RollingUpdate(groups, list)
 }

--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 	"time"
 
+	"strings"
+
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,7 +39,6 @@ import (
 	"k8s.io/kops/util/pkg/tables"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	"k8s.io/kubernetes/pkg/util/i18n"
-	"strings"
 )
 
 var (
@@ -218,6 +219,10 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 		return err
 	}
 
+	if cluster == nil {
+		return fmt.Errorf("Cluster is not set")
+	}
+
 	contextName := cluster.ObjectMeta.Name
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		clientcmd.NewDefaultClientConfigLoadingRules(),
@@ -389,6 +394,7 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 		DrainInterval:    options.DrainInterval,
 		Clientset:        clientset,
 		Algorithm:        options.Algorithm,
+		Cluster:          cluster,
 	}
 	return d.RollingUpdate(groups, list)
 }

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -5,13 +5,21 @@ Rolling update a cluster.
 ### Synopsis
 
 
-This command updates a kubernetes cluster to match the cloud, and kops specifications. 
+This command updates a Kubernetes cluster to match the cloud, and kops specifications. 
 
-To perform rolling update, you need to update the cloud resources first with "kops update cluster" 
+The Examples below include a series of command for Terraform users.  The workflow includes using Terraform. 
 
-Note: terraform users will need run the following commands all from the same directory "kops update cluster --target=terraform" then "terraform plan" then "terraform apply" prior to running "kops rolling-update cluster" 
+Use export KOPS FEATURE FLAGS="+DrainAndValidateRollingUpdate" to use beta code that drains the nodes and validates the cluster.  New flags for Drain and Validation operations will be shown when the environment variable is set. 
 
-Use export KOPS FEATURE FLAGS="+DrainAndValidateRollingUpdate" to use beta code that drains the nodes and validates the cluster.  New flags for Drain and Validation operations will be shown when the environment variable is set.
+Node Replacement Algorithm Alpa Feature 
+
+We are now including three new algorithms that influence node replacement. All masters and bastions are rolled sequentially before the nodes, and this flag does not influence their replacement.  These algorithms utilize the feature flag mentioned above. 
+
+  1. "asg" - A node is drained then deleted.  The cloud then replaces the node automatically. (default)  
+  2. "pre-create" - All node instance groups are duplicated first; then all old nodes are cordoned.  
+  3. "create" - As each node instance group rolls, the instance group is duplicated, then all old nodes are cordoned.  
+
+The second and third options create new instance groups; next, the old nodes are cardoned. The old nodes are drained, and then the instance group(s) is deleted.
 
 ```
 kops rolling-update cluster
@@ -23,35 +31,47 @@ kops rolling-update cluster
   # Roll the currently selected kops cluster
   kops rolling-update cluster --yes
   
-  # Roll the k8s-cluster.example.com kops cluster
-  # use the new drain an validate functionality
+  # Update instructions for Terraform users
+  kops update cluster --target=terraform
+  terraform plan
+  terraform apply
+  kops rolling-update cluster --yes
+  
+  # Roll the k8s-cluster.example.com kops cluster and use the new drain an validate functionality
   export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate"
   kops rolling-update cluster k8s-cluster.example.com --yes \
   --fail-on-validate-error="false" \
   --master-interval=8m \
   --node-interval=8m
   
-  
-  # Roll the k8s-cluster.example.com kops cluster
-  # only roll the node instancegroup
-  # use the new drain an validate functionality
+  # Use the pre-create node algorithm. First all new nodes are created
+  # The old nodes are cordon, drained and deleted.
   export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate"
+  kops rolling-update cluster k8s-cluster.example.com --yes \
+  --algorithm pre-create
+  
+  # Roll the k8s-cluster.example.com kops cluster, and only roll the instancegroup named "foo".
   kops rolling-update cluster k8s-cluster.example.com --yes \
   --fail-on-validate-error="false" \
   --node-interval 8m \
-  --instance-group nodes
+  --instance-group foo
 ```
 
 ### Options
 
 ```
+  -a, --algorithm string             When new nodes are created. Supported: asg, create, pre-create. (default "asg")
       --bastion-interval duration    Time to wait between restarting bastions (default 5m0s)
       --cloudonly                    Perform rolling update without confirming progress with k8s
-      --force                        Force rolling update, even if no changes
+      --drain-interval duration      The duration that a rolling-update will wait after the node is drained. (default 1m30s)
+      --fail-on-drain-error          The rolling-update will fail if draining a node fails. (default true)
+      --fail-on-validate-error       The rolling-update will fail if the cluster fails to validate. (default true)
+  -f, --force                        Force rolling update, even if no changes
       --instance-group stringSlice   List of instance groups to update (defaults to all if not specified)
       --master-interval duration     Time to wait between restarting masters (default 5m0s)
       --node-interval duration       Time to wait between restarting nodes (default 2m0s)
-      --yes                          perform rolling update without confirmation
+      --validate-retries int         The number of times that a node will be validated.  Validation will sleep the master-interval/2 or node-interval/2 duration. (default 8)
+  -y, --yes                          perform rolling update without confirmation
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -60,17 +60,12 @@ kops rolling-update cluster
 ### Options
 
 ```
-  -a, --algorithm string             When new nodes are created. Supported: asg, create, pre-create. (default "asg")
       --bastion-interval duration    Time to wait between restarting bastions (default 5m0s)
       --cloudonly                    Perform rolling update without confirming progress with k8s
-      --drain-interval duration      The duration that a rolling-update will wait after the node is drained. (default 1m30s)
-      --fail-on-drain-error          The rolling-update will fail if draining a node fails. (default true)
-      --fail-on-validate-error       The rolling-update will fail if the cluster fails to validate. (default true)
   -f, --force                        Force rolling update, even if no changes
       --instance-group stringSlice   List of instance groups to update (defaults to all if not specified)
       --master-interval duration     Time to wait between restarting masters (default 5m0s)
       --node-interval duration       Time to wait between restarting nodes (default 2m0s)
-      --validate-retries int         The number of times that a node will be validated.  Validation will sleep the master-interval/2 or node-interval/2 duration. (default 8)
   -y, --yes                          perform rolling update without confirmation
 ```
 

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -103,11 +103,18 @@ type ApplyClusterCmd struct {
 }
 
 func (c *ApplyClusterCmd) Run() error {
+	if c.Cluster == nil {
+		return fmt.Errorf("cluster cannot be nil")
+	}
+
 	if c.MaxTaskDuration == 0 {
 		c.MaxTaskDuration = DefaultMaxTaskDuration
 	}
 
 	if c.InstanceGroups == nil {
+		if c.Cluster.ObjectMeta.Name == "" {
+			return fmt.Errorf("cluster name must be set")
+		}
 		list, err := c.Clientset.InstanceGroups(c.Cluster.ObjectMeta.Name).List(metav1.ListOptions{})
 		if err != nil {
 			return err

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -24,6 +24,7 @@ import (
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/apis/kops/validation"
+	"k8s.io/kops/pkg/client/simple"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/utils"
@@ -257,4 +258,18 @@ func defaultImage(cluster *api.Cluster, channel *api.Channel) string {
 	}
 	glog.Infof("Cannot set default Image for CloudProvider=%q", cluster.Spec.CloudProvider)
 	return ""
+}
+
+// CreateInstanceGroup validates and creates a new instance group.
+func CreateInstanceGroup(ig *api.InstanceGroup, clusterName string, clientset simple.Clientset) error {
+
+	if err := validation.ValidateInstanceGroup(ig); err != nil {
+		return fmt.Errorf("error validating InstanceGroup: %v", err)
+	}
+
+	if _, err := clientset.InstanceGroups(clusterName).Create(ig); err != nil {
+		return fmt.Errorf("error storing InstanceGroup: %v", err)
+	}
+
+	return nil
 }

--- a/upup/pkg/kutil/delete_instancegroup.go
+++ b/upup/pkg/kutil/delete_instancegroup.go
@@ -32,6 +32,8 @@ type DeleteInstanceGroup struct {
 }
 
 func (c *DeleteInstanceGroup) DeleteInstanceGroup(group *api.InstanceGroup) error {
+
+	// TODO we should thing about draining :)
 	groups, err := FindCloudInstanceGroups(c.Cloud, c.Cluster, []*api.InstanceGroup{group}, false, nil)
 	cig := groups[group.ObjectMeta.Name]
 	if cig == nil {

--- a/upup/pkg/kutil/rollingupdate_cluster.go
+++ b/upup/pkg/kutil/rollingupdate_cluster.go
@@ -21,22 +21,36 @@ import (
 	"sync"
 	"time"
 
+	"os"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	api "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/client/simple"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/validation"
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kubernetes/pkg/kubectl/cmd"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	"os"
 )
+
+const (
+	PRE_CREATE = "pre-create"
+	CREATE     = "create"
+	ASG_CREATE = "asg" // TODO what is a better more cloud generic term?
+)
+
+var AlgorithmTypes = sets.NewString(PRE_CREATE, CREATE, ASG_CREATE)
 
 // RollingUpdateCluster is a struct containing cluster information for a rolling update.
 type RollingUpdateCluster struct {
@@ -52,18 +66,22 @@ type RollingUpdateCluster struct {
 	ClientConfig     clientcmd.ClientConfig
 	FailOnDrainError bool
 	FailOnValidate   bool
+	Algorithm        string
 	CloudOnly        bool
 	ClusterName      string
 	ValidateRetries  int
 	DrainInterval    time.Duration
+
+	Cluster   *api.Cluster
+	Clientset simple.Clientset
 }
 
 // FindCloudInstanceGroups joins data from the cloud and the instance groups into a map that can be used for updates.
 func FindCloudInstanceGroups(cloud fi.Cloud, cluster *api.Cluster, instancegroups []*api.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*CloudInstanceGroup, error) {
+
 	awsCloud := cloud.(awsup.AWSCloud)
 
 	groups := make(map[string]*CloudInstanceGroup)
-
 	tags := awsCloud.Tags()
 
 	asgs, err := findAutoscalingGroups(awsCloud, tags)
@@ -165,6 +183,7 @@ func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*CloudInstanceGro
 		wg.Wait()
 	}
 
+	// TODO do we need a go func() here?
 	// Upgrade master next
 	{
 		var wg sync.WaitGroup
@@ -197,8 +216,11 @@ func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*CloudInstanceGro
 		wg.Wait()
 	}
 
-	// Upgrade nodes, with greater parallelism
-	{
+	// TODO - Do we want a WaitGroup on this?  I am not sure why we have wait groups and
+	// TODO - go func() here?
+	if c.Algorithm == PRE_CREATE && featureflag.DrainAndValidateRollingUpdate.Enabled() {
+		return c.RollingUpdateNodesPreCreate(nodeGroups)
+	} else {
 		var wg sync.WaitGroup
 
 		// We run nodes in series, even if they are in separate instance groups
@@ -217,9 +239,13 @@ func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*CloudInstanceGro
 			}
 
 			defer wg.Done()
-
 			for k, group := range nodeGroups {
-				err := group.RollingUpdate(c, instanceGroups, false, c.NodeInterval)
+				var err error
+				if c.Algorithm == CREATE && featureflag.DrainAndValidateRollingUpdate.Enabled() {
+					err = c.RollingUpdateNodesCreate(group)
+				} else {
+					err = group.RollingUpdate(c, instanceGroups, false, c.NodeInterval)
+				}
 
 				resultsMutex.Lock()
 				results[k] = err
@@ -230,11 +256,11 @@ func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*CloudInstanceGro
 		}()
 
 		wg.Wait()
-	}
 
-	for _, err := range results {
-		if err != nil {
-			return err
+		for _, err := range results {
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -300,9 +326,167 @@ func buildCloudInstanceGroup(ig *api.InstanceGroup, g *autoscaling.Group, nodeMa
 	return n
 }
 
-// TODO: Temporarily increase size of ASG?
-// TODO: Remove from ASG first so status is immediately updated?
-// TODO: Batch termination, like a rolling-update
+func (c *RollingUpdateCluster) updateCluster() error {
+	applyCmd := &cloudup.ApplyClusterCmd{
+		Cluster:         c.Cluster,
+		Models:          nil,
+		Clientset:       c.Clientset,
+		TargetName:      cloudup.TargetDirect,
+		OutDir:          ".",
+		DryRun:          false,
+		MaxTaskDuration: cloudup.DefaultMaxTaskDuration,
+		InstanceGroups:  nil,
+	}
+
+	if err := applyCmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RollingUpdateNodesPreCreate iterates throw each instance group.  First a new instance groups is created
+// and the old nodes are cardoned.  Next the old nodes are drained and the old instance groups is deleted.
+func (c *RollingUpdateCluster) RollingUpdateNodesCreate(group *CloudInstanceGroup) error {
+
+	// Figure out which CloudInstanceGroups need updating and create a new instancegroup for each
+	update := group.NeedUpdate
+	if c.Force {
+		update = append(update, group.Ready...)
+	}
+
+	if len(update) == 0 {
+		return nil
+	}
+
+	if _, err := c.createInstanceGroup(group.InstanceGroup, getSuffix()); err != nil {
+		return fmt.Errorf("unable to create new instance group: %v", err)
+	}
+
+	if err := c.updateCluster(); err != nil {
+		return fmt.Errorf("unable to update cluster: %v", err)
+	}
+
+	time.Sleep(c.NodeInterval)
+
+	// get the new list of ig and validate cluster
+	if err := c.getIGAndValidateCluster(); err != nil {
+		return fmt.Errorf("unable to validate cluster: %v", err)
+	}
+
+	if !c.CloudOnly {
+		// cardon the nodes
+		for _, u := range update {
+			if err := group.CardonNode(u, c); err != nil {
+				return fmt.Errorf("unable to cardon node: %v", err)
+			}
+		}
+	}
+
+	// Drain the nodes
+	// TODO move Drain code into delete code
+	if !c.CloudOnly {
+		for _, u := range update {
+			// TODO handle pod disruption budgets
+			if err := group.DrainNode(u, c, false); err != nil {
+				if c.FailOnDrainError {
+					return fmt.Errorf("Failed to drain node %q: %v", u.Node.Name, err)
+				}
+				glog.Infof("Ignoring error draining node %q: %v", u.Node.Name, err)
+			}
+
+		}
+	}
+
+	return c.deleteInstanceGroups(group)
+}
+
+// RollingUpdateNodesPreCreate create all new nodes instance group(s) then cardons all nodes.
+// Old nodes are then drained and the old instance group(s) is deleted.
+func (c *RollingUpdateCluster) RollingUpdateNodesPreCreate(nodeGroups map[string]*CloudInstanceGroup) error {
+
+	nodeGroupsUpdate := make([]*CloudInstanceGroup, 0)
+	instanceGroupsNew := make([]*api.InstanceGroup, 0)
+
+	// Figure out which CloudInstanceGroups need updating and create a new instancegroup for each
+	{
+		suffix := getSuffix()
+		for _, group := range nodeGroups {
+			update := group.NeedUpdate
+			if c.Force {
+				update = append(update, group.Ready...)
+			}
+
+			if len(update) == 0 {
+				return nil
+			}
+
+			ig, err := c.createInstanceGroup(group.InstanceGroup, suffix)
+			if err != nil {
+				return fmt.Errorf("unable to create instance group: %v", err)
+			}
+
+			nodeGroupsUpdate = append(nodeGroupsUpdate, group)
+			instanceGroupsNew = append(instanceGroupsNew, ig)
+			glog.Infof("Creating Replacement Instance Group, %q, based on Instance Group %q.", ig.Name, group.InstanceGroup.Name)
+		}
+	}
+
+	if err := c.updateCluster(); err != nil {
+		return fmt.Errorf("unable to update cluster: %v", err)
+	}
+
+	glog.Info("Waiting for new Instance Group(s) to start")
+	time.Sleep(c.NodeInterval)
+
+	// get the new list of ig and validate cluster
+	if err := c.getIGAndValidateCluster(); err != nil {
+		return fmt.Errorf("unable to validate cluster: %v", err)
+	}
+
+	if !c.CloudOnly {
+		// cardon the nodes
+		glog.Infof("Cordoning all nodes")
+		for _, group := range nodeGroupsUpdate {
+			for _, u := range group.NeedUpdate {
+				if err := group.CardonNode(u, c); err != nil {
+					return fmt.Errorf("unable to cardon node: %v", err)
+				}
+				glog.Infof("Cordoned %q", u.Node.Name)
+			}
+		}
+	}
+
+	for _, group := range nodeGroupsUpdate {
+
+		// Drain the nodes
+		// TODO move Drain code into delete code
+		if !c.CloudOnly {
+			for _, u := range group.NeedUpdate {
+				// TODO handle pod disruption budgets
+				if err := group.DrainNode(u, c, false); err != nil {
+					if c.FailOnDrainError {
+						return fmt.Errorf("Failed to drain node %q: %v", u.Node.Name, err)
+					}
+					glog.Infof("Ignoring error draining node %q: %v", u.Node.Name, err)
+					continue
+				}
+
+				glog.Infof("Drained node %q", u.Node.Name)
+			}
+		}
+
+		if err := c.deleteInstanceGroups(group); err != nil {
+			return err
+		}
+
+		glog.Infof("Deleted old Instance Group: %q", group.InstanceGroup.Name)
+	}
+
+	glog.Infof("Nodes rolling-update completed")
+
+	return nil
+}
 
 // RollingUpdate performs a rolling update on a list of ec2 instances.
 func (n *CloudInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpdateCluster, instanceGroupList *api.InstanceGroupList, isBastion bool, t time.Duration) (err error) {
@@ -340,10 +524,9 @@ func (n *CloudInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpdateClust
 		if err = n.ValidateCluster(rollingUpdateData, instanceGroupList); err != nil {
 			if rollingUpdateData.FailOnValidate {
 				return fmt.Errorf("error validating cluster: %v", err)
-			} else {
-				glog.V(2).Infof("Ignoring cluster validation error: %v", err)
-				glog.Infof("Cluster validation failed, but proceeding since fail-on-validate-error is set to false")
 			}
+			glog.V(2).Infof("Ignoring cluster validation error: %v", err)
+			glog.Infof("Cluster validation failed, but proceeding since fail-on-validate-error is set to false")
 		}
 	}
 
@@ -376,12 +559,11 @@ func (n *CloudInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpdateClust
 			if u.Node != nil {
 				glog.Infof("Draining the node: %q.", nodeName)
 
-				if err = n.DrainNode(u, rollingUpdateData); err != nil {
+				if err = n.DrainNode(u, rollingUpdateData, false); err != nil {
 					if rollingUpdateData.FailOnDrainError {
 						return fmt.Errorf("Failed to drain node %q: %v", nodeName, err)
-					} else {
-						glog.Infof("Ignoring error draining node %q: %v", nodeName, err)
 					}
+					glog.Infof("Ignoring error draining node %q: %v", nodeName, err)
 				}
 			} else {
 				glog.Warningf("Skipping drain of instance %q, because it is not registered in kubernetes", instanceId)
@@ -405,13 +587,8 @@ func (n *CloudInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpdateClust
 
 			glog.Infof("Validating the cluster.")
 
-			if err = n.ValidateClusterWithRetries(rollingUpdateData, instanceGroupList, t); err != nil {
-
-				if rollingUpdateData.FailOnValidate {
-					return fmt.Errorf("error validating cluster after removing a node: %v", err)
-				}
-
-				glog.Warningf("Cluster validation failed after removing instance, proceeding since fail-on-validate is set to false: %v", err)
+			if err = rollingUpdateData.validateClusterWithRetries(instanceGroupList, t); err != nil {
+				return fmt.Errorf("error validating cluster after removing a node: %v", err)
 			}
 		}
 	}
@@ -419,14 +596,74 @@ func (n *CloudInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpdateClust
 	return nil
 }
 
+func (c *RollingUpdateCluster) getIGAndValidateCluster() error {
+	// get the new list of ig
+	list, err := c.Clientset.InstanceGroups(c.ClusterName).List(metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to get instance groups: %v", err)
+	}
+
+	// validate the cluster
+	if err := c.validateClusterWithRetries(list, c.NodeInterval); err != nil {
+		return fmt.Errorf("unable to validate cluster: %v", err)
+	}
+	return nil
+}
+
+func (c *RollingUpdateCluster) deleteInstanceGroups(group *CloudInstanceGroup) error {
+	// Delete the cloud group
+	if err := group.Delete(c.Cloud); err != nil {
+		return fmt.Errorf("Failed to delete cloud group %q: %v", group.ASGName, err)
+	}
+
+	// Delete the instance group
+	if err := c.Clientset.InstanceGroups(c.ClusterName).Delete(group.InstanceGroup.Name, &metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("Failed to delete instance group %q: %v", group.InstanceGroup.Name, err)
+	}
+
+	return nil
+}
+
+func getSuffix() string {
+	t := time.Now()
+	return " rolling-update " + t.Format("2006-01-02-15:04:05")
+}
+
+func (c *RollingUpdateCluster) createInstanceGroup(orig *api.InstanceGroup, suffix string) (*api.InstanceGroup, error) {
+	obj, err := conversion.NewCloner().DeepCopy(orig)
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to clone instance group: %v", err)
+	}
+	ig, ok := obj.(*api.InstanceGroup)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected object type: %T", obj)
+	}
+
+	// DeepCopy does not get the maps need to copy those through
+	ig.ObjectMeta.Labels = orig.ObjectMeta.Labels
+	ig.ObjectMeta.Annotations = orig.ObjectMeta.Annotations
+	ig.Spec.CloudLabels = orig.Spec.CloudLabels
+	ig.Spec.NodeLabels = orig.Spec.NodeLabels
+	ig.ObjectMeta.Name = orig.ObjectMeta.Name + suffix
+
+	if err := cloudup.CreateInstanceGroup(ig, c.ClusterName, c.Clientset); err != nil {
+		return nil, fmt.Errorf("unable to create new instance group: %v", err)
+	}
+
+	glog.V(4).Infof("adding instance group: %+v", ig)
+	glog.V(4).Infof("based on instance group: %+v", orig)
+
+	return ig, nil
+}
+
 // ValidateClusterWithRetries runs our validation methods on the K8s Cluster x times and then fails.
-func (n *CloudInstanceGroup) ValidateClusterWithRetries(rollingUpdateData *RollingUpdateCluster, instanceGroupList *api.InstanceGroupList, t time.Duration) (err error) {
+func (c *RollingUpdateCluster) validateClusterWithRetries(instanceGroupList *api.InstanceGroupList, t time.Duration) (err error) {
 
-	// TODO - We are going to need to improve Validate to allow for more than one node, not master
-	// TODO - going down at a time.
-	for i := 0; i <= rollingUpdateData.ValidateRetries; i++ {
+	for i := 0; i <= c.ValidateRetries; i++ {
 
-		if _, err = validation.ValidateCluster(rollingUpdateData.ClusterName, instanceGroupList, rollingUpdateData.K8sClient); err != nil {
+		if _, err = validation.ValidateCluster(c.ClusterName, instanceGroupList, c.K8sClient); err != nil {
 			glog.Infof("Cluster did not validate, and waiting longer: %v.", err)
 			time.Sleep(t / 2)
 		} else {
@@ -436,8 +673,13 @@ func (n *CloudInstanceGroup) ValidateClusterWithRetries(rollingUpdateData *Rolli
 
 	}
 
-	// for loop is done, and did not end when the cluster validated
-	return fmt.Errorf("cluster validation failed: %v", err)
+	if c.FailOnValidate {
+		return fmt.Errorf("cluster validation failed: %v", err)
+	}
+
+	glog.Warningf("Cluster validation failed after removing instance, proceeding since fail-on-validate is set to false: %v", err)
+
+	return nil
 }
 
 // ValidateCluster runs our validation methods on the K8s Cluster.
@@ -477,7 +719,7 @@ func (n *CloudInstanceGroup) DeleteAWSInstance(u *CloudInstanceGroupInstance, in
 }
 
 // DrainNode drains a K8s node.
-func (n *CloudInstanceGroup) DrainNode(u *CloudInstanceGroupInstance, rollingUpdateData *RollingUpdateCluster) error {
+func (n *CloudInstanceGroup) DrainNode(u *CloudInstanceGroupInstance, rollingUpdateData *RollingUpdateCluster, cardon bool) error {
 	if rollingUpdateData.ClientConfig == nil {
 		return fmt.Errorf("ClientConfig not set")
 	}
@@ -500,18 +742,17 @@ func (n *CloudInstanceGroup) DrainNode(u *CloudInstanceGroupInstance, rollingUpd
 		Use: "cordon NODE",
 	}
 	args := []string{u.Node.Name}
-	err := options.SetupDrain(cmd, args)
-	if err != nil {
+	if err := options.SetupDrain(cmd, args); err != nil {
 		return fmt.Errorf("error setting up drain: %v", err)
 	}
 
-	err = options.RunCordonOrUncordon(true)
-	if err != nil {
-		return fmt.Errorf("error cordoning node node: %v", err)
+	if cardon {
+		if err := options.RunCordonOrUncordon(true); err != nil {
+			return fmt.Errorf("error cordoning node node: %v", err)
+		}
 	}
 
-	err = options.RunDrain()
-	if err != nil {
+	if err := options.RunDrain(); err != nil {
 		return fmt.Errorf("error draining node: %v", err)
 	}
 
@@ -523,10 +764,45 @@ func (n *CloudInstanceGroup) DrainNode(u *CloudInstanceGroupInstance, rollingUpd
 	return nil
 }
 
+// CardonNode cardons a K8s node.
+func (n *CloudInstanceGroup) CardonNode(u *CloudInstanceGroupInstance, rollingUpdateData *RollingUpdateCluster) error {
+	if rollingUpdateData.ClientConfig == nil {
+		return fmt.Errorf("ClientConfig not set")
+	}
+	f := cmdutil.NewFactory(rollingUpdateData.ClientConfig)
+
+	// TODO: Send out somewhere else, also DrainOptions has errout
+	out := os.Stdout
+	errOut := os.Stderr
+
+	options := &cmd.DrainOptions{
+		Factory:          f,
+		Out:              out,
+		IgnoreDaemonsets: true,
+		Force:            true,
+		DeleteLocalData:  true,
+		ErrOut:           errOut,
+	}
+
+	cmd := &cobra.Command{
+		Use: "cordon NODE",
+	}
+	args := []string{u.Node.Name}
+	if err := options.SetupDrain(cmd, args); err != nil {
+		return fmt.Errorf("error setting up drain: %v", err)
+	}
+
+	if err := options.RunCordonOrUncordon(true); err != nil {
+		return fmt.Errorf("error cordoning node node: %v", err)
+	}
+	return nil
+}
+
 func (g *CloudInstanceGroup) Delete(cloud fi.Cloud) error {
+	// TODO add code for aws, gce, vsphere
 	c := cloud.(awsup.AWSCloud)
 
-	// TODO: Graceful?
+	// TODO: Graceful? Use cordon and drain?
 
 	// Delete ASG
 	{
@@ -536,8 +812,7 @@ func (g *CloudInstanceGroup) Delete(cloud fi.Cloud) error {
 			AutoScalingGroupName: g.asg.AutoScalingGroupName,
 			ForceDelete:          aws.Bool(true),
 		}
-		_, err := c.Autoscaling().DeleteAutoScalingGroup(request)
-		if err != nil {
+		if _, err := c.Autoscaling().DeleteAutoScalingGroup(request); err != nil {
 			return fmt.Errorf("error deleting autoscaling group %q: %v", asgName, err)
 		}
 	}
@@ -549,8 +824,7 @@ func (g *CloudInstanceGroup) Delete(cloud fi.Cloud) error {
 		request := &autoscaling.DeleteLaunchConfigurationInput{
 			LaunchConfigurationName: g.asg.LaunchConfigurationName,
 		}
-		_, err := c.Autoscaling().DeleteLaunchConfiguration(request)
-		if err != nil {
+		if _, err := c.Autoscaling().DeleteLaunchConfiguration(request); err != nil {
 			return fmt.Errorf("error deleting autoscaling launch configuration %q: %v", lcName, err)
 		}
 	}


### PR DESCRIPTION
Including two new algorithms that influence node replacement.  The first option is the current code path. All masters and bastions are rolled sequentially before the nodes, and this flag does not control their replacement.

1. "asg" - A node is drained then deleted.  The cloud then replaces the node automatically. (default)
2. "pre-create" - All node instance groups are duplicated first; then all old nodes are cordoned.
3. "create" - As each node instance group rolls, the instance group is duplicated, then all old nodes are cordoned.

The second and third options create new instance groups; next, the old nodes are cardoned.  The old nodes are drained, and then the instance group(s) is deleted. 

The second option pre-creates a whole new set of instance groups first, while the third option only creates a new ig as each ig is rolled.

The first and default option is the original code path.

TODO

- [ ] more testing


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2621)
<!-- Reviewable:end -->
