### PR TITLE
new work on rolling update strategies

### DIFF
--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -52,7 +53,22 @@ var (
 
 	Use ` + pretty.Bash("export KOPS_FEATURE_FLAGS=\"+DrainAndValidateRollingUpdate\"") + ` to use beta code that drains the nodes
 	and validates the cluster.  New flags for Drain and Validation operations will be shown when
-	the environment variable is set.`))
+	the environment variable is set.
+
+	Node Replacement Strategies Alpha Feature
+
+	We are now including three new strategies that influence node replacement. All masters and bastions
+	are rolled sequentially before the nodes, and this flag does not influence their replacement.  These
+	strategies utilize the feature flag mentioned above.
+
+	1. "default" - A node is drained then deleted.  The cloud then replaces the node automatically.
+	2. "create-all-new-ig-first" - All node instance groups are duplicated first; then all old nodes are cordoned.
+	3. "create-new-by-ig" - As each node instance group rolls, the instance group is duplicated, then all
+	old nodes are cordoned.
+
+	The second and third options create new instance groups. In order to use this ALPHA feature
+	you need to enable +DrainAndValidateRollingUpdate,+RollingUpdateStrategies feature flags.
+	`))
 
 	rollingupdate_example = templates.Examples(i18n.T(`
 		# Roll the currently selected kops cluster
@@ -75,6 +91,21 @@ var (
 		  --fail-on-validate-error="false" \
 		  --node-interval 8m \
 		  --instance-group nodes
+
+		# Roll the k8s-cluster.example.com kops cluster, and only roll the instancegroup named "foo".
+		kops rolling-update cluster k8s-cluster.example.com --yes \
+		  --fail-on-validate-error="false" \
+		  --node-interval 8m \
+		  --instance-group foo
+
+		# Use the create-new-by-ig node strategy. Master(s) are update in series, and then
+		# each instance groups is updated in a loop. A new instance group is created, cluster is validated,
+		# and then the old nodes are cordon, drained and deleted. This process is repeated
+		# for every node instance group.
+		export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate,+RollingUpdateStrategies"
+		kops rolling-update cluster k8s-cluster.example.com --yes \
+		  --strategy create-new-by-ig --master-interval=4m \
+		  --node-interval=4m
 		`))
 
 	rollingupdate_short = i18n.T(`Rolling update a cluster.`)
@@ -109,6 +140,8 @@ type RollingUpdateOptions struct {
 	// InstanceGroups is the list of instance groups to rolling-update;
 	// if not specified all instance groups will be updated
 	InstanceGroups []string
+
+	Strategy string
 }
 
 func (o *RollingUpdateOptions) InitDefaults() {
@@ -123,8 +156,8 @@ func (o *RollingUpdateOptions) InitDefaults() {
 	o.BastionInterval = 5 * time.Minute
 
 	o.ValidateRetries = 8
-
 	o.DrainInterval = 90 * time.Second
+	o.Strategy = instancegroups.DEFAULT
 
 }
 
@@ -140,7 +173,7 @@ func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 		Example: rollingupdate_example,
 	}
 
-	cmd.Flags().BoolVar(&options.Yes, "yes", options.Yes, "perform rolling update without confirmation")
+	cmd.Flags().BoolVarP(&options.Yes, "yes", "y", options.Yes, "perform rolling update without confirmation")
 	cmd.Flags().BoolVar(&options.Force, "force", options.Force, "Force rolling update, even if no changes")
 	cmd.Flags().BoolVar(&options.CloudOnly, "cloudonly", options.CloudOnly, "Perform rolling update without confirming progress with k8s")
 
@@ -154,6 +187,10 @@ func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 		cmd.Flags().BoolVar(&options.FailOnValidate, "fail-on-validate-error", true, "The rolling-update will fail if the cluster fails to validate.")
 		cmd.Flags().IntVar(&options.ValidateRetries, "validate-retries", options.ValidateRetries, "The number of times that a node will be validated.  Between validation kops sleeps the master-interval/2 or node-interval/2 duration.")
 		cmd.Flags().DurationVar(&options.DrainInterval, "drain-interval", options.DrainInterval, "The duration that a rolling-update will wait after the node is drained.")
+		if featureflag.RollingUpdateStrategies.Enabled() {
+			cmd.Flags().StringVarP(&options.Strategy, "strategy", "s", options.Strategy, "When new nodes are created. Supported: "+strings.Join(instancegroups.StrategyTypes.List(), ", ")+".")
+		}
+
 	}
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
@@ -204,6 +241,13 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 
 	if options.ValidateRetries <= 0 {
 		return fmt.Errorf("validate-retries flag cannot be 0 or smaller")
+	}
+
+	if featureflag.DrainAndValidateRollingUpdate.Enabled() {
+		if !instancegroups.StrategyTypes.Has(options.Strategy) {
+			return fmt.Errorf("Strategy: %q not known, please use one of: %q", options.Strategy,
+				strings.Join(instancegroups.StrategyTypes.List(), ", "))
+		}
 	}
 
 	var nodes []v1.Node
@@ -340,6 +384,9 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 
 	if featureflag.DrainAndValidateRollingUpdate.Enabled() {
 		glog.V(2).Infof("New rolling update with drain and validate enabled.")
+		if featureflag.RollingUpdateStrategies.Enabled() {
+			glog.V(2).Infof("Using %s algorithm to create new nodes.", options.Strategy)
+		}
 	}
 	d := &instancegroups.RollingUpdateCluster{
 		MasterInterval:   options.MasterInterval,
@@ -354,6 +401,9 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 		ClusterName:      options.ClusterName,
 		ValidateRetries:  options.ValidateRetries,
 		DrainInterval:    options.DrainInterval,
+		Clientset:        clientset,
+		Strategy:         options.Strategy,
+		Cluster:          cluster,
 	}
 	return d.RollingUpdate(groups, list)
 }

--- a/docs/cli/kops_rolling-update.md
+++ b/docs/cli/kops_rolling-update.md
@@ -14,7 +14,17 @@ To perform rolling update, you need to update the cloud resources first with "ko
 
 Note: terraform users will need run the following commands all from the same directory "kops update cluster --target=terraform" then "terraform plan" then "terraform apply" prior to running "kops rolling-update cluster" 
 
-Use export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate"to use beta code that drains the nodes and validates the cluster.  New flags for Drain and Validation operations will be shown when the environment variable is set.
+Use export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate"to use beta code that drains the nodes and validates the cluster.  New flags for Drain and Validation operations will be shown when the environment variable is set. 
+
+Node Replacement Strategies Alpha Feature 
+
+We are now including three new strategies that influence node replacement. All masters and bastions are rolled sequentially before the nodes, and this flag does not influence their replacement.  These strategies utilize the feature flag mentioned above. 
+
+  1. "default" - A node is drained then deleted.  The cloud then replaces the node automatically.  
+  2. "create-all-new-ig-first" - All node instance groups are duplicated first; then all old nodes are cordoned.  
+  3. "create-new-by-ig" - As each node instance group rolls, the instance group is duplicated, then all old nodes are cordoned.  
+
+The second and third options create new instance groups. In order to use this ALPHA feature you need to enable +DrainAndValidateRollingUpdate,+RollingUpdateStrategies feature flags.
 
 ### Examples
 
@@ -39,6 +49,21 @@ Use export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate"to use beta code t
   --fail-on-validate-error="false" \
   --node-interval 8m \
   --instance-group nodes
+  
+  # Roll the k8s-cluster.example.com kops cluster, and only roll the instancegroup named "foo".
+  kops rolling-update cluster k8s-cluster.example.com --yes \
+  --fail-on-validate-error="false" \
+  --node-interval 8m \
+  --instance-group foo
+  
+  # Use the create-new-by-ig node strategy. Master(s) are update in series, and then
+  # each instance groups is updated in a loop. A new instance group is created, cluster is validated,
+  # and then the old nodes are cordon, drained and deleted. This process is repeated
+  # for every node instance group.
+  export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate,+RollingUpdateStrategies"
+  kops rolling-update cluster k8s-cluster.example.com --yes \
+  --strategy create-new-by-ig --master-interval=4m \
+  --node-interval=4m
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -14,7 +14,17 @@ To perform rolling update, you need to update the cloud resources first with "ko
 
 Note: terraform users will need run the following commands all from the same directory "kops update cluster --target=terraform" then "terraform plan" then "terraform apply" prior to running "kops rolling-update cluster" 
 
