### PR TITLE
Cluster Hooks Enhancement

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -200,19 +200,24 @@ spec:
     - some_service.service
     requires:
     - docker.service
-    execContainer:
+      execContainer:
       image: kopeio/nvidia-bootstrap:1.6
+      # these are added as -e to the docker environment
+      environment:
+        AWS_REGION: eu-west-1
+        SOME_VAR: SOME_VALUE
 
   # or a raw systemd unit
   hooks:
   - name: iptable-restore.service
-    masterOnly: true|false # only run this on masters
-    nodeOnly: true|false   # only run this on compute nodes
+    roles:
+    - Node
+    - Master
     before:
     - kubelet.service
     manifest: |
       [Service]
-      EnvironmentFile=/etc/enviroment
+      EnvironmentFile=/etc/environment
       # do some stuff
 
   # or disable a systemd unit

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -188,7 +188,7 @@ spec:
 
 More information about running in an existing VPC is [here](run_in_existing_vpc.md).
 
-### hooks
+### Hooks
 
 Hooks allow the execution of a container before the installation of Kubneretes on every node in a cluster.  For intance you can install nvidia drivers for using GPUs.
 
@@ -197,6 +197,11 @@ spec:
   # many sections removed
   hooks:
   - execContainer:
+      documentation: http://some_url
+      before:
+      - some_service.service
+      requires:
+      - docker.service
       image: kopeio/nvidia-bootstrap:1.6
 ```
 

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -188,9 +188,9 @@ spec:
 
 More information about running in an existing VPC is [here](run_in_existing_vpc.md).
 
-### Hooks
+### hooks
 
-Hooks allow the execution of a container before the installation of Kubneretes on every node in a cluster.  For intance you can install nvidia drivers for using GPUs.
+Hooks allow for the execution of an action before the installation of Kubernetes on every node in a cluster.  For instance you can install nvidia drivers for using GPUs. This hooks can be in the form on docker images or manifest files (systemd units). Hooks can be place in either then cluster spec, meaning the will be globally deployed, or they can be placed into the instanceGroup specification. Note, service names on the instanceGroup which overlap with the cluster spec take precedence and ignore the cluster spec definition, i.e. if you have a unit file 'myunit.service' in cluster and then one in the instanceGroup, only the instanceGroup is applied.
 
 ```
 spec:
@@ -219,6 +219,15 @@ spec:
   hooks:
   - name: update-engine.service
     disable: true
+
+  # or you could wrap this into a full unit
+  hooks:
+  - name: disable-update-engine.service
+    before:
+    - update-engine.service
+    manifest: |
+      Type=oneshot
+      ExecStart=/usr/bin/systemctl stop update-engine.service
 ```
 
 Install Ceph

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -196,13 +196,29 @@ Hooks allow the execution of a container before the installation of Kubneretes o
 spec:
   # many sections removed
   hooks:
-  - execContainer:
-      documentation: http://some_url
-      before:
-      - some_service.service
-      requires:
-      - docker.service
+  - before:
+    - some_service.service
+    requires:
+    - docker.service
+    execContainer:
       image: kopeio/nvidia-bootstrap:1.6
+
+  # or a raw systemd unit
+  hooks:
+  - name: iptable-restore.service
+    masterOnly: true|false # only run this on masters
+    nodeOnly: true|false   # only run this on compute nodes
+    before:
+    - kubelet.service
+    manifest: |
+      [Service]
+      EnvironmentFile=/etc/enviroment
+      # do some stuff
+
+  # or disable a systemd unit
+  hooks:
+  - name: update-engine.service
+    disable: true
 ```
 
 Install Ceph

--- a/nodeup/pkg/model/convenience.go
+++ b/nodeup/pkg/model/convenience.go
@@ -44,6 +44,27 @@ func b(v bool) *bool {
 	return fi.Bool(v)
 }
 
