### PR TITLE
adding socat with rhel family

### DIFF
--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -39,6 +39,7 @@ func (b *PackagesBuilder) Build(c *fi.ModelBuilderContext) error {
 	} else if b.Distribution.IsRHELFamily() {
 		c.AddTask(&nodetasks.Package{Name: "ebtables"})
 		c.AddTask(&nodetasks.Package{Name: "ethtool"})
+		c.AddTask(&nodetasks.Package{Name: "socat"})
 	} else {
 		// Hopefully it's already installed
 		glog.Infof("ebtables package not known for distro %q", b.Distribution)


### PR DESCRIPTION
Socat is not installed by default with RHEL, and k8s needs it.