### PR TITLE
fixing bug with using shell flag

### DIFF
--- a/cmd/kops/completion.go
+++ b/cmd/kops/completion.go
@@ -125,7 +125,7 @@ func RunCompletion(f *util.Factory, cmd *cobra.Command, args []string, out io.Wr
 		return fmt.Errorf("shell is required")
 	}
 
-	run, found := completion_shells[args[0]]
+	run, found := completion_shells[c.Shell]
 	if !found {
 		return fmt.Errorf("Unsupported shell type %q.", args[0])
 	}


### PR DESCRIPTION
We needed to use `c.Shell` instead.

Fixes https://github.com/kubernetes/kops/issues/2841
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2843)
<!-- Reviewable:end -->
