### PR TITLE
AWS: Always use verbose errors

### DIFF
--- a/protokube/pkg/protokube/aws_volume.go
+++ b/protokube/pkg/protokube/aws_volume.go
@@ -58,7 +58,10 @@ func NewAWSVolumes() (*AWSVolumes, error) {
 		deviceMap: make(map[string]string),
 	}
 
-	s, err := session.NewSession()
+	config := aws.NewConfig()
+	config = config.WithCredentialsChainVerboseErrors(true)
+
+	s, err := session.NewSession(config)
 	if err != nil {
 		return nil, fmt.Errorf("error starting new AWS session: %v", err)
 	}
@@ -66,9 +69,6 @@ func NewAWSVolumes() (*AWSVolumes, error) {
 		// Log requests
 		glog.V(4).Infof("AWS API Request: %s/%s", r.ClientInfo.ServiceName, r.Operation.Name)
 	})
-
-	config := aws.NewConfig()
-	config = config.WithCredentialsChainVerboseErrors(true)
 
 	a.metadata = ec2metadata.New(s, config)
 

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -168,42 +168,42 @@ func NewAWSCloud(region string, tags map[string]string) (AWSCloud, error) {
 
 		requestLogger := newRequestLogger(2)
 
-		sess, err := session.NewSession()
+		sess, err := session.NewSession(config)
 		if err != nil {
 			return c, err
 		}
 		c.cf = cloudformation.New(sess, config)
 		c.cf.Handlers.Send.PushFront(requestLogger)
 
-		sess, err = session.NewSession()
+		sess, err = session.NewSession(config)
 		if err != nil {
 			return c, err
 		}
 		c.ec2 = ec2.New(sess, config)
 		c.ec2.Handlers.Send.PushFront(requestLogger)
 
-		sess, err = session.NewSession()
+		sess, err = session.NewSession(config)
 		if err != nil {
 			return c, err
 		}
 		c.iam = iam.New(sess, config)
 		c.iam.Handlers.Send.PushFront(requestLogger)
 
-		sess, err = session.NewSession()
+		sess, err = session.NewSession(config)
 		if err != nil {
 			return c, err
 		}
 		c.elb = elb.New(sess, config)
 		c.elb.Handlers.Send.PushFront(requestLogger)
 
-		sess, err = session.NewSession()
+		sess, err = session.NewSession(config)
 		if err != nil {
 			return c, err
 		}
 		c.autoscaling = autoscaling.New(sess, config)
 		c.autoscaling.Handlers.Send.PushFront(requestLogger)
 
-		sess, err = session.NewSession()
+		sess, err = session.NewSession(config)
 		if err != nil {
 			return c, err
 		}

--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -45,7 +45,7 @@ func ValidateRegion(region string) error {
 		config := aws.NewConfig().WithRegion(awsRegion)
 		config = config.WithCredentialsChainVerboseErrors(true)
 
-		sess, err := session.NewSession()
+		sess, err := session.NewSession(config)
 		if err != nil {
 			return fmt.Errorf("Error starting a new AWS session: %v", err)
 		}

--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -65,9 +65,9 @@ func (s *S3Context) getClient(region string) (*s3.S3, error) {
 			}
 		}
 
-		sess, err := session.NewSession()
+		sess, err := session.NewSession(config)
 		if err != nil {
-			return nil, fmt.Errorf("error starting new AWS session:%v", err)
+			return nil, fmt.Errorf("error starting new AWS session: %v", err)
 		}
 		s3Client = s3.New(sess, config)
 		s.clients[region] = s3Client
@@ -92,6 +92,7 @@ func getCustomS3Config(endpoint string, region string) (*aws.Config, error) {
 		Region:           aws.String(region),
 		S3ForcePathStyle: aws.Bool(true),
 	}
+	s3Config = s3Config.WithCredentialsChainVerboseErrors(true)
 
 	return s3Config, nil
 }
@@ -181,7 +182,10 @@ out the first result.
 See also: https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLocationRequest
 */
 func bruteforceBucketLocation(region *string, request *s3.GetBucketLocationInput) (*s3.GetBucketLocationOutput, error) {
-	session, _ := session.NewSession(&aws.Config{Region: region})
+	config := &aws.Config{Region: region}
+	config = config.WithCredentialsChainVerboseErrors(true)
+
+	session, _ := session.NewSession(config)
 
 	regions, err := ec2.New(session).DescribeRegions(nil)
 	if err != nil {


### PR DESCRIPTION
As otherwise very difficult to diagnose errors