### PR TITLE
Update weave to 2.0.1

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
@@ -1,149 +1,159 @@
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: weave-net
-  labels:
-    role.kubernetes.io/networking: "1"
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - namespaces
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
----
 apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: weave-net
-  namespace: kube-system
-  labels:
-    role.kubernetes.io/networking: "1"
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: weave-net
-  labels:
-    role.kubernetes.io/networking: "1"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: weave-net
-subjects:
-- kind: ServiceAccount
-  name: weave-net
-  namespace: kube-system
----
-apiVersion: extensions/v1beta1
-kind: DaemonSet
-metadata:
-  name: weave-net
-  namespace: kube-system
-  labels:
-    name: weave-net
-    role.kubernetes.io/networking: "1"
-spec:
-  template:
+kind: List
+items:
+  - apiVersion: v1
+    kind: ServiceAccount
     metadata:
+      name: weave-net
       labels:
         name: weave-net
         role.kubernetes.io/networking: "1"
+      namespace: kube-system
+  - apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRole
+    metadata:
+      name: weave-net
+      labels:
+        name: weave-net
+        role.kubernetes.io/networking: "1"
+    rules:
+      - apiGroups:
+          - ''
+        resources:
+          - pods
+          - namespaces
+          - nodes
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - extensions
+        resources:
+          - networkpolicies
+        verbs:
+          - get
+          - list
+          - watch
+  - apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRoleBinding
+    metadata:
+      name: weave-net
+      labels:
+        name: weave-net
+        role.kubernetes.io/networking: "1"
+    roleRef:
+      kind: ClusterRole
+      name: weave-net
+      apiGroup: rbac.authorization.k8s.io
+    subjects:
+      - kind: ServiceAccount
+        name: weave-net
+        namespace: kube-system
+  - apiVersion: extensions/v1beta1
+    kind: DaemonSet
+    metadata:
+      name: weave-net
+      labels:
+        name: weave-net
+        role.kubernetes.io/networking: "1"
+      namespace: kube-system
     spec:
-      hostNetwork: true
-      hostPID: true
-      containers:
-        - name: weave
-          image: weaveworks/weave-kube:1.9.8
-          command:
-            - /home/weave/launch.sh
-          livenessProbe:
-            initialDelaySeconds: 30
-            httpGet:
-              host: 127.0.0.1
-              path: /status
-              port: 6784
+      template:
+        metadata:
+          labels:
+            name: weave-net
+            role.kubernetes.io/networking: "1"
+        spec:
+          containers:
+            - name: weave
+              command:
+                - /home/weave/launch.sh
+              env:
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: spec.nodeName
+                - name: IPALLOC_RANGE
+                  value: {{ .KubeControllerManager.ClusterCIDR }}
+                {{- if .Networking.Weave.MTU }}
+                - name: WEAVE_MTU
+                  value: "{{ .Networking.Weave.MTU }}"
+                {{- end }}
+              image: 'weaveworks/weave-kube:2.0.1'
+              livenessProbe:
+                httpGet:
+                  host: 127.0.0.1
+                  path: /status
+                  port: 6784
+                initialDelaySeconds: 30
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 200Mi
+                limits:
+                  cpu: 100m
+                  memory: 200Mi
+              securityContext:
+                privileged: true
+              volumeMounts:
+                - name: weavedb
+                  mountPath: /weavedb
+                - name: cni-bin
+                  mountPath: /host/opt
+                - name: cni-bin2
+                  mountPath: /host/home
+                - name: cni-conf
+                  mountPath: /host/etc
+                - name: dbus
+                  mountPath: /host/var/lib/dbus
+                - name: lib-modules
+                  mountPath: /lib/modules
+            - name: weave-npc
+              env:
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: spec.nodeName
+              image: 'weaveworks/weave-npc:2.0.1'
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 200Mi
+                limits:
+                  cpu: 100m
+                  memory: 200Mi
+              securityContext:
+                privileged: true
+          hostNetwork: true
+          hostPID: true
+          restartPolicy: Always
           securityContext:
-            privileged: true
-          volumeMounts:
+            seLinuxOptions: {}
+          serviceAccountName: weave-net
+          tolerations:
+            - effect: NoSchedule
+              operator: Exists
+          volumes:
             - name: weavedb
-              mountPath: /weavedb
+              hostPath:
+                path: /var/lib/weave
             - name: cni-bin
-              mountPath: /host/opt
+              hostPath:
+                path: /opt
             - name: cni-bin2
-              mountPath: /host/home
+              hostPath:
+                path: /home
             - name: cni-conf
