### PR TITLE
inventory 07 limiting addons to only k8s versions

### DIFF
--- a/channels/pkg/channels/addons.go
+++ b/channels/pkg/channels/addons.go
@@ -60,14 +60,14 @@ func ParseAddons(name string, location *url.URL, data []byte) (*Addons, error) {
 }
 
 func (a *Addons) GetCurrent(kubernetesVersion semver.Version) (*AddonMenu, error) {
-	all, err := a.wrapInAddons()
+	all, err := a.WrapInAddons()
 	if err != nil {
 		return nil, err
 	}
 
 	menu := NewAddonMenu()
 	for _, addon := range all {
-		if !addon.matches(kubernetesVersion) {
+		if !addon.Matches(kubernetesVersion) {
 			continue
 		}
 		name := addon.Name
@@ -81,7 +81,7 @@ func (a *Addons) GetCurrent(kubernetesVersion semver.Version) (*AddonMenu, error
 	return menu, nil
 }
 
-func (a *Addons) wrapInAddons() ([]*Addon, error) {
+func (a *Addons) WrapInAddons() ([]*Addon, error) {
 	var addons []*Addon
 	for _, s := range a.APIObject.Spec.Addons {
 		name := a.APIObject.ObjectMeta.Name
@@ -101,7 +101,7 @@ func (a *Addons) wrapInAddons() ([]*Addon, error) {
 	return addons, nil
 }
 
-func (s *Addon) matches(kubernetesVersion semver.Version) bool {
+func (s *Addon) Matches(kubernetesVersion semver.Version) bool {
 	if s.Spec.KubernetesVersion != "" {
 		versionRange, err := semver.ParseRange(s.Spec.KubernetesVersion)
 		if err != nil {

--- a/channels/pkg/channels/addons_test.go
+++ b/channels/pkg/channels/addons_test.go
@@ -69,7 +69,7 @@ func Test_Filtering(t *testing.T) {
 		addon := &Addon{
 			Spec: &g.Input,
 		}
-		actual := addon.matches(k8sVersion)
+		actual := addon.Matches(k8sVersion)
 		if actual != g.Expected {
 			t.Errorf("unexpected result from %v, %s.  got %v", g.Input.KubernetesVersion, g.KubernetesVersion, actual)
 		}


### PR DESCRIPTION
Currently, we are uploading manifests for addons for all k8s versions.  This PR filters addons to only the needed versions.  This becomes important as we cannot print or gather an inventory accurately for a cluster, and we upload unneeded containers to the customer container registry.