### PR TITLE
Rename OWNERS assignees: to approvers:

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,4 @@
-assignees:
+approvers:
   - justinsb
   - kris-nova
   - chrislovecnm


### PR DESCRIPTION
They are effectively the same, assignees is deprecated

ref: kubernetes/test-infra#3851

I broke this into two commits around vendor/ because I'm not sure it's kosher to be editing vendored OWNERS directly. ref: kubernetes/test-infra#3694

ref: https://github.com/kubernetes/gengo/pull/71 for the gengo OWNERS changes if that's the more appropriate route to go