### PR TITLE
Vetting / Formatting / Cleanup

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"fmt"
+
 	"github.com/blang/semver"
 	"k8s.io/kops/nodeup/pkg/distros"
 	"k8s.io/kops/pkg/apis/kops"
@@ -28,7 +29,7 @@ import (
 )
 
 type NodeupModelContext struct {
-	NodeupConfig *nodeup.NodeUpConfig
+	NodeupConfig *nodeup.Config
 
 	Cluster       *kops.Cluster
 	InstanceGroup *kops.InstanceGroup

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -19,8 +19,9 @@ package model
 import (
 	"bytes"
 	"fmt"
-	"github.com/blang/semver"
-	"github.com/golang/glog"
+	"os"
+	"strings"
+
 	kopsbase "k8s.io/kops"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/util"
@@ -29,8 +30,9 @@ import (
 	"k8s.io/kops/pkg/systemd"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
-	"os"
-	"strings"
+
+	"github.com/blang/semver"
+	"github.com/golang/glog"
 )
 
 // ProtokubeBuilder configures protokube

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -24,6 +24,7 @@ import (
 
 // +genclient=true
 
+// Cluster is a specific cluster wrapper
 type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -31,6 +32,7 @@ type Cluster struct {
 	Spec ClusterSpec `json:"spec,omitempty"`
 }
 
+// ClusterList is a list of clusters
 type ClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -38,48 +40,36 @@ type ClusterList struct {
 	Items []Cluster `json:"items"`
 }
 
+// ClusterSpec defines the configuration for a cluster
 type ClusterSpec struct {
 	// The Channel we are following
 	Channel string `json:"channel,omitempty"`
-
 	// ConfigBase is the path where we store configuration for the cluster
 	// This might be different that the location when the cluster spec itself is stored,
 	// both because this must be accessible to the cluster,
 	// and because it might be on a different cloud or storage system (etcd vs S3)
 	ConfigBase string `json:"configBase,omitempty"`
-
 	// The CloudProvider to use (aws or gce)
 	CloudProvider string `json:"cloudProvider,omitempty"`
-
 	// The version of kubernetes to install (optional, and can be a "spec" like stable)
 	KubernetesVersion string `json:"kubernetesVersion,omitempty"`
-
-	//// The Node initializer technique to use: cloudinit or nodeup
-	//NodeInit                      string `json:",omitempty"`
-
 	// Configuration of subnets we are targeting
 	Subnets []ClusterSubnetSpec `json:"subnets,omitempty"`
-
 	// Project is the cloud project we should use, required on GCE
 	Project string `json:"project,omitempty"`
-
 	// MasterPublicName is the external DNS name for the master nodes
 	MasterPublicName string `json:"masterPublicName,omitempty"`
 	// MasterInternalName is the internal DNS name for the master nodes
 	MasterInternalName string `json:"masterInternalName,omitempty"`
-
 	// The CIDR used for the AWS VPC / GCE Network, or otherwise allocated to k8s
 	// This is a real CIDR, not the internal k8s network
 	NetworkCIDR string `json:"networkCIDR,omitempty"`
-
 	// NetworkID is an identifier of a network, if we want to reuse/share an existing network (e.g. an AWS VPC)
 	NetworkID string `json:"networkID,omitempty"`
-
 	// Topology defines the type of network topology to use on the cluster - default public
 	// This is heavily weighted towards AWS for the time being, but should also be agnostic enough
 	// to port out to GCE later if needed
 	Topology *TopologySpec `json:"topology,omitempty"`
-
 	// SecretStore is the VFS path to where secrets are stored
 	SecretStore string `json:"secretStore,omitempty"`
 	// KeyStore is the VFS path to where SSL keys and certificates are stored
@@ -94,31 +84,17 @@ type ClusterSpec struct {
 	// Note that DNSZone can either by the host name of the zone (containing dots),
 	// or can be an identifier for the zone.
 	DNSZone string `json:"dnsZone,omitempty"`
-
 	// ClusterDNSDomain is the suffix we use for internal DNS names (normally cluster.local)
 	ClusterDNSDomain string `json:"clusterDNSDomain,omitempty"`
-
-	//InstancePrefix                string `json:",omitempty"`
-
-	// ClusterName is a unique identifier for the cluster, and currently must be a DNS name
-	//ClusterName       string `json:",omitempty"`
-
-	//ClusterIPRange                string `json:",omitempty"`
-
 	// ServiceClusterIPRange is the CIDR, from the internal network, where we allocate IPs for services
 	ServiceClusterIPRange string `json:"serviceClusterIPRange,omitempty"`
-	//MasterIPRange                 string `json:",omitempty"`
-
 	// NonMasqueradeCIDR is the CIDR for the internal k8s network (on which pods & services live)
 	// It cannot overlap ServiceClusterIPRange
 	NonMasqueradeCIDR string `json:"nonMasqueradeCIDR,omitempty"`
-
 	// SSHAccess is a list of the CIDRs that can access SSH.
 	SSHAccess []string `json:"sshAccess,omitempty"`
-
 	// KubernetesAPIAccess is a list of the CIDRs that can access the Kubernetes API endpoint (master HTTPS)
 	KubernetesAPIAccess []string `json:"kubernetesApiAccess,omitempty"`
-
 	// IsolatesMasters determines whether we should lock down masters so that they are not on the pod network.
 	// true is the kube-up behaviour, but it is very surprising: it means that daemonsets only work on the master
 	// if they have hostNetwork=true.
@@ -127,100 +103,15 @@ type ClusterSpec struct {
 	//  * run kube-proxy on the master
 	//  * enable debugging handlers on the master, so kubectl logs works
 	IsolateMasters *bool `json:"isolateMasters,omitempty"`
-
 	// UpdatePolicy determines the policy for applying upgrades automatically.
 	// Valid values:
 	//   'external' do not apply updates automatically - they are applied manually or by an external system
 	//   missing: default policy (currently OS security upgrades that do not require a reboot)
 	UpdatePolicy *string `json:"updatePolicy,omitempty"`
-
 	// Additional policies to add for roles
 	AdditionalPolicies *map[string]string `json:"additionalPolicies,omitempty"`
-
-	//HairpinMode                   string `json:",omitempty"`
-	//
-	//OpencontrailTag               string `json:",omitempty"`
-	//OpencontrailKubernetesTag     string `json:",omitempty"`
-	//OpencontrailPublicSubnet      string `json:",omitempty"`
-	//
-	//EnableClusterMonitoring       string `json:",omitempty"`
-	//EnableL7LoadBalancing         string `json:",omitempty"`
-	//EnableClusterUI               *bool  `json:",omitempty"`
-	//
-	//EnableClusterDNS              *bool  `json:",omitempty"`
-	//DNSReplicas                   int    `json:",omitempty"`
-	//DNSServerIP                   string `json:",omitempty"`
-
-	//EnableClusterLogging          *bool  `json:",omitempty"`
-	//EnableNodeLogging             *bool  `json:",omitempty"`
-	//LoggingDestination            string `json:",omitempty"`
-	//ElasticsearchLoggingReplicas  int    `json:",omitempty"`
-	//
-	//EnableClusterRegistry         *bool  `json:",omitempty"`
-	//ClusterRegistryDisk           string `json:",omitempty"`
-	//ClusterRegistryDiskSize       int    `json:",omitempty"`
-	//
-	//EnableCustomMetrics           *bool `json:",omitempty"`
-	//
-	//RegisterMasterKubelet         *bool  `json:",omitempty"`
-
-	//// Image is the default image spec to use for the cluster
-	//Image                     string `json:",omitempty"`
-
-	//KubeUser                      string `json:",omitempty"`
-	//
-	//// These are moved to CAStore / SecretStore
-	////KubePassword			string
-	////KubeletToken                  string
-	////KubeProxyToken                string
-	////BearerToken                   string
-	////CACert                        []byte
-	////CAKey                         []byte
-	////KubeletCert                   []byte
-	////KubeletKey                    []byte
-	////MasterCert                    []byte
-	////MasterKey                     []byte
-	////KubecfgCert                   []byte
-	////KubecfgKey                    []byte
-	//
-	//AdmissionControl              string `json:",omitempty"`
-	//
-	//KubeImageTag                  string `json:",omitempty"`
-	//KubeDockerRegistry            string `json:",omitempty"`
-	//KubeAddonRegistry             string `json:",omitempty"`
-	//
-	//KubeletPort                   int `json:",omitempty"`
-	//
-	//KubeApiserverRequestTimeout   int `json:",omitempty"`
-	//
-	//TerminatedPodGcThreshold      string `json:",omitempty"`
-	//
-	//EnableManifestURL             *bool  `json:",omitempty"`
-	//ManifestURL                   string `json:",omitempty"`
-	//ManifestURLHeader             string `json:",omitempty"`
-	//
-	//TestCluster                   string `json:",omitempty"`
-	//
-	//E2EStorageTestEnvironment     string `json:",omitempty"`
-	//KubeletTestArgs               string `json:",omitempty"`
-	//KubeletTestLogLevel           string `json:",omitempty"`
-	//DockerTestArgs                string `json:",omitempty"`
-	//DockerTestLogLevel            string `json:",omitempty"`
-	//ApiserverTestArgs             string `json:",omitempty"`
-	//ApiserverTestLogLevel         string `json:",omitempty"`
-	//ControllerManagerTestArgs     string `json:",omitempty"`
-	//ControllerManagerTestLogLevel string `json:",omitempty"`
-	//SchedulerTestArgs             string `json:",omitempty"`
-	//SchedulerTestLogLevel         string `json:",omitempty"`
-	//KubeProxyTestArgs             string `json:",omitempty"`
-	//KubeProxyTestLogLevel         string `json:",omitempty"`
-
-	//// Masters is the configuration for each master in the cluster
-	//Masters []*MasterConfig `json:",omitempty"`
-
 	// EtcdClusters stores the configuration for each cluster
 	EtcdClusters []*EtcdClusterSpec `json:"etcdClusters,omitempty"`
-
 	// Component configurations
 	Docker                *DockerConfig                `json:"docker,omitempty"`
 	KubeDNS               *KubeDNSConfig               `json:"kubeDNS,omitempty"`
@@ -237,19 +128,14 @@ type ClusterSpec struct {
 
 	// API field controls how the API is exposed outside the cluster
 	API *AccessSpec `json:"api,omitempty"`
-
 	// Authentication field controls how the cluster is configured for authentication
 	Authentication *AuthenticationSpec `json:"authentication,omitempty"`
-
 	// Authorization field controls how the cluster is configured for authorization
 	Authorization *AuthorizationSpec `json:"authorization,omitempty"`
-
 	// Tags for AWS instance groups
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`
-
 	// Hooks for custom actions e.g. on first installation
 	Hooks []HookSpec `json:"hooks,omitempty"`
-
 	// Alternative locations for files and containers
 	// This API component is under contruction, will remove this comment
 	// once this API is fully functional.
@@ -335,7 +221,6 @@ type KubeDNSConfig struct {
 type EtcdClusterSpec struct {
 	// Name is the name of the etcd cluster (main, events etc)
 	Name string `json:"name,omitempty"`
-
 	// EtcdMember stores the configurations for each member of the cluster (including the data volume)
 	Members []*EtcdMemberSpec `json:"etcdMembers,omitempty"`
 }

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -18,166 +18,41 @@ package kops
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+// KubeletConfigSpec defines the kubelet configuration
 type KubeletConfigSpec struct {
-	// not used for clusters version 1.6 and later - flag removed
+	// APIServers is not used for clusters version 1.6 and later - flag removed
 	APIServers string `json:"apiServers,omitempty" flag:"api-servers"`
-
 	// AnonymousAuth permits you to control auth to the kubelet api
 	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"anonymous-auth"`
 	// ClientCAFile is the path to a CA certificate
 	ClientCAFile string `json:"clientCaFile,omitempty" flag:"client-ca-file"`
-
-	// kubeconfigPath is the path to the kubeconfig file with authorization
-	// information and API server location
-	// kops will only use this for clusters version 1.6 and later
-	KubeconfigPath    string `json:"kubeconfigPath,omitempty" flag:"kubeconfig"`
-	RequireKubeconfig *bool  `json:"requireKubeconfig,omitempty" flag:"require-kubeconfig"`
-
+	// KubeconfigPath is the path of kubeconfig for the kubelet
+	KubeconfigPath string `json:"kubeconfigPath,omitempty" flag:"kubeconfig"`
+	// RequireKubeconfig indicates a kubeconfig is required
+	RequireKubeconfig *bool `json:"requireKubeconfig,omitempty" flag:"require-kubeconfig"`
+	// LogLevel is the logging level of the kubelet
 	LogLevel *int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
-
-	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
-
 	// config is the path to the config file or directory of files
 	PodManifestPath string `json:"podManifestPath,omitempty" flag:"pod-manifest-path"`
-	//// syncFrequency is the max period between synchronizing running
-	//// containers and config
-	//SyncFrequency unversioned.Duration `json:"syncFrequency"`
-	//// fileCheckFrequency is the duration between checking config files for
-	//// new data
-	//FileCheckFrequency unversioned.Duration `json:"fileCheckFrequency"`
-	//// httpCheckFrequency is the duration between checking http for new data
-	//HTTPCheckFrequency unversioned.Duration `json:"httpCheckFrequency"`
-	//// manifestURL is the URL for accessing the container manifest
-	//ManifestURL string `json:"manifestURL"`
-	//// manifestURLHeader is the HTTP header to use when accessing the manifest
-	//// URL, with the key separated from the value with a ':', as in 'key:value'
-	//ManifestURLHeader string `json:"manifestURLHeader"`
-	//// enableServer enables the Kubelet's server
-	//EnableServer bool `json:"enableServer"`
-	//// address is the IP address for the Kubelet to serve on (set to 0.0.0.0
-	//// for all interfaces)
-	//Address string `json:"address"`
-	//// port is the port for the Kubelet to serve on.
-	//Port uint `json:"port"`
-	//// readOnlyPort is the read-only port for the Kubelet to serve on with
-	//// no authentication/authorization (set to 0 to disable)
-	//ReadOnlyPort uint `json:"readOnlyPort"`
-	//// tLSCertFile is the file containing x509 Certificate for HTTPS.  (CA cert,
-	//// if any, concatenated after server cert). If tlsCertFile and
-	//// tlsPrivateKeyFile are not provided, a self-signed certificate
-	//// and key are generated for the public address and saved to the directory
-	//// passed to certDir.
-	//TLSCertFile string `json:"tlsCertFile"`
-	//// tLSPrivateKeyFile is the ile containing x509 private key matching
-	//// tlsCertFile.
-	//TLSPrivateKeyFile string `json:"tlsPrivateKeyFile"`
-	//// certDirectory is the directory where the TLS certs are located (by
-	//// default /var/run/kubernetes). If tlsCertFile and tlsPrivateKeyFile
-	//// are provided, this flag will be ignored.
-	//CertDirectory string `json:"certDirectory"`
-	// hostnameOverride is the hostname used to identify the kubelet instead
-	// of the actual hostname.
-	// Note: We recognize some additional values:
-	//  @aws uses the hostname from the AWS metadata service
+	// HostnameOverride is the hostname used to identify the kubelet instead of the actual hostname.
 	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
-	// podInfraContainerImage is the image whose network/ipc namespaces
-	// containers in each pod will use.
+	// PodInfraContainerImage is the image whose network/ipc containers in each pod will use.
 	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty" flag:"pod-infra-container-image"`
-	//// dockerEndpoint is the path to the docker endpoint to communicate with.
-	//DockerEndpoint string `json:"dockerEndpoint"`
-	//// rootDirectory is the directory path to place kubelet files (volume
-	//// mounts,etc).
-	//RootDirectory string `json:"rootDirectory"`
-	//// seccompProfileRoot is the directory path for seccomp profiles.
-	//SeccompProfileRoot string `json:"seccompProfileRoot"`
-	// allowPrivileged enables containers to request privileged mode.
-	// Defaults to false.
+	// SeccompProfileRoot is the directory path for seccomp profiles.
+	SeccompProfileRoot *string `json:"seccompProfileRoot,omitempty" flag:"seccomp-profile-root"`
+	// AllowPrivileged enables containers to request privileged mode (defaults to false)
 	AllowPrivileged *bool `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
-	//// hostNetworkSources is a comma-separated list of sources from which the
-	//// Kubelet allows pods to use of host network. Defaults to "*".
-	//HostNetworkSources []string `json:"hostNetworkSources"`
-	//// hostPIDSources is a comma-separated list of sources from which the
-	//// Kubelet allows pods to use the host pid namespace. Defaults to "*".
-	//HostPIDSources []string `json:"hostPIDSources"`
-	//// hostIPCSources is a comma-separated list of sources from which the
-	//// Kubelet allows pods to use the host ipc namespace. Defaults to "*".
-	//HostIPCSources []string `json:"hostIPCSources"`
-	//// registryPullQPS is the limit of registry pulls per second. If 0,
-	//// unlimited. Set to 0 for no limit. Defaults to 5.0.
-	//RegistryPullQPS float64 `json:"registryPullQPS"`
-	//// registryBurst is the maximum size of a bursty pulls, temporarily allows
-	//// pulls to burst to this number, while still not exceeding registryQps.
-	//// Only used if registryQps > 0.
-	//RegistryBurst int32 `json:"registryBurst"`
-	//// eventRecordQPS is the maximum event creations per second. If 0, there
-	//// is no limit enforced.
-	//EventRecordQPS float32 `json:"eventRecordQPS"`
-	//// eventBurst is the maximum size of a bursty event records, temporarily
-	//// allows event records to burst to this number, while still not exceeding
-	//// event-qps. Only used if eventQps > 0
-	//EventBurst int32 `json:"eventBurst"`
-	// enableDebuggingHandlers enables server endpoints for log collection
-	// and local running of containers and commands
+	// EnableDebuggingHandlers enables server endpoints for log collection and local running of containers and commands
 	EnableDebuggingHandlers *bool `json:"enableDebuggingHandlers,omitempty" flag:"enable-debugging-handlers"`
-	//// minimumGCAge is the minimum age for a finished container before it is
-	//// garbage collected.
-	//MinimumGCAge unversioned.Duration `json:"minimumGCAge"`
-	//// maxPerPodContainerCount is the maximum number of old instances to
-	//// retain per container. Each container takes up some disk space.
-	//MaxPerPodContainerCount int32 `json:"maxPerPodContainerCount"`
-	//// maxContainerCount is the maximum number of old instances of containers
-	//// to retain globally. Each container takes up some disk space.
-	//MaxContainerCount int32 `json:"maxContainerCount"`
-	//// cAdvisorPort is the port of the localhost cAdvisor endpoint
-	//CAdvisorPort uint `json:"cAdvisorPort"`
-	//// healthzPort is the port of the localhost healthz endpoint
-	//HealthzPort int32 `json:"healthzPort"`
-	//// healthzBindAddress is the IP address for the healthz server to serve
-	//// on.
-	//HealthzBindAddress string `json:"healthzBindAddress"`
-	//// oomScoreAdj is The oom-score-adj value for kubelet process. Values
-	//// must be within the range [-1000, 1000].
-	//OOMScoreAdj int32 `json:"oomScoreAdj"`
-	//// registerNode enables automatic registration with the apiserver.
-	//RegisterNode bool `json:"registerNode"`
-	// clusterDomain is the DNS domain for this cluster. If set, kubelet will
-	// configure all containers to search this domain in addition to the
-	// host's search domains.
+	// RegisterNode enables automatic registration with the apiserver.
+	RegisterNode *bool `json:"registerNode,omitempty" flag:"register-node"`
+	// ClusterDomain is the DNS domain for this cluster
 	ClusterDomain string `json:"clusterDomain,omitempty" flag:"cluster-domain"`
-	//// masterServiceNamespace is The namespace from which the kubernetes
-	//// master services should be injected into pods.
-	//MasterServiceNamespace string `json:"masterServiceNamespace"`
-	// clusterDNS is the IP address for a cluster DNS server.  If set, kubelet
-	// will configure all containers to use this for DNS resolution in
-	// addition to the host's DNS servers
+	// ClusterDNS is the IP address for a cluster DNS server
 	ClusterDNS string `json:"clusterDNS,omitempty" flag:"cluster-dns"`
-	//// streamingConnectionIdleTimeout is the maximum time a streaming connection
-	//// can be idle before the connection is automatically closed.
-	//StreamingConnectionIdleTimeout unversioned.Duration `json:"streamingConnectionIdleTimeout"`
-	//// nodeStatusUpdateFrequency is the frequency that kubelet posts node
-	//// status to master. Note: be cautious when changing the constant, it
-	//// must work with nodeMonitorGracePeriod in nodecontroller.
-	//NodeStatusUpdateFrequency unversioned.Duration `json:"nodeStatusUpdateFrequency"`
-	//// minimumGCAge is the minimum age for a unused image before it is
-	//// garbage collected.
-	//ImageMinimumGCAge unversioned.Duration `json:"imageMinimumGCAge"`
-
-	//// lowDiskSpaceThresholdMB is the absolute free disk space, in MB, to
-	//// maintain. When disk space falls below this threshold, new pods would
-	//// be rejected.
-	//LowDiskSpaceThresholdMB int32 `json:"lowDiskSpaceThresholdMB"`
-	//// How frequently to calculate and cache volume disk usage for all pods
-	//VolumeStatsAggPeriod unversioned.Duration `json:"volumeStatsAggPeriod"`
-	// networkPluginName is the name of the network plugin to be invoked for
-	// various events in kubelet/pod lifecycle
+	// NetworkPluginName is the name of the network plugin to be invoked for various events in kubelet/pod lifecycle
 	NetworkPluginName string `json:"networkPluginName,omitempty" flag:"network-plugin"`
-	//// networkPluginDir is the full path of the directory in which to search
-	//// for network plugins
-	//NetworkPluginDir string `json:"networkPluginDir"`
-	//// volumePluginDir is the full path of the directory in which to search
-	//// for additional third party volume plugins
-	//VolumePluginDir string `json:"volumePluginDir"`
-	// cloudProvider is the provider for cloud services.
+	// CloudProvider is the provider for cloud services.
 	CloudProvider string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
 	// KubeletCgroups is the absolute name of cgroups to isolate the kubelet in.
 	KubeletCgroups string `json:"kubeletCgroups,omitempty" flag:"kubelet-cgroups"`
@@ -187,30 +62,9 @@ type KubeletConfigSpec struct {
 	// all non-kernel processes that are not already in a container. Empty
 	// for no container. Rolling back the flag requires a reboot.
 	SystemCgroups string `json:"systemCgroups,omitempty" flag:"system-cgroups"`
-	// cgroupRoot is the root cgroup to use for pods. This is handled by the
-	// container runtime on a best effort basis.
+	// cgroupRoot is the root cgroup to use for pods. This is handled by the container runtime on a best effort basis.
 	CgroupRoot string `json:"cgroupRoot,omitempty" flag:"cgroup-root"`
-	//// containerRuntime is the container runtime to use.
-	//ContainerRuntime string `json:"containerRuntime"`
-	//// rktPath is the path of rkt binary. Leave empty to use the first rkt in
-	//// $PATH.
-	//RktPath string `json:"rktPath,omitempty"`
-	//// rktApiEndpoint is the endpoint of the rkt API service to communicate with.
-	//RktAPIEndpoint string `json:"rktAPIEndpoint,omitempty"`
-	//// rktStage1Image is the image to use as stage1. Local paths and
-	//// http/https URLs are supported.
-	//RktStage1Image string `json:"rktStage1Image,omitempty"`
-	//// lockFilePath is the path that kubelet will use to as a lock file.
-	//// It uses this file as a lock to synchronize with other kubelet processes
-	//// that may be running.
-	//LockFilePath string `json:"lockFilePath"`
-	//// ExitOnLockContention is a flag that signifies to the kubelet that it is running
-	//// in "bootstrap" mode. This requires that 'LockFilePath' has been set.
-	//// This will cause the kubelet to listen to inotify events on the lock file,
-	//// releasing it and exiting when another process tries to open that file.
-	//ExitOnLockContention bool `json:"exitOnLockContention"`
-	// configureCBR0 enables the kublet to configure cbr0 based on
-	// Node.Spec.PodCIDR.
+	// configureCBR0 enables the kublet to configure cbr0 based on Node.Spec.PodCIDR.
 	ConfigureCBR0 *bool `json:"configureCbr0,omitempty" flag:"configure-cbr0"`
 	// How should the kubelet configure the container bridge for hairpin packets.
 	// Setting this flag allows endpoints in a Service to loadbalance back to
@@ -222,92 +76,44 @@ type KubeletConfigSpec struct {
 	// one must set --hairpin-mode=veth-flag, because bridge assumes the
 	// existence of a container bridge named cbr0.
 	HairpinMode string `json:"hairpinMode,omitempty" flag:"hairpin-mode"`
-
-	// The node has babysitter process monitoring docker and kubelet.
-	// Removed as of 1.7
+	// The node has babysitter process monitoring docker and kubelet. Removed as of 1.7
 	BabysitDaemons *bool `json:"babysitDaemons,omitempty" flag:"babysit-daemons"`
-
-	// maxPods is the number of pods that can run on this Kubelet.
+	// MaxPods is the number of pods that can run on this Kubelet.
 	MaxPods *int32 `json:"maxPods,omitempty" flag:"max-pods"`
-
-	// nvidiaGPUs is the number of NVIDIA GPU devices on this node.
+	// NvidiaGPUs is the number of NVIDIA GPU devices on this node.
 	NvidiaGPUs int32 `json:"nvidiaGPUs,omitempty" flag:"experimental-nvidia-gpus" flag-empty:"0"`
-
-	//// dockerExecHandlerName is the handler to use when executing a command
-	//// in a container. Valid values are 'native' and 'nsenter'. Defaults to
-	//// 'native'.
-	//DockerExecHandlerName string `json:"dockerExecHandlerName"`
-	// The CIDR to use for pod IP addresses, only used in standalone mode.
+	// PodCIDR is the CIDR to use for pod IP addresses, only used in standalone mode.
 	// In cluster mode, this is obtained from the master.
 	PodCIDR string `json:"podCIDR,omitempty" flag:"pod-cidr"`
-	// ResolverConfig is the resolver configuration file used as the basis
-	// for the container DNS resolution configuration."), []
+	// ResolverConfig is the resolver configuration file used as the basis for the container DNS resolution configuration."), []
 	ResolverConfig *string `json:"resolvConf,omitempty" flag:"resolv-conf" flag-include-empty:"true"`
-	//// cpuCFSQuota is Enable CPU CFS quota enforcement for containers that
-	//// specify CPU limits
-	//CPUCFSQuota bool `json:"cpuCFSQuota"`
-	//// containerized should be set to true if kubelet is running in a container.
-	//Containerized bool `json:"containerized"`
-	//// maxOpenFiles is Number of files that can be opened by Kubelet process.
-	//MaxOpenFiles uint64 `json:"maxOpenFiles"`
-	// reconcileCIDR is Reconcile node CIDR with the CIDR specified by the
+	// ReconcileCIDR is Reconcile node CIDR with the CIDR specified by the
 	// API server. No-op if register-node or configure-cbr0 is false.
 	ReconcileCIDR *bool `json:"reconcileCIDR,omitempty" flag:"reconcile-cidr"`
-	// registerSchedulable tells the kubelet to register the node as
-	// schedulable. No-op if register-node is false.
+	// registerSchedulable tells the kubelet to register the node as schedulable. No-op if register-node is false.
 	RegisterSchedulable *bool `json:"registerSchedulable,omitempty" flag:"register-schedulable"`
-	//// contentType is contentType of requests sent to apiserver.
-	//ContentType string `json:"contentType"`
-	//// kubeAPIQPS is the QPS to use while talking with kubernetes apiserver
-	//KubeAPIQPS float32 `json:"kubeAPIQPS"`
-	//// kubeAPIBurst is the burst to allow while talking with kubernetes
-	//// apiserver
-	//KubeAPIBurst int32 `json:"kubeAPIBurst"`
-	//// serializeImagePulls when enabled, tells the Kubelet to pull images one
+	//// SerializeImagePulls when enabled, tells the Kubelet to pull images one
 	//// at a time. We recommend *not* changing the default value on nodes that
 	//// run docker daemon with version  < 1.9 or an Aufs storage backend.
 	//// Issue #10959 has more details.
-	//SerializeImagePulls bool `json:"serializeImagePulls"`
-	//// experimentalFlannelOverlay enables experimental support for starting the
-	//// kubelet with the default overlay network (flannel). Assumes flanneld
-	//// is already running in client mode.
-	//ExperimentalFlannelOverlay bool `json:"experimentalFlannelOverlay"`
-	//// outOfDiskTransitionFrequency is duration for which the kubelet has to
-	//// wait before transitioning out of out-of-disk node condition status.
-	//OutOfDiskTransitionFrequency unversioned.Duration `json:"outOfDiskTransitionFrequency,omitempty"`
-	//// nodeIP is IP address of the node. If set, kubelet will use this IP
-	//// address for the node.
-	//NodeIP string `json:"nodeIP,omitempty"`
-
-	// nodeLabels to add when registering the node in the cluster.
+	SerializeImagePulls *bool `json:"serializeImagePulls,omitempty" flag:"serialize-image-pulls"`
+	// NodeLabels to add when registering the node in the cluster.
 	NodeLabels map[string]string `json:"nodeLabels,omitempty" flag:"node-labels"`
-
-	// nonMasqueradeCIDR configures masquerading: traffic to IPs outside this range will use IP masquerade.
+	// NonMasqueradeCIDR configures masquerading: traffic to IPs outside this range will use IP masquerade.
 	NonMasqueradeCIDR string `json:"nonMasqueradeCIDR,omitempty" flag:"non-masquerade-cidr"`
-
-	// enable gathering custom metrics.
+	// Enable gathering custom metrics.
 	EnableCustomMetrics *bool `json:"enableCustomMetrics,omitempty" flag:"enable-custom-metrics"`
-
-	//// Maximum number of pods per core. Cannot exceed MaxPods
-	//PodsPerCore int32 `json:"podsPerCore"`
-	//// enableControllerAttachDetach enables the Attach/Detach controller to
-	//// manage attachment/detachment of volumes scheduled to this node, and
-	//// disables kubelet from executing any attach/detach operations
-	//EnableControllerAttachDetach bool `json:"enableControllerAttachDetach"`
-
-	// networkPluginMTU is the MTU to be passed to the network plugin,
+	// NetworkPluginMTU is the MTU to be passed to the network plugin,
 	// and overrides the default MTU for cases where it cannot be automatically
 	// computed (such as IPSEC).
 	NetworkPluginMTU *int32 `json:"networkPluginMTU,omitempty" flag:"network-plugin-mtu"`
-
-	// imageGCHighThresholdPercent is the percent of disk usage after which
+	// ImageGCHighThresholdPercent is the percent of disk usage after which
 	// image garbage collection is always run.
 	ImageGCHighThresholdPercent *int32 `json:"imageGCHighThresholdPercent,omitempty" flag:"image-gc-high-threshold"`
-	// imageGCLowThresholdPercent is the percent of disk usage before which
+	// ImageGCLowThresholdPercent is the percent of disk usage before which
 	// image garbage collection is never run. Lowest disk usage to garbage
 	// collect to.
 	ImageGCLowThresholdPercent *int32 `json:"imageGCLowThresholdPercent,omitempty" flag:"image-gc-low-threshold"`
-
 	// Comma-delimited list of hard eviction expressions.  For example, 'memory.available<300Mi'.
 	EvictionHard *string `json:"evictionHard,omitempty" flag:"eviction-hard"`
 	// Comma-delimited list of soft eviction expressions.  For example, 'memory.available<300Mi'.
@@ -320,18 +126,13 @@ type KubeletConfigSpec struct {
 	EvictionMaxPodGracePeriod int32 `json:"evictionMaxPodGracePeriod,omitempty" flag:"eviction-max-pod-grace-period" flag-empty:"0"`
 	// Comma-delimited list of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.
 	EvictionMinimumReclaim string `json:"evictionMinimumReclaim,omitempty" flag:"eviction-minimum-reclaim"`
-
 	// The full path of the directory in which to search for additional third party volume plugins
 	VolumePluginDirectory string `json:"volumePluginDirectory,omitempty" flag:"volume-plugin-dir"`
-
 	// Taints to add when registering a node in the cluster
 	Taints []string `json:"taints,omitempty" flag:"register-with-taints"`
-
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
-
-	// Resource reservation for kubernetes system daemons like the kubelet,
-	// container runtime, node problem detector, etc.
+	// Resource reservation for kubernetes system daemons like the kubelet, container runtime, node problem detector, etc.
 	KubeReserved map[string]string `json:"kubeReserved,omitempty" flag:"kube-reserved"`
 	// Control group for kube daemons.
 	KubeReservedCgroup string `json:"kubeReservedCgroup,omitempty" flag:"kube-reserved-cgroup"`
@@ -339,122 +140,75 @@ type KubeletConfigSpec struct {
 	SystemReserved map[string]string `json:"systemReserved,omitempty" flag:"system-reserved"`
 	// Parent control group for OS system daemons.
 	SystemReservedCgroup string `json:"systemReservedCgroup,omitempty" flag:"system-reserved-cgroup"`
-	// Enforce Allocatable across pods whenever the overall usage across all pods
-	// exceeds Allocatable.
+	// Enforce Allocatable across pods whenever the overall usage across all pods exceeds Allocatable.
 	EnforceNodeAllocatable string `json:"enforceNodeAllocatable,omitempty" flag:"enforce-node-allocatable"`
 }
 
+// KubeProxyConfig defined the configuration for a proxy
 type KubeProxyConfig struct {
 	Image string `json:"image,omitempty"`
 	// TODO: Better type ?
 	CPURequest string `json:"cpuRequest,omitempty"` // e.g. "20m"
-
+	// LogLevel is the logging level of the proxy
 	LogLevel int32 `json:"logLevel,omitempty" flag:"v"`
-
-	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
-
-	//// bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0
-	//// for all interfaces)
-	//BindAddress string `json:"bindAddress"`
-
-	// clusterCIDR is the CIDR range of the pods in the cluster. It is used to
-	// bridge traffic coming from outside of the cluster. If not provided,
-	// no off-cluster bridging will be performed.
+	// ClusterCIDR is the CIDR range of the pods in the cluster
 	ClusterCIDR string `json:"clusterCIDR,omitempty" flag:"cluster-cidr"`
-
-	//// healthzBindAddress is the IP address for the health check server to serve on,
-	//// defaulting to 127.0.0.1 (set to 0.0.0.0 for all interfaces)
-	//HealthzBindAddress string `json:"healthzBindAddress"`
-	//// healthzPort is the port to bind the health check server. Use 0 to disable.
-	//HealthzPort int32 `json:"healthzPort"`
-
-	// hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
-	// Note: We recognize some additional values:
-	//  @aws uses the hostname from the AWS metadata service
+	// HostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
 	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
-
-	//// iptablesMasqueradeBit is the bit of the iptables fwmark space to use for SNAT if using
-	//// the pure iptables proxy mode. Values must be within the range [0, 31].
-	//IPTablesMasqueradeBit *int32 `json:"iptablesMasqueradeBit"`
-	//// iptablesSyncPeriod is the period that iptables rules are refreshed (e.g. '5s', '1m',
-	//// '2h22m').  Must be greater than 0.
-	//IPTablesSyncPeriod unversioned.Duration `json:"iptablesSyncPeriodSeconds"`
-	//// kubeconfigPath is the path to the kubeconfig file with authorization information (the
-	//// master location is set by the master flag).
-	//KubeconfigPath string `json:"kubeconfigPath"`
-	//// masqueradeAll tells kube-proxy to SNAT everything if using the pure iptables proxy mode.
-	//MasqueradeAll bool `json:"masqueradeAll"`
-	// master is the address of the Kubernetes API server (overrides any value in kubeconfig)
+	// Master is the address of the Kubernetes API server (overrides any value in kubeconfig)
 	Master string `json:"master,omitempty" flag:"master"`
-	//// oomScoreAdj is the oom-score-adj value for kube-proxy process. Values must be within
-	//// the range [-1000, 1000]
-	//OOMScoreAdj *int32 `json:"oomScoreAdj"`
-	//// mode specifies which proxy mode to use.
-	//Mode ProxyMode `json:"mode"`
-	//// portRange is the range of host ports (beginPort-endPort, inclusive) that may be consumed
-	//// in order to proxy service traffic. If unspecified (0-0) then ports will be randomly chosen.
-	//PortRange string `json:"portRange"`
-	//// resourceContainer is the bsolute name of the resource-only container to create and run
-	//// the Kube-proxy in (Default: /kube-proxy).
-	//ResourceContainer string `json:"resourceContainer"`
-	//// udpIdleTimeout is how long an idle UDP connection will be kept open (e.g. '250ms', '2s').
-	//// Must be greater than 0. Only applicable for proxyMode=userspace.
-	//UDPIdleTimeout unversioned.Duration `json:"udpTimeoutMilliseconds"`
-	//// conntrackMax is the maximum number of NAT connections to track (0 to leave as-is)")
-	//ConntrackMax int32 `json:"conntrackMax"`
-	//// conntrackTCPEstablishedTimeout is how long an idle UDP connection will be kept open
-	//// (e.g. '250ms', '2s').  Must be greater than 0. Only applicable for proxyMode is Userspace
-	//ConntrackTCPEstablishedTimeout unversioned.Duration `json:"conntrackTCPEstablishedTimeout"`
+	// FeatureGates is a series of key pairs used to switch on features for the proxy
+	FeatureGates []string `json:"feature-gates" flag:"feature-gates"`
 }
 
+// KubeAPIServerConfig defines the configuration for the kube api
 type KubeAPIServerConfig struct {
-	// TODO: Remove PathSrvKubernetes - unused
-	PathSrvKubernetes string `json:"pathSrvKubernetes,omitempty"`
-	// TODO: Remove PathSrvSshProxy - unused
-	PathSrvSshproxy string `json:"pathSrvSshproxy,omitempty"`
-
+	// Image is the docker container used
 	Image string `json:"image,omitempty"`
-
+	// LogLevel is the logging level of the api
 	LogLevel int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
-
-	CloudProvider         string   `json:"cloudProvider,omitempty" flag:"cloud-provider"`
-	SecurePort            int32    `json:"securePort,omitempty" flag:"secure-port"`
-	InsecurePort          int32    `json:"insecurePort,omitempty" flag:"insecure-port"`
-	Address               string   `json:"address,omitempty" flag:"address"`
-	EtcdServers           []string `json:"etcdServers,omitempty" flag:"etcd-servers"`
-	EtcdServersOverrides  []string `json:"etcdServersOverrides,omitempty" flag:"etcd-servers-overrides"`
-	AdmissionControl      []string `json:"admissionControl,omitempty" flag:"admission-control"`
-	ServiceClusterIPRange string   `json:"serviceClusterIPRange,omitempty" flag:"service-cluster-ip-range"`
-
+	// CloudProvider is the name of the cloudProvider we are using, aws, gce etcd
+	CloudProvider string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
+	// SecurePort is the port the kube runs on
+	SecurePort int32 `json:"securePort,omitempty" flag:"secure-port"`
+	// InsecurePort is the port the insecure api runs
+	InsecurePort int32 `json:"insecurePort,omitempty" flag:"insecure-port"`
+	// Address is the binding address for the kube api
+	Address string `json:"address,omitempty" flag:"address"`
+	// AdmissionControl is a list of admission controllers to user
+	AdmissionControl []string `json:"admissionControl,omitempty" flag:"admission-control"`
+	// ServiceClusterIPRange is the service address range
+	ServiceClusterIPRange string `json:"serviceClusterIPRange,omitempty" flag:"service-cluster-ip-range"`
+	// EtcdServers is a list of the etcd service to connect
+	EtcdServers []string `json:"etcdServers,omitempty" flag:"etcd-servers"`
+	// EtcdServersOverrides is per-resource etcd servers overrides, comma separated. The individual override format: group/resource#servers, where servers are http://ip:port, semicolon separated
+	EtcdServersOverrides []string `json:"etcdServersOverrides,omitempty" flag:"etcd-servers-overrides"`
 	// TODO: Remove unused BasicAuthFile
 	BasicAuthFile string `json:"basicAuthFile,omitempty" flag:"basic-auth-file"`
-
 	// TODO: Remove unused ClientCAFile
 	ClientCAFile string `json:"clientCAFile,omitempty" flag:"client-ca-file"`
 	// TODO: Remove unused TLSCertFile
 	TLSCertFile string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
 	// TODO: Remove unused TLSPrivateKeyFile
 	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
-
-	KubeletClientCertificate string `json:"kubeletClientCertificate,omitempty" flag:"kubelet-client-certificate"`
-	KubeletClientKey         string `json:"kubeletClientKey,omitempty" flag:"kubelet-client-key"`
-
 	// TODO: Remove unused TokenAuthFile
 	TokenAuthFile string `json:"tokenAuthFile,omitempty" flag:"token-auth-file"`
-
-	AllowPrivileged *bool  `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
-	APIServerCount  *int32 `json:"apiServerCount,omitempty" flag:"apiserver-count"`
-	// keys and values in RuntimeConfig are parsed into the `--runtime-config` parameter
-	// for KubeAPIServer, concatenated with commas. ex: `--runtime-config=key1=value1,key2=value2`.
-	// Use this to enable alpha resources on kube-apiserver
+	// AllowPrivileged indicates if we can run privileged containers
+	AllowPrivileged *bool `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
+	// APIServerCount is the number of api servers
+	APIServerCount *int32 `json:"apiServerCount,omitempty" flag:"apiserver-count"`
+	// RuntimeConfig is a series of keys/values are parsed into the `--runtime-config` parameters
 	RuntimeConfig map[string]string `json:"runtimeConfig,omitempty" flag:"runtime-config"`
-
+	// KubeletClientCertificate is the path of a certificate for secure communication between api and kubelet
+	KubeletClientCertificate string `json:"kubeletClientCertificate,omitempty" flag:"kubelet-client-certificate"`
+	// KubeletClientKey is the path of a private to secure communication between api and kubelet
+	KubeletClientKey string `json:"kubeletClientKey,omitempty" flag:"kubelet-client-key"`
+	// AnonymousAuth indicates if anonymous authentication is permitted
 	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"anonymous-auth"`
-
+	// KubeletPreferredAddressTypes is a list of the preferred NodeAddressTypes to use for kubelet connections
 	KubeletPreferredAddressTypes []string `json:"kubeletPreferredAddressTypes,omitempty" flag:"kubelet-preferred-address-types"`
-
+	// StorageBackend is the backend storage
 	StorageBackend *string `json:"storageBackend,omitempty" flag:"storage-backend"`
-
 	// The OpenID claim to use as the user name.
 	// Note that claims other than the default ('sub') is not guaranteed to be unique and immutable.
 	OIDCUsernameClaim *string `json:"oidcUsernameClaim,omitempty" flag:"oidc-username-claim"`
@@ -467,9 +221,7 @@ type KubeAPIServerConfig struct {
 	// The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
 	OIDCClientID *string `json:"oidcClientID,omitempty" flag:"oidc-client-id"`
 	// If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file
-	// otherwise the host's root CA set will be used.
 	OIDCCAFile *string `json:"oidcCAFile,omitempty" flag:"oidc-ca-file"`
-
 	// If set, all requests coming to the apiserver will be logged to this file.
 	AuditLogPath *string `json:"auditLogPath,omitempty" flag:"audit-log-path"`
 	// The maximum number of days to retain old audit log files based on the timestamp encoded in their filename.
@@ -478,211 +230,61 @@ type KubeAPIServerConfig struct {
 	AuditLogMaxBackups *int32 `json:"auditLogMaxBackups,omitempty" flag:"audit-log-maxbackup"`
 	// The maximum size in megabytes of the audit log file before it gets rotated. Defaults to 100MB.
 	AuditLogMaxSize *int32 `json:"auditLogMaxSize,omitempty" flag:"audit-log-maxsize"`
-
 	// File with webhook configuration for token authentication in kubeconfig format. The API server will query the remote service to determine authentication for bearer tokens.
 	AuthenticationTokenWebhookConfigFile *string `json:"authenticationTokenWebhookConfigFile,omitempty" flag:"authentication-token-webhook-config-file"`
 	// The duration to cache responses from the webhook token authenticator. Default is 2m. (default 2m0s)
-	AuthenticationTokenWebhookCacheTtl *metav1.Duration `json:"authenticationTokenWebhookCacheTtl,omitempty" flag:"authentication-token-webhook-cache-ttl"`
-
-	AuthorizationMode          *string `json:"authorizationMode,omitempty" flag:"authorization-mode"`
+	AuthenticationTokenWebhookCacheTTL *metav1.Duration `json:"authenticationTokenWebhookCacheTtl,omitempty" flag:"authentication-token-webhook-cache-ttl"`
+	// AuthorizationMode is the authorization mode the kubeapi is running in
+	AuthorizationMode *string `json:"authorizationMode,omitempty" flag:"authorization-mode"`
+	// AuthorizationRBACSuperUser is the name of the superuser for default rbac
 	AuthorizationRBACSuperUser *string `json:"authorizationRbacSuperUser,omitempty" flag:"authorization-rbac-super-user"`
 }
 
+// KubeControllerManagerConfig is the configuration for the controller
 type KubeControllerManagerConfig struct {
-	Master   string `json:"master,omitempty" flag:"master"`
-	LogLevel int32  `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
-
-	// TODO: Remove as unused
+	// Master is the url for the kube api master
+	Master string `json:"master,omitempty" flag:"master"`
+	// LogLevel is the defined logLevel
+	LogLevel int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
+	// ServiceAccountPrivateKeyFile the location for a certificate for service account signing
 	ServiceAccountPrivateKeyFile string `json:"serviceAccountPrivateKeyFile,omitempty" flag:"service-account-private-key-file"`
-
+	// Image is the docker image to use
 	Image string `json:"image,omitempty"`
-
-	// TODO: Remove PathSrvKubernetes - unused
-	PathSrvKubernetes string `json:"pathSrvKubernetes,omitempty"`
-
-	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
-
-	//// port is the port that the controller-manager's http service runs on.
-	//Port int32 `json:"port"`
-	//// address is the IP address to serve on (set to 0.0.0.0 for all interfaces).
-	//Address string `json:"address"`
-	// cloudProvider is the provider for cloud services.
+	// CloudProvider is the provider for cloud services.
 	CloudProvider string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
-	//// concurrentEndpointSyncs is the number of endpoint syncing operations
-	//// that will be done concurrently. Larger number = faster endpoint updating,
-	//// but more CPU (and network) load.
-	//ConcurrentEndpointSyncs int32 `json:"concurrentEndpointSyncs"`
-	//// concurrentRSSyncs is the number of replica sets that are  allowed to sync
-	//// concurrently. Larger number = more responsive replica  management, but more
-	//// CPU (and network) load.
-	//ConcurrentRSSyncs int32 `json:"concurrentRSSyncs"`
-	//// concurrentRCSyncs is the number of replication controllers that are
-	//// allowed to sync concurrently. Larger number = more responsive replica
-	//// management, but more CPU (and network) load.
-	//ConcurrentRCSyncs int32 `json:"concurrentRCSyncs"`
-	//// concurrentResourceQuotaSyncs is the number of resource quotas that are
-	//// allowed to sync concurrently. Larger number = more responsive quota
-	//// management, but more CPU (and network) load.
-	//ConcurrentResourceQuotaSyncs int32 `json:"concurrentResourceQuotaSyncs"`
-	//// concurrentDeploymentSyncs is the number of deployment objects that are
-	//// allowed to sync concurrently. Larger number = more responsive deployments,
-	//// but more CPU (and network) load.
-	//ConcurrentDeploymentSyncs int32 `json:"concurrentDeploymentSyncs"`
-	//// concurrentDaemonSetSyncs is the number of daemonset objects that are
-	//// allowed to sync concurrently. Larger number = more responsive daemonset,
-	//// but more CPU (and network) load.
-	//ConcurrentDaemonSetSyncs int32 `json:"concurrentDaemonSetSyncs"`
-	//// concurrentJobSyncs is the number of job objects that are
-	//// allowed to sync concurrently. Larger number = more responsive jobs,
-	//// but more CPU (and network) load.
-	//ConcurrentJobSyncs int32 `json:"concurrentJobSyncs"`
-	//// concurrentNamespaceSyncs is the number of namespace objects that are
-	//// allowed to sync concurrently.
-	//ConcurrentNamespaceSyncs int32 `json:"concurrentNamespaceSyncs"`
-	//// lookupCacheSizeForRC is the size of lookup cache for replication controllers.
-	//// Larger number = more responsive replica management, but more MEM load.
-	//LookupCacheSizeForRC int32 `json:"lookupCacheSizeForRC"`
-	//// lookupCacheSizeForRS is the size of lookup cache for replicatsets.
-	//// Larger number = more responsive replica management, but more MEM load.
-	//LookupCacheSizeForRS int32 `json:"lookupCacheSizeForRS"`
-	//// lookupCacheSizeForDaemonSet is the size of lookup cache for daemonsets.
-	//// Larger number = more responsive daemonset, but more MEM load.
-	//LookupCacheSizeForDaemonSet int32 `json:"lookupCacheSizeForDaemonSet"`
-	//// serviceSyncPeriod is the period for syncing services with their external
-	//// load balancers.
-	//ServiceSyncPeriod unversioned.Duration `json:"serviceSyncPeriod"`
-	//// nodeSyncPeriod is the period for syncing nodes from cloudprovider. Longer
-	//// periods will result in fewer calls to cloud provider, but may delay addition
-	//// of new nodes to cluster.
-	//NodeSyncPeriod unversioned.Duration `json:"nodeSyncPeriod"`
-	//// resourceQuotaSyncPeriod is the period for syncing quota usage status
-	//// in the system.
-	//ResourceQuotaSyncPeriod unversioned.Duration `json:"resourceQuotaSyncPeriod"`
-	//// namespaceSyncPeriod is the period for syncing namespace life-cycle
-	//// updates.
-	//NamespaceSyncPeriod unversioned.Duration `json:"namespaceSyncPeriod"`
-	//// pvClaimBinderSyncPeriod is the period for syncing persistent volumes
-	//// and persistent volume claims.
-	//PVClaimBinderSyncPeriod unversioned.Duration `json:"pvClaimBinderSyncPeriod"`
-	//// minResyncPeriod is the resync period in reflectors; will be random between
-	//// minResyncPeriod and 2*minResyncPeriod.
-	//MinResyncPeriod unversioned.Duration `json:"minResyncPeriod"`
-	//// horizontalPodAutoscalerSyncPeriod is the period for syncing the number of
-	//// pods in horizontal pod autoscaler.
-	//HorizontalPodAutoscalerSyncPeriod unversioned.Duration `json:"horizontalPodAutoscalerSyncPeriod"`
-	//// deploymentControllerSyncPeriod is the period for syncing the deployments.
-	//DeploymentControllerSyncPeriod unversioned.Duration `json:"deploymentControllerSyncPeriod"`
-	//// podEvictionTimeout is the grace period for deleting pods on failed nodes.
-	//PodEvictionTimeout unversioned.Duration `json:"podEvictionTimeout"`
-	//// deletingPodsQps is the number of nodes per second on which pods are deleted in
-	//// case of node failure.
-	//DeletingPodsQps float32 `json:"deletingPodsQps"`
-	//// deletingPodsBurst is the number of nodes on which pods are bursty deleted in
-	//// case of node failure. For more details look into RateLimiter.
-	//DeletingPodsBurst int32 `json:"deletingPodsBurst"`
-	//// nodeMontiorGracePeriod is the amount of time which we allow a running node to be
-	//// unresponsive before marking it unhealthy. Must be N times more than kubelet's
-	//// nodeStatusUpdateFrequency, where N means number of retries allowed for kubelet
-	//// to post node status.
-	//NodeMonitorGracePeriod unversioned.Duration `json:"nodeMonitorGracePeriod"`
-	//// registerRetryCount is the number of retries for initial node registration.
-	//// Retry interval equals node-sync-period.
-	//RegisterRetryCount int32 `json:"registerRetryCount"`
-	//// nodeStartupGracePeriod is the amount of time which we allow starting a node to
-	//// be unresponsive before marking it unhealthy.
-	//NodeStartupGracePeriod unversioned.Duration `json:"nodeStartupGracePeriod"`
-	//// nodeMonitorPeriod is the period for syncing NodeStatus in NodeController.
-	//NodeMonitorPeriod unversioned.Duration `json:"nodeMonitorPeriod"`
-	//// serviceAccountKeyFile is the filename containing a PEM-encoded private RSA key
-	//// used to sign service account tokens.
-	//ServiceAccountKeyFile string `json:"serviceAccountKeyFile"`
-	//// enableProfiling enables profiling via web interface host:port/debug/pprof/
-	//EnableProfiling bool `json:"enableProfiling"`
-	// clusterName is the instance prefix for the cluster.
+	// ClusterName is the instance prefix for the cluster.
 	ClusterName string `json:"clusterName,omitempty" flag:"cluster-name"`
-	// clusterCIDR is CIDR Range for Pods in cluster.
+	// ClusterCIDR is CIDR Range for Pods in cluster.
 	ClusterCIDR string `json:"clusterCIDR,omitempty" flag:"cluster-cidr"`
-	//// serviceCIDR is CIDR Range for Services in cluster.
-	//ServiceCIDR string `json:"serviceCIDR"`
-	//// NodeCIDRMaskSize is the mask size for node cidr in cluster.
-	//NodeCIDRMaskSize int32 `json:"nodeCIDRMaskSize"`
-	// allocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
+	// AllocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
 	// ConfigureCloudRoutes is true, to be set on the cloud provider.
 	AllocateNodeCIDRs *bool `json:"allocateNodeCIDRs,omitempty" flag:"allocate-node-cidrs"`
-	// configureCloudRoutes enables CIDRs allocated with allocateNodeCIDRs
-	// to be configured on the cloud provider.
+	// ConfigureCloudRoutes enables CIDRs allocated with to be configured on the cloud provider.
 	ConfigureCloudRoutes *bool `json:"configureCloudRoutes,omitempty" flag:"configure-cloud-routes"`
-
-	// TODO: Remove as unused
-	// rootCAFile is the root certificate authority will be included in service
-	// account's token secret. This must be a valid PEM-encoded CA bundle.
+	// rootCAFile is the root certificate authority will be included in service account's token secret. This must be a valid PEM-encoded CA bundle.
 	RootCAFile string `json:"rootCAFile,omitempty" flag:"root-ca-file"`
-
-	//// contentType is contentType of requests sent to apiserver.
-	//ContentType string `json:"contentType"`
-	//// kubeAPIQPS is the QPS to use while talking with kubernetes apiserver.
-	//KubeAPIQPS float32 `json:"kubeAPIQPS"`
-	//// kubeAPIBurst is the burst to use while talking with kubernetes apiserver.
-	//KubeAPIBurst int32 `json:"kubeAPIBurst"`
-	// leaderElection defines the configuration of leader election client.
+	// LeaderElection defines the configuration of leader election client.
 	LeaderElection *LeaderElectionConfiguration `json:"leaderElection,omitempty"`
-	//// volumeConfiguration holds configuration for volume related features.
-	//VolumeConfiguration VolumeConfiguration `json:"volumeConfiguration"`
-	//// How long to wait between starting controller managers
-	//ControllerStartInterval unversioned.Duration `json:"controllerStartInterval"`
-	//// enables the generic garbage collector. MUST be synced with the
-	//// corresponding flag of the kube-apiserver. WARNING: the generic garbage
-	//// collector is an alpha feature.
-	//EnableGarbageCollector bool `json:"enableGarbageCollector"`
-
 	// ReconcilerSyncLoopPeriod is the amount of time the reconciler sync states loop
 	// wait between successive executions. Is set to 1 min by kops by default
 	AttachDetachReconcileSyncPeriod *metav1.Duration `json:"attachDetachReconcileSyncPeriod,omitempty" flag:"attach-detach-reconcile-sync-period"`
-
-	// terminatedPodGCThreshold is the number of terminated pods that can exist
+	// TerminatedPodGCThreshold is the number of terminated pods that can exist
 	// before the terminated pod garbage collector starts deleting terminated pods.
 	// If <= 0, the terminated pod garbage collector is disabled.
 	TerminatedPodGCThreshold *int32 `json:"terminatedPodGCThreshold,omitempty" flag:"terminated-pod-gc-threshold"`
-
 	// UseServiceAccountCredentials controls whether we use individual service account credentials for each controller.
 	UseServiceAccountCredentials *bool `json:"useServiceAccountCredentials,omitempty" flag:"use-service-account-credentials"`
 }
 
+// KubeSchedulerConfig is the configuration for the kube-scheduler
 type KubeSchedulerConfig struct {
-	Master   string `json:"master,omitempty" flag:"master"`
-	LogLevel int32  `json:"logLevel,omitempty" flag:"v"`
-
+	// Master is a url to the kube master
+	Master string `json:"master,omitempty" flag:"master"`
+	// LogLevel is the logging level
+	LogLevel int32 `json:"logLevel,omitempty" flag:"v"`
+	// Image is the docker image to use
 	Image string `json:"image,omitempty"`
-
-	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
-
-	//// port is the port that the scheduler's http service runs on.
-	//Port int32 `json:"port"`
-	//// address is the IP address to serve on.
-	//Address string `json:"address"`
-	//// algorithmProvider is the scheduling algorithm provider to use.
-	//AlgorithmProvider string `json:"algorithmProvider"`
-	//// policyConfigFile is the filepath to the scheduler policy configuration.
-	//PolicyConfigFile string `json:"policyConfigFile"`
-	//// enableProfiling enables profiling via web interface.
-	//EnableProfiling bool `json:"enableProfiling"`
-	//// contentType is contentType of requests sent to apiserver.
-	//ContentType string `json:"contentType"`
-	//// kubeAPIQPS is the QPS to use while talking with kubernetes apiserver.
-	//KubeAPIQPS float32 `json:"kubeAPIQPS"`
-	//// kubeAPIBurst is the QPS burst to use while talking with kubernetes apiserver.
-	//KubeAPIBurst int32 `json:"kubeAPIBurst"`
-	//// schedulerName is name of the scheduler, used to select which pods
-	//// will be processed by this scheduler, based on pod's annotation with
-	//// key 'scheduler.alpha.kubernetes.io/name'.
-	//SchedulerName string `json:"schedulerName"`
-	//// RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule
-	//// corresponding to every RequiredDuringScheduling affinity rule.
-	//// HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 0-100.
-	//HardPodAffinitySymmetricWeight int `json:"hardPodAffinitySymmetricWeight"`
-	//// Indicate the "all topologies" set for empty topologyKey when it's used for PreferredDuringScheduling pod anti-affinity.
-	//FailureDomains string `json:"failureDomains"`
-	// leaderElection defines the configuration of leader election client.
+	// LeaderElection defines the configuration of leader election client.
 	LeaderElection *LeaderElectionConfiguration `json:"leaderElection,omitempty"`
 }
 
@@ -693,24 +295,9 @@ type LeaderElectionConfiguration struct {
 	// before executing the main loop. Enable this when running replicated
 	// components for high availability.
 	LeaderElect *bool `json:"leaderElect,omitempty" flag:"leader-elect"`
-	//// leaseDuration is the duration that non-leader candidates will wait
-	//// after observing a leadership renewal until attempting to acquire
-	//// leadership of a led but unrenewed leader slot. This is effectively the
-	//// maximum duration that a leader can be stopped before it is replaced
-	//// by another candidate. This is only applicable if leader election is
-	//// enabled.
-	//LeaseDuration unversioned.Duration `json:"leaseDuration"`
-	//// renewDeadline is the interval between attempts by the acting master to
-	//// renew a leadership slot before it stops leading. This must be less
-	//// than or equal to the lease duration. This is only applicable if leader
-	//// election is enabled.
-	//RenewDeadline unversioned.Duration `json:"renewDeadline"`
-	//// retryPeriod is the duration the clients should wait between attempting
-	//// acquisition and renewal of a leadership. This is only applicable if
-	//// leader election is enabled.
-	//RetryPeriod unversioned.Duration `json:"retryPeriod"`
 }
 
+// CloudConfiguration is defines the cloud provider configuration
 type CloudConfiguration struct {
 	// GCE cloud-config options
 	Multizone          *bool   `json:"multizone,omitempty"`
@@ -719,7 +306,6 @@ type CloudConfiguration struct {
 	// AWS cloud-config options
 	DisableSecurityGroupIngress *bool   `json:"disableSecurityGroupIngress,omitempty"`
 	ElbSecurityGroup            *string `json:"elbSecurityGroup,omitempty"`
-
 	// vSphere cloud-config specs
 	VSphereUsername      *string `json:"vSphereUsername,omitempty"`
 	VSpherePassword      *string `json:"vSpherePassword,omitempty"`

--- a/pkg/apis/kops/dockerconfig.go
+++ b/pkg/apis/kops/dockerconfig.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package kops
 
+// DockerConfig is the configuration for docker
 type DockerConfig struct {
 	Bridge   *string `json:"bridge,omitempty" flag:"bridge"`
 	LogLevel *string `json:"logLevel,omitempty" flag:"log-level"`

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -18,165 +18,41 @@ package v1alpha1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+// KubeletConfigSpec defines the kubelet configuration
 type KubeletConfigSpec struct {
-	// not used for clusters version 1.6 and later
+	// APIServers is not used for clusters version 1.6 and later - flag removed
 	APIServers string `json:"apiServers,omitempty" flag:"api-servers"`
-
-	// AnonymousAuth chooses if you want anonymous auth on the kubelet api
+	// AnonymousAuth permits you to control auth to the kubelet api
 	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"anonymous-auth"`
-	// ClientCAFile is the path to a file container the CA certificate
+	// ClientCAFile is the path to a CA certificate
 	ClientCAFile string `json:"clientCaFile,omitempty" flag:"client-ca-file"`
-
-	// kubeconfigPath is the path to the kubeconfig file with authorization
-	// information and API server location
-	// kops will only use this for clusters version 1.6 and later
-	KubeconfigPath    string `json:"kubeconfigPath,omitempty" flag:"kubeconfig"`
-	RequireKubeconfig *bool  `json:"requireKubeconfig,omitempty" flag:"require-kubeconfig"`
-
-	LogLevel *int32 `json:"logLevel,omitempty" flag:"v"`
-
-	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
-
+	// KubeconfigPath is the path of kubeconfig for the kubelet
+	KubeconfigPath string `json:"kubeconfigPath,omitempty" flag:"kubeconfig"`
+	// RequireKubeconfig indicates a kubeconfig is required
+	RequireKubeconfig *bool `json:"requireKubeconfig,omitempty" flag:"require-kubeconfig"`
+	// LogLevel is the logging level of the kubelet
+	LogLevel *int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
 	// config is the path to the config file or directory of files
 	PodManifestPath string `json:"podManifestPath,omitempty" flag:"pod-manifest-path"`
-	//// syncFrequency is the max period between synchronizing running
-	//// containers and config
-	//SyncFrequency unversioned.Duration `json:"syncFrequency"`
-	//// fileCheckFrequency is the duration between checking config files for
-	//// new data
-	//FileCheckFrequency unversioned.Duration `json:"fileCheckFrequency"`
-	//// httpCheckFrequency is the duration between checking http for new data
-	//HTTPCheckFrequency unversioned.Duration `json:"httpCheckFrequency"`
-	//// manifestURL is the URL for accessing the container manifest
-	//ManifestURL string `json:"manifestURL"`
-	//// manifestURLHeader is the HTTP header to use when accessing the manifest
-	//// URL, with the key separated from the value with a ':', as in 'key:value'
-	//ManifestURLHeader string `json:"manifestURLHeader"`
-	//// enableServer enables the Kubelet's server
-	//EnableServer bool `json:"enableServer"`
-	//// address is the IP address for the Kubelet to serve on (set to 0.0.0.0
-	//// for all interfaces)
-	//Address string `json:"address"`
-	//// port is the port for the Kubelet to serve on.
-	//Port uint `json:"port"`
-	//// readOnlyPort is the read-only port for the Kubelet to serve on with
-	//// no authentication/authorization (set to 0 to disable)
-	//ReadOnlyPort uint `json:"readOnlyPort"`
-	//// tLSCertFile is the file containing x509 Certificate for HTTPS.  (CA cert,
-	//// if any, concatenated after server cert). If tlsCertFile and
-	//// tlsPrivateKeyFile are not provided, a self-signed certificate
-	//// and key are generated for the public address and saved to the directory
-	//// passed to certDir.
-	//TLSCertFile string `json:"tlsCertFile"`
-	//// tLSPrivateKeyFile is the ile containing x509 private key matching
-	//// tlsCertFile.
-	//TLSPrivateKeyFile string `json:"tlsPrivateKeyFile"`
-	//// certDirectory is the directory where the TLS certs are located (by
-	//// default /var/run/kubernetes). If tlsCertFile and tlsPrivateKeyFile
-	//// are provided, this flag will be ignored.
-	//CertDirectory string `json:"certDirectory"`
-	// hostnameOverride is the hostname used to identify the kubelet instead
-	// of the actual hostname.
-	// Note: We recognize some additional values:
-	//  @aws uses the hostname from the AWS metadata service
+	// HostnameOverride is the hostname used to identify the kubelet instead of the actual hostname.
 	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
-	// podInfraContainerImage is the image whose network/ipc namespaces
-	// containers in each pod will use.
+	// PodInfraContainerImage is the image whose network/ipc containers in each pod will use.
 	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty" flag:"pod-infra-container-image"`
-	//// dockerEndpoint is the path to the docker endpoint to communicate with.
-	//DockerEndpoint string `json:"dockerEndpoint"`
-	//// rootDirectory is the directory path to place kubelet files (volume
-	//// mounts,etc).
-	//RootDirectory string `json:"rootDirectory"`
-	//// seccompProfileRoot is the directory path for seccomp profiles.
-	//SeccompProfileRoot string `json:"seccompProfileRoot"`
-	// allowPrivileged enables containers to request privileged mode.
-	// Defaults to false.
+	// SeccompProfileRoot is the directory path for seccomp profiles.
+	SeccompProfileRoot *string `json:"seccompProfileRoot,omitempty" flag:"seccomp-profile-root"`
+	// AllowPrivileged enables containers to request privileged mode (defaults to false)
 	AllowPrivileged *bool `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
-	//// hostNetworkSources is a comma-separated list of sources from which the
-	//// Kubelet allows pods to use of host network. Defaults to "*".
-	//HostNetworkSources []string `json:"hostNetworkSources"`
-	//// hostPIDSources is a comma-separated list of sources from which the
-	//// Kubelet allows pods to use the host pid namespace. Defaults to "*".
-	//HostPIDSources []string `json:"hostPIDSources"`
-	//// hostIPCSources is a comma-separated list of sources from which the
-	//// Kubelet allows pods to use the host ipc namespace. Defaults to "*".
-	//HostIPCSources []string `json:"hostIPCSources"`
-	//// registryPullQPS is the limit of registry pulls per second. If 0,
-	//// unlimited. Set to 0 for no limit. Defaults to 5.0.
-	//RegistryPullQPS float64 `json:"registryPullQPS"`
-	//// registryBurst is the maximum size of a bursty pulls, temporarily allows
-	//// pulls to burst to this number, while still not exceeding registryQps.
-	//// Only used if registryQps > 0.
-	//RegistryBurst int32 `json:"registryBurst"`
-	//// eventRecordQPS is the maximum event creations per second. If 0, there
-	//// is no limit enforced.
-	//EventRecordQPS float32 `json:"eventRecordQPS"`
-	//// eventBurst is the maximum size of a bursty event records, temporarily
-	//// allows event records to burst to this number, while still not exceeding
-	//// event-qps. Only used if eventQps > 0
-	//EventBurst int32 `json:"eventBurst"`
-	// enableDebuggingHandlers enables server endpoints for log collection
-	// and local running of containers and commands
+	// EnableDebuggingHandlers enables server endpoints for log collection and local running of containers and commands
 	EnableDebuggingHandlers *bool `json:"enableDebuggingHandlers,omitempty" flag:"enable-debugging-handlers"`
-	//// minimumGCAge is the minimum age for a finished container before it is
-	//// garbage collected.
-	//MinimumGCAge unversioned.Duration `json:"minimumGCAge"`
-	//// maxPerPodContainerCount is the maximum number of old instances to
-	//// retain per container. Each container takes up some disk space.
-	//MaxPerPodContainerCount int32 `json:"maxPerPodContainerCount"`
-	//// maxContainerCount is the maximum number of old instances of containers
-	//// to retain globally. Each container takes up some disk space.
-	//MaxContainerCount int32 `json:"maxContainerCount"`
-	//// cAdvisorPort is the port of the localhost cAdvisor endpoint
-	//CAdvisorPort uint `json:"cAdvisorPort"`
-	//// healthzPort is the port of the localhost healthz endpoint
-	//HealthzPort int32 `json:"healthzPort"`
-	//// healthzBindAddress is the IP address for the healthz server to serve
-	//// on.
-	//HealthzBindAddress string `json:"healthzBindAddress"`
-	//// oomScoreAdj is The oom-score-adj value for kubelet process. Values
-	//// must be within the range [-1000, 1000].
-	//OOMScoreAdj int32 `json:"oomScoreAdj"`
-	//// registerNode enables automatic registration with the apiserver.
-	//RegisterNode bool `json:"registerNode"`
-	// clusterDomain is the DNS domain for this cluster. If set, kubelet will
-	// configure all containers to search this domain in addition to the
-	// host's search domains.
+	// RegisterNode enables automatic registration with the apiserver.
+	RegisterNode *bool `json:"registerNode,omitempty" flag:"register-node"`
+	// ClusterDomain is the DNS domain for this cluster
 	ClusterDomain string `json:"clusterDomain,omitempty" flag:"cluster-domain"`
-	//// masterServiceNamespace is The namespace from which the kubernetes
-	//// master services should be injected into pods.
-	//MasterServiceNamespace string `json:"masterServiceNamespace"`
-	// clusterDNS is the IP address for a cluster DNS server.  If set, kubelet
-	// will configure all containers to use this for DNS resolution in
-	// addition to the host's DNS servers
+	// ClusterDNS is the IP address for a cluster DNS server
 	ClusterDNS string `json:"clusterDNS,omitempty" flag:"cluster-dns"`
-	//// streamingConnectionIdleTimeout is the maximum time a streaming connection
-	//// can be idle before the connection is automatically closed.
-	//StreamingConnectionIdleTimeout unversioned.Duration `json:"streamingConnectionIdleTimeout"`
-	//// nodeStatusUpdateFrequency is the frequency that kubelet posts node
-	//// status to master. Note: be cautious when changing the constant, it
-	//// must work with nodeMonitorGracePeriod in nodecontroller.
-	//NodeStatusUpdateFrequency unversioned.Duration `json:"nodeStatusUpdateFrequency"`
-	//// minimumGCAge is the minimum age for a unused image before it is
-	//// garbage collected.
-	//ImageMinimumGCAge unversioned.Duration `json:"imageMinimumGCAge"`
-	//// lowDiskSpaceThresholdMB is the absolute free disk space, in MB, to
-	//// maintain. When disk space falls below this threshold, new pods would
-	//// be rejected.
-	//LowDiskSpaceThresholdMB int32 `json:"lowDiskSpaceThresholdMB"`
-	//// How frequently to calculate and cache volume disk usage for all pods
-	//VolumeStatsAggPeriod unversioned.Duration `json:"volumeStatsAggPeriod"`
-	// networkPluginName is the name of the network plugin to be invoked for
-	// various events in kubelet/pod lifecycle
+	// NetworkPluginName is the name of the network plugin to be invoked for various events in kubelet/pod lifecycle
 	NetworkPluginName string `json:"networkPluginName,omitempty" flag:"network-plugin"`
-	//// networkPluginDir is the full path of the directory in which to search
-	//// for network plugins
-	//NetworkPluginDir string `json:"networkPluginDir"`
-	//// volumePluginDir is the full path of the directory in which to search
-	//// for additional third party volume plugins
-	//VolumePluginDir string `json:"volumePluginDir"`
-	// cloudProvider is the provider for cloud services.
+	// CloudProvider is the provider for cloud services.
 	CloudProvider string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
 	// KubeletCgroups is the absolute name of cgroups to isolate the kubelet in.
 	KubeletCgroups string `json:"kubeletCgroups,omitempty" flag:"kubelet-cgroups"`
@@ -186,30 +62,9 @@ type KubeletConfigSpec struct {
 	// all non-kernel processes that are not already in a container. Empty
 	// for no container. Rolling back the flag requires a reboot.
 	SystemCgroups string `json:"systemCgroups,omitempty" flag:"system-cgroups"`
-	// cgroupRoot is the root cgroup to use for pods. This is handled by the
-	// container runtime on a best effort basis.
+	// cgroupRoot is the root cgroup to use for pods. This is handled by the container runtime on a best effort basis.
 	CgroupRoot string `json:"cgroupRoot,omitempty" flag:"cgroup-root"`
-	//// containerRuntime is the container runtime to use.
-	//ContainerRuntime string `json:"containerRuntime"`
-	//// rktPath is the path of rkt binary. Leave empty to use the first rkt in
-	//// $PATH.
-	//RktPath string `json:"rktPath,omitempty"`
-	//// rktApiEndpoint is the endpoint of the rkt API service to communicate with.
-	//RktAPIEndpoint string `json:"rktAPIEndpoint,omitempty"`
-	//// rktStage1Image is the image to use as stage1. Local paths and
-	//// http/https URLs are supported.
-	//RktStage1Image string `json:"rktStage1Image,omitempty"`
-	//// lockFilePath is the path that kubelet will use to as a lock file.
-	//// It uses this file as a lock to synchronize with other kubelet processes
-	//// that may be running.
-	//LockFilePath string `json:"lockFilePath"`
-	//// ExitOnLockContention is a flag that signifies to the kubelet that it is running
-	//// in "bootstrap" mode. This requires that 'LockFilePath' has been set.
-	//// This will cause the kubelet to listen to inotify events on the lock file,
-	//// releasing it and exiting when another process tries to open that file.
-	//ExitOnLockContention bool `json:"exitOnLockContention"`
-	// configureCBR0 enables the kublet to configure cbr0 based on
-	// Node.Spec.PodCIDR.
+	// configureCBR0 enables the kublet to configure cbr0 based on Node.Spec.PodCIDR.
 	ConfigureCBR0 *bool `json:"configureCbr0,omitempty" flag:"configure-cbr0"`
 	// How should the kubelet configure the container bridge for hairpin packets.
 	// Setting this flag allows endpoints in a Service to loadbalance back to
@@ -221,92 +76,44 @@ type KubeletConfigSpec struct {
 	// one must set --hairpin-mode=veth-flag, because bridge assumes the
 	// existence of a container bridge named cbr0.
 	HairpinMode string `json:"hairpinMode,omitempty" flag:"hairpin-mode"`
-
-	// The node has babysitter process monitoring docker and kubelet.
-	// Removed as of 1.7
+	// The node has babysitter process monitoring docker and kubelet. Removed as of 1.7
 	BabysitDaemons *bool `json:"babysitDaemons,omitempty" flag:"babysit-daemons"`
-
-	// maxPods is the number of pods that can run on this Kubelet.
+	// MaxPods is the number of pods that can run on this Kubelet.
 	MaxPods *int32 `json:"maxPods,omitempty" flag:"max-pods"`
-
-	// nvidiaGPUs is the number of NVIDIA GPU devices on this node.
-	NvidiaGPUs int32 `json:"nvidiaGPUs,omitempty" flag:"experimental-nvidia-gpus"`
-
-	//// dockerExecHandlerName is the handler to use when executing a command
-	//// in a container. Valid values are 'native' and 'nsenter'. Defaults to
-	//// 'native'.
-	//DockerExecHandlerName string `json:"dockerExecHandlerName"`
-	// The CIDR to use for pod IP addresses, only used in standalone mode.
+	// NvidiaGPUs is the number of NVIDIA GPU devices on this node.
+	NvidiaGPUs int32 `json:"nvidiaGPUs,omitempty" flag:"experimental-nvidia-gpus" flag-empty:"0"`
+	// PodCIDR is the CIDR to use for pod IP addresses, only used in standalone mode.
 	// In cluster mode, this is obtained from the master.
 	PodCIDR string `json:"podCIDR,omitempty" flag:"pod-cidr"`
-	// ResolverConfig is the resolver configuration file used as the basis
-	// for the container DNS resolution configuration."), []
+	// ResolverConfig is the resolver configuration file used as the basis for the container DNS resolution configuration."), []
 	ResolverConfig *string `json:"resolvConf,omitempty" flag:"resolv-conf" flag-include-empty:"true"`
-	//// cpuCFSQuota is Enable CPU CFS quota enforcement for containers that
-	//// specify CPU limits
-	//CPUCFSQuota bool `json:"cpuCFSQuota"`
-	//// containerized should be set to true if kubelet is running in a container.
-	//Containerized bool `json:"containerized"`
-	//// maxOpenFiles is Number of files that can be opened by Kubelet process.
-	//MaxOpenFiles uint64 `json:"maxOpenFiles"`
-	// reconcileCIDR is Reconcile node CIDR with the CIDR specified by the
+	// ReconcileCIDR is Reconcile node CIDR with the CIDR specified by the
 	// API server. No-op if register-node or configure-cbr0 is false.
 	ReconcileCIDR *bool `json:"reconcileCIDR,omitempty" flag:"reconcile-cidr"`
-	// registerSchedulable tells the kubelet to register the node as
-	// schedulable. No-op if register-node is false.
+	// registerSchedulable tells the kubelet to register the node as schedulable. No-op if register-node is false.
 	RegisterSchedulable *bool `json:"registerSchedulable,omitempty" flag:"register-schedulable"`
-	//// contentType is contentType of requests sent to apiserver.
-	//ContentType string `json:"contentType"`
-	//// kubeAPIQPS is the QPS to use while talking with kubernetes apiserver
-	//KubeAPIQPS float32 `json:"kubeAPIQPS"`
-	//// kubeAPIBurst is the burst to allow while talking with kubernetes
-	//// apiserver
-	//KubeAPIBurst int32 `json:"kubeAPIBurst"`
-	//// serializeImagePulls when enabled, tells the Kubelet to pull images one
+	//// SerializeImagePulls when enabled, tells the Kubelet to pull images one
 	//// at a time. We recommend *not* changing the default value on nodes that
 	//// run docker daemon with version  < 1.9 or an Aufs storage backend.
 	//// Issue #10959 has more details.
-	//SerializeImagePulls bool `json:"serializeImagePulls"`
-	//// experimentalFlannelOverlay enables experimental support for starting the
-	//// kubelet with the default overlay network (flannel). Assumes flanneld
-	//// is already running in client mode.
-	//ExperimentalFlannelOverlay bool `json:"experimentalFlannelOverlay"`
-	//// outOfDiskTransitionFrequency is duration for which the kubelet has to
-	//// wait before transitioning out of out-of-disk node condition status.
-	//OutOfDiskTransitionFrequency unversioned.Duration `json:"outOfDiskTransitionFrequency,omitempty"`
-	//// nodeIP is IP address of the node. If set, kubelet will use this IP
-	//// address for the node.
-	//NodeIP string `json:"nodeIP,omitempty"`
-
-	// nodeLabels to add when registering the node in the cluster.
+	SerializeImagePulls *bool `json:"serializeImagePulls,omitempty" flag:"serialize-image-pulls"`
+	// NodeLabels to add when registering the node in the cluster.
 	NodeLabels map[string]string `json:"nodeLabels,omitempty" flag:"node-labels"`
-
-	// nonMasqueradeCIDR configures masquerading: traffic to IPs outside this range will use IP masquerade.
+	// NonMasqueradeCIDR configures masquerading: traffic to IPs outside this range will use IP masquerade.
 	NonMasqueradeCIDR string `json:"nonMasqueradeCIDR,omitempty" flag:"non-masquerade-cidr"`
-
-	// enable gathering custom metrics.
+	// Enable gathering custom metrics.
 	EnableCustomMetrics *bool `json:"enableCustomMetrics,omitempty" flag:"enable-custom-metrics"`
-
-	//// Maximum number of pods per core. Cannot exceed MaxPods
-	//PodsPerCore int32 `json:"podsPerCore"`
-	//// enableControllerAttachDetach enables the Attach/Detach controller to
-	//// manage attachment/detachment of volumes scheduled to this node, and
-	//// disables kubelet from executing any attach/detach operations
-	//EnableControllerAttachDetach bool `json:"enableControllerAttachDetach"`
-
-	// networkPluginMTU is the MTU to be passed to the network plugin,
+	// NetworkPluginMTU is the MTU to be passed to the network plugin,
 	// and overrides the default MTU for cases where it cannot be automatically
 	// computed (such as IPSEC).
 	NetworkPluginMTU *int32 `json:"networkPluginMTU,omitempty" flag:"network-plugin-mtu"`
-
-	// imageGCHighThresholdPercent is the percent of disk usage after which
+	// ImageGCHighThresholdPercent is the percent of disk usage after which
 	// image garbage collection is always run.
 	ImageGCHighThresholdPercent *int32 `json:"imageGCHighThresholdPercent,omitempty" flag:"image-gc-high-threshold"`
-	// imageGCLowThresholdPercent is the percent of disk usage before which
+	// ImageGCLowThresholdPercent is the percent of disk usage before which
 	// image garbage collection is never run. Lowest disk usage to garbage
 	// collect to.
 	ImageGCLowThresholdPercent *int32 `json:"imageGCLowThresholdPercent,omitempty" flag:"image-gc-low-threshold"`
-
 	// Comma-delimited list of hard eviction expressions.  For example, 'memory.available<300Mi'.
 	EvictionHard *string `json:"evictionHard,omitempty" flag:"eviction-hard"`
 	// Comma-delimited list of soft eviction expressions.  For example, 'memory.available<300Mi'.
@@ -314,23 +121,18 @@ type KubeletConfigSpec struct {
 	// Comma-delimited list of grace periods for each soft eviction signal.  For example, 'memory.available=30s'.
 	EvictionSoftGracePeriod string `json:"evictionSoftGracePeriod,omitempty" flag:"eviction-soft-grace-period"`
 	// Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.
-	EvictionPressureTransitionPeriod *metav1.Duration `json:"evictionPressureTransitionPeriod,omitempty" flag:"eviction-pressure-transition-period"`
+	EvictionPressureTransitionPeriod *metav1.Duration `json:"evictionPressureTransitionPeriod,omitempty" flag:"eviction-pressure-transition-period" flag-empty:"0s"`
 	// Maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.
-	EvictionMaxPodGracePeriod int32 `json:"evictionMaxPodGracePeriod,omitempty" flag:"eviction-max-pod-grace-period"`
+	EvictionMaxPodGracePeriod int32 `json:"evictionMaxPodGracePeriod,omitempty" flag:"eviction-max-pod-grace-period" flag-empty:"0"`
 	// Comma-delimited list of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.
 	EvictionMinimumReclaim string `json:"evictionMinimumReclaim,omitempty" flag:"eviction-minimum-reclaim"`
-
 	// The full path of the directory in which to search for additional third party volume plugins
 	VolumePluginDirectory string `json:"volumePluginDirectory,omitempty" flag:"volume-plugin-dir"`
-
 	// Taints to add when registering a node in the cluster
 	Taints []string `json:"taints,omitempty" flag:"register-with-taints"`
-
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
-
-	// Resource reservation for kubernetes system daemons like the kubelet,
-	// container runtime, node problem detector, etc.
+	// Resource reservation for kubernetes system daemons like the kubelet, container runtime, node problem detector, etc.
 	KubeReserved map[string]string `json:"kubeReserved,omitempty" flag:"kube-reserved"`
 	// Control group for kube daemons.
 	KubeReservedCgroup string `json:"kubeReservedCgroup,omitempty" flag:"kube-reserved-cgroup"`
@@ -338,107 +140,75 @@ type KubeletConfigSpec struct {
 	SystemReserved map[string]string `json:"systemReserved,omitempty" flag:"system-reserved"`
 	// Parent control group for OS system daemons.
 	SystemReservedCgroup string `json:"systemReservedCgroup,omitempty" flag:"system-reserved-cgroup"`
-	// Enforce Allocatable across pods whenever the overall usage across all pods
-	// exceeds Allocatable.
+	// Enforce Allocatable across pods whenever the overall usage across all pods exceeds Allocatable.
 	EnforceNodeAllocatable string `json:"enforceNodeAllocatable,omitempty" flag:"enforce-node-allocatable"`
 }
 
+// KubeProxyConfig defined the configuration for a proxy
 type KubeProxyConfig struct {
 	Image string `json:"image,omitempty"`
 	// TODO: Better type ?
 	CPURequest string `json:"cpuRequest,omitempty"` // e.g. "20m"
-
+	// LogLevel is the logging level of the proxy
 	LogLevel int32 `json:"logLevel,omitempty" flag:"v"`
-
-	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
-
-	//// bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0
-	//// for all interfaces)
-	//BindAddress string `json:"bindAddress"`
-
-	// clusterCIDR is the CIDR range of the pods in the cluster. It is used to
-	// bridge traffic coming from outside of the cluster. If not provided,
-	// no off-cluster bridging will be performed.
+	// ClusterCIDR is the CIDR range of the pods in the cluster
 	ClusterCIDR string `json:"clusterCIDR,omitempty" flag:"cluster-cidr"`
-
-	//// healthzBindAddress is the IP address for the health check server to serve on,
-	//// defaulting to 127.0.0.1 (set to 0.0.0.0 for all interfaces)
-	//HealthzBindAddress string `json:"healthzBindAddress"`
-	//// healthzPort is the port to bind the health check server. Use 0 to disable.
-	//HealthzPort int32 `json:"healthzPort"`
-
-	// hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
-	// Note: We recognize some additional values:
-	//  @aws uses the hostname from the AWS metadata service
+	// HostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
 	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
-
-	//// iptablesMasqueradeBit is the bit of the iptables fwmark space to use for SNAT if using
-	//// the pure iptables proxy mode. Values must be within the range [0, 31].
-	//IPTablesMasqueradeBit *int32 `json:"iptablesMasqueradeBit"`
-	//// iptablesSyncPeriod is the period that iptables rules are refreshed (e.g. '5s', '1m',
-	//// '2h22m').  Must be greater than 0.
-	//IPTablesSyncPeriod unversioned.Duration `json:"iptablesSyncPeriodSeconds"`
-	//// kubeconfigPath is the path to the kubeconfig file with authorization information (the
-	//// master location is set by the master flag).
-	//KubeconfigPath string `json:"kubeconfigPath"`
-	//// masqueradeAll tells kube-proxy to SNAT everything if using the pure iptables proxy mode.
-	//MasqueradeAll bool `json:"masqueradeAll"`
-	// master is the address of the Kubernetes API server (overrides any value in kubeconfig)
+	// Master is the address of the Kubernetes API server (overrides any value in kubeconfig)
 	Master string `json:"master,omitempty" flag:"master"`
-	//// oomScoreAdj is the oom-score-adj value for kube-proxy process. Values must be within
-	//// the range [-1000, 1000]
-	//OOMScoreAdj *int32 `json:"oomScoreAdj"`
-	//// mode specifies which proxy mode to use.
-	//Mode ProxyMode `json:"mode"`
-	//// portRange is the range of host ports (beginPort-endPort, inclusive) that may be consumed
-	//// in order to proxy service traffic. If unspecified (0-0) then ports will be randomly chosen.
-	//PortRange string `json:"portRange"`
-	//// resourceContainer is the bsolute name of the resource-only container to create and run
-	//// the Kube-proxy in (Default: /kube-proxy).
-	//ResourceContainer string `json:"resourceContainer"`
-	//// udpIdleTimeout is how long an idle UDP connection will be kept open (e.g. '250ms', '2s').
-	//// Must be greater than 0. Only applicable for proxyMode=userspace.
-	//UDPIdleTimeout unversioned.Duration `json:"udpTimeoutMilliseconds"`
-	//// conntrackMax is the maximum number of NAT connections to track (0 to leave as-is)")
-	//ConntrackMax int32 `json:"conntrackMax"`
-	//// conntrackTCPEstablishedTimeout is how long an idle UDP connection will be kept open
-	//// (e.g. '250ms', '2s').  Must be greater than 0. Only applicable for proxyMode is Userspace
-	//ConntrackTCPEstablishedTimeout unversioned.Duration `json:"conntrackTCPEstablishedTimeout"`
+	// FeatureGates is a series of key pairs used to switch on features for the proxy
+	FeatureGates []string `json:"feature-gates" flag:"feature-gates"`
 }
 
+// KubeAPIServerConfig defines the configuration for the kube api
 type KubeAPIServerConfig struct {
-	PathSrvKubernetes string `json:"pathSrvKubernetes,omitempty"`
-	PathSrvSshproxy   string `json:"pathSrvSshproxy,omitempty"`
-	Image             string `json:"image,omitempty"`
-
-	LogLevel int32 `json:"logLevel,omitempty" flag:"v"`
-
-	CloudProvider         string            `json:"cloudProvider,omitempty" flag:"cloud-provider"`
-	SecurePort            int32             `json:"securePort,omitempty" flag:"secure-port"`
-	InsecurePort          int32             `json:"insecurePort,omitempty" flag:"insecure-port"`
-	Address               string            `json:"address,omitempty" flag:"address"`
-	EtcdServers           []string          `json:"etcdServers,omitempty" flag:"etcd-servers"`
-	EtcdServersOverrides  []string          `json:"etcdServersOverrides,omitempty" flag:"etcd-servers-overrides"`
-	AdmissionControl      []string          `json:"admissionControl,omitempty" flag:"admission-control"`
-	ServiceClusterIPRange string            `json:"serviceClusterIPRange,omitempty" flag:"service-cluster-ip-range"`
-	ClientCAFile          string            `json:"clientCAFile,omitempty" flag:"client-ca-file"`
-	BasicAuthFile         string            `json:"basicAuthFile,omitempty" flag:"basic-auth-file"`
-	TLSCertFile           string            `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
-	TLSPrivateKeyFile     string            `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
-	TokenAuthFile         string            `json:"tokenAuthFile,omitempty" flag:"token-auth-file"`
-	AllowPrivileged       *bool             `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
-	APIServerCount        *int32            `json:"apiServerCount,omitempty" flag:"apiserver-count"`
-	RuntimeConfig         map[string]string `json:"runtimeConfig,omitempty" flag:"runtime-config"`
-
+	// Image is the docker container used
+	Image string `json:"image,omitempty"`
+	// LogLevel is the logging level of the api
+	LogLevel int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
+	// CloudProvider is the name of the cloudProvider we are using, aws, gce etcd
+	CloudProvider string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
+	// SecurePort is the port the kube runs on
+	SecurePort int32 `json:"securePort,omitempty" flag:"secure-port"`
+	// InsecurePort is the port the insecure api runs
+	InsecurePort int32 `json:"insecurePort,omitempty" flag:"insecure-port"`
+	// Address is the binding address for the kube api
+	Address string `json:"address,omitempty" flag:"address"`
+	// AdmissionControl is a list of admission controllers to user
+	AdmissionControl []string `json:"admissionControl,omitempty" flag:"admission-control"`
+	// ServiceClusterIPRange is the service address range
+	ServiceClusterIPRange string `json:"serviceClusterIPRange,omitempty" flag:"service-cluster-ip-range"`
+	// EtcdServers is a list of the etcd service to connect
+	EtcdServers []string `json:"etcdServers,omitempty" flag:"etcd-servers"`
+	// EtcdServersOverrides is per-resource etcd servers overrides, comma separated. The individual override format: group/resource#servers, where servers are http://ip:port, semicolon separated
+	EtcdServersOverrides []string `json:"etcdServersOverrides,omitempty" flag:"etcd-servers-overrides"`
+	// TODO: Remove unused BasicAuthFile
+	BasicAuthFile string `json:"basicAuthFile,omitempty" flag:"basic-auth-file"`
+	// TODO: Remove unused ClientCAFile
+	ClientCAFile string `json:"clientCAFile,omitempty" flag:"client-ca-file"`
+	// TODO: Remove unused TLSCertFile
+	TLSCertFile string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
+	// TODO: Remove unused TLSPrivateKeyFile
+	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
+	// TODO: Remove unused TokenAuthFile
+	TokenAuthFile string `json:"tokenAuthFile,omitempty" flag:"token-auth-file"`
+	// AllowPrivileged indicates if we can run privileged containers
+	AllowPrivileged *bool `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
+	// APIServerCount is the number of api servers
+	APIServerCount *int32 `json:"apiServerCount,omitempty" flag:"apiserver-count"`
+	// RuntimeConfig is a series of keys/values are parsed into the `--runtime-config` parameters
+	RuntimeConfig map[string]string `json:"runtimeConfig,omitempty" flag:"runtime-config"`
+	// KubeletClientCertificate is the path of a certificate for secure communication between api and kubelet
 	KubeletClientCertificate string `json:"kubeletClientCertificate,omitempty" flag:"kubelet-client-certificate"`
-	KubeletClientKey         string `json:"kubeletClientKey,omitempty" flag:"kubelet-client-key"`
-
+	// KubeletClientKey is the path of a private to secure communication between api and kubelet
+	KubeletClientKey string `json:"kubeletClientKey,omitempty" flag:"kubelet-client-key"`
+	// AnonymousAuth indicates if anonymous authentication is permitted
 	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"anonymous-auth"`
-
+	// KubeletPreferredAddressTypes is a list of the preferred NodeAddressTypes to use for kubelet connections
 	KubeletPreferredAddressTypes []string `json:"kubeletPreferredAddressTypes,omitempty" flag:"kubelet-preferred-address-types"`
-
+	// StorageBackend is the backend storage
 	StorageBackend *string `json:"storageBackend,omitempty" flag:"storage-backend"`
-
 	// The OpenID claim to use as the user name.
 	// Note that claims other than the default ('sub') is not guaranteed to be unique and immutable.
 	OIDCUsernameClaim *string `json:"oidcUsernameClaim,omitempty" flag:"oidc-username-claim"`
@@ -451,9 +221,7 @@ type KubeAPIServerConfig struct {
 	// The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
 	OIDCClientID *string `json:"oidcClientID,omitempty" flag:"oidc-client-id"`
 	// If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file
-	// otherwise the host's root CA set will be used.
 	OIDCCAFile *string `json:"oidcCAFile,omitempty" flag:"oidc-ca-file"`
-
 	// If set, all requests coming to the apiserver will be logged to this file.
 	AuditLogPath *string `json:"auditLogPath,omitempty" flag:"audit-log-path"`
 	// The maximum number of days to retain old audit log files based on the timestamp encoded in their filename.
@@ -462,206 +230,61 @@ type KubeAPIServerConfig struct {
 	AuditLogMaxBackups *int32 `json:"auditLogMaxBackups,omitempty" flag:"audit-log-maxbackup"`
 	// The maximum size in megabytes of the audit log file before it gets rotated. Defaults to 100MB.
 	AuditLogMaxSize *int32 `json:"auditLogMaxSize,omitempty" flag:"audit-log-maxsize"`
-
 	// File with webhook configuration for token authentication in kubeconfig format. The API server will query the remote service to determine authentication for bearer tokens.
 	AuthenticationTokenWebhookConfigFile *string `json:"authenticationTokenWebhookConfigFile,omitempty" flag:"authentication-token-webhook-config-file"`
 	// The duration to cache responses from the webhook token authenticator. Default is 2m. (default 2m0s)
-	AuthenticationTokenWebhookCacheTtl *metav1.Duration `json:"authenticationTokenWebhookCacheTtl,omitempty" flag:"authentication-token-webhook-cache-ttl"`
-
-	AuthorizationMode          *string `json:"authorizationMode,omitempty" flag:"authorization-mode"`
+	AuthenticationTokenWebhookCacheTTL *metav1.Duration `json:"authenticationTokenWebhookCacheTtl,omitempty" flag:"authentication-token-webhook-cache-ttl"`
+	// AuthorizationMode is the authorization mode the kubeapi is running in
+	AuthorizationMode *string `json:"authorizationMode,omitempty" flag:"authorization-mode"`
+	// AuthorizationRBACSuperUser is the name of the superuser for default rbac
 	AuthorizationRBACSuperUser *string `json:"authorizationRbacSuperUser,omitempty" flag:"authorization-rbac-super-user"`
 }
 
+// KubeControllerManagerConfig is the configuration for the controller
 type KubeControllerManagerConfig struct {
-	Master   string `json:"master,omitempty" flag:"master"`
-	LogLevel int32  `json:"logLevel,omitempty" flag:"v"`
-
+	// Master is the url for the kube api master
+	Master string `json:"master,omitempty" flag:"master"`
+	// LogLevel is the defined logLevel
+	LogLevel int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
+	// ServiceAccountPrivateKeyFile the location for a certificate for service account signing
 	ServiceAccountPrivateKeyFile string `json:"serviceAccountPrivateKeyFile,omitempty" flag:"service-account-private-key-file"`
-
+	// Image is the docker image to use
 	Image string `json:"image,omitempty"`
-
-	PathSrvKubernetes string `json:"pathSrvKubernetes,omitempty"`
-
-	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
-
-	//// port is the port that the controller-manager's http service runs on.
-	//Port int32 `json:"port"`
-	//// address is the IP address to serve on (set to 0.0.0.0 for all interfaces).
-	//Address string `json:"address"`
-	// cloudProvider is the provider for cloud services.
+	// CloudProvider is the provider for cloud services.
 	CloudProvider string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
-	//// concurrentEndpointSyncs is the number of endpoint syncing operations
-	//// that will be done concurrently. Larger number = faster endpoint updating,
-	//// but more CPU (and network) load.
-	//ConcurrentEndpointSyncs int32 `json:"concurrentEndpointSyncs"`
-	//// concurrentRSSyncs is the number of replica sets that are  allowed to sync
-	//// concurrently. Larger number = more responsive replica  management, but more
-	//// CPU (and network) load.
-	//ConcurrentRSSyncs int32 `json:"concurrentRSSyncs"`
-	//// concurrentRCSyncs is the number of replication controllers that are
-	//// allowed to sync concurrently. Larger number = more responsive replica
-	//// management, but more CPU (and network) load.
-	//ConcurrentRCSyncs int32 `json:"concurrentRCSyncs"`
-	//// concurrentResourceQuotaSyncs is the number of resource quotas that are
-	//// allowed to sync concurrently. Larger number = more responsive quota
-	//// management, but more CPU (and network) load.
-	//ConcurrentResourceQuotaSyncs int32 `json:"concurrentResourceQuotaSyncs"`
-	//// concurrentDeploymentSyncs is the number of deployment objects that are
-	//// allowed to sync concurrently. Larger number = more responsive deployments,
-	//// but more CPU (and network) load.
-	//ConcurrentDeploymentSyncs int32 `json:"concurrentDeploymentSyncs"`
-	//// concurrentDaemonSetSyncs is the number of daemonset objects that are
-	//// allowed to sync concurrently. Larger number = more responsive daemonset,
-	//// but more CPU (and network) load.
-	//ConcurrentDaemonSetSyncs int32 `json:"concurrentDaemonSetSyncs"`
-	//// concurrentJobSyncs is the number of job objects that are
-	//// allowed to sync concurrently. Larger number = more responsive jobs,
-	//// but more CPU (and network) load.
-	//ConcurrentJobSyncs int32 `json:"concurrentJobSyncs"`
-	//// concurrentNamespaceSyncs is the number of namespace objects that are
-	//// allowed to sync concurrently.
-	//ConcurrentNamespaceSyncs int32 `json:"concurrentNamespaceSyncs"`
-	//// lookupCacheSizeForRC is the size of lookup cache for replication controllers.
-	//// Larger number = more responsive replica management, but more MEM load.
-	//LookupCacheSizeForRC int32 `json:"lookupCacheSizeForRC"`
-	//// lookupCacheSizeForRS is the size of lookup cache for replicatsets.
-	//// Larger number = more responsive replica management, but more MEM load.
-	//LookupCacheSizeForRS int32 `json:"lookupCacheSizeForRS"`
-	//// lookupCacheSizeForDaemonSet is the size of lookup cache for daemonsets.
-	//// Larger number = more responsive daemonset, but more MEM load.
-	//LookupCacheSizeForDaemonSet int32 `json:"lookupCacheSizeForDaemonSet"`
-	//// serviceSyncPeriod is the period for syncing services with their external
-	//// load balancers.
-	//ServiceSyncPeriod unversioned.Duration `json:"serviceSyncPeriod"`
-	//// nodeSyncPeriod is the period for syncing nodes from cloudprovider. Longer
-	//// periods will result in fewer calls to cloud provider, but may delay addition
-	//// of new nodes to cluster.
-	//NodeSyncPeriod unversioned.Duration `json:"nodeSyncPeriod"`
-	//// resourceQuotaSyncPeriod is the period for syncing quota usage status
-	//// in the system.
-	//ResourceQuotaSyncPeriod unversioned.Duration `json:"resourceQuotaSyncPeriod"`
-	//// namespaceSyncPeriod is the period for syncing namespace life-cycle
-	//// updates.
-	//NamespaceSyncPeriod unversioned.Duration `json:"namespaceSyncPeriod"`
-	//// pvClaimBinderSyncPeriod is the period for syncing persistent volumes
-	//// and persistent volume claims.
-	//PVClaimBinderSyncPeriod unversioned.Duration `json:"pvClaimBinderSyncPeriod"`
-	//// minResyncPeriod is the resync period in reflectors; will be random between
-	//// minResyncPeriod and 2*minResyncPeriod.
-	//MinResyncPeriod unversioned.Duration `json:"minResyncPeriod"`
-	//// horizontalPodAutoscalerSyncPeriod is the period for syncing the number of
-	//// pods in horizontal pod autoscaler.
-	//HorizontalPodAutoscalerSyncPeriod unversioned.Duration `json:"horizontalPodAutoscalerSyncPeriod"`
-	//// deploymentControllerSyncPeriod is the period for syncing the deployments.
-	//DeploymentControllerSyncPeriod unversioned.Duration `json:"deploymentControllerSyncPeriod"`
-	//// podEvictionTimeout is the grace period for deleting pods on failed nodes.
-	//PodEvictionTimeout unversioned.Duration `json:"podEvictionTimeout"`
-	//// deletingPodsQps is the number of nodes per second on which pods are deleted in
-	//// case of node failure.
-	//DeletingPodsQps float32 `json:"deletingPodsQps"`
-	//// deletingPodsBurst is the number of nodes on which pods are bursty deleted in
-	//// case of node failure. For more details look into RateLimiter.
-	//DeletingPodsBurst int32 `json:"deletingPodsBurst"`
-	//// nodeMontiorGracePeriod is the amount of time which we allow a running node to be
-	//// unresponsive before marking it unhealthy. Must be N times more than kubelet's
-	//// nodeStatusUpdateFrequency, where N means number of retries allowed for kubelet
-	//// to post node status.
-	//NodeMonitorGracePeriod unversioned.Duration `json:"nodeMonitorGracePeriod"`
-	//// registerRetryCount is the number of retries for initial node registration.
-	//// Retry interval equals node-sync-period.
-	//RegisterRetryCount int32 `json:"registerRetryCount"`
-	//// nodeStartupGracePeriod is the amount of time which we allow starting a node to
-	//// be unresponsive before marking it unhealthy.
-	//NodeStartupGracePeriod unversioned.Duration `json:"nodeStartupGracePeriod"`
-	//// nodeMonitorPeriod is the period for syncing NodeStatus in NodeController.
-	//NodeMonitorPeriod unversioned.Duration `json:"nodeMonitorPeriod"`
-	//// serviceAccountKeyFile is the filename containing a PEM-encoded private RSA key
-	//// used to sign service account tokens.
-	//ServiceAccountKeyFile string `json:"serviceAccountKeyFile"`
-	//// enableProfiling enables profiling via web interface host:port/debug/pprof/
-	//EnableProfiling bool `json:"enableProfiling"`
-	// clusterName is the instance prefix for the cluster.
+	// ClusterName is the instance prefix for the cluster.
 	ClusterName string `json:"clusterName,omitempty" flag:"cluster-name"`
-	// clusterCIDR is CIDR Range for Pods in cluster.
+	// ClusterCIDR is CIDR Range for Pods in cluster.
 	ClusterCIDR string `json:"clusterCIDR,omitempty" flag:"cluster-cidr"`
-	//// serviceCIDR is CIDR Range for Services in cluster.
-	//ServiceCIDR string `json:"serviceCIDR"`
-	//// NodeCIDRMaskSize is the mask size for node cidr in cluster.
-	//NodeCIDRMaskSize int32 `json:"nodeCIDRMaskSize"`
-	// allocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
+	// AllocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
 	// ConfigureCloudRoutes is true, to be set on the cloud provider.
 	AllocateNodeCIDRs *bool `json:"allocateNodeCIDRs,omitempty" flag:"allocate-node-cidrs"`
-	// configureCloudRoutes enables CIDRs allocated with allocateNodeCIDRs
-	// to be configured on the cloud provider.
+	// ConfigureCloudRoutes enables CIDRs allocated with to be configured on the cloud provider.
 	ConfigureCloudRoutes *bool `json:"configureCloudRoutes,omitempty" flag:"configure-cloud-routes"`
-	// rootCAFile is the root certificate authority will be included in service
-	// account's token secret. This must be a valid PEM-encoded CA bundle.
+	// rootCAFile is the root certificate authority will be included in service account's token secret. This must be a valid PEM-encoded CA bundle.
 	RootCAFile string `json:"rootCAFile,omitempty" flag:"root-ca-file"`
-	//// contentType is contentType of requests sent to apiserver.
-	//ContentType string `json:"contentType"`
-	//// kubeAPIQPS is the QPS to use while talking with kubernetes apiserver.
-	//KubeAPIQPS float32 `json:"kubeAPIQPS"`
-	//// kubeAPIBurst is the burst to use while talking with kubernetes apiserver.
-	//KubeAPIBurst int32 `json:"kubeAPIBurst"`
-	// leaderElection defines the configuration of leader election client.
+	// LeaderElection defines the configuration of leader election client.
 	LeaderElection *LeaderElectionConfiguration `json:"leaderElection,omitempty"`
-	//// volumeConfiguration holds configuration for volume related features.
-	//VolumeConfiguration VolumeConfiguration `json:"volumeConfiguration"`
-	//// How long to wait between starting controller managers
-	//ControllerStartInterval unversioned.Duration `json:"controllerStartInterval"`
-	//// enables the generic garbage collector. MUST be synced with the
-	//// corresponding flag of the kube-apiserver. WARNING: the generic garbage
-	//// collector is an alpha feature.
-	//EnableGarbageCollector bool `json:"enableGarbageCollector"`
-
 	// ReconcilerSyncLoopPeriod is the amount of time the reconciler sync states loop
 	// wait between successive executions. Is set to 1 min by kops by default
 	AttachDetachReconcileSyncPeriod *metav1.Duration `json:"attachDetachReconcileSyncPeriod,omitempty" flag:"attach-detach-reconcile-sync-period"`
-
-	// terminatedPodGCThreshold is the number of terminated pods that can exist
+	// TerminatedPodGCThreshold is the number of terminated pods that can exist
 	// before the terminated pod garbage collector starts deleting terminated pods.
 	// If <= 0, the terminated pod garbage collector is disabled.
 	TerminatedPodGCThreshold *int32 `json:"terminatedPodGCThreshold,omitempty" flag:"terminated-pod-gc-threshold"`
-
 	// UseServiceAccountCredentials controls whether we use individual service account credentials for each controller.
 	UseServiceAccountCredentials *bool `json:"useServiceAccountCredentials,omitempty" flag:"use-service-account-credentials"`
 }
 
+// KubeSchedulerConfig is the configuration for the kube-scheduler
 type KubeSchedulerConfig struct {
-	Master   string `json:"master,omitempty" flag:"master"`
-	LogLevel int32  `json:"logLevel,omitempty" flag:"v"`
-
+	// Master is a url to the kube master
+	Master string `json:"master,omitempty" flag:"master"`
+	// LogLevel is the logging level
+	LogLevel int32 `json:"logLevel,omitempty" flag:"v"`
+	// Image is the docker image to use
 	Image string `json:"image,omitempty"`
-
-	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
-
-	//// port is the port that the scheduler's http service runs on.
-	//Port int32 `json:"port"`
-	//// address is the IP address to serve on.
-	//Address string `json:"address"`
-	//// algorithmProvider is the scheduling algorithm provider to use.
-	//AlgorithmProvider string `json:"algorithmProvider"`
-	//// policyConfigFile is the filepath to the scheduler policy configuration.
-	//PolicyConfigFile string `json:"policyConfigFile"`
-	//// enableProfiling enables profiling via web interface.
-	//EnableProfiling bool `json:"enableProfiling"`
-	//// contentType is contentType of requests sent to apiserver.
-	//ContentType string `json:"contentType"`
-	//// kubeAPIQPS is the QPS to use while talking with kubernetes apiserver.
-	//KubeAPIQPS float32 `json:"kubeAPIQPS"`
-	//// kubeAPIBurst is the QPS burst to use while talking with kubernetes apiserver.
-	//KubeAPIBurst int32 `json:"kubeAPIBurst"`
-	//// schedulerName is name of the scheduler, used to select which pods
-	//// will be processed by this scheduler, based on pod's annotation with
-	//// key 'scheduler.alpha.kubernetes.io/name'.
-	//SchedulerName string `json:"schedulerName"`
-	//// RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule
-	//// corresponding to every RequiredDuringScheduling affinity rule.
-	//// HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 0-100.
-	//HardPodAffinitySymmetricWeight int `json:"hardPodAffinitySymmetricWeight"`
-	//// Indicate the "all topologies" set for empty topologyKey when it's used for PreferredDuringScheduling pod anti-affinity.
-	//FailureDomains string `json:"failureDomains"`
-	// leaderElection defines the configuration of leader election client.
+	// LeaderElection defines the configuration of leader election client.
 	LeaderElection *LeaderElectionConfiguration `json:"leaderElection,omitempty"`
 }
 
@@ -672,24 +295,9 @@ type LeaderElectionConfiguration struct {
 	// before executing the main loop. Enable this when running replicated
 	// components for high availability.
 	LeaderElect *bool `json:"leaderElect,omitempty" flag:"leader-elect"`
-	//// leaseDuration is the duration that non-leader candidates will wait
-	//// after observing a leadership renewal until attempting to acquire
-	//// leadership of a led but unrenewed leader slot. This is effectively the
-	//// maximum duration that a leader can be stopped before it is replaced
-	//// by another candidate. This is only applicable if leader election is
-	//// enabled.
-	//LeaseDuration unversioned.Duration `json:"leaseDuration"`
-	//// renewDeadline is the interval between attempts by the acting master to
-	//// renew a leadership slot before it stops leading. This must be less
-	//// than or equal to the lease duration. This is only applicable if leader
-	//// election is enabled.
-	//RenewDeadline unversioned.Duration `json:"renewDeadline"`
-	//// retryPeriod is the duration the clients should wait between attempting
-	//// acquisition and renewal of a leadership. This is only applicable if
-	//// leader election is enabled.
-	//RetryPeriod unversioned.Duration `json:"retryPeriod"`
 }
 
+// CloudConfiguration is defines the cloud provider configuration
 type CloudConfiguration struct {
 	// GCE cloud-config options
 	Multizone          *bool   `json:"multizone,omitempty"`
@@ -698,13 +306,12 @@ type CloudConfiguration struct {
 	// AWS cloud-config options
 	DisableSecurityGroupIngress *bool   `json:"disableSecurityGroupIngress,omitempty"`
 	ElbSecurityGroup            *string `json:"elbSecurityGroup,omitempty"`
-
 	// vSphere cloud-config specs
 	VSphereUsername      *string `json:"vSphereUsername,omitempty"`
 	VSpherePassword      *string `json:"vSpherePassword,omitempty"`
 	VSphereServer        *string `json:"vSphereServer,omitempty"`
 	VSphereDatacenter    *string `json:"vSphereDatacenter,omitempty"`
-	VSphereDatastore     *string `json:"vSphereDatastore,omitempty"`
 	VSphereResourcePool  *string `json:"vSphereResourcePool,omitempty"`
+	VSphereDatastore     *string `json:"vSphereDatastore,omitempty"`
 	VSphereCoreDNSServer *string `json:"vSphereCoreDNSServer,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha1/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha1/dockerconfig.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package v1alpha1
 
+// DockerConfig is the configuration for docker
 type DockerConfig struct {
 	Bridge   *string `json:"bridge,omitempty" flag:"bridge"`
 	LogLevel *string `json:"logLevel,omitempty" flag:"log-level"`

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -392,8 +392,8 @@ func autoConvert_v1alpha1_CloudConfiguration_To_kops_CloudConfiguration(in *Clou
 	out.VSpherePassword = in.VSpherePassword
 	out.VSphereServer = in.VSphereServer
 	out.VSphereDatacenter = in.VSphereDatacenter
-	out.VSphereDatastore = in.VSphereDatastore
 	out.VSphereResourcePool = in.VSphereResourcePool
+	out.VSphereDatastore = in.VSphereDatastore
 	out.VSphereCoreDNSServer = in.VSphereCoreDNSServer
 	return nil
 }
@@ -1359,20 +1359,18 @@ func Convert_kops_KopeioNetworkingSpec_To_v1alpha1_KopeioNetworkingSpec(in *kops
 }
 
 func autoConvert_v1alpha1_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *KubeAPIServerConfig, out *kops.KubeAPIServerConfig, s conversion.Scope) error {
-	out.PathSrvKubernetes = in.PathSrvKubernetes
-	out.PathSrvSshproxy = in.PathSrvSshproxy
 	out.Image = in.Image
 	out.LogLevel = in.LogLevel
 	out.CloudProvider = in.CloudProvider
 	out.SecurePort = in.SecurePort
 	out.InsecurePort = in.InsecurePort
 	out.Address = in.Address
-	out.EtcdServers = in.EtcdServers
-	out.EtcdServersOverrides = in.EtcdServersOverrides
 	out.AdmissionControl = in.AdmissionControl
 	out.ServiceClusterIPRange = in.ServiceClusterIPRange
-	out.ClientCAFile = in.ClientCAFile
+	out.EtcdServers = in.EtcdServers
+	out.EtcdServersOverrides = in.EtcdServersOverrides
 	out.BasicAuthFile = in.BasicAuthFile
+	out.ClientCAFile = in.ClientCAFile
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	out.TokenAuthFile = in.TokenAuthFile
@@ -1394,7 +1392,7 @@ func autoConvert_v1alpha1_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.AuditLogMaxBackups = in.AuditLogMaxBackups
 	out.AuditLogMaxSize = in.AuditLogMaxSize
 	out.AuthenticationTokenWebhookConfigFile = in.AuthenticationTokenWebhookConfigFile
-	out.AuthenticationTokenWebhookCacheTtl = in.AuthenticationTokenWebhookCacheTtl
+	out.AuthenticationTokenWebhookCacheTTL = in.AuthenticationTokenWebhookCacheTTL
 	out.AuthorizationMode = in.AuthorizationMode
 	out.AuthorizationRBACSuperUser = in.AuthorizationRBACSuperUser
 	return nil
@@ -1406,28 +1404,26 @@ func Convert_v1alpha1_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *KubeAP
 }
 
 func autoConvert_kops_KubeAPIServerConfig_To_v1alpha1_KubeAPIServerConfig(in *kops.KubeAPIServerConfig, out *KubeAPIServerConfig, s conversion.Scope) error {
-	out.PathSrvKubernetes = in.PathSrvKubernetes
-	out.PathSrvSshproxy = in.PathSrvSshproxy
 	out.Image = in.Image
 	out.LogLevel = in.LogLevel
 	out.CloudProvider = in.CloudProvider
 	out.SecurePort = in.SecurePort
 	out.InsecurePort = in.InsecurePort
 	out.Address = in.Address
-	out.EtcdServers = in.EtcdServers
-	out.EtcdServersOverrides = in.EtcdServersOverrides
 	out.AdmissionControl = in.AdmissionControl
 	out.ServiceClusterIPRange = in.ServiceClusterIPRange
+	out.EtcdServers = in.EtcdServers
+	out.EtcdServersOverrides = in.EtcdServersOverrides
 	out.BasicAuthFile = in.BasicAuthFile
 	out.ClientCAFile = in.ClientCAFile
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
-	out.KubeletClientCertificate = in.KubeletClientCertificate
-	out.KubeletClientKey = in.KubeletClientKey
 	out.TokenAuthFile = in.TokenAuthFile
 	out.AllowPrivileged = in.AllowPrivileged
 	out.APIServerCount = in.APIServerCount
 	out.RuntimeConfig = in.RuntimeConfig
+	out.KubeletClientCertificate = in.KubeletClientCertificate
+	out.KubeletClientKey = in.KubeletClientKey
 	out.AnonymousAuth = in.AnonymousAuth
 	out.KubeletPreferredAddressTypes = in.KubeletPreferredAddressTypes
 	out.StorageBackend = in.StorageBackend
@@ -1441,7 +1437,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha1_KubeAPIServerConfig(in *ko
 	out.AuditLogMaxBackups = in.AuditLogMaxBackups
 	out.AuditLogMaxSize = in.AuditLogMaxSize
 	out.AuthenticationTokenWebhookConfigFile = in.AuthenticationTokenWebhookConfigFile
-	out.AuthenticationTokenWebhookCacheTtl = in.AuthenticationTokenWebhookCacheTtl
+	out.AuthenticationTokenWebhookCacheTTL = in.AuthenticationTokenWebhookCacheTTL
 	out.AuthorizationMode = in.AuthorizationMode
 	out.AuthorizationRBACSuperUser = in.AuthorizationRBACSuperUser
 	return nil
@@ -1457,7 +1453,6 @@ func autoConvert_v1alpha1_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.LogLevel = in.LogLevel
 	out.ServiceAccountPrivateKeyFile = in.ServiceAccountPrivateKeyFile
 	out.Image = in.Image
-	out.PathSrvKubernetes = in.PathSrvKubernetes
 	out.CloudProvider = in.CloudProvider
 	out.ClusterName = in.ClusterName
 	out.ClusterCIDR = in.ClusterCIDR
@@ -1489,7 +1484,6 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha1_KubeControllerMana
 	out.LogLevel = in.LogLevel
 	out.ServiceAccountPrivateKeyFile = in.ServiceAccountPrivateKeyFile
 	out.Image = in.Image
-	out.PathSrvKubernetes = in.PathSrvKubernetes
 	out.CloudProvider = in.CloudProvider
 	out.ClusterName = in.ClusterName
 	out.ClusterCIDR = in.ClusterCIDR
@@ -1549,6 +1543,7 @@ func autoConvert_v1alpha1_KubeProxyConfig_To_kops_KubeProxyConfig(in *KubeProxyC
 	out.ClusterCIDR = in.ClusterCIDR
 	out.HostnameOverride = in.HostnameOverride
 	out.Master = in.Master
+	out.FeatureGates = in.FeatureGates
 	return nil
 }
 
@@ -1564,6 +1559,7 @@ func autoConvert_kops_KubeProxyConfig_To_v1alpha1_KubeProxyConfig(in *kops.KubeP
 	out.ClusterCIDR = in.ClusterCIDR
 	out.HostnameOverride = in.HostnameOverride
 	out.Master = in.Master
+	out.FeatureGates = in.FeatureGates
 	return nil
 }
 
@@ -1624,8 +1620,10 @@ func autoConvert_v1alpha1_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride
 	out.PodInfraContainerImage = in.PodInfraContainerImage
+	out.SeccompProfileRoot = in.SeccompProfileRoot
 	out.AllowPrivileged = in.AllowPrivileged
 	out.EnableDebuggingHandlers = in.EnableDebuggingHandlers
+	out.RegisterNode = in.RegisterNode
 	out.ClusterDomain = in.ClusterDomain
 	out.ClusterDNS = in.ClusterDNS
 	out.NetworkPluginName = in.NetworkPluginName
@@ -1643,6 +1641,7 @@ func autoConvert_v1alpha1_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.ResolverConfig = in.ResolverConfig
 	out.ReconcileCIDR = in.ReconcileCIDR
 	out.RegisterSchedulable = in.RegisterSchedulable
+	out.SerializeImagePulls = in.SerializeImagePulls
 	out.NodeLabels = in.NodeLabels
 	out.NonMasqueradeCIDR = in.NonMasqueradeCIDR
 	out.EnableCustomMetrics = in.EnableCustomMetrics
@@ -1681,8 +1680,10 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha1_KubeletConfigSpec(in *kops.K
 	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride
 	out.PodInfraContainerImage = in.PodInfraContainerImage
+	out.SeccompProfileRoot = in.SeccompProfileRoot
 	out.AllowPrivileged = in.AllowPrivileged
 	out.EnableDebuggingHandlers = in.EnableDebuggingHandlers
+	out.RegisterNode = in.RegisterNode
 	out.ClusterDomain = in.ClusterDomain
 	out.ClusterDNS = in.ClusterDNS
 	out.NetworkPluginName = in.NetworkPluginName
@@ -1700,6 +1701,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha1_KubeletConfigSpec(in *kops.K
 	out.ResolverConfig = in.ResolverConfig
 	out.ReconcileCIDR = in.ReconcileCIDR
 	out.RegisterSchedulable = in.RegisterSchedulable
+	out.SerializeImagePulls = in.SerializeImagePulls
 	out.NodeLabels = in.NodeLabels
 	out.NonMasqueradeCIDR = in.NonMasqueradeCIDR
 	out.EnableCustomMetrics = in.EnableCustomMetrics

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -18,52 +18,41 @@ package v1alpha2
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+// KubeletConfigSpec defines the kubelet configuration
 type KubeletConfigSpec struct {
-	// not used for clusters version 1.6 and later
+	// APIServers is not used for clusters version 1.6 and later - flag removed
 	APIServers string `json:"apiServers,omitempty" flag:"api-servers"`
-
-	// AnonymousAuth chooses if you want anonymous auth on the kubelet api
+	// AnonymousAuth permits you to control auth to the kubelet api
 	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"anonymous-auth"`
-	// The client CA which the requestes for the above must be signed by
+	// ClientCAFile is the path to a CA certificate
 	ClientCAFile string `json:"clientCaFile,omitempty" flag:"client-ca-file"`
-
-	// kubeconfigPath is the path to the kubeconfig file with authorization
-	// information and API server location
-	// kops will only use this for clusters version 1.6 and later
-	KubeconfigPath    string `json:"kubeconfigPath,omitempty" flag:"kubeconfig"`
-	RequireKubeconfig *bool  `json:"requireKubeconfig,omitempty" flag:"require-kubeconfig"`
-
-	LogLevel *int32 `json:"logLevel,omitempty" flag:"v"`
-
-	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
-
+	// KubeconfigPath is the path of kubeconfig for the kubelet
+	KubeconfigPath string `json:"kubeconfigPath,omitempty" flag:"kubeconfig"`
+	// RequireKubeconfig indicates a kubeconfig is required
+	RequireKubeconfig *bool `json:"requireKubeconfig,omitempty" flag:"require-kubeconfig"`
+	// LogLevel is the logging level of the kubelet
+	LogLevel *int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
+	// config is the path to the config file or directory of files
 	PodManifestPath string `json:"podManifestPath,omitempty" flag:"pod-manifest-path"`
-	// hostnameOverride is the hostname used to identify the kubelet instead
-	// of the actual hostname.
-	// Note: We recognize some additional values:
-	//  @aws uses the hostname from the AWS metadata service
+	// HostnameOverride is the hostname used to identify the kubelet instead of the actual hostname.
 	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
-	// podInfraContainerImage is the image whose network/ipc namespaces
-	// containers in each pod will use.
+	// PodInfraContainerImage is the image whose network/ipc containers in each pod will use.
 	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty" flag:"pod-infra-container-image"`
-	// allowPrivileged enables containers to request privileged mode.
-	// Defaults to false.
+	// SeccompProfileRoot is the directory path for seccomp profiles.
+	SeccompProfileRoot *string `json:"seccompProfileRoot,omitempty" flag:"seccomp-profile-root"`
+	// AllowPrivileged enables containers to request privileged mode (defaults to false)
 	AllowPrivileged *bool `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
-	// enableDebuggingHandlers enables server endpoints for log collection
-	// and local running of containers and commands
+	// EnableDebuggingHandlers enables server endpoints for log collection and local running of containers and commands
 	EnableDebuggingHandlers *bool `json:"enableDebuggingHandlers,omitempty" flag:"enable-debugging-handlers"`
-	// clusterDomain is the DNS domain for this cluster. If set, kubelet will
-	// configure all containers to search this domain in addition to the
-	// host's search domains.
+	// RegisterNode enables automatic registration with the apiserver.
+	RegisterNode *bool `json:"registerNode,omitempty" flag:"register-node"`
+	// ClusterDomain is the DNS domain for this cluster
 	ClusterDomain string `json:"clusterDomain,omitempty" flag:"cluster-domain"`
-	// clusterDNS is the IP address for a cluster DNS server.  If set, kubelet
-	// will configure all containers to use this for DNS resolution in
-	// addition to the host's DNS servers
+	// ClusterDNS is the IP address for a cluster DNS server
 	ClusterDNS string `json:"clusterDNS,omitempty" flag:"cluster-dns"`
-	// networkPluginName is the name of the network plugin to be invoked for
-	// various events in kubelet/pod lifecycle
+	// NetworkPluginName is the name of the network plugin to be invoked for various events in kubelet/pod lifecycle
 	NetworkPluginName string `json:"networkPluginName,omitempty" flag:"network-plugin"`
-	// cloudProvider is the provider for cloud services.
+	// CloudProvider is the provider for cloud services.
 	CloudProvider string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
 	// KubeletCgroups is the absolute name of cgroups to isolate the kubelet in.
 	KubeletCgroups string `json:"kubeletCgroups,omitempty" flag:"kubelet-cgroups"`
@@ -73,11 +62,9 @@ type KubeletConfigSpec struct {
 	// all non-kernel processes that are not already in a container. Empty
 	// for no container. Rolling back the flag requires a reboot.
 	SystemCgroups string `json:"systemCgroups,omitempty" flag:"system-cgroups"`
-	// cgroupRoot is the root cgroup to use for pods. This is handled by the
-	// container runtime on a best effort basis.
+	// cgroupRoot is the root cgroup to use for pods. This is handled by the container runtime on a best effort basis.
 	CgroupRoot string `json:"cgroupRoot,omitempty" flag:"cgroup-root"`
-	// configureCBR0 enables the kublet to configure cbr0 based on
-	// Node.Spec.PodCIDR.
+	// configureCBR0 enables the kublet to configure cbr0 based on Node.Spec.PodCIDR.
 	ConfigureCBR0 *bool `json:"configureCbr0,omitempty" flag:"configure-cbr0"`
 	// How should the kubelet configure the container bridge for hairpin packets.
 	// Setting this flag allows endpoints in a Service to loadbalance back to
@@ -89,53 +76,44 @@ type KubeletConfigSpec struct {
 	// one must set --hairpin-mode=veth-flag, because bridge assumes the
 	// existence of a container bridge named cbr0.
 	HairpinMode string `json:"hairpinMode,omitempty" flag:"hairpin-mode"`
-
-	// The node has babysitter process monitoring docker and kubelet.
-	// Removed as of 1.7
+	// The node has babysitter process monitoring docker and kubelet. Removed as of 1.7
 	BabysitDaemons *bool `json:"babysitDaemons,omitempty" flag:"babysit-daemons"`
-
-	// maxPods is the number of pods that can run on this Kubelet.
+	// MaxPods is the number of pods that can run on this Kubelet.
 	MaxPods *int32 `json:"maxPods,omitempty" flag:"max-pods"`
-
-	// nvidiaGPUs is the number of NVIDIA GPU devices on this node.
-	NvidiaGPUs int32 `json:"nvidiaGPUs,omitempty" flag:"experimental-nvidia-gpus"`
-
-	// The CIDR to use for pod IP addresses, only used in standalone mode.
+	// NvidiaGPUs is the number of NVIDIA GPU devices on this node.
+	NvidiaGPUs int32 `json:"nvidiaGPUs,omitempty" flag:"experimental-nvidia-gpus" flag-empty:"0"`
+	// PodCIDR is the CIDR to use for pod IP addresses, only used in standalone mode.
 	// In cluster mode, this is obtained from the master.
 	PodCIDR string `json:"podCIDR,omitempty" flag:"pod-cidr"`
-	// reconcileCIDR is Reconcile node CIDR with the CIDR specified by the
+	// ResolverConfig is the resolver configuration file used as the basis for the container DNS resolution configuration."), []
+	ResolverConfig *string `json:"resolvConf,omitempty" flag:"resolv-conf" flag-include-empty:"true"`
+	// ReconcileCIDR is Reconcile node CIDR with the CIDR specified by the
 	// API server. No-op if register-node or configure-cbr0 is false.
 	ReconcileCIDR *bool `json:"reconcileCIDR,omitempty" flag:"reconcile-cidr"`
-	// registerSchedulable tells the kubelet to register the node as
-	// schedulable. No-op if register-node is false.
+	// registerSchedulable tells the kubelet to register the node as schedulable. No-op if register-node is false.
 	RegisterSchedulable *bool `json:"registerSchedulable,omitempty" flag:"register-schedulable"`
-
-	// ResolverConfig is the resolver configuration file used as the basis
-	// for the container DNS resolution configuration."), []
-	ResolverConfig *string `json:"resolvConf,omitempty" flag:"resolv-conf" flag-include-empty:"true"`
-
-	// nodeLabels to add when registering the node in the cluster.
+	//// SerializeImagePulls when enabled, tells the Kubelet to pull images one
+	//// at a time. We recommend *not* changing the default value on nodes that
+	//// run docker daemon with version  < 1.9 or an Aufs storage backend.
+	//// Issue #10959 has more details.
+	SerializeImagePulls *bool `json:"serializeImagePulls,omitempty" flag:"serialize-image-pulls"`
+	// NodeLabels to add when registering the node in the cluster.
 	NodeLabels map[string]string `json:"nodeLabels,omitempty" flag:"node-labels"`
-
-	// nonMasqueradeCIDR configures masquerading: traffic to IPs outside this range will use IP masquerade.
+	// NonMasqueradeCIDR configures masquerading: traffic to IPs outside this range will use IP masquerade.
 	NonMasqueradeCIDR string `json:"nonMasqueradeCIDR,omitempty" flag:"non-masquerade-cidr"`
-
-	// enable gathering custom metrics.
+	// Enable gathering custom metrics.
 	EnableCustomMetrics *bool `json:"enableCustomMetrics,omitempty" flag:"enable-custom-metrics"`
-
-	// networkPluginMTU is the MTU to be passed to the network plugin,
+	// NetworkPluginMTU is the MTU to be passed to the network plugin,
 	// and overrides the default MTU for cases where it cannot be automatically
 	// computed (such as IPSEC).
 	NetworkPluginMTU *int32 `json:"networkPluginMTU,omitempty" flag:"network-plugin-mtu"`
-
-	// imageGCHighThresholdPercent is the percent of disk usage after which
+	// ImageGCHighThresholdPercent is the percent of disk usage after which
 	// image garbage collection is always run.
 	ImageGCHighThresholdPercent *int32 `json:"imageGCHighThresholdPercent,omitempty" flag:"image-gc-high-threshold"`
-	// imageGCLowThresholdPercent is the percent of disk usage before which
+	// ImageGCLowThresholdPercent is the percent of disk usage before which
 	// image garbage collection is never run. Lowest disk usage to garbage
 	// collect to.
 	ImageGCLowThresholdPercent *int32 `json:"imageGCLowThresholdPercent,omitempty" flag:"image-gc-low-threshold"`
-
 	// Comma-delimited list of hard eviction expressions.  For example, 'memory.available<300Mi'.
 	EvictionHard *string `json:"evictionHard,omitempty" flag:"eviction-hard"`
 	// Comma-delimited list of soft eviction expressions.  For example, 'memory.available<300Mi'.
@@ -143,23 +121,18 @@ type KubeletConfigSpec struct {
 	// Comma-delimited list of grace periods for each soft eviction signal.  For example, 'memory.available=30s'.
 	EvictionSoftGracePeriod string `json:"evictionSoftGracePeriod,omitempty" flag:"eviction-soft-grace-period"`
 	// Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.
-	EvictionPressureTransitionPeriod *metav1.Duration `json:"evictionPressureTransitionPeriod,omitempty" flag:"eviction-pressure-transition-period"`
+	EvictionPressureTransitionPeriod *metav1.Duration `json:"evictionPressureTransitionPeriod,omitempty" flag:"eviction-pressure-transition-period" flag-empty:"0s"`
 	// Maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.
-	EvictionMaxPodGracePeriod int32 `json:"evictionMaxPodGracePeriod,omitempty" flag:"eviction-max-pod-grace-period"`
+	EvictionMaxPodGracePeriod int32 `json:"evictionMaxPodGracePeriod,omitempty" flag:"eviction-max-pod-grace-period" flag-empty:"0"`
 	// Comma-delimited list of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.
 	EvictionMinimumReclaim string `json:"evictionMinimumReclaim,omitempty" flag:"eviction-minimum-reclaim"`
-
 	// The full path of the directory in which to search for additional third party volume plugins
 	VolumePluginDirectory string `json:"volumePluginDirectory,omitempty" flag:"volume-plugin-dir"`
-
 	// Taints to add when registering a node in the cluster
 	Taints []string `json:"taints,omitempty" flag:"register-with-taints"`
-
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
-
-	// Resource reservation for kubernetes system daemons like the kubelet,
-	// container runtime, node problem detector, etc.
+	// Resource reservation for kubernetes system daemons like the kubelet, container runtime, node problem detector, etc.
 	KubeReserved map[string]string `json:"kubeReserved,omitempty" flag:"kube-reserved"`
 	// Control group for kube daemons.
 	KubeReservedCgroup string `json:"kubeReservedCgroup,omitempty" flag:"kube-reserved-cgroup"`
@@ -167,70 +140,75 @@ type KubeletConfigSpec struct {
 	SystemReserved map[string]string `json:"systemReserved,omitempty" flag:"system-reserved"`
 	// Parent control group for OS system daemons.
 	SystemReservedCgroup string `json:"systemReservedCgroup,omitempty" flag:"system-reserved-cgroup"`
-	// Enforce Allocatable across pods whenever the overall usage across all pods
-	// exceeds Allocatable.
+	// Enforce Allocatable across pods whenever the overall usage across all pods exceeds Allocatable.
 	EnforceNodeAllocatable string `json:"enforceNodeAllocatable,omitempty" flag:"enforce-node-allocatable"`
 }
 
+// KubeProxyConfig defined the configuration for a proxy
 type KubeProxyConfig struct {
 	Image string `json:"image,omitempty"`
 	// TODO: Better type ?
 	CPURequest string `json:"cpuRequest,omitempty"` // e.g. "20m"
-
+	// LogLevel is the logging level of the proxy
 	LogLevel int32 `json:"logLevel,omitempty" flag:"v"`
-
-	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
-
-	// hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
-	// Note: We recognize some additional values:
-	//  @aws uses the hostname from the AWS metadata service
-	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
-
-	// master is the address of the Kubernetes API server (overrides any value in kubeconfig)
-	Master string `json:"master,omitempty" flag:"master"`
-
-	// clusterCIDR is the CIDR range of the pods in the cluster. It is used to
-	// bridge traffic coming from outside of the cluster. If not provided,
-	// no off-cluster bridging will be performed.
+	// ClusterCIDR is the CIDR range of the pods in the cluster
 	ClusterCIDR string `json:"clusterCIDR,omitempty" flag:"cluster-cidr"`
+	// HostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
+	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
+	// Master is the address of the Kubernetes API server (overrides any value in kubeconfig)
+	Master string `json:"master,omitempty" flag:"master"`
+	// FeatureGates is a series of key pairs used to switch on features for the proxy
+	FeatureGates []string `json:"feature-gates" flag:"feature-gates"`
 }
 
+// KubeAPIServerConfig defines the configuration for the kube api
 type KubeAPIServerConfig struct {
-	PathSrvKubernetes string `json:"pathSrvKubernetes,omitempty"`
-	PathSrvSshproxy   string `json:"pathSrvSshproxy,omitempty"`
-	Image             string `json:"image,omitempty"`
-
-	LogLevel int32 `json:"logLevel,omitempty" flag:"v"`
-
-	CloudProvider         string   `json:"cloudProvider,omitempty" flag:"cloud-provider"`
-	SecurePort            int32    `json:"securePort,omitempty" flag:"secure-port"`
-	InsecurePort          int32    `json:"insecurePort,omitempty" flag:"insecure-port"`
-	Address               string   `json:"address,omitempty" flag:"address"`
-	EtcdServers           []string `json:"etcdServers,omitempty" flag:"etcd-servers"`
-	EtcdServersOverrides  []string `json:"etcdServersOverrides,omitempty" flag:"etcd-servers-overrides"`
-	AdmissionControl      []string `json:"admissionControl,omitempty" flag:"admission-control"`
-	ServiceClusterIPRange string   `json:"serviceClusterIPRange,omitempty" flag:"service-cluster-ip-range"`
-	ClientCAFile          string   `json:"clientCAFile,omitempty" flag:"client-ca-file"`
-	BasicAuthFile         string   `json:"basicAuthFile,omitempty" flag:"basic-auth-file"`
-	TLSCertFile           string   `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
-	TLSPrivateKeyFile     string   `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
-	TokenAuthFile         string   `json:"tokenAuthFile,omitempty" flag:"token-auth-file"`
-	AllowPrivileged       *bool    `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
-	APIServerCount        *int32   `json:"apiServerCount,omitempty" flag:"apiserver-count"`
-	// keys and values in RuntimeConfig are parsed into the `--runtime-config` parameter
-	// for KubeAPIServer, concatenated with commas. ex: `--runtime-config=key1=value1,key2=value2`.
-	// Use this to enable alpha resources on kube-apiserver
+	// Image is the docker container used
+	Image string `json:"image,omitempty"`
+	// LogLevel is the logging level of the api
+	LogLevel int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
+	// CloudProvider is the name of the cloudProvider we are using, aws, gce etcd
+	CloudProvider string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
+	// SecurePort is the port the kube runs on
+	SecurePort int32 `json:"securePort,omitempty" flag:"secure-port"`
+	// InsecurePort is the port the insecure api runs
+	InsecurePort int32 `json:"insecurePort,omitempty" flag:"insecure-port"`
+	// Address is the binding address for the kube api
+	Address string `json:"address,omitempty" flag:"address"`
+	// AdmissionControl is a list of admission controllers to user
+	AdmissionControl []string `json:"admissionControl,omitempty" flag:"admission-control"`
+	// ServiceClusterIPRange is the service address range
+	ServiceClusterIPRange string `json:"serviceClusterIPRange,omitempty" flag:"service-cluster-ip-range"`
+	// EtcdServers is a list of the etcd service to connect
+	EtcdServers []string `json:"etcdServers,omitempty" flag:"etcd-servers"`
+	// EtcdServersOverrides is per-resource etcd servers overrides, comma separated. The individual override format: group/resource#servers, where servers are http://ip:port, semicolon separated
+	EtcdServersOverrides []string `json:"etcdServersOverrides,omitempty" flag:"etcd-servers-overrides"`
+	// TODO: Remove unused BasicAuthFile
+	BasicAuthFile string `json:"basicAuthFile,omitempty" flag:"basic-auth-file"`
+	// TODO: Remove unused ClientCAFile
+	ClientCAFile string `json:"clientCAFile,omitempty" flag:"client-ca-file"`
+	// TODO: Remove unused TLSCertFile
+	TLSCertFile string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
+	// TODO: Remove unused TLSPrivateKeyFile
+	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
+	// TODO: Remove unused TokenAuthFile
+	TokenAuthFile string `json:"tokenAuthFile,omitempty" flag:"token-auth-file"`
+	// AllowPrivileged indicates if we can run privileged containers
+	AllowPrivileged *bool `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
+	// APIServerCount is the number of api servers
+	APIServerCount *int32 `json:"apiServerCount,omitempty" flag:"apiserver-count"`
+	// RuntimeConfig is a series of keys/values are parsed into the `--runtime-config` parameters
 	RuntimeConfig map[string]string `json:"runtimeConfig,omitempty" flag:"runtime-config"`
-
+	// KubeletClientCertificate is the path of a certificate for secure communication between api and kubelet
 	KubeletClientCertificate string `json:"kubeletClientCertificate,omitempty" flag:"kubelet-client-certificate"`
-	KubeletClientKey         string `json:"kubeletClientKey,omitempty" flag:"kubelet-client-key"`
-
+	// KubeletClientKey is the path of a private to secure communication between api and kubelet
+	KubeletClientKey string `json:"kubeletClientKey,omitempty" flag:"kubelet-client-key"`
+	// AnonymousAuth indicates if anonymous authentication is permitted
 	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"anonymous-auth"`
-
+	// KubeletPreferredAddressTypes is a list of the preferred NodeAddressTypes to use for kubelet connections
 	KubeletPreferredAddressTypes []string `json:"kubeletPreferredAddressTypes,omitempty" flag:"kubelet-preferred-address-types"`
-
+	// StorageBackend is the backend storage
 	StorageBackend *string `json:"storageBackend,omitempty" flag:"storage-backend"`
-
 	// The OpenID claim to use as the user name.
 	// Note that claims other than the default ('sub') is not guaranteed to be unique and immutable.
 	OIDCUsernameClaim *string `json:"oidcUsernameClaim,omitempty" flag:"oidc-username-claim"`
@@ -243,9 +221,7 @@ type KubeAPIServerConfig struct {
 	// The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
 	OIDCClientID *string `json:"oidcClientID,omitempty" flag:"oidc-client-id"`
 	// If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file
-	// otherwise the host's root CA set will be used.
 	OIDCCAFile *string `json:"oidcCAFile,omitempty" flag:"oidc-ca-file"`
-
 	// If set, all requests coming to the apiserver will be logged to this file.
 	AuditLogPath *string `json:"auditLogPath,omitempty" flag:"audit-log-path"`
 	// The maximum number of days to retain old audit log files based on the timestamp encoded in their filename.
@@ -254,67 +230,61 @@ type KubeAPIServerConfig struct {
 	AuditLogMaxBackups *int32 `json:"auditLogMaxBackups,omitempty" flag:"audit-log-maxbackup"`
 	// The maximum size in megabytes of the audit log file before it gets rotated. Defaults to 100MB.
 	AuditLogMaxSize *int32 `json:"auditLogMaxSize,omitempty" flag:"audit-log-maxsize"`
-
 	// File with webhook configuration for token authentication in kubeconfig format. The API server will query the remote service to determine authentication for bearer tokens.
 	AuthenticationTokenWebhookConfigFile *string `json:"authenticationTokenWebhookConfigFile,omitempty" flag:"authentication-token-webhook-config-file"`
 	// The duration to cache responses from the webhook token authenticator. Default is 2m. (default 2m0s)
-	AuthenticationTokenWebhookCacheTtl *metav1.Duration `json:"authenticationTokenWebhookCacheTtl,omitempty" flag:"authentication-token-webhook-cache-ttl"`
-
-	AuthorizationMode          *string `json:"authorizationMode,omitempty" flag:"authorization-mode"`
+	AuthenticationTokenWebhookCacheTTL *metav1.Duration `json:"authenticationTokenWebhookCacheTtl,omitempty" flag:"authentication-token-webhook-cache-ttl"`
+	// AuthorizationMode is the authorization mode the kubeapi is running in
+	AuthorizationMode *string `json:"authorizationMode,omitempty" flag:"authorization-mode"`
+	// AuthorizationRBACSuperUser is the name of the superuser for default rbac
 	AuthorizationRBACSuperUser *string `json:"authorizationRbacSuperUser,omitempty" flag:"authorization-rbac-super-user"`
 }
 
+// KubeControllerManagerConfig is the configuration for the controller
 type KubeControllerManagerConfig struct {
-	Master   string `json:"master,omitempty" flag:"master"`
-	LogLevel int32  `json:"logLevel,omitempty" flag:"v"`
-
+	// Master is the url for the kube api master
+	Master string `json:"master,omitempty" flag:"master"`
+	// LogLevel is the defined logLevel
+	LogLevel int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
+	// ServiceAccountPrivateKeyFile the location for a certificate for service account signing
 	ServiceAccountPrivateKeyFile string `json:"serviceAccountPrivateKeyFile,omitempty" flag:"service-account-private-key-file"`
-
+	// Image is the docker image to use
 	Image string `json:"image,omitempty"`
-
-	PathSrvKubernetes string `json:"pathSrvKubernetes,omitempty"`
-
-	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
-
-	// cloudProvider is the provider for cloud services.
+	// CloudProvider is the provider for cloud services.
 	CloudProvider string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
-	// clusterName is the instance prefix for the cluster.
+	// ClusterName is the instance prefix for the cluster.
 	ClusterName string `json:"clusterName,omitempty" flag:"cluster-name"`
-	// clusterCIDR is CIDR Range for Pods in cluster.
+	// ClusterCIDR is CIDR Range for Pods in cluster.
 	ClusterCIDR string `json:"clusterCIDR,omitempty" flag:"cluster-cidr"`
-	// allocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
+	// AllocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
 	// ConfigureCloudRoutes is true, to be set on the cloud provider.
 	AllocateNodeCIDRs *bool `json:"allocateNodeCIDRs,omitempty" flag:"allocate-node-cidrs"`
-	// configureCloudRoutes enables CIDRs allocated with allocateNodeCIDRs
-	// to be configured on the cloud provider.
+	// ConfigureCloudRoutes enables CIDRs allocated with to be configured on the cloud provider.
 	ConfigureCloudRoutes *bool `json:"configureCloudRoutes,omitempty" flag:"configure-cloud-routes"`
-	// rootCAFile is the root certificate authority will be included in service
-	// account's token secret. This must be a valid PEM-encoded CA bundle.
+	// rootCAFile is the root certificate authority will be included in service account's token secret. This must be a valid PEM-encoded CA bundle.
 	RootCAFile string `json:"rootCAFile,omitempty" flag:"root-ca-file"`
-	// leaderElection defines the configuration of leader election client.
+	// LeaderElection defines the configuration of leader election client.
 	LeaderElection *LeaderElectionConfiguration `json:"leaderElection,omitempty"`
 	// ReconcilerSyncLoopPeriod is the amount of time the reconciler sync states loop
 	// wait between successive executions. Is set to 1 min by kops by default
 	AttachDetachReconcileSyncPeriod *metav1.Duration `json:"attachDetachReconcileSyncPeriod,omitempty" flag:"attach-detach-reconcile-sync-period"`
-
-	// terminatedPodGCThreshold is the number of terminated pods that can exist
+	// TerminatedPodGCThreshold is the number of terminated pods that can exist
 	// before the terminated pod garbage collector starts deleting terminated pods.
 	// If <= 0, the terminated pod garbage collector is disabled.
 	TerminatedPodGCThreshold *int32 `json:"terminatedPodGCThreshold,omitempty" flag:"terminated-pod-gc-threshold"`
-
 	// UseServiceAccountCredentials controls whether we use individual service account credentials for each controller.
 	UseServiceAccountCredentials *bool `json:"useServiceAccountCredentials,omitempty" flag:"use-service-account-credentials"`
 }
 
+// KubeSchedulerConfig is the configuration for the kube-scheduler
 type KubeSchedulerConfig struct {
-	Master   string `json:"master,omitempty" flag:"master"`
-	LogLevel int32  `json:"logLevel,omitempty" flag:"v"`
-
+	// Master is a url to the kube master
+	Master string `json:"master,omitempty" flag:"master"`
+	// LogLevel is the logging level
+	LogLevel int32 `json:"logLevel,omitempty" flag:"v"`
+	// Image is the docker image to use
 	Image string `json:"image,omitempty"`
-
-	// Configuration flags - a subset of https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/componentconfig/types.go
-
-	// leaderElection defines the configuration of leader election client.
+	// LeaderElection defines the configuration of leader election client.
 	LeaderElection *LeaderElectionConfiguration `json:"leaderElection,omitempty"`
 }
 
@@ -327,6 +297,7 @@ type LeaderElectionConfiguration struct {
 	LeaderElect *bool `json:"leaderElect,omitempty" flag:"leader-elect"`
 }
 
+// CloudConfiguration is defines the cloud provider configuration
 type CloudConfiguration struct {
 	// GCE cloud-config options
 	Multizone          *bool   `json:"multizone,omitempty"`
@@ -335,13 +306,12 @@ type CloudConfiguration struct {
 	// AWS cloud-config options
 	DisableSecurityGroupIngress *bool   `json:"disableSecurityGroupIngress,omitempty"`
 	ElbSecurityGroup            *string `json:"elbSecurityGroup,omitempty"`
-
 	// vSphere cloud-config specs
 	VSphereUsername      *string `json:"vSphereUsername,omitempty"`
 	VSpherePassword      *string `json:"vSpherePassword,omitempty"`
 	VSphereServer        *string `json:"vSphereServer,omitempty"`
 	VSphereDatacenter    *string `json:"vSphereDatacenter,omitempty"`
-	VSphereDatastore     *string `json:"vSphereDatastore,omitempty"`
 	VSphereResourcePool  *string `json:"vSphereResourcePool,omitempty"`
+	VSphereDatastore     *string `json:"vSphereDatastore,omitempty"`
 	VSphereCoreDNSServer *string `json:"vSphereCoreDNSServer,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha2/dockerconfig.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package v1alpha2
 
+// DockerConfig is the configuration for docker
 type DockerConfig struct {
 	Bridge   *string `json:"bridge,omitempty" flag:"bridge"`
 	LogLevel *string `json:"logLevel,omitempty" flag:"log-level"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -420,8 +420,8 @@ func autoConvert_v1alpha2_CloudConfiguration_To_kops_CloudConfiguration(in *Clou
 	out.VSpherePassword = in.VSpherePassword
 	out.VSphereServer = in.VSphereServer
 	out.VSphereDatacenter = in.VSphereDatacenter
-	out.VSphereDatastore = in.VSphereDatastore
 	out.VSphereResourcePool = in.VSphereResourcePool
+	out.VSphereDatastore = in.VSphereDatastore
 	out.VSphereCoreDNSServer = in.VSphereCoreDNSServer
 	return nil
 }
@@ -1467,20 +1467,18 @@ func Convert_kops_KopeioNetworkingSpec_To_v1alpha2_KopeioNetworkingSpec(in *kops
 }
 
 func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *KubeAPIServerConfig, out *kops.KubeAPIServerConfig, s conversion.Scope) error {
-	out.PathSrvKubernetes = in.PathSrvKubernetes
-	out.PathSrvSshproxy = in.PathSrvSshproxy
 	out.Image = in.Image
 	out.LogLevel = in.LogLevel
 	out.CloudProvider = in.CloudProvider
 	out.SecurePort = in.SecurePort
 	out.InsecurePort = in.InsecurePort
 	out.Address = in.Address
-	out.EtcdServers = in.EtcdServers
-	out.EtcdServersOverrides = in.EtcdServersOverrides
 	out.AdmissionControl = in.AdmissionControl
 	out.ServiceClusterIPRange = in.ServiceClusterIPRange
-	out.ClientCAFile = in.ClientCAFile
+	out.EtcdServers = in.EtcdServers
+	out.EtcdServersOverrides = in.EtcdServersOverrides
 	out.BasicAuthFile = in.BasicAuthFile
+	out.ClientCAFile = in.ClientCAFile
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	out.TokenAuthFile = in.TokenAuthFile
@@ -1502,7 +1500,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.AuditLogMaxBackups = in.AuditLogMaxBackups
 	out.AuditLogMaxSize = in.AuditLogMaxSize
 	out.AuthenticationTokenWebhookConfigFile = in.AuthenticationTokenWebhookConfigFile
-	out.AuthenticationTokenWebhookCacheTtl = in.AuthenticationTokenWebhookCacheTtl
+	out.AuthenticationTokenWebhookCacheTTL = in.AuthenticationTokenWebhookCacheTTL
 	out.AuthorizationMode = in.AuthorizationMode
 	out.AuthorizationRBACSuperUser = in.AuthorizationRBACSuperUser
 	return nil
@@ -1514,28 +1512,26 @@ func Convert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *KubeAP
 }
 
 func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *kops.KubeAPIServerConfig, out *KubeAPIServerConfig, s conversion.Scope) error {
-	out.PathSrvKubernetes = in.PathSrvKubernetes
-	out.PathSrvSshproxy = in.PathSrvSshproxy
 	out.Image = in.Image
 	out.LogLevel = in.LogLevel
 	out.CloudProvider = in.CloudProvider
 	out.SecurePort = in.SecurePort
 	out.InsecurePort = in.InsecurePort
 	out.Address = in.Address
-	out.EtcdServers = in.EtcdServers
-	out.EtcdServersOverrides = in.EtcdServersOverrides
 	out.AdmissionControl = in.AdmissionControl
 	out.ServiceClusterIPRange = in.ServiceClusterIPRange
+	out.EtcdServers = in.EtcdServers
+	out.EtcdServersOverrides = in.EtcdServersOverrides
 	out.BasicAuthFile = in.BasicAuthFile
 	out.ClientCAFile = in.ClientCAFile
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
-	out.KubeletClientCertificate = in.KubeletClientCertificate
-	out.KubeletClientKey = in.KubeletClientKey
 	out.TokenAuthFile = in.TokenAuthFile
 	out.AllowPrivileged = in.AllowPrivileged
 	out.APIServerCount = in.APIServerCount
 	out.RuntimeConfig = in.RuntimeConfig
+	out.KubeletClientCertificate = in.KubeletClientCertificate
+	out.KubeletClientKey = in.KubeletClientKey
 	out.AnonymousAuth = in.AnonymousAuth
 	out.KubeletPreferredAddressTypes = in.KubeletPreferredAddressTypes
 	out.StorageBackend = in.StorageBackend
@@ -1549,7 +1545,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.AuditLogMaxBackups = in.AuditLogMaxBackups
 	out.AuditLogMaxSize = in.AuditLogMaxSize
 	out.AuthenticationTokenWebhookConfigFile = in.AuthenticationTokenWebhookConfigFile
-	out.AuthenticationTokenWebhookCacheTtl = in.AuthenticationTokenWebhookCacheTtl
+	out.AuthenticationTokenWebhookCacheTTL = in.AuthenticationTokenWebhookCacheTTL
 	out.AuthorizationMode = in.AuthorizationMode
 	out.AuthorizationRBACSuperUser = in.AuthorizationRBACSuperUser
 	return nil
@@ -1565,7 +1561,6 @@ func autoConvert_v1alpha2_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.LogLevel = in.LogLevel
 	out.ServiceAccountPrivateKeyFile = in.ServiceAccountPrivateKeyFile
 	out.Image = in.Image
-	out.PathSrvKubernetes = in.PathSrvKubernetes
 	out.CloudProvider = in.CloudProvider
 	out.ClusterName = in.ClusterName
 	out.ClusterCIDR = in.ClusterCIDR
@@ -1597,7 +1592,6 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha2_KubeControllerMana
 	out.LogLevel = in.LogLevel
 	out.ServiceAccountPrivateKeyFile = in.ServiceAccountPrivateKeyFile
 	out.Image = in.Image
-	out.PathSrvKubernetes = in.PathSrvKubernetes
 	out.CloudProvider = in.CloudProvider
 	out.ClusterName = in.ClusterName
 	out.ClusterCIDR = in.ClusterCIDR
@@ -1654,9 +1648,10 @@ func autoConvert_v1alpha2_KubeProxyConfig_To_kops_KubeProxyConfig(in *KubeProxyC
 	out.Image = in.Image
 	out.CPURequest = in.CPURequest
 	out.LogLevel = in.LogLevel
+	out.ClusterCIDR = in.ClusterCIDR
 	out.HostnameOverride = in.HostnameOverride
 	out.Master = in.Master
-	out.ClusterCIDR = in.ClusterCIDR
+	out.FeatureGates = in.FeatureGates
 	return nil
 }
 
@@ -1672,6 +1667,7 @@ func autoConvert_kops_KubeProxyConfig_To_v1alpha2_KubeProxyConfig(in *kops.KubeP
 	out.ClusterCIDR = in.ClusterCIDR
 	out.HostnameOverride = in.HostnameOverride
 	out.Master = in.Master
+	out.FeatureGates = in.FeatureGates
 	return nil
 }
 
@@ -1732,8 +1728,10 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride
 	out.PodInfraContainerImage = in.PodInfraContainerImage
+	out.SeccompProfileRoot = in.SeccompProfileRoot
 	out.AllowPrivileged = in.AllowPrivileged
 	out.EnableDebuggingHandlers = in.EnableDebuggingHandlers
+	out.RegisterNode = in.RegisterNode
 	out.ClusterDomain = in.ClusterDomain
 	out.ClusterDNS = in.ClusterDNS
 	out.NetworkPluginName = in.NetworkPluginName
@@ -1748,9 +1746,10 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.MaxPods = in.MaxPods
 	out.NvidiaGPUs = in.NvidiaGPUs
 	out.PodCIDR = in.PodCIDR
+	out.ResolverConfig = in.ResolverConfig
 	out.ReconcileCIDR = in.ReconcileCIDR
 	out.RegisterSchedulable = in.RegisterSchedulable
-	out.ResolverConfig = in.ResolverConfig
+	out.SerializeImagePulls = in.SerializeImagePulls
 	out.NodeLabels = in.NodeLabels
 	out.NonMasqueradeCIDR = in.NonMasqueradeCIDR
 	out.EnableCustomMetrics = in.EnableCustomMetrics
@@ -1789,8 +1788,10 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride
 	out.PodInfraContainerImage = in.PodInfraContainerImage
+	out.SeccompProfileRoot = in.SeccompProfileRoot
 	out.AllowPrivileged = in.AllowPrivileged
 	out.EnableDebuggingHandlers = in.EnableDebuggingHandlers
+	out.RegisterNode = in.RegisterNode
 	out.ClusterDomain = in.ClusterDomain
 	out.ClusterDNS = in.ClusterDNS
 	out.NetworkPluginName = in.NetworkPluginName
@@ -1808,6 +1809,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.ResolverConfig = in.ResolverConfig
 	out.ReconcileCIDR = in.ReconcileCIDR
 	out.RegisterSchedulable = in.RegisterSchedulable
+	out.SerializeImagePulls = in.SerializeImagePulls
 	out.NodeLabels = in.NodeLabels
 	out.NonMasqueradeCIDR = in.NonMasqueradeCIDR
 	out.EnableCustomMetrics = in.EnableCustomMetrics

--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -16,52 +16,35 @@ limitations under the License.
 
 package nodeup
 
-import (
-//"k8s.io/kops/upup/pkg/fi"
-)
-
-type NodeUpConfig struct {
+// Config is the configuration for the nodeup binary
+type Config struct {
 	// Tags enable/disable chunks of the model
 	Tags []string `json:",omitempty"`
 	// Assets are locations where we can find files to be installed
 	// TODO: Remove once everything is in containers?
 	Assets []string `json:",omitempty"`
-
 	// Images are a list of images we should preload
 	Images []*Image `json:"images,omitempty"`
-
 	// ConfigBase is the base VFS path for config objects
 	ConfigBase *string `json:",omitempty"`
-
-	// ClusterLocation is the VFS path to the cluster spec
-	// Deprecated: prefer ConfigBase
+	// ClusterLocation is the VFS path to the cluster spec (deprecated: prefer ConfigBase)
 	ClusterLocation *string `json:",omitempty"`
-
 	// InstanceGroupName is the name of the instance group
 	InstanceGroupName string `json:",omitempty"`
-
 	// ClusterName is the name of the cluster
-	// Technically this is redundant - it is in ClusterLocation, but this can serve as a cross-check,
-	// and it allows us to more easily identify the cluster, for example when we are deleting resources.
 	ClusterName string `json:",omitempty"`
-
 	// ProtokubeImage is the docker image to load for protokube (bootstrapping)
 	ProtokubeImage *Image `json:"protokubeImage,omitempty"`
-
 	// Channels is a list of channels that we should apply
 	Channels []string `json:"channels,omitempty"`
 }
 
 // Image is a docker image we should pre-load
 type Image struct {
-	// Name is the name of the tagged image
-	// This is the name we would pass to "docker run", whereas source could be a URL from which
-	// we would download an image.
+	// This is the name we would pass to "docker run", whereas source could be a URL from which we would download an image.
 	Name string `json:"name,omitempty"`
-
 	// Source is the URL from which we should download the image
 	Source string `json:"source,omitempty"`
-
 	// Hash is the hash of the file, to verify image integrity (even over http)
 	Hash string `json:"hash,omitempty"`
 }

--- a/pkg/flagbuilder/build_flags.go
+++ b/pkg/flagbuilder/build_flags.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
-	"github.com/golang/glog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kops/upup/pkg/fi/utils"
-	"strconv"
+
+	"github.com/golang/glog"
 )
 
 // BuildFlags builds flag arguments based on "flag" tags on the structure
@@ -98,9 +99,9 @@ func BuildFlags(options interface{}) (string, error) {
 					flags = append(flags, flag)
 				}
 				return utils.SkipReflection
-			} else {
-				return fmt.Errorf("BuildFlags of value type not handled: %T %s=%v", val.Interface(), path, val.Interface())
 			}
+
+			return fmt.Errorf("BuildFlags of value type not handled: %T %s=%v", val.Interface(), path, val.Interface())
 		}
 
 		if val.Kind() == reflect.Slice {
@@ -121,9 +122,9 @@ func BuildFlags(options interface{}) (string, error) {
 					}
 				}
 				return utils.SkipReflection
-			} else {
-				return fmt.Errorf("BuildFlags of value type not handled: %T %s=%v", val.Interface(), path, val.Interface())
 			}
+
+			return fmt.Errorf("BuildFlags of value type not handled: %T %s=%v", val.Interface(), path, val.Interface())
 		}
 
 		var flag string

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -18,19 +18,20 @@ package model
 
 import (
 	"fmt"
+	"os"
+	"text/template"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/nodeup"
 	"k8s.io/kops/pkg/model/resources"
 	"k8s.io/kops/upup/pkg/fi"
-	"os"
-	"text/template"
 )
 
 // BootstrapScript creates the bootstrap script
 type BootstrapScript struct {
 	NodeUpSource        string
 	NodeUpSourceHash    string
-	NodeUpConfigBuilder func(ig *kops.InstanceGroup) (*nodeup.NodeUpConfig, error)
+	NodeUpConfigBuilder func(ig *kops.InstanceGroup) (*nodeup.Config, error)
 }
 
 func (b *BootstrapScript) ResourceNodeUp(ig *kops.InstanceGroup) (*fi.ResourceHolder, error) {

--- a/upup/pkg/fi/assetstore.go
+++ b/upup/pkg/fi/assetstore.go
@@ -18,16 +18,18 @@ package fi
 
 import (
 	"fmt"
-	"github.com/golang/glog"
 	"io"
-	"k8s.io/kops/upup/pkg/fi/utils"
-	"k8s.io/kops/util/pkg/hashing"
 	"net/http"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"k8s.io/kops/upup/pkg/fi/utils"
+	"k8s.io/kops/util/pkg/hashing"
+
+	"github.com/golang/glog"
 )
 
 type asset struct {

--- a/upup/pkg/fi/cloud.go
+++ b/upup/pkg/fi/cloud.go
@@ -79,6 +79,8 @@ var zonesToCloud = map[string]kops.CloudProviderID{
 	"eu-west-1c": kops.CloudProviderAWS,
 	"eu-west-1d": kops.CloudProviderAWS,
 	"eu-west-1e": kops.CloudProviderAWS,
+	"eu-west-2a": kops.CloudProviderAWS,
+	"eu-west-2b": kops.CloudProviderAWS,
 
 	"eu-central-1a": kops.CloudProviderAWS,
 	"eu-central-1b": kops.CloudProviderAWS,

--- a/upup/pkg/fi/cloudup/loader.go
+++ b/upup/pkg/fi/cloudup/loader.go
@@ -20,8 +20,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/golang/glog"
 	"io"
+	"os"
+	"reflect"
+	"strings"
+	"text/template"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/assets"
@@ -30,10 +34,8 @@ import (
 	"k8s.io/kops/upup/pkg/fi/loader"
 	"k8s.io/kops/upup/pkg/fi/utils"
 	"k8s.io/kops/util/pkg/vfs"
-	"os"
-	"reflect"
-	"strings"
-	"text/template"
+
+	"github.com/golang/glog"
 )
 
 const (

--- a/upup/pkg/fi/fitasks/cert_utils.go
+++ b/upup/pkg/fi/fitasks/cert_utils.go
@@ -21,8 +21,9 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
-	"github.com/golang/glog"
 	"strings"
+
+	"github.com/golang/glog"
 )
 
 func pkixNameToString(name *pkix.Name) string {

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -46,7 +46,7 @@ import (
 const MaxTaskDuration = 365 * 24 * time.Hour
 
 type NodeUpCommand struct {
-	config         *nodeup.NodeUpConfig
+	config         *nodeup.Config
 	cluster        *api.Cluster
 	instanceGroup  *api.InstanceGroup
 	ConfigLocation string

--- a/upup/pkg/fi/nodeup/loader.go
+++ b/upup/pkg/fi/nodeup/loader.go
@@ -20,7 +20,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/golang/glog"
+	"strings"
+	"text/template"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/nodeup"
@@ -28,15 +30,15 @@ import (
 	"k8s.io/kops/upup/pkg/fi/loader"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 	"k8s.io/kops/util/pkg/vfs"
-	"strings"
-	"text/template"
+
+	"github.com/golang/glog"
 )
 
 type Loader struct {
 	Builders []fi.ModelBuilder
 
 	templates []*template.Template
-	config    *nodeup.NodeUpConfig
+	config    *nodeup.Config
 	cluster   *api.Cluster
 
 	assets *fi.AssetStore
@@ -46,7 +48,7 @@ type Loader struct {
 	TemplateFunctions template.FuncMap
 }
 
-func NewLoader(config *nodeup.NodeUpConfig, cluster *api.Cluster, assets *fi.AssetStore, tags sets.String) *Loader {
+func NewLoader(config *nodeup.Config, cluster *api.Cluster, assets *fi.AssetStore, tags sets.String) *Loader {
 	l := &Loader{}
 	l.assets = assets
 	l.tasks = make(map[string]fi.Task)

--- a/upup/pkg/fi/nodeup/template_functions.go
+++ b/upup/pkg/fi/nodeup/template_functions.go
@@ -36,7 +36,7 @@ const TagMaster = "_kubernetes_master"
 
 // templateFunctions is a simple helper-class for the functions accessible to templates
 type templateFunctions struct {
-	nodeupConfig *nodeup.NodeUpConfig
+	nodeupConfig *nodeup.Config
 
 	// cluster is populated with the current cluster
 	cluster *api.Cluster
@@ -52,7 +52,7 @@ type templateFunctions struct {
 }
 
 // newTemplateFunctions is the constructor for templateFunctions
-func newTemplateFunctions(nodeupConfig *nodeup.NodeUpConfig, cluster *api.Cluster, instanceGroup *api.InstanceGroup, tags sets.String) (*templateFunctions, error) {
+func newTemplateFunctions(nodeupConfig *nodeup.Config, cluster *api.Cluster, instanceGroup *api.InstanceGroup, tags sets.String) (*templateFunctions, error) {
 	t := &templateFunctions{
 		nodeupConfig:  nodeupConfig,
 		cluster:       cluster,


### PR DESCRIPTION
- fixed any of the vettting / formatting issues that i'm came across on the update
- removed the commented out lines from the componentconfig as it make its increasingly difficult to find what is supported, what is not and the difference between them.
- added SerializeImagePulls, RegisterSchedulable to kubelet (by default they are ignored)
- added FeatureGates to the kube-proxy
- fixed the vetting issue with NodeUpConfig -> Config
- added the aws london regions for cloud provider lookup

Out of interest can someone point me to where these multi-versioned componentconfig are being used?