### PR TITLE
WIP: Allow kops cluster behind a proxy

### DIFF
--- a/nodeup/pkg/model/kubeapiserver.go
+++ b/nodeup/pkg/model/kubeapiserver.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kops/pkg/flagbuilder"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
+	"os"
 )
 
 // KubeAPIServerBuilder install kube-apiserver (just the manifest at the moment)
@@ -158,6 +159,14 @@ func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 				HostPort:      8080,
 			},
 		},
+	}
+
+	if os.Getenv("HTTP_PROXY") != "" || os.Getenv("HTTPS_PROXY") != "" {
+		container.Env = []v1.EnvVar{
+			{Name: "HTTP_PROXY", Value: os.Getenv("HTTP_PROXY")},
+			{Name: "HTTPS_PROXY", Value: os.Getenv("HTTPS_PROXY")},
+			{Name: "NO_PROXY", Value: os.Getenv("NO_PROXY")},
+		}
 	}
 
 	for _, path := range b.SSLHostPaths() {

--- a/nodeup/pkg/model/kubecontrollermanager.go
+++ b/nodeup/pkg/model/kubecontrollermanager.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kops/pkg/flagbuilder"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
+	"os"
 )
 
 // KubeControllerManagerBuilder install kube-controller-manager (just the manifest at the moment)
@@ -186,6 +187,14 @@ func (b *KubeControllerManagerBuilder) buildPod() (*v1.Pod, error) {
 			InitialDelaySeconds: 15,
 			TimeoutSeconds:      15,
 		},
+	}
+
+	if os.Getenv("HTTP_PROXY") != "" || os.Getenv("HTTPS_PROXY") != "" {
+		container.Env = []v1.EnvVar{
+			{Name: "HTTP_PROXY", Value: os.Getenv("HTTP_PROXY")},
+			{Name: "HTTPS_PROXY", Value: os.Getenv("HTTPS_PROXY")},
+			{Name: "NO_PROXY", Value: os.Getenv("NO_PROXY")},
+		}
 	}
 
 	for _, path := range b.SSLHostPaths() {

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 	"k8s.io/kops/upup/pkg/fi/utils"
+	"os"
 )
 
 // KubeletBuilder install kubelet
@@ -146,6 +147,12 @@ func (b *KubeletBuilder) buildSystemdEnvironmentFile(kubeletConfig *kops.Kubelet
 	}
 
 	sysconfig := "DAEMON_ARGS=\"" + flags + "\"\n"
+
+	if os.Getenv("HTTP_PROXY") != "" || os.Getenv("HTTPS_PROXY") != "" {
+		sysconfig += "HTTP_PROXY=" + os.Getenv("HTTP_PROXY") + "\n"
+		sysconfig += "HTTPS_PROXY=" + os.Getenv("HTTPS_PROXY") + "\n"
+		sysconfig += "NO_PROXY=" + os.Getenv("NO_PROXY") + "\n"
+	}
 
 	t := &nodetasks.File{
 		Path:     "/etc/sysconfig/kubelet",

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -95,7 +95,7 @@ func (b *ProtokubeBuilder) buildSystemdService() (*nodetasks.Service, error) {
 	manifest.Set("Unit", "Description", "Kubernetes Protokube Service")
 	manifest.Set("Unit", "Documentation", "https://github.com/kubernetes/kops")
 
-	//manifest.Set("Service", "EnvironmentFile", "/etc/sysconfig/protokube")
+	manifest.Set("Service", "EnvironmentFile", "/etc/environment")
 	manifest.Set("Service", "ExecStartPre", b.ProtokubeImagePullCommand())
 	manifest.Set("Service", "ExecStart", protokubeCommand)
 	manifest.Set("Service", "Restart", "always")
@@ -246,9 +246,9 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) *ProtokubeF
 }
 
 func (t *ProtokubeBuilder) ProtokubeEnvironmentVariables() string {
+	var buffer bytes.Buffer
 	// Pass in required credentials when using user-defined s3 endpoint
 	if os.Getenv("S3_ENDPOINT") != "" {
-		var buffer bytes.Buffer
 		buffer.WriteString(" ")
 		buffer.WriteString("-e S3_ENDPOINT=")
 		buffer.WriteString("'")
@@ -267,9 +267,9 @@ func (t *ProtokubeBuilder) ProtokubeEnvironmentVariables() string {
 		buffer.WriteString(os.Getenv("S3_SECRET_ACCESS_KEY"))
 		buffer.WriteString("'")
 		buffer.WriteString(" ")
-
-		return buffer.String()
 	}
 
-	return ""
+	buffer.WriteString(" --env-file=/etc/environment ")
+
+	return buffer.String()
 }

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -71,6 +71,17 @@ func (b *BootstrapScript) ResourceNodeUp(ig *kops.InstanceGroup) (*fi.ResourceHo
 			}
 			return ""
 		},
