### PR TITLE
review doc on creating instance group

### DIFF
--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -62,7 +62,7 @@ var (
 
 	# Create an instancegroup for the k8s-cluster.example.com cluster.
 	kops create ig --name=k8s-cluster.example.com node-example \
-		--role node --subnet 172.16.32.1/24
+		--role node --subnet my-subnet-name
 
 	# Create an new ssh public key called admin.
 	kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \

--- a/cmd/kops/create_ig.go
+++ b/cmd/kops/create_ig.go
@@ -50,7 +50,7 @@ var (
 
 		# Create an instancegroup for the k8s-cluster.example.com cluster.
 		kops create ig --name=k8s-cluster.example.com node-example \
-		  --role node --subnet 172.16.32.1/24
+		  --role node --subnet my-subnet-name
 		`))
 
 	create_ig_short = i18n.T(`Create an instancegroup.`)

--- a/docs/cli/kops_create.md
+++ b/docs/cli/kops_create.md
@@ -32,7 +32,7 @@ kops create -f FILENAME
   
   # Create an instancegroup for the k8s-cluster.example.com cluster.
   kops create ig --name=k8s-cluster.example.com node-example \
-  --role node --subnet 172.16.32.1/24
+  --role node --subnet my-subnet-name
   
   # Create an new ssh public key called admin.
   kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \

--- a/docs/cli/kops_create_instancegroup.md
+++ b/docs/cli/kops_create_instancegroup.md
@@ -16,7 +16,7 @@ kops create instancegroup
 ```
   # Create an instancegroup for the k8s-cluster.example.com cluster.
   kops create ig --name=k8s-cluster.example.com node-example \
-  --role node --subnet 172.16.32.1/24
+  --role node --subnet my-subnet-name
 ```
 
 ### Options


### PR DESCRIPTION
The current doc specify the cidr of the subnet. This is a little bit confusing for the user, the suggestion should be the name of the subnet