### PR TITLE
Add AntiAffinity to kube-dns. #2693

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -86,25 +86,18 @@ spec:
         scheduler.alpha.kubernetes.io/affinity: >
           {
             "podAntiAffinity": {
-              "preferredDuringSchedulingIgnoredDuringExecution": [
+              "requiredDuringSchedulingIgnoredDuringExecution": [
                 {
-                  "weight": 100,
-                  "podAffinityTerm": {
-                    "labelSelector": {
-                      "matchExpressions": [
-                        {
-                          "key": "k8s-addon",
-                          "operator": "In",
-                          "values": ["dns-controller.addons.k8s.io"]
-                        },
-                        {
-                          "key": "k8s-app",
-                          "operator": "In",
-                          "values": ["dns-controller"]
-                        }
-                      ]
-                    }
-                  }
+                  "labelSelector": {
+                    "matchExpressions": [
+                      {
+                        "key": "k8s-app",
+                        "operator": "In",
+                        "values": ["kube-dns"]
+                      }
+                    ]
+                  },
+                  "topologyKey": "kubernetes.io/hostname"
                 }
               ]
             }
@@ -112,17 +105,13 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: k8s-addon
-                      operator: In
-                      values: ["dns-controller.addons.k8s.io"]
-                    - key: k8s-app
-                      operator: In
-                      values: ["dns-controller"]
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: k8s-app
+                    operator: In
+                    values: ["kube-dns"]
+              topologyKey: kubernetes.io/hostname
       dnsPolicy: Default  # Don't use cluster DNS.
       serviceAccountName: kube-dns
       volumes:

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -82,7 +82,47 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         # For 1.6, we keep the old tolerations in case of a downgrade to 1.5
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+        # For 1.6, we keep the old affinity annotation in case of a downgrade to 1.5
+        scheduler.alpha.kubernetes.io/affinity: >
+          {
+            "podAntiAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "weight": 100,
+                  "podAffinityTerm": {
+                    "labelSelector": {
+                      "matchExpressions": [
+                        {
+                          "key": "k8s-addon",
+                          "operator": "In",
+                          "values": ["dns-controller.addons.k8s.io"]
+                        },
+                        {
+                          "key": "k8s-app",
+                          "operator": "In",
+                          "values": ["dns-controller"]
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: k8s-addon
+                      operator: In
+                      values: ["dns-controller.addons.k8s.io"]
+                    - key: k8s-app
+                      operator: In
+                      values: ["dns-controller"]
       dnsPolicy: Default  # Don't use cluster DNS.
       serviceAccountName: kube-dns
       volumes:

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
@@ -29,32 +29,6 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
-        scheduler.alpha.kubernetes.io/affinity: >
-          {
-            "podAntiAffinity": {
-              "preferredDuringSchedulingIgnoredDuringExecution": [
-                {
-                  "weight": 100,
-                  "podAffinityTerm": {
-                    "labelSelector": {
-                      "matchExpressions": [
-                        {
-                          "key": "k8s-addon",
-                          "operator": "In",
-                          "values": ["dns-controller.addons.k8s.io"]
-                        },
-                        {
-                          "key": "k8s-app",
-                          "operator": "In",
-                          "values": ["dns-controller"]
-                        }
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
-          }
     spec:
       containers:
       - name: autoscaler
@@ -106,6 +80,25 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+        scheduler.alpha.kubernetes.io/affinity: >
+          {
+            "podAntiAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "labelSelector": {
+                    "matchExpressions": [
+                      {
+                        "key": "k8s-app",
+                        "operator": "In",
+                        "values": ["kube-dns"]
+                      }
+                    ]
+                  },
+                  "topologyKey": "kubernetes.io/hostname"
+                }
+              ]
+            }
+          }
     spec:
       containers:
       - name: kubedns

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
@@ -29,6 +29,32 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+        scheduler.alpha.kubernetes.io/affinity: >
+          {
+            "podAntiAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "weight": 100,
+                  "podAffinityTerm": {
+                    "labelSelector": {
+                      "matchExpressions": [
+                        {
+                          "key": "k8s-addon",
+                          "operator": "In",
+                          "values": ["dns-controller.addons.k8s.io"]
+                        },
+                        {
+                          "key": "k8s-app",
+                          "operator": "In",
+                          "values": ["dns-controller"]
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
     spec:
       containers:
       - name: autoscaler


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kops/issues/2693

This is not quite ready as I have the following left to do:

- Testing (Waiting on DNS registration stuffs so I can use Kops from my home machine).

- Determine if "preferredDuringSchedulingIgnoredDuringExecution" the correct setting? Other settings would prevent the pod from scheduling on the same node and I think mark the pod as un-schedulable. Since DNS is pretty critical to a cluster it is probably better to have the scheduler attempt to schedule the pod to be resilient against DNS pod crashes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2705)
<!-- Reviewable:end -->
