### PR TITLE
Change to EtcdBuilder in ETCD model

### DIFF
--- a/nodeup/pkg/model/etcd.go
+++ b/nodeup/pkg/model/etcd.go
@@ -28,7 +28,7 @@ type EtcdBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &LogrotateBuilder{}
+var _ fi.ModelBuilder = &EtcdBuilder{}
 
 func (b *EtcdBuilder) Build(c *fi.ModelBuilderContext) error {
 	if !b.IsMaster {


### PR DESCRIPTION
Not sure why this line exists and if it's needed at all, @justinb, @chrislovecnm?
In any case, this should be `EtcdBuilder` and not `LogrotateBuilder`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2813)
<!-- Reviewable:end -->
