### PR TITLE
Bump canal addon version

### DIFF
--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -388,7 +388,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Canal != nil {
 		key := "networking.projectcalico.org.canal"
-		version := "1.0"
+		version := "1.1"
 
 		{
 			location := key + "/pre-k8s-1.6.yaml"


### PR DESCRIPTION
In PR [#2635](https://github.com/kubernetes/kops/pull/2635) the version of calico was updated as part of canal.  What this PR missed was bumping the version of the addon.  This meant that if you upgraded a kops cluster from v1.6.0 to v1.6.1 the new version of calico was not picked up because `channels apply` does not think the daemonset needs to be updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2823)
<!-- Reviewable:end -->
