### PR TITLE
Weave daemonset configuration for k8s 1.6.x

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -91,11 +91,15 @@ step is to install CNI networking. Most of the CNI network providers are
 moving to installing their components plugins via a Daemonset.  For instance weave will
 install with the following command:
 
+Daemonset installation for K8s 1.6.x or above.
+```console
+$ kubectl create -f https://git.io/weave-kube-1.6
+```
+
+Daemonset installation for K8s 1.4.x or 1.5.x.
 ```console
 $ kubectl create -f https://git.io/weave-kube
 ```
-
-The above daemonset installation requires K8s 1.4.x or above.
 
 ### Calico Example for CNI and Network Policy
 


### PR DESCRIPTION
The current configuration is not correct for k8s 1.6.x

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2629)
<!-- Reviewable:end -->
