### PR TITLE
Flannel: change default backend type

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -687,8 +687,14 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 			jumboFrameMTUSize := int32(8912)
 			cluster.Spec.Networking.Weave.MTU = &jumboFrameMTUSize
 		}
-	case "flannel":
-		cluster.Spec.Networking.Flannel = &api.FlannelNetworkingSpec{}
+	case "flannel", "flannel-vxlan":
+		cluster.Spec.Networking.Flannel = &api.FlannelNetworkingSpec{
+			Backend: "vxlan",
+		}
+	case "flannel-udp":
+		cluster.Spec.Networking.Flannel = &api.FlannelNetworkingSpec{
+			Backend: "udp",
+		}
 	case "calico":
 		cluster.Spec.Networking.Calico = &api.CalicoNetworkingSpec{}
 	case "canal":

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -248,7 +248,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd.Flags().StringVar(&options.Image, "image", options.Image, "Image to use for all instances.")
 
-	cmd.Flags().StringVar(&options.Networking, "networking", "kubenet", "Networking mode to use.  kubenet (default), classic, external, kopeio-vxlan (or kopeio), weave, flannel, calico, canal, kube-router.")
+	cmd.Flags().StringVar(&options.Networking, "networking", "kubenet", "Networking mode to use.  kubenet (default), classic, external, kopeio-vxlan (or kopeio), weave, flannel-vxlan (or flannel), flannel-udp, calico, canal, kube-router.")
 
 	cmd.Flags().StringVar(&options.DNSZone, "dns-zone", options.DNSZone, "DNS hosted zone to use (defaults to longest matching zone)")
 	cmd.Flags().StringVar(&options.OutDir, "out", options.OutDir, "Path to write any local output")
@@ -692,6 +692,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 			Backend: "vxlan",
 		}
 	case "flannel-udp":
+		glog.Warningf("flannel UDP mode is not recommended; consider flannel-vxlan instead")
 		cluster.Spec.Networking.Flannel = &api.FlannelNetworkingSpec{
 			Backend: "udp",
 		}

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -82,7 +82,7 @@ kops create cluster
       --master-zones stringSlice             Zones in which to run masters (must be an odd number)
       --model string                         Models to apply (separate multiple models with commas) (default "config,proto,cloudup")
       --network-cidr string                  Set to override the default network CIDR
-      --networking string                    Networking mode to use.  kubenet (default), classic, external, kopeio-vxlan (or kopeio), weave, flannel, calico, canal, kube-router. (default "kubenet")
+      --networking string                    Networking mode to use.  kubenet (default), classic, external, kopeio-vxlan (or kopeio), weave, flannel-vxlan (or flannel), flannel-udp, calico, canal, kube-router. (default "kubenet")
       --node-count int32                     Set the number of nodes
       --node-security-groups stringSlice     Add precreated additional security groups to nodes.
       --node-size string                     Set instance size for nodes

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -32,7 +32,7 @@ Several different providers are currently built into kops:
 
 * [Calico](http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/)
 * [Canal (Flannel + Calico)](https://github.com/projectcalico/canal)
-* [flannel](https://github.com/coreos/flannel)
+* [flannel](https://github.com/coreos/flannel) - use `--networking flannel-vxlan` (recommended) or `--networking flannel-udp` (legacy).  `--networking flannel` now selects `flannel-vxlan`.
 * [kopeio-vxlan](https://github.com/kopeio/networking)
 * [kube-router](./networking.md#kube-router-example-for-cni-ipvs-based-service-proxy-and-network-policy-enforcer)
 * [weave](https://github.com/weaveworks/weave-kube)

--- a/docs/releases/1.8-NOTES.md
+++ b/docs/releases/1.8-NOTES.md
@@ -1,0 +1,8 @@
+_This is a WIP document describing changes to the upcoming kops 1.8 release_
+
+# Significant changes
+
+* flannel now has a `backend` property in the manifest, which can be either `udp` or `vxlan`.  `udp`
+is not recommended, but will be the default value for existing clusters or clusters created via manifests.
+`kops create cluster` with `--networking flannel` will use `vxlan`, `--networking flannel-vxlan`
+or `--networking flannel-udp` can be specified to explicitly choose a backend mode.

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -60,6 +60,8 @@ type WeaveNetworkingSpec struct {
 
 // Flannel declares that we want Flannel networking
 type FlannelNetworkingSpec struct {
+	// Backend is the backend overlay type we want to use
+	Backend string `json:"backend,omitempty"`
 }
 
 // Calico declares that we want Calico networking

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -60,7 +60,7 @@ type WeaveNetworkingSpec struct {
 
 // Flannel declares that we want Flannel networking
 type FlannelNetworkingSpec struct {
-	// Backend is the backend overlay type we want to use
+	// Backend is the backend overlay type we want to use (vxlan or udp)
 	Backend string `json:"backend,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha1/defaults.go
+++ b/pkg/apis/kops/v1alpha1/defaults.go
@@ -81,4 +81,13 @@ func SetDefaults_ClusterSpec(obj *ClusterSpec) {
 		}
 	}
 
+	if obj.Networking != nil {
+		if obj.Networking.Flannel != nil {
+			if obj.Networking.Flannel.Backend == "" {
+				// Populate with legacy default value; new clusters will be created with vxlan by create cluster
+				obj.Networking.Flannel.Backend = "udp"
+			}
+		}
+	}
+
 }

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -60,6 +60,8 @@ type WeaveNetworkingSpec struct {
 
 // Flannel declares that we want Flannel networking
 type FlannelNetworkingSpec struct {
+	// Backend is the backend overlay type we want to use
+	Backend string `json:"backend,omitempty"`
 }
 
 // Calico declares that we want Calico networking

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -60,7 +60,7 @@ type WeaveNetworkingSpec struct {
 
 // Flannel declares that we want Flannel networking
 type FlannelNetworkingSpec struct {
-	// Backend is the backend overlay type we want to use
+	// Backend is the backend overlay type we want to use (vxlan or udp)
 	Backend string `json:"backend,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1337,6 +1337,7 @@ func Convert_kops_FileAssetSpec_To_v1alpha1_FileAssetSpec(in *kops.FileAssetSpec
 }
 
 func autoConvert_v1alpha1_FlannelNetworkingSpec_To_kops_FlannelNetworkingSpec(in *FlannelNetworkingSpec, out *kops.FlannelNetworkingSpec, s conversion.Scope) error {
+	out.Backend = in.Backend
 	return nil
 }
 
@@ -1346,6 +1347,7 @@ func Convert_v1alpha1_FlannelNetworkingSpec_To_kops_FlannelNetworkingSpec(in *Fl
 }
 
 func autoConvert_kops_FlannelNetworkingSpec_To_v1alpha1_FlannelNetworkingSpec(in *kops.FlannelNetworkingSpec, out *FlannelNetworkingSpec, s conversion.Scope) error {
+	out.Backend = in.Backend
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/defaults.go
+++ b/pkg/apis/kops/v1alpha2/defaults.go
@@ -80,4 +80,13 @@ func SetDefaults_ClusterSpec(obj *ClusterSpec) {
 			Legacy: true,
 		}
 	}
+
+	if obj.Networking != nil {
+		if obj.Networking.Flannel != nil {
+			if obj.Networking.Flannel.Backend == "" {
+				// Populate with legacy default value; new clusters will be created with vxlan by create cluster
+				obj.Networking.Flannel.Backend = "udp"
+			}
+		}
+	}
 }

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -60,6 +60,8 @@ type WeaveNetworkingSpec struct {
 
 // Flannel declares that we want Flannel networking
 type FlannelNetworkingSpec struct {
+	// Backend is the backend overlay type we want to use
+	Backend string `json:"backend,omitempty"`
 }
 
 // Calico declares that we want Calico networking

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -60,7 +60,7 @@ type WeaveNetworkingSpec struct {
 
 // Flannel declares that we want Flannel networking
 type FlannelNetworkingSpec struct {
-	// Backend is the backend overlay type we want to use
+	// Backend is the backend overlay type we want to use (vxlan or udp)
 	Backend string `json:"backend,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1435,6 +1435,7 @@ func Convert_kops_FileAssetSpec_To_v1alpha2_FileAssetSpec(in *kops.FileAssetSpec
 }
 
 func autoConvert_v1alpha2_FlannelNetworkingSpec_To_kops_FlannelNetworkingSpec(in *FlannelNetworkingSpec, out *kops.FlannelNetworkingSpec, s conversion.Scope) error {
+	out.Backend = in.Backend
 	return nil
 }
 
@@ -1444,6 +1445,7 @@ func Convert_v1alpha2_FlannelNetworkingSpec_To_kops_FlannelNetworkingSpec(in *Fl
 }
 
 func autoConvert_kops_FlannelNetworkingSpec_To_v1alpha2_FlannelNetworkingSpec(in *kops.FlannelNetworkingSpec, out *FlannelNetworkingSpec, s conversion.Scope) error {
+	out.Backend = in.Backend
 	return nil
 }
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -70,6 +70,10 @@ func validateClusterSpec(spec *kops.ClusterSpec, fieldPath *field.Path) field.Er
 		allErrs = append(allErrs, validateKubeAPIServer(spec.KubeAPIServer, fieldPath.Child("kubeAPIServer"))...)
 	}
 
+	if spec.Networking != nil {
+		allErrs = append(allErrs, validateNetworking(spec.Networking, fieldPath.Child("networking"))...)
+	}
+
 	return allErrs
 }
 
@@ -181,7 +185,6 @@ func validateExecContainerAction(v *kops.ExecContainerAction, fldPath *field.Pat
 }
 
 func validateKubeAPIServer(v *kops.KubeAPIServerConfig, fldPath *field.Path) field.ErrorList {
-
 	allErrs := field.ErrorList{}
 
 	proxyClientCertIsNil := v.ProxyClientCertFile == nil
@@ -190,6 +193,30 @@ func validateKubeAPIServer(v *kops.KubeAPIServerConfig, fldPath *field.Path) fie
 	if (proxyClientCertIsNil && !proxyClientKeyIsNil) || (!proxyClientCertIsNil && proxyClientKeyIsNil) {
 		flds := [2]*string{v.ProxyClientCertFile, v.ProxyClientKeyFile}
 		allErrs = append(allErrs, field.Invalid(fldPath, flds, "ProxyClientCertFile and ProxyClientKeyFile must both be specified (or not all)"))
+	}
+
+	return allErrs
+}
+
+func validateNetworking(v *kops.NetworkingSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if v.Flannel != nil {
+		allErrs = append(allErrs, validateNetworkingFlannel(v.Flannel, fldPath.Child("Flannel"))...)
+	}
+	return allErrs
+}
+
+func validateNetworkingFlannel(v *kops.FlannelNetworkingSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	switch v.Backend {
+	case "":
+		allErrs = append(allErrs, field.Required(fldPath.Child("Backend"), "Flannel backend must be specified"))
+	case "udp", "vxlan":
+		// OK
+	default:
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("Backend"), v.Backend, []string{"udp", "vxlan"}))
 	}
 
 	return allErrs

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -195,3 +195,41 @@ func Test_Validate_DockerConfig_Storage(t *testing.T) {
 		}
 	}
 }
+
+func Test_Validate_Networking_Flannel(t *testing.T) {
+
+	grid := []struct {
+		Input          kops.FlannelNetworkingSpec
+		ExpectedErrors []string
+	}{
+		{
+			Input: kops.FlannelNetworkingSpec{
+				Backend: "udp",
+			},
+		},
+		{
+			Input: kops.FlannelNetworkingSpec{
+				Backend: "vxlan",
+			},
+		},
+		{
+			Input: kops.FlannelNetworkingSpec{
+				Backend: "",
+			},
+			ExpectedErrors: []string{"Required value::Networking.Flannel.Backend"},
+		},
+		{
+			Input: kops.FlannelNetworkingSpec{
+				Backend: "nope",
+			},
+			ExpectedErrors: []string{"Unsupported value::Networking.Flannel.Backend"},
+		},
+	}
+	for _, g := range grid {
+		networking := &kops.NetworkingSpec{}
+		networking.Flannel = &g.Input
+
+		errs := validateNetworking(networking, field.NewPath("Networking"))
+		testErrors(t, g.Input, errs, g.ExpectedErrors)
+	}
+}

--- a/pkg/model/firewall.go
+++ b/pkg/model/firewall.go
@@ -129,7 +129,14 @@ func (b *FirewallModelBuilder) applyNodeToMasterAllowSpecificPorts(c *fi.ModelBu
 		}
 
 		if b.Cluster.Spec.Networking.Flannel != nil {
-			udpPorts = append(udpPorts, 8285)
+			switch b.Cluster.Spec.Networking.Flannel.Backend {
+			case "", "udp":
+				udpPorts = append(udpPorts, 8285)
+			case "vxlan":
+				udpPorts = append(udpPorts, 8472)
+			default:
+				glog.Warningf("unknown flannel networking backend %q", b.Cluster.Spec.Networking.Flannel.Backend)
+			}
 		}
 
 		if b.Cluster.Spec.Networking.Calico != nil {

--- a/tests/integration/privateflannel/in-v1alpha1.yaml
+++ b/tests/integration/privateflannel/in-v1alpha1.yaml
@@ -23,7 +23,8 @@ spec:
   masterPublicName: api.privateflannel.example.com
   networkCIDR: 172.20.0.0/16
   networking:
-    flannel: {}
+    flannel:
+      backend: vxlan
   nonMasqueradeCIDR: 100.64.0.0/10
   topology:
     bastion:

--- a/tests/integration/privateflannel/in-v1alpha2.yaml
+++ b/tests/integration/privateflannel/in-v1alpha2.yaml
@@ -23,7 +23,8 @@ spec:
   masterPublicName: api.privateflannel.example.com
   networkCIDR: 172.20.0.0/16
   networking:
-    flannel: {}
+    flannel:
+      backend: vxlan
   nonMasqueradeCIDR: 100.64.0.0/10
   sshAccess:
   - 0.0.0.0/0

--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.6.yaml.template
@@ -71,7 +71,7 @@ data:
     {
       "Network": "100.64.0.0/10",
       "Backend": {
-        "Type": "udp"
+        "Type": "{{FlannelBackendType}}"
       }
     }
 ---

--- a/upup/models/cloudup/resources/addons/networking.flannel/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/pre-k8s-1.6.yaml.template
@@ -28,7 +28,7 @@ data:
     {
       "Network": "100.64.0.0/10",
       "Backend": {
-        "Type": "udp"
+        "Type": "{{FlannelBackendType}}"
       }
     }
 ---

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -30,12 +30,8 @@ package cloudup
 import (
 	"encoding/base64"
 	"fmt"
-
-	"github.com/golang/glog"
-
 	"os"
 	"strconv"
-
 	"strings"
 	"text/template"
 
@@ -44,9 +40,7 @@ import (
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/dns"
 	"k8s.io/kops/pkg/model"
-
 	"k8s.io/kops/upup/pkg/fi"
-
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 )
 

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -39,6 +39,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/dns"
@@ -109,6 +110,15 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap) {
 	}
 
 	dest["ProxyEnv"] = tf.ProxyEnv
+
+	if tf.cluster.Spec.Networking != nil && tf.cluster.Spec.Networking.Flannel != nil {
+		flannelBackendType := tf.cluster.Spec.Networking.Flannel.Backend
+		if flannelBackendType == "" {
+			glog.Warningf("Defaulting flannel backend to udp (not a recommended configuration)")
+			flannelBackendType = "udp"
+		}
+		dest["FlannelBackendType"] = func() string { return flannelBackendType }
+	}
 }
 
 // SharedVPC is a simple helper function which makes the templates for a shared VPC clearer


### PR DESCRIPTION
We support udp, which has to the default for backwards-compatibility,
but also new clusters will now use vxlan.