### PR TITLE
Update kube-proxy to handle aws returning multiple hostnames

### DIFF
--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -346,13 +346,20 @@ func evaluateHostnameOverride(hostnameOverride string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error reading local hostname from AWS metadata: %v", err)
 	}
-	v := strings.TrimSpace(string(vBytes))
-	if v == "" {
+
+	// The local-hostname gets it's hostname from the AWS DHCP Option Set, which
+	// may provide multiple hostnames separated by spaces. For now just choose
+	// the first one as the hostname.
+	domains := strings.Fields(string(vBytes))
+	if len(domains) == 0 {
 		glog.Warningf("Local hostname from AWS metadata service was empty")
+		return "", nil
 	} else {
-		glog.Infof("Using hostname from AWS metadata service: %s", v)
+		domain := domains[0]
+		glog.Infof("Using hostname from AWS metadata service: %s", domain)
+
+		return domain, nil
 	}
-	return v, nil
 }
 
 // evaluateDockerSpec selects the first supported storage mode, if it is a list


### PR DESCRIPTION
Amazon's dhcp service supports returning a space separated list of hostnames. This patch makes sure to split the domains first before picking the hostname override.

Closes #3060.