### PR TITLE
increase default instance root volume size

### DIFF
--- a/docs/instance_groups.md
+++ b/docs/instance_groups.md
@@ -10,7 +10,7 @@ By default, a cluster has:
   minimum size and maximum size = 1, so they will run a single instance.  We do this so that the cloud will
   always relaunch masters, even if everything is terminated at once.  We have an instance group per zone
   because we need to force the cloud to run an instance in every zone, so we can mount the master volumes - we
-  can't do that across zones.
+  cannot do that across zones.
 
 ## Listing instance groups
 
@@ -61,8 +61,9 @@ The procedure to resize an instance group works the same way:
 * Apply changes: `kops update cluster <clustername>  --yes`
 * (you do not need a `rolling-update` when changing instancegroup sizes)
 
-
 ## Changing the root volume size or type
+
+The default volume size for Masters is 50 GB, while the default volume size for a node is 100 GB.
 
 The procedure to resize the root volume works the same way:
 
@@ -71,7 +72,7 @@ The procedure to resize the root volume works the same way:
 * Apply changes: `kops update cluster <clustername> --yes`
 * Rolling update to update existing instances: `kops rolling-update cluster --yes`
 
-For example, to set up a 100GB gp2 root volume, your InstanceGroup spec might look like:
+For example, to set up a 200GB gp2 root volume, your InstanceGroup spec might look like:
 
 ```
 metadata:
@@ -82,7 +83,7 @@ spec:
   maxSize: 2
   minSize: 2
   role: Node
-  rootVolumeSize: 100
+  rootVolumeSize: 200
   rootVolumeType: gp2
 ```
 

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -26,8 +26,10 @@ import (
 )
 
 const (
-	DefaultVolumeSize = 20
-	DefaultVolumeType = "gp2"
+	DefaultVolumeSizeNode    = 128
+	DefaultVolumeSizeMaster  = 64
+	DefaultVolumeSizeBastion = 32
+	DefaultVolumeType        = "gp2"
 )
 
 // AutoscalingGroupModelBuilder configures AutoscalingGroup objects
@@ -48,7 +50,16 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		{
 			volumeSize := fi.Int32Value(ig.Spec.RootVolumeSize)
 			if volumeSize == 0 {
-				volumeSize = DefaultVolumeSize
+				switch ig.Spec.Role {
+				case kops.InstanceGroupRoleMaster:
+					volumeSize = DefaultVolumeSizeMaster
+				case kops.InstanceGroupRoleNode:
+					volumeSize = DefaultVolumeSizeNode
+				case kops.InstanceGroupRoleBastion:
+					volumeSize = DefaultVolumeSizeBastion
+				default:
+					return fmt.Errorf("this case should not get hit, kops.Role not found %s", ig.Spec.Role)
+				}
 			}
 			volumeType := fi.StringValue(ig.Spec.RootVolumeType)
 			if volumeType == "" {

--- a/tests/integration/complex/kubernetes.tf
+++ b/tests/integration/complex/kubernetes.tf
@@ -204,7 +204,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-complex-example-c
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 64
     delete_on_termination = true
   }
 
@@ -230,7 +230,7 @@ resource "aws_launch_configuration" "nodes-complex-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 128
     delete_on_termination = true
   }
 

--- a/tests/integration/ha/kubernetes.tf
+++ b/tests/integration/ha/kubernetes.tf
@@ -284,7 +284,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-ha-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 64
     delete_on_termination = true
   }
 
@@ -310,7 +310,7 @@ resource "aws_launch_configuration" "master-us-test-1b-masters-ha-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 64
     delete_on_termination = true
   }
 
@@ -336,7 +336,7 @@ resource "aws_launch_configuration" "master-us-test-1c-masters-ha-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 64
     delete_on_termination = true
   }
 
@@ -362,7 +362,7 @@ resource "aws_launch_configuration" "nodes-ha-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 128
     delete_on_termination = true
   }
 

--- a/tests/integration/minimal-141/kubernetes.tf
+++ b/tests/integration/minimal-141/kubernetes.tf
@@ -176,7 +176,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-minimal-141-examp
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 64
     delete_on_termination = true
   }
 
@@ -202,7 +202,7 @@ resource "aws_launch_configuration" "nodes-minimal-141-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 128
     delete_on_termination = true
   }
 

--- a/tests/integration/minimal/cloudformation.json
+++ b/tests/integration/minimal/cloudformation.json
@@ -73,7 +73,7 @@
             "DeviceName": "/dev/xvda",
             "Ebs": {
               "VolumeType": "gp2",
-              "VolumeSize": 20,
+              "VolumeSize": 64,
               "DeleteOnTermination": true
             }
           },
