### PR TITLE
Update aws.md for SSH Key pair generation instructions

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -317,7 +317,7 @@ aws ec2 describe-availability-zones --region us-west-2
 
 Below is a create cluster command.  We'll use the most basic example possible,
 with more verbose examples in [advanced creation](advanced_create.md).  The
-below command will generate a cluster configuration, but not start building it.
+below command will generate a cluster configuration, but not start building it. Make sure that you have generated SSH key pair before creating the cluster.
 
 ```bash
 kops create cluster \


### PR DESCRIPTION
SSH key pair must be available before creating the cluster, adding the instructions.