### PR TITLE
Remove unnecessary --privileged flag for protokube

### DIFF
--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -83,7 +83,6 @@ func (b *ProtokubeBuilder) buildSystemdService() (*nodetasks.Service, error) {
 		"-v", "/var/run/dbus:/var/run/dbus",
 		"-v", "/run/systemd:/run/systemd",
 		"--net=host",
-		"--privileged",
 		"--env", "KUBECONFIG=/rootfs/var/lib/kops/kubeconfig",
 		b.ProtokubeEnvironmentVariables(),
 		b.ProtokubeImageName(),


### PR DESCRIPTION
The --privileged flag is unnecessary and therefore increases the attack surface of the container

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2775)
<!-- Reviewable:end -->
