### PR TITLE
Add hooks to bootstrapscript output

### DIFF
--- a/pkg/model/tests/data/bootstrapscript_1.txt
+++ b/pkg/model/tests/data/bootstrapscript_1.txt
@@ -149,16 +149,47 @@ cloudConfig:
   nodeTags: something
 docker:
   logLevel: INFO
+hooks:
+- execContainer:
+    command:
+    - sh
+    - -c
+    - chroot /rootfs apt-get update && chroot /rootfs apt-get install -y ceph-common
+    image: busybox
+  roles:
+  - Master
+kubeAPIServer:
+  image: CoreOS
+kubeControllerManager:
+  cloudProvider: aws
 kubeProxy:
   cpuRequest: 30m
   featureGates:
     AdvancedAuditing: "true"
+kubeScheduler:
+  image: SomeImage
 kubelet:
   kubeconfigPath: /etc/kubernetes/config.txt
+masterKubelet:
+  kubeconfigPath: /etc/kubernetes/config.cfg
 
 __EOF_CLUSTER_SPEC
 
 cat > ig_spec.yaml << __EOF_IG_SPEC
+hooks:
+- before:
+  - update-engine.service
+  - kubelet.service
+  manifest: |-
+    Type=oneshot
+    ExecStart=/usr/bin/systemctl stop update-engine.service
+  name: disable-update-engine.service
+  roles:
+  - Master
+- manifest: |-
+    Type=oneshot
+    ExecStart=/usr/bin/systemctl start apply-to-all.service
+  name: apply-to-all.service
 kubelet:
   kubeconfigPath: /etc/kubernetes/igconfig.txt
 nodeLabels:

--- a/pkg/model/tests/data/bootstrapscript_2.txt
+++ b/pkg/model/tests/data/bootstrapscript_2.txt
@@ -149,6 +149,16 @@ cloudConfig:
   nodeTags: something
 docker:
   logLevel: INFO
+hooks:
+- execContainer:
+    command:
+    - sh
+    - -c
+    - chroot /rootfs apt-get update && chroot /rootfs apt-get install -y ceph-common
+    image: busybox
+  roles:
+  - Master
+  - Node
 kubeAPIServer:
   image: CoreOS
 kubeControllerManager:
@@ -168,6 +178,16 @@ __EOF_CLUSTER_SPEC
 
 cat > ig_spec.yaml << __EOF_IG_SPEC
 hooks:
+- before:
+  - update-engine.service
+  - kubelet.service
+  manifest: |-
+    Type=oneshot
+    ExecStart=/usr/bin/systemctl stop update-engine.service
+  name: disable-update-engine.service
+  roles:
+  - Master
+  - Node
 - manifest: |-
     Type=oneshot
     ExecStart=/usr/bin/systemctl start apply-to-all.service

--- a/pkg/model/tests/data/bootstrapscript_3.txt
+++ b/pkg/model/tests/data/bootstrapscript_3.txt
@@ -149,20 +149,12 @@ cloudConfig:
   nodeTags: something
 docker:
   logLevel: INFO
-kubeAPIServer:
-  image: CoreOS
-kubeControllerManager:
-  cloudProvider: aws
 kubeProxy:
   cpuRequest: 30m
   featureGates:
     AdvancedAuditing: "true"
-kubeScheduler:
-  image: SomeImage
 kubelet:
   kubeconfigPath: /etc/kubernetes/config.txt
-masterKubelet:
-  kubeconfigPath: /etc/kubernetes/config.cfg
 
 __EOF_CLUSTER_SPEC
 

--- a/pkg/model/tests/data/bootstrapscript_4.txt
+++ b/pkg/model/tests/data/bootstrapscript_4.txt
@@ -149,25 +149,35 @@ cloudConfig:
   nodeTags: something
 docker:
   logLevel: INFO
-kubeAPIServer:
-  image: CoreOS
-kubeControllerManager:
-  cloudProvider: aws
+hooks:
+- execContainer:
+    command:
+    - sh
+    - -c
+    - chroot /rootfs apt-get update && chroot /rootfs apt-get install -y ceph-common
+    image: busybox
+  roles:
+  - Node
 kubeProxy:
   cpuRequest: 30m
   featureGates:
     AdvancedAuditing: "true"
-kubeScheduler:
-  image: SomeImage
 kubelet:
   kubeconfigPath: /etc/kubernetes/config.txt
-masterKubelet:
-  kubeconfigPath: /etc/kubernetes/config.cfg
 
 __EOF_CLUSTER_SPEC
 
 cat > ig_spec.yaml << __EOF_IG_SPEC
 hooks:
+- before:
+  - update-engine.service
+  - kubelet.service
+  manifest: |-
+    Type=oneshot
+    ExecStart=/usr/bin/systemctl stop update-engine.service
+  name: disable-update-engine.service
+  roles:
+  - Node
 - manifest: |-
     Type=oneshot
     ExecStart=/usr/bin/systemctl start apply-to-all.service

--- a/pkg/model/tests/data/bootstrapscript_5.txt
+++ b/pkg/model/tests/data/bootstrapscript_5.txt
@@ -149,25 +149,37 @@ cloudConfig:
   nodeTags: something
 docker:
   logLevel: INFO
-kubeAPIServer:
-  image: CoreOS
-kubeControllerManager:
-  cloudProvider: aws
+hooks:
+- execContainer:
+    command:
+    - sh
+    - -c
+    - chroot /rootfs apt-get update && chroot /rootfs apt-get install -y ceph-common
+    image: busybox
+  roles:
+  - Master
+  - Node
 kubeProxy:
   cpuRequest: 30m
   featureGates:
     AdvancedAuditing: "true"
-kubeScheduler:
-  image: SomeImage
 kubelet:
   kubeconfigPath: /etc/kubernetes/config.txt
-masterKubelet:
-  kubeconfigPath: /etc/kubernetes/config.cfg
 
 __EOF_CLUSTER_SPEC
 
 cat > ig_spec.yaml << __EOF_IG_SPEC
 hooks:
+- before:
+  - update-engine.service
+  - kubelet.service
+  manifest: |-
+    Type=oneshot
+    ExecStart=/usr/bin/systemctl stop update-engine.service
+  name: disable-update-engine.service
+  roles:
+  - Master
+  - Node
 - manifest: |-
     Type=oneshot
     ExecStart=/usr/bin/systemctl start apply-to-all.service


### PR DESCRIPTION
Ping @gambol99 

Related to:
- https://github.com/kubernetes/kops/pull/3120
- https://github.com/kubernetes/kops/pull/3063

Cluster Hooks are now added in their entirety to the nodeup user data scripts, dependant on whether the instance group roles match. This could increase the size of the user-data files significantly (getting closer to the 16KB mark) depending on users' hooks content. I considered hashing and fingerprinting the cluster hooks, but following discussions in https://github.com/kubernetes/kops/pull/3120 thought we should keep the full output instead.