### PR TITLE
Change logrotate compress to delaycompress to prevent fluentd log tailing from getting stuck

### DIFF
--- a/nodeup/pkg/model/logrotate.go
+++ b/nodeup/pkg/model/logrotate.go
@@ -96,7 +96,7 @@ func (b *LogrotateBuilder) addLogRotate(c *fi.ModelBuilderContext, name, path st
 		"  copytruncate",
 		"  missingok",
 		"  notifempty",
-		"  compress",
+		"  delaycompress",
 		"  maxsize " + options.MaxSize,
 		"  daily",
 		"  create 0644 root root",


### PR DESCRIPTION
Fluent log tailing fails sporadically, seemingly due to logrotate setings.

Source of the setting: https://github.com/fluent/fluentd/issues/780#issuecomment-178065328

If this the wrong way and there are other ideas on the cause of this issue they are more than welcome! We can change this PR accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2835)
<!-- Reviewable:end -->
