### PR TITLE
Inventory assets - adding default pause container

### DIFF
--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -180,5 +180,13 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		}
 	}
 
+	// We can do this, or check if we are re-writing the assets to a container registry.
+	// I think it is easiest to just always set it.
+
+	// Set the pause container as a kubelet flag
+	if clusterSpec.Kubelet.PodInfraContainerImage == "" {
+		clusterSpec.Kubelet.PodInfraContainerImage = "gcr.io/google_containers/pause-amd64:3.0"
+	}
+
 	return nil
 }


### PR DESCRIPTION
We need to add in a default pause container so that it can be remapped to another registry.  We have two choices, set a default, or set a default when we are re mapping the google containers.  Seems a bit odd to set a default if you need to remap.