### PR TITLE
Updating flannel to use RBAC in 1.6 so its not broken when deploying

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.6.yaml
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.6.yaml
@@ -1,3 +1,45 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+  labels:
+    role.kubernetes.io/networking: "1"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+  labels:
+    role.kubernetes.io/networking: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flannel
+subjects:
+- kind: ServiceAccount
+  name: flannel
+  namespace: kube-system
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:


### PR DESCRIPTION
Should address: https://github.com/kubernetes/kops/issues/2863

Clusters spawned with --networking=flannel and --autorization=rbac aren't functional as we are missing the ClusterRole and ClusterRoleBinding