### PR TITLE
Fix space in rolling-update cluster help

### DIFF
--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -42,7 +42,7 @@ import (
 )
 
 var (
-	rollingupdate_long = templates.LongDesc(i18n.T(`
+	rollingupdate_long = pretty.LongDesc(i18n.T(`
 	This command updates a kubernetes cluster to match the cloud, and kops specifications.
 
 	To perform rolling update, you need to update the cloud resources first with "kops update cluster"

--- a/docs/cli/kops_rolling-update.md
+++ b/docs/cli/kops_rolling-update.md
@@ -8,13 +8,16 @@ Rolling update a cluster.
 ### Synopsis
 
 
-This command updates a kubernetes cluster to match the cloud, and kops specifications. 
+This command updates a kubernetes cluster to match the cloud, and kops specifications.
 
-To perform rolling update, you need to update the cloud resources first with "kops update cluster" 
+To perform rolling update, you need to update the cloud resources first with "kops update cluster"
 
-Note: terraform users will need run the following commands all from the same directory "kops update cluster --target=terraform" then "terraform plan" then "terraform apply" prior to running "kops rolling-update cluster" 
+Note: terraform users will need run the following commands all from the same directory "kops update cluster --target=terraform" then "terraform plan" then "terraform apply"
+prior to running "kops rolling-update cluster"
 
-Use export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate"to use beta code that drains the nodes and validates the cluster.  New flags for Drain and Validation operations will be shown when the environment variable is set.
+Use `export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate"` to use beta code that drains the nodes
+and validates the cluster.  New flags for Drain and Validation operations will be shown when
+the environment variable is set.
 
 ### Examples
 

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -8,13 +8,16 @@ Rolling update a cluster.
 ### Synopsis
 
 
-This command updates a kubernetes cluster to match the cloud, and kops specifications. 
+This command updates a kubernetes cluster to match the cloud, and kops specifications.
 
-To perform rolling update, you need to update the cloud resources first with "kops update cluster" 
+To perform rolling update, you need to update the cloud resources first with "kops update cluster"
 
-Note: terraform users will need run the following commands all from the same directory "kops update cluster --target=terraform" then "terraform plan" then "terraform apply" prior to running "kops rolling-update cluster" 
+Note: terraform users will need run the following commands all from the same directory "kops update cluster --target=terraform" then "terraform plan" then "terraform apply"
+prior to running "kops rolling-update cluster"
 
-Use export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate"to use beta code that drains the nodes and validates the cluster.  New flags for Drain and Validation operations will be shown when the environment variable is set.
+Use `export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate"` to use beta code that drains the nodes
+and validates the cluster.  New flags for Drain and Validation operations will be shown when
+the environment variable is set.
 
 ```
 kops rolling-update cluster


### PR DESCRIPTION
When we use pretty.Bash, we must use pretty.LongDesc to stop the spacing
being mangled.