### PR TITLE
Add SG parameter into AWS cloud-config

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -193,4 +193,23 @@ spec:
       image: busybox
 ```
 
+### cloudConfig
 
+If you are using aws as `cloudProvider`, you can disable authorization of ELB security group to Kubernetes Nodes security group. In other words, it will not add security group rule.
+This can be usefull to avoid AWS limit: 50 rules per security group.
+```yaml
+spec:
+  cloudConfig:
+    disableSecurityGroupIngress: true
+```
+
+#### WARNING: this works only for Kubernetes version above 1.7.0.
+
+For avoid to create security group per each elb, you can specify security group id, that will be assigned to your LoadBalancer. It must be security group id, not name. Also, security group must be empty, because Kubernetes will add rules per ports that are specified in service file.
+This can be usefull to avoid AWS limits: 500 security groups per region and 50 rules per security group.
+
+```yaml
+spec:
+  cloudConfig:
+    elbSecurityGroup: sg-123445678
+```

--- a/nodeup/pkg/model/cloudconfig.go
+++ b/nodeup/pkg/model/cloudconfig.go
@@ -68,6 +68,9 @@ func (b *CloudConfigBuilder) Build(c *fi.ModelBuilderContext) error {
 		if cloudConfig.DisableSecurityGroupIngress != nil {
 			lines = append(lines, fmt.Sprintf("DisableSecurityGroupIngress = %t", *cloudConfig.DisableSecurityGroupIngress))
 		}
+		if cloudConfig.ElbSecurityGroup != nil {
+			lines = append(lines, "ElbSecurityGroup = "+*cloudConfig.ElbSecurityGroup)
+		}
 	case "vsphere":
 		vm_uuid, err := getVMUUID(b.Cluster.Spec.KubernetesVersion)
 		if err != nil {

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -700,7 +700,8 @@ type CloudConfiguration struct {
 	NodeTags           *string `json:"nodeTags,omitempty"`
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
 	// AWS cloud-config options
-	DisableSecurityGroupIngress *bool `json:"disableSecurityGroupIngress,omitempty"`
+	DisableSecurityGroupIngress *bool   `json:"disableSecurityGroupIngress,omitempty"`
+	ElbSecurityGroup            *string `json:"elbSecurityGroup,omitempty"`
 
 	// vSphere cloud-config specs
 	VSphereUsername      *string `json:"vSphereUsername,omitempty"`

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -679,7 +679,8 @@ type CloudConfiguration struct {
 	NodeTags           *string `json:"nodeTags,omitempty"`
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
 	// AWS cloud-config options
-	DisableSecurityGroupIngress *bool `json:"disableSecurityGroupIngress,omitempty"`
+	DisableSecurityGroupIngress *bool   `json:"disableSecurityGroupIngress,omitempty"`
+	ElbSecurityGroup            *string `json:"elbSecurityGroup,omitempty"`
 
 	// vSphere cloud-config specs
 	VSphereUsername      *string `json:"vSphereUsername,omitempty"`

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -323,6 +323,7 @@ func autoConvert_v1alpha1_CloudConfiguration_To_kops_CloudConfiguration(in *Clou
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
 	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
+	out.ElbSecurityGroup = in.ElbSecurityGroup
 	out.VSphereUsername = in.VSphereUsername
 	out.VSpherePassword = in.VSpherePassword
 	out.VSphereServer = in.VSphereServer
@@ -343,6 +344,7 @@ func autoConvert_kops_CloudConfiguration_To_v1alpha1_CloudConfiguration(in *kops
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
 	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
+	out.ElbSecurityGroup = in.ElbSecurityGroup
 	out.VSphereUsername = in.VSphereUsername
 	out.VSpherePassword = in.VSpherePassword
 	out.VSphereServer = in.VSphereServer

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -312,7 +312,8 @@ type CloudConfiguration struct {
 	NodeTags           *string `json:"nodeTags,omitempty"`
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
 	// AWS cloud-config options
-	DisableSecurityGroupIngress *bool `json:"disableSecurityGroupIngress,omitempty"`
+	DisableSecurityGroupIngress *bool   `json:"disableSecurityGroupIngress,omitempty"`
+	ElbSecurityGroup            *string `json:"elbSecurityGroup,omitempty"`
 
 	// vSphere cloud-config specs
 	VSphereUsername      *string `json:"vSphereUsername,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -351,6 +351,7 @@ func autoConvert_v1alpha2_CloudConfiguration_To_kops_CloudConfiguration(in *Clou
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
 	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
+	out.ElbSecurityGroup = in.ElbSecurityGroup
 	out.VSphereUsername = in.VSphereUsername
 	out.VSpherePassword = in.VSpherePassword
 	out.VSphereServer = in.VSphereServer
@@ -371,6 +372,7 @@ func autoConvert_kops_CloudConfiguration_To_v1alpha2_CloudConfiguration(in *kops
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
 	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
+	out.ElbSecurityGroup = in.ElbSecurityGroup
 	out.VSphereUsername = in.VSphereUsername
 	out.VSpherePassword = in.VSpherePassword
 	out.VSphereServer = in.VSphereServer


### PR DESCRIPTION
Added parameter **ElbSecurityGroup**, which resolve this issue:
```
RulesPerSecurityGroupLimitExceeded and HardLimit of 500 security groups per region.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2808)
<!-- Reviewable:end -->