@@ -105,7 +105,7 @@
             "DeviceName": "/dev/xvda",
             "Ebs": {
               "VolumeType": "gp2",
-              "VolumeSize": 20,
+              "VolumeSize": 128,
               "DeleteOnTermination": true
             }
           }

--- a/tests/integration/minimal/kubernetes.tf
+++ b/tests/integration/minimal/kubernetes.tf
@@ -176,7 +176,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-minimal-example-c
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 64
     delete_on_termination = true
   }
 
@@ -202,7 +202,7 @@ resource "aws_launch_configuration" "nodes-minimal-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 128
     delete_on_termination = true
   }
 

--- a/tests/integration/privatecalico/kubernetes.tf
+++ b/tests/integration/privatecalico/kubernetes.tf
@@ -301,7 +301,7 @@ resource "aws_launch_configuration" "bastion-privatecalico-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 32
     delete_on_termination = true
   }
 
@@ -322,7 +322,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privatecalico-exa
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 64
     delete_on_termination = true
   }
 
@@ -348,7 +348,7 @@ resource "aws_launch_configuration" "nodes-privatecalico-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 128
     delete_on_termination = true
   }
 

--- a/tests/integration/privatecanal/kubernetes.tf
+++ b/tests/integration/privatecanal/kubernetes.tf
@@ -301,7 +301,7 @@ resource "aws_launch_configuration" "bastion-privatecanal-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 32
     delete_on_termination = true
   }
 
@@ -322,7 +322,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privatecanal-exam
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 64
     delete_on_termination = true
   }
 
@@ -348,7 +348,7 @@ resource "aws_launch_configuration" "nodes-privatecanal-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 128
     delete_on_termination = true
   }
 

--- a/tests/integration/privatedns1/kubernetes.tf
+++ b/tests/integration/privatedns1/kubernetes.tf
@@ -301,7 +301,7 @@ resource "aws_launch_configuration" "bastion-privatedns1-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 32
     delete_on_termination = true
   }
 
@@ -322,7 +322,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privatedns1-examp
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 64
     delete_on_termination = true
   }
 
@@ -348,7 +348,7 @@ resource "aws_launch_configuration" "nodes-privatedns1-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 128
     delete_on_termination = true
   }
 

--- a/tests/integration/privatedns2/kubernetes.tf
+++ b/tests/integration/privatedns2/kubernetes.tf
@@ -292,7 +292,7 @@ resource "aws_launch_configuration" "bastion-privatedns2-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 32
     delete_on_termination = true
   }
 
@@ -313,7 +313,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privatedns2-examp
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 64
     delete_on_termination = true
   }
 
@@ -339,7 +339,7 @@ resource "aws_launch_configuration" "nodes-privatedns2-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 128
     delete_on_termination = true
   }
 

--- a/tests/integration/privateflannel/kubernetes.tf
+++ b/tests/integration/privateflannel/kubernetes.tf
@@ -301,7 +301,7 @@ resource "aws_launch_configuration" "bastion-privateflannel-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 32
     delete_on_termination = true
   }
 
@@ -322,7 +322,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privateflannel-ex
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 64
     delete_on_termination = true
   }
 
@@ -348,7 +348,7 @@ resource "aws_launch_configuration" "nodes-privateflannel-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 128
     delete_on_termination = true
   }
 

--- a/tests/integration/privatekopeio/kubernetes.tf
+++ b/tests/integration/privatekopeio/kubernetes.tf
@@ -297,7 +297,7 @@ resource "aws_launch_configuration" "bastion-privatekopeio-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 32
     delete_on_termination = true
   }
 
@@ -318,7 +318,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privatekopeio-exa
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 64
     delete_on_termination = true
   }
 
@@ -344,7 +344,7 @@ resource "aws_launch_configuration" "nodes-privatekopeio-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 128
     delete_on_termination = true
   }
 

--- a/tests/integration/privateweave/kubernetes.tf
+++ b/tests/integration/privateweave/kubernetes.tf
@@ -301,7 +301,7 @@ resource "aws_launch_configuration" "bastion-privateweave-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 32
     delete_on_termination = true
   }
 
@@ -322,7 +322,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privateweave-exam
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 64
     delete_on_termination = true
   }
 
@@ -348,7 +348,7 @@ resource "aws_launch_configuration" "nodes-privateweave-example-com" {
 
   root_block_device = {
     volume_type           = "gp2"
-    volume_size           = 20
+    volume_size           = 128
     delete_on_termination = true
   }
 


### PR DESCRIPTION
Fixing https://github.com/kubernetes/kops/issues/1929

masters will default 50 GB
nodes will default to 100 GB

50 and 100 just seemed weird ... doing 64 and 128 next rebase ...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kops/2847)
<!-- Reviewable:end -->
