### PR TITLE
Set lifecycle on ElasticIP and NAT Gateway tasks to avoid spurious changes

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
@@ -165,6 +165,9 @@ func (e *ElasticIP) find(cloud awsup.AWSCloud) (*ElasticIP, error) {
 
 		e.ID = actual.ID
 
+		// Avoid spurious changes
+		actual.Lifecycle = e.Lifecycle
+
 		return actual, nil
 	}
 	return nil, nil

--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -109,6 +109,7 @@ func (e *NatGateway) Find(c *fi.Context) (*NatGateway, error) {
 
 	// NATGateways don't have a Name (no tags), so we set the name to avoid spurious changes
 	actual.Name = e.Name
+	actual.Lifecycle = e.Lifecycle
 
 	actual.AssociatedRouteTable = e.AssociatedRouteTable
 


### PR DESCRIPTION
Identified in issue #476
Extension of fixes within PR #3226