### PR TITLE
Allow cluster-autoscaler to list/watch StatefulSets

### DIFF
--- a/addons/cluster-autoscaler/v1.6.0.yaml
+++ b/addons/cluster-autoscaler/v1.6.0.yaml
@@ -66,6 +66,13 @@ rules:
   verbs:
   - watch
   - list
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - watch
+  - list
 
 ---
 


### PR DESCRIPTION
Otherwise we get the error

    k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/client/informers/informers_generated/externalversions/factory.go:72: Failed to list *v1beta1.StatefulSet: User "system:serviceaccount:kube-system:cluster-autoscaler" cannot list statefulsets.apps at the cluster scope. (get statefulsets.apps)