### PR TITLE
Specify initial period in gossip-based cluster name pattern

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -83,7 +83,7 @@ export AWS_SECRET_ACCESS_KEY=<secret key>
 Note: If you are using Kops 1.6.2 or later, then DNS configuration is 
 optional. Instead, a gossip-based cluster can be easily created. The 
 only requirement to trigger this is to have the cluster name end with 
-`k8s.local`. If a gossip-based cluster is created then you can skip 
+`.k8s.local`. If a gossip-based cluster is created then you can skip 
 this section.
 
 In order to build a Kubernetes cluster with `kops`, we need to prepare


### PR DESCRIPTION
This is the most trivial change ever, but I actually got bitten by this and had to grep the source code to figure out that the initial period needed to be in the cluster name suffix.