### PR TITLE
Unsetting the variable in the Make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,7 @@ gcs-publish-ci: gcs-upload
 .PHONY: gen-cli-docs
 gen-cli-docs: kops # Regenerate CLI docs
 	KOPS_STATE_STORE= \
+	KOPS_FEATURE_FLAGS= \
 	${KOPS} genhelpdocs --out docs/cli
 
 .PHONY: push


### PR DESCRIPTION
Fix for:
https://github.com/kubernetes/kops/issues/2642

Unsetting in the makefile so it's simpler and easier to change in the future.