### PR TITLE
added wider toleration to calico-node daemonset (#2857)

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.6.yaml.template
@@ -118,9 +118,11 @@ spec:
       hostNetwork: true
       serviceAccountName: calico
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
       - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
         operator: Exists
       containers:
         # Runs calico/node container on each Kubernetes node.  This


### PR DESCRIPTION
Calico pod needs to run on all nodes, regardless of their taints. Otherwise the node cannot join the cluster. See #2857 for more discussion. This commit was originally https://github.com/ca16/kops/commit/b66b6260e79c432ec15f6165be930fd252eb563a by @ca16. It's also similar to the PR that kube-aws recently merged: https://github.com/kubernetes-incubator/kube-aws/pull/687/files.

Would you mind merging this to 1.7 branch too?