### PR TITLE
KubeAPI  & Kubelet Loglevels

### DIFF
--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -17,11 +17,12 @@ limitations under the License.
 package components
 
 import (
+	"strings"
+
 	"github.com/golang/glog"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/loader"
-	"strings"
 )
 
 // KubeletOptionsBuilder adds options for kubelets
@@ -55,7 +56,7 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 	clusterSpec.Kubelet.EnableDebuggingHandlers = fi.Bool(true)
 	clusterSpec.Kubelet.PodManifestPath = "/etc/kubernetes/manifests"
 	clusterSpec.Kubelet.AllowPrivileged = fi.Bool(true)
-	clusterSpec.Kubelet.LogLevel = fi.Int32(2)
+	clusterSpec.Kubelet.LogLevel = fi.Int32(0)
 	clusterSpec.Kubelet.ClusterDNS = ip.String()
 	clusterSpec.Kubelet.ClusterDomain = clusterSpec.ClusterDNSDomain
 	clusterSpec.Kubelet.NonMasqueradeCIDR = clusterSpec.NonMasqueradeCIDR

--- a/upup/models/config/components/kube-apiserver/kube-apiserver.options
+++ b/upup/models/config/components/kube-apiserver/kube-apiserver.options
@@ -6,6 +6,6 @@ KubeAPIServer:
   EtcdServersOverrides:
   - /events#http://127.0.0.1:4002
   ServiceClusterIPRange: {{ .ServiceClusterIPRange }}
-  LogLevel: 2
+  LogLevel: 0
   AllowPrivileged: true
   Image: {{ Image "kube-apiserver" }}


### PR DESCRIPTION
The current default logging levels for kube-apiserver and kubelet are quite high; reducing them to make the user decide