+
+		// Pass in configuration for the cluster proxy
+		"ProxyEnv": func() string {
+			if os.Getenv("CLUSTER_HTTP_PROXY") != "" || os.Getenv("CLUSTER_HTTPS_PROXY") != "" {
+				return fmt.Sprintf("export HTTP_PROXY=%s\nexport HTTPS_PROXY=%s\nexport NO_PROXY=%s\n",
+					os.Getenv("CLUSTER_HTTP_PROXY"),
+					os.Getenv("CLUSTER_HTTPS_PROXY"),
+					os.Getenv("CLUSTER_NO_PROXY"))
+			}
+			return ""
+		},
 	}
 
 	templateResource, err := NewTemplateResource("nodeup", resources.AWSNodeUpTemplate, functions, nil)

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.6.yaml.template
@@ -34,6 +34,13 @@ spec:
       containers:
       - name: dns-controller
         image: kope/dns-controller:1.6.1
+{{ if ProxyEnv }}
+        env:
+{{ end }}
+{{ range $name, $value := ProxyEnv }}
+        - name: {{ $name }}
+          value: "{{ $value }}"
+{{ end }}
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/pre-k8s-1.6.yaml.template
@@ -29,6 +29,13 @@ spec:
       containers:
       - name: dns-controller
         image: {{ DnsControllerImage }}:1.6.1
+{{ if ProxyEnv }}
+        env:
+{{ end }}
+{{ range $name, $value := ProxyEnv }}
+        - name: {{ $name }}
+          value: "{{ $value }}"
+{{ end }}
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -101,6 +101,8 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap) {
 	dest["EncodeGCELabel"] = gce.EncodeGCELabel
 
 	dest["DnsControllerImage"] = tf.DnsControllerImage
+
+	dest["ProxyEnv"] = tf.ProxyEnv
 }
 
 // SharedVPC is a simple helper function which makes the templates for a shared VPC clearer
@@ -204,4 +206,16 @@ func (tf *TemplateFunctions) ExternalDnsArgv() ([]string, error) {
 	argv = append(argv, "--source=ingress")
 
 	return argv, nil
+}
+
+func (tf *TemplateFunctions) ProxyEnv() map[string]string {
+	if os.Getenv("CLUSTER_HTTP_PROXY") != "" || os.Getenv("CLUSTER_HTTPS_PROXY") != "" {
+		return map[string]string {
+			"HTTP_PROXY": os.Getenv("CLUSTER_HTTP_PROXY"),
+			"HTTPS_PROXY": os.Getenv("CLUSTER_HTTPS_PROXY"),
+			"NO_PROXY": os.Getenv("CLUSTER_NO_PROXY"),
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Allow a kops cluster to operate behind a proxy by passing proxy
configuration to addons and nodes. The API will change to be consistent
with the rest of the project, but currently uses the environment
variables `CLUSTER_HTTP_PROXY`, `CLUSTER_HTTPS_PROXY`, and
`CLUSTER_NO_PROXY` available when and where kops is invoked.

Relates to #2481

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2749)
<!-- Reviewable:end -->
