### PR TITLE
Striking unnecessary conversion-gen instruction

### DIFF
--- a/docs/development/api_updates.md
+++ b/docs/development/api_updates.md
@@ -17,7 +17,6 @@ go get k8s.io/kubernetes
 cd ${GOPATH}/src/k8s.io/kubernetes
 git checkout master
 git pull
-go install ./cmd/libs/go2idl/conversion-gen
 ```
 
 Then you can run `make apimachinery && make` to update the generated API machinery code (conversion functions).  Note


### PR DESCRIPTION
Spoke with @chrislovecnm about this. go2idl is installed out of vendor/k8s.io/kubernetes/cmd/libs/go2idl/conversion-gen in the Makefile. It is not necessary to install it explicitly and the current instruction is incorrect.