### PR TITLE
Fixing deleting shared network items

### DIFF
--- a/cmd/kops/delete_cluster.go
+++ b/cmd/kops/delete_cluster.go
@@ -151,6 +151,7 @@ func RunDeleteCluster(f *util.Factory, out io.Writer, options *DeleteClusterOpti
 		if len(clusterResources) == 0 {
 			fmt.Fprintf(out, "No cloud resources to delete\n")
 		} else {
+			resources.FilterUserProvidedItems(clusterResources, cluster.Spec)
 			wouldDeleteCloudResources = true
 
 			t := &tables.Table{}


### PR DESCRIPTION
No longer WIP, but https://github.com/kubernetes/kops/pull/2666 needs to be resolved first as I am using some of his code.

This prevents `kops` from deleting shared / user provided:

1. subnets
2. nat-gw
3. the vpc, including route-tables and dhcp-options

I am using the actual IDs because, with the upcoming phases, we may not enforce the tag names fully.  The IDs are immutable, and the tags are not.  It is super important that we do not delete shared items.  I am not changing the list function calls, as they are being used by other code, I am removing the resource before deleting.

@robertojrojas I have based the code on your PR, let me know if you want to submit your PR first.  If we do not hear from you this PR will be merged.

/assign @justinsb @andrewsykim 

Fixes https://github.com/kubernetes/kops/issues/2877, https://github.com/kubernetes/kops/issues/2212