### PR TITLE
Correctly set lifecycle on LB resources

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/dnsname.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname.go
@@ -104,6 +104,7 @@ func (e *DNSName) Find(c *fi.Context) (*DNSName, error) {
 	actual.Zone = e.Zone
 	actual.Name = e.Name
 	actual.ResourceType = e.ResourceType
+	actual.Lifecycle = e.Lifecycle
 
 	if found.AliasTarget != nil {
 		dnsName := aws.StringValue(found.AliasTarget.DNSName)

--- a/upup/pkg/fi/cloudup/awstasks/load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/load_balancer.go
@@ -18,9 +18,8 @@ package awstasks
 
 import (
 	"fmt"
-
+	"sort"
 	"strconv"
-
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -32,7 +31,6 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
-	"sort"
 )
 
 // LoadBalancer manages an ELB.  We find the existing ELB using the Name tag.
@@ -286,6 +284,7 @@ func (e *LoadBalancer) Find(c *fi.Context) (*LoadBalancer, error) {
 	actual.DNSName = lb.DNSName
 	actual.HostedZoneId = lb.CanonicalHostedZoneNameID
 	actual.Scheme = lb.Scheme
+	actual.Lifecycle = e.Lifecycle
 
 	for _, subnet := range lb.Subnets {
 		actual.Subnets = append(actual.Subnets, &Subnet{ID: subnet})

--- a/upup/pkg/fi/cloudup/awstasks/load_balancer_attachment.go
+++ b/upup/pkg/fi/cloudup/awstasks/load_balancer_attachment.go
@@ -84,6 +84,7 @@ func (e *LoadBalancerAttachment) Find(c *fi.Context) (*LoadBalancerAttachment, e
 
 			// Prevent spurious changes
 			actual.Name = e.Name // ELB attachments don't have tags
+			actual.Lifecycle = e.Lifecycle
 
 			return actual, nil
 		}


### PR DESCRIPTION
When the cluster is configured with an ELB, the following resources show up on every update as requiring changes:
```
Will modify resources:
  DNSName/api.kash-kops.example.com
  	Lifecycle           	 <nil> -> Sync

    LoadBalancer/api.kash-kops.example.com
    	Lifecycle           	 <nil> -> Sync

    LoadBalancerAttachment/api-master-eu-west-1a
    	Lifecycle           	 <nil> -> Sync

    LoadBalancerAttachment/api-master-eu-west-1b
    	Lifecycle           	 <nil> -> Sync

    LoadBalancerAttachment/api-master-eu-west-1c
    	Lifecycle           	 <nil> -> Sync
```

This PR sets the lifecycle property on the above awstask objects.