### PR TITLE
Add more logging on IAM failure

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
@@ -316,6 +316,7 @@ func (_ *LaunchConfiguration) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *La
 				if attempt > maxAttempts {
 					return fmt.Errorf("IAM instance profile not yet created/propagated (original error: %v)", message)
 				}
+				glog.V(4).Infof("got an error indicating that the IAM instance profile %q is not ready: %q", fi.StringValue(e.IAMInstanceProfile.Name), message)
 				glog.Infof("waiting for IAM instance profile %q to be ready", fi.StringValue(e.IAMInstanceProfile.Name))
 				time.Sleep(10 * time.Second)
 				continue


### PR DESCRIPTION
I hit an odd IAM failure yesterday, and this information would have been
helpful.  It only proved a negative - it turned out to be an AWS problem
that was solved by deleting and recreating the IAM roles - but still
makes diagnosis much easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2701)
<!-- Reviewable:end -->
