### PR TITLE
Create YAML or JSON Clusterspec without creating the cluster

### DIFF
--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -130,6 +130,7 @@ func RunCreate(f *util.Factory, out io.Writer, c *CreateOptions) error {
 			return fmt.Errorf("error reading file %q: %v", f, err)
 		}
 
+		// TODO: this does not support a JSON array
 		sections := bytes.Split(contents, []byte("\n---\n"))
 		for _, section := range sections {
 			defaults := &schema.GroupVersionKind{

--- a/cmd/kops/create_ig.go
+++ b/cmd/kops/create_ig.go
@@ -39,6 +39,10 @@ import (
 type CreateInstanceGroupOptions struct {
 	Role    string
 	Subnets []string
+	// DryRun mode output an ig manifest of Output type.
+	DryRun bool
+	// Output type during a DryRun
+	Output string
 }
 
 var (
@@ -52,6 +56,10 @@ var (
 		# Create an instancegroup for the k8s-cluster.example.com cluster.
 		kops create ig --name=k8s-cluster.example.com node-example \
 		  --role node --subnet my-subnet-name
+
+		# Create a YAML manifest for an instancegroup for the k8s-cluster.example.com cluster.
+		kops create ig --name=k8s-cluster.example.com node-example \
+		  --role node --subnet my-subnet-name --dry-run -oyaml
 		`))
 
 	create_ig_short = i18n.T(`Create an instancegroup.`)
@@ -85,6 +93,9 @@ func NewCmdCreateInstanceGroup(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd.Flags().StringVar(&options.Role, "role", options.Role, "Type of instance group to create ("+strings.Join(allRoles, ",")+")")
 	cmd.Flags().StringSliceVar(&options.Subnets, "subnet", options.Subnets, "Subnets in which to create instance group")
+	// DryRun mode that will print YAML or JSON
+	cmd.Flags().BoolVar(&options.DryRun, "dry-run", options.DryRun, "If true, only print the object that would be sent, without sending it. This flag can be used to create a cluster YAML or JSON manifest.")
+	cmd.Flags().StringVarP(&options.Output, "output", "o", options.Output, "Ouput format. One of json|yaml")
 
 	return cmd
 }
@@ -140,6 +151,32 @@ func RunCreateInstanceGroup(f *util.Factory, cmd *cobra.Command, args []string, 
 	ig, err = cloudup.PopulateInstanceGroupSpec(cluster, ig, channel)
 	if err != nil {
 		return err
+	}
+
+	if options.DryRun {
+
+		if options.Output == "" {
+			return fmt.Errorf("must set output flag; yaml or json")
+		}
+
+		// Cluster name is not populated, and we need it
+		ig.ObjectMeta.Labels = make(map[string]string)
+		ig.ObjectMeta.Labels[api.LabelClusterName] = cluster.ObjectMeta.Name
+
+		switch options.Output {
+		case OutputYaml:
+			if err := fullOutputYAML(out, ig); err != nil {
+				return fmt.Errorf("error writing cluster yaml to stdout: %v", err)
+			}
+			return nil
+		case OutputJSON:
+			if err := fullOutputJSON(out, ig); err != nil {
+				return fmt.Errorf("error writing cluster json to stdout: %v", err)
+			}
+			return nil
+		default:
+			return fmt.Errorf("unsupported output type %q", options.Output)
+		}
 	}
 
 	var (

--- a/cmd/kops/get_federation.go
+++ b/cmd/kops/get_federation.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kops/cmd/kops/util"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/util/pkg/tables"
@@ -85,10 +86,16 @@ func RunGetFederations(context Factory, out io.Writer, options *GetFederationOpt
 	if len(federations) == 0 {
 		return fmt.Errorf("No federations found")
 	}
+
+	var obj []runtime.Object
+	if options.output != OutputTable {
+		for _, c := range federations {
+			obj = append(obj, c)
+		}
+	}
+
 	switch options.output {
-
 	case OutputTable:
-
 		t := &tables.Table{}
 		t.AddColumn("NAME", func(f *api.Federation) string {
 			return f.ObjectMeta.Name
@@ -102,25 +109,10 @@ func RunGetFederations(context Factory, out io.Writer, options *GetFederationOpt
 		return t.Render(federations, out, "NAME", "CONTROLLERS", "MEMBERS")
 
 	case OutputYaml:
-		for i, f := range federations {
-			if i != 0 {
-				_, err = out.Write([]byte("\n\n---\n\n"))
-				if err != nil {
-					return fmt.Errorf("error writing to stdout: %v", err)
-				}
-			}
-			if err := marshalToWriter(f, marshalYaml, os.Stdout); err != nil {
-				return err
-			}
-		}
+		return fullOutputYAML(out, obj...)
 	case OutputJSON:
-		for _, f := range federations {
-			if err := marshalToWriter(f, marshalJSON, os.Stdout); err != nil {
-				return err
-			}
-		}
+		return fullOutputJSON(out, obj...)
 	default:
 		return fmt.Errorf("Unknown output format: %q", options.output)
 	}
-	return nil
 }

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -56,6 +56,10 @@ kops create cluster
   --project my-gce-project \
   --image "ubuntu-os-cloud/ubuntu-1604-xenial-v20170202" \
   --yes
+  # Create manifest for a cluster in AWS
+  kops create cluster --name=kubernetes-cluster.example.com \
+  --state=s3://kops-state-1234 --zones=eu-west-1a \
+  --node-count=2 --dry-run -oyaml
 ```
 
 ### Options
@@ -71,6 +75,7 @@ kops create cluster
       --cloud-labels string                  A list of KV pairs used to tag all instance groups in AWS (eg "Owner=John Doe,Team=Some Team").
       --dns string                           DNS hosted zone to use: public|private. Default is 'public'. (default "Public")
       --dns-zone string                      DNS hosted zone to use (defaults to longest matching zone)
+      --dry-run                              If true, only print the object that would be sent, without sending it. This flag can be used to create a cluster YAML or JSON manifest.
       --encrypt-etcd-storage                 Generate key in aws kms and use it for encrypt etcd volumes
       --image string                         Image to use for all instances.
       --kubernetes-version string            Version of kubernetes to run (defaults to version in channel)
@@ -89,10 +94,11 @@ kops create cluster
       --node-tenancy string                  The tenancy of the node group on AWS. Can be either default or dedicated.
       --node-volume-size int32               Set instance volume size (in GB) for nodes
       --out string                           Path to write any local output
+  -o, --output string                        Ouput format. One of json|yaml. Used with the --dry-run flag.
       --project string                       Project to use (must be set on GCE)
       --ssh-access stringSlice               Restrict SSH access to this CIDR.  If not set, access will not be restricted by IP. (default [0.0.0.0/0])
       --ssh-public-key string                SSH public key to use (default "~/.ssh/id_rsa.pub")
-      --target string                        Target - direct, terraform, cloudformation (default "direct")
+      --target string                        Valid targets: direct, terraform, direct. Set this flag to terraform if you want kops to generate terraform (default "direct")
   -t, --topology string                      Controls network topology for the cluster. public|private. Default is 'public'. (default "public")
       --vpc string                           Set to use a shared VPC
       --yes                                  Specify --yes to immediately create the cluster

--- a/docs/cli/kops_create_instancegroup.md
+++ b/docs/cli/kops_create_instancegroup.md
@@ -20,11 +20,17 @@ kops create instancegroup
   # Create an instancegroup for the k8s-cluster.example.com cluster.
   kops create ig --name=k8s-cluster.example.com node-example \
   --role node --subnet my-subnet-name
+  
+  # Create a YAML manifest for an instancegroup for the k8s-cluster.example.com cluster.
+  kops create ig --name=k8s-cluster.example.com node-example \
+  --role node --subnet my-subnet-name --dry-run -oyaml
 ```
 
 ### Options
 
 ```
+      --dry-run              If true, only print the object that would be sent, without sending it. This flag can be used to create a cluster YAML or JSON manifest.
+  -o, --output string        Ouput format. One of json|yaml
       --role string          Type of instance group to create (Node,Master,Bastion) (default "Node")
       --subnet stringSlice   Subnets in which to create instance group
 ```


### PR DESCRIPTION
Allowing a user to create a YAML or JSON cluster or instance group without creating the object.  Some of the new methods will be used to fix the problems we are having with JSON output as well.  Reading an array of JSON objects is not yet supported by `kops create -f`, but a single JSON object is supported.

This implements

`kops create cluster --dry-run -oyaml`

TODOs

- [x] init or create
- [x] update cobra docs
- [x] figure out what is going on with unit tests
- [ ] figure out was issue(s) this closes
