### PR TITLE
Add proxy client support

### DIFF
--- a/nodeup/pkg/model/kubeapiserver.go
+++ b/nodeup/pkg/model/kubeapiserver.go
@@ -170,6 +170,13 @@ func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 		kubeAPIServer.KubeletClientKey = filepath.Join(b.PathSrvKubernetes(), "kubelet-api-key.pem")
 	}
 
+	if b.IsKubernetesGTE("1.7") {
+		certPath := filepath.Join(b.PathSrvKubernetes(), "proxy-client.cert")
+		kubeAPIServer.ProxyClientCertFile = &certPath
+		keyPath := filepath.Join(b.PathSrvKubernetes(), "proxy-client.key")
+		kubeAPIServer.ProxyClientKeyFile = &keyPath
+	}
+
 	// build the kube-apiserver flags for the service
 	flags, err := flagbuilder.BuildFlags(b.Cluster.Spec.KubeAPIServer)
 	if err != nil {

--- a/nodeup/pkg/model/secrets.go
+++ b/nodeup/pkg/model/secrets.go
@@ -116,6 +116,43 @@ func (b *SecretBuilder) Build(c *fi.ModelBuilderContext) error {
 		c.AddTask(t)
 	}
 
+	if b.IsKubernetesGTE("1.7") {
+
+		cert, err := b.KeyStore.Cert("apiserver-proxy-client")
+		if err != nil {
+			return fmt.Errorf("apiserver proxy client cert lookup failed: %v", err.Error())
+		}
+
+		serialized, err := cert.AsString()
+		if err != nil {
+			return err
+		}
+
+		t := &nodetasks.File{
+			Path:     filepath.Join(b.PathSrvKubernetes(), "proxy-client.cert"),
+			Contents: fi.NewStringResource(serialized),
+			Type:     nodetasks.FileType_File,
+		}
+		c.AddTask(t)
+
+		key, err := b.KeyStore.PrivateKey("apiserver-proxy-client")
+		if err != nil {
+			return fmt.Errorf("apiserver proxy client private key lookup failed: %v", err.Error())
+		}
+
+		serialized, err = key.AsString()
+		if err != nil {
+			return err
+		}
+
+		t = &nodetasks.File{
+			Path:     filepath.Join(b.PathSrvKubernetes(), "proxy-client.key"),
+			Contents: fi.NewStringResource(serialized),
+			Type:     nodetasks.FileType_File,
+		}
+		c.AddTask(t)
+	}
+
 	if b.SecretStore != nil {
 		key := "kube"
 		token, err := b.SecretStore.FindSecret(key)

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -228,6 +228,10 @@ type KubeAPIServerConfig struct {
 	OIDCClientID *string `json:"oidcClientID,omitempty" flag:"oidc-client-id"`
 	// If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file
 	OIDCCAFile *string `json:"oidcCAFile,omitempty" flag:"oidc-ca-file"`
+	// The apiserver's client certificate used for outbound requests.
+	ProxyClientCertFile *string `json:"proxyClientCertFile,omitempty" flag:"proxy-client-cert-file"`
+	// The apiserver's client key used for outbound requests.
+	ProxyClientKeyFile *string `json:"proxyClientKeyFile,omitempty" flag:"proxy-client-key-file"`
 	// If set, all requests coming to the apiserver will be logged to this file.
 	AuditLogPath *string `json:"auditLogPath,omitempty" flag:"audit-log-path"`
 	// The maximum number of days to retain old audit log files based on the timestamp encoded in their filename.

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -228,6 +228,10 @@ type KubeAPIServerConfig struct {
 	OIDCClientID *string `json:"oidcClientID,omitempty" flag:"oidc-client-id"`
 	// If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file
 	OIDCCAFile *string `json:"oidcCAFile,omitempty" flag:"oidc-ca-file"`
+	// The apiserver's client certificate used for outbound requests.
+	ProxyClientCertFile *string `json:"proxyClientCertFile,omitempty" flag:"proxy-client-cert-file"`
+	// The apiserver's client key used for outbound requests.
+	ProxyClientKeyFile *string `json:"proxyClientKeyFile,omitempty" flag:"proxy-client-key-file"`
 	// If set, all requests coming to the apiserver will be logged to this file.
 	AuditLogPath *string `json:"auditLogPath,omitempty" flag:"audit-log-path"`
 	// The maximum number of days to retain old audit log files based on the timestamp encoded in their filename.

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1518,6 +1518,8 @@ func autoConvert_v1alpha1_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.OIDCIssuerURL = in.OIDCIssuerURL
 	out.OIDCClientID = in.OIDCClientID
 	out.OIDCCAFile = in.OIDCCAFile
+	out.ProxyClientCertFile = in.ProxyClientCertFile
+	out.ProxyClientKeyFile = in.ProxyClientKeyFile
 	out.AuditLogPath = in.AuditLogPath
 	out.AuditLogMaxAge = in.AuditLogMaxAge
 	out.AuditLogMaxBackups = in.AuditLogMaxBackups
@@ -1566,6 +1568,8 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha1_KubeAPIServerConfig(in *ko
 	out.OIDCIssuerURL = in.OIDCIssuerURL
 	out.OIDCClientID = in.OIDCClientID
 	out.OIDCCAFile = in.OIDCCAFile
+	out.ProxyClientCertFile = in.ProxyClientCertFile
+	out.ProxyClientKeyFile = in.ProxyClientKeyFile
 	out.AuditLogPath = in.AuditLogPath
 	out.AuditLogMaxAge = in.AuditLogMaxAge
 	out.AuditLogMaxBackups = in.AuditLogMaxBackups

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -228,6 +228,10 @@ type KubeAPIServerConfig struct {
 	OIDCClientID *string `json:"oidcClientID,omitempty" flag:"oidc-client-id"`
 	// If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file
 	OIDCCAFile *string `json:"oidcCAFile,omitempty" flag:"oidc-ca-file"`
+	// The apiserver's client certificate used for outbound requests.
+	ProxyClientCertFile *string `json:"proxyClientCertFile,omitempty" flag:"proxy-client-cert-file"`
+	// The apiserver's client key used for outbound requests.
+	ProxyClientKeyFile *string `json:"proxyClientKeyFile,omitempty" flag:"proxy-client-key-file"`
 	// If set, all requests coming to the apiserver will be logged to this file.
 	AuditLogPath *string `json:"auditLogPath,omitempty" flag:"audit-log-path"`
 	// The maximum number of days to retain old audit log files based on the timestamp encoded in their filename.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1626,6 +1626,8 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.OIDCIssuerURL = in.OIDCIssuerURL
 	out.OIDCClientID = in.OIDCClientID
 	out.OIDCCAFile = in.OIDCCAFile
+	out.ProxyClientCertFile = in.ProxyClientCertFile
+	out.ProxyClientKeyFile = in.ProxyClientKeyFile
 	out.AuditLogPath = in.AuditLogPath
 	out.AuditLogMaxAge = in.AuditLogMaxAge
 	out.AuditLogMaxBackups = in.AuditLogMaxBackups
@@ -1674,6 +1676,8 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.OIDCIssuerURL = in.OIDCIssuerURL
 	out.OIDCClientID = in.OIDCClientID
 	out.OIDCCAFile = in.OIDCCAFile
+	out.ProxyClientCertFile = in.ProxyClientCertFile
+	out.ProxyClientKeyFile = in.ProxyClientKeyFile
 	out.AuditLogPath = in.AuditLogPath
 	out.AuditLogMaxAge = in.AuditLogMaxAge
 	out.AuditLogMaxBackups = in.AuditLogMaxBackups

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -60,6 +60,10 @@ func validateClusterSpec(spec *kops.ClusterSpec, fieldPath *field.Path) field.Er
 		allErrs = append(allErrs, validateHook(&spec.Hooks[i], fieldPath.Child("hooks").Index(i))...)
 	}
 
+	if spec.KubeAPIServer != nil {
+		allErrs = append(allErrs, validateKubeAPIServer(spec.KubeAPIServer, fieldPath.Child("kubeAPIServer"))...)
+	}
+
 	return allErrs
 }
 
@@ -151,6 +155,21 @@ func validateExecContainerAction(v *kops.ExecContainerAction, fldPath *field.Pat
 
 	if v.Image == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("Image"), "Image must be specified"))
+	}
+
+	return allErrs
+}
+
+func validateKubeAPIServer(v *kops.KubeAPIServerConfig, fldPath *field.Path) field.ErrorList {
+
+	allErrs := field.ErrorList{}
+
+	proxyClientCertIsNil := v.ProxyClientCertFile == nil
+	proxyClientKeyIsNil := v.ProxyClientKeyFile == nil
+
+	if (proxyClientCertIsNil && !proxyClientKeyIsNil) || (!proxyClientCertIsNil && proxyClientKeyIsNil) {
+		flds := [2]*string{v.ProxyClientCertFile, v.ProxyClientKeyFile}
+		allErrs = append(allErrs, field.Invalid(fldPath, flds, "ProxyClientCertFile and ProxyClientKeyFile must both be specified (or not all)"))
 	}
 
 	return allErrs

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package validation
 
 import (
+	"testing"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kops/pkg/apis/kops"
-	"testing"
 )
 
 func Test_Validate_DNS(t *testing.T) {
@@ -138,6 +139,37 @@ func TestValidateSubnets(t *testing.T) {
 	}
 	for _, g := range grid {
 		errs := validateSubnets(g.Input, field.NewPath("Subnets"))
+
+		testErrors(t, g.Input, errs, g.ExpectedErrors)
+	}
+}
+
+func TestValidateKubeAPIServer(t *testing.T) {
+	str := "foobar"
+
+	grid := []struct {
+		Input          kops.KubeAPIServerConfig
+		ExpectedErrors []string
+	}{
+		{
+			Input: kops.KubeAPIServerConfig{
+				ProxyClientCertFile: &str,
+			},
+			ExpectedErrors: []string{
+				"Invalid value::KubeAPIServer",
+			},
+		},
+		{
+			Input: kops.KubeAPIServerConfig{
+				ProxyClientKeyFile: &str,
+			},
+			ExpectedErrors: []string{
+				"Invalid value::KubeAPIServer",
+			},
+		},
+	}
+	for _, g := range grid {
+		errs := validateKubeAPIServer(&g.Input, field.NewPath("KubeAPIServer"))
 
 		testErrors(t, g.Input, errs, g.ExpectedErrors)
 	}

--- a/pkg/model/pki.go
+++ b/pkg/model/pki.go
@@ -133,6 +133,16 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 
 	{
 		t := &fitasks.Keypair{
+			Name:      fi.String("apiserver-proxy-client"),
+			Lifecycle: b.Lifecycle,
+			Subject:   "cn=apiserver-proxy-client",
+			Type:      "client",
+		}
+		c.AddTask(t)
+	}
+
+	{
+		t := &fitasks.Keypair{
 			Name:      fi.String("kops"),
 			Lifecycle: b.Lifecycle,
 			Subject:   "o=" + user.SystemPrivilegedGroup + ",cn=kops",


### PR DESCRIPTION
This PR adds support for the `--proxy-client-cert-file` and `--proxy-client-key-file` cmd line args that the apiserver accepts now.

/cc @chrislovecnm @blakebarnett 