### PR TITLE
Add SG parameter into AWS cloud-config

### DIFF
--- a/nodeup/pkg/model/cloudconfig.go
+++ b/nodeup/pkg/model/cloudconfig.go
@@ -68,6 +68,9 @@ func (b *CloudConfigBuilder) Build(c *fi.ModelBuilderContext) error {
 		if cloudConfig.DisableSecurityGroupIngress != nil {
 			lines = append(lines, fmt.Sprintf("DisableSecurityGroupIngress = %t", *cloudConfig.DisableSecurityGroupIngress))
 		}
+		if cloudConfig.ElbSecurityGroup != nil {
+			lines = append(lines, fmt.Sprintf("ElbSecurityGroup = %t", *cloudConfig.ElbSecurityGroup))
+		}
 	case "vsphere":
 		vm_uuid, err := getVMUUID(b.Cluster.Spec.KubernetesVersion)
 		if err != nil {

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -692,7 +692,8 @@ type CloudConfiguration struct {
 	NodeTags           *string `json:"nodeTags,omitempty"`
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
 	// AWS cloud-config options
-	DisableSecurityGroupIngress *bool `json:"disableSecurityGroupIngress,omitempty"`
+	DisableSecurityGroupIngress *bool   `json:"disableSecurityGroupIngress,omitempty"`
+	ElbSecurityGroup            *string `json:"elbSecurityGroup,omitempty"`
 
 	// vSphere cloud-config specs
 	VSphereUsername      *string `json:"vSphereUsername,omitempty"`

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -671,7 +671,8 @@ type CloudConfiguration struct {
 	NodeTags           *string `json:"nodeTags,omitempty"`
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
 	// AWS cloud-config options
-	DisableSecurityGroupIngress *bool `json:"disableSecurityGroupIngress,omitempty"`
+	DisableSecurityGroupIngress *bool   `json:"disableSecurityGroupIngress,omitempty"`
+	ElbSecurityGroup            *string `json:"elbSecurityGroup,omitempty"`
 
 	// vSphere cloud-config specs
 	VSphereUsername      *string `json:"vSphereUsername,omitempty"`

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -309,6 +309,7 @@ func autoConvert_v1alpha1_CloudConfiguration_To_kops_CloudConfiguration(in *Clou
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
 	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
+	out.ElbSecurityGroup = in.ElbSecurityGroup
 	out.VSphereUsername = in.VSphereUsername
 	out.VSpherePassword = in.VSpherePassword
 	out.VSphereServer = in.VSphereServer
@@ -328,6 +329,7 @@ func autoConvert_kops_CloudConfiguration_To_v1alpha1_CloudConfiguration(in *kops
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
 	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
+	out.ElbSecurityGroup = in.ElbSecurityGroup
 	out.VSphereUsername = in.VSphereUsername
 	out.VSpherePassword = in.VSpherePassword
 	out.VSphereServer = in.VSphereServer

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -304,7 +304,8 @@ type CloudConfiguration struct {
 	NodeTags           *string `json:"nodeTags,omitempty"`
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
 	// AWS cloud-config options
-	DisableSecurityGroupIngress *bool `json:"disableSecurityGroupIngress,omitempty"`
+	DisableSecurityGroupIngress *bool   `json:"disableSecurityGroupIngress,omitempty"`
+	ElbSecurityGroup            *string `json:"elbSecurityGroup,omitempty"`
 
 	// vSphere cloud-config specs
 	VSphereUsername      *string `json:"vSphereUsername,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -335,6 +335,7 @@ func autoConvert_v1alpha2_CloudConfiguration_To_kops_CloudConfiguration(in *Clou
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
 	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
+	out.ElbSecurityGroup = in.ElbSecurityGroup
 	out.VSphereUsername = in.VSphereUsername
 	out.VSpherePassword = in.VSpherePassword
 	out.VSphereServer = in.VSphereServer
@@ -354,6 +355,7 @@ func autoConvert_kops_CloudConfiguration_To_v1alpha2_CloudConfiguration(in *kops
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
 	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
+	out.ElbSecurityGroup = in.ElbSecurityGroup
 	out.VSphereUsername = in.VSphereUsername
 	out.VSpherePassword = in.VSpherePassword
 	out.VSphereServer = in.VSphereServer
@@ -1476,7 +1478,6 @@ func autoConvert_kops_KubeProxyConfig_To_v1alpha2_KubeProxyConfig(in *kops.KubeP
 	out.CPURequest = in.CPURequest
 	out.LogLevel = in.LogLevel
 	out.ClusterCIDR = in.ClusterCIDR
-	// WARNING: in.HostnameOverride requires manual conversion: does not exist in peer-type
 	out.Master = in.Master
 	return nil
 }


### PR DESCRIPTION
Added parameter **ElbSecurityGroup**, which resolve this issue:
```
RulesPerSecurityGroupLimitExceeded and HardLimit of 500 security groups per region.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2784)
<!-- Reviewable:end -->
