### PR TITLE
kube-proxy: set hostname-override on AWS

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -354,8 +354,12 @@ type KubeProxyConfig struct {
 	//HealthzBindAddress string `json:"healthzBindAddress"`
 	//// healthzPort is the port to bind the health check server. Use 0 to disable.
 	//HealthzPort int32 `json:"healthzPort"`
-	//// hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
-	//HostnameOverride string `json:"hostnameOverride"`
+
+	// hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
+	// Note: We recognize some additional values:
+	//  @aws uses the hostname from the AWS metadata service
+	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
+
 	//// iptablesMasqueradeBit is the bit of the iptables fwmark space to use for SNAT if using
 	//// the pure iptables proxy mode. Values must be within the range [0, 31].
 	//IPTablesMasqueradeBit *int32 `json:"iptablesMasqueradeBit"`

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -353,8 +353,12 @@ type KubeProxyConfig struct {
 	//HealthzBindAddress string `json:"healthzBindAddress"`
 	//// healthzPort is the port to bind the health check server. Use 0 to disable.
 	//HealthzPort int32 `json:"healthzPort"`
-	//// hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
-	//HostnameOverride string `json:"hostnameOverride"`
+
+	// hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
+	// Note: We recognize some additional values:
+	//  @aws uses the hostname from the AWS metadata service
+	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
+
 	//// iptablesMasqueradeBit is the bit of the iptables fwmark space to use for SNAT if using
 	//// the pure iptables proxy mode. Values must be within the range [0, 31].
 	//IPTablesMasqueradeBit *int32 `json:"iptablesMasqueradeBit"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -165,6 +165,11 @@ type KubeProxyConfig struct {
 
 	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
 
+	// hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
+	// Note: We recognize some additional values:
+	//  @aws uses the hostname from the AWS metadata service
+	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
+
 	// master is the address of the Kubernetes API server (overrides any value in kubeconfig)
 	Master string `json:"master,omitempty" flag:"master"`
 

--- a/pkg/model/components/kubeproxy.go
+++ b/pkg/model/components/kubeproxy.go
@@ -65,5 +65,12 @@ func (b *KubeProxyOptionsBuilder) BuildOptions(o interface{}) error {
 		}
 	}
 
+	// Set the kube-proxy hostname-override (actually the NodeName), to avoid #2915 et al
+	cloudProvider := kops.CloudProviderID(clusterSpec.CloudProvider)
+	if cloudProvider == kops.CloudProviderAWS {
+		// Use the hostname from the AWS metadata service
+		config.HostnameOverride = "@aws"
+	}
+
 	return nil
 }

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -313,6 +313,13 @@ func evaluateSpec(c *api.Cluster) error {
 		return err
 	}
 
+	if c.Spec.KubeProxy != nil {
+		c.Spec.KubeProxy.HostnameOverride, err = evaluateHostnameOverride(c.Spec.KubeProxy.HostnameOverride)
+		if err != nil {
+			return err
+		}
+	}
+
 	if c.Spec.Docker != nil {
 		err = evaluateDockerSpecStorage(c.Spec.Docker)
 		if err != nil {


### PR DESCRIPTION
So that it matches the Node.Name

Fix #2915