### PR TITLE
Adding target to check apimachinery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -415,6 +415,16 @@ verify-gofmt:
 verify-packages:
 	hack/verify-packages.sh
 
+.PHONY: verify-apimachinery
+verify-apimachinery: apimachinery
+	if [[ `git status --porcelain` ]]; then \
+	    echo "Changes found when creating apimachinery." 1>&2; \
+	    echo `git status --porcelain` 1>&2; \
+	    echo "This test will fail if git changes are not committed." 1>&2; \
+	    echo "Please run make apimachinery." 1>&2; \
+	    exit 1; \
+	fi 
+
 .PHONY: verify-gendocs
 verify-gendocs: kops
 	TMP_DOCS="$$(mktemp -d)"; \
@@ -435,7 +445,7 @@ verify-gendocs: kops
 # verify-package has to be after verify-gendoc, because with .gitignore for federation bindata
 # it bombs in travis. verify-gendoc generates the bindata file.
 .PHONY: ci
-ci: govet verify-gofmt verify-boilerplate nodeup-gocode examples test | verify-gendocs verify-packages
+ci: govet verify-gofmt verify-boilerplate nodeup-gocode examples test | verify-gendocs verify-packages verify-apimachinery
 	echo "Done!"
 
 # --------------------------------------------------

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1476,7 +1476,6 @@ func autoConvert_kops_KubeProxyConfig_To_v1alpha2_KubeProxyConfig(in *kops.KubeP
 	out.CPURequest = in.CPURequest
 	out.LogLevel = in.LogLevel
 	out.ClusterCIDR = in.ClusterCIDR
-	// WARNING: in.HostnameOverride requires manual conversion: does not exist in peer-type
 	out.Master = in.Master
 	return nil
 }


### PR DESCRIPTION
- New make target verify-apimachinery.  We will need to iterate on this as I am not a huge fan of how I am checking, but it works.
- running apimachinery target remove a comment from on of the autogenerated files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2792)
<!-- Reviewable:end -->
