### PR TITLE
Use SSL in ELB API server health check

### DIFF
--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -116,7 +116,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 
 			// Configure fast-recovery health-checks
 			HealthCheck: &awstasks.LoadBalancerHealthCheck{
-				Target:             s("TCP:443"),
+				Target:             s("SSL:443"),
 				Timeout:            i64(5),
 				Interval:           i64(10),
 				HealthyThreshold:   i64(2),

--- a/tests/integration/privatecalico/kubernetes.tf
+++ b/tests/integration/privatecalico/kubernetes.tf
@@ -184,7 +184,7 @@ resource "aws_elb" "api-privatecalico-example-com" {
   subnets         = ["${aws_subnet.utility-us-test-1a-privatecalico-example-com.id}"]
 
   health_check = {
-    target              = "TCP:443"
+    target              = "SSL:443"
     healthy_threshold   = 2
     unhealthy_threshold = 2
     interval            = 10

--- a/tests/integration/privatecanal/kubernetes.tf
+++ b/tests/integration/privatecanal/kubernetes.tf
@@ -184,7 +184,7 @@ resource "aws_elb" "api-privatecanal-example-com" {
   subnets         = ["${aws_subnet.utility-us-test-1a-privatecanal-example-com.id}"]
 
   health_check = {
-    target              = "TCP:443"
+    target              = "SSL:443"
     healthy_threshold   = 2
     unhealthy_threshold = 2
     interval            = 10

--- a/tests/integration/privatedns1/kubernetes.tf
+++ b/tests/integration/privatedns1/kubernetes.tf
@@ -184,7 +184,7 @@ resource "aws_elb" "api-privatedns1-example-com" {
   subnets         = ["${aws_subnet.utility-us-test-1a-privatedns1-example-com.id}"]
 
   health_check = {
-    target              = "TCP:443"
+    target              = "SSL:443"
     healthy_threshold   = 2
     unhealthy_threshold = 2
     interval            = 10

--- a/tests/integration/privatedns2/kubernetes.tf
+++ b/tests/integration/privatedns2/kubernetes.tf
@@ -184,7 +184,7 @@ resource "aws_elb" "api-privatedns2-example-com" {
   subnets         = ["${aws_subnet.utility-us-test-1a-privatedns2-example-com.id}"]
 
   health_check = {
-    target              = "TCP:443"
+    target              = "SSL:443"
     healthy_threshold   = 2
     unhealthy_threshold = 2
     interval            = 10

--- a/tests/integration/privateflannel/kubernetes.tf
+++ b/tests/integration/privateflannel/kubernetes.tf
@@ -184,7 +184,7 @@ resource "aws_elb" "api-privateflannel-example-com" {
   subnets         = ["${aws_subnet.utility-us-test-1a-privateflannel-example-com.id}"]
 
   health_check = {
-    target              = "TCP:443"
+    target              = "SSL:443"
     healthy_threshold   = 2
     unhealthy_threshold = 2
     interval            = 10

--- a/tests/integration/privatekopeio/kubernetes.tf
+++ b/tests/integration/privatekopeio/kubernetes.tf
@@ -180,7 +180,7 @@ resource "aws_elb" "api-privatekopeio-example-com" {
   subnets         = ["${aws_subnet.utility-us-test-1a-privatekopeio-example-com.id}"]
 
   health_check = {
-    target              = "TCP:443"
+    target              = "SSL:443"
     healthy_threshold   = 2
     unhealthy_threshold = 2
     interval            = 10

--- a/tests/integration/privateweave/kubernetes.tf
+++ b/tests/integration/privateweave/kubernetes.tf
@@ -184,7 +184,7 @@ resource "aws_elb" "api-privateweave-example-com" {
   subnets         = ["${aws_subnet.utility-us-test-1a-privateweave-example-com.id}"]
 
   health_check = {
-    target              = "TCP:443"
+    target              = "SSL:443"
     healthy_threshold   = 2
     unhealthy_threshold = 2
     interval            = 10


### PR DESCRIPTION
This switch causes the ELB to perform a SSL handshake and makes the
`I0427 03:57:55.059255       1 logs.go:41] http: TLS handshake error from IP:PORT: EOF`
disappear from the apiserver logs.

Tested manually and everything looks :white_check_mark: 

Inspiration from https://github.com/kubernetes-incubator/kube-aws/pull/604