### PR TITLE
Improve rolling-update cluster docs

### DIFF
--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -5,11 +5,11 @@ Rolling update a cluster.
 ### Synopsis
 
 
-This command updates a kubernetes cluster to match the cloud, and kops specifications. 
+This command updates a kubernetes cluster to match the cloud, and kops specifications.
 
-To perform rolling update, you need to update the cloud resources first with "kops update cluster" 
+To perform rolling update, you need to update the cloud resources first with "kops update cluster"
 
-Note: terraform users will need run the following commands all from the same directory "kops update cluster --target=terraform" then "terraform plan" then "terraform apply" prior to running "kops rolling-update cluster" 
+Note: terraform users will need run the following commands all from the same directory `kops update cluster --target=terraform --out=.` then `terraform plan` then `terraform apply` prior to running `kops rolling-update cluster --yes`.
 
 Use export KOPS FEATURE FLAGS="+DrainAndValidateRollingUpdate" to use beta code that drains the nodes and validates the cluster.  New flags for Drain and Validation operations will be shown when the environment variable is set.
 
@@ -22,7 +22,7 @@ kops rolling-update cluster
 ```
   # Roll the currently selected kops cluster
   kops rolling-update cluster --yes
-  
+
   # Roll the k8s-cluster.example.com kops cluster
   # use the new drain an validate functionality
   export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate"
@@ -30,8 +30,8 @@ kops rolling-update cluster
   --fail-on-validate-error="false" \
   --master-interval=8m \
   --node-interval=8m
-  
-  
+
+
   # Roll the k8s-cluster.example.com kops cluster
   # only roll the node instancegroup
   # use the new drain an validate functionality
@@ -41,6 +41,18 @@ kops rolling-update cluster
   --node-interval 8m \
   --instance-group nodes
 ```
+
+#### Using rolling update with Terraform
+
+    # Update the cluster and place the terraform files in the current directory
+    $ kops update cluster --target=terraform --out=.
+
+    # Plan and apply the changes
+    $ terraform plan
+    $ terraform apply
+
+    # Restart the instances
+    $ kops rolling-update cluster --yes
 
 ### Options
 


### PR DESCRIPTION
The formatting for the terraform instructions were off. I also added an
example in markdown code which is easier to read.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2802)
<!-- Reviewable:end -->
