### PR TITLE
Replace deprecated aws session.New() with session.NewSession()

### DIFF
--- a/protokube/pkg/protokube/aws_volume.go
+++ b/protokube/pkg/protokube/aws_volume.go
@@ -58,7 +58,10 @@ func NewAWSVolumes() (*AWSVolumes, error) {
 		deviceMap: make(map[string]string),
 	}
 
-	s := session.New()
+	s, err := session.NewSession()
+	if err != nil {
+		return nil, fmt.Errorf("error starting new AWS session: %v", err)
+	}
 	s.Handlers.Send.PushFront(func(r *request.Request) {
 		// Log requests
 		glog.V(4).Infof("AWS API Request: %s/%s", r.ClientInfo.ServiceName, r.Operation.Name)

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -170,42 +170,42 @@ func NewAWSCloud(region string, tags map[string]string) (AWSCloud, error) {
 
 		sess, err := session.NewSession()
 		if err != nil {
-			return &awsCloudImplementation{}, err
+			return c, err
 		}
 		c.cf = cloudformation.New(sess, config)
 		c.cf.Handlers.Send.PushFront(requestLogger)
 
 		sess, err = session.NewSession()
 		if err != nil {
-			return &awsCloudImplementation{}, err
+			return c, err
 		}
 		c.ec2 = ec2.New(sess, config)
 		c.ec2.Handlers.Send.PushFront(requestLogger)
 
 		sess, err = session.NewSession()
 		if err != nil {
-			return &awsCloudImplementation{}, err
+			return c, err
 		}
 		c.iam = iam.New(sess, config)
 		c.iam.Handlers.Send.PushFront(requestLogger)
 
 		sess, err = session.NewSession()
 		if err != nil {
-			return &awsCloudImplementation{}, err
+			return c, err
 		}
 		c.elb = elb.New(sess, config)
 		c.elb.Handlers.Send.PushFront(requestLogger)
 
 		sess, err = session.NewSession()
 		if err != nil {
-			return &awsCloudImplementation{}, err
+			return c, err
 		}
 		c.autoscaling = autoscaling.New(sess, config)
 		c.autoscaling.Handlers.Send.PushFront(requestLogger)
 
 		sess, err = session.NewSession()
 		if err != nil {
-			return &awsCloudImplementation{}, err
+			return c, err
 		}
 		c.route53 = route53.New(sess, config)
 		c.route53.Handlers.Send.PushFront(requestLogger)

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -168,22 +168,46 @@ func NewAWSCloud(region string, tags map[string]string) (AWSCloud, error) {
 
 		requestLogger := newRequestLogger(2)
 
-		c.cf = cloudformation.New(session.New(), config)
+		sess, err := session.NewSession()
+		if err != nil {
+			return &awsCloudImplementation{}, err
+		}
+		c.cf = cloudformation.New(sess, config)
 		c.cf.Handlers.Send.PushFront(requestLogger)
 
-		c.ec2 = ec2.New(session.New(), config)
+		sess, err = session.NewSession()
+		if err != nil {
+			return &awsCloudImplementation{}, err
+		}
+		c.ec2 = ec2.New(sess, config)
 		c.ec2.Handlers.Send.PushFront(requestLogger)
 
-		c.iam = iam.New(session.New(), config)
+		sess, err = session.NewSession()
+		if err != nil {
+			return &awsCloudImplementation{}, err
+		}
+		c.iam = iam.New(sess, config)
 		c.iam.Handlers.Send.PushFront(requestLogger)
 
-		c.elb = elb.New(session.New(), config)
+		sess, err = session.NewSession()
+		if err != nil {
+			return &awsCloudImplementation{}, err
+		}
+		c.elb = elb.New(sess, config)
 		c.elb.Handlers.Send.PushFront(requestLogger)
 
-		c.autoscaling = autoscaling.New(session.New(), config)
+		sess, err = session.NewSession()
+		if err != nil {
+			return &awsCloudImplementation{}, err
+		}
+		c.autoscaling = autoscaling.New(sess, config)
 		c.autoscaling.Handlers.Send.PushFront(requestLogger)
 
-		c.route53 = route53.New(session.New(), config)
+		sess, err = session.NewSession()
+		if err != nil {
+			return &awsCloudImplementation{}, err
+		}
+		c.route53 = route53.New(sess, config)
 		c.route53.Handlers.Send.PushFront(requestLogger)
 
 		awsCloudInstances[region] = c

--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -45,7 +45,12 @@ func ValidateRegion(region string) error {
 		config := aws.NewConfig().WithRegion(awsRegion)
 		config = config.WithCredentialsChainVerboseErrors(true)
 
-		client := ec2.New(session.New(), config)
+		sess, err := session.NewSession()
+		if err != nil {
+			return fmt.Errorf("Error starting a new AWS session: %v", err)
+		}
+
+		client := ec2.New(sess, config)
 
 		response, err := client.DescribeRegions(request)
 		if err != nil {

--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -67,7 +67,7 @@ func (s *S3Context) getClient(region string) (*s3.S3, error) {
 
 		sess, err := session.NewSession()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error starting new AWS session:%v", err)
 		}
 		s3Client = s3.New(sess, config)
 		s.clients[region] = s3Client

--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -65,8 +65,11 @@ func (s *S3Context) getClient(region string) (*s3.S3, error) {
 			}
 		}
 
-		session := session.New()
-		s3Client = s3.New(session, config)
+		sess, err := session.NewSession()
+		if err != nil {
+			return nil, err
+		}
+		s3Client = s3.New(sess, config)
 		s.clients[region] = s3Client
 	}
 


### PR DESCRIPTION
From the `godoc github.com/aws/aws-sdk-go/aws/session.New`:

> Deprecated: Use NewSession functions to create sessions instead. NewSession has the same functionality as New except an error can be returned when the func is called instead of waiting to receive an error until a request is made.

This PR replaces every use of session.New() with session.NewSession(), and additionally sets the variable name as `sess` in places where it was being set to `session`.