-Use export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate"to use beta code that drains the nodes and validates the cluster.  New flags for Drain and Validation operations will be shown when the environment variable is set.
+Use export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate"to use beta code that drains the nodes and validates the cluster.  New flags for Drain and Validation operations will be shown when the environment variable is set. 
+
+Node Replacement Strategies Alpha Feature 
+
+We are now including three new strategies that influence node replacement. All masters and bastions are rolled sequentially before the nodes, and this flag does not influence their replacement.  These strategies utilize the feature flag mentioned above. 
+
+  1. "default" - A node is drained then deleted.  The cloud then replaces the node automatically.  
+  2. "create-all-new-ig-first" - All node instance groups are duplicated first; then all old nodes are cordoned.  
+  3. "create-new-by-ig" - As each node instance group rolls, the instance group is duplicated, then all old nodes are cordoned.  
+
+The second and third options create new instance groups. In order to use this ALPHA feature you need to enable +DrainAndValidateRollingUpdate,+RollingUpdateStrategies feature flags.
 
 ```
 kops rolling-update cluster
@@ -43,6 +53,21 @@ kops rolling-update cluster
   --fail-on-validate-error="false" \
   --node-interval 8m \
   --instance-group nodes
+  
+  # Roll the k8s-cluster.example.com kops cluster, and only roll the instancegroup named "foo".
+  kops rolling-update cluster k8s-cluster.example.com --yes \
+  --fail-on-validate-error="false" \
+  --node-interval 8m \
+  --instance-group foo
+  
+  # Use the create-new-by-ig node strategy. Master(s) are update in series, and then
+  # each instance groups is updated in a loop. A new instance group is created, cluster is validated,
+  # and then the old nodes are cordon, drained and deleted. This process is repeated
+  # for every node instance group.
+  export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate,+RollingUpdateStrategies"
+  kops rolling-update cluster k8s-cluster.example.com --yes \
+  --strategy create-new-by-ig --master-interval=4m \
+  --node-interval=4m
 ```
 
 ### Options
@@ -54,7 +79,7 @@ kops rolling-update cluster
       --instance-group stringSlice   List of instance groups to update (defaults to all if not specified)
       --master-interval duration     Time to wait between restarting masters (default 5m0s)
       --node-interval duration       Time to wait between restarting nodes (default 2m0s)
-      --yes                          perform rolling update without confirmation
+  -y, --yes                          perform rolling update without confirmation
 ```
 
 ### Options inherited from parent commands

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -9,3 +9,8 @@ The following experimental features are currently available:
 * `+VSphereCloudProvider` - Enable vSphere cloud provider.
 * `+DrainAndValidateRollingUpdate` - Enable drain and validate for rolling updates.
 * `+EnableExternalDNS` - Enable external-dns with default settings (ingress sources only).
+* `+RollingUpdateStrategies` - Enable strategies for replacing nodes during rolling updates.
+* `+VPCSkipEnableDNSSupport` - if set will mean that VPC does not need DNSSupport enabled.
+* `+SkipTerraformFormat` - if set will mean that we will not `tf fmt` the generated terraform.
+
+

--- a/hack/.packages
+++ b/hack/.packages
@@ -55,6 +55,7 @@ k8s.io/kops/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha1
 k8s.io/kops/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha2
 k8s.io/kops/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha2/fake
 k8s.io/kops/pkg/client/simple
+k8s.io/kops/pkg/client/simple/fake
 k8s.io/kops/pkg/client/simple/vfsclientset
 k8s.io/kops/pkg/diff
 k8s.io/kops/pkg/dns

--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -46,6 +46,7 @@ func TestDefaultTaintsEnforcedBefore160(t *testing.T) {
 			Spec: kops.InstanceGroupSpec{
 				Taints: p.taints,
 				Role:   p.role,
+				AdditionalSecurityGroups: []string{"sg-1234abcd"},
 			},
 		}
 

--- a/pkg/client/simple/fake/doc.go
+++ b/pkg/client/simple/fake/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This package has the fake for simple.clientset.
+package fake

--- a/pkg/client/simple/fake/register.go
+++ b/pkg/client/simple/fake/register.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"os"
+
+	"k8s.io/apimachinery/pkg/apimachinery/announced"
+	"k8s.io/apimachinery/pkg/apimachinery/registered"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	kops "k8s.io/kops/pkg/apis/kops/install"
+)
+
+var scheme = runtime.NewScheme()
+var codecs = serializer.NewCodecFactory(scheme)
+var parameterCodec = runtime.NewParameterCodec(scheme)
+
+var registry = registered.NewOrDie(os.Getenv("KUBE_API_VERSIONS"))
+var groupFactoryRegistry = make(announced.APIGroupFactoryRegistry)
+
+func init() {
+	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	Install(groupFactoryRegistry, registry, scheme)
+}
+
+// Install registers the API group and adds types to a scheme
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+	kops.Install(groupFactoryRegistry, registry, scheme)
+
+}

--- a/pkg/client/simple/fake/simple_clientset.go
+++ b/pkg/client/simple/fake/simple_clientset.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/testing"
+	"k8s.io/kops/pkg/apis/kops"
+	kopsinternalversion "k8s.io/kops/pkg/client/clientset_generated/clientset/typed/kops/internalversion"
+	fakekopsinternalversion "k8s.io/kops/pkg/client/clientset_generated/clientset/typed/kops/internalversion/fake"
+	"k8s.io/kops/pkg/client/simple"
+	"k8s.io/kops/util/pkg/vfs"
+)
+
+// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	fakePtr := testing.Fake{}
+	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
+
+	fakePtr.AddWatchReactor("*", testing.DefaultWatchReactor(watch.NewFake(), nil))
+
+	return &Clientset{fakePtr}
+}
+
+// Clientset implements simple.Clientset. Meant to be embedded into a
+// struct to get a default implementation. This makes faking out just the method
+// you want to test easier.
+type Clientset struct {
+	testing.Fake
+}
+
+var _ simple.Clientset = &Clientset{}
+
+// ClustersFor returns the ClusterInterface bound to the namespace for a particular Cluster
+func (c *Clientset) ClustersFor(cluster *kops.Cluster) kopsinternalversion.ClusterInterface {
+	/*
+		fk := &fakekopsinternalversion.FakeKops{&c.Fake}
+		return fk.Clusters("")
+	*/
+	return nil
+}
+
+// GetCluster reads a cluster by name
+func (c *Clientset) GetCluster(name string) (*kops.Cluster, error) {
+	fk := &fakekopsinternalversion.FakeKops{&c.Fake}
+	return fk.Clusters("").Get(name, metav1.GetOptions{})
+}
+
+// ListClusters returns all clusters
+func (c *Clientset) ListClusters(options metav1.ListOptions) (*kops.ClusterList, error) {
+	fk := &fakekopsinternalversion.FakeKops{&c.Fake}
+	return fk.Clusters("").List(options)
+}
+
+// ConfigBaseFor returns the vfs path where we will read configuration information from
+func (c *Clientset) ConfigBaseFor(cluster *kops.Cluster) (vfs.Path, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+// InstanceGroupsFor returns the InstanceGroupInterface bounds to the namespace for a particular Cluster
+func (c *Clientset) InstanceGroupsFor(cluster *kops.Cluster) kopsinternalversion.InstanceGroupInterface {
+	clusterName := cluster.ObjectMeta.Name
+	fk := &fakekopsinternalversion.FakeKops{&c.Fake}
+	return fk.InstanceGroups(clusterName)
+}
+
+// FederationsFor returns the FederationInterface bounds to the namespace for a particular Federation
+func (c *Clientset) FederationsFor(federation *kops.Federation) kopsinternalversion.FederationInterface {
+	return nil
+}
+
+// ListFederations returns all federations
+func (c *Clientset) ListFederations(options metav1.ListOptions) (*kops.FederationList, error) {
+	fk := &fakekopsinternalversion.FakeKops{&c.Fake}
+	return fk.Federations("").List(options)
+}
+
+// GetFederation reads a federation by name
+func (c *Clientset) GetFederation(name string) (*kops.Federation, error) {
+	fk := &fakekopsinternalversion.FakeKops{&c.Fake}
+	return fk.Federations("").Get(name, metav1.GetOptions{})
+}

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -42,6 +42,9 @@ var DNSPreCreate = New("DNSPreCreate", Bool(true))
 // DrainAndValidateRollingUpdate if set will use new rolling update code that will drain and validate.
 var DrainAndValidateRollingUpdate = New("DrainAndValidateRollingUpdate", Bool(false))
 
+// RollingUpdateStrategies if set will use new rolling update code that will drain and validate.
+var RollingUpdateStrategies = New("RollingUpdateStrategies", Bool(false))
+
 // VPCSkipEnableDNSSupport if set will make that a VPC does not need DNSSupport enabled.
 var VPCSkipEnableDNSSupport = New("VPCSkipEnableDNSSupport", Bool(false))
 

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -18,13 +18,13 @@ package instancegroups
 
 import (
 	"fmt"
-	"os"
+	"regexp"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/golang/glog"
-	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/client-go/pkg/api/v1"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/client/simple"
@@ -32,13 +32,14 @@ import (
 	"k8s.io/kops/pkg/resources"
 	"k8s.io/kops/pkg/validation"
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
-	"k8s.io/kubernetes/pkg/kubectl/cmd"
-	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
+// TODO test that parent IG has a child that is properly created
+
 // FindCloudInstanceGroups joins data from the cloud and the instance groups into a map that can be used for updates.
-func FindCloudInstanceGroups(cloud fi.Cloud, cluster *api.Cluster, instancegroups []*api.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*CloudInstanceGroup, error) {
+func FindCloudInstanceGroups(cloud fi.Cloud, cluster *api.Cluster, igs []*api.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*CloudInstanceGroup, error) {
 	awsCloud := cloud.(awsup.AWSCloud)
 
 	groups := make(map[string]*CloudInstanceGroup)
@@ -59,8 +60,8 @@ func FindCloudInstanceGroups(cloud fi.Cloud, cluster *api.Cluster, instancegroup
 
 	for _, asg := range asgs {
 		name := aws.StringValue(asg.AutoScalingGroupName)
-		var instancegroup *api.InstanceGroup
-		for _, g := range instancegroups {
+		var ig *api.InstanceGroup
+		for _, g := range igs {
 			var asgName string
 			switch g.Spec.Role {
 			case api.InstanceGroupRoleMaster:
@@ -75,20 +76,20 @@ func FindCloudInstanceGroups(cloud fi.Cloud, cluster *api.Cluster, instancegroup
 			}
 
 			if name == asgName {
-				if instancegroup != nil {
+				if ig != nil {
 					return nil, fmt.Errorf("Found multiple instance groups matching ASG %q", asgName)
 				}
-				instancegroup = g
+				ig = g
 			}
 		}
-		if instancegroup == nil {
+		if ig == nil {
 			if warnUnmatched {
 				glog.Warningf("Found ASG with no corresponding instance group %q", name)
 			}
 			continue
 		}
-		group := buildCloudInstanceGroup(instancegroup, asg, nodeMap)
-		groups[instancegroup.ObjectMeta.Name] = group
+		group := buildCloudInstanceGroup(ig, asg, nodeMap)
+		groups[ig.ObjectMeta.Name] = group
 	}
 
 	return groups, nil
@@ -101,11 +102,21 @@ type DeleteInstanceGroup struct {
 	Clientset simple.Clientset
 }
 
-func (c *DeleteInstanceGroup) DeleteInstanceGroup(group *api.InstanceGroup) error {
-	groups, err := FindCloudInstanceGroups(c.Cloud, c.Cluster, []*api.InstanceGroup{group}, false, nil)
-	if err != nil {
-		return fmt.Errorf("error finding CloudInstanceGroups: %v", err)
+// DeleteInstanceGroup deletes an InstanceGroup.
+func (d *DeleteInstanceGroup) DeleteInstanceGroup(group *api.InstanceGroup) error {
+
+	if group == nil {
+		return fmt.Errorf("unable to delete instance as function call with nil value")
 	}
+
+	if d.Cluster == nil {
+		return fmt.Errorf("unable to delete instance as cluster is not defined")
+	}
+	if d.Cloud == nil {
+		return fmt.Errorf("unable to delete instance as cloud is not defined")
+	}
+
+	groups, err := FindCloudInstanceGroups(d.Cloud, d.Cluster, []*api.InstanceGroup{group}, false, nil)
 	cig := groups[group.ObjectMeta.Name]
 	if cig == nil {
 		glog.Warningf("AutoScalingGroup %q not found in cloud - skipping delete", group.ObjectMeta.Name)
@@ -116,15 +127,14 @@ func (c *DeleteInstanceGroup) DeleteInstanceGroup(group *api.InstanceGroup) erro
 
 		glog.Infof("Deleting AutoScalingGroup %q", group.ObjectMeta.Name)
 
-		err = cig.Delete(c.Cloud)
+		err = cig.Delete(d.Cloud)
 		if err != nil {
 			return fmt.Errorf("error deleting cloud resources for InstanceGroup: %v", err)
 		}
 	}
 
-	err = c.Clientset.InstanceGroupsFor(c.Cluster).Delete(group.ObjectMeta.Name, nil)
-	if err != nil {
-		return err
+	if err = d.Clientset.InstanceGroupsFor(d.Cluster).Delete(group.ObjectMeta.Name, nil); err != nil {
+		return fmt.Errorf("unable to delete instance group: %q, %v", group.ObjectMeta.Name, err)
 	}
 
 	return nil
@@ -180,31 +190,32 @@ type CloudInstanceGroupInstance struct {
 	Node        *v1.Node
 }
 
-func (n *CloudInstanceGroup) String() string {
-	return "CloudInstanceGroup:" + n.ASGName
+// String provides a helper method for printing a string value of a CloudInstanceGroup.
+func (c *CloudInstanceGroup) String() string {
+	return "CloudInstanceGroup:" + c.ASGName
 }
 
+// MinSize returns the aws autoscale group minimum size.
 func (c *CloudInstanceGroup) MinSize() int {
 	return int(aws.Int64Value(c.asg.MinSize))
 }
 
+// MinSize returns the aws autoscale group maximum size.
 func (c *CloudInstanceGroup) MaxSize() int {
 	return int(aws.Int64Value(c.asg.MaxSize))
 }
 
-// TODO: Temporarily increase size of ASG?
 // TODO: Remove from ASG first so status is immediately updated?
-// TODO: Batch termination, like a rolling-update
 
 // RollingUpdate performs a rolling update on a list of ec2 instances.
-func (n *CloudInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpdateCluster, instanceGroupList *api.InstanceGroupList, isBastion bool, t time.Duration) (err error) {
+func (c *CloudInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpdateCluster, instanceGroupList *api.InstanceGroupList, isBastion bool, t time.Duration) (err error) {
 
 	// we should not get here, but hey I am going to check.
 	if rollingUpdateData == nil {
 		return fmt.Errorf("rollingUpdate cannot be nil")
 	}
 
-	// Do not need a k8s client if you are doing cloudonly.
+	// Do not need a k8s client if you are doing cloud only.
 	if rollingUpdateData.K8sClient == nil && !rollingUpdateData.CloudOnly {
 		return fmt.Errorf("rollingUpdate is missing a k8s client")
 	}
@@ -213,15 +224,23 @@ func (n *CloudInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpdateClust
 		return fmt.Errorf("rollingUpdate is missing the InstanceGroupList")
 	}
 
-	c := rollingUpdateData.Cloud.(awsup.AWSCloud)
+	cloud := rollingUpdateData.Cloud.(awsup.AWSCloud)
 
-	update := n.NeedUpdate
+	update := c.NeedUpdate
 	if rollingUpdateData.Force {
-		update = append(update, n.Ready...)
+		update = append(update, c.Ready...)
 	}
 
 	if len(update) == 0 {
 		return nil
+	}
+
+	v := &validation.ValidateClusterRetries{
+		Cluster:         rollingUpdateData.Cluster,
+		Clientset:       rollingUpdateData.Clientset,
+		Interval:        rollingUpdateData.NodeInterval,
+		K8sClient:       rollingUpdateData.K8sClient,
+		ValidateRetries: rollingUpdateData.ValidateRetries,
 	}
 
 	if isBastion {
@@ -229,7 +248,7 @@ func (n *CloudInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpdateClust
 	} else if rollingUpdateData.CloudOnly {
 		glog.V(3).Info("Not validating cluster as validation is turned off via the cloud-only flag.")
 	} else if featureflag.DrainAndValidateRollingUpdate.Enabled() {
-		if err = n.ValidateCluster(rollingUpdateData, instanceGroupList); err != nil {
+		if err = v.ValidateCluster(instanceGroupList); err != nil {
 			if rollingUpdateData.FailOnValidate {
 				return fmt.Errorf("error validating cluster: %v", err)
 			} else {
@@ -238,6 +257,8 @@ func (n *CloudInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpdateClust
 			}
 		}
 	}
+
+	nodeAdapter, err := validation.NewNodeAPIAdapter(rollingUpdateData.K8sClient, rollingUpdateData.NodeInterval, rollingUpdateData.ClientConfig)
 
 	for _, u := range update {
 
@@ -250,7 +271,7 @@ func (n *CloudInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpdateClust
 
 		if isBastion {
 
-			if err = n.DeleteAWSInstance(u, instanceId, nodeName, c); err != nil {
+			if err = c.DeleteAWSInstance(u, instanceId, nodeName, cloud); err != nil {
 				glog.Errorf("Error deleting aws instance %q: %v", instanceId, err)
 				return err
 			}
@@ -268,7 +289,7 @@ func (n *CloudInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpdateClust
 			if u.Node != nil {
 				glog.Infof("Draining the node: %q.", nodeName)
 
-				if err = n.DrainNode(u, rollingUpdateData); err != nil {
+				if err = nodeAdapter.DrainNode(u.Node.Name, false, rollingUpdateData.DrainInterval); err != nil {
 					if rollingUpdateData.FailOnDrainError {
 						return fmt.Errorf("Failed to drain node %q: %v", nodeName, err)
 					} else {
@@ -280,7 +301,7 @@ func (n *CloudInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpdateClust
 			}
 		}
 
-		if err = n.DeleteAWSInstance(u, instanceId, nodeName, c); err != nil {
+		if err = c.DeleteAWSInstance(u, instanceId, nodeName, cloud); err != nil {
 			glog.Errorf("Error deleting aws instance %q, node %q: %v", instanceId, nodeName, err)
 			return err
 		}
@@ -297,7 +318,7 @@ func (n *CloudInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpdateClust
 
 			glog.Infof("Validating the cluster.")
 
-			if err = n.ValidateClusterWithRetries(rollingUpdateData, instanceGroupList, t); err != nil {
+			if err = v.ValidateClusterWithRetries(instanceGroupList); err != nil {
 
 				if rollingUpdateData.FailOnValidate {
 					return fmt.Errorf("error validating cluster after removing a node: %v", err)
@@ -311,45 +332,116 @@ func (n *CloudInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpdateClust
 	return nil
 }
 
-// ValidateClusterWithRetries runs our validation methods on the K8s Cluster x times and then fails.
-func (n *CloudInstanceGroup) ValidateClusterWithRetries(rollingUpdateData *RollingUpdateCluster, instanceGroupList *api.InstanceGroupList, t time.Duration) (err error) {
+// RollingUpdateNodesCreate iterates through each instance group.  First a new instance groups is created
+// and the old nodes are cordoned.  Next the old nodes are drained and the old instance groups is deleted.
+func (c *CloudInstanceGroup) RollingUpdateNodesCreate(r *RollingUpdateCluster) error {
 
-	// TODO - We are going to need to improve Validate to allow for more than one node, not master
-	// TODO - going down at a time.
-	for i := 0; i <= rollingUpdateData.ValidateRetries; i++ {
+	// Figure out which CloudInstanceGroups need updating and create a new instance group for each
+	if r.Force {
+		c.NeedUpdate = append(c.NeedUpdate, c.Ready...)
+	}
 
-		if _, err = validation.ValidateCluster(rollingUpdateData.ClusterName, instanceGroupList, rollingUpdateData.K8sClient); err != nil {
-			glog.Infof("Cluster did not validate, and waiting longer: %v.", err)
-			time.Sleep(t / 2)
-		} else {
-			glog.Infof("Cluster validated.")
-			return nil
+	if len(c.NeedUpdate) == 0 {
+		return nil
+	}
+
+	if _, ok := c.InstanceGroup.ObjectMeta.Annotations[KOPS_IG_CHILD]; !ok {
+
+		suffix := getSuffix(c.InstanceGroup.ObjectMeta.Name)
+
+		if _, err := c.DuplicateClusterInstanceGroup(r.Cluster, r.Clientset, suffix); err != nil {
+			return fmt.Errorf("unable to create new instance group: %v", err)
+		}
+	}
+
+	if err := updateCluster(r.Cluster, r.Clientset); err != nil {
+		return fmt.Errorf("unable to update cluster: %v", err)
+	}
+
+	glog.Info("Waiting for new Instance Group to start")
+	time.Sleep(r.NodeInterval)
+
+	// get the new list of ig and validate cluster
+	if err := validateCluster(r); err != nil {
+		return fmt.Errorf("unable to validate cluster: %v", err)
+	}
+
+	if err := c.CordonNodes(r); err != nil {
+		return fmt.Errorf("unable to cordon nodes: %v", err)
+	}
+
+	if err := c.DrainAndDelete(r); err != nil {
+		return fmt.Errorf("unable to drain and delete nodes: %v", err)
+	}
+
+	// validate new nodes
+	if err := validateCluster(r); err != nil {
+		return fmt.Errorf("unable to validate cluster: %v", err)
+	}
+
+	return nil
+}
+
+// CordonNodes take the nodes in the NeedUpdate slice and cordons the Kubernetes node
+// using the validation node adapter.
+func (c *CloudInstanceGroup) CordonNodes(r *RollingUpdateCluster) error {
+
+	if r.CloudOnly {
+		glog.Warningf("not cordoning nodes as --cloud-only is set")
+	}
+
+	nodeAdapter, _ := validation.NewNodeAPIAdapter(r.K8sClient, r.NodeInterval, r.ClientConfig)
+	for _, u := range c.NeedUpdate {
+		if err := nodeAdapter.CordonNode(u.Node.Name); err != nil {
+			if r.FailOnDrainError {
+				return fmt.Errorf("unable to cardon node: %v", err)
+			}
+		}
+		glog.Infof("Cordoned %q", u.Node.Name)
+	}
+
+	return nil
+}
+
+// DrainAndDelete drains and deletes all nodes in the need update slice.
+func (c *CloudInstanceGroup) DrainAndDelete(r *RollingUpdateCluster) error {
+
+	if r.CloudOnly {
+		glog.Warningf("not draining nodes as --cloud-only is set")
+	} else {
+		nodeAdapter, _ := validation.NewNodeAPIAdapter(r.K8sClient, r.NodeInterval, r.ClientConfig)
+		// Drain the nodes
+		// TODO move Drain code into delete code
+		for _, u := range c.NeedUpdate {
+			// TODO handle pod disruption budgets
+			if err := nodeAdapter.DrainNode(u.Node.Name, false, r.DrainInterval); err != nil {
+				if r.FailOnDrainError {
+					return fmt.Errorf("Failed to drain node %q: %v", u.Node.Name, err)
+				}
+				glog.Infof("Ignoring error draining node %q: %v", u.Node.Name, err)
+			}
+
+			glog.Infof("Drained node %q", u.Node.Name)
 		}
 
 	}
 
-	// for loop is done, and did not end when the cluster validated
-	return fmt.Errorf("cluster validation failed: %v", err)
-}
-
-// ValidateCluster runs our validation methods on the K8s Cluster.
-func (n *CloudInstanceGroup) ValidateCluster(rollingUpdateData *RollingUpdateCluster, instanceGroupList *api.InstanceGroupList) error {
-
-	if _, err := validation.ValidateCluster(rollingUpdateData.ClusterName, instanceGroupList, rollingUpdateData.K8sClient); err != nil {
-		return fmt.Errorf("cluster %q did not pass validation: %v", rollingUpdateData.ClusterName, err)
+	d := &DeleteInstanceGroup{
+		Cluster:   r.Cluster,
+		Clientset: r.Clientset,
+		Cloud:     r.Cloud,
 	}
-
-	return nil
+	return d.DeleteInstanceGroup(c.InstanceGroup)
 
 }
 
 // DeleteAWSInstance deletes an EC2 AWS Instance.
-func (n *CloudInstanceGroup) DeleteAWSInstance(u *CloudInstanceGroupInstance, instanceId string, nodeName string, c awsup.AWSCloud) error {
+func (c *CloudInstanceGroup) DeleteAWSInstance(u *CloudInstanceGroupInstance, instanceId string, nodeName string, cloud awsup.AWSCloud) error {
 
 	if nodeName != "" {
-		glog.Infof("Stopping instance %q, node %q, in AWS ASG %q.", instanceId, nodeName, n.ASGName)
+		glog.Infof("Stopping instance %q, node %q, in AWS ASG %q.", instanceId, nodeName, c.ASGName)
 	} else {
-		glog.Infof("Stopping instance %q, in AWS ASG %q.", instanceId, n.ASGName)
+		glog.Infof("Stopping instance %q, in AWS ASG %q.", instanceId, c.ASGName)
 	}
 
 	request := &autoscaling.TerminateInstanceInAutoScalingGroupInput{
@@ -357,7 +449,7 @@ func (n *CloudInstanceGroup) DeleteAWSInstance(u *CloudInstanceGroupInstance, in
 		ShouldDecrementDesiredCapacity: aws.Bool(false),
 	}
 
-	if _, err := c.Autoscaling().TerminateInstanceInAutoScalingGroup(request); err != nil {
+	if _, err := cloud.Autoscaling().TerminateInstanceInAutoScalingGroup(request); err != nil {
 		if nodeName != "" {
 			return fmt.Errorf("error deleting instance %q, node %q: %v", instanceId, nodeName, err)
 		}
@@ -368,67 +460,21 @@ func (n *CloudInstanceGroup) DeleteAWSInstance(u *CloudInstanceGroupInstance, in
 
 }
 
-// DrainNode drains a K8s node.
-func (n *CloudInstanceGroup) DrainNode(u *CloudInstanceGroupInstance, rollingUpdateData *RollingUpdateCluster) error {
-	if rollingUpdateData.ClientConfig == nil {
-		return fmt.Errorf("ClientConfig not set")
-	}
-	f := cmdutil.NewFactory(rollingUpdateData.ClientConfig)
-
-	// TODO: Send out somewhere else, also DrainOptions has errout
-	out := os.Stdout
-	errOut := os.Stderr
-
-	options := &cmd.DrainOptions{
-		Factory:          f,
-		Out:              out,
-		IgnoreDaemonsets: true,
-		Force:            true,
-		DeleteLocalData:  true,
-		ErrOut:           errOut,
-	}
-
-	cmd := &cobra.Command{
-		Use: "cordon NODE",
-	}
-	args := []string{u.Node.Name}
-	err := options.SetupDrain(cmd, args)
-	if err != nil {
-		return fmt.Errorf("error setting up drain: %v", err)
-	}
-
-	err = options.RunCordonOrUncordon(true)
-	if err != nil {
-		return fmt.Errorf("error cordoning node node: %v", err)
-	}
-
-	err = options.RunDrain()
-	if err != nil {
-		return fmt.Errorf("error draining node: %v", err)
-	}
-
-	if rollingUpdateData.DrainInterval > time.Second*0 {
-		glog.V(3).Infof("Waiting for %s for pods to stabilize after draining.", rollingUpdateData.DrainInterval)
-		time.Sleep(rollingUpdateData.DrainInterval)
-	}
-
-	return nil
-}
-
-func (g *CloudInstanceGroup) Delete(cloud fi.Cloud) error {
-	c := cloud.(awsup.AWSCloud)
+// Delete removes an instance in AWS.
+func (c *CloudInstanceGroup) Delete(cloud fi.Cloud) error {
+	cloudInterface := cloud.(awsup.AWSCloud)
 
 	// TODO: Graceful?
 
 	// Delete ASG
 	{
-		asgName := aws.StringValue(g.asg.AutoScalingGroupName)
+		asgName := aws.StringValue(c.asg.AutoScalingGroupName)
 		glog.V(2).Infof("Deleting autoscaling group %q", asgName)
 		request := &autoscaling.DeleteAutoScalingGroupInput{
-			AutoScalingGroupName: g.asg.AutoScalingGroupName,
+			AutoScalingGroupName: c.asg.AutoScalingGroupName,
 			ForceDelete:          aws.Bool(true),
 		}
-		_, err := c.Autoscaling().DeleteAutoScalingGroup(request)
+		_, err := cloudInterface.Autoscaling().DeleteAutoScalingGroup(request)
 		if err != nil {
 			return fmt.Errorf("error deleting autoscaling group %q: %v", asgName, err)
 		}
@@ -436,16 +482,154 @@ func (g *CloudInstanceGroup) Delete(cloud fi.Cloud) error {
 
 	// Delete LaunchConfig
 	{
-		lcName := aws.StringValue(g.asg.LaunchConfigurationName)
+		lcName := aws.StringValue(c.asg.LaunchConfigurationName)
 		glog.V(2).Infof("Deleting autoscaling launch configuration %q", lcName)
 		request := &autoscaling.DeleteLaunchConfigurationInput{
-			LaunchConfigurationName: g.asg.LaunchConfigurationName,
+			LaunchConfigurationName: c.asg.LaunchConfigurationName,
 		}
-		_, err := c.Autoscaling().DeleteLaunchConfiguration(request)
+		_, err := cloudInterface.Autoscaling().DeleteLaunchConfiguration(request)
 		if err != nil {
 			return fmt.Errorf("error deleting autoscaling launch configuration %q: %v", lcName, err)
 		}
 	}
 
 	return nil
+}
+
+const (
+	// Instance group annotation name used when duplicating a cluster instance group.
+	KOPS_IG_PARENT = "kops.alpha.kubernetes.io/instancegroup/parent"
+	// Instance group annotation name used when duplicating a cluster instance group.
+	KOPS_IG_CHILD = "kops.alpha.kubernetes.io/instancegroup/child"
+)
+
+// DuplicateClusterInstanceGroup creates a copy of the CloudInstanceGroup cluster instance group for the provided cluster.
+// The cluster instance groups are updated with annotations that denote a child an parent relationship.
+func (c *CloudInstanceGroup) DuplicateClusterInstanceGroup(cluster *api.Cluster, clientSet simple.Clientset, newName string) (*api.InstanceGroup, error) {
+	obj, err := conversion.NewCloner().DeepCopy(c.InstanceGroup)
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to clone instance group: %v", err)
+	}
+
+	ig, ok := obj.(*api.InstanceGroup)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected object type: %T", obj)
+	}
+
+	{
+		// DeepCopy does not get the maps need to copy those through
+		ig.ObjectMeta.Labels = c.InstanceGroup.ObjectMeta.Labels
+		ig.ObjectMeta.Annotations = c.InstanceGroup.ObjectMeta.Annotations
+		ig.ObjectMeta.Name = newName
+		ig.Spec.Role = c.InstanceGroup.Spec.Role
+
+		if ig.ObjectMeta.Annotations == nil {
+			ig.ObjectMeta.Annotations = make(map[string]string)
+		}
+		if c.InstanceGroup.ObjectMeta.Annotations == nil {
+			c.InstanceGroup.ObjectMeta.Annotations = make(map[string]string)
+		}
+
+		ig.ObjectMeta.Annotations[KOPS_IG_PARENT] = c.InstanceGroup.ObjectMeta.Name
+		c.InstanceGroup.ObjectMeta.Annotations[KOPS_IG_CHILD] = ig.ObjectMeta.Name
+		ig.Spec.CloudLabels = c.InstanceGroup.Spec.CloudLabels
+		ig.Spec.NodeLabels = c.InstanceGroup.Spec.NodeLabels
+	}
+
+	{
+		if err := cloudup.CreateInstanceGroup(ig, cluster, clientSet); err != nil {
+			return nil, fmt.Errorf("unable to create new instance group: %v", err)
+		}
+
+		if _, err := clientSet.InstanceGroupsFor(cluster).Update(c.InstanceGroup); err != nil {
+			return nil, fmt.Errorf("unable to update instance group: %v", err)
+		}
+	}
+
+	glog.V(4).Infof("adding instance group: %+v", ig)
+	glog.V(4).Infof("based on instance group: %+v", c.InstanceGroup)
+
+	return ig, nil
+}
+
+func validateCluster(r *RollingUpdateCluster) error {
+	if r.CloudOnly {
+		glog.Warningf("Not validating cluster as --cloud-only is set")
+		return nil
+	}
+	v := &validation.ValidateClusterRetries{
+		Cluster:         r.Cluster,
+		Clientset:       r.Clientset,
+		Interval:        r.NodeInterval,
+		K8sClient:       r.K8sClient,
+		ValidateRetries: r.ValidateRetries,
+	}
+
+	// get the new list of ig and validate cluster
+	if err := v.GetInstanceGroupsAndValidateCluster(); err != nil {
+		if r.FailOnValidate {
+			return fmt.Errorf("unable to validate cluster: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func updateCluster(cluster *api.Cluster, clientset simple.Clientset) error {
+
+	if clientset == nil {
+		return fmt.Errorf("client must be set, it is nil")
+	}
+	if cluster == nil {
+		return fmt.Errorf("cluster must be set, it is nil")
+	}
+
+	glog.V(4).Infof("cluster: %+v", cluster)
+	glog.V(4).Infof("client set: %+v", clientset)
+
+	applyCmd := &cloudup.ApplyClusterCmd{
+		Cluster:         cluster,
+		Models:          nil,
+		Clientset:       clientset,
+		TargetName:      cloudup.TargetDirect,
+		OutDir:          ".",
+		DryRun:          false,
+		MaxTaskDuration: cloudup.DefaultMaxTaskDuration,
+		InstanceGroups:  nil,
+	}
+
+	if err := applyCmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// These are used for creating the new name of a duplicate instance group.
+// If you have a instance group that is "nodes01" a name of "nodes01-rolling-update-006-01-02-15-04-05"
+// will be created.
+const (
+	IG_PREFIX    = "-rolling-update-"
+	IG_TS_LAYOUT = "2006-01-02-15-04-05"
+)
+
+var igRegex = regexp.MustCompile(IG_PREFIX + "(\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}$)")
+
+func getSuffix(oldName string) string {
+	t := time.Now()
+	return getSuffixWithTime(oldName, t)
+}
+
+func getSuffixWithTime(oldName string, t time.Time) string {
+
+	timeStamp := IG_PREFIX + t.Format(IG_TS_LAYOUT)
+
+	if igRegex.MatchString(oldName) {
+		return igRegex.ReplaceAllString(oldName, timeStamp)
+	}
+
+	return oldName + timeStamp
+
 }

--- a/pkg/instancegroups/instancegroups_test.go
+++ b/pkg/instancegroups/instancegroups_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancegroups
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	api "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/client/simple/fake"
+)
+
+func TestGetPrefix(t *testing.T) {
+	timeStamp := time.Now()
+	timeStampLayout := timeStamp.Format(IG_TS_LAYOUT)
+	grid := []struct {
+		Input  string
+		Output string
+	}{
+		{
+			Input:  "foo",
+			Output: fmt.Sprintf("foo%s%s", IG_PREFIX, timeStampLayout),
+		},
+		{
+			Input:  "node01-rolling-update-2017-01-02-15-04-05",
+			Output: fmt.Sprintf("node01%s%s", IG_PREFIX, timeStampLayout),
+		},
+	}
+
+	for _, g := range grid {
+		result := getSuffixWithTime(g.Input, timeStamp)
+		if result != g.Output {
+			t.Fatalf("testing %q failed, expected %q, got %q", g.Input, g.Output, result)
+		}
+	}
+}
+
+func pointerInt32(v int) *int32 {
+	i := int32(v)
+	return &i
+}
+
+func pointerString(v string) *string {
+	return &v
+}
+
+func pointerbool(v bool) *bool {
+	return &v
+}
+
+func TestDuplicateIG(t *testing.T) {
+
+	cluster := &api.Cluster{
+		ObjectMeta: v1meta.ObjectMeta{
+			Name: "test-cluster.example.com",
+		},
+		Spec: api.ClusterSpec{
+			KubernetesVersion: "1.6.4",
+		},
+	}
+
+	tm := time.Now()
+	ts := tm.Format(IG_TS_LAYOUT)
+
+	grid := []struct {
+		Input        *CloudInstanceGroup
+		ExpectedName string
+	}{
+		{
+			ExpectedName: "nodes-01" + IG_PREFIX + ts,
+			Input: &CloudInstanceGroup{
+				InstanceGroup: &api.InstanceGroup{
+					ObjectMeta: v1meta.ObjectMeta{
+						Name:        "nodes-01",
+						ClusterName: "test-cluster.example.com",
+						Namespace:   "test-cluster.example.com",
+					},
+					Spec: api.InstanceGroupSpec{
+						Role:           api.InstanceGroupRoleNode,
+						Image:          "foo",
+						MinSize:        pointerInt32(42),
+						MaxSize:        pointerInt32(42),
+						MachineType:    "m4.10xlarge",
+						RootVolumeSize: pointerInt32(248),
+						RootVolumeType: pointerString("gp2"),
+						Subnets: []string{
+							"us-east-2a",
+							"us-east-2c",
+						},
+						MaxPrice:          pointerString("0.42"),
+						AssociatePublicIP: pointerbool(true),
+						AdditionalSecurityGroups: []string{
+							"i-123455",
+							"i-232425",
+						},
+						CloudLabels: map[string]string{
+							"foo": "bar",
+							"car": "ferarri",
+						},
+
+						NodeLabels: map[string]string{
+							"1": "2",
+							"4": "5",
+						},
+						Tenancy: "default",
+						Kubelet: &api.KubeletConfigSpec{
+							NvidiaGPUs:    1,
+							CloudProvider: "aws",
+							Taints:        []string{"foo", "bar", "baz"},
+							NodeLabels: map[string]string{
+								"1": "2",
+								"4": "5",
+							},
+						},
+
+						Taints: []string{"foo", "bar", "baz"},
+					},
+				},
+			},
+		},
+		{
+			ExpectedName: "node02" + IG_PREFIX + ts,
+			Input: &CloudInstanceGroup{
+				InstanceGroup: &api.InstanceGroup{
+					ObjectMeta: v1meta.ObjectMeta{
+						Name:        "node02-rolling-update-2017-01-02-15-04-05",
+						ClusterName: "test-cluster.example.com",
+						Namespace:   "test-cluster.example.com",
+					},
+					Spec: api.InstanceGroupSpec{
+						Role:        api.InstanceGroupRoleNode,
+						Image:       "foo",
+						MinSize:     pointerInt32(42),
+						MaxSize:     pointerInt32(42),
+						MachineType: "m4.xlarge",
+						Subnets: []string{
+							"us-east-1a",
+							"us-east-1b",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, g := range grid {
+		ig := g.Input.InstanceGroup
+		fakeCS := fake.NewSimpleClientset(cluster, ig)
+		newName := getSuffixWithTime(g.Input.InstanceGroup.ObjectMeta.Name, tm)
+
+		duplicate, err := g.Input.DuplicateClusterInstanceGroup(cluster, fakeCS, newName)
+		if duplicate == nil {
+			t.Fatalf("testing failed nil returned")
+		}
+
+		if err != nil {
+			t.Fatalf("testing failed: %v", err)
+		}
+
+		if duplicate.ObjectMeta.Name != g.ExpectedName {
+			t.Fatalf("testing failed as ig was not named correctly: expected %s, got %s", g.ExpectedName, duplicate.ObjectMeta.Name)
+		}
+
+		if _, ok := duplicate.Annotations[KOPS_IG_PARENT]; !ok {
+			t.Fatalf("parent annotation not found")
+		}
+
+		// FIXME: Need to do integration testing on this.  Not certain this is the
+		// FIXME: fake or actually is a bug.
+
+		origIG, err := fakeCS.InstanceGroupsFor(cluster).Get(ig.ObjectMeta.Name, v1meta.GetOptions{})
+
+		if err != nil {
+			t.Fatalf("unable to retrieve original instance group: %v", err)
+		}
+
+		if _, ok := origIG.Annotations[KOPS_IG_CHILD]; !ok {
+			t.Fatalf("child annotation not found")
+		}
+
+		duplicate.ObjectMeta.Name = ig.ObjectMeta.Name
+		duplicate.Annotations = nil
+		g.Input.InstanceGroup.Annotations = nil
+
+		if !reflect.DeepEqual(duplicate, ig) {
+			y, err := api.ToVersionedYaml(duplicate)
+			if err != nil {
+				t.Fatalf("unable to marshal yaml")
+			}
+
+			t.Fatalf("duplicate is not equal\n\n %s", y)
+		}
+
+	}
+}

--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -22,11 +22,29 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	api "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/client/simple"
+	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi"
 )
+
+// Different rolling update strategy types
+const (
+	// Create all new instance groups before removing the old instance groups.
+	PRE_CREATE = "create-all-new-ig-first"
+	// Iterate through the instance groups and create new replacement ig one by one.
+	CREATE = "create-new-by-ig"
+	// Origin method, which removes a node one by one and the node is replaced via
+	// the cloud, such as ASG.
+	DEFAULT = "default"
+)
+
+// StrategyTypes are used for checking an outputting the strategies.
+var StrategyTypes = sets.NewString(PRE_CREATE, CREATE, DEFAULT)
 
 // RollingUpdateCluster is a struct containing cluster information for a rolling update.
 type RollingUpdateCluster struct {
@@ -46,10 +64,15 @@ type RollingUpdateCluster struct {
 	ClusterName      string
 	ValidateRetries  int
 	DrainInterval    time.Duration
+
+	Strategy string
+
+	Cluster   *api.Cluster
+	Clientset simple.Clientset
 }
 
 // RollingUpdate performs a rolling update on a K8s Cluster.
-func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*CloudInstanceGroup, instanceGroups *api.InstanceGroupList) error {
+func (r *RollingUpdateCluster) RollingUpdate(groups map[string]*CloudInstanceGroup, instanceGroups *api.InstanceGroupList) error {
 	if len(groups) == 0 {
 		glog.Infof("Cloud Instance Group length is zero. Not doing a rolling-update.")
 		return nil
@@ -87,7 +110,7 @@ func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*CloudInstanceGro
 
 				defer wg.Done()
 
-				err := group.RollingUpdate(c, instanceGroups, true, c.BastionInterval)
+				err := group.RollingUpdate(r, instanceGroups, true, r.BastionInterval)
 
 				resultsMutex.Lock()
 				results[k] = err
@@ -117,7 +140,7 @@ func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*CloudInstanceGro
 			defer wg.Done()
 
 			for k, group := range masterGroups {
-				err := group.RollingUpdate(c, instanceGroups, false, c.MasterInterval)
+				err := group.RollingUpdate(r, instanceGroups, false, r.MasterInterval)
 
 				resultsMutex.Lock()
 				results[k] = err
@@ -130,40 +153,46 @@ func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*CloudInstanceGro
 		wg.Wait()
 	}
 
-	// Upgrade nodes, with greater parallelism
-	{
-		var wg sync.WaitGroup
-
-		// We run nodes in series, even if they are in separate instance groups
-		// typically they will not being separate instance groups. If you roll the nodes in parallel
-		// you can get into a scenario where you can evict multiple statefulset pods from the same
-		// statefulset at the same time. Further improvements needs to be made to protect from this as
-		// well.
-
-		wg.Add(1)
-
-		go func() {
-			for k := range nodeGroups {
-				resultsMutex.Lock()
-				results[k] = fmt.Errorf("function panic nodes")
-				resultsMutex.Unlock()
-			}
-
-			defer wg.Done()
-
-			for k, group := range nodeGroups {
-				err := group.RollingUpdate(c, instanceGroups, false, c.NodeInterval)
-
-				resultsMutex.Lock()
-				results[k] = err
-				resultsMutex.Unlock()
-
-				// TODO: Bail on error?
-			}
-		}()
-
-		wg.Wait()
+	// TODO - Do we want a WaitGroup on this?  I am not sure why we have wait groups and
+	// TODO - go func() here?
+	if r.Strategy == PRE_CREATE && featureflag.DrainAndValidateRollingUpdate.Enabled() && featureflag.RollingUpdateStrategies.Enabled() {
+		return r.RollingUpdateNodesPreCreate(nodeGroups)
 	}
+	var wg sync.WaitGroup
+
+	// We run nodes in series, even if they are in separate instance groups
+	// typically they will not being separate instance groups. If you roll the nodes in parallel
+	// you can get into a scenario where you can evict multiple statefulset pods from the same
+	// statefulset at the same time. Further improvements needs to be made to protect from this as
+	// well.
+
+	wg.Add(1)
+
+	go func() {
+		for k := range nodeGroups {
+			resultsMutex.Lock()
+			results[k] = fmt.Errorf("function panic nodes")
+			resultsMutex.Unlock()
+		}
+
+		defer wg.Done()
+		for k, group := range nodeGroups {
+			var err error
+			if r.Strategy == CREATE && featureflag.DrainAndValidateRollingUpdate.Enabled() && featureflag.RollingUpdateStrategies.Enabled() {
+				err = group.RollingUpdateNodesCreate(r)
+			} else {
+				err = group.RollingUpdate(r, instanceGroups, false, r.NodeInterval)
+			}
+
+			resultsMutex.Lock()
+			results[k] = err
+			resultsMutex.Unlock()
+
+			// TODO: Bail on error?
+		}
+	}()
+
+	wg.Wait()
 
 	for _, err := range results {
 		if err != nil {
@@ -172,5 +201,79 @@ func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*CloudInstanceGro
 	}
 
 	glog.Infof("Rolling update completed!")
+	return nil
+}
+
+// RollingUpdateNodesPreCreate create all new nodes instance group(s) then cordons all nodes.
+// Old nodes are then drained and the old instance group(s) is deleted.
+func (r *RollingUpdateCluster) RollingUpdateNodesPreCreate(nodeGroups map[string]*CloudInstanceGroup) error {
+
+	nodeGroupsUpdate := make([]*CloudInstanceGroup, 0)
+
+	// Figure out which CloudInstanceGroups need updating and create a new instance group for each
+	{
+		for _, group := range nodeGroups {
+			update := group.NeedUpdate
+			if r.Force {
+				update = append(update, group.Ready...)
+			}
+
+			if len(update) == 0 {
+				return nil
+			}
+
+			if _, ok := group.InstanceGroup.ObjectMeta.Annotations[KOPS_IG_CHILD]; !ok {
+				suffix := getSuffix(group.InstanceGroup.ObjectMeta.Name)
+				ig, err := group.DuplicateClusterInstanceGroup(r.Cluster, r.Clientset, suffix)
+				if err != nil {
+					return fmt.Errorf("unable to create instance group: %v", err)
+				}
+				glog.Infof("Creating Replacement Instance Group, %q, based on Instance Group %q.", ig.Name, group.InstanceGroup.Name)
+			}
+
+			nodeGroupsUpdate = append(nodeGroupsUpdate, group)
+		}
+	}
+
+	if err := updateCluster(r.Cluster, r.Clientset); err != nil {
+		return fmt.Errorf("unable to update cluster: %v", err)
+	}
+
+	glog.Info("Waiting for new Instance Group(s) to start")
+	time.Sleep(r.NodeInterval)
+
+	// get the new list of ig and validate cluster
+	if err := validateCluster(r); err != nil {
+		return fmt.Errorf("unable to validate cluster: %v", err)
+	}
+
+	if r.CloudOnly {
+		glog.Warningf("not cordoning nodes as --cloud-only is set")
+	} else {
+		// cardon the nodes
+		glog.Infof("Cordoning all nodes")
+		for _, group := range nodeGroupsUpdate {
+			if err := group.CordonNodes(r); err != nil {
+				return fmt.Errorf("unable to cordon nodes: %v", err)
+			}
+		}
+	}
+
+	for _, group := range nodeGroupsUpdate {
+
+		if err := group.DrainAndDelete(r); err != nil {
+			return fmt.Errorf("unable to drain and delete nodes: %v", err)
+		}
+
+		// validate new nodes
+		if err := validateCluster(r); err != nil {
+			return fmt.Errorf("unable to validate cluster: %v", err)
+		}
+
+		glog.Infof("Deleted old Instance Group: %q", group.InstanceGroup.Name)
+	}
+
+	glog.Infof("Nodes rolling-update completed")
+
 	return nil
 }

--- a/pkg/validation/node_api_adapter.go
+++ b/pkg/validation/node_api_adapter.go
@@ -20,11 +20,17 @@ import (
 	"fmt"
 	"time"
 
+	"os"
+
 	"github.com/golang/glog"
+	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubernetes/pkg/kubectl/cmd"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
 const (
@@ -46,17 +52,97 @@ type NodeAPIAdapter struct {
 
 	//TODO: convert to arg on WaitForNodeToBe
 	// K8s timeout on method call
-	timeout time.Duration
+	timeout      time.Duration
+	clientConfig clientcmd.ClientConfig
 }
 
-func NewNodeAPIAdapter(client kubernetes.Interface, timeout time.Duration) (*NodeAPIAdapter, error) {
+func NewNodeAPIAdapter(client kubernetes.Interface, timeout time.Duration, clientConfig clientcmd.ClientConfig) (*NodeAPIAdapter, error) {
 	if client == nil {
 		return nil, fmt.Errorf("client not provided")
 	}
 	return &NodeAPIAdapter{
-		client:  client,
-		timeout: timeout,
+		client:       client,
+		timeout:      timeout,
+		clientConfig: clientConfig,
 	}, nil
+}
+
+// DrainNode drains a K8s node.
+func (nodeAA *NodeAPIAdapter) DrainNode(nodeName string, cordon bool, drainInterval time.Duration) error {
+
+	options, err := nodeAA.setupOptions()
+
+	if err != nil {
+		return err
+	}
+
+	cmd := &cobra.Command{
+		Use: "cordon NODE",
+	}
+	args := []string{nodeName}
+	if err := options.SetupDrain(cmd, args); err != nil {
+		return fmt.Errorf("error setting up drain: %v", err)
+	}
+
+	if cordon {
+		if err := options.RunCordonOrUncordon(true); err != nil {
+			return fmt.Errorf("error cordoning node node: %v", err)
+		}
+	}
+
+	if err := options.RunDrain(); err != nil {
+		return fmt.Errorf("error draining node: %v", err)
+	}
+
+	if drainInterval > time.Second*0 {
+		glog.V(3).Infof("Waiting for %s for pods to stabilize after draining.", drainInterval.String())
+		time.Sleep(drainInterval)
+	}
+
+	return nil
+}
+
+// CordonNode cardons a K8s node.
+func (nodeAA *NodeAPIAdapter) CordonNode(nodeName string) error {
+
+	options, err := nodeAA.setupOptions()
+
+	if err != nil {
+		return err
+	}
+
+	cmd := &cobra.Command{
+		Use: "cordon NODE",
+	}
+	args := []string{nodeName}
+	if err := options.SetupDrain(cmd, args); err != nil {
+		return fmt.Errorf("error setting up drain: %v", err)
+	}
+
+	if err := options.RunCordonOrUncordon(true); err != nil {
+		return fmt.Errorf("error cordoning node node: %v", err)
+	}
+	return nil
+}
+
+func (nodeAA *NodeAPIAdapter) setupOptions() (options *cmd.DrainOptions, err error) {
+	if nodeAA.clientConfig == nil {
+		return nil, fmt.Errorf("ClientConfig not set")
+	}
+	f := cmdutil.NewFactory(nodeAA.clientConfig)
+
+	// TODO: Send out somewhere else, also DrainOptions has errout
+
+	options = &cmd.DrainOptions{
+		Factory:          f,
+		Out:              os.Stdout,
+		IgnoreDaemonsets: true,
+		Force:            true,
+		DeleteLocalData:  true,
+		ErrOut:           os.Stderr,
+	}
+
+	return options, nil
 }
 
 // GetAllNodes is a access to get all nodes from a cluster api

--- a/pkg/validation/node_api_adapter_test.go
+++ b/pkg/validation/node_api_adapter_test.go
@@ -74,7 +74,7 @@ func setupNodeAA(t *testing.T, conditions []v1.NodeCondition, nodeName string) *
 
 	c := fake.NewSimpleClientset(node)
 	//c.Validate(t, response, err)
-	nodeAA, err := NewNodeAPIAdapter(c, time.Duration(10)*time.Millisecond)
+	nodeAA, err := NewNodeAPIAdapter(c, time.Duration(10)*time.Millisecond, nil)
 	if err != nil {
 		t.Fatalf("unexpected error building NodeAPIAdapter: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/apis/kops/validation"
+	"k8s.io/kops/pkg/client/simple"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/utils"
@@ -148,6 +149,26 @@ func PopulateInstanceGroupSpec(cluster *kops.Cluster, input *kops.InstanceGroup,
 	}
 
 	return ig, nil
+}
+
+// CreateInstanceGroup validates and creates a new instance group.
+func CreateInstanceGroup(ig *kops.InstanceGroup, cluster *kops.Cluster, clientset simple.Clientset) error {
+
+	if err := validation.ValidateInstanceGroup(ig); err != nil {
+		return fmt.Errorf("error validating InstanceGroup: %v", err)
+	}
+
+	igNew, err := clientset.InstanceGroupsFor(cluster).Create(ig)
+
+	if err != nil {
+		return fmt.Errorf("error storing InstanceGroup: %v", err)
+	}
+
+	if igNew == nil {
+		return fmt.Errorf("error storing instance group, instance group was not returned")
+	}
+
+	return nil
 }
 
 // defaultMachineType returns the default MachineType for the instance group, based on the cloudprovider


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kops/issues/1718

This PR includes two new strategies that influence node replacement.  The first option is the current code path. All masters and bastions are rolled sequentially before the nodes, and this flag does not control their replacement.

We are now including three new strategies that influence node replacement. All masters and bastions are rolled sequentially before the nodes, and this flag does not influence their replacement.  These strategies utilize the feature flag mentioned above.

1. "default" - A node is drained then deleted.  The cloud then replaces the node automatically.
2. "create-all-new-ig-first" - All node instance groups are duplicated first; then all old nodes are cordoned.
3. "create-new-by-ig" - As each node instance group rolls, the instance group is duplicated, then all old nodes are cordoned.

	The second and third options create new instance groups. In order to use this ALPHA feature
	you need to enable +DrainAndValidateRollingUpdate,+RollingUpdateStrategies feature flags.
	 

The second option pre-creates a whole new set of instance groups first, while the third option only creates a new ig as each ig is rolled.

The first and default option is the original code path.

This is a refactor of https://github.com/kubernetes/kops/pull/2621

TODO

- [x] more testing
- [ ] pick better names for strategies
- [x] figure out biz logic for cloud only and force
- [x] instance group naming is kinda monkeyed on renames.
- [x] remove docker SHA update

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2818)
<!-- Reviewable:end -->
