### PR TITLE
Update calico to use the correct CIDR for pods

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.6.yaml.template
@@ -146,7 +146,7 @@ spec:
                   key: enable_bgp
             # Configure the IP Pool from which Pod IPs will be chosen.
             - name: CALICO_IPV4POOL_CIDR
-              value: "{{ .NonMasqueradeCIDR }}"
+              value: "{{ .KubeControllerManager.ClusterCIDR }}"
             - name: CALICO_IPV4POOL_IPIP
               value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}cross-subnet{{- else -}}always{{- end -}}"
             # Disable file logging so `kubectl logs` works.

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/pre-k8s-1.6.yaml.template
@@ -92,7 +92,7 @@ spec:
               value: "true"
             # Configure the IP Pool from which Pod IPs will be chosen.
             - name: CALICO_IPV4POOL_CIDR
-              value: "{{ .NonMasqueradeCIDR }}"
+              value: "{{ .KubeControllerManager.ClusterCIDR }}"
             - name: CALICO_IPV4POOL_IPIP
               value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}cross-subnet{{- else -}}always{{- end -}}"
             # Auto-detect the BGP IP address.

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -353,7 +353,8 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Calico != nil {
 		key := "networking.projectcalico.org"
-		version := "2.1.1"
+		// 2.1.2-kops.1 = 2.1.1 with CIDR change
+		version := "2.1.2-kops.1"
 
 		{
 			location := key + "/pre-k8s-1.6.yaml"


### PR DESCRIPTION
This PR is in relations to the conversations had in #1171.

For reference, here's the default values for the individual components.
```
  kubeAPIServer:
    serviceClusterIPRange: 100.64.0.0/13
  kubeControllerManager:
    # I do not think we need this with CNI
    clusterCIDR: 100.96.0.0/11
  kubeDNS:
    serverIP: 100.64.0.10
  kubeProxy:
    clusterCIDR: 100.96.0.0/11
  kubelet:
    clusterDNS: 100.64.0.10
    networkPluginName: cni
    nonMasqueradeCIDR: 100.64.0.0/10
  # these values are the base subnets that everything is setup from
  # I do not believe that these should overlap
  nonMasqueradeCIDR: 100.64.0.0/10
  serviceClusterIPRange: 100.64.0.0/13
```

Currently, we are using `.NonMasqueradeCIDR` in the wrong fashion. We
should be using `.KubeControllerManager.ClusterCIDR` instead to prevent IP
collision with Service IPs.

Note: The `.NonMasqueradeCIDR` is the cluster's base subnet, and should not be directly used by the components because of overlap.

## Scenarios Tested

### New Cluster Creation for k8s 1.6 - PASS
Deployed a new Kubernetes 1.6.4 cluster using this branch with the changes. Pods are now being allocated an IP within the 100.96.0.0/11 range (as defined by `.KubeControllerManager.ClusterCIDR` vs `.NonMasqueradeCIDR`

Tested: 
- Pod to Service IP (100.64.0.10/kube-dns and example nginx service)
-  Pod to Pod
-  Pod to External (google.com)

Observation:
- Nodes are assigned a Pod CIDR within the .KubeControllerManager.ClusterCIDR range as expected
- Pods are being assigned IPs in the proper range
- Service IP range remains unchanged

### Cluster Upgrade for k8s 1.6 (cluster first created using kops-1.6.2)

Deployed a new Kubernetes 1.6.4 cluster using kops-1.6.2, then ran kops built from this branch:
- `kops update cluster --yes` to change the CIDR.
Observation: All pods are still functional and running with the existing Pod IPs. Pod to Service IP, Pod to Pod, Pod to External (google.com) tested.

#### Upgrade strategy attempts
1. `kops rolling-update --force --yes`  to do rolling restart - FAIL
Observation: Existing Pods continue to be functional with its old Pod IPs (which may or may not lie within the newly defined IP range) while nodes are being cycled. A period of several minutes where DNS is not responsive in Pods, and shortly recovers. Not sure if it has anything to do with the CIDR change. Seems more to do with the "rolling" update. New Nodes are still assigned old CIDR range. Service IP range remains unchanged.

2. Deleting running calico/node pods from calico daemonset - FAIL
`kubectl get pods --namespace kube-system | grep calico-node | awk '{print $1}' | xargs kubectl delete pod --namespace kube-system `

Observation: Existing Pods continue to be functional with its old Pod IPs. New Pods being rescheduled on existing Nodes are still getting a Pod IP in the old IP range. New Nodes are still assigned old CIDR range.

##### Failure Investigation
Calico only uses the `CALICO_IPV4POOL_CIDR` to create a default IPv4 pool if a pool doesn't exist already:
https://github.com/projectcalico/calicoctl/blob/v1.3.0/calico_node/startup/startup.go#L463

Because of this, we need to run two jobs that execute calicoctl manually to migrate on the new CIDR - one to create a new IPv4 pool that we want, and one to delete the existing IP pool that we no longer want. This is to be executed after executing one of the listed upgrade strategies:

```
# This ConfigMap is used to configure a self-hosted Calico installation.
kind: ConfigMap
apiVersion: v1
metadata:
  name: calico-config-ippool
  namespace: kube-system
data:
  # The default IP Pool to be created for the cluster.
  # Pod IP addresses will be assigned from this pool.
  ippool.yaml: |
      apiVersion: v1
      kind: ipPool
      metadata:
        cidr: 100.96.0.0/11
      spec:
        ipip:
          enabled: true
          mode: cross-subnet
        nat-outgoing: true
---
## This manifest deploys a Job which adds a new ippool to calico
apiVersion: batch/v1
kind: Job
metadata:
  name: configure-calico-ippool
  namespace: kube-system
  labels:
    k8s-app: calico
    role.kubernetes.io/networking: "1"
spec:
  template:
    metadata:
      name: configure-calico-ippool
      annotations:
        scheduler.alpha.kubernetes.io/critical-pod: ''
    spec:
      hostNetwork: true
      serviceAccountName: calico
      tolerations:
      - key: node-role.kubernetes.io/master
        effect: NoSchedule
      - key: CriticalAddonsOnly
        operator: Exists
      restartPolicy: OnFailure
      containers:
        # Writes basic configuration to datastore.
        - name: configure-calico
          image: calico/ctl:v1.2.1
          args:
          - apply
          - -f
          - /etc/config/calico/ippool.yaml
          volumeMounts:
            - name: config-volume
              mountPath: /etc/config
          env:
            # The location of the etcd cluster.
            - name: ETCD_ENDPOINTS
              valueFrom:
                configMapKeyRef:
                  name: calico-config
                  key: etcd_endpoints
      volumes:
       - name: config-volume
         configMap:
           name: calico-config-ippool
           items:
            - key: ippool.yaml
---
## This manifest deploys a Job which deletes the old ippool from calico
apiVersion: batch/v1
kind: Job
metadata:
  name: configure-calico-ippool
  namespace: kube-system
  labels:
    k8s-app: calico
    role.kubernetes.io/networking: "1"
spec:
  template:
    metadata:
      name: configure-calico-ippool
      annotations:
        scheduler.alpha.kubernetes.io/critical-pod: ''
    spec:
      hostNetwork: true
      serviceAccountName: calico
      tolerations:
      - key: node-role.kubernetes.io/master
        effect: NoSchedule
      - key: CriticalAddonsOnly
        operator: Exists
      restartPolicy: OnFailure
      containers:
        # Writes basic configuration to datastore.
        - name: configure-calico
          image: calico/ctl:v1.2.1
          args:
          - delete
          - ipPool
          - 100.64.0.0/10
          env:
            # The location of the etcd cluster.
            - name: ETCD_ENDPOINTS
              valueFrom:
                configMapKeyRef:
                  name: calico-config
```
By doing that, new Pods will get new IPs in the right range, and existing Pods with existing IPs continue to function.

### Operations on k8s 1.5 using the same tests as above
- [x] New Cluster Creation for k8s 1.5 - **PASS**
- [x] Cluster Upgrade for k8s 1.5 - **SAME ISSUE AS DESCRIBED ABOVE WITH K8S 1.6**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2768)
<!-- Reviewable:end -->