-              mountPath: /host/etc
+              hostPath:
+                path: /etc
             - name: dbus
-              mountPath: /host/var/lib/dbus
+              hostPath:
+                path: /var/lib/dbus
             - name: lib-modules
-              mountPath: /lib/modules
-          resources:
-            requests:
-              cpu: 100m
-              memory: 200Mi
-            limits:
-              cpu: 100m
-              memory: 200Mi
-          env:
-            - name: IPALLOC_RANGE
-              value: {{ .KubeControllerManager.ClusterCIDR }}
-            {{- if .Networking.Weave.MTU }}
-            - name: WEAVE_MTU
-              value: "{{ .Networking.Weave.MTU }}"
-            {{- end }}
-        - name: weave-npc
-          image: weaveworks/weave-npc:1.9.8
-          resources:
-            requests:
-              cpu: 100m
-              memory: 200Mi
-            limits:
-              cpu: 100m
-              memory: 200Mi
-          env:
-            - name: HOSTNAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: spec.nodeName
-          securityContext:
-            privileged: true
-      restartPolicy: Always
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-      serviceAccountName: weave-net
-      securityContext:
-        seLinuxOptions:
-          type: spc_t
-      volumes:
-        - name: weavedb
-          emptyDir: {}
-        - name: cni-bin
-          hostPath:
-            path: /opt
-        - name: cni-bin2
-          hostPath:
-            path: /home
-        - name: cni-conf
-          hostPath:
-            path: /etc
-        - name: dbus
-          hostPath:
-            path: /var/lib/dbus
-        - name: lib-modules
-          hostPath:
-            path: /lib/modules
+              hostPath:
+                path: /lib/modules
+      updateStrategy:
+        type: RollingUpdate

--- a/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
@@ -1,103 +1,116 @@
-apiVersion: extensions/v1beta1
-kind: DaemonSet
-metadata:
-  name: weave-net
-  namespace: kube-system
-  labels:
-    name: weave-net
-    role.kubernetes.io/networking: "1"
-spec:
-  template:
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: ServiceAccount
     metadata:
+      name: weave-net
       labels:
         name: weave-net
         role.kubernetes.io/networking: "1"
-      annotations:
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [
-            {
-              "key": "dedicated",
-              "operator": "Equal",
-              "value": "master",
-              "effect": "NoSchedule"
-            }
-          ]
+      namespace: kube-system
+  - apiVersion: extensions/v1beta1
+    kind: DaemonSet
+    metadata:
+      name: weave-net
+      labels:
+        name: weave-net
+        role.kubernetes.io/networking: "1"
+      namespace: kube-system
     spec:
-      hostNetwork: true
-      hostPID: true
-      containers:
-        - name: weave
-          image: weaveworks/weave-kube:1.9.8
-          command:
-            - /home/weave/launch.sh
-          livenessProbe:
-            initialDelaySeconds: 30
-            httpGet:
-              host: 127.0.0.1
-              path: /status
-              port: 6784
+      template:
+        metadata:
+          annotations:
+            scheduler.alpha.kubernetes.io/tolerations: >-
+              [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
+          labels:
+            name: weave-net
+            role.kubernetes.io/networking: "1"
+        spec:
+          containers:
+            - name: weave
+              command:
+                - /home/weave/launch.sh
+              env:
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: spec.nodeName
+                - name: IPALLOC_RANGE
+                  value: {{ .KubeControllerManager.ClusterCIDR }}
+                {{- if .Networking.Weave.MTU }}
+                - name: WEAVE_MTU
+                  value: "{{ .Networking.Weave.MTU }}"
+                {{- end }}
+              image: 'weaveworks/weave-kube:2.0.1'
+              livenessProbe:
+                httpGet:
+                  host: 127.0.0.1
+                  path: /status
+                  port: 6784
+                initialDelaySeconds: 30
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 200Mi
+                limits:
+                  cpu: 100m
+                  memory: 200Mi
+              securityContext:
+                privileged: true
+              volumeMounts:
+                - name: weavedb
+                  mountPath: /weavedb
+                - name: cni-bin
+                  mountPath: /host/opt
+                - name: cni-bin2
+                  mountPath: /host/home
+                - name: cni-conf
+                  mountPath: /host/etc
+                - name: dbus
+                  mountPath: /host/var/lib/dbus
+                - name: lib-modules
+                  mountPath: /lib/modules
+            - name: weave-npc
+              env:
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: spec.nodeName
+              image: 'weaveworks/weave-npc:2.0.1'
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 200Mi
+                limits:
+                  cpu: 100m
+                  memory: 200Mi
+              securityContext:
+                privileged: true
+          hostNetwork: true
+          hostPID: true
+          restartPolicy: Always
           securityContext:
-            privileged: true
-          volumeMounts:
+            seLinuxOptions: {}
+          serviceAccountName: weave-net
+          volumes:
             - name: weavedb
-              mountPath: /weavedb
+              hostPath:
+                path: /var/lib/weave
             - name: cni-bin
-              mountPath: /host/opt
+              hostPath:
+                path: /opt
             - name: cni-bin2
-              mountPath: /host/home
+              hostPath:
+                path: /home
             - name: cni-conf
-              mountPath: /host/etc
+              hostPath:
+                path: /etc
             - name: dbus
-              mountPath: /host/var/lib/dbus
+              hostPath:
+                path: /var/lib/dbus
             - name: lib-modules
-              mountPath: /lib/modules
-          resources:
-            requests:
-              cpu: 100m
-              memory: 200Mi
-            limits:
-              cpu: 100m
-              memory: 200Mi
-          env:
-            - name: IPALLOC_RANGE
-              value: {{ .KubeControllerManager.ClusterCIDR }}
-            {{- if .Networking.Weave.MTU }}
-            - name: WEAVE_MTU
-              value: "{{ .Networking.Weave.MTU }}"
-            {{- end }}
-        - name: weave-npc
-          image: weaveworks/weave-npc:1.9.8
-          resources:
-            requests:
-              cpu: 100m
-              memory: 200Mi
-            limits:
-              cpu: 100m
-              memory: 200Mi
-          env:
-            - name: HOSTNAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: spec.nodeName
-          securityContext:
-            privileged: true
-      restartPolicy: Always
-      volumes:
-        - name: weavedb
-          emptyDir: {}
-        - name: cni-bin
-          hostPath:
-            path: /opt
-        - name: cni-bin2
-          hostPath:
-            path: /home
-        - name: cni-conf
-          hostPath:
-            path: /etc
-        - name: dbus
-          hostPath:
-            path: /var/lib/dbus
-        - name: lib-modules
-          hostPath:
-            path: /lib/modules
+              hostPath:
+                path: /lib/modules

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -280,8 +280,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 	if b.cluster.Spec.Networking.Weave != nil {
 		key := "networking.weave"
 
-		// 1.9.8-kops.2 = 1.9.8 plus IPALLOC_RANGE and WEAVE_MTU
-		version := "1.9.8-kops.2"
+		version := "2.0.1"
 
 		{
 			location := key + "/pre-k8s-1.6.yaml"


### PR DESCRIPTION
## Description:

Upgrade from 1.9.8 to 2.0.1, see full list of changes here:
- https://github.com/weaveworks/weave/blob/master/CHANGELOG.md#release-200
- https://github.com/weaveworks/weave/blob/master/CHANGELOG.md#release-201

## Steps:

As the `diff` may be hard to digest, here are the steps I followed for this PR:

1. I identified the changes made in `kops` YAML templates vs. static YAMLs provided with `weave`:

        $ curl -fsSLo 1.6.yaml https://github.com/weaveworks/weave/releases/download/v1.9.8/weave-daemonset-k8s-1.6.yaml
        $ curl -fsSLo 1.5.yaml https://github.com/weaveworks/weave/releases/download/v1.9.8/weave-daemonset.yaml
        $ diff 1.6.yaml k8s-1.6.yaml.template
        $ diff 1.5.yaml pre-k8s-1.6.yaml.template

    These highlighted the below changes:
    1. for `labels`:

            +   labels:
            +     role.kubernetes.io/networking: "1"

    2. for `resources` (both for `weave` and `weave-npc`):

            -               cpu: 10m
            ---
            +               cpu: 100m
            +               memory: 200Mi
            +             limits:
            +               cpu: 100m
            +               memory: 200Mi

    3. for `env`:

            +           env:
            +             - name: IPALLOC_RANGE
            +               value: {{ .KubeControllerManager.ClusterCIDR }}
            +             {{- if .Networking.Weave.MTU }}
            +             - name: WEAVE_MTU
            +               value: "{{ .Networking.Weave.MTU }}"
            +             {{- end }}

2. I then re-applied the above changes to the latest (`2.0.1`) YAML files:

        $ curl -fsSLo k8s-1.6.yaml.template https://github.com/weaveworks/weave/releases/download/v2.0.1/weave-daemonset-k8s-1.6.yaml
        $ curl -fsSLo pre-k8s-1.6.yaml.template https://github.com/weaveworks/weave/releases/download/v2.0.1/weave-daemonset.yaml

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2829)
<!-- Reviewable:end -->
