### PR TITLE
Etcd v3 Support

### DIFF
--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -181,7 +181,7 @@ type ProtokubeFlags struct {
 	DNSInternalSuffix *string  `json:"dnsInternalSuffix,omitempty" flag:"dns-internal-suffix"`
 	DNSProvider       *string  `json:"dnsProvider,omitempty" flag:"dns"`
 	DNSServer         *string  `json:"dns-server,omitempty" flag:"dns-server"`
-	Image             *string  `json:"image,omitempty" flag:"image"`
+	EtcdImage         *string  `json:"etcd-image,omitempty" flag:"etcd-image"`
 	InitializeRBAC    *bool    `json:"initializeRBAC,omitempty" flag:"initialize-rbac"`
 	LogLevel          *int32   `json:"logLevel,omitempty" flag:"v"`
 	Master            *bool    `json:"master,omitempty" flag:"master"`
@@ -203,7 +203,7 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) *ProtokubeF
 	f := &ProtokubeFlags{
 		Channels:      t.NodeupConfig.Channels,
 		Containerized: fi.Bool(true),
-		Image:         s(fmt.Sprintf("gcr.io/google_containers/etcd:%s", imageVersion)),
+		EtcdImage:     s(fmt.Sprintf("gcr.io/google_containers/etcd:%s", imageVersion)),
 		LogLevel:      fi.Int32(4),
 		Master:        b(t.IsMaster),
 	}

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -181,6 +181,7 @@ type ProtokubeFlags struct {
 	DNSInternalSuffix *string  `json:"dnsInternalSuffix,omitempty" flag:"dns-internal-suffix"`
 	DNSProvider       *string  `json:"dnsProvider,omitempty" flag:"dns"`
 	DNSServer         *string  `json:"dns-server,omitempty" flag:"dns-server"`
+	Image             *string  `json:"image,omitempty" flag:"image"`
 	InitializeRBAC    *bool    `json:"initializeRBAC,omitempty" flag:"initialize-rbac"`
 	LogLevel          *int32   `json:"logLevel,omitempty" flag:"v"`
 	Master            *bool    `json:"master,omitempty" flag:"master"`
@@ -195,9 +196,14 @@ type ProtokubeFlags struct {
 
 // ProtokubeFlags is responsible for building the command line flags for protokube
 func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) *ProtokubeFlags {
+	// @todo: i think we should allow the user to override the source of the image, but for now
+	// lets keep that for another PR and allow the version change
+	imageVersion := t.Cluster.Spec.EtcdClusters[0].Version
+
 	f := &ProtokubeFlags{
 		Channels:      t.NodeupConfig.Channels,
 		Containerized: fi.Bool(true),
+		Image:         s(fmt.Sprintf("gcr.io/google_containers/etcd:%s", imageVersion)),
 		LogLevel:      fi.Int32(4),
 		Master:        b(t.IsMaster),
 	}

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -234,14 +234,23 @@ const (
 	EtcdStorageTypeV3 EtcdStorageType = "etcd3"
 )
 
+var (
+	// EtcdStorageTypes is a list of accepted storage types
+	EtcdStorageTypes = []EtcdStorageType{EtcdStorageTypeV2, EtcdStorageTypeV3}
+)
+
 // EtcdClusterSpec is the etcd cluster specification
 type EtcdClusterSpec struct {
 	// Name is the name of the etcd cluster (main, events etc)
 	Name string `json:"name,omitempty"`
-	// EnableEtcdTLS indicates the etcd service should use TLS between peers and clients
-	EnableEtcdTLS bool `json:"enableEtcdTLS,omitempty"`
 	// Members stores the configurations for each member of the cluster (including the data volume)
 	Members []*EtcdMemberSpec `json:"etcdMembers,omitempty"`
+	// EnableEtcdTLS indicates the etcd service should use TLS between peers and clients
+	EnableEtcdTLS bool `json:"enableEtcdTLS,omitempty"`
+	// StorageType indicates the storage type of the cluster v2 or v3
+	StorageType EtcdStorageType `json:"storageType,omitempty"`
+	// Version is the version of etcd to run
+	Version string `json:"version,omitempty"`
 }
 
 // EtcdMemberSpec is a specification for a etcd member

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -224,21 +224,6 @@ type KubeDNSConfig struct {
 	ServerIP string `json:"serverIP,omitempty"`
 }
 
-// EtcdStorageType defined the etcd storage backend
-type EtcdStorageType string
-
-const (
-	// EtcdStorageTypeV2 is the old v2 storage
-	EtcdStorageTypeV2 EtcdStorageType = "etcd2"
-	// EtcdStorageTypeV3 is the new v3 storage
-	EtcdStorageTypeV3 EtcdStorageType = "etcd3"
-)
-
-var (
-	// EtcdStorageTypes is a list of accepted storage types
-	EtcdStorageTypes = []EtcdStorageType{EtcdStorageTypeV2, EtcdStorageTypeV3}
-)
-
 // EtcdClusterSpec is the etcd cluster specification
 type EtcdClusterSpec struct {
 	// Name is the name of the etcd cluster (main, events etc)
@@ -247,9 +232,7 @@ type EtcdClusterSpec struct {
 	Members []*EtcdMemberSpec `json:"etcdMembers,omitempty"`
 	// EnableEtcdTLS indicates the etcd service should use TLS between peers and clients
 	EnableEtcdTLS bool `json:"enableEtcdTLS,omitempty"`
-	// StorageType indicates the storage type of the cluster v2 or v3
-	StorageType EtcdStorageType `json:"storageType,omitempty"`
-	// Version is the version of etcd to run
+	// Version is the version of etcd to run i.e. 2.1.2, 3.0.17 etcd
 	Version string `json:"version,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -327,21 +327,6 @@ type KubeDNSConfig struct {
 	ServerIP string `json:"serverIP,omitempty"`
 }
 
-// EtcdStorageType defined the etcd storage backend
-type EtcdStorageType string
-
-const (
-	// EtcdStorageTypeV2 is the old v2 storage
-	EtcdStorageTypeV2 EtcdStorageType = "etcd2"
-	// EtcdStorageTypeV3 is the new v3 storage
-	EtcdStorageTypeV3 EtcdStorageType = "etcd3"
-)
-
-var (
-	// EtcdStorageTypes is a list of accepted storage types
-	EtcdStorageTypes = []EtcdStorageType{EtcdStorageTypeV2, EtcdStorageTypeV3}
-)
-
 // EtcdClusterSpec is the etcd cluster specification
 type EtcdClusterSpec struct {
 	// Name is the name of the etcd cluster (main, events etc)
@@ -350,9 +335,7 @@ type EtcdClusterSpec struct {
 	Members []*EtcdMemberSpec `json:"etcdMembers,omitempty"`
 	// EnableEtcdTLS indicates the etcd service should use TLS between peers and clients
 	EnableEtcdTLS bool `json:"enableEtcdTLS,omitempty"`
-	// StorageType indicates the storage type of the cluster v2 or v3
-	StorageType EtcdStorageType `json:"storageType,omitempty"`
-	// Version is the version of etcd to run
+	// Version is the version of etcd to run i.e. 2.1.2, 3.0.17 etcd
 	Version string `json:"version,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -327,32 +327,49 @@ type KubeDNSConfig struct {
 	ServerIP string `json:"serverIP,omitempty"`
 }
 
-//type MasterConfig struct {
-//	Name string `json:",omitempty"`
-//
-//	Image       string `json:",omitempty"`
-//	Zone        string `json:",omitempty"`
-//	MachineType string `json:",omitempty"`
-//}
+// EtcdStorageType defined the etcd storage backend
+type EtcdStorageType string
 
+const (
+	// EtcdStorageTypeV2 is the old v2 storage
+	EtcdStorageTypeV2 EtcdStorageType = "etcd2"
+	// EtcdStorageTypeV3 is the new v3 storage
+	EtcdStorageTypeV3 EtcdStorageType = "etcd3"
+)
+
+var (
+	// EtcdStorageTypes is a list of accepted storage types
+	EtcdStorageTypes = []EtcdStorageType{EtcdStorageTypeV2, EtcdStorageTypeV3}
+)
+
+// EtcdClusterSpec is the etcd cluster specification
 type EtcdClusterSpec struct {
 	// Name is the name of the etcd cluster (main, events etc)
 	Name string `json:"name,omitempty"`
+	// Members stores the configurations for each member of the cluster (including the data volume)
+	Members []*EtcdMemberSpec `json:"etcdMembers,omitempty"`
 	// EnableEtcdTLS indicates the etcd service should use TLS between peers and clients
 	EnableEtcdTLS bool `json:"enableEtcdTLS,omitempty"`
-	// EtcdMember stores the configurations for each member of the cluster (including the data volume)
-	Members []*EtcdMemberSpec `json:"etcdMembers,omitempty"`
+	// StorageType indicates the storage type of the cluster v2 or v3
+	StorageType EtcdStorageType `json:"storageType,omitempty"`
+	// Version is the version of etcd to run
+	Version string `json:"version,omitempty"`
 }
 
+// EtcdMemberSpec is a specification for a etcd member
 type EtcdMemberSpec struct {
 	// Name is the name of the member within the etcd cluster
-	Name string  `json:"name,omitempty"`
+	Name string `json:"name,omitempty"`
+	// Zone is the zone the member lives
 	Zone *string `json:"zone,omitempty"`
-
-	VolumeType      *string `json:"volumeType,omitempty"`
-	VolumeSize      *int32  `json:"volumeSize,omitempty"`
-	KmsKeyId        *string `json:"kmsKeyId,omitempty"`
-	EncryptedVolume *bool   `json:"encryptedVolume,omitempty"`
+	// VolumeType is the underlining cloud storage class
+	VolumeType *string `json:"volumeType,omitempty"`
+	// VolumeSize is the underlining cloud volume size
+	VolumeSize *int32 `json:"volumeSize,omitempty"`
+	// KmsKeyId is a AWS KMS ID used to encrypt the volume
+	KmsKeyId *string `json:"kmsKeyId,omitempty"`
+	// EncryptedVolume indicates you want to encrypt the volume
+	EncryptedVolume *bool `json:"encryptedVolume,omitempty"`
 }
 
 type ClusterZoneSpec struct {

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -997,6 +997,7 @@ func Convert_kops_EgressProxySpec_To_v1alpha1_EgressProxySpec(in *kops.EgressPro
 func autoConvert_v1alpha1_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdClusterSpec, out *kops.EtcdClusterSpec, s conversion.Scope) error {
 	out.Name = in.Name
 	out.EnableEtcdTLS = in.EnableEtcdTLS
+	out.StorageType = kops.EtcdStorageType(in.StorageType)
 	if in.Members != nil {
 		in, out := &in.Members, &out.Members
 		*out = make([]*kops.EtcdMemberSpec, len(*in))
@@ -1020,6 +1021,7 @@ func Convert_v1alpha1_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdClusterSpe
 func autoConvert_kops_EtcdClusterSpec_To_v1alpha1_EtcdClusterSpec(in *kops.EtcdClusterSpec, out *EtcdClusterSpec, s conversion.Scope) error {
 	out.Name = in.Name
 	out.EnableEtcdTLS = in.EnableEtcdTLS
+	out.StorageType = EtcdStorageType(in.StorageType)
 	if in.Members != nil {
 		in, out := &in.Members, &out.Members
 		*out = make([]*EtcdMemberSpec, len(*in))

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -996,8 +996,6 @@ func Convert_kops_EgressProxySpec_To_v1alpha1_EgressProxySpec(in *kops.EgressPro
 
 func autoConvert_v1alpha1_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdClusterSpec, out *kops.EtcdClusterSpec, s conversion.Scope) error {
 	out.Name = in.Name
-	out.EnableEtcdTLS = in.EnableEtcdTLS
-	out.StorageType = kops.EtcdStorageType(in.StorageType)
 	if in.Members != nil {
 		in, out := &in.Members, &out.Members
 		*out = make([]*kops.EtcdMemberSpec, len(*in))
@@ -1010,6 +1008,8 @@ func autoConvert_v1alpha1_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdCluste
 	} else {
 		out.Members = nil
 	}
+	out.EnableEtcdTLS = in.EnableEtcdTLS
+	out.Version = in.Version
 	return nil
 }
 
@@ -1020,8 +1020,6 @@ func Convert_v1alpha1_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdClusterSpe
 
 func autoConvert_kops_EtcdClusterSpec_To_v1alpha1_EtcdClusterSpec(in *kops.EtcdClusterSpec, out *EtcdClusterSpec, s conversion.Scope) error {
 	out.Name = in.Name
-	out.EnableEtcdTLS = in.EnableEtcdTLS
-	out.StorageType = EtcdStorageType(in.StorageType)
 	if in.Members != nil {
 		in, out := &in.Members, &out.Members
 		*out = make([]*EtcdMemberSpec, len(*in))
@@ -1034,6 +1032,8 @@ func autoConvert_kops_EtcdClusterSpec_To_v1alpha1_EtcdClusterSpec(in *kops.EtcdC
 	} else {
 		out.Members = nil
 	}
+	out.EnableEtcdTLS = in.EnableEtcdTLS
+	out.Version = in.Version
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -253,24 +253,49 @@ type KubeDNSConfig struct {
 	ServerIP string `json:"serverIP,omitempty"`
 }
 
+// EtcdStorageType defined the etcd storage backend
+type EtcdStorageType string
+
+const (
+	// EtcdStorageTypeV2 is the old v2 storage
+	EtcdStorageTypeV2 EtcdStorageType = "etcd2"
+	// EtcdStorageTypeV3 is the new v3 storage
+	EtcdStorageTypeV3 EtcdStorageType = "etcd3"
+)
+
+var (
+	// EtcdStorageTypes is a list of accepted storage types
+	EtcdStorageTypes = []EtcdStorageType{EtcdStorageTypeV2, EtcdStorageTypeV3}
+)
+
+// EtcdClusterSpec is the etcd cluster specification
 type EtcdClusterSpec struct {
 	// Name is the name of the etcd cluster (main, events etc)
 	Name string `json:"name,omitempty"`
+	// Members stores the configurations for each member of the cluster (including the data volume)
+	Members []*EtcdMemberSpec `json:"etcdMembers,omitempty"`
 	// EnableEtcdTLS indicates the etcd service should use TLS between peers and clients
 	EnableEtcdTLS bool `json:"enableEtcdTLS,omitempty"`
-	// EtcdMember stores the configurations for each member of the cluster (including the data volume)
-	Members []*EtcdMemberSpec `json:"etcdMembers,omitempty"`
+	// StorageType indicates the storage type of the cluster v2 or v3
+	StorageType EtcdStorageType `json:"storageType,omitempty"`
+	// Version is the version of etcd to run
+	Version string `json:"version,omitempty"`
 }
 
+// EtcdMemberSpec is a specification for a etcd member
 type EtcdMemberSpec struct {
 	// Name is the name of the member within the etcd cluster
-	Name          string  `json:"name,omitempty"`
+	Name string `json:"name,omitempty"`
+	// InstanceGroup is the instanceGroup this volume is associated
 	InstanceGroup *string `json:"instanceGroup,omitempty"`
-
-	VolumeType      *string `json:"volumeType,omitempty"`
-	VolumeSize      *int32  `json:"volumeSize,omitempty"`
-	KmsKeyId        *string `json:"kmsKeyId,omitempty"`
-	EncryptedVolume *bool   `json:"encryptedVolume,omitempty"`
+	// VolumeType is the underlining cloud storage class
+	VolumeType *string `json:"volumeType,omitempty"`
+	// VolumeSize is the underlining cloud volume size
+	VolumeSize *int32 `json:"volumeSize,omitempty"`
+	// KmsKeyId is a AWS KMS ID used to encrypt the volume
+	KmsKeyId *string `json:"kmsKeyId,omitempty"`
+	// EncryptedVolume indicates you want to encrypt the volume
+	EncryptedVolume *bool `json:"encryptedVolume,omitempty"`
 }
 
 // SubnetType string describes subnet types (public, private, utility)

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -253,21 +253,6 @@ type KubeDNSConfig struct {
 	ServerIP string `json:"serverIP,omitempty"`
 }
 
-// EtcdStorageType defined the etcd storage backend
-type EtcdStorageType string
-
-const (
-	// EtcdStorageTypeV2 is the old v2 storage
-	EtcdStorageTypeV2 EtcdStorageType = "etcd2"
-	// EtcdStorageTypeV3 is the new v3 storage
-	EtcdStorageTypeV3 EtcdStorageType = "etcd3"
-)
-
-var (
-	// EtcdStorageTypes is a list of accepted storage types
-	EtcdStorageTypes = []EtcdStorageType{EtcdStorageTypeV2, EtcdStorageTypeV3}
-)
-
 // EtcdClusterSpec is the etcd cluster specification
 type EtcdClusterSpec struct {
 	// Name is the name of the etcd cluster (main, events etc)
@@ -276,9 +261,7 @@ type EtcdClusterSpec struct {
 	Members []*EtcdMemberSpec `json:"etcdMembers,omitempty"`
 	// EnableEtcdTLS indicates the etcd service should use TLS between peers and clients
 	EnableEtcdTLS bool `json:"enableEtcdTLS,omitempty"`
-	// StorageType indicates the storage type of the cluster v2 or v3
-	StorageType EtcdStorageType `json:"storageType,omitempty"`
-	// Version is the version of etcd to run
+	// Version is the version of etcd to run i.e. 2.1.2, 3.0.17 etcd
 	Version string `json:"version,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1084,8 +1084,6 @@ func Convert_kops_EgressProxySpec_To_v1alpha2_EgressProxySpec(in *kops.EgressPro
 
 func autoConvert_v1alpha2_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdClusterSpec, out *kops.EtcdClusterSpec, s conversion.Scope) error {
 	out.Name = in.Name
-	out.EnableEtcdTLS = in.EnableEtcdTLS
-	out.StorageType = kops.EtcdStorageType(in.StorageType)
 	if in.Members != nil {
 		in, out := &in.Members, &out.Members
 		*out = make([]*kops.EtcdMemberSpec, len(*in))
@@ -1098,6 +1096,8 @@ func autoConvert_v1alpha2_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdCluste
 	} else {
 		out.Members = nil
 	}
+	out.EnableEtcdTLS = in.EnableEtcdTLS
+	out.Version = in.Version
 	return nil
 }
 
@@ -1108,8 +1108,6 @@ func Convert_v1alpha2_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdClusterSpe
 
 func autoConvert_kops_EtcdClusterSpec_To_v1alpha2_EtcdClusterSpec(in *kops.EtcdClusterSpec, out *EtcdClusterSpec, s conversion.Scope) error {
 	out.Name = in.Name
-	out.EnableEtcdTLS = in.EnableEtcdTLS
-	out.StorageType = EtcdStorageType(in.StorageType)
 	if in.Members != nil {
 		in, out := &in.Members, &out.Members
 		*out = make([]*EtcdMemberSpec, len(*in))
@@ -1122,6 +1120,8 @@ func autoConvert_kops_EtcdClusterSpec_To_v1alpha2_EtcdClusterSpec(in *kops.EtcdC
 	} else {
 		out.Members = nil
 	}
+	out.EnableEtcdTLS = in.EnableEtcdTLS
+	out.Version = in.Version
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1085,6 +1085,7 @@ func Convert_kops_EgressProxySpec_To_v1alpha2_EgressProxySpec(in *kops.EgressPro
 func autoConvert_v1alpha2_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdClusterSpec, out *kops.EtcdClusterSpec, s conversion.Scope) error {
 	out.Name = in.Name
 	out.EnableEtcdTLS = in.EnableEtcdTLS
+	out.StorageType = kops.EtcdStorageType(in.StorageType)
 	if in.Members != nil {
 		in, out := &in.Members, &out.Members
 		*out = make([]*kops.EtcdMemberSpec, len(*in))
@@ -1108,6 +1109,7 @@ func Convert_v1alpha2_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdClusterSpe
 func autoConvert_kops_EtcdClusterSpec_To_v1alpha2_EtcdClusterSpec(in *kops.EtcdClusterSpec, out *EtcdClusterSpec, s conversion.Scope) error {
 	out.Name = in.Name
 	out.EnableEtcdTLS = in.EnableEtcdTLS
+	out.StorageType = EtcdStorageType(in.StorageType)
 	if in.Members != nil {
 		in, out := &in.Members, &out.Members
 		*out = make([]*EtcdMemberSpec, len(*in))

--- a/pkg/model/components/context.go
+++ b/pkg/model/components/context.go
@@ -19,16 +19,18 @@ package components
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/blang/semver"
-	"github.com/golang/glog"
+	"math/big"
+	"net"
+	"strings"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/assets"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/util/pkg/vfs"
-	"math/big"
-	"net"
-	"strings"
+
+	"github.com/blang/semver"
+	"github.com/golang/glog"
 )
 
 // OptionsContext is the context object for options builders
@@ -63,6 +65,20 @@ func KubernetesVersion(clusterSpec *kops.ClusterSpec) (*semver.Version, error) {
 	}
 
 	return sv, nil
+}
+
+// UseEtcdV3 checks to see if etcd v3 is enabled.
+// @question: I kinda feel like this functionality should be on the kops.CluserSpec itself, though I don't
+// know how to do this without duplicating methods and how it effects the versions v1, v2 etc
+func UseEtcdV3(spec *kops.ClusterSpec) bool {
+	// validation ensure the etcd must be both one or the other
+	for _, x := range spec.EtcdClusters {
+		if x.StorageType == kops.EtcdStorageTypeV3 {
+			return true
+		}
+	}
+
+	return false
 }
 
 // UsesKubenet returns true if our networking is derived from kubenet

--- a/pkg/model/components/context.go
+++ b/pkg/model/components/context.go
@@ -67,20 +67,6 @@ func KubernetesVersion(clusterSpec *kops.ClusterSpec) (*semver.Version, error) {
 	return sv, nil
 }
 
-// UseEtcdV3 checks to see if etcd v3 is enabled.
-// @question: I kinda feel like this functionality should be on the kops.CluserSpec itself, though I don't
-// know how to do this without duplicating methods and how it effects the versions v1, v2 etc
-func UseEtcdV3(spec *kops.ClusterSpec) bool {
-	// validation ensure the etcd must be both one or the other
-	for _, x := range spec.EtcdClusters {
-		if x.StorageType == kops.EtcdStorageTypeV3 {
-			return true
-		}
-	}
-
-	return false
-}
-
 // UsesKubenet returns true if our networking is derived from kubenet
 func UsesKubenet(clusterSpec *kops.ClusterSpec) (bool, error) {
 	networking := clusterSpec.Networking

--- a/pkg/model/components/docker.go
+++ b/pkg/model/components/docker.go
@@ -18,6 +18,7 @@ package components
 
 import (
 	"fmt"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/loader"
@@ -30,6 +31,7 @@ type DockerOptionsBuilder struct {
 
 var _ loader.OptionsBuilder = &DockerOptionsBuilder{}
 
+// BuildOptions is responsible for filling in the default setting for docker daemon
 func (b *DockerOptionsBuilder) BuildOptions(o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 

--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -34,16 +34,10 @@ func (b *EtcdOptionsBuilder) BuildOptions(o interface{}) error {
 
 	// @check the version are set and if not preset the defaults
 	for _, x := range spec.EtcdClusters {
-		if x.StorageType == "" {
-			x.StorageType = kops.EtcdStorageTypeV2
-		}
+		// @TODO if nothing is set, set the defaults. At a late date once we have a way of detecting a 'new' cluster
+		// we can default all clusters to v3
 		if x.Version == "" {
-			switch UseEtcdV3(spec) {
-			case true:
-				x.Version = "3.0.17"
-			default:
-				x.Version = "2.2.1"
-			}
+			x.Version = "2.2.1"
 		}
 	}
 

--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+import (
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/upup/pkg/fi/loader"
+)
+
+// EtcdOptionsBuilder adds options for etcd to the model
+type EtcdOptionsBuilder struct {
+	Context *OptionsContext
+}
+
+var _ loader.OptionsBuilder = &EtcdOptionsBuilder{}
+
+// BuildOptions is responsible for filling in the defaults for the etcd cluster model
+func (b *EtcdOptionsBuilder) BuildOptions(o interface{}) error {
+	spec := o.(*kops.ClusterSpec)
+
+	// @check the version are set and if not preset the defaults
+	for _, x := range spec.EtcdClusters {
+		if x.StorageType == "" {
+			x.StorageType = kops.EtcdStorageTypeV2
+		}
+		if x.Version == "" {
+			switch UseEtcdV3(spec) {
+			case true:
+				x.Version = "3.0.17"
+			default:
+				x.Version = "2.2.1"
+			}
+		}
+	}
+
+	return nil
+}

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -82,7 +82,7 @@ func run() error {
 	flag.StringVar(&tlsKey, "tls-key", tlsKey, "Path to a file containing the private key for etcd server")
 	flags.StringSliceVarP(&zones, "zone", "z", []string{}, "Configure permitted zones and their mappings")
 	flags.StringVar(&dnsProviderID, "dns", "aws-route53", "DNS provider we should use (aws-route53, google-clouddns, coredns)")
-	flags.StringVar(&etcdImageSource, "image", "gcr.io/google_containers/etcd:2.2.1", "Etcd Source Container Registry")
+	flags.StringVar(&etcdImageSource, "etcd-image", "gcr.io/google_containers/etcd:2.2.1", "Etcd Source Container Registry")
 	flags.StringVar(&gossipSecret, "gossip-secret", gossipSecret, "Secret to use to secure gossip")
 
 	// Trick to avoid 'logging before flag.Parse' warning

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -82,7 +82,7 @@ func run() error {
 	flag.StringVar(&tlsKey, "tls-key", tlsKey, "Path to a file containing the private key for etcd server")
 	flags.StringSliceVarP(&zones, "zone", "z", []string{}, "Configure permitted zones and their mappings")
 	flags.StringVar(&dnsProviderID, "dns", "aws-route53", "DNS provider we should use (aws-route53, google-clouddns, coredns)")
-	flags.StringVar(&etcdImageSource, "etcd-image-source", etcdImageSource, "Etcd Source Container Registry")
+	flags.StringVar(&etcdImageSource, "image", "gcr.io/google_containers/etcd:2.2.1", "Etcd Source Container Registry")
 	flags.StringVar(&gossipSecret, "gossip-secret", gossipSecret, "Secret to use to secure gossip")
 
 	// Trick to avoid 'logging before flag.Parse' warning

--- a/protokube/pkg/protokube/etcd_manifest.go
+++ b/protokube/pkg/protokube/etcd_manifest.go
@@ -33,22 +33,11 @@ func BuildEtcdManifest(c *EtcdCluster) *v1.Pod {
 	pod.Name = c.PodName
 	pod.Namespace = "kube-system"
 	pod.Labels = map[string]string{"k8s-app": c.PodName}
-
-	etcdImage := "/etcd:2.2.1"
-	etcdRegistry := "gcr.io/google_containers"
-
-	// @check if the container is being overloaded via flags
-	if c.ImageSource == "" {
-		etcdImage = etcdRegistry + etcdImage
-	} else {
-		etcdImage = strings.TrimSuffix(c.ImageSource, "/") + etcdImage
-	}
-
 	pod.Spec.HostNetwork = true
 	{
 		container := v1.Container{
 			Name:  "etcd-container",
-			Image: etcdImage,
+			Image: c.ImageSource,
 			Resources: v1.ResourceRequirements{
 				Requests: v1.ResourceList{
 					v1.ResourceCPU: c.CPURequest,

--- a/protokube/tests/integration/build_etcd_manifest/main/non_tls.yaml
+++ b/protokube/tests/integration/build_etcd_manifest/main/non_tls.yaml
@@ -3,6 +3,7 @@ clusterName: etcd-main
 clusterToken: token-main
 cpuRequest: "200m"
 dataDirName: data-main
+imageSource: gcr.io/google_containers/etcd:2.2.1
 logFile: /var/log/etcd.log
 peerPort: 2380
 podName: etcd-server-main

--- a/protokube/tests/integration/build_etcd_manifest/main/tls.yaml
+++ b/protokube/tests/integration/build_etcd_manifest/main/tls.yaml
@@ -6,6 +6,7 @@ clusterName: etcd-main
 clusterToken: token-main
 cpuRequest: "200m"
 dataDirName: data-main
+imageSource: gcr.io/google_containers/etcd:2.2.1
 logFile: /var/log/etcd.log
 peerCA: /srv/kubernetes/ca.crt
 peerCert: /srv/kubernetes/etcd.pem

--- a/upup/pkg/fi/cloudup/deepvalidate_test.go
+++ b/upup/pkg/fi/cloudup/deepvalidate_test.go
@@ -18,11 +18,12 @@ package cloudup
 
 import (
 	"fmt"
+	"strings"
+	"testing"
+
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/validation"
 	"k8s.io/kops/upup/pkg/fi"
-	"strings"
-	"testing"
 )
 
 func TestDeepValidate_OK(t *testing.T) {
@@ -139,7 +140,7 @@ func TestDeepValidate_EvenEtcdClusterSize(t *testing.T) {
 	groups = append(groups, buildMinimalMasterInstanceGroup("subnet-us-mock-1a", "subnet-us-mock-1b", "subnet-us-mock-1c", "subnet-us-mock-1d"))
 	groups = append(groups, buildMinimalNodeInstanceGroup("subnet-us-mock-1a"))
 
-	expectErrorFromDeepValidate(t, c, groups, "There should be an odd number of master-zones, for etcd's quorum.  Hint: Use --zones and --master-zones to declare node zones and master zones separately.")
+	expectErrorFromDeepValidate(t, c, groups, "should be an odd number of master-zones for quorum. Use --zones and --master-zones to declare node zones and master zones separately")
 }
 
 func expectErrorFromDeepValidate(t *testing.T, c *api.Cluster, groups []*api.InstanceGroup, message string) {

--- a/upup/pkg/fi/cloudup/deepvalidate_test.go
+++ b/upup/pkg/fi/cloudup/deepvalidate_test.go
@@ -140,7 +140,7 @@ func TestDeepValidate_EvenEtcdClusterSize(t *testing.T) {
 	groups = append(groups, buildMinimalMasterInstanceGroup("subnet-us-mock-1a", "subnet-us-mock-1b", "subnet-us-mock-1c", "subnet-us-mock-1d"))
 	groups = append(groups, buildMinimalNodeInstanceGroup("subnet-us-mock-1a"))
 
-	expectErrorFromDeepValidate(t, c, groups, "should be an odd number of master-zones for quorum. Use --zones and --master-zones to declare node zones and master zones separately")
+	expectErrorFromDeepValidate(t, c, groups, "Should be an odd number of master-zones for quorum. Use --zones and --master-zones to declare node zones and master zones separately")
 }
 
 func expectErrorFromDeepValidate(t *testing.T, c *api.Cluster, groups []*api.InstanceGroup, message string) {

--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -290,8 +290,8 @@ func (c *populateClusterSpec) run() error {
 		switch m {
 		case "config":
 			// Note: DefaultOptionsBuilder comes first
-			codeModels = append(codeModels, &components.EtcdOptionsBuilder{Context: optionsContext})
 			codeModels = append(codeModels, &components.DefaultsOptionsBuilder{Context: optionsContext})
+			codeModels = append(codeModels, &components.EtcdOptionsBuilder{Context: optionsContext})
 			codeModels = append(codeModels, &components.KubeAPIServerOptionsBuilder{OptionsContext: optionsContext})
 			codeModels = append(codeModels, &components.DockerOptionsBuilder{Context: optionsContext})
 			codeModels = append(codeModels, &components.NetworkingOptionsBuilder{Context: optionsContext})

--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -290,6 +290,7 @@ func (c *populateClusterSpec) run() error {
 		switch m {
 		case "config":
 			// Note: DefaultOptionsBuilder comes first
+			codeModels = append(codeModels, &components.EtcdOptionsBuilder{Context: optionsContext})
 			codeModels = append(codeModels, &components.DefaultsOptionsBuilder{Context: optionsContext})
 			codeModels = append(codeModels, &components.KubeAPIServerOptionsBuilder{OptionsContext: optionsContext})
 			codeModels = append(codeModels, &components.DockerOptionsBuilder{Context: optionsContext})


### PR DESCRIPTION
Etcd V3 Support
    
The current implementation is running v2.2.1 which is two years old and end of life. This PR adds the ability to use etcd v3 and set the versions if required. Note at the moment the image is still using the gcr.io registry image and much like Etcd TLS PR there presently is no 'automated' migration path from v2 to v3.
    
- the feature is gated behind the version of the etcd cluster, both clusters events and main must use the same storage type
- the version for v2 is unchanged and pinned at v2.2.1 with v3 using v3.0.17
- @question: we should consider allowing the user to override the images though I think this should be addressed generically, than one offs here and then. I know @chrislovecnm is working on a asset registry??