### PR TITLE
Fix Wildcard domains returned as ASCII in dns-controller

### DIFF
--- a/dns-controller/pkg/dns/dnscontroller.go
+++ b/dns-controller/pkg/dns/dnscontroller.go
@@ -503,6 +503,10 @@ func isCoreDNSZone(zone dnsprovider.Zone) bool {
 	return ok
 }
 
+func FixWildcards(s string) string {
+	return strings.Replace(s, "\\052", "*", 1)
+}
+
 func (o *dnsOp) updateRecords(k recordKey, newRecords []string, ttl int64) error {
 	fqdn := EnsureDotSuffix(k.FQDN)
 
@@ -539,7 +543,7 @@ func (o *dnsOp) updateRecords(k recordKey, newRecords []string, ttl int64) error
 		}
 
 		for _, rr := range rrs {
-			rrName := EnsureDotSuffix(rr.Name())
+			rrName := EnsureDotSuffix(FixWildcards(rr.Name()))
 			if rrName != fqdn {
 				glog.V(8).Infof("Skipping record %q (name != %s)", rrName, fqdn)
 				continue
@@ -564,7 +568,7 @@ func (o *dnsOp) updateRecords(k recordKey, newRecords []string, ttl int64) error
 	}
 
 	if existing != nil {
-		glog.V(2).Infof("will replace existing dns record %s %s", existing.Type(), existing.Name())
+		glog.V(2).Infof("will replace existing dns record %s %s", existing.Type(), FixWildcards(existing.Name()))
 		cs.Remove(existing)
 	}
 


### PR DESCRIPTION
After running into https://github.com/kubernetes/kops/issues/2671 whenever dns-controller restarted, I looked into why dns-controller successfully creates entries for wildcard domains (e.g. `*.example.com` ) but after restarting, it errors, unable to find the old record.  It looks amazon returns ascii `\\052.example.com` instead of the `*.example.com` we expect. This was a simple fix I tested in our cluster and it seems to have fixed the issue.  I'm open to any changes but I think this could be a useful fix for those that may run into this in the future.

This isn't a new thing apparently: https://github.com/boto/boto/issues/818

Fixes https://github.com/kubernetes/kops/issues/2671