### PR TITLE
Updates for g3 machine type

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/machine_types.go
+++ b/upup/pkg/fi/cloudup/awsup/machine_types.go
@@ -562,4 +562,30 @@ var MachineTypes []AWSMachineTypeInfo = []AWSMachineTypeInfo{
 		EphemeralDisks: nil,
 		GPU:            true,
 	},
+
+	// g3 family
+	{
+		Name:           "g3.4xlarge",
+		MemoryGB:       122,
+		Cores:          16,
+		ECU:            47,
+		EphemeralDisks: nil,
+		GPU:            true,
+	},
+	{
+		Name:           "g3.8xlarge",
+		MemoryGB:       244,
+		ECU:            94,
+		Cores:          32,
+		EphemeralDisks: nil,
+		GPU:            true,
+	},
+	{
+		Name:           "g3.16xlarge",
+		MemoryGB:       488,
+		ECU:            188,
+		Cores:          64,
+		EphemeralDisks: nil,
+		GPU:            true,
+	},
 }


### PR DESCRIPTION
I am not sure how to compute or find ECU, @justinsb can you add some clarity?  We do not seem to be using it.  And it seems like AWS has moved away from using it.

Fixes: https://github.com/kubernetes/kops/issues/2978