### PR TITLE
Fix typo in the apireference README

### DIFF
--- a/docs/apireference/README.md
+++ b/docs/apireference/README.md
@@ -1,4 +1,4 @@
-# How to update the apirefrence docs
+# How to update the apireference docs
 
 These instructions assume:
 


### PR DESCRIPTION
Small typo fix. 😀

Signed-off-by: Jean-Pierre Huynh <jean-pierre.huynh@ounet.fr>