### PR TITLE
Support setting empty --resolv-conf

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -135,6 +135,15 @@ Will result in the flag `--runtime-config=batch/v2alpha1=true,apps/v1alpha1=true
 
 This block contains configurations for `kubelet`.  See https://kubernetes.io/docs/admin/kubelet/
 
+NOTE: Arguments can be set to empty if the field is included in the spec, and an empty string is passed to it.
+ ```yaml
+ spec:
+   kubelet:
+     resolvConf: ""
+```
+
+Will result in the flag `--resolv-conf=` being built.
+
 ####  Feature Gates
 
 ```yaml

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -235,9 +235,9 @@ type KubeletConfigSpec struct {
 	// The CIDR to use for pod IP addresses, only used in standalone mode.
 	// In cluster mode, this is obtained from the master.
 	PodCIDR string `json:"podCIDR,omitempty" flag:"pod-cidr"`
-	//// ResolverConfig is the resolver configuration file used as the basis
-	//// for the container DNS resolution configuration."), []
-	//ResolverConfig string `json:"resolvConf"`
+	// ResolverConfig is the resolver configuration file used as the basis
+	// for the container DNS resolution configuration."), []
+	ResolverConfig *string `json:"resolvConf" flag:"resolv-conf" flag-include-empty:"true"`
 	//// cpuCFSQuota is Enable CPU CFS quota enforcement for containers that
 	//// specify CPU limits
 	//CPUCFSQuota bool `json:"cpuCFSQuota"`

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -234,9 +234,9 @@ type KubeletConfigSpec struct {
 	// The CIDR to use for pod IP addresses, only used in standalone mode.
 	// In cluster mode, this is obtained from the master.
 	PodCIDR string `json:"podCIDR,omitempty" flag:"pod-cidr"`
-	//// ResolverConfig is the resolver configuration file used as the basis
-	//// for the container DNS resolution configuration."), []
-	//ResolverConfig string `json:"resolvConf"`
+	// ResolverConfig is the resolver configuration file used as the basis
+	// for the container DNS resolution configuration."), []
+	ResolverConfig *string `json:"resolvConf" flag:"resolv-conf" flag-include-empty:"true"`
 	//// cpuCFSQuota is Enable CPU CFS quota enforcement for containers that
 	//// specify CPU limits
 	//CPUCFSQuota bool `json:"cpuCFSQuota"`

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1445,6 +1445,7 @@ func autoConvert_v1alpha1_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.MaxPods = in.MaxPods
 	out.NvidiaGPUs = in.NvidiaGPUs
 	out.PodCIDR = in.PodCIDR
+	out.ResolverConfig = in.ResolverConfig
 	out.ReconcileCIDR = in.ReconcileCIDR
 	out.RegisterSchedulable = in.RegisterSchedulable
 	out.NodeLabels = in.NodeLabels
@@ -1492,6 +1493,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha1_KubeletConfigSpec(in *kops.K
 	out.MaxPods = in.MaxPods
 	out.NvidiaGPUs = in.NvidiaGPUs
 	out.PodCIDR = in.PodCIDR
+	out.ResolverConfig = in.ResolverConfig
 	out.ReconcileCIDR = in.ReconcileCIDR
 	out.RegisterSchedulable = in.RegisterSchedulable
 	out.NodeLabels = in.NodeLabels

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -102,6 +102,10 @@ type KubeletConfigSpec struct {
 	// schedulable. No-op if register-node is false.
 	RegisterSchedulable *bool `json:"registerSchedulable,omitempty" flag:"register-schedulable"`
 
+	// ResolverConfig is the resolver configuration file used as the basis
+	// for the container DNS resolution configuration."), []
+	ResolverConfig *string `json:"resolvConf" flag:"resolv-conf" flag-include-empty:"true"`
+
 	// nodeLabels to add when registering the node in the cluster.
 	NodeLabels map[string]string `json:"nodeLabels,omitempty" flag:"node-labels"`
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1545,6 +1545,7 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.PodCIDR = in.PodCIDR
 	out.ReconcileCIDR = in.ReconcileCIDR
 	out.RegisterSchedulable = in.RegisterSchedulable
+	out.ResolverConfig = in.ResolverConfig
 	out.NodeLabels = in.NodeLabels
 	out.NonMasqueradeCIDR = in.NonMasqueradeCIDR
 	out.EnableCustomMetrics = in.EnableCustomMetrics
@@ -1590,6 +1591,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.MaxPods = in.MaxPods
 	out.NvidiaGPUs = in.NvidiaGPUs
 	out.PodCIDR = in.PodCIDR
+	out.ResolverConfig = in.ResolverConfig
 	out.ReconcileCIDR = in.ReconcileCIDR
 	out.RegisterSchedulable = in.RegisterSchedulable
 	out.NodeLabels = in.NodeLabels

--- a/pkg/flagbuilder/buildflags_test.go
+++ b/pkg/flagbuilder/buildflags_test.go
@@ -24,6 +24,14 @@ import (
 	"time"
 )
 
+func stringPointer(s string) *string {
+	return &s
+}
+
+func int34Pointer(i32 int32) *int32 {
+	return &i32
+}
+
 func TestBuildKCMFlags(t *testing.T) {
 	grid := []struct {
 		Config   interface{}
@@ -79,7 +87,53 @@ func TestKubeletConfigSpec(t *testing.T) {
 			Expected: "--eviction-pressure-transition-period=5s",
 		},
 		{
+			Config: &kops.KubeletConfigSpec{
+				LogLevel: new(int32),
+			},
+			Expected: "",
+		},
+		{
+			Config: &kops.KubeletConfigSpec{
+				LogLevel: int34Pointer(2),
+			},
+			Expected: "--v=2",
+		},
+
+		// Test string pointers without the "flag-include-empty" tag
+		{
+			Config: &kops.KubeletConfigSpec{
+				EvictionHard: stringPointer("memory.available<100Mi"),
+			},
+			Expected: "--eviction-hard=memory.available<100Mi",
+		},
+		{
+			Config: &kops.KubeletConfigSpec{
+				EvictionHard: stringPointer(""),
+			},
+			Expected: "",
+		},
+
+		// Test string pointers with the "flag-include-empty" tag
+		{
 			Config:   &kops.KubeletConfigSpec{},
+			Expected: "",
+		},
+		{
+			Config: &kops.KubeletConfigSpec{
+				ResolverConfig: stringPointer("test"),
+			},
+			Expected: "--resolv-conf=test",
+		},
+		{
+			Config: &kops.KubeletConfigSpec{
+				ResolverConfig: stringPointer(""),
+			},
+			Expected: "--resolv-conf=",
+		},
+		{
+			Config: &kops.KubeletConfigSpec{
+				ResolverConfig: nil,
+			},
 			Expected: "",
 		},
 	}


### PR DESCRIPTION
Adds support for setting the resolv-conf flag on the kubelet through the cluster spec.

If the `spec.kubelet.resolvConf` field is set to an empty string in the cluster spec, the empty string will carry over to the argument like so:
```
--resolv-conf=
```

If the field is not found in the cluster spec, the argument will simply be omitted.

Resolves #2638

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2662)
<!-- Reviewable:end -->
