### PR TITLE
Add reserve compute resources kubelet flags

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -155,6 +155,27 @@ spec:
 
 Will result in the flag `--feature-gates=ExperimentalCriticalPodAnnotation=true,AllowExtTrafficLocalEndpoints=false`
 
+####  Compute Resources Reservation
+
+```yaml
+spec:
+  kubelet:
+    kubeReserved:
+        cpu: "100m"
+        memory: "100Mi"
+        storage: "1Gi"
+    kubeReservedCgroup: "/kube-reserved"
+    systemReserved:
+        cpu: "100m"
+        memory: "100Mi"
+        storage: "1Gi"
+    systemReservedCgroup: "/system-reserved"
+    enforceNodeAllocatable: "pods,system-reserved,kube-reserved"
+```
+
+Will result in the flag `--kube-reserved=cpu=100m,memory=100Mi,storage=1Gi --kube-reserved-cgroup=/kube-reserved --system-reserved=cpu=100mi,memory=100Mi,storage=1Gi --system-reserved-cgroup=/system-reserved --enforce-node-allocatable=pods,system-reserved,kube-reserved`
+
+Learn [more about reserving compute resources](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/).
 
 ### networkID
 

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -329,6 +329,19 @@ type KubeletConfigSpec struct {
 
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
+
+	// Resource reservation for kubernetes system daemons like the kubelet,
+	// container runtime, node problem detector, etc.
+	KubeReserved map[string]string `json:"kubeReserved,omitempty" flag:"kube-reserved"`
+	// Control group for kube daemons.
+	KubeReservedCgroup string `json:"kubeReservedCgroup,omitempty" flag:"kube-reserved-cgroup"`
+	// Capture resource reservation for OS system daemons like sshd, udev, etc.
+	SystemReserved map[string]string `json:"systemReserved,omitempty" flag:"system-reserved"`
+	// Parent control group for OS system daemons.
+	SystemReservedCgroup string `json:"systemReservedCgroup,omitempty" flag:"system-reserved-cgroup"`
+	// Enforce Allocatable across pods whenever the overall usage across all pods
+	// exceeds Allocatable.
+	EnforceNodeAllocatable string `json:"enforceNodeAllocatable,omitempty" flag:"enforce-node-allocatable"`
 }
 
 type KubeProxyConfig struct {

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -328,6 +328,19 @@ type KubeletConfigSpec struct {
 
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
+
+	// Resource reservation for kubernetes system daemons like the kubelet,
+	// container runtime, node problem detector, etc.
+	KubeReserved map[string]string `json:"kubeReserved,omitempty" flag:"kube-reserved"`
+	// Control group for kube daemons.
+	KubeReservedCgroup string `json:"kubeReservedCgroup,omitempty" flag:"kube-reserved-cgroup"`
+	// Capture resource reservation for OS system daemons like sshd, udev, etc.
+	SystemReserved map[string]string `json:"systemReserved,omitempty" flag:"system-reserved"`
+	// Parent control group for OS system daemons.
+	SystemReservedCgroup string `json:"systemReservedCgroup,omitempty" flag:"system-reserved-cgroup"`
+	// Enforce Allocatable across pods whenever the overall usage across all pods
+	// exceeds Allocatable.
+	EnforceNodeAllocatable string `json:"enforceNodeAllocatable,omitempty" flag:"enforce-node-allocatable"`
 }
 
 type KubeProxyConfig struct {

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1615,6 +1615,11 @@ func autoConvert_v1alpha1_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.VolumePluginDirectory = in.VolumePluginDirectory
 	out.Taints = in.Taints
 	out.FeatureGates = in.FeatureGates
+	out.KubeReserved = in.KubeReserved
+	out.KubeReservedCgroup = in.KubeReservedCgroup
+	out.SystemReserved = in.SystemReserved
+	out.SystemReservedCgroup = in.SystemReservedCgroup
+	out.EnforceNodeAllocatable = in.EnforceNodeAllocatable
 	return nil
 }
 
@@ -1666,6 +1671,11 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha1_KubeletConfigSpec(in *kops.K
 	out.VolumePluginDirectory = in.VolumePluginDirectory
 	out.Taints = in.Taints
 	out.FeatureGates = in.FeatureGates
+	out.KubeReserved = in.KubeReserved
+	out.KubeReservedCgroup = in.KubeReservedCgroup
+	out.SystemReserved = in.SystemReserved
+	out.SystemReservedCgroup = in.SystemReservedCgroup
+	out.EnforceNodeAllocatable = in.EnforceNodeAllocatable
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -154,6 +154,19 @@ type KubeletConfigSpec struct {
 
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
+
+	// Resource reservation for kubernetes system daemons like the kubelet,
+	// container runtime, node problem detector, etc.
+	KubeReserved map[string]string `json:"kubeReserved,omitempty" flag:"kube-reserved"`
+	// Control group for kube daemons.
+	KubeReservedCgroup string `json:"kubeReservedCgroup,omitempty" flag:"kube-reserved-cgroup"`
+	// Capture resource reservation for OS system daemons like sshd, udev, etc.
+	SystemReserved map[string]string `json:"systemReserved,omitempty" flag:"system-reserved"`
+	// Parent control group for OS system daemons.
+	SystemReservedCgroup string `json:"systemReservedCgroup,omitempty" flag:"system-reserved-cgroup"`
+	// Enforce Allocatable across pods whenever the overall usage across all pods
+	// exceeds Allocatable.
+	EnforceNodeAllocatable string `json:"enforceNodeAllocatable,omitempty" flag:"enforce-node-allocatable"`
 }
 
 type KubeProxyConfig struct {

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1723,6 +1723,11 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.VolumePluginDirectory = in.VolumePluginDirectory
 	out.Taints = in.Taints
 	out.FeatureGates = in.FeatureGates
+	out.KubeReserved = in.KubeReserved
+	out.KubeReservedCgroup = in.KubeReservedCgroup
+	out.SystemReserved = in.SystemReserved
+	out.SystemReservedCgroup = in.SystemReservedCgroup
+	out.EnforceNodeAllocatable = in.EnforceNodeAllocatable
 	return nil
 }
 
@@ -1774,6 +1779,11 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.VolumePluginDirectory = in.VolumePluginDirectory
 	out.Taints = in.Taints
 	out.FeatureGates = in.FeatureGates
+	out.KubeReserved = in.KubeReserved
+	out.KubeReservedCgroup = in.KubeReservedCgroup
+	out.SystemReserved = in.SystemReserved
+	out.SystemReservedCgroup = in.SystemReservedCgroup
+	out.EnforceNodeAllocatable = in.EnforceNodeAllocatable
 	return nil
 }
 


### PR DESCRIPTION
Adds kubelet flags required to set values necessary to configure resources available for system daemons.  Relevant reading:

* [Reserve Compute Resources for System Daemons](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/)
* [Configure Out Of Resource Handling](https://kubernetes.io/docs/tasks/administer-cluster/out-of-resource/#best_practices)

Closes https://github.com/kubernetes/kops/issues/1869. 