### PR TITLE
Fixes reading /root/.docker/config.json on debian

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -180,6 +180,7 @@ func (b *KubeletBuilder) buildSystemdService() *nodetasks.Service {
 	manifest.Set("Service", "RestartSec", "2s")
 	manifest.Set("Service", "StartLimitInterval", "0")
 	manifest.Set("Service", "KillMode", "process")
+	manifest.Set("Service", "User", "root")
 	manifestString := manifest.Render()
 
 	glog.V(8).Infof("Built service manifest %q\n%s", "kubelet", manifestString)


### PR DESCRIPTION
Debian and probably others apparently don't automatically default to using the root account if it's not specified.

ref: https://github.com/kubernetes/kubernetes/issues/45487#issuecomment-312042754