### PR TITLE
warning on network phase

### DIFF
--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -464,8 +464,9 @@ func (c *ApplyClusterCmd) Run() error {
 			iamLifecycle = lifecyclePointer(fi.LifecycleExistsAndWarnIfChanges)
 			networkLifecycle = lifecyclePointer(fi.LifecycleExistsAndWarnIfChanges)
 		} else {
+			// TODO: when the PR for custom IAM roles is merge we may want want to warn as well
 			iamLifecycle = lifecyclePointer(fi.LifecycleExistsAndValidates)
-			networkLifecycle = lifecyclePointer(fi.LifecycleExistsAndValidates)
+			networkLifecycle = lifecyclePointer(fi.LifecycleExistsAndWarnIfChanges)
 		}
 	default:
 		return fmt.Errorf("unknown phase %q", c.Phase)


### PR DESCRIPTION
This will allow for further network configurations such as ignoring tags, not having IG, not having NAT gateways.  These are multiple issues that we can close with this.  This would also allow for the use of private networks in regions that do not support nat gateways.  A user couple build the network themselves and build there own nat boxes.

Fixes: https://github.com/kubernetes/kops/issues/780, https://github.com/kubernetes/kops/issues/1530, https://github.com/kubernetes/kops/issues/971