### PR TITLE
Skip the creation of a IGW

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -74,6 +74,8 @@ type ClusterSpec struct {
 	AdditionalNetworkCIDRs []string `json:"additionalNetworkCIDRs,omitempty"`
 	// NetworkID is an identifier of a network, if we want to reuse/share an existing network (e.g. an AWS VPC)
 	NetworkID string `json:"networkID,omitempty"`
+	// NetworkRequireGateway set to false and a gateway will not be created.  Only supported in AWS at this time.
+	NetworkRequireGateway *bool `json:"networkRequireGateway,omitempty"`
 	// Topology defines the type of network topology to use on the cluster - default public
 	// This is heavily weighted towards AWS for the time being, but should also be agnostic enough
 	// to port out to GCE later if needed

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -73,6 +73,8 @@ type ClusterSpec struct {
 	AdditionalNetworkCIDRs []string `json:"additionalNetworkCIDRs,omitempty"`
 	// NetworkID is an identifier of a network, if we want to reuse/share an existing network (e.g. an AWS VPC)
 	NetworkID string `json:"networkID,omitempty"`
+	// NetworkRequireGateway set to false and a gateway will not be created.  Only supported in AWS at this time.
+	NetworkRequireGateway *bool `json:"networkRequireGateway,omitempty"`
 	// Topology defines the type of network topology to use on the cluster - default public
 	// This is heavily weighted towards AWS for the time being, but should also be agnostic enough
 	// to port out to GCE later if needed

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -610,6 +610,7 @@ func autoConvert_v1alpha1_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 	out.NetworkCIDR = in.NetworkCIDR
 	out.AdditionalNetworkCIDRs = in.AdditionalNetworkCIDRs
 	out.NetworkID = in.NetworkID
+	out.NetworkRequireGateway = in.NetworkRequireGateway
 	if in.Topology != nil {
 		in, out := &in.Topology, &out.Topology
 		*out = new(kops.TopologySpec)
@@ -855,6 +856,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha1_ClusterSpec(in *kops.ClusterSpec, 
 	out.NetworkCIDR = in.NetworkCIDR
 	out.AdditionalNetworkCIDRs = in.AdditionalNetworkCIDRs
 	out.NetworkID = in.NetworkID
+	out.NetworkRequireGateway = in.NetworkRequireGateway
 	if in.Topology != nil {
 		in, out := &in.Topology, &out.Topology
 		*out = new(TopologySpec)

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -531,6 +531,15 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.NetworkRequireGateway != nil {
+		in, out := &in.NetworkRequireGateway, &out.NetworkRequireGateway
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	if in.Topology != nil {
 		in, out := &in.Topology, &out.Topology
 		if *in == nil {

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -71,6 +71,8 @@ type ClusterSpec struct {
 	AdditionalNetworkCIDRs []string `json:"additionalNetworkCIDRs,omitempty"`
 	// NetworkID is an identifier of a network, if we want to reuse/share an existing network (e.g. an AWS VPC)
 	NetworkID string `json:"networkID,omitempty"`
+	// NetworkRequireGateway set to false and a gateway will not be created.  Only supported in AWS at this time.
+	NetworkRequireGateway *bool `json:"networkRequireGateway,omitempty"`
 	// Topology defines the type of network topology to use on the cluster - default public
 	// This is heavily weighted towards AWS for the time being, but should also be agnostic enough
 	// to port out to GCE later if needed

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -656,6 +656,7 @@ func autoConvert_v1alpha2_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 	out.NetworkCIDR = in.NetworkCIDR
 	out.AdditionalNetworkCIDRs = in.AdditionalNetworkCIDRs
 	out.NetworkID = in.NetworkID
+	out.NetworkRequireGateway = in.NetworkRequireGateway
 	if in.Topology != nil {
 		in, out := &in.Topology, &out.Topology
 		*out = new(kops.TopologySpec)
@@ -917,6 +918,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, 
 	out.NetworkCIDR = in.NetworkCIDR
 	out.AdditionalNetworkCIDRs = in.AdditionalNetworkCIDRs
 	out.NetworkID = in.NetworkID
+	out.NetworkRequireGateway = in.NetworkRequireGateway
 	if in.Topology != nil {
 		in, out := &in.Topology, &out.Topology
 		*out = new(TopologySpec)

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -524,6 +524,15 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.NetworkRequireGateway != nil {
+		in, out := &in.NetworkRequireGateway, &out.NetworkRequireGateway
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	if in.Topology != nil {
 		in, out := &in.Topology, &out.Topology
 		if *in == nil {

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -629,6 +629,15 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.NetworkRequireGateway != nil {
+		in, out := &in.NetworkRequireGateway, &out.NetworkRequireGateway
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	if in.Topology != nil {
 		in, out := &in.Topology, &out.Topology
 		if *in == nil {


### PR DESCRIPTION
Fixes #780 

Allows a user to set `networkSkipCreateGateway: true` and kops does not create an IGW or a default route.

/assign @justinsb @andrewsykim @sethpollack 

Update:

This PR adds a new API field called networkRequireGateway which when
set to false stops the creation of an IGW, and a default route is not
added to the route table