### PR TITLE
Only list the latest coreos stable image

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -98,7 +98,7 @@ CoreOS support is highly experimental.  Please report any issues.
 
 The following steps are known:
 
-* CoreOS AMIs can be found using `aws ec2 describe-images --region=us-east-1 --owner=595879546273 --filters Name=virtualization-type,Values=hvm`
+* CoreOS AMIs can be found using `aws ec2 describe-images --region=us-east-1 --owner=595879546273 --filters "Name=virtualization-type,Values=hvm" "Name=name,Values=CoreOS-stable*" --query 'Images[-1].{id:ImageLocation}'`
 * You can specify the name using the `coreos.com` owner alias, for example `coreos.com/CoreOS-stable-1235.9.0-hvm`
 
 > Note: SSH username will be `core`


### PR DESCRIPTION
It's a bit confused for the users to "choose" the right ami

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2689)
<!-- Reviewable:end -->
