### PR TITLE
Bump version to 1.7.1-beta.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))
 # Keep in sync with upup/models/cloudup/resources/addons/dns-controller/
 DNS_CONTROLLER_TAG=1.7.1
 
-KOPS_RELEASE_VERSION = 1.7.0
-KOPS_CI_VERSION      = 1.7.1-beta.1
+KOPS_RELEASE_VERSION = 1.7.1-beta.1
+KOPS_CI_VERSION      = 1.7.1-beta.2
 
 # kops install location
 KOPS                 = ${GOPATH_1ST}/bin/kops


### PR DESCRIPTION
This also will let master work again without a custom nodeup (nodeup changes)