### PR TITLE
Allow user defined endpoint to host action for Canal

### DIFF
--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -67,8 +67,12 @@ type CalicoNetworkingSpec struct {
 	CrossSubnet bool `json:"crossSubnet,omitempty"` // Enables Calico's cross-subnet mode when set to true
 }
 
-// Canal declares that we want Canal networking
+// CanalNetworkingSpec declares that we want Canal networking
 type CanalNetworkingSpec struct {
+	// DefaultEndpointToHostAction allows users to configure the default behaviour
+	// for traffic between pod to host after calico rules have been processed.
+	// Default: ACCEPT (other options: DROP, RETURN)
+	DefaultEndpointToHostAction string `json:"defaultEndpointToHostAction,omitempty"`
 }
 
 // Kuberouter declares that we want Kube-router networking

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -67,8 +67,12 @@ type CalicoNetworkingSpec struct {
 	CrossSubnet bool `json:"crossSubnet,omitempty"` // Enables Calico's cross-subnet mode when set to true
 }
 
-// Canal declares that we want Canal networking
+// CanalNetworkingSpec declares that we want Canal networking
 type CanalNetworkingSpec struct {
+	// DefaultEndpointToHostAction allows users to configure the default behaviour
+	// for traffic between pod to host after calico rules have been processed.
+	// Default: ACCEPT (other options: DROP, RETURN)
+	DefaultEndpointToHostAction string `json:"defaultEndpointToHostAction,omitempty"`
 }
 
 // Kuberouter declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -361,6 +361,7 @@ func Convert_kops_CalicoNetworkingSpec_To_v1alpha1_CalicoNetworkingSpec(in *kops
 }
 
 func autoConvert_v1alpha1_CanalNetworkingSpec_To_kops_CanalNetworkingSpec(in *CanalNetworkingSpec, out *kops.CanalNetworkingSpec, s conversion.Scope) error {
+	out.DefaultEndpointToHostAction = in.DefaultEndpointToHostAction
 	return nil
 }
 
@@ -370,6 +371,7 @@ func Convert_v1alpha1_CanalNetworkingSpec_To_kops_CanalNetworkingSpec(in *CanalN
 }
 
 func autoConvert_kops_CanalNetworkingSpec_To_v1alpha1_CanalNetworkingSpec(in *kops.CanalNetworkingSpec, out *CanalNetworkingSpec, s conversion.Scope) error {
+	out.DefaultEndpointToHostAction = in.DefaultEndpointToHostAction
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -67,8 +67,12 @@ type CalicoNetworkingSpec struct {
 	CrossSubnet bool `json:"crossSubnet,omitempty"` // Enables Calico's cross-subnet mode when set to true
 }
 
-// Canal declares that we want Canal networking
+// CanalNetworkingSpec declares that we want Canal networking
 type CanalNetworkingSpec struct {
+	// DefaultEndpointToHostAction allows users to configure the default behaviour
+	// for traffic between pod to host after calico rules have been processed.
+	// Default: ACCEPT (other options: DROP, RETURN)
+	DefaultEndpointToHostAction string `json:"defaultEndpointToHostAction,omitempty"`
 }
 
 // Kuberouter declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -389,6 +389,7 @@ func Convert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *kops
 }
 
 func autoConvert_v1alpha2_CanalNetworkingSpec_To_kops_CanalNetworkingSpec(in *CanalNetworkingSpec, out *kops.CanalNetworkingSpec, s conversion.Scope) error {
+	out.DefaultEndpointToHostAction = in.DefaultEndpointToHostAction
 	return nil
 }
 
@@ -398,6 +399,7 @@ func Convert_v1alpha2_CanalNetworkingSpec_To_kops_CanalNetworkingSpec(in *CanalN
 }
 
 func autoConvert_kops_CanalNetworkingSpec_To_v1alpha2_CanalNetworkingSpec(in *kops.CanalNetworkingSpec, out *CanalNetworkingSpec, s conversion.Scope) error {
+	out.DefaultEndpointToHostAction = in.DefaultEndpointToHostAction
 	return nil
 }
 

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -167,6 +167,16 @@ func ValidateCluster(c *kops.Cluster, strict bool) *field.Error {
 		}
 	}
 
+	// Check Canal Networking Spec if used
+	if c.Spec.Networking.Canal != nil {
+		action := c.Spec.Networking.Canal.DefaultEndpointToHostAction
+		switch action {
+		case "", "ACCEPT", "DROP", "RETURN":
+		default:
+			return field.Invalid(fieldSpec.Child("Networking", "Canal", "DefaultEndpointToHostAction"), action, fmt.Sprintf("Unsupported value: %s, supports ACCEPT, DROP or RETURN", action))
+		}
+	}
+
 	// Check ClusterCIDR
 	if c.Spec.KubeControllerManager != nil {
 		var clusterCIDR *net.IPNet

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.6.yaml.template
@@ -119,7 +119,7 @@ spec:
                   fieldPath: spec.nodeName
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
-              value: "ACCEPT"
+              value: "{{- or .Networking.Canal.DefaultEndpointToHostAction "ACCEPT" }}"
           securityContext:
             privileged: true
           resources:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/pre-k8s-1.6.yaml.template
@@ -111,7 +111,7 @@ spec:
                   fieldPath: spec.nodeName
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
-              value: "ACCEPT"
+              value: "{{- or .Networking.Canal.DefaultEndpointToHostAction "ACCEPT" }}"
           securityContext:
             privileged: true
           resources:

--- a/upup/pkg/fi/cloudup/populatecluster_test.go
+++ b/upup/pkg/fi/cloudup/populatecluster_test.go
@@ -55,6 +55,8 @@ func buildMinimalCluster() *api.Cluster {
 	// TODO: Mock cloudprovider
 	c.Spec.DNSZone = "test.com"
 
+	c.Spec.Networking = &api.NetworkingSpec{}
+
 	return c
 }
 


### PR DESCRIPTION
Adds ability to define `Networking.Canal.DefaultEndpointToHostAction` in the Cluster Spec. This allows you to customise the behaviour of traffic routing from a pod to the host (after calico iptables chains have been processed). `ACCEPT` is the default value and is left as-is.

`If you want to allow some or all traffic from endpoint to host, set this parameter to “RETURN” or “ACCEPT”. Use “RETURN” if you have your own rules in the iptables “INPUT” chain; Calico will insert its rules at the top of that chain, then “RETURN” packets to the “INPUT” chain once it has completed processing workload endpoint egress policy.`