### PR TITLE
Kube Proxy Feature Gates

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -158,7 +158,7 @@ type KubeProxyConfig struct {
 	// Master is the address of the Kubernetes API server (overrides any value in kubeconfig)
 	Master string `json:"master,omitempty" flag:"master"`
 	// FeatureGates is a series of key pairs used to switch on features for the proxy
-	FeatureGates []string `json:"feature-gates" flag:"feature-gates"`
+	FeatureGates map[string]string `json:"featureGates" flag:"feature-gates"`
 }
 
 // KubeAPIServerConfig defines the configuration for the kube api

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -158,7 +158,7 @@ type KubeProxyConfig struct {
 	// Master is the address of the Kubernetes API server (overrides any value in kubeconfig)
 	Master string `json:"master,omitempty" flag:"master"`
 	// FeatureGates is a series of key pairs used to switch on features for the proxy
-	FeatureGates []string `json:"feature-gates" flag:"feature-gates"`
+	FeatureGates map[string]string `json:"featureGates" flag:"feature-gates"`
 }
 
 // KubeAPIServerConfig defines the configuration for the kube api

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -158,7 +158,7 @@ type KubeProxyConfig struct {
 	// Master is the address of the Kubernetes API server (overrides any value in kubeconfig)
 	Master string `json:"master,omitempty" flag:"master"`
 	// FeatureGates is a series of key pairs used to switch on features for the proxy
-	FeatureGates []string `json:"feature-gates" flag:"feature-gates"`
+	FeatureGates map[string]string `json:"featureGates" flag:"feature-gates"`
 }
 
 // KubeAPIServerConfig defines the configuration for the kube api


### PR DESCRIPTION
- fixing the [kubeproxy feature gates](https://github.com/kubernetes/kops/pull/3078), this should have been a [map](https://github.com/kubernetes/kops/blob/master/pkg/apis/kops/v1alpha2/componentconfig.go#L134) not  an array ... apologizes!! from 