### PR TITLE
Setting versions for go and kubectl in protokube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: go
 go:
-  #- 1.5  go test arguments are different in 1.5 :-(
-  #- 1.6 issues with OSX release, and 1.7 is required now by core
-  - 1.7
   - 1.8
   - tip
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GCS_URL=$(GCS_LOCATION:gs://%=https://storage.googleapis.com/%)
 LATEST_FILE?=latest-ci.txt
 GOPATH_1ST=$(shell echo ${GOPATH} | cut -d : -f 1)
 UNIQUE:=$(shell date +%s)
-GOVERSION=1.8.1
+GOVERSION=1.8.3
 
 # See http://stackoverflow.com/questions/18136918/how-to-get-current-relative-directory-of-your-makefile
 MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))

--- a/images/protokube-builder/Dockerfile
+++ b/images/protokube-builder/Dockerfile
@@ -21,7 +21,7 @@ FROM debian:jessie
 RUN apt-get update && apt-get install --yes curl git gcc make
 
 # Install golang
-RUN curl -L https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz | tar zx -C /usr/local
+RUN curl -L https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz | tar zx -C /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 COPY onbuild.sh /onbuild.sh

--- a/images/protokube-builder/onbuild.sh
+++ b/images/protokube-builder/onbuild.sh
@@ -34,5 +34,5 @@ cp /go/bin/channels /src/.build/artifacts/
 
 # channels uses protokube
 cd /src/.build/artifacts/
-curl -O https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/linux/amd64/kubectl
+curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
 chmod +x kubectl


### PR DESCRIPTION
- removing 1.7 in build
- upgrading build to 1.8.3
- upgrade build in protokube to go 1.8.3
- setting protokube to always use the latest version of kubectl during the build.  We could set the kubectl version as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2814)
<!-- Reviewable:end -->
