### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -5,9 +5,9 @@ Create a Kubernetes cluster.
 ### Synopsis
 
 
-Create a kubernetes cluster using command line flags. This command creates cloud based resources such as networks and virtual machine. Once the infrastructure is in place Kubernetes is installed on the virtual machines. 
+Create a kubernetes cluster using command line flags. This command creates cloud based resources such as networks and virtual machines. Once the infrastructure is in place Kubernetes is installed on the virtual machines. 
 
-These operations are done in parrellel and rely on eventual consitency.
+These operations are done in parallel and rely on eventual consistency.
 
 ```
 kops create cluster


### PR DESCRIPTION
Just a couple of minor typo fixes in `create cluster` docs