+// containsRole checks if a collection roles contains role v
+func containsRole(v kops.InstanceGroupRole, list []kops.InstanceGroupRole) bool {
+	for _, x := range list {
+		if v == x {
+			return true
+		}
+	}
+
+	return false
+}
+
+// buildDockerEnvironmentVars just converts a series of keypairs to docker environment variables switches
+func buildDockerEnvironmentVars(env map[string]string) []string {
+	var list []string
+	for k, v := range env {
+		list = append(list, []string{"-e", fmt.Sprintf("%s=%s", k, v)}...)
+	}
+
+	return list
+}
+
 func getProxyEnvVars(proxies *kops.EgressProxySpec) []v1.EnvVar {
 	if proxies == nil {
 		glog.V(8).Info("proxies is == nil, returning empty list")

--- a/nodeup/pkg/model/hooks.go
+++ b/nodeup/pkg/model/hooks.go
@@ -17,14 +17,16 @@ limitations under the License.
 package model
 
 import (
-	"strconv"
+	"errors"
+	"fmt"
 	"strings"
 
-	"github.com/golang/glog"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/systemd"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
+
+	"github.com/golang/glog"
 )
 
 // HookBuilder configures the hooks
@@ -34,37 +36,98 @@ type HookBuilder struct {
 
 var _ fi.ModelBuilder = &HookBuilder{}
 
-func (b *HookBuilder) Build(c *fi.ModelBuilderContext) error {
-	for i := range b.Cluster.Spec.Hooks {
-		hook := &b.Cluster.Spec.Hooks[i]
+// Build is responsible for implementing the cluster hook
+func (h *HookBuilder) Build(c *fi.ModelBuilderContext) error {
+	// iterate the hooks and render the systemd units
+	for i := range h.Cluster.Spec.Hooks {
+		hook := &h.Cluster.Spec.Hooks[i]
 
-		// TODO: Allow (alphanumeric?) names
-		name := strconv.Itoa(i + 1)
+		// filter out on master and node flags if required
+		if (hook.MasterOnly && !h.IsMaster) || (hook.NodeOnly && h.IsMaster) {
+			continue
+		}
 
-		service, err := b.buildSystemdService(name, hook)
+		// are we disabling the service?
+		if hook.Disabled {
+			enabled := false
+			managed := true
+			c.AddTask(&nodetasks.Service{
+				Name:        hook.Name,
+				ManageState: &managed,
+				Enabled:     &enabled,
+				Running:     &enabled,
+			})
+			continue
+		}
+
+		// use the default naming convention - kops-hook-<index>
+		name := fmt.Sprintf("kops-hook-%d", i)
+		if hook.Name != "" {
+			name = hook.Name
+		}
+
+		// generate the systemd service
+		service, err := h.buildSystemdService(name, hook)
 		if err != nil {
 			return err
 		}
-		c.AddTask(service)
+
+		if service != nil {
+			c.AddTask(service)
+		}
 	}
 
 	return nil
 }
 
-func (b *HookBuilder) buildSystemdService(name string, hook *kops.HookSpec) (*nodetasks.Service, error) {
-	// We could give the container a kubeconfig, but we would probably do better to have a real pod / daemonset / job at that point
-	execContainer := hook.ExecContainer
-	if execContainer == nil {
-		glog.Warningf("No ExecContainer found for hook: %v", hook)
+// buildSystemdService is responsible for generating the service
+func (h *HookBuilder) buildSystemdService(name string, hook *kops.HookSpec) (*nodetasks.Service, error) {
+	// perform some basic validation
+	if hook.ExecContainer == nil && hook.Manifest == "" {
+		glog.Warningf("hook: %s has neither a raw unit or exec image configured", name)
 		return nil, nil
 	}
+	if hook.ExecContainer != nil {
+		if err := isValidExecContainerAction(hook.ExecContainer); err != nil {
+			glog.Warningf("invalid hook action, name: %s, error: %v", name, err)
+			return nil, nil
+		}
+	}
+	// build the base unit file
+	unit := &systemd.Manifest{}
+	unit.Set("Unit", "Description", "Kops Hook "+name)
 
-	image := strings.TrimSpace(execContainer.Image)
-	if image == "" {
-		glog.Warningf("No Image found for hook: %v", hook)
-		return nil, nil
+	// add any service dependencies to the unit
+	for _, x := range hook.Requires {
+		unit.Set("Unit", "Requires", x)
+	}
+	for _, x := range hook.Before {
+		unit.Set("Unit", "Before", x)
 	}
 
+	// are we a raw unit file or a docker exec?
+	switch hook.ExecContainer {
+	case nil:
+		unit.SetSection("Service", hook.Manifest)
+	default:
+		if err := h.buildDockerService(unit, hook); err != nil {
+			return nil, err
+		}
+	}
+
+	service := &nodetasks.Service{
+		Name:       name,
+		Definition: s(unit.Render()),
+	}
+
+	service.InitDefaults()
+
+	return service, nil
+}
+
+// buildDockerService is responsible for generating a docker exec unit file
+func (h *HookBuilder) buildDockerService(unit *systemd.Manifest, hook *kops.HookSpec) error {
+	// the docker command line
 	dockerArgs := []string{
 		"/usr/bin/docker",
 		"run",
@@ -75,38 +138,26 @@ func (b *HookBuilder) buildSystemdService(name string, hook *kops.HookSpec) (*no
 		"--privileged",
 		hook.ExecContainer.Image,
 	}
-
-	dockerArgs = append(dockerArgs, execContainer.Command...)
+	dockerArgs = append(dockerArgs, hook.ExecContainer.Command...)
 
 	dockerRunCommand := systemd.EscapeCommand(dockerArgs)
 	dockerPullCommand := systemd.EscapeCommand([]string{"/usr/bin/docker", "pull", hook.ExecContainer.Image})
 
-	manifest := &systemd.Manifest{}
-	manifest.Set("Unit", "Description", "Kops Hook "+name)
-	if hook.Documentation != "" {
-		manifest.Set("Unit", "Documentation", hook.Documentation)
-	}
-	for _, x := range hook.Requires {
-		manifest.Set("Unit", "Requires", x)
-	}
-	for _, x := range hook.Before {
-		manifest.Set("Unit", "Before", x)
-	}
+	unit.Set("Service", "ExecStartPre", dockerPullCommand)
+	unit.Set("Service", "ExecStart", dockerRunCommand)
+	unit.Set("Service", "Type", "oneshot")
+	unit.Set("Install", "WantedBy", "multi-user.target")
 
-	manifest.Set("Service", "ExecStartPre", dockerPullCommand)
-	manifest.Set("Service", "ExecStart", dockerRunCommand)
-	manifest.Set("Service", "Type", "oneshot")
-	manifest.Set("Install", "WantedBy", "multi-user.target")
+	return nil
+}
 
-	manifestString := manifest.Render()
-	glog.V(8).Infof("Built systemd manifest %q\n%s", name, manifestString)
-
-	service := &nodetasks.Service{
-		Name:       "kops-hook-" + name + ".service",
-		Definition: s(manifestString),
+// isValidExecContainerAction checks the validatity of the execContainer - personally i think this validation
+// should be done high up the chain, but
+func isValidExecContainerAction(action *kops.ExecContainerAction) error {
+	action.Image = strings.TrimSpace(action.Image)
+	if action.Image == "" {
+		return errors.New("the image for the hook exec action not set")
 	}
 
-	service.InitDefaults()
-
-	return service, nil
+	return nil
 }

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -152,14 +152,22 @@ type Assets struct {
 
 // HookSpec is a definition hook
 type HookSpec struct {
-	// Documentation is a link the documentation
-	Documentation string `json:"documentation,omitempty"`
+	// Name is an optional name for the hook, otherwise the name is kops-hook-<index>
+	Name string `json:"name,omitempty"`
+	// Disabled indicates if you want the unit switched off
+	Disabled bool `json:"disabled,omitempty"`
+	// MasterOnly indicates this hooks should only run on a master
+	MasterOnly bool `json:"masterOnly,omitempty"`
+	// NodeOnly indicates this hooks should only run on a compute node
+	NodeOnly bool `json:"nodeOnly,omitempty"`
 	// Requires is a series of systemd units the action requires
 	Requires []string `json:"requires,omitempty"`
 	// Before is a series of systemd units which this hook must run before
 	Before []string `json:"before,omitempty"`
 	// ExecContainer is the image itself
 	ExecContainer *ExecContainerAction `json:"execContainer,omitempty"`
+	// Manifest is a raw systemd unit file
+	Manifest string `json:"manifest,omitempty"`
 }
 
 // ExecContainerAction defines an hood action

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -156,10 +156,8 @@ type HookSpec struct {
 	Name string `json:"name,omitempty"`
 	// Disabled indicates if you want the unit switched off
 	Disabled bool `json:"disabled,omitempty"`
-	// MasterOnly indicates this hooks should only run on a master
-	MasterOnly bool `json:"masterOnly,omitempty"`
-	// NodeOnly indicates this hooks should only run on a compute node
-	NodeOnly bool `json:"nodeOnly,omitempty"`
+	// Roles is an optional list of roles the hook should be rolled out to, defaults to all
+	Roles []InstanceGroupRole `json:"roles,omitempty"`
 	// Requires is a series of systemd units the action requires
 	Requires []string `json:"requires,omitempty"`
 	// Before is a series of systemd units which this hook must run before
@@ -176,6 +174,8 @@ type ExecContainerAction struct {
 	Image string `json:"image,omitempty" `
 	// Command is the command supplied to the above image
 	Command []string `json:"command,omitempty"`
+	// Environment is a map of environment variables added to the hook
+	Environment map[string]string `json:"environment,omitempty"`
 }
 
 type AuthenticationSpec struct {

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -150,14 +150,23 @@ type Assets struct {
 	FileRepository    *string `json:"fileRepository,omitempty"`
 }
 
+// HookSpec is a definition hook
 type HookSpec struct {
+	// Documentation is a link the documentation
+	Documentation string `json:"documentation,omitempty"`
+	// Requires is a series of systemd units the action requires
+	Requires []string `json:"requires,omitempty"`
+	// Before is a series of systemd units which this hook must run before
+	Before []string `json:"before,omitempty"`
+	// ExecContainer is the image itself
 	ExecContainer *ExecContainerAction `json:"execContainer,omitempty"`
 }
 
+// ExecContainerAction defines an hood action
 type ExecContainerAction struct {
-	// Docker image name.
+	// Image is the docker image
 	Image string `json:"image,omitempty" `
-
+	// Command is the command supplied to the above image
 	Command []string `json:"command,omitempty"`
 }
 

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -60,18 +60,18 @@ var AllInstanceGroupRoles = []InstanceGroupRole{
 	InstanceGroupRoleBastion,
 }
 
+// InstanceGroupSpec is the specification for a instanceGroup
 type InstanceGroupSpec struct {
 	// Type determines the role of instances in this group: masters or nodes
 	Role InstanceGroupRole `json:"role,omitempty"`
-
-	Image   string `json:"image,omitempty"`
+	// Image is the instance instance (ami etc) we should use
+	Image string `json:"image,omitempty"`
+	// MinSize is the minimum size of the pool
 	MinSize *int32 `json:"minSize,omitempty"`
+	// MaxSize is the maximum size of the pool
 	MaxSize *int32 `json:"maxSize,omitempty"`
-	//NodeInstancePrefix string `json:",omitempty"`
-	//NodeLabels         string `json:",omitempty"`
+	// MachineType is the instance class
 	MachineType string `json:"machineType,omitempty"`
-	//NodeTag            string `json:",omitempty"`
-
 	// RootVolumeSize is the size of the EBS root volume to use, in GB
 	RootVolumeSize *int32 `json:"rootVolumeSize,omitempty"`
 	// RootVolumeType is the type of the EBS root volume to use (e.g. gp2)
@@ -80,32 +80,25 @@ type InstanceGroupSpec struct {
 	RootVolumeIops *int32 `json:"rootVolumeIops,omitempty"`
 	// RootVolumeOptimization enables EBS optimization for an instance
 	RootVolumeOptimization *bool `json:"rootVolumeOptimization,omitempty"`
-
 	// Subnets is the names of the Subnets (as specified in the Cluster) where machines in this instance group should be placed
 	Subnets []string `json:"subnets,omitempty"`
-
+	// Hooks is a list of hooks for this instanceGroup, note: these can override the cluster wide ones if required
+	Hooks []HookSpec `json:"hooks,omitempty"`
 	// MaxPrice indicates this is a spot-pricing group, with the specified value as our max-price bid
 	MaxPrice *string `json:"maxPrice,omitempty"`
-
 	// AssociatePublicIP is true if we want instances to have a public IP
 	AssociatePublicIP *bool `json:"associatePublicIp,omitempty"`
-
 	// AdditionalSecurityGroups attaches additional security groups (e.g. i-123456)
 	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
-
 	// CloudLabels indicates the labels for instances in this group, at the AWS level
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`
-
 	// NodeLabels indicates the kubernetes labels for nodes in this group
 	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
-
 	// Describes the tenancy of the instance group. Can be either default or dedicated.
 	// Currently only applies to AWS.
 	Tenancy string `json:"tenancy,omitempty"`
-
 	// Kubelet overrides kubelet config from the ClusterSpec
 	Kubelet *KubeletConfigSpec `json:"kubelet,omitempty"`
-
 	// Taints indicates the kubernetes taints for nodes in this group
 	Taints []string `json:"taints,omitempty"`
 }
@@ -137,6 +130,7 @@ func PerformAssignmentsInstanceGroups(groups []*InstanceGroup) error {
 	return nil
 }
 
+// IsMaster checks if the instanceGroup is a master role
 func (g *InstanceGroup) IsMaster() bool {
 	switch g.Spec.Role {
 	case InstanceGroupRoleMaster:
@@ -145,7 +139,6 @@ func (g *InstanceGroup) IsMaster() bool {
 		return false
 	case InstanceGroupRoleBastion:
 		return false
-
 	default:
 		glog.Fatalf("Role not set in group %v", g)
 		return false

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -256,14 +256,23 @@ type Assets struct {
 	FileRepository    *string `json:"fileRepository,omitempty"`
 }
 
+// HookSpec is a definition hook
 type HookSpec struct {
+	// Documentation is a link the documentation
+	Documentation string `json:"documentation,omitempty"`
+	// Requires is a series of systemd units the action requires
+	Requires []string `json:"requires,omitempty"`
+	// Before is a series of systemd units which this hook must run before
+	Before []string `json:"before,omitempty"`
+	// ExecContainer is the image itself
 	ExecContainer *ExecContainerAction `json:"execContainer,omitempty"`
 }
 
+// ExecContainerAction defines an hood action
 type ExecContainerAction struct {
-	// Docker image name.
+	// Image is the docker image
 	Image string `json:"image,omitempty" `
-
+	// Command is the command supplied to the above image
 	Command []string `json:"command,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -262,10 +262,8 @@ type HookSpec struct {
 	Name string `json:"name,omitempty"`
 	// Disabled indicates if you want the unit switched off
 	Disabled bool `json:"disabled,omitempty"`
-	// MasterOnly indicates this hooks should only run on a master
-	MasterOnly bool `json:"masterOnly,omitempty"`
-	// NodeOnly indicates this hooks should only run on a compute node
-	NodeOnly bool `json:"nodeOnly,omitempty"`
+	// Roles is an optional list of roles the hook should be rolled out to, defaults to all
+	Roles []InstanceGroupRole `json:"roles,omitempty"`
 	// Requires is a series of systemd units the action requires
 	Requires []string `json:"requires,omitempty"`
 	// Before is a series of systemd units which this hook must run before
@@ -282,6 +280,8 @@ type ExecContainerAction struct {
 	Image string `json:"image,omitempty" `
 	// Command is the command supplied to the above image
 	Command []string `json:"command,omitempty"`
+	// Environment is a map of environment variables added to the hook
+	Environment map[string]string `json:"environment,omitempty"`
 }
 
 type AuthenticationSpec struct {

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -258,14 +258,22 @@ type Assets struct {
 
 // HookSpec is a definition hook
 type HookSpec struct {
-	// Documentation is a link the documentation
-	Documentation string `json:"documentation,omitempty"`
+	// Name is an optional name for the hook, otherwise the name is kops-hook-<index>
+	Name string `json:"name,omitempty"`
+	// Disabled indicates if you want the unit switched off
+	Disabled bool `json:"disabled,omitempty"`
+	// MasterOnly indicates this hooks should only run on a master
+	MasterOnly bool `json:"masterOnly,omitempty"`
+	// NodeOnly indicates this hooks should only run on a compute node
+	NodeOnly bool `json:"nodeOnly,omitempty"`
 	// Requires is a series of systemd units the action requires
 	Requires []string `json:"requires,omitempty"`
 	// Before is a series of systemd units which this hook must run before
 	Before []string `json:"before,omitempty"`
 	// ExecContainer is the image itself
 	ExecContainer *ExecContainerAction `json:"execContainer,omitempty"`
+	// Manifest is a raw systemd unit file
+	Manifest string `json:"manifest,omitempty"`
 }
 
 // ExecContainerAction defines an hood action

--- a/pkg/apis/kops/v1alpha1/instancegroup.go
+++ b/pkg/apis/kops/v1alpha1/instancegroup.go
@@ -45,18 +45,18 @@ const (
 	InstanceGroupRoleNode   InstanceGroupRole = "Node"
 )
 
+// InstanceGroupSpec is the specification for a instanceGroup
 type InstanceGroupSpec struct {
 	// Type determines the role of instances in this group: masters or nodes
 	Role InstanceGroupRole `json:"role,omitempty"`
-
-	Image   string `json:"image,omitempty"`
+	// Image is the instance instance (ami etc) we should use
+	Image string `json:"image,omitempty"`
+	// MinSize is the minimum size of the pool
 	MinSize *int32 `json:"minSize,omitempty"`
+	// MaxSize is the maximum size of the pool
 	MaxSize *int32 `json:"maxSize,omitempty"`
-	//NodeInstancePrefix string `json:",omitempty"`
-	//NodeLabels         string `json:",omitempty"`
+	// MachineType is the instance class
 	MachineType string `json:"machineType,omitempty"`
-	//NodeTag            string `json:",omitempty"`
-
 	// RootVolumeSize is the size of the EBS root volume to use, in GB
 	RootVolumeSize *int32 `json:"rootVolumeSize,omitempty"`
 	// RootVolumeType is the type of the EBS root volume to use (e.g. gp2)
@@ -65,31 +65,25 @@ type InstanceGroupSpec struct {
 	RootVolumeIops *int32 `json:"rootVolumeIops,omitempty"`
 	// RootVolumeOptimization enables EBS optimization for an instance
 	RootVolumeOptimization *bool `json:"rootVolumeOptimization,omitempty"`
-
-	Zones []string `json:"zones,omitempty"`
-
+	// Hooks is a list of hooks for this instanceGroup, note: these can override the cluster wide ones if required
+	Hooks []HookSpec `json:"hooks,omitempty"`
 	// MaxPrice indicates this is a spot-pricing group, with the specified value as our max-price bid
 	MaxPrice *string `json:"maxPrice,omitempty"`
-
 	// AssociatePublicIP is true if we want instances to have a public IP
 	AssociatePublicIP *bool `json:"associatePublicIp,omitempty"`
-
 	// AdditionalSecurityGroups attaches additional security groups (e.g. i-123456)
 	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
-
 	// CloudLabels indicates the labels for instances in this group, at the AWS level
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`
-
 	// NodeLabels indicates the kubernetes labels for nodes in this group
 	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
-
 	// Describes the tenancy of the instance group. Can be either default or dedicated.
 	// Currently only applies to AWS.
 	Tenancy string `json:"tenancy,omitempty"`
-
 	// Kubelet overrides kubelet config from the ClusterSpec
 	Kubelet *KubeletConfigSpec `json:"kubelet,omitempty"`
-
 	// Taints indicates the kubernetes taints for nodes in this group
 	Taints []string `json:"taints,omitempty"`
+	// @should this be here??
+	Zones []string `json:"zones,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1233,6 +1233,9 @@ func Convert_kops_HTTPProxy_To_v1alpha1_HTTPProxy(in *kops.HTTPProxy, out *HTTPP
 }
 
 func autoConvert_v1alpha1_HookSpec_To_kops_HookSpec(in *HookSpec, out *kops.HookSpec, s conversion.Scope) error {
+	out.Documentation = in.Documentation
+	out.Requires = in.Requires
+	out.Before = in.Before
 	if in.ExecContainer != nil {
 		in, out := &in.ExecContainer, &out.ExecContainer
 		*out = new(kops.ExecContainerAction)
@@ -1251,6 +1254,9 @@ func Convert_v1alpha1_HookSpec_To_kops_HookSpec(in *HookSpec, out *kops.HookSpec
 }
 
 func autoConvert_kops_HookSpec_To_v1alpha1_HookSpec(in *kops.HookSpec, out *HookSpec, s conversion.Scope) error {
+	out.Documentation = in.Documentation
+	out.Requires = in.Requires
+	out.Before = in.Before
 	if in.ExecContainer != nil {
 		in, out := &in.ExecContainer, &out.ExecContainer
 		*out = new(ExecContainerAction)

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1063,6 +1063,7 @@ func autoConvert_kops_EtcdMemberSpec_To_v1alpha1_EtcdMemberSpec(in *kops.EtcdMem
 func autoConvert_v1alpha1_ExecContainerAction_To_kops_ExecContainerAction(in *ExecContainerAction, out *kops.ExecContainerAction, s conversion.Scope) error {
 	out.Image = in.Image
 	out.Command = in.Command
+	out.Environment = in.Environment
 	return nil
 }
 
@@ -1074,6 +1075,7 @@ func Convert_v1alpha1_ExecContainerAction_To_kops_ExecContainerAction(in *ExecCo
 func autoConvert_kops_ExecContainerAction_To_v1alpha1_ExecContainerAction(in *kops.ExecContainerAction, out *ExecContainerAction, s conversion.Scope) error {
 	out.Image = in.Image
 	out.Command = in.Command
+	out.Environment = in.Environment
 	return nil
 }
 
@@ -1235,8 +1237,15 @@ func Convert_kops_HTTPProxy_To_v1alpha1_HTTPProxy(in *kops.HTTPProxy, out *HTTPP
 func autoConvert_v1alpha1_HookSpec_To_kops_HookSpec(in *HookSpec, out *kops.HookSpec, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Disabled = in.Disabled
-	out.MasterOnly = in.MasterOnly
-	out.NodeOnly = in.NodeOnly
+	if in.Roles != nil {
+		in, out := &in.Roles, &out.Roles
+		*out = make([]kops.InstanceGroupRole, len(*in))
+		for i := range *in {
+			(*out)[i] = kops.InstanceGroupRole((*in)[i])
+		}
+	} else {
+		out.Roles = nil
+	}
 	out.Requires = in.Requires
 	out.Before = in.Before
 	if in.ExecContainer != nil {
@@ -1260,8 +1269,15 @@ func Convert_v1alpha1_HookSpec_To_kops_HookSpec(in *HookSpec, out *kops.HookSpec
 func autoConvert_kops_HookSpec_To_v1alpha1_HookSpec(in *kops.HookSpec, out *HookSpec, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Disabled = in.Disabled
-	out.MasterOnly = in.MasterOnly
-	out.NodeOnly = in.NodeOnly
+	if in.Roles != nil {
+		in, out := &in.Roles, &out.Roles
+		*out = make([]InstanceGroupRole, len(*in))
+		for i := range *in {
+			(*out)[i] = InstanceGroupRole((*in)[i])
+		}
+	} else {
+		out.Roles = nil
+	}
 	out.Requires = in.Requires
 	out.Before = in.Before
 	if in.ExecContainer != nil {

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1360,7 +1360,17 @@ func autoConvert_v1alpha1_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	out.RootVolumeType = in.RootVolumeType
 	out.RootVolumeIops = in.RootVolumeIops
 	out.RootVolumeOptimization = in.RootVolumeOptimization
-	// WARNING: in.Zones requires manual conversion: does not exist in peer-type
+	if in.Hooks != nil {
+		in, out := &in.Hooks, &out.Hooks
+		*out = make([]kops.HookSpec, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha1_HookSpec_To_kops_HookSpec(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Hooks = nil
+	}
 	out.MaxPrice = in.MaxPrice
 	out.AssociatePublicIP = in.AssociatePublicIP
 	out.AdditionalSecurityGroups = in.AdditionalSecurityGroups
@@ -1377,6 +1387,7 @@ func autoConvert_v1alpha1_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 		out.Kubelet = nil
 	}
 	out.Taints = in.Taints
+	// WARNING: in.Zones requires manual conversion: does not exist in peer-type
 	return nil
 }
 
@@ -1391,6 +1402,17 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha1_InstanceGroupSpec(in *kops.I
 	out.RootVolumeIops = in.RootVolumeIops
 	out.RootVolumeOptimization = in.RootVolumeOptimization
 	// WARNING: in.Subnets requires manual conversion: does not exist in peer-type
+	if in.Hooks != nil {
+		in, out := &in.Hooks, &out.Hooks
+		*out = make([]HookSpec, len(*in))
+		for i := range *in {
+			if err := Convert_kops_HookSpec_To_v1alpha1_HookSpec(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Hooks = nil
+	}
 	out.MaxPrice = in.MaxPrice
 	out.AssociatePublicIP = in.AssociatePublicIP
 	out.AdditionalSecurityGroups = in.AdditionalSecurityGroups

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1233,7 +1233,10 @@ func Convert_kops_HTTPProxy_To_v1alpha1_HTTPProxy(in *kops.HTTPProxy, out *HTTPP
 }
 
 func autoConvert_v1alpha1_HookSpec_To_kops_HookSpec(in *HookSpec, out *kops.HookSpec, s conversion.Scope) error {
-	out.Documentation = in.Documentation
+	out.Name = in.Name
+	out.Disabled = in.Disabled
+	out.MasterOnly = in.MasterOnly
+	out.NodeOnly = in.NodeOnly
 	out.Requires = in.Requires
 	out.Before = in.Before
 	if in.ExecContainer != nil {
@@ -1245,6 +1248,7 @@ func autoConvert_v1alpha1_HookSpec_To_kops_HookSpec(in *HookSpec, out *kops.Hook
 	} else {
 		out.ExecContainer = nil
 	}
+	out.Manifest = in.Manifest
 	return nil
 }
 
@@ -1254,7 +1258,10 @@ func Convert_v1alpha1_HookSpec_To_kops_HookSpec(in *HookSpec, out *kops.HookSpec
 }
 
 func autoConvert_kops_HookSpec_To_v1alpha1_HookSpec(in *kops.HookSpec, out *HookSpec, s conversion.Scope) error {
-	out.Documentation = in.Documentation
+	out.Name = in.Name
+	out.Disabled = in.Disabled
+	out.MasterOnly = in.MasterOnly
+	out.NodeOnly = in.NodeOnly
 	out.Requires = in.Requires
 	out.Before = in.Before
 	if in.ExecContainer != nil {
@@ -1266,6 +1273,7 @@ func autoConvert_kops_HookSpec_To_v1alpha1_HookSpec(in *kops.HookSpec, out *Hook
 	} else {
 		out.ExecContainer = nil
 	}
+	out.Manifest = in.Manifest
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -188,10 +188,8 @@ type HookSpec struct {
 	Name string `json:"name,omitempty"`
 	// Disabled indicates if you want the unit switched off
 	Disabled bool `json:"disabled,omitempty"`
-	// MasterOnly indicates this hooks should only run on a master
-	MasterOnly bool `json:"masterOnly,omitempty"`
-	// NodeOnly indicates this hooks should only run on a compute node
-	NodeOnly bool `json:"nodeOnly,omitempty"`
+	// Roles is an optional list of roles the hook should be rolled out to, defaults to all
+	Roles []InstanceGroupRole `json:"roles,omitempty"`
 	// Requires is a series of systemd units the action requires
 	Requires []string `json:"requires,omitempty"`
 	// Before is a series of systemd units which this hook must run before
@@ -208,6 +206,8 @@ type ExecContainerAction struct {
 	Image string `json:"image,omitempty" `
 	// Command is the command supplied to the above image
 	Command []string `json:"command,omitempty"`
+	// Environment is a map of environment variables added to the hook
+	Environment map[string]string `json:"environment,omitempty"`
 }
 
 type AuthenticationSpec struct {

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -184,14 +184,22 @@ type Assets struct {
 
 // HookSpec is a definition hook
 type HookSpec struct {
-	// Documentation is a link the documentation
-	Documentation string `json:"documentation,omitempty"`
+	// Name is an optional name for the hook, otherwise the name is kops-hook-<index>
+	Name string `json:"name,omitempty"`
+	// Disabled indicates if you want the unit switched off
+	Disabled bool `json:"disabled,omitempty"`
+	// MasterOnly indicates this hooks should only run on a master
+	MasterOnly bool `json:"masterOnly,omitempty"`
+	// NodeOnly indicates this hooks should only run on a compute node
+	NodeOnly bool `json:"nodeOnly,omitempty"`
 	// Requires is a series of systemd units the action requires
 	Requires []string `json:"requires,omitempty"`
 	// Before is a series of systemd units which this hook must run before
 	Before []string `json:"before,omitempty"`
 	// ExecContainer is the image itself
 	ExecContainer *ExecContainerAction `json:"execContainer,omitempty"`
+	// Manifest is a raw systemd unit file
+	Manifest string `json:"manifest,omitempty"`
 }
 
 // ExecContainerAction defines an hood action

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -182,14 +182,23 @@ type Assets struct {
 	FileRepository    *string `json:"fileRepository,omitempty"`
 }
 
+// HookSpec is a definition hook
 type HookSpec struct {
+	// Documentation is a link the documentation
+	Documentation string `json:"documentation,omitempty"`
+	// Requires is a series of systemd units the action requires
+	Requires []string `json:"requires,omitempty"`
+	// Before is a series of systemd units which this hook must run before
+	Before []string `json:"before,omitempty"`
+	// ExecContainer is the image itself
 	ExecContainer *ExecContainerAction `json:"execContainer,omitempty"`
 }
 
+// ExecContainerAction defines an hood action
 type ExecContainerAction struct {
-	// Docker image name.
+	// Image is the docker image
 	Image string `json:"image,omitempty" `
-
+	// Command is the command supplied to the above image
 	Command []string `json:"command,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -52,18 +52,18 @@ var AllInstanceGroupRoles = []InstanceGroupRole{
 	InstanceGroupRoleBastion,
 }
 
+// InstanceGroupSpec is the specification for a instanceGroup
 type InstanceGroupSpec struct {
 	// Type determines the role of instances in this group: masters or nodes
 	Role InstanceGroupRole `json:"role,omitempty"`
-
-	Image   string `json:"image,omitempty"`
+	// Image is the instance instance (ami etc) we should use
+	Image string `json:"image,omitempty"`
+	// MinSize is the minimum size of the pool
 	MinSize *int32 `json:"minSize,omitempty"`
+	// MaxSize is the maximum size of the pool
 	MaxSize *int32 `json:"maxSize,omitempty"`
-	//NodeInstancePrefix string `json:",omitempty"`
-	//NodeLabels         string `json:",omitempty"`
+	// MachineType is the instance class
 	MachineType string `json:"machineType,omitempty"`
-	//NodeTag            string `json:",omitempty"`
-
 	// RootVolumeSize is the size of the EBS root volume to use, in GB
 	RootVolumeSize *int32 `json:"rootVolumeSize,omitempty"`
 	// RootVolumeType is the type of the EBS root volume to use (e.g. gp2)
@@ -72,32 +72,25 @@ type InstanceGroupSpec struct {
 	RootVolumeIops *int32 `json:"rootVolumeIops,omitempty"`
 	// RootVolumeOptimization enables EBS optimization for an instance
 	RootVolumeOptimization *bool `json:"rootVolumeOptimization,omitempty"`
-
 	// Subnets is the names of the Subnets (as specified in the Cluster) where machines in this instance group should be placed
 	Subnets []string `json:"subnets,omitempty"`
-
+	// Hooks is a list of hooks for this instanceGroup, note: these can override the cluster wide ones if required
+	Hooks []HookSpec `json:"hooks,omitempty"`
 	// MaxPrice indicates this is a spot-pricing group, with the specified value as our max-price bid
 	MaxPrice *string `json:"maxPrice,omitempty"`
-
 	// AssociatePublicIP is true if we want instances to have a public IP
 	AssociatePublicIP *bool `json:"associatePublicIp,omitempty"`
-
 	// AdditionalSecurityGroups attaches additional security groups (e.g. i-123456)
 	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
-
 	// CloudLabels indicates the labels for instances in this group, at the AWS level
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`
-
 	// NodeLabels indicates the kubernetes labels for nodes in this group
 	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
-
 	// Describes the tenancy of the instance group. Can be either default or dedicated.
 	// Currently only applies to AWS.
 	Tenancy string `json:"tenancy,omitempty"`
-
 	// Kubelet overrides kubelet config from the ClusterSpec
 	Kubelet *KubeletConfigSpec `json:"kubelet,omitempty"`
-
 	// Taints indicates the kubernetes taints for nodes in this group
 	Taints []string `json:"taints,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1331,7 +1331,10 @@ func Convert_kops_HTTPProxy_To_v1alpha2_HTTPProxy(in *kops.HTTPProxy, out *HTTPP
 }
 
 func autoConvert_v1alpha2_HookSpec_To_kops_HookSpec(in *HookSpec, out *kops.HookSpec, s conversion.Scope) error {
-	out.Documentation = in.Documentation
+	out.Name = in.Name
+	out.Disabled = in.Disabled
+	out.MasterOnly = in.MasterOnly
+	out.NodeOnly = in.NodeOnly
 	out.Requires = in.Requires
 	out.Before = in.Before
 	if in.ExecContainer != nil {
@@ -1343,6 +1346,7 @@ func autoConvert_v1alpha2_HookSpec_To_kops_HookSpec(in *HookSpec, out *kops.Hook
 	} else {
 		out.ExecContainer = nil
 	}
+	out.Manifest = in.Manifest
 	return nil
 }
 
@@ -1352,7 +1356,10 @@ func Convert_v1alpha2_HookSpec_To_kops_HookSpec(in *HookSpec, out *kops.HookSpec
 }
 
 func autoConvert_kops_HookSpec_To_v1alpha2_HookSpec(in *kops.HookSpec, out *HookSpec, s conversion.Scope) error {
-	out.Documentation = in.Documentation
+	out.Name = in.Name
+	out.Disabled = in.Disabled
+	out.MasterOnly = in.MasterOnly
+	out.NodeOnly = in.NodeOnly
 	out.Requires = in.Requires
 	out.Before = in.Before
 	if in.ExecContainer != nil {
@@ -1364,6 +1371,7 @@ func autoConvert_kops_HookSpec_To_v1alpha2_HookSpec(in *kops.HookSpec, out *Hook
 	} else {
 		out.ExecContainer = nil
 	}
+	out.Manifest = in.Manifest
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1331,6 +1331,9 @@ func Convert_kops_HTTPProxy_To_v1alpha2_HTTPProxy(in *kops.HTTPProxy, out *HTTPP
 }
 
 func autoConvert_v1alpha2_HookSpec_To_kops_HookSpec(in *HookSpec, out *kops.HookSpec, s conversion.Scope) error {
+	out.Documentation = in.Documentation
+	out.Requires = in.Requires
+	out.Before = in.Before
 	if in.ExecContainer != nil {
 		in, out := &in.ExecContainer, &out.ExecContainer
 		*out = new(kops.ExecContainerAction)
@@ -1349,6 +1352,9 @@ func Convert_v1alpha2_HookSpec_To_kops_HookSpec(in *HookSpec, out *kops.HookSpec
 }
 
 func autoConvert_kops_HookSpec_To_v1alpha2_HookSpec(in *kops.HookSpec, out *HookSpec, s conversion.Scope) error {
+	out.Documentation = in.Documentation
+	out.Requires = in.Requires
+	out.Before = in.Before
 	if in.ExecContainer != nil {
 		in, out := &in.ExecContainer, &out.ExecContainer
 		*out = new(ExecContainerAction)

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1459,6 +1459,17 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	out.RootVolumeIops = in.RootVolumeIops
 	out.RootVolumeOptimization = in.RootVolumeOptimization
 	out.Subnets = in.Subnets
+	if in.Hooks != nil {
+		in, out := &in.Hooks, &out.Hooks
+		*out = make([]kops.HookSpec, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha2_HookSpec_To_kops_HookSpec(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Hooks = nil
+	}
 	out.MaxPrice = in.MaxPrice
 	out.AssociatePublicIP = in.AssociatePublicIP
 	out.AdditionalSecurityGroups = in.AdditionalSecurityGroups
@@ -1494,6 +1505,17 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	out.RootVolumeIops = in.RootVolumeIops
 	out.RootVolumeOptimization = in.RootVolumeOptimization
 	out.Subnets = in.Subnets
+	if in.Hooks != nil {
+		in, out := &in.Hooks, &out.Hooks
+		*out = make([]HookSpec, len(*in))
+		for i := range *in {
+			if err := Convert_kops_HookSpec_To_v1alpha2_HookSpec(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Hooks = nil
+	}
 	out.MaxPrice = in.MaxPrice
 	out.AssociatePublicIP = in.AssociatePublicIP
 	out.AdditionalSecurityGroups = in.AdditionalSecurityGroups

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1161,6 +1161,7 @@ func Convert_kops_EtcdMemberSpec_To_v1alpha2_EtcdMemberSpec(in *kops.EtcdMemberS
 func autoConvert_v1alpha2_ExecContainerAction_To_kops_ExecContainerAction(in *ExecContainerAction, out *kops.ExecContainerAction, s conversion.Scope) error {
 	out.Image = in.Image
 	out.Command = in.Command
+	out.Environment = in.Environment
 	return nil
 }
 
@@ -1172,6 +1173,7 @@ func Convert_v1alpha2_ExecContainerAction_To_kops_ExecContainerAction(in *ExecCo
 func autoConvert_kops_ExecContainerAction_To_v1alpha2_ExecContainerAction(in *kops.ExecContainerAction, out *ExecContainerAction, s conversion.Scope) error {
 	out.Image = in.Image
 	out.Command = in.Command
+	out.Environment = in.Environment
 	return nil
 }
 
@@ -1333,8 +1335,15 @@ func Convert_kops_HTTPProxy_To_v1alpha2_HTTPProxy(in *kops.HTTPProxy, out *HTTPP
 func autoConvert_v1alpha2_HookSpec_To_kops_HookSpec(in *HookSpec, out *kops.HookSpec, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Disabled = in.Disabled
-	out.MasterOnly = in.MasterOnly
-	out.NodeOnly = in.NodeOnly
+	if in.Roles != nil {
+		in, out := &in.Roles, &out.Roles
+		*out = make([]kops.InstanceGroupRole, len(*in))
+		for i := range *in {
+			(*out)[i] = kops.InstanceGroupRole((*in)[i])
+		}
+	} else {
+		out.Roles = nil
+	}
 	out.Requires = in.Requires
 	out.Before = in.Before
 	if in.ExecContainer != nil {
@@ -1358,8 +1367,15 @@ func Convert_v1alpha2_HookSpec_To_kops_HookSpec(in *HookSpec, out *kops.HookSpec
 func autoConvert_kops_HookSpec_To_v1alpha2_HookSpec(in *kops.HookSpec, out *HookSpec, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Disabled = in.Disabled
-	out.MasterOnly = in.MasterOnly
-	out.NodeOnly = in.NodeOnly
+	if in.Roles != nil {
+		in, out := &in.Roles, &out.Roles
+		*out = make([]InstanceGroupRole, len(*in))
+		for i := range *in {
+			(*out)[i] = InstanceGroupRole((*in)[i])
+		}
+	} else {
+		out.Roles = nil
+	}
 	out.Requires = in.Requires
 	out.Before = in.Before
 	if in.ExecContainer != nil {

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -132,16 +132,21 @@ func validateSubnet(subnet *kops.ClusterSubnetSpec, fieldPath *field.Path) field
 	return allErrs
 }
 
-func validateHook(v *kops.HookSpec, fldPath *field.Path) field.ErrorList {
+func validateHook(v *kops.HookSpec, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if v.ExecContainer == nil {
-		allErrs = append(allErrs, field.Required(fldPath, "An action is required"))
+	if !v.Disabled && v.MasterOnly && v.NodeOnly {
+		allErrs = append(allErrs, field.Invalid(fieldPath, v.MasterOnly, "you cannot have both masterOnly and nodeOnly set true"))
 	}
 
-	if v.ExecContainer != nil {
-		allErrs = append(allErrs, validateExecContainerAction(v.ExecContainer, fldPath.Child("ExecContainer"))...)
+	if !v.Disabled && v.ExecContainer == nil && v.Manifest == "" {
+		allErrs = append(allErrs, field.Required(fieldPath, "you must set either manifest or execContainer for a hook"))
 	}
+
+	if !v.Disabled && v.ExecContainer != nil {
+		allErrs = append(allErrs, validateExecContainerAction(v.ExecContainer, fieldPath.Child("ExecContainer"))...)
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -135,10 +135,6 @@ func validateSubnet(subnet *kops.ClusterSubnetSpec, fieldPath *field.Path) field
 func validateHook(v *kops.HookSpec, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if !v.Disabled && v.MasterOnly && v.NodeOnly {
-		allErrs = append(allErrs, field.Invalid(fieldPath, v.MasterOnly, "you cannot have both masterOnly and nodeOnly set true"))
-	}
-
 	if !v.Disabled && v.ExecContainer == nil && v.Manifest == "" {
 		allErrs = append(allErrs, field.Required(fieldPath, "you must set either manifest or execContainer for a hook"))
 	}

--- a/pkg/systemd/escaping.go
+++ b/pkg/systemd/escaping.go
@@ -19,10 +19,12 @@ package systemd
 import (
 	"bytes"
 	"encoding/hex"
-	"github.com/golang/glog"
 	"strings"
+
+	"github.com/golang/glog"
 )
 
+// EscapeCommand is used to escape a command
 func EscapeCommand(argv []string) string {
 	var escaped []string
 	for _, arg := range argv {
@@ -69,7 +71,7 @@ func escapeArg(s string) string {
 
 	if needQuotes {
 		return "\"" + b.String() + "\""
-	} else {
-		return b.String()
 	}
+
+	return b.String()
 }

--- a/pkg/systemd/manifest_test.go
+++ b/pkg/systemd/manifest_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package systemd
+
+import (
+	"testing"
+)
+
+func TestRawManifest(t *testing.T) {
+	expected := `[Unit]
+Description=test
+Requires=docker.service
+
+[Service]
+run the command
+in this manifest`
+	m := &Manifest{}
+	m.Set("Unit", "Description", "test")
+	m.Set("Unit", "Requires", "docker.service")
+	m.SetSection("Service", `run the command
+in this manifest`)
+
+	rendered := m.Render()
+	if rendered != expected {
+		t.Errorf("the rendered manifest is not as expected: '%v', got: '%v'", expected, rendered)
+	}
+}
+
+func TestRawMixedManifest(t *testing.T) {
+	expected := `[Unit]
+Description=test
+Requires=docker.service
+
+[Service]
+run the command
+in this manifest
+key=pair
+another=pair
+`
+	m := &Manifest{}
+	m.Set("Unit", "Description", "test")
+	m.Set("Unit", "Requires", "docker.service")
+	m.SetSection("Service", `run the command
+in this manifest
+`)
+	m.Set("Service", "key", "pair")
+	m.Set("Service", "another", "pair")
+
+	rendered := m.Render()
+	if rendered != expected {
+		t.Errorf("the rendered manifest is not as expected: '%v', got: '%v'", expected, rendered)
+	}
+}
+
+func TestKeyPairOnlyManifest(t *testing.T) {
+	expected := `[Unit]
+Description=test
+Requires=docker.service
+
+[Service]
+EnvironmentFile=/etc/somefile
+EnvironmentFile=/etc/another_file
+StartExecPre=some_command
+Start=command
+`
+	m := &Manifest{}
+	m.Set("Unit", "Description", "test")
+	m.Set("Unit", "Requires", "docker.service")
+	m.Set("Service", "EnvironmentFile", "/etc/somefile")
+	m.Set("Service", "EnvironmentFile", "/etc/another_file")
+	m.Set("Service", "StartExecPre", "some_command")
+	m.Set("Service", "Start", "command")
+
+	rendered := m.Render()
+	if rendered != expected {
+		t.Errorf("the rendered manifest is not as expected: '%v'\n, got: '%v'\n", expected, rendered)
+	}
+}

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kops/nodeup/pkg/distros"
 	"k8s.io/kops/nodeup/pkg/model"
@@ -40,11 +39,14 @@ import (
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 	"k8s.io/kops/upup/pkg/fi/utils"
 	"k8s.io/kops/util/pkg/vfs"
+
+	"github.com/golang/glog"
 )
 
 // We should probably retry for a long time - there is not really any great fallback
 const MaxTaskDuration = 365 * 24 * time.Hour
 
+// NodeUpCommand defines the nodeup command configuration
 type NodeUpCommand struct {
 	config         *nodeup.Config
 	cluster        *api.Cluster
@@ -56,6 +58,7 @@ type NodeUpCommand struct {
 	FSRoot         string
 }
 
+// Run implements the nodeup process
 func (c *NodeUpCommand) Run(out io.Writer) error {
 	if c.FSRoot == "" {
 		return fmt.Errorf("FSRoot is required")
@@ -144,8 +147,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 			return fmt.Errorf("error loading InstanceGroup %q: %v", instanceGroupLocation, err)
 		}
 
-		err = utils.YamlUnmarshal(b, c.instanceGroup)
-		if err != nil {
+		if err = utils.YamlUnmarshal(b, c.instanceGroup); err != nil {
 			return fmt.Errorf("error parsing InstanceGroup %q: %v", instanceGroupLocation, err)
 		}
 	} else {
@@ -156,26 +158,6 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 	if err != nil {
 		return err
 	}
-
-	//if c.Config.ConfigurationStore != "" {
-	//	// TODO: If we ever delete local files, we need to filter so we only copy
-	//	// certain directories (i.e. not secrets / keys), because dest is a parent dir!
-	//	p, err := c.buildPath(c.Config.ConfigurationStore)
-	//	if err != nil {
-	//		return fmt.Errorf("error building config store: %v", err)
-	//	}
-	//
-	//	dest := vfs.NewFSPath("/etc/kubernetes")
-	//	scanner := vfs.NewVFSScan(p)
-	//	err = vfs.SyncDir(scanner, dest)
-	//	if err != nil {
-	//		return fmt.Errorf("error copying config store: %v", err)
-	//	}
-	//
-	//	c.Config.Tags = append(c.Config.Tags, "_config_store")
-	//} else {
-	//	c.Config.Tags = append(c.Config.Tags, "_not_config_store")
-	//}
 
 	distribution, err := distros.FindDistribution(c.FSRoot)
 	if err != nil {
@@ -202,17 +184,16 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 	}
 
 	modelContext := &model.NodeupModelContext{
-		NodeupConfig:  c.config,
-		Cluster:       c.cluster,
-		Distribution:  distribution,
-		Architecture:  model.ArchitectureAmd64,
-		InstanceGroup: c.instanceGroup,
-		IsMaster:      nodeTags.Has(TagMaster),
-		Assets:        assetStore,
-		KeyStore:      tf.keyStore,
-		SecretStore:   tf.secretStore,
-
+		Architecture:      model.ArchitectureAmd64,
+		Assets:            assetStore,
+		Cluster:           c.cluster,
+		Distribution:      distribution,
+		InstanceGroup:     c.instanceGroup,
+		IsMaster:          nodeTags.Has(TagMaster),
+		KeyStore:          tf.keyStore,
 		KubernetesVersion: *k8sVersion,
+		NodeupConfig:      c.config,
+		SecretStore:       tf.secretStore,
 	}
 
 	loader := NewLoader(c.config, c.cluster, assetStore, nodeTags)
@@ -220,6 +201,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 	loader.Builders = append(loader.Builders, &model.DockerBuilder{NodeupModelContext: modelContext})
 	loader.Builders = append(loader.Builders, &model.ProtokubeBuilder{NodeupModelContext: modelContext})
 	loader.Builders = append(loader.Builders, &model.CloudConfigBuilder{NodeupModelContext: modelContext})
+	loader.Builders = append(loader.Builders, &model.HookBuilder{NodeupModelContext: modelContext})
 	loader.Builders = append(loader.Builders, &model.KubeletBuilder{NodeupModelContext: modelContext})
 	loader.Builders = append(loader.Builders, &model.KubectlBuilder{NodeupModelContext: modelContext})
 	loader.Builders = append(loader.Builders, &model.EtcdBuilder{NodeupModelContext: modelContext})
@@ -237,7 +219,6 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 	} else {
 		loader.Builders = append(loader.Builders, &model.KubeRouterBuilder{NodeupModelContext: modelContext})
 	}
-	loader.Builders = append(loader.Builders, &model.HookBuilder{NodeupModelContext: modelContext})
 
 	tf.populate(loader.TemplateFunctions)
 
@@ -382,8 +363,7 @@ func evaluateDockerSpecStorage(spec *api.DockerConfig) error {
 				// overlay -> overlay
 				// aufs -> aufs
 				module := fs
-				err := modprobe(fs)
-				if err != nil {
+				if err = modprobe(fs); err != nil {
 					glog.Warningf("error running `modprobe %q`: %v", module, err)
 				}
 			}

--- a/upup/pkg/fi/nodeup/loader.go
+++ b/upup/pkg/fi/nodeup/loader.go
@@ -91,6 +91,7 @@ func ignoreHandler(i *loader.TreeWalkItem) error {
 	return nil
 }
 
+// Build is responsible for running the build tasks for nodeup
 func (l *Loader) Build(baseDir vfs.Path) (map[string]fi.Task, error) {
 	// First pass: load options
 	tw := &loader.TreeWalker{
@@ -156,7 +157,7 @@ func (l *Loader) Build(baseDir vfs.Path) (map[string]fi.Task, error) {
 
 type TaskBuilder func(name string, contents string, meta string) (fi.Task, error)
 
-func (r *Loader) newTaskHandler(prefix string, builder TaskBuilder) loader.Handler {
+func (l *Loader) newTaskHandler(prefix string, builder TaskBuilder) loader.Handler {
 	return func(i *loader.TreeWalkItem) error {
 		contents, err := i.ReadString()
 		if err != nil {
@@ -165,7 +166,7 @@ func (r *Loader) newTaskHandler(prefix string, builder TaskBuilder) loader.Handl
 		name := i.Name
 		if strings.HasSuffix(name, ".template") {
 			name = strings.TrimSuffix(name, ".template")
-			expanded, err := r.executeTemplate(name, contents)
+			expanded, err := l.executeTemplate(name, contents)
 			if err != nil {
 				return fmt.Errorf("error executing template %q: %v", i.RelativePath, err)
 			}
@@ -180,13 +181,13 @@ func (r *Loader) newTaskHandler(prefix string, builder TaskBuilder) loader.Handl
 		key := prefix + i.RelativePath
 
 		if task != nil {
-			r.tasks[key] = task
+			l.tasks[key] = task
 		}
 		return nil
 	}
 }
 
-func (r *Loader) handleFile(i *loader.TreeWalkItem) error {
+func (l *Loader) handleFile(i *loader.TreeWalkItem) error {
 	var task *nodetasks.File
 	defaultFileType := nodetasks.FileType_File
 
@@ -199,7 +200,7 @@ func (r *Loader) handleFile(i *loader.TreeWalkItem) error {
 		// TODO: Use template resource here to defer execution?
 		destPath := "/" + strings.TrimSuffix(i.RelativePath, ".template")
 		name := strings.TrimSuffix(i.Name, ".template")
-		expanded, err := r.executeTemplate(name, contents)
+		expanded, err := l.executeTemplate(name, contents)
 		if err != nil {
 			return fmt.Errorf("error executing template %q: %v", i.RelativePath, err)
 		}
@@ -223,7 +224,7 @@ func (r *Loader) handleFile(i *loader.TreeWalkItem) error {
 			return fmt.Errorf("error parsing json for asset %q: %v", name, err)
 		}
 
-		asset, err := r.assets.Find(name, def.AssetPath)
+		asset, err := l.assets.Find(name, def.AssetPath)
 		if err != nil {
 			return fmt.Errorf("error trying to locate asset %q: %v", name, err)
 		}
@@ -257,7 +258,8 @@ func (r *Loader) handleFile(i *loader.TreeWalkItem) error {
 
 	if task != nil {
 		key := "file/" + i.RelativePath
-		r.tasks[key] = task
+		l.tasks[key] = task
 	}
+
 	return nil
 }

--- a/upup/pkg/fi/nodeup/nodetasks/service.go
+++ b/upup/pkg/fi/nodeup/nodetasks/service.go
@@ -26,11 +26,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/cloudinit"
 	"k8s.io/kops/upup/pkg/fi/nodeup/local"
 	"k8s.io/kops/upup/pkg/fi/nodeup/tags"
+
+	"github.com/golang/glog"
 )
 
 const (


### PR DESCRIPTION
Cluster Hook Enhancement

The current implementation is presently limited to docker exec, without ordering or any bells and whistles. This PR extends the functionality of the hook spec by;

- adds ordering to the hooks, with users able to set the requires and before of the unit
- cleaned up the manifest code, added tests and permit setting a section raw
- added the ability to filter hooks via master and node roles
- updated the documentation to reflect the changes
- extending the hooks to permit adding hooks per instancegroup as well cluster
- @note, instanceGroup are permitted to override the cluster wide one for ease of testing
- on the journey tried to fix an go idioms such as import ordering, comments for global export etc
- @question: v1alpha1 doesn't appear to have Subnet fields, are these different version being used anywhere?