### PR TITLE
fixing remapping, as it was not returning the remapped data

### DIFF
--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -44,6 +44,8 @@ func (a *AssetBuilder) RemapManifest(data []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	var yamlSep = []byte("\n\n---\n\n")
+	var remappedManifest []byte
 	for _, manifest := range manifests {
 		err := manifest.RemapImages(a.remapImage)
 		if err != nil {
@@ -54,10 +56,12 @@ func (a *AssetBuilder) RemapManifest(data []byte) ([]byte, error) {
 			return nil, fmt.Errorf("error re-marshalling manifest: %v", err)
 		}
 
-		glog.Infof("manifest: %v", string(y))
+		glog.V(10).Infof("manifest: %v", string(y))
+		remappedManifest = append(remappedManifest, y...)
+		remappedManifest = append(remappedManifest, yamlSep...)
 	}
 
-	return data, nil
+	return remappedManifest, nil
 }
 
 func (a *AssetBuilder) remapImage(image string) (string, error) {

--- a/pkg/kubemanifest/images.go
+++ b/pkg/kubemanifest/images.go
@@ -32,10 +32,6 @@ func (m *Manifest) RemapImages(mapper ImageRemapFunction) error {
 	if err != nil {
 		return err
 	}
-	//if changed {
-	//	// invalidate cached rendering
-	//	m.bytes = nil
-	//}
 	return nil
 }
 

--- a/pkg/kubemanifest/manifest.go
+++ b/pkg/kubemanifest/manifest.go
@@ -24,7 +24,6 @@ import (
 )
 
 type Manifest struct {
-	//bytes []byte
 	data map[string]interface{}
 }
 
@@ -52,14 +51,10 @@ func LoadManifestsFrom(contents []byte) ([]*Manifest, error) {
 }
 
 func (m *Manifest) ToYAML() ([]byte, error) {
-	//if m.bytes == nil {
 	b, err := yaml.Marshal(m.data)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling manifest to yaml: %v", err)
 	}
-	//	m.bytes = b
-	//}
-	//return m.bytes, nil
 	return b, nil
 }
 

--- a/pkg/kubemanifest/visitor.go
+++ b/pkg/kubemanifest/visitor.go
@@ -26,17 +26,17 @@ type visitorBase struct {
 }
 
 func (m *visitorBase) VisitString(path []string, v string, mutator func(string)) error {
-	glog.Infof("string value at %s: %s", strings.Join(path, "."), v)
+	glog.V(10).Infof("string value at %s: %s", strings.Join(path, "."), v)
 	return nil
 }
 
 func (m *visitorBase) VisitBool(path []string, v bool, mutator func(bool)) error {
-	glog.Infof("string value at %s: %s", strings.Join(path, "."), v)
+	glog.V(10).Infof("string value at %s: %s", strings.Join(path, "."), v)
 	return nil
 }
 
 func (m *visitorBase) VisitFloat64(path []string, v float64, mutator func(float64)) error {
-	glog.Infof("float64 value at %s: %s", strings.Join(path, "."), v)
+	glog.V(10).Infof("float64 value at %s: %s", strings.Join(path, "."), v)
 	return nil
 }
 


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kops/issues/2903

- `RemapManifest` was not returning the remapped manifests, instead, it was returning the original manifests
- Code cleanup removed commented code.
- Fixed logging levels remapping code was quite chatty