### PR TITLE
docs/topology - Fix the rolling-update command

### DIFF
--- a/docs/topology.md
+++ b/docs/topology.md
@@ -62,6 +62,6 @@ The AWS ELB does not support changing from internet facing to Internal.  However
  - Run the update commmand to check the config: `kops update cluster $NAME`
  - BEFORE DOING the same command with the `--yes` option go into the AWS console and DELETE the api ELB!!!!!!
  - Now run: `kops update cluster $NAME --yes`
- - Finally execute a rolling update so that the instances register with the new internal ELB,  execute: `kops rolling update --cloudonly --force` command.  We have to use the  `--cloudonly` option because we deleted the api ELB so there is no way to talk to the cluster through the k8s api.  The force option is there because kops / terraform doesn't know that we need to update the instances with the ELB so we have to force it.
+ - Finally execute a rolling update so that the instances register with the new internal ELB,  execute: `kops rolling-update cluster --cloudonly --force` command.  We have to use the  `--cloudonly` option because we deleted the api ELB so there is no way to talk to the cluster through the k8s api.  The force option is there because kops / terraform doesn't know that we need to update the instances with the ELB so we have to force it.
  Once the rolling update has completed you have an internal only ELB that has the master k8s nodes registered with it.
 


### PR DESCRIPTION
This patch updates the `kops rolling-update` command which should be
run after making changes to the API server topology.

Fixes #3093 

Signed-off-by: M S Vishwanath Bhat <msvbhat@gmail.com>