### PR TITLE
Kops command fixes

### DIFF
--- a/cmd/kops/delete_confirm_test.go
+++ b/cmd/kops/delete_confirm_test.go
@@ -49,7 +49,7 @@ func TestConfirmation(t *testing.T) {
 	}
 
 	c.Default = "yes"
-	answer, err = ui.GetConfirm(c)
+	_, err = ui.GetConfirm(c)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/kops/root.go
+++ b/cmd/kops/root.go
@@ -128,7 +128,7 @@ func NewCmdRoot(f *util.Factory, out io.Writer) *cobra.Command {
 
 	defaultStateStore := os.Getenv("KOPS_STATE_STORE")
 	if strings.HasSuffix(defaultStateStore, "/") {
-		strings.TrimSuffix(defaultStateStore, "/")
+		defaultStateStore = strings.TrimSuffix(defaultStateStore, "/")
 	}
 	cmd.PersistentFlags().StringVarP(&rootCommand.RegistryPath, "state", "", defaultStateStore, "Location of state storage")
 


### PR DESCRIPTION
TrimSuffix() on defaultStateStore doesn't actually do anything, and there is an unused answer variable in the tests.