### PR TITLE
Fix dropped error in kops cmd package

### DIFF
--- a/cmd/kops/get.go
+++ b/cmd/kops/get.go
@@ -138,6 +138,9 @@ func RunGet(context Factory, out io.Writer, options *GetOptions) error {
 	args := make([]string, 0)
 
 	clusters, err := buildClusters(args, clusterList)
+	if err != nil {
+		return fmt.Errorf("error on buildClusters(): %v", err)
+	}
 
 	ig, err := client.InstanceGroupsFor(cluster).List(metav1.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
This fixes a dropped error variable in the kops cmd package.