### PR TITLE
Have kops 1.7 use k8s 1.7

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -27,6 +27,10 @@ spec:
     recommendedVersion: 1.4.12
     requiredVersion: 1.4.2
   kopsVersions:
+  - range: ">=1.7.0-alpha.1"
+    #recommendedVersion: 1.6.0
+    #requiredVersion: 1.6.0
+    kubernetesVersion: 1.7.0
   - range: ">=1.6.0-alpha.1"
     #recommendedVersion: 1.6.0
     #requiredVersion: 1.6.0

--- a/channels/stable
+++ b/channels/stable
@@ -27,6 +27,10 @@ spec:
     recommendedVersion: 1.4.12
     requiredVersion: 1.4.2
   kopsVersions:
+  - range: ">=1.7.0-alpha.1"
+    #recommendedVersion: 1.6.0
+    #requiredVersion: 1.6.0
+    kubernetesVersion: 1.7.0
   - range: ">=1.6.0-alpha.1"
     #recommendedVersion: 1.6.0
     #requiredVersion: 1.6.0


### PR DESCRIPTION
Neither is released yet, but this will help with testing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2838)
<!-- Reviewable:end -->
