### PR TITLE
Limit the IAM EC2 policy for the master nodes

### DIFF
--- a/tests/integration/minimal/cloudformation.json
+++ b/tests/integration/minimal/cloudformation.json
@@ -536,13 +536,7 @@
           "Statement": [
             {
               "Action": [
-                "ecr:GetAuthorizationToken",
-                "ecr:BatchCheckLayerAvailability",
-                "ecr:GetDownloadUrlForLayer",
-                "ecr:GetRepositoryPolicy",
-                "ecr:DescribeRepositories",
-                "ecr:ListImages",
-                "ecr:BatchGetImage"
+                "ec2:Describe*"
               ],
               "Effect": "Allow",
               "Resource": [
@@ -552,6 +546,21 @@
             {
               "Action": [
                 "ec2:*"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
+                "ecr:GetAuthorizationToken",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:GetRepositoryPolicy",
+                "ecr:DescribeRepositories",
+                "ecr:ListImages",
+                "ecr:BatchGetImage"
               ],
               "Effect": "Allow",
               "Resource": [


### PR DESCRIPTION
Related to: https://github.com/kubernetes/kops/pull/3158

The EC2 policy for the master nodes are quite open currently, allowing them to create/delete/modify resources that are not associated with the cluster the node originates from. I've come up with a potential solution using condition keys to validate that the `ec2:ResourceTag/KubernetesCluster` matches the cluster name.