### PR TITLE
Move CloudProvider to kops API

### DIFF
--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -21,7 +21,8 @@ import (
 	"fmt"
 	"github.com/blang/semver"
 	"github.com/golang/glog"
-	"k8s.io/kops"
+	kopsbase "k8s.io/kops"
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/dns"
 	"k8s.io/kops/pkg/flagbuilder"
@@ -125,7 +126,7 @@ func (t *ProtokubeBuilder) ProtokubeImageName() string {
 	}
 	if name == "" {
 		// use current default corresponding to this version of nodeup
-		name = kops.DefaultProtokubeImageName()
+		name = kopsbase.DefaultProtokubeImageName()
 	}
 	return name
 }
@@ -219,12 +220,12 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) *ProtokubeF
 		f.Cloud = fi.String(t.Cluster.Spec.CloudProvider)
 
 		if f.DNSProvider == nil {
-			switch fi.CloudProviderID(t.Cluster.Spec.CloudProvider) {
-			case fi.CloudProviderAWS:
+			switch kops.CloudProviderID(t.Cluster.Spec.CloudProvider) {
+			case kops.CloudProviderAWS:
 				f.DNSProvider = fi.String("aws-route53")
-			case fi.CloudProviderGCE:
+			case kops.CloudProviderGCE:
 				f.DNSProvider = fi.String("google-clouddns")
-			case fi.CloudProviderVSphere:
+			case kops.CloudProviderVSphere:
 				f.DNSProvider = fi.String("coredns")
 				f.ClusterId = fi.String(t.Cluster.ObjectMeta.Name)
 				f.DNSServer = fi.String(*t.Cluster.Spec.CloudConfig.VSphereCoreDNSServer)

--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -19,6 +19,7 @@ package model
 import (
 	"strings"
 
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 )
@@ -98,7 +99,7 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 		)
 	}
 
-	if b.Cluster.Spec.CloudProvider == string(fi.CloudProviderAWS) {
+	if b.Cluster.Spec.CloudProvider == string(kops.CloudProviderAWS) {
 		sysctls = append(sysctls,
 			"# AWS settings",
 			"",
@@ -107,7 +108,7 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"")
 	}
 
-	if b.Cluster.Spec.CloudProvider == string(fi.CloudProviderGCE) {
+	if b.Cluster.Spec.CloudProvider == string(kops.CloudProviderGCE) {
 		sysctls = append(sysctls,
 			"# GCE settings",
 			"",

--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kops/pkg/apis/kops/util"
-	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/util/pkg/vfs"
 	"net/url"
 )
@@ -241,8 +240,14 @@ func FindKopsVersionSpec(versions []KopsVersionSpec, version semver.Version) *Ko
 	return nil
 }
 
+type CloudProviderID string
+
+const CloudProviderAWS CloudProviderID = "aws"
+const CloudProviderGCE CloudProviderID = "gce"
+const CloudProviderVSphere CloudProviderID = "vsphere"
+
 // FindImage returns the image for the cloudprovider, or nil if none found
-func (c *Channel) FindImage(provider fi.CloudProviderID, kubernetesVersion semver.Version) *ChannelImageSpec {
+func (c *Channel) FindImage(provider CloudProviderID, kubernetesVersion semver.Version) *ChannelImageSpec {
 	var matches []*ChannelImageSpec
 
 	for _, image := range c.Spec.Images {

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -443,8 +443,8 @@ func DeepValidate(c *kops.Cluster, groups []*kops.InstanceGroup, strict bool) er
 
 		// Additional cloud-specific validation rules,
 		// such as making sure that identifiers match the expected formats for the given cloud
-		switch fi.CloudProviderID(c.Spec.CloudProvider) {
-		case fi.CloudProviderAWS:
+		switch kops.CloudProviderID(c.Spec.CloudProvider) {
+		case kops.CloudProviderAWS:
 			errs := awsValidateInstanceGroup(g)
 			if len(errs) != 0 {
 				return errs[0]

--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -96,15 +96,15 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 	}
 
 	kcm.ClusterName = b.Context.ClusterName
-	switch fi.CloudProviderID(clusterSpec.CloudProvider) {
-	case fi.CloudProviderAWS:
+	switch kops.CloudProviderID(clusterSpec.CloudProvider) {
+	case kops.CloudProviderAWS:
 		kcm.CloudProvider = "aws"
 
-	case fi.CloudProviderGCE:
+	case kops.CloudProviderGCE:
 		kcm.CloudProvider = "gce"
 		kcm.ClusterName = gce.SafeClusterName(b.Context.ClusterName)
 
-	case fi.CloudProviderVSphere:
+	case kops.CloudProviderVSphere:
 		kcm.CloudProvider = "vsphere"
 
 	default:

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -132,12 +132,12 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.MasterKubelet.HairpinMode = "none"
 	}
 
-	cloudProvider := fi.CloudProviderID(clusterSpec.CloudProvider)
+	cloudProvider := kops.CloudProviderID(clusterSpec.CloudProvider)
 
 	clusterSpec.Kubelet.CgroupRoot = "/"
 
 	glog.V(1).Infof("Cloud Provider: %s", cloudProvider)
-	if cloudProvider == fi.CloudProviderAWS {
+	if cloudProvider == kops.CloudProviderAWS {
 		clusterSpec.Kubelet.CloudProvider = "aws"
 
 		// For 1.6 we're using much cleaner cgroup hierarchies
@@ -151,7 +151,7 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.Kubelet.HostnameOverride = "@aws"
 	}
 
-	if cloudProvider == fi.CloudProviderGCE {
+	if cloudProvider == kops.CloudProviderGCE {
 		clusterSpec.Kubelet.CloudProvider = "gce"
 		clusterSpec.Kubelet.HairpinMode = "promiscuous-bridge"
 
@@ -162,7 +162,7 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.CloudConfig.NodeTags = fi.String(GCETagForRole(b.Context.ClusterName, kops.InstanceGroupRoleNode))
 	}
 
-	if cloudProvider == fi.CloudProviderVSphere {
+	if cloudProvider == kops.CloudProviderVSphere {
 		clusterSpec.Kubelet.CloudProvider = "vsphere"
 		clusterSpec.Kubelet.HairpinMode = "promiscuous-bridge"
 	}

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/model/components"
-	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 )
@@ -195,8 +194,8 @@ func (m *KopsModelContext) CloudTagsForInstanceGroup(ig *kops.InstanceGroup) (ma
 func (m *KopsModelContext) CloudTags(name string, shared bool) map[string]string {
 	tags := make(map[string]string)
 
-	switch fi.CloudProviderID(m.Cluster.Spec.CloudProvider) {
-	case fi.CloudProviderAWS:
+	switch kops.CloudProviderID(m.Cluster.Spec.CloudProvider) {
+	case kops.CloudProviderAWS:
 		tags[awsup.TagClusterName] = m.Cluster.ObjectMeta.Name
 		if name != "" {
 			tags["Name"] = name

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -83,12 +83,12 @@ func (b *MasterVolumeBuilder) Build(c *fi.ModelBuilderContext) error {
 			}
 			sort.Strings(allMembers)
 
-			switch fi.CloudProviderID(b.Cluster.Spec.CloudProvider) {
-			case fi.CloudProviderAWS:
+			switch kops.CloudProviderID(b.Cluster.Spec.CloudProvider) {
+			case kops.CloudProviderAWS:
 				b.addAWSVolume(c, name, volumeSize, subnet, etcd, m, allMembers)
-			case fi.CloudProviderGCE:
+			case kops.CloudProviderGCE:
 				b.addGCEVolume(c, name, volumeSize, subnet, etcd, m, allMembers)
-			case fi.CloudProviderVSphere:
+			case kops.CloudProviderVSphere:
 				b.addVSphereVolume(c, name, volumeSize, subnet, etcd, m, allMembers)
 			default:
 				return fmt.Errorf("unknown cloudprovider %q", b.Cluster.Spec.CloudProvider)
@@ -144,7 +144,7 @@ func (b *MasterVolumeBuilder) addGCEVolume(c *fi.ModelBuilderContext, name strin
 	//// The name is normally something like "us-east1-a", and the dashes are particularly expensive
 	//// because of the escaping needed (3 characters for each dash)
 	//switch tf.cluster.Spec.CloudProvider {
-	//case string(fi.CloudProviderGCE):
+	//case string(kops.CloudProviderGCE):
 	//	// TODO: If we're still struggling for size, we don't need to put ourselves in the allmembers list
 	//	for i := range allMembers {
 	//		allMembers[i] = strings.Replace(allMembers[i], "-", "", -1)

--- a/pkg/resources/cluster_resources.go
+++ b/pkg/resources/cluster_resources.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 )
 
@@ -63,11 +64,11 @@ type ClusterResources struct {
 
 func (c *ClusterResources) ListResources() (map[string]*ResourceTracker, error) {
 	switch c.Cloud.ProviderID() {
-	case fi.CloudProviderAWS:
+	case kops.CloudProviderAWS:
 		return c.listResourcesAWS()
-	case fi.CloudProviderGCE:
+	case kops.CloudProviderGCE:
 		return c.listResourcesGCE()
-	case fi.CloudProviderVSphere:
+	case kops.CloudProviderVSphere:
 		return c.listResourcesVSphere()
 	default:
 		return nil, fmt.Errorf("Delete on clusters on %q not (yet) supported", c.Cloud.ProviderID())

--- a/tests/integration/channel/integration_test.go
+++ b/tests/integration/channel/integration_test.go
@@ -239,7 +239,7 @@ func TestFindImage(t *testing.T) {
 	for _, g := range grid {
 		kubernetesVersion := semver.MustParse(g.KubernetesVersion)
 
-		image := channel.FindImage(fi.CloudProviderAWS, kubernetesVersion)
+		image := channel.FindImage(kops.CloudProviderAWS, kubernetesVersion)
 		name := ""
 		if image != nil {
 			name = image.Name

--- a/upup/pkg/fi/cloud.go
+++ b/upup/pkg/fi/cloud.go
@@ -16,16 +16,13 @@ limitations under the License.
 
 package fi
 
-import "k8s.io/kubernetes/federation/pkg/dnsprovider"
-
-type CloudProviderID string
-
-const CloudProviderAWS CloudProviderID = "aws"
-const CloudProviderGCE CloudProviderID = "gce"
-const CloudProviderVSphere CloudProviderID = "vsphere"
+import (
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+)
 
 type Cloud interface {
-	ProviderID() CloudProviderID
+	ProviderID() kops.CloudProviderID
 
 	DNS() (dnsprovider.Interface, error)
 
@@ -49,124 +46,124 @@ type SubnetInfo struct {
 
 // zonesToCloud allows us to infer from certain well-known zones to a cloud
 // Note it is safe to "overmap" zones that don't exist: we'll check later if the zones actually exist
-var zonesToCloud = map[string]CloudProviderID{
-	"us-east-1a": CloudProviderAWS,
-	"us-east-1b": CloudProviderAWS,
-	"us-east-1c": CloudProviderAWS,
-	"us-east-1d": CloudProviderAWS,
-	"us-east-1e": CloudProviderAWS,
+var zonesToCloud = map[string]kops.CloudProviderID{
+	"us-east-1a": kops.CloudProviderAWS,
+	"us-east-1b": kops.CloudProviderAWS,
+	"us-east-1c": kops.CloudProviderAWS,
+	"us-east-1d": kops.CloudProviderAWS,
+	"us-east-1e": kops.CloudProviderAWS,
 
-	"us-east-2a": CloudProviderAWS,
-	"us-east-2b": CloudProviderAWS,
-	"us-east-2c": CloudProviderAWS,
-	"us-east-2d": CloudProviderAWS,
-	"us-east-2e": CloudProviderAWS,
+	"us-east-2a": kops.CloudProviderAWS,
+	"us-east-2b": kops.CloudProviderAWS,
+	"us-east-2c": kops.CloudProviderAWS,
+	"us-east-2d": kops.CloudProviderAWS,
+	"us-east-2e": kops.CloudProviderAWS,
 
-	"us-west-1a": CloudProviderAWS,
-	"us-west-1b": CloudProviderAWS,
-	"us-west-1c": CloudProviderAWS,
-	"us-west-1d": CloudProviderAWS,
-	"us-west-1e": CloudProviderAWS,
+	"us-west-1a": kops.CloudProviderAWS,
+	"us-west-1b": kops.CloudProviderAWS,
+	"us-west-1c": kops.CloudProviderAWS,
+	"us-west-1d": kops.CloudProviderAWS,
+	"us-west-1e": kops.CloudProviderAWS,
 
-	"us-west-2a": CloudProviderAWS,
-	"us-west-2b": CloudProviderAWS,
-	"us-west-2c": CloudProviderAWS,
-	"us-west-2d": CloudProviderAWS,
-	"us-west-2e": CloudProviderAWS,
+	"us-west-2a": kops.CloudProviderAWS,
+	"us-west-2b": kops.CloudProviderAWS,
+	"us-west-2c": kops.CloudProviderAWS,
+	"us-west-2d": kops.CloudProviderAWS,
+	"us-west-2e": kops.CloudProviderAWS,
 
-	"ca-central-1a": CloudProviderAWS,
-	"ca-central-1b": CloudProviderAWS,
+	"ca-central-1a": kops.CloudProviderAWS,
+	"ca-central-1b": kops.CloudProviderAWS,
 
-	"eu-west-1a": CloudProviderAWS,
-	"eu-west-1b": CloudProviderAWS,
-	"eu-west-1c": CloudProviderAWS,
-	"eu-west-1d": CloudProviderAWS,
-	"eu-west-1e": CloudProviderAWS,
+	"eu-west-1a": kops.CloudProviderAWS,
+	"eu-west-1b": kops.CloudProviderAWS,
+	"eu-west-1c": kops.CloudProviderAWS,
+	"eu-west-1d": kops.CloudProviderAWS,
+	"eu-west-1e": kops.CloudProviderAWS,
 
-	"eu-central-1a": CloudProviderAWS,
-	"eu-central-1b": CloudProviderAWS,
-	"eu-central-1c": CloudProviderAWS,
-	"eu-central-1d": CloudProviderAWS,
-	"eu-central-1e": CloudProviderAWS,
+	"eu-central-1a": kops.CloudProviderAWS,
+	"eu-central-1b": kops.CloudProviderAWS,
+	"eu-central-1c": kops.CloudProviderAWS,
+	"eu-central-1d": kops.CloudProviderAWS,
+	"eu-central-1e": kops.CloudProviderAWS,
 
-	"ap-south-1a": CloudProviderAWS,
-	"ap-south-1b": CloudProviderAWS,
-	"ap-south-1c": CloudProviderAWS,
-	"ap-south-1d": CloudProviderAWS,
-	"ap-south-1e": CloudProviderAWS,
+	"ap-south-1a": kops.CloudProviderAWS,
+	"ap-south-1b": kops.CloudProviderAWS,
+	"ap-south-1c": kops.CloudProviderAWS,
+	"ap-south-1d": kops.CloudProviderAWS,
+	"ap-south-1e": kops.CloudProviderAWS,
 
-	"ap-southeast-1a": CloudProviderAWS,
-	"ap-southeast-1b": CloudProviderAWS,
-	"ap-southeast-1c": CloudProviderAWS,
-	"ap-southeast-1d": CloudProviderAWS,
-	"ap-southeast-1e": CloudProviderAWS,
+	"ap-southeast-1a": kops.CloudProviderAWS,
+	"ap-southeast-1b": kops.CloudProviderAWS,
+	"ap-southeast-1c": kops.CloudProviderAWS,
+	"ap-southeast-1d": kops.CloudProviderAWS,
+	"ap-southeast-1e": kops.CloudProviderAWS,
 
-	"ap-southeast-2a": CloudProviderAWS,
-	"ap-southeast-2b": CloudProviderAWS,
-	"ap-southeast-2c": CloudProviderAWS,
-	"ap-southeast-2d": CloudProviderAWS,
-	"ap-southeast-2e": CloudProviderAWS,
+	"ap-southeast-2a": kops.CloudProviderAWS,
+	"ap-southeast-2b": kops.CloudProviderAWS,
+	"ap-southeast-2c": kops.CloudProviderAWS,
+	"ap-southeast-2d": kops.CloudProviderAWS,
+	"ap-southeast-2e": kops.CloudProviderAWS,
 
-	"ap-northeast-1a": CloudProviderAWS,
-	"ap-northeast-1b": CloudProviderAWS,
-	"ap-northeast-1c": CloudProviderAWS,
-	"ap-northeast-1d": CloudProviderAWS,
-	"ap-northeast-1e": CloudProviderAWS,
+	"ap-northeast-1a": kops.CloudProviderAWS,
+	"ap-northeast-1b": kops.CloudProviderAWS,
+	"ap-northeast-1c": kops.CloudProviderAWS,
+	"ap-northeast-1d": kops.CloudProviderAWS,
+	"ap-northeast-1e": kops.CloudProviderAWS,
 
-	"ap-northeast-2a": CloudProviderAWS,
-	"ap-northeast-2b": CloudProviderAWS,
-	"ap-northeast-2c": CloudProviderAWS,
-	"ap-northeast-2d": CloudProviderAWS,
-	"ap-northeast-2e": CloudProviderAWS,
+	"ap-northeast-2a": kops.CloudProviderAWS,
+	"ap-northeast-2b": kops.CloudProviderAWS,
+	"ap-northeast-2c": kops.CloudProviderAWS,
+	"ap-northeast-2d": kops.CloudProviderAWS,
+	"ap-northeast-2e": kops.CloudProviderAWS,
 
-	"sa-east-1a": CloudProviderAWS,
-	"sa-east-1b": CloudProviderAWS,
-	"sa-east-1c": CloudProviderAWS,
-	"sa-east-1d": CloudProviderAWS,
-	"sa-east-1e": CloudProviderAWS,
+	"sa-east-1a": kops.CloudProviderAWS,
+	"sa-east-1b": kops.CloudProviderAWS,
+	"sa-east-1c": kops.CloudProviderAWS,
+	"sa-east-1d": kops.CloudProviderAWS,
+	"sa-east-1e": kops.CloudProviderAWS,
 
-	"cn-north-1a": CloudProviderAWS,
-	"cn-north-1b": CloudProviderAWS,
+	"cn-north-1a": kops.CloudProviderAWS,
+	"cn-north-1b": kops.CloudProviderAWS,
 
 	// GCE
-	"asia-east1-a": CloudProviderGCE,
-	"asia-east1-b": CloudProviderGCE,
-	"asia-east1-c": CloudProviderGCE,
-	"asia-east1-d": CloudProviderGCE,
+	"asia-east1-a": kops.CloudProviderGCE,
+	"asia-east1-b": kops.CloudProviderGCE,
+	"asia-east1-c": kops.CloudProviderGCE,
+	"asia-east1-d": kops.CloudProviderGCE,
 
-	"asia-northeast1-a": CloudProviderGCE,
-	"asia-northeast1-b": CloudProviderGCE,
-	"asia-northeast1-c": CloudProviderGCE,
-	"asia-northeast1-d": CloudProviderGCE,
+	"asia-northeast1-a": kops.CloudProviderGCE,
+	"asia-northeast1-b": kops.CloudProviderGCE,
+	"asia-northeast1-c": kops.CloudProviderGCE,
+	"asia-northeast1-d": kops.CloudProviderGCE,
 
-	"europe-west1-a": CloudProviderGCE,
-	"europe-west1-b": CloudProviderGCE,
-	"europe-west1-c": CloudProviderGCE,
-	"europe-west1-d": CloudProviderGCE,
-	"europe-west1-e": CloudProviderGCE,
+	"europe-west1-a": kops.CloudProviderGCE,
+	"europe-west1-b": kops.CloudProviderGCE,
+	"europe-west1-c": kops.CloudProviderGCE,
+	"europe-west1-d": kops.CloudProviderGCE,
+	"europe-west1-e": kops.CloudProviderGCE,
 
-	"us-central1-a": CloudProviderGCE,
-	"us-central1-b": CloudProviderGCE,
-	"us-central1-c": CloudProviderGCE,
-	"us-central1-d": CloudProviderGCE,
-	"us-central1-e": CloudProviderGCE,
-	"us-central1-f": CloudProviderGCE,
-	"us-central1-g": CloudProviderGCE,
-	"us-central1-h": CloudProviderGCE,
+	"us-central1-a": kops.CloudProviderGCE,
+	"us-central1-b": kops.CloudProviderGCE,
+	"us-central1-c": kops.CloudProviderGCE,
+	"us-central1-d": kops.CloudProviderGCE,
+	"us-central1-e": kops.CloudProviderGCE,
+	"us-central1-f": kops.CloudProviderGCE,
+	"us-central1-g": kops.CloudProviderGCE,
+	"us-central1-h": kops.CloudProviderGCE,
 
-	"us-east1-a": CloudProviderGCE,
-	"us-east1-b": CloudProviderGCE,
-	"us-east1-c": CloudProviderGCE,
-	"us-east1-d": CloudProviderGCE,
+	"us-east1-a": kops.CloudProviderGCE,
+	"us-east1-b": kops.CloudProviderGCE,
+	"us-east1-c": kops.CloudProviderGCE,
+	"us-east1-d": kops.CloudProviderGCE,
 
-	"us-west1-a": CloudProviderGCE,
-	"us-west1-b": CloudProviderGCE,
-	"us-west1-c": CloudProviderGCE,
-	"us-west1-d": CloudProviderGCE,
+	"us-west1-a": kops.CloudProviderGCE,
+	"us-west1-b": kops.CloudProviderGCE,
+	"us-west1-c": kops.CloudProviderGCE,
+	"us-west1-d": kops.CloudProviderGCE,
 }
 
 // GuessCloudForZone tries to infer the cloudprovider from the zone name
-func GuessCloudForZone(zone string) (CloudProviderID, bool) {
+func GuessCloudForZone(zone string) (kops.CloudProviderID, bool) {
 	c, found := zonesToCloud[zone]
 	return c, found
 }

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/golang/glog"
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	k8sroute53 "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/aws/route53"
@@ -132,8 +133,8 @@ type awsCloudImplementation struct {
 
 var _ fi.Cloud = &awsCloudImplementation{}
 
-func (c *awsCloudImplementation) ProviderID() fi.CloudProviderID {
-	return fi.CloudProviderAWS
+func (c *awsCloudImplementation) ProviderID() kops.CloudProviderID {
+	return kops.CloudProviderAWS
 }
 
 func (c *awsCloudImplementation) Region() string {

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/golang/glog"
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	dnsproviderroute53 "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/aws/route53"
@@ -72,7 +73,7 @@ type MockCloud struct {
 	MockRoute53        route53iface.Route53API
 }
 
-func (c *MockCloud) ProviderID() fi.CloudProviderID {
+func (c *MockCloud) ProviderID() kops.CloudProviderID {
 	return "mock"
 }
 

--- a/upup/pkg/fi/cloudup/cloudformation/target.go
+++ b/upup/pkg/fi/cloudup/cloudformation/target.go
@@ -128,12 +128,12 @@ func (t *CloudformationTarget) Finish(taskMap map[string]fi.Task) error {
 	//}
 
 	//providersByName := make(map[string]map[string]interface{})
-	//if t.Cloud.ProviderID() == fi.CloudProviderGCE {
+	//if t.Cloud.ProviderID() == kops.CloudProviderGCE {
 	//	providerGoogle := make(map[string]interface{})
 	//	providerGoogle["project"] = t.Project
 	//	providerGoogle["region"] = t.Region
 	//	providersByName["google"] = providerGoogle
-	//} else if t.Cloud.ProviderID() == fi.CloudProviderAWS {
+	//} else if t.Cloud.ProviderID() == kops.CloudProviderAWS {
 	//	providerAWS := make(map[string]interface{})
 	//	providerAWS["region"] = t.Region
 	//	providersByName["aws"] = providerAWS

--- a/upup/pkg/fi/cloudup/dns.go
+++ b/upup/pkg/fi/cloudup/dns.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"github.com/golang/glog"
 	"k8s.io/kops/dns-controller/pkg/dns"
-	api "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops"
 	kopsdns "k8s.io/kops/pkg/dns"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/model"
@@ -39,7 +39,7 @@ const (
 	PlaceholderTTL = 10
 )
 
-func findZone(cluster *api.Cluster, cloud fi.Cloud) (dnsprovider.Zone, error) {
+func findZone(cluster *kops.Cluster, cloud fi.Cloud) (dnsprovider.Zone, error) {
 	dns, err := cloud.DNS()
 	if err != nil {
 		return nil, fmt.Errorf("error building DNS provider: %v", err)
@@ -81,7 +81,7 @@ func findZone(cluster *api.Cluster, cloud fi.Cloud) (dnsprovider.Zone, error) {
 	return zone, nil
 }
 
-func validateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
+func validateDNS(cluster *kops.Cluster, cloud fi.Cloud) error {
 	kopsModelContext := &model.KopsModelContext{
 		Cluster: cluster,
 		// We are not initializing a lot of the fields here; revisit once UsePrivateDNS is "real"
@@ -121,7 +121,7 @@ func validateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
 	return nil
 }
 
-func precreateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
+func precreateDNS(cluster *kops.Cluster, cloud fi.Cloud) error {
 	// TODO: Move to update
 	if !featureflag.DNSPreCreate.Enabled() {
 		glog.V(4).Infof("Skipping DNS record pre-creation because feature flag not enabled")
@@ -164,7 +164,7 @@ func precreateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
 	recordsMap := make(map[string]dnsprovider.ResourceRecordSet)
 	// vSphere provider uses CoreDNS, which doesn't have rrs.List() function supported.
 	// Thus we use rrs.Get() to check every dnsHostname instead
-	if cloud.ProviderID() != fi.CloudProviderVSphere {
+	if cloud.ProviderID() != kops.CloudProviderVSphere {
 		// TODO: We should change the filter to be a suffix match instead
 		//records, err := rrs.List("", "")
 		records, err := rrs.List()
@@ -186,7 +186,7 @@ func precreateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
 	for _, dnsHostname := range dnsHostnames {
 		dnsHostname = dns.EnsureDotSuffix(dnsHostname)
 		found := false
-		if cloud.ProviderID() != fi.CloudProviderVSphere {
+		if cloud.ProviderID() != kops.CloudProviderVSphere {
 			dnsRecord := recordsMap["A::"+dnsHostname]
 			if dnsRecord != nil {
 				rrdatas := dnsRecord.Rrdatas()
@@ -243,7 +243,7 @@ func precreateDNS(cluster *api.Cluster, cloud fi.Cloud) error {
 }
 
 // buildPrecreateDNSHostnames returns the hostnames we should precreate
-func buildPrecreateDNSHostnames(cluster *api.Cluster) []string {
+func buildPrecreateDNSHostnames(cluster *kops.Cluster) []string {
 	dnsInternalSuffix := ".internal." + cluster.ObjectMeta.Name
 
 	var dnsHostnames []string

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -41,8 +41,8 @@ type GCECloud struct {
 
 var _ fi.Cloud = &GCECloud{}
 
-func (c *GCECloud) ProviderID() fi.CloudProviderID {
-	return fi.CloudProviderGCE
+func (c *GCECloud) ProviderID() kops.CloudProviderID {
+	return kops.CloudProviderGCE
 }
 
 func NewGCECloud(region string, project string, labels map[string]string) (*GCECloud, error) {

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -35,17 +35,16 @@ import (
 	"text/template"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	api "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/dns"
 	"k8s.io/kops/pkg/model"
 	"k8s.io/kops/pkg/model/components"
-	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 )
 
 type TemplateFunctions struct {
-	cluster        *api.Cluster
-	instanceGroups []*api.InstanceGroup
+	cluster        *kops.Cluster
+	instanceGroups []*kops.InstanceGroup
 
 	tags   sets.String
 	region string
@@ -89,7 +88,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap) {
 
 	dest["CloudTags"] = tf.modelContext.CloudTagsForInstanceGroup
 
-	dest["KubeDNS"] = func() *api.KubeDNSConfig {
+	dest["KubeDNS"] = func() *kops.KubeDNSConfig {
 		return tf.cluster.Spec.KubeDNS
 	}
 
@@ -120,7 +119,7 @@ func (tf *TemplateFunctions) HasTag(tag string) bool {
 }
 
 // GetInstanceGroup returns the instance group with the specified name
-func (tf *TemplateFunctions) GetInstanceGroup(name string) (*api.InstanceGroup, error) {
+func (tf *TemplateFunctions) GetInstanceGroup(name string) (*kops.InstanceGroup, error) {
 	for _, ig := range tf.instanceGroups {
 		if ig.ObjectMeta.Name == name {
 			return ig, nil
@@ -136,12 +135,12 @@ func (tf *TemplateFunctions) DnsControllerArgv() ([]string, error) {
 
 	argv = append(argv, "--watch-ingress=false")
 
-	switch fi.CloudProviderID(tf.cluster.Spec.CloudProvider) {
-	case fi.CloudProviderAWS:
+	switch kops.CloudProviderID(tf.cluster.Spec.CloudProvider) {
+	case kops.CloudProviderAWS:
 		argv = append(argv, "--dns=aws-route53")
-	case fi.CloudProviderGCE:
+	case kops.CloudProviderGCE:
 		argv = append(argv, "--dns=google-clouddns")
-	case fi.CloudProviderVSphere:
+	case kops.CloudProviderVSphere:
 		argv = append(argv, "--dns=coredns")
 		argv = append(argv, "--dns-server="+*tf.cluster.Spec.CloudConfig.VSphereCoreDNSServer)
 
@@ -190,10 +189,10 @@ func (tf *TemplateFunctions) ExternalDnsArgv() ([]string, error) {
 
 	cloudProvider := tf.cluster.Spec.CloudProvider
 
-	switch fi.CloudProviderID(cloudProvider) {
-	case fi.CloudProviderAWS:
+	switch kops.CloudProviderID(cloudProvider) {
+	case kops.CloudProviderAWS:
 		argv = append(argv, "--provider=aws")
-	case fi.CloudProviderGCE:
+	case kops.CloudProviderGCE:
 		project := tf.cluster.Spec.Project
 		argv = append(argv, "--provider=google")
 		argv = append(argv, "--google-project="+project)

--- a/upup/pkg/fi/cloudup/terraform/target.go
+++ b/upup/pkg/fi/cloudup/terraform/target.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/glog"
 	hcl_parser "github.com/hashicorp/hcl/json/parser"
 	"io/ioutil"
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"os"
 	"path"
@@ -176,16 +177,16 @@ func (t *TerraformTarget) Finish(taskMap map[string]fi.Task) error {
 	}
 
 	providersByName := make(map[string]map[string]interface{})
-	if t.Cloud.ProviderID() == fi.CloudProviderGCE {
+	if t.Cloud.ProviderID() == kops.CloudProviderGCE {
 		providerGoogle := make(map[string]interface{})
 		providerGoogle["project"] = t.Project
 		providerGoogle["region"] = t.Region
 		providersByName["google"] = providerGoogle
-	} else if t.Cloud.ProviderID() == fi.CloudProviderAWS {
+	} else if t.Cloud.ProviderID() == kops.CloudProviderAWS {
 		providerAWS := make(map[string]interface{})
 		providerAWS["region"] = t.Region
 		providersByName["aws"] = providerAWS
-	} else if t.Cloud.ProviderID() == fi.CloudProviderVSphere {
+	} else if t.Cloud.ProviderID() == kops.CloudProviderVSphere {
 		providerVSphere := make(map[string]interface{})
 		providerVSphere["region"] = t.Region
 		providersByName["vsphere"] = providerVSphere

--- a/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
+++ b/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
@@ -62,8 +62,8 @@ const (
 var _ fi.Cloud = &VSphereCloud{}
 
 // ProviderID returns ID for vSphere type cloud provider.
-func (c *VSphereCloud) ProviderID() fi.CloudProviderID {
-	return fi.CloudProviderVSphere
+func (c *VSphereCloud) ProviderID() kops.CloudProviderID {
+	return kops.CloudProviderVSphere
 }
 
 // NewVSphereCloud returns VSphereCloud instance for given ClusterSpec.


### PR DESCRIPTION
This avoids a circular reference when breaking up the fi package

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2770)
<!-- Reviewable:end -->
