### PR TITLE
Add back integration tests into CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ test: # Run tests locally
 	go test k8s.io/kops/cmd/... -args -v=1 -logtostderr
 	go test k8s.io/kops/channels/... -args -v=1 -logtostderr
 	go test k8s.io/kops/util/... -args -v=1 -logtostderr
+	go test k8s.io/kops/tests/... -args -v=1 -logtostderr
 
 .PHONY: crossbuild-nodeup
 crossbuild-nodeup:


### PR DESCRIPTION
Looks like I accidentally (rebase?) removed it in
a7c2c554e1e1b70bb16b51075e25f63dd2be9a56