### PR TITLE
Example of how to do bash in our CLI help

### DIFF
--- a/cmd/kops/edit_federation.go
+++ b/cmd/kops/edit_federation.go
@@ -19,34 +19,35 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
-
-	"io"
 
 	"github.com/spf13/cobra"
 	"k8s.io/kops/cmd/kops/util"
 	kopsapi "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/validation"
+	"k8s.io/kops/pkg/pretty"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util/editor"
 	"k8s.io/kubernetes/pkg/util/i18n"
 )
 
 var (
-	edit_federation_long = templates.LongDesc(i18n.T(`Edit a cluster configuration.
+	edit_federation_long = pretty.LongDesc(`
+		Edit a cluster configuration.
 
-	This command changes the federation cloud specification in the registry.
+		This command changes the federation cloud specification in the registry.
 
-    	To set your preferred editor, you can define the EDITOR environment variable.
-    	When you have done this, kops will use the editor that you have set.
+		To set your preferred editor, you can define the EDITOR environment variable.
+		When you have done this, kops will use the editor that you have set.
 
-	kops edit does not update the cloud resources, to apply the changes use "kops update cluster".`))
+		kops edit does not update the cloud resources, to apply the changes use ` + pretty.Bash("kops update cluster") + `.`)
 
 	edit_federation_example = templates.Examples(i18n.T(`
-	# Edit a cluster dederation configuration.
-	kops edit federation k8s-cluster.example.com --state=s3://kops-state-1234
-	`))
+		# Edit a cluster dederation configuration.
+		kops edit federation k8s-cluster.example.com --state=s3://kops-state-1234
+		`))
 
 	edit_federation_short = i18n.T(`Edit federation.`)
 )

--- a/docs/cli/kops_edit_federation.md
+++ b/docs/cli/kops_edit_federation.md
@@ -8,14 +8,14 @@ Edit federation.
 ### Synopsis
 
 
-Edit a cluster configuration. 
+Edit a cluster configuration.
 
-This command changes the federation cloud specification in the registry. 
+This command changes the federation cloud specification in the registry.
 
-  To set your preferred editor, you can define the EDITOR environment variable.
-  When you have done this, kops will use the editor that you have set.
-  
-kops edit does not update the cloud resources, to apply the changes use "kops update cluster".
+To set your preferred editor, you can define the EDITOR environment variable.
+When you have done this, kops will use the editor that you have set.
+
+kops edit does not update the cloud resources, to apply the changes use `kops update cluster`.
 
 ```
 kops edit federation

--- a/hack/.packages
+++ b/hack/.packages
@@ -70,6 +70,7 @@ k8s.io/kops/pkg/model/gcemodel
 k8s.io/kops/pkg/model/iam
 k8s.io/kops/pkg/model/resources
 k8s.io/kops/pkg/model/vspheremodel
+k8s.io/kops/pkg/pretty
 k8s.io/kops/pkg/resources
 k8s.io/kops/pkg/resources/digitalocean
 k8s.io/kops/pkg/resources/digitalocean/dns

--- a/pkg/pretty/help.go
+++ b/pkg/pretty/help.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pretty
+
+import (
+	"fmt"
+	"github.com/MakeNowJust/heredoc"
+	"strings"
+)
+
+func Bash(s string) string {
+	return fmt.Sprintf("`%s`", s)
+}
+
+func LongDesc(s string) string {
+	s = heredoc.Doc(s)
+	s = strings.TrimSpace(s)
+	return s
+}

--- a/pkg/pretty/help.go
+++ b/pkg/pretty/help.go
@@ -22,10 +22,13 @@ import (
 	"strings"
 )
 
+// Bash markdown-quotes a bash command for insertion into help text.
 func Bash(s string) string {
 	return fmt.Sprintf("`%s`", s)
 }
 
+// LongDesc is used for formatting help text for a commands Long Description.
+// It de-dents it and trims it.
 func LongDesc(s string) string {
 	s = heredoc.Doc(s)
 	s = strings.TrimSpace(s)


### PR DESCRIPTION
* Use the pretty.LongDesc function (which doesn't pipe it through
markdown -> ascii)
* Use pretty.Bash helper to avoid problems with backticks in
go-backtick-quoted-strings
* Make sure indentation is consistent