### PR TITLE
Disable Protokube Options - Nodes

### DIFF
--- a/nodeup/pkg/model/kubectl.go
+++ b/nodeup/pkg/model/kubectl.go
@@ -18,10 +18,12 @@ package model
 
 import (
 	"fmt"
-	"github.com/golang/glog"
+
 	"k8s.io/kops/nodeup/pkg/distros"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
+
+	"github.com/golang/glog"
 )
 
 // KubectlBuilder install kubectl
@@ -31,13 +33,12 @@ type KubectlBuilder struct {
 
 var _ fi.ModelBuilder = &KubectlBuilder{}
 
+// Build is responsible for mananging the kubectl on the nodes
 func (b *KubectlBuilder) Build(c *fi.ModelBuilderContext) error {
 	if !b.IsMaster {
-		// We don't have the configuration on the machines, so it only works on the master anyway
 		return nil
 	}
 
-	// Add kubectl file as an asset
 	{
 		// TODO: Extract to common function?
 		assetName := "kubectl"
@@ -59,7 +60,6 @@ func (b *KubectlBuilder) Build(c *fi.ModelBuilderContext) error {
 		c.AddTask(t)
 	}
 
-	// Add kubeconfig
 	{
 		kubeconfig, err := b.buildPKIKubeconfig("kubecfg")
 		if err != nil {
@@ -84,6 +84,7 @@ func (b *KubectlBuilder) Build(c *fi.ModelBuilderContext) error {
 				Group: s("admin"),
 			})
 
+			// @question is this required?
 			c.AddTask(&nodetasks.File{
 				Path:     "/home/admin/.kube/config",
 				Contents: fi.NewStringResource(kubeconfig),


### PR DESCRIPTION
The current implementation runs protokube on all the nodes which isn't really required anymore. This PR disable by default the protokube service unless the gossip dns is being used. 

- cleans up any vetting issues and comment i came across on the journey
- disabled the protokube service on non master nodes
- enables the kubelet service if gossip is disabled (by default this waited on the protokube service to enable it)