### PR TITLE
protokube changes for allowing running a custom etcd container

### DIFF
--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -101,6 +101,10 @@ func run() error {
 	// Trick to avoid 'logging before flag.Parse' warning
 	flag.CommandLine.Parse([]string{})
 
+	// optional flag to override the location of etcd.  Utilized with cluster asset container registry.
+	var etcdImageSource string
+	flags.StringVar(&etcdImageSource, "etcd-image-source", etcdImageSource, "Etcd Source Container Registry")
+
 	flag.Set("logtostderr", "true")
 
 	flags.AddGoFlagSet(flag.CommandLine)
@@ -322,7 +326,8 @@ func run() error {
 
 		Channels: channels,
 
-		Kubernetes: protokube.NewKubernetesContext(),
+		Kubernetes:      protokube.NewKubernetesContext(),
+		EtcdImageSource: etcdImageSource,
 	}
 	k.Init(volumes)
 

--- a/protokube/pkg/protokube/etcd_cluster.go
+++ b/protokube/pkg/protokube/etcd_cluster.go
@@ -54,6 +54,7 @@ type EtcdCluster struct {
 	Spec *EtcdClusterSpec
 
 	VolumeMountPath string
+	ImageSource     string
 }
 
 func (e *EtcdCluster) String() string {
@@ -92,6 +93,7 @@ func newEtcdController(kubeBoot *KubeBoot, v *Volume, spec *EtcdClusterSpec) (*E
 	cluster.CPURequest = resource.MustParse("100m")
 	cluster.ClientPort = 4001
 	cluster.PeerPort = 2380
+	cluster.ImageSource = kubeBoot.EtcdImageSource
 
 	// We used to build this through text files ... it turns out to just be more complicated than code!
 	switch spec.ClusterKey {

--- a/protokube/pkg/protokube/etcd_manifest.go
+++ b/protokube/pkg/protokube/etcd_manifest.go
@@ -35,12 +35,24 @@ func BuildEtcdManifest(c *EtcdCluster) *v1.Pod {
 		"k8s-app": c.PodName,
 	}
 
+	// TODO another hardcoded version
+	image := "/etcd:2.2.1"
+	imageRegistry := "gcr.io/google_containers"
+
+	// Test to determine if the container registry has been passed in as a flag.
+	// If so use the provider registry location.
+	if c.ImageSource == "" {
+		image = imageRegistry + image
+	} else {
+		image = strings.TrimSuffix(c.ImageSource, "/") + image
+	}
+
 	pod.Spec.HostNetwork = true
 
 	{
 		container := v1.Container{
 			Name:  "etcd-container",
-			Image: "gcr.io/google_containers/etcd:2.2.1",
+			Image: image,
 			Resources: v1.ResourceRequirements{
 				Requests: v1.ResourceList{
 					v1.ResourceCPU: c.CPURequest,

--- a/protokube/pkg/protokube/kube_boot.go
+++ b/protokube/pkg/protokube/kube_boot.go
@@ -50,6 +50,9 @@ type KubeBoot struct {
 	Channels []string
 
 	Kubernetes *KubernetesContext
+
+	// Etcd container registry location.
+	EtcdImageSource string
 }
 
 func (k *KubeBoot) Init(volumesProvider Volumes) {


### PR DESCRIPTION
First PR of many for the Assets functionality.

See #2917 for details

This PR allows for setting a custom location of the etcd container.  The container version is hardcoded in protokube as it has been, we are just able to set the location of the container.