### PR TITLE
Add omitempty json tag to resolvConf fields

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -242,7 +242,7 @@ type KubeletConfigSpec struct {
 	PodCIDR string `json:"podCIDR,omitempty" flag:"pod-cidr"`
 	// ResolverConfig is the resolver configuration file used as the basis
 	// for the container DNS resolution configuration."), []
-	ResolverConfig *string `json:"resolvConf" flag:"resolv-conf" flag-include-empty:"true"`
+	ResolverConfig *string `json:"resolvConf,omitempty" flag:"resolv-conf" flag-include-empty:"true"`
 	//// cpuCFSQuota is Enable CPU CFS quota enforcement for containers that
 	//// specify CPU limits
 	//CPUCFSQuota bool `json:"cpuCFSQuota"`

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -241,7 +241,7 @@ type KubeletConfigSpec struct {
 	PodCIDR string `json:"podCIDR,omitempty" flag:"pod-cidr"`
 	// ResolverConfig is the resolver configuration file used as the basis
 	// for the container DNS resolution configuration."), []
-	ResolverConfig *string `json:"resolvConf" flag:"resolv-conf" flag-include-empty:"true"`
+	ResolverConfig *string `json:"resolvConf,omitempty" flag:"resolv-conf" flag-include-empty:"true"`
 	//// cpuCFSQuota is Enable CPU CFS quota enforcement for containers that
 	//// specify CPU limits
 	//CPUCFSQuota bool `json:"cpuCFSQuota"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -109,7 +109,7 @@ type KubeletConfigSpec struct {
 
 	// ResolverConfig is the resolver configuration file used as the basis
 	// for the container DNS resolution configuration."), []
-	ResolverConfig *string `json:"resolvConf" flag:"resolv-conf" flag-include-empty:"true"`
+	ResolverConfig *string `json:"resolvConf,omitempty" flag:"resolv-conf" flag-include-empty:"true"`
 
 	// nodeLabels to add when registering the node in the cluster.
 	NodeLabels map[string]string `json:"nodeLabels,omitempty" flag:"node-labels"`


### PR DESCRIPTION
Fixes #2908

I'd like to get a test in so we can ensure bugs like this don't occur again, but unsure how to properly test that the generated YAML in edits comes out correctly. I'm currently playing around with adding tests for [edit.go](https://github.com/kubernetes/kops/blob/master/pkg/edit/edit.go), but I'm open to suggestions. 