### PR TITLE
CoreOS: Ensure docker configuration is loaded

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -476,6 +476,10 @@ func (b *DockerBuilder) buildContainerOSConfigurationDropIn(c *fi.ModelBuilderCo
 		Path:     "/etc/systemd/system/docker.service.d/10-kops.conf",
 		Contents: fi.NewStringResource(contents),
 		Type:     nodetasks.FileType_File,
+		OnChangeExecute: [][]string{
+			{"systemctl", "daemon-reload"},
+			{"systemctl", "restart", "docker.service"},
+		},
 	}
 	c.AddTask(t)
 


### PR DESCRIPTION
Previously the configuration has been written after docker has been started and
was actually only applied after a reboot.

Manually reload system and restart docker to ensure the configuration has been
applied.