### PR TITLE
remove --cluster-cidr from kube-router's manifest.

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
@@ -67,7 +67,6 @@ spec:
         - --run-firewall=true
         - --run-service-proxy=true
         - --kubeconfig=/var/lib/kube-router/kubeconfig
-        - --cluster-cidr={{ .NonMasqueradeCIDR }}
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
Kube-router was using --cluster-cidr flag to get the subnet allocated
for pod CIDR's. But now kube-router has the ability internally to infer
the CIDR allocated for the pod's by getting the information from
kubernetes API server node spec's