### PR TITLE
Increase fs.inotify.max_user_instances limit. Fixes #2912

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -97,10 +97,11 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"fs.file-max = 2097152",
 			"",
 
-			"# Max number of inotify watches for a user",
-			"# Since dockerd runs as a single user, the default value of 128 per user is too low",
+			"# Max number of inotify instances and watches for a user",
+			"# Since dockerd runs as a single user, the default instances value of 128 per user is too low",
 			"# e.g. uses of inotify: nginx ingress controller, kubectl logs -f",
 			"fs.inotify.max_user_instances = 8192",
+			"fs.inotify.max_user_watches = 524288",
 			"",
 		)
 	}

--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -96,6 +96,12 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"# Increase size of file handles and inode cache",
 			"fs.file-max = 2097152",
 			"",
+
+			"# Max number of inotify watches for a user",
+			"# Since dockerd runs as a single user, the default value of 128 per user is too low",
+			"# e.g. uses of inotify: nginx ingress controller, kubectl logs -f",
+			"fs.inotify.max_user_instances = 8192",
+			"",
 		)
 	}
 


### PR DESCRIPTION
Summary:

This commit proposes a more sane default limit for fs.inotify.max_user_instances of 8192, since dockerd only runs under a single user.

Context and background: 

In production we kept encountering multiple problems revolving around "too many open files" in different locations (e.g. nginx ingress controller). 

After doing much digging, and finally reproducing the problem by running (on a node with the problem) the command "kubectl logs -c container pod -n namespace -f" vs no error without the -f (follow), we managed to get a meaningful and reproducible error message ("failed to create fsnotify watcher: too many open files") and isolate the problem to the fs.inotify.max_user_instances limit for any single user.

We determined that dockerd, running under a single user, was at the default limit of 128, and by increasing this limit temporarily for testing, via:
`echo fs.inotify.max_user_instances=8192 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p`

We confirmed the problem disappeared after multiple tests via the log follow command. We further decreased the limit back down to 128 once more and reproduced the problem via the above log follow command.

Further see issue #2912 