### PR TITLE
Fix typos in create cluster docs

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -136,10 +136,10 @@ func (o *CreateClusterOptions) InitDefaults() {
 var (
 	create_cluster_long = templates.LongDesc(i18n.T(`
 	Create a kubernetes cluster using command line flags.
-	This command creates cloud based resources such as networks and virtual machine. Once
+	This command creates cloud based resources such as networks and virtual machines. Once
 	the infrastructure is in place Kubernetes is installed on the virtual machines.
 
-	These operations are done in parrellel and rely on eventual consitency.
+	These operations are done in parallel and rely on eventual consistency.
 	`))
 
 	create_cluster_example = templates.Examples(i18n.T(`

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -50,7 +50,7 @@ var (
 	`))
 
 	update_cluster_example = templates.Examples(i18n.T(`
-	# After cluster has been editted or upgraded, configure it with:
+	# After cluster has been edited or upgraded, configure it with:
 	kops update cluster k8s-cluster.example.com --yes --state=s3://kops-state-1234 --yes
 	`))
 

--- a/cmd/kops/update_federation.go
+++ b/cmd/kops/update_federation.go
@@ -33,7 +33,7 @@ var (
 	`))
 
 	update_federation_example = templates.Examples(i18n.T(`
-	# After cluster has been editted or upgraded, configure it with:
+	# After cluster has been edited or upgraded, configure it with:
 	kops update federation k8s-cluster.example.com --yes --state=s3://kops-state-1234 --yes
 	`))
 

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -5,9 +5,9 @@ Create a Kubernetes cluster.
 ### Synopsis
 
 
-Create a kubernetes cluster using command line flags. This command creates cloud based resources such as networks and virtual machine. Once the infrastructure is in place Kubernetes is installed on the virtual machines. 
+Create a kubernetes cluster using command line flags. This command creates cloud based resources such as networks and virtual machines. Once the infrastructure is in place Kubernetes is installed on the virtual machines. 
 
-These operations are done in parrellel and rely on eventual consitency.
+These operations are done in parallel and rely on eventual consistency.
 
 ```
 kops create cluster

--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -16,7 +16,7 @@ kops update cluster
 ### Examples
 
 ```
-  # After cluster has been editted or upgraded, configure it with:
+  # After cluster has been edited or upgraded, configure it with:
   kops update cluster k8s-cluster.example.com --yes --state=s3://kops-state-1234 --yes
 ```
 

--- a/docs/cli/kops_update_federation.md
+++ b/docs/cli/kops_update_federation.md
@@ -14,7 +14,7 @@ kops update federation
 ### Examples
 
 ```
-  # After cluster has been editted or upgraded, configure it with:
+  # After cluster has been edited or upgraded, configure it with:
   kops update federation k8s-cluster.example.com --yes --state=s3://kops-state-1234 --yes
 ```
 


### PR DESCRIPTION
Just a couple of minor typo fixes in `create cluster` docs

Replaces kubernetes/kops#2927