### PR TITLE
Add hints to CF integration test

### DIFF
--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -313,7 +313,8 @@ func runTestCloudformation(t *testing.T, clusterName string, srcDir string, vers
 			t.Fatalf("unexpected files.  actual=%q, expected=%q", actualFilenames, expectedFilenames)
 		}
 
-		actualCF, err := ioutil.ReadFile(path.Join(h.TempDir, "out", "kubernetes.json"))
+		actualPath := path.Join(h.TempDir, "out", "kubernetes.json")
+		actualCF, err := ioutil.ReadFile(actualPath)
 		if err != nil {
 			t.Fatalf("unexpected error reading actual cloudformation output: %v", err)
 		}
@@ -325,6 +326,12 @@ func runTestCloudformation(t *testing.T, clusterName string, srcDir string, vers
 		if !bytes.Equal(actualCF, expectedCF) {
 			diffString := diff.FormatDiff(string(expectedCF), string(actualCF))
 			t.Logf("diff:\n%s\n", diffString)
+
+			if os.Getenv("KEEP_TEMP_DIR") == "" {
+				t.Logf("(hint: setting KEEP_TEMP_DIR will preserve test output")
+			} else {
+				t.Logf("actual terraform output in %s", actualPath)
+			}
 
 			t.Fatalf("cloudformation output differed from expected")
 		}


### PR DESCRIPTION
We can save the CF output, which makes dealing with the base64 blob much
more convenient.