### PR TITLE
Allow specifying a SSH key name for AWS

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -313,3 +313,13 @@ spec:
   cloudConfig:
     elbSecurityGroup: sg-123445678
 ```
+
+### sshKeyName
+
+In some cases, it may be desirable to use an existing AWS SSH key instead of allowing kops to create a new one.
+Providing the name of a key already in AWS is an alternative to `--ssh-public-key`.
+
+```yaml
+spec:
+  sshKeyName: myexistingkey
+```

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -94,6 +94,8 @@ type ClusterSpec struct {
 	SSHAccess []string `json:"sshAccess,omitempty"`
 	// HTTPProxy defines connection information to support use of a private cluster behind an forward HTTP Proxy
 	EgressProxy *EgressProxySpec `json:"egressProxy,omitempty"`
+	// SSHKeyName specifies a preexisting SSH key to use
+	SSHKeyName string `json:"sshKeyName,omitempty"`
 
 	// KubernetesAPIAccess is a list of the CIDRs that can access the Kubernetes API endpoint (master HTTPS)
 	KubernetesAPIAccess []string `json:"kubernetesApiAccess,omitempty"`

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -218,6 +218,9 @@ type ClusterSpec struct {
 	// HTTPProxy defines connection information to support use of a private cluster behind an forward HTTP Proxy
 	EgressProxy *EgressProxySpec `json:"egressProxy,omitempty"`
 
+	// SSHKeyName specifies a preexisting SSH key to use
+	SSHKeyName string `json:"sshKeyName,omitempty"`
+
 	// EtcdClusters stores the configuration for each cluster
 	EtcdClusters []*EtcdClusterSpec `json:"etcdClusters,omitempty"`
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -562,6 +562,7 @@ func autoConvert_v1alpha1_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 	} else {
 		out.EgressProxy = nil
 	}
+	out.SSHKeyName = in.SSHKeyName
 	if in.EtcdClusters != nil {
 		in, out := &in.EtcdClusters, &out.EtcdClusters
 		*out = make([]*kops.EtcdClusterSpec, len(*in))
@@ -770,6 +771,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha1_ClusterSpec(in *kops.ClusterSpec, 
 	} else {
 		out.EgressProxy = nil
 	}
+	out.SSHKeyName = in.SSHKeyName
 	// WARNING: in.KubernetesAPIAccess requires manual conversion: does not exist in peer-type
 	out.IsolateMasters = in.IsolateMasters
 	out.UpdatePolicy = in.UpdatePolicy

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -115,6 +115,9 @@ type ClusterSpec struct {
 	// HTTPProxy defines connection information to support use of a private cluster behind an forward HTTP Proxy
 	EgressProxy *EgressProxySpec `json:"egressProxy,omitempty"`
 
+	// SSHKeyName specifies a preexisting SSH key to use
+	SSHKeyName string `json:"sshKeyName,omitempty"`
+
 	// KubernetesAPIAccess determines the permitted access to the API endpoints (master HTTPS)
 	// Currently only a single CIDR is supported (though a richer grammar could be added in future)
 	KubernetesAPIAccess []string `json:"kubernetesApiAccess,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -593,6 +593,7 @@ func autoConvert_v1alpha2_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 	} else {
 		out.EgressProxy = nil
 	}
+	out.SSHKeyName = in.SSHKeyName
 	out.KubernetesAPIAccess = in.KubernetesAPIAccess
 	out.IsolateMasters = in.IsolateMasters
 	out.UpdatePolicy = in.UpdatePolicy
@@ -831,6 +832,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, 
 	} else {
 		out.EgressProxy = nil
 	}
+	out.SSHKeyName = in.SSHKeyName
 	out.KubernetesAPIAccess = in.KubernetesAPIAccess
 	out.IsolateMasters = in.IsolateMasters
 	out.UpdatePolicy = in.UpdatePolicy

--- a/pkg/model/names.go
+++ b/pkg/model/names.go
@@ -116,14 +116,21 @@ func (b *KopsModelContext) LinkToIAMInstanceProfile(ig *kops.InstanceGroup) *aws
 	return &awstasks.IAMInstanceProfile{Name: &name}
 }
 
-// SSHKeyName computes a unique SSH key name, combining the cluster name and the SSH public key fingerprint
+// SSHKeyName computes a unique SSH key name, combining the cluster name and the SSH public key fingerprint.
+// If an SSH key name is provided in the cluster configuration, it will use that instead.
 func (c *KopsModelContext) SSHKeyName() (string, error) {
+	// use configured SSH key name if present
+	name := c.Cluster.Spec.SSHKeyName
+	if name != "" {
+		return name, nil
+	}
+
 	fingerprint, err := awstasks.ComputeOpenSSHKeyFingerprint(string(c.SSHPublicKeys[0]))
 	if err != nil {
 		return "", err
 	}
 
-	name := "kubernetes." + c.Cluster.ObjectMeta.Name + "-" + fingerprint
+	name = "kubernetes." + c.Cluster.ObjectMeta.Name + "-" + fingerprint
 	return name, nil
 }
 


### PR DESCRIPTION
Related to #2309, this allows naming an existing key pair using the
cluster spec field `sshKeyName`.

In our use case, kops can now be used without providing the ability to
create EC2 key pairs.