### PR TITLE
Fix misspellings in create cluster documentation

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -136,7 +136,7 @@ var (
 	This command creates cloud based resources such as networks and virtual machine. Once
 	the infrastructure is in place Kubernetes is installed on the virtual machines.
 
-	These operations are done in parrellel and rely on eventual consitency.
+	These operations are done in parallel and rely on eventual consistency.
 	`))
 
 	create_cluster_example = templates.Examples(i18n.T(`

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -7,7 +7,7 @@ Create a Kubernetes cluster.
 
 Create a kubernetes cluster using command line flags. This command creates cloud based resources such as networks and virtual machine. Once the infrastructure is in place Kubernetes is installed on the virtual machines. 
 
-These operations are done in parrellel and rely on eventual consitency.
+These operations are done in parallel and rely on eventual consistency.
 
 ```
 kops create cluster


### PR DESCRIPTION
Update misspellings of "parallel" and "consistency"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2636)
<!-- Reviewable:end -->
