### PR TITLE
fix the path of the link to vSphere dev docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -97,7 +97,7 @@
 ## Development
 
 * [Developing using Docker](development/Docker.md)
-* [Development with vSphere](development/vsphere-dev.md)
+* [Development with vSphere](vsphere-dev.md)
 * [Documentation Guidelines](development/documentation.md)
 * [E2E testing with `kops` clusters](development/testing.md)
 * [Example on how to add a feature](development/adding_a_feature.md)


### PR DESCRIPTION
Resolves issue #3122

Happy to fix by moving the files instead, but this seemed less obtrusive.