### PR TITLE
Recognize 1.8 and 1.9 in URLs

### DIFF
--- a/pkg/apis/kops/util/versions.go
+++ b/pkg/apis/kops/util/versions.go
@@ -48,6 +48,10 @@ func ParseKubernetesVersion(version string) (*semver.Version, error) {
 			sv = semver.Version{Major: 1, Minor: 6}
 		} else if strings.Contains(v, "/v1.7.") {
 			sv = semver.Version{Major: 1, Minor: 7}
+		} else if strings.Contains(v, "/v1.8.") {
+			sv = semver.Version{Major: 1, Minor: 8}
+		} else if strings.Contains(v, "/v1.9.") {
+			sv = semver.Version{Major: 1, Minor: 9}
 		} else {
 			glog.Errorf("unable to parse Kubernetes version %q", version)
 			return nil, fmt.Errorf("unable to parse kubernetes version %q", version)


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/46853

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2675)
<!-- Reviewable:end -->
