### PR TITLE
Read the channel from the local filesystem during tests

### DIFF
--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -27,7 +27,8 @@ import (
 	"net/url"
 )
 
-const DefaultChannelBase = "https://raw.githubusercontent.com/kubernetes/kops/master/channels/"
+var DefaultChannelBase = "https://raw.githubusercontent.com/kubernetes/kops/master/channels/"
+
 const DefaultChannel = "stable"
 const AlphaChannel = "alpha"
 


### PR DESCRIPTION
Another step towards working totally offline (which may never be fully
achievable, because of the need to hash assets).  But should ensure that
when we update the stable channel, we are testing against that version
in the tests, otherwise it is easy to break master.