### PR TITLE
Modify `kops create instancegroup` commands in single-to-multi-master doc

### DIFF
--- a/docs/single-to-multi-master.md
+++ b/docs/single-to-multi-master.md
@@ -64,11 +64,10 @@ Create 1 kops instance group for the first one of your new masters, in
 a different AZ from the existing one.
 
 ```bash
-$ kops create instancegroup master-<availability-zone2>
+$ kops create instancegroup master-<availability-zone2> --subnet <availability-zone2> --role Master
 ```
 
  * ``maxSize`` and ``minSize`` should be 1,
- * ``role`` should be ``Master``,
  * only one zone should be listed.
 
 ### b - Reference the new masters in your cluster configuration
@@ -147,11 +146,10 @@ Create 1 kops instance group for the third master, in
 a different AZ from the existing ones.
 
 ```bash
-$ kops create instancegroup master-<availability-zone3>
+$ kops create instancegroup master-<availability-zone3> --subnet <availability-zone3> --role Master
 ```
 
  * ``maxSize`` and ``minSize`` should be 1,
- * ``role`` should be ``Master``,
  * only one zone should be listed.
 
 ### b - Add a new member to the etcd clusters


### PR DESCRIPTION
`kops create instancegroup` command requires `--subnet` flag.

```sh-session
$ kops create ig nodes-foo
Using cluster from kubectl context: k8s.test-cluster.example.com


cannot create instance group without subnets; specify --subnet flag(s)
```

In addition, `--role Master` option can be used to specify role. It's easy and clear than editing yaml by hand.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2718)
<!-- Reviewable:end -->
