### PR TITLE
Toolbox template

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -322,3 +322,18 @@
 [submodule "_vendor/github.com/tent/http-link-go"]
 	path = _vendor/github.com/tent/http-link-go
 	url = https://github.com/tent/http-link-go.git
+[submodule "_vendor/github.com/Masterminds/semver"]
+	path = _vendor/github.com/Masterminds/semver
+	url = https://github.com/Masterminds/semver.git
+[submodule "_vendor/github.com/huandu/xstrings"]
+	path = _vendor/github.com/huandu/xstrings
+	url = https://github.com/huandu/xstrings.git
+[submodule "_vendor/github.com/satori/go.uuid"]
+	path = _vendor/github.com/satori/go.uuid
+	url = https://github.com/satori/go.uuid.git
+[submodule "_vendor/github.com/Masterminds/sprig"]
+	path = _vendor/github.com/Masterminds/sprig
+	url = https://github.com/Masterminds/sprig.git
+[submodule "_vendor/github.com/aokoli/goutils"]
+	path = _vendor/github.com/aokoli/goutils
+	url = https://github.com/aokoli/goutils.git

--- a/docs/cli/kops_toolbox_template.md
+++ b/docs/cli/kops_toolbox_template.md
@@ -20,17 +20,19 @@ kops toolbox template
   # generate cluster.yaml from template and input values
   
   kops toolbox template \
-  --values values.yaml \
-  --template cluster.tmpl.yaml \
+  --values values.yaml --values=another.yaml \
+  --snippets file_or_directory --snippets=another.dir \
+  --template file_or_directory --template=directory  \
   --output cluster.yaml
 ```
 
 ### Options
 
 ```
-      --output string     Path to output file, default: cluster.yaml
-      --template string   Path to template file, default: cluster.tmpl.yaml
-      --values string     Path to values yaml file, default: values.yaml
+      --output string          Path to output file, otherwise defaults to stdout
+      --snippets stringSlice   Path to directory containing snippets used for templating
+      --template stringSlice   Path to template file or directory of templates to render
+      --values stringSlice     Path to a configuration file containing values to include in template
 ```
 
 ### Options inherited from parent commands

--- a/hack/.packages
+++ b/hack/.packages
@@ -83,6 +83,7 @@ k8s.io/kops/pkg/systemd
 k8s.io/kops/pkg/templates
 k8s.io/kops/pkg/testutils
 k8s.io/kops/pkg/util/stringorslice
+k8s.io/kops/pkg/util/templater
 k8s.io/kops/pkg/validation
 k8s.io/kops/protokube/cmd/protokube
 k8s.io/kops/protokube/pkg/gossip

--- a/pkg/util/templater/integration_tests.yml
+++ b/pkg/util/templater/integration_tests.yml
@@ -1,0 +1,91 @@
+#
+# Basic Check
+#
+- context:
+    hello: world
+  template: |
+    hello {{ .hello }}
+  expected: |
+    hello world
+- template: |
+    {{ upper "hello" }} world its {{ lower "Me" }}
+  expected: |
+    HELLO world its me
+
+#
+# Snippets
+#
+- context:
+    etcd:
+    - name: main
+      members:
+      - a1
+      - b1
+    - name: events
+      members:
+      - a1
+      - b1
+  snippets:
+    cluster: |
+      {{- range .etcd -}}
+      - name: {{ .name }}
+        members: {{ .members | join "," }}
+      {{ end -}}
+  template: |
+    cluster:
+    {{ include "cluster" . -}}
+  expected: |
+    cluster:
+    - name: main
+      members: a1,b1
+    - name: events
+      members: a1,b1
+- snippets:
+    unit: |
+      [Unit]
+      Name: somename
+
+      [Service]
+      This is a service
+  template: |
+    hooks:
+      name: myservice.service
+      manifest: |
+        {{ include "unit" . | indent 4 -}}
+  expected: |
+    hooks:
+      name: myservice.service
+      manifest: |
+        [Unit]
+        Name: somename
+
+        [Service]
+        This is a service
+#
+# Iterations
+#
+- context:
+    etcd:
+    - name: main
+      members: [a1,b1]
+    - name: events
+      members: [a1,b1]
+  template: |
+    cluster:
+    {{- range .etcd }}
+    - name: {{ .name }}
+      members: {{ .members -}}
+    {{ end }}
+  expected: |
+    cluster:
+    - name: main
+      members: [a1 b1]
+    - name: events
+      members: [a1 b1]
+
+
+
+
+
+
+

--- a/pkg/util/templater/templater.go
+++ b/pkg/util/templater/templater.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templater
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/Masterminds/sprig"
+)
+
+const (
+	templateName = "mainTemplate"
+)
+
+// Templater is golang template renders
+type Templater struct{}
+
+// NewTemplater returns a new renderer implementation
+func NewTemplater() *Templater {
+	return &Templater{}
+}
+
+// Render is responsible for actually rendering the template
+func (r *Templater) Render(content string, context map[string]interface{}, snippets map[string]string) (rendered string, err error) {
+
+	// @step: create the template
+	tm := template.New(templateName)
+	if _, err = tm.Funcs(r.templateFuncsMap(tm)).Parse(content); err != nil {
+		return
+	}
+	tm.Option("missingkey=error")
+
+	// @step: add the snippits into the mix
+	for filename, snippet := range snippets {
+		name := filepath.Base(filename)
+		if name == templateName {
+			return "", fmt.Errorf("snippet cannot have the same name as the template: %s", name)
+		}
+		if _, err = tm.New(name).Parse(snippet); err != nil {
+			return rendered, fmt.Errorf("unable to parse snippet: %s, error: %s", filename, err)
+		}
+	}
+
+	// @step: render the actual template
+	writer := new(bytes.Buffer)
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("failed to parse template, error: %s", r)
+		}
+	}()
+	if err = tm.ExecuteTemplate(writer, templateName, context); err != nil {
+		return
+	}
+
+	return writer.String(), nil
+}
+
+// templateFuncsMap returns a map if the template functions for this template
+func (r *Templater) templateFuncsMap(tm *template.Template) template.FuncMap {
+	// grab the template functions from sprig which are pretty awesome
+	funcs := sprig.TxtFuncMap()
+
+	funcs["indent"] = indentContent
+	// @step: as far as i can see there's no native way in sprig in include external snippets of code
+	funcs["include"] = func(name string, context map[string]interface{}) string {
+		content, err := includeSnippet(tm, name, context)
+		if err != nil {
+			panic(err.Error())
+		}
+
+		return content
+	}
+
+	return funcs
+}
+
+// indentContent is responsible for indenting the string content
+func indentContent(indent int, content string) string {
+	var b bytes.Buffer
+	length := len(strings.Split(content, "\n")) - 1
+	for i, x := range strings.Split(content, "\n") {
+		// @check if the length of the line is zero and set spacer
+		spacer := indent
+		if i == 0 || len(x) <= 0 {
+			spacer = 0
+		}
+		// @step: write the line to the buffer
+		line := fmt.Sprintf("%"+fmt.Sprintf("%d", spacer)+"s%s", "", x)
+		b.WriteString(line)
+
+		// @check if we need a newline
+		if i < length {
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}
+
+// includenSnippet is responsible for including a snippet
+func includeSnippet(tm *template.Template, name string, context map[string]interface{}) (string, error) {
+	b := bytes.NewBufferString("")
+	if err := tm.ExecuteTemplate(b, name, context); err != nil {
+		return "", fmt.Errorf("snippet: %s, issue: %s", name, err)
+	}
+
+	return b.String(), nil
+}

--- a/pkg/util/templater/templater_test.go
+++ b/pkg/util/templater/templater_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templater
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"k8s.io/kops/pkg/diff"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestRenderGeneralOK(t *testing.T) {
+	cases := []renderTest{
+		{
+			Template: "hello",
+			Expected: "hello",
+		},
+		{
+			Template: `{{ lower "Hello" }}`,
+			Expected: "hello",
+		},
+		{
+			Template: `{{ upper "Hello" }}`,
+			Expected: "HELLO",
+		},
+		{
+			Context:  map[string]interface{}{"list": []string{"a", "b", "c"}},
+			Template: `{{ .list | join "," }}`,
+			Expected: "a,b,c",
+		},
+	}
+	makeRenderTests(t, cases)
+}
+
+func TestRenderMissingValue(t *testing.T) {
+	cases := []renderTest{
+		{
+			Context:  map[string]interface{}{"missing": "no"},
+			Template: `{{ .missing  }}`,
+			Expected: "no",
+		},
+		{
+			Context:  map[string]interface{}{"is_missing": "no"},
+			Template: `{{ .missing  }}`,
+			NotOK:    true,
+		},
+		{
+			Context:  map[string]interface{}{"missing": "no"},
+			Snippets: map[string]string{"snip": "{{ .is_missing }}"},
+			Template: `{{ .missing  }}{{ include "snip" . }}`,
+			NotOK:    true,
+		},
+	}
+	makeRenderTests(t, cases)
+}
+
+func TestRenderIndent(t *testing.T) {
+	cases := []renderTest{
+		{
+			Context:  map[string]interface{}{"line": "this is a line of\ntext"},
+			Template: `{{ .line | indent 2 }}`,
+			Expected: "this is a line of\n  text",
+		},
+	}
+	makeRenderTests(t, cases)
+}
+
+func TestRenderSnippet(t *testing.T) {
+	cases := []renderTest{
+		{
+			Context:  map[string]interface{}{"name": "world"},
+			Snippets: map[string]string{"snip": "hello world"},
+			Template: `this should say {{ include "snip" . }}`,
+			Expected: "this should say hello world",
+		},
+		{
+			Context: map[string]interface{}{"name": "world"},
+			Snippets: map[string]string{
+				"one": "hello world",
+				"two": "hello everyone",
+			},
+			Template: `this should say {{ include "one" . }} {{ include "two" . }}`,
+			Expected: "this should say hello world hello everyone",
+		},
+	}
+	makeRenderTests(t, cases)
+}
+
+func TestRenderContext(t *testing.T) {
+	cases := []renderTest{
+		{
+			Context:  map[string]interface{}{"name": "world"},
+			Template: `hello {{ .name }}`,
+			Expected: "hello world",
+		},
+		{
+			Context:  map[string]interface{}{"name": "world", "id": 99},
+			Template: `hello {{ .name }} {{.id}}`,
+			Expected: "hello world 99",
+		},
+		{
+			Context: map[string]interface{}{
+				"struct": map[string]interface{}{
+					"id":   1,
+					"name": "test",
+				},
+			},
+			Template: `hello {{ .struct.name }} {{ .struct.id }}`,
+			Expected: "hello test 1",
+		},
+		{
+			Context: map[string]interface{}{
+				"members": []struct {
+					Name    string
+					Members []string
+				}{
+					{
+						Name:    "etcd0",
+						Members: []string{"1", "2"},
+					},
+					{
+						Name:    "etcd1",
+						Members: []string{"1", "2"},
+					},
+				},
+			},
+			Template: `{{ range .members }}{{ .Name }},{{ end }}`,
+			Expected: "etcd0,etcd1,",
+		},
+	}
+	makeRenderTests(t, cases)
+}
+
+func TestRenderIntegration(t *testing.T) {
+	var cases []renderTest
+	content, err := ioutil.ReadFile("integration_tests.yml")
+	if err != nil {
+		t.Fatalf("unable to load the integration tests, error: %s", err)
+	}
+	if err := yaml.Unmarshal(content, &cases); err != nil {
+		t.Fatalf("unable to decode the integration tests, error: %s", err)
+	}
+
+	makeRenderTests(t, cases)
+}
+
+type renderTest struct {
+	Expected string
+	Snippets map[string]string
+	Context  map[string]interface{}
+	Template string
+	NotOK    bool
+}
+
+func makeRenderTests(t *testing.T, tests []renderTest) {
+	r := NewTemplater()
+	for i, x := range tests {
+		render, err := r.Render(x.Template, x.Context, x.Snippets)
+		if x.NotOK {
+			if err == nil {
+				t.Errorf("case %d: should have thrown an error", i)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("case %d: failed to render template, error: %s", i, err)
+			continue
+		}
+		if x.Expected != render {
+			t.Logf("diff:\n%s\n", diff.FormatDiff(x.Expected, render))
+			t.Errorf("case %d failed, policy output differed from expected.", i)
+		}
+	}
+}

--- a/upup/pkg/fi/loader/options_loader.go
+++ b/upup/pkg/fi/loader/options_loader.go
@@ -20,13 +20,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/golang/glog"
-	"k8s.io/kops/upup/pkg/fi/utils"
 	"os"
 	"reflect"
 	"sort"
 	"strings"
 	"text/template"
+
+	"github.com/golang/glog"
+	"k8s.io/kops/upup/pkg/fi/utils"
 )
 
 const maxIterations = 10
@@ -108,7 +109,7 @@ func (l *OptionsLoader) iterate(userConfig interface{}, current interface{}) (in
 
 		yamlBytes := buffer.Bytes()
 
-		jsonBytes, err := utils.YamlToJson(yamlBytes)
+		jsonBytes, err := utils.YAMLToJSON(yamlBytes)
 		if err != nil {
 			// TODO: It would be nice if yaml returned us the line number here
 			glog.Infof("error parsing yaml.  yaml follows:")

--- a/upup/pkg/fi/utils/sanitize.go
+++ b/upup/pkg/fi/utils/sanitize.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 )
 
+// SanitizeString iterated a strings and removes any characters not in the allow list
 func SanitizeString(s string) string {
 	var out bytes.Buffer
 	allowed := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
@@ -32,6 +33,7 @@ func SanitizeString(s string) string {
 			out.WriteRune('_')
 		}
 	}
+
 	return string(out.Bytes())
 }
 
@@ -40,5 +42,6 @@ func ExpandPath(p string) string {
 	if strings.HasPrefix(p, "~/") {
 		p = os.Getenv("HOME") + p[1:]
 	}
+
 	return p
 }

--- a/upup/pkg/fi/utils/yaml.go
+++ b/upup/pkg/fi/utils/yaml.go
@@ -23,14 +23,17 @@ import (
 
 // See http://ghodss.com/2014/the-right-way-to-handle-yaml-in-golang/
 
-func YamlToJson(yamlBytes []byte) ([]byte, error) {
+// YAMLToJSON converts yaml to json
+func YAMLToJSON(yamlBytes []byte) ([]byte, error) {
 	return yaml.YAMLToJSON(yamlBytes)
 }
 
+// YamlUnmarshal unmarshalls the yaml content to an interface
 func YamlUnmarshal(yamlBytes []byte, dest interface{}) error {
 	return yaml.Unmarshal(yamlBytes, dest)
 }
 
+// YamlMarshal trys to marshal the input struct into yaml content
 func YamlMarshal(o interface{}) ([]byte, error) {
 	return yaml.Marshal(o)
 }

--- a/util/pkg/hashing/hash.go
+++ b/util/pkg/hashing/hash.go
@@ -23,11 +23,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"github.com/golang/glog"
 	"hash"
 	"io"
 	"os"
 	"strings"
+
+	"github.com/golang/glog"
 )
 
 type HashAlgorithm string

--- a/vendor/github.com/Masterminds/semver/.travis.yml
+++ b/vendor/github.com/Masterminds/semver/.travis.yml
@@ -1,0 +1,25 @@
+language: go
+
+go:
+  - 1.6
+  - 1.7
+  - 1.8
+  - tip
+
+# Setting sudo access to false will let Travis CI use containers rather than
+# VMs to run the tests. For more details see:
+# - http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+# - http://docs.travis-ci.com/user/workers/standard-infrastructure/
+sudo: false
+
+script:
+  - GO15VENDOREXPERIMENT=1 make setup
+  - GO15VENDOREXPERIMENT=1 make test
+
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/06e3328629952dabe3e0
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: never     # options: [always|never|change] default: always

--- a/vendor/github.com/Masterminds/semver/CHANGELOG.md
+++ b/vendor/github.com/Masterminds/semver/CHANGELOG.md
@@ -1,0 +1,67 @@
+# 1.3.1 (2017-07-10)
+
+## Fixed
+- Fixed #57: number comparisons in prerelease sometimes inaccurate
+
+# 1.3.0 (2017-05-02)
+
+## Added
+- #45: Added json (un)marshaling support (thanks @mh-cbon)
+- Stability marker. See https://masterminds.github.io/stability/
+
+## Fixed
+- #51: Fix handling of single digit tilde constraint (thanks @dgodd)
+
+## Changed
+- #55: The godoc icon moved from png to svg
+
+# 1.2.3 (2017-04-03)
+
+## Fixed
+- #46: Fixed 0.x.x and 0.0.x in constraints being treated as *
+
+# Release 1.2.2 (2016-12-13)
+
+## Fixed
+- #34: Fixed issue where hyphen range was not working with pre-release parsing.
+
+# Release 1.2.1 (2016-11-28)
+
+## Fixed
+- #24: Fixed edge case issue where constraint "> 0" does not handle "0.0.1-alpha"
+  properly.
+
+# Release 1.2.0 (2016-11-04)
+
+## Added
+- #20: Added MustParse function for versions (thanks @adamreese)
+- #15: Added increment methods on versions (thanks @mh-cbon)
+
+## Fixed
+- Issue #21: Per the SemVer spec (section 9) a pre-release is unstable and
+  might not satisfy the intended compatibility. The change here ignores pre-releases
+  on constraint checks (e.g., ~ or ^) when a pre-release is not part of the
+  constraint. For example, `^1.2.3` will ignore pre-releases while
+  `^1.2.3-alpha` will include them.
+
+# Release 1.1.1 (2016-06-30)
+
+## Changed
+- Issue #9: Speed up version comparison performance (thanks @sdboyer)
+- Issue #8: Added benchmarks (thanks @sdboyer)
+- Updated Go Report Card URL to new location
+- Updated Readme to add code snippet formatting (thanks @mh-cbon)
+- Updating tagging to v[SemVer] structure for compatibility with other tools.
+
+# Release 1.1.0 (2016-03-11)
+
+- Issue #2: Implemented validation to provide reasons a versions failed a
+  constraint.
+
+# Release 1.0.1 (2015-12-31)
+
+- Fixed #1: * constraint failing on valid versions.
+
+# Release 1.0.0 (2015-10-20)
+
+- Initial release

--- a/vendor/github.com/Masterminds/semver/LICENSE.txt
+++ b/vendor/github.com/Masterminds/semver/LICENSE.txt
@@ -1,0 +1,20 @@
+The Masterminds
+Copyright (C) 2014-2015, Matt Butcher and Matt Farina
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/Masterminds/semver/Makefile
+++ b/vendor/github.com/Masterminds/semver/Makefile
@@ -1,0 +1,36 @@
+.PHONY: setup
+setup:
+	go get -u gopkg.in/alecthomas/gometalinter.v1
+	gometalinter.v1 --install
+
+.PHONY: test
+test: validate lint
+	@echo "==> Running tests"
+	go test -v
+
+.PHONY: validate
+validate:
+	@echo "==> Running static validations"
+	@gometalinter.v1 \
+	  --disable-all \
+	  --enable deadcode \
+	  --severity deadcode:error \
+	  --enable gofmt \
+	  --enable gosimple \
+	  --enable ineffassign \
+	  --enable misspell \
+	  --enable vet \
+	  --tests \
+	  --vendor \
+	  --deadline 60s \
+	  ./... || exit_code=1
+
+.PHONY: lint
+lint:
+	@echo "==> Running linters"
+	@gometalinter.v1 \
+	  --disable-all \
+	  --enable golint \
+	  --vendor \
+	  --deadline 60s \
+	  ./... || :

--- a/vendor/github.com/Masterminds/semver/README.md
+++ b/vendor/github.com/Masterminds/semver/README.md
@@ -1,0 +1,165 @@
+# SemVer
+
+The `semver` package provides the ability to work with [Semantic Versions](http://semver.org) in Go. Specifically it provides the ability to:
+
+* Parse semantic versions
+* Sort semantic versions
+* Check if a semantic version fits within a set of constraints
+* Optionally work with a `v` prefix
+
+[![Stability:
+Active](https://masterminds.github.io/stability/active.svg)](https://masterminds.github.io/stability/active.html)
+[![Build Status](https://travis-ci.org/Masterminds/semver.svg)](https://travis-ci.org/Masterminds/semver) [![Build status](https://ci.appveyor.com/api/projects/status/jfk66lib7hb985k8/branch/master?svg=true&passingText=windows%20build%20passing&failingText=windows%20build%20failing)](https://ci.appveyor.com/project/mattfarina/semver/branch/master) [![GoDoc](https://godoc.org/github.com/Masterminds/semver?status.svg)](https://godoc.org/github.com/Masterminds/semver) [![Go Report Card](https://goreportcard.com/badge/github.com/Masterminds/semver)](https://goreportcard.com/report/github.com/Masterminds/semver)
+
+## Parsing Semantic Versions
+
+To parse a semantic version use the `NewVersion` function. For example,
+
+```go
+    v, err := semver.NewVersion("1.2.3-beta.1+build345")
+```
+
+If there is an error the version wasn't parseable. The version object has methods
+to get the parts of the version, compare it to other versions, convert the
+version back into a string, and get the original string. For more details
+please see the [documentation](https://godoc.org/github.com/Masterminds/semver).
+
+## Sorting Semantic Versions
+
+A set of versions can be sorted using the [`sort`](https://golang.org/pkg/sort/)
+package from the standard library. For example,
+
+```go
+    raw := []string{"1.2.3", "1.0", "1.3", "2", "0.4.2",}
+    vs := make([]*semver.Version, len(raw))
+	for i, r := range raw {
+		v, err := semver.NewVersion(r)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		vs[i] = v
+	}
+
+	sort.Sort(semver.Collection(vs))
+```
+
+## Checking Version Constraints
+
+Checking a version against version constraints is one of the most featureful
+parts of the package.
+
+```go
+    c, err := semver.NewConstraint(">= 1.2.3")
+    if err != nil {
+        // Handle constraint not being parseable.
+    }
+
+    v, _ := semver.NewVersion("1.3")
+    if err != nil {
+        // Handle version not being parseable.
+    }
+    // Check if the version meets the constraints. The a variable will be true.
+    a := c.Check(v)
+```
+
+## Basic Comparisons
+
+There are two elements to the comparisons. First, a comparison string is a list
+of comma separated and comparisons. These are then separated by || separated or
+comparisons. For example, `">= 1.2, < 3.0.0 || >= 4.2.3"` is looking for a
+comparison that's greater than or equal to 1.2 and less than 3.0.0 or is
+greater than or equal to 4.2.3.
+
+The basic comparisons are:
+
+* `=`: equal (aliased to no operator)
+* `!=`: not equal
+* `>`: greater than
+* `<`: less than
+* `>=`: greater than or equal to
+* `<=`: less than or equal to
+
+_Note, according to the Semantic Version specification pre-releases may not be
+API compliant with their release counterpart. It says,_
+
+> _A pre-release version indicates that the version is unstable and might not satisfy the intended compatibility requirements as denoted by its associated normal version._
+
+_SemVer comparisons without a pre-release value will skip pre-release versions.
+For example, `>1.2.3` will skip pre-releases when looking at a list of values
+while `>1.2.3-alpha.1` will evaluate pre-releases._
+
+## Hyphen Range Comparisons
+
+There are multiple methods to handle ranges and the first is hyphens ranges.
+These look like:
+
+* `1.2 - 1.4.5` which is equivalent to `>= 1.2, <= 1.4.5`
+* `2.3.4 - 4.5` which is equivalent to `>= 2.3.4, <= 4.5`
+
+## Wildcards In Comparisons
+
+The `x`, `X`, and `*` characters can be used as a wildcard character. This works
+for all comparison operators. When used on the `=` operator it falls
+back to the pack level comparison (see tilde below). For example,
+
+* `1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
+* `>= 1.2.x` is equivalent to `>= 1.2.0`
+* `<= 2.x` is equivalent to `<= 3`
+* `*` is equivalent to `>= 0.0.0`
+
+## Tilde Range Comparisons (Patch)
+
+The tilde (`~`) comparison operator is for patch level ranges when a minor
+version is specified and major level changes when the minor number is missing.
+For example,
+
+* `~1.2.3` is equivalent to `>= 1.2.3, < 1.3.0`
+* `~1` is equivalent to `>= 1, < 2`
+* `~2.3` is equivalent to `>= 2.3, < 2.4`
+* `~1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
+* `~1.x` is equivalent to `>= 1, < 2`
+
+## Caret Range Comparisons (Major)
+
+The caret (`^`) comparison operator is for major level changes. This is useful
+when comparisons of API versions as a major change is API breaking. For example,
+
+* `^1.2.3` is equivalent to `>= 1.2.3, < 2.0.0`
+* `^1.2.x` is equivalent to `>= 1.2.0, < 2.0.0`
+* `^2.3` is equivalent to `>= 2.3, < 3`
+* `^2.x` is equivalent to `>= 2.0.0, < 3`
+
+# Validation
+
+In addition to testing a version against a constraint, a version can be validated
+against a constraint. When validation fails a slice of errors containing why a
+version didn't meet the constraint is returned. For example,
+
+```go
+    c, err := semver.NewConstraint("<= 1.2.3, >= 1.4")
+    if err != nil {
+        // Handle constraint not being parseable.
+    }
+
+    v, _ := semver.NewVersion("1.3")
+    if err != nil {
+        // Handle version not being parseable.
+    }
+
+    // Validate a version against a constraint.
+    a, msgs := c.Validate(v)
+    // a is false
+    for _, m := range msgs {
+        fmt.Println(m)
+
+        // Loops over the errors which would read
+        // "1.3 is greater than 1.2.3"
+        // "1.3 is less than 1.4"
+    }
+```
+
+# Contribute
+
+If you find an issue or want to contribute please file an [issue](https://github.com/Masterminds/semver/issues)
+or [create a pull request](https://github.com/Masterminds/semver/pulls).

--- a/vendor/github.com/Masterminds/semver/appveyor.yml
+++ b/vendor/github.com/Masterminds/semver/appveyor.yml
@@ -1,0 +1,44 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\Masterminds\semver
+shallow_clone: true
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+install:
+  - go version
+  - go env
+  - go get -u gopkg.in/alecthomas/gometalinter.v1
+  - set PATH=%PATH%;%GOPATH%\bin
+  - gometalinter.v1.exe --install
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - "gometalinter.v1 \
+    --disable-all \
+    --enable deadcode \
+    --severity deadcode:error \
+    --enable gofmt \
+    --enable gosimple \
+    --enable ineffassign \
+    --enable misspell \
+    --enable vet \
+    --tests \
+    --vendor \
+    --deadline 60s \
+    ./... || exit_code=1"
+  - "gometalinter.v1 \
+    --disable-all \
+    --enable golint \
+    --vendor \
+    --deadline 60s \
+    ./... || :"
+  - go test -v
+
+deploy: off

--- a/vendor/github.com/Masterminds/semver/benchmark_test.go
+++ b/vendor/github.com/Masterminds/semver/benchmark_test.go
@@ -1,0 +1,157 @@
+package semver_test
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver"
+)
+
+/* Constraint creation benchmarks */
+
+func benchNewConstraint(c string, b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		semver.NewConstraint(c)
+	}
+}
+
+func BenchmarkNewConstraintUnary(b *testing.B) {
+	benchNewConstraint("=2.0", b)
+}
+
+func BenchmarkNewConstraintTilde(b *testing.B) {
+	benchNewConstraint("~2.0.0", b)
+}
+
+func BenchmarkNewConstraintCaret(b *testing.B) {
+	benchNewConstraint("^2.0.0", b)
+}
+
+func BenchmarkNewConstraintWildcard(b *testing.B) {
+	benchNewConstraint("1.x", b)
+}
+
+func BenchmarkNewConstraintRange(b *testing.B) {
+	benchNewConstraint(">=2.1.x, <3.1.0", b)
+}
+
+func BenchmarkNewConstraintUnion(b *testing.B) {
+	benchNewConstraint("~2.0.0 || =3.1.0", b)
+}
+
+/* Check benchmarks */
+
+func benchCheckVersion(c, v string, b *testing.B) {
+	version, _ := semver.NewVersion(v)
+	constraint, _ := semver.NewConstraint(c)
+
+	for i := 0; i < b.N; i++ {
+		constraint.Check(version)
+	}
+}
+
+func BenchmarkCheckVersionUnary(b *testing.B) {
+	benchCheckVersion("=2.0", "2.0.0", b)
+}
+
+func BenchmarkCheckVersionTilde(b *testing.B) {
+	benchCheckVersion("~2.0.0", "2.0.5", b)
+}
+
+func BenchmarkCheckVersionCaret(b *testing.B) {
+	benchCheckVersion("^2.0.0", "2.1.0", b)
+}
+
+func BenchmarkCheckVersionWildcard(b *testing.B) {
+	benchCheckVersion("1.x", "1.4.0", b)
+}
+
+func BenchmarkCheckVersionRange(b *testing.B) {
+	benchCheckVersion(">=2.1.x, <3.1.0", "2.4.5", b)
+}
+
+func BenchmarkCheckVersionUnion(b *testing.B) {
+	benchCheckVersion("~2.0.0 || =3.1.0", "3.1.0", b)
+}
+
+func benchValidateVersion(c, v string, b *testing.B) {
+	version, _ := semver.NewVersion(v)
+	constraint, _ := semver.NewConstraint(c)
+
+	for i := 0; i < b.N; i++ {
+		constraint.Validate(version)
+	}
+}
+
+/* Validate benchmarks, including fails */
+
+func BenchmarkValidateVersionUnary(b *testing.B) {
+	benchValidateVersion("=2.0", "2.0.0", b)
+}
+
+func BenchmarkValidateVersionUnaryFail(b *testing.B) {
+	benchValidateVersion("=2.0", "2.0.1", b)
+}
+
+func BenchmarkValidateVersionTilde(b *testing.B) {
+	benchValidateVersion("~2.0.0", "2.0.5", b)
+}
+
+func BenchmarkValidateVersionTildeFail(b *testing.B) {
+	benchValidateVersion("~2.0.0", "1.0.5", b)
+}
+
+func BenchmarkValidateVersionCaret(b *testing.B) {
+	benchValidateVersion("^2.0.0", "2.1.0", b)
+}
+
+func BenchmarkValidateVersionCaretFail(b *testing.B) {
+	benchValidateVersion("^2.0.0", "4.1.0", b)
+}
+
+func BenchmarkValidateVersionWildcard(b *testing.B) {
+	benchValidateVersion("1.x", "1.4.0", b)
+}
+
+func BenchmarkValidateVersionWildcardFail(b *testing.B) {
+	benchValidateVersion("1.x", "2.4.0", b)
+}
+
+func BenchmarkValidateVersionRange(b *testing.B) {
+	benchValidateVersion(">=2.1.x, <3.1.0", "2.4.5", b)
+}
+
+func BenchmarkValidateVersionRangeFail(b *testing.B) {
+	benchValidateVersion(">=2.1.x, <3.1.0", "1.4.5", b)
+}
+
+func BenchmarkValidateVersionUnion(b *testing.B) {
+	benchValidateVersion("~2.0.0 || =3.1.0", "3.1.0", b)
+}
+
+func BenchmarkValidateVersionUnionFail(b *testing.B) {
+	benchValidateVersion("~2.0.0 || =3.1.0", "3.1.1", b)
+}
+
+/* Version creation benchmarks */
+
+func benchNewVersion(v string, b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		semver.NewVersion(v)
+	}
+}
+
+func BenchmarkNewVersionSimple(b *testing.B) {
+	benchNewVersion("1.0.0", b)
+}
+
+func BenchmarkNewVersionPre(b *testing.B) {
+	benchNewVersion("1.0.0-alpha", b)
+}
+
+func BenchmarkNewVersionMeta(b *testing.B) {
+	benchNewVersion("1.0.0+metadata", b)
+}
+
+func BenchmarkNewVersionMetaDash(b *testing.B) {
+	benchNewVersion("1.0.0+metadata-dash", b)
+}

--- a/vendor/github.com/Masterminds/semver/collection.go
+++ b/vendor/github.com/Masterminds/semver/collection.go
@@ -1,0 +1,24 @@
+package semver
+
+// Collection is a collection of Version instances and implements the sort
+// interface. See the sort package for more details.
+// https://golang.org/pkg/sort/
+type Collection []*Version
+
+// Len returns the length of a collection. The number of Version instances
+// on the slice.
+func (c Collection) Len() int {
+	return len(c)
+}
+
+// Less is needed for the sort interface to compare two Version objects on the
+// slice. If checks if one is less than the other.
+func (c Collection) Less(i, j int) bool {
+	return c[i].LessThan(c[j])
+}
+
+// Swap is needed for the sort interface to replace the Version objects
+// at two different positions in the slice.
+func (c Collection) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}

--- a/vendor/github.com/Masterminds/semver/collection_test.go
+++ b/vendor/github.com/Masterminds/semver/collection_test.go
@@ -1,0 +1,46 @@
+package semver
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestCollection(t *testing.T) {
+	raw := []string{
+		"1.2.3",
+		"1.0",
+		"1.3",
+		"2",
+		"0.4.2",
+	}
+
+	vs := make([]*Version, len(raw))
+	for i, r := range raw {
+		v, err := NewVersion(r)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		vs[i] = v
+	}
+
+	sort.Sort(Collection(vs))
+
+	e := []string{
+		"0.4.2",
+		"1.0.0",
+		"1.2.3",
+		"1.3.0",
+		"2.0.0",
+	}
+
+	a := make([]string, len(vs))
+	for i, v := range vs {
+		a[i] = v.String()
+	}
+
+	if !reflect.DeepEqual(a, e) {
+		t.Error("Sorting Collection failed")
+	}
+}

--- a/vendor/github.com/Masterminds/semver/constraints.go
+++ b/vendor/github.com/Masterminds/semver/constraints.go
@@ -1,0 +1,426 @@
+package semver
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Constraints is one or more constraint that a semantic version can be
+// checked against.
+type Constraints struct {
+	constraints [][]*constraint
+}
+
+// NewConstraint returns a Constraints instance that a Version instance can
+// be checked against. If there is a parse error it will be returned.
+func NewConstraint(c string) (*Constraints, error) {
+
+	// Rewrite - ranges into a comparison operation.
+	c = rewriteRange(c)
+
+	ors := strings.Split(c, "||")
+	or := make([][]*constraint, len(ors))
+	for k, v := range ors {
+		cs := strings.Split(v, ",")
+		result := make([]*constraint, len(cs))
+		for i, s := range cs {
+			pc, err := parseConstraint(s)
+			if err != nil {
+				return nil, err
+			}
+
+			result[i] = pc
+		}
+		or[k] = result
+	}
+
+	o := &Constraints{constraints: or}
+	return o, nil
+}
+
+// Check tests if a version satisfies the constraints.
+func (cs Constraints) Check(v *Version) bool {
+	// loop over the ORs and check the inner ANDs
+	for _, o := range cs.constraints {
+		joy := true
+		for _, c := range o {
+			if !c.check(v) {
+				joy = false
+				break
+			}
+		}
+
+		if joy {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Validate checks if a version satisfies a constraint. If not a slice of
+// reasons for the failure are returned in addition to a bool.
+func (cs Constraints) Validate(v *Version) (bool, []error) {
+	// loop over the ORs and check the inner ANDs
+	var e []error
+	for _, o := range cs.constraints {
+		joy := true
+		for _, c := range o {
+			if !c.check(v) {
+				em := fmt.Errorf(c.msg, v, c.orig)
+				e = append(e, em)
+				joy = false
+			}
+		}
+
+		if joy {
+			return true, []error{}
+		}
+	}
+
+	return false, e
+}
+
+var constraintOps map[string]cfunc
+var constraintMsg map[string]string
+var constraintRegex *regexp.Regexp
+
+func init() {
+	constraintOps = map[string]cfunc{
+		"":   constraintTildeOrEqual,
+		"=":  constraintTildeOrEqual,
+		"!=": constraintNotEqual,
+		">":  constraintGreaterThan,
+		"<":  constraintLessThan,
+		">=": constraintGreaterThanEqual,
+		"=>": constraintGreaterThanEqual,
+		"<=": constraintLessThanEqual,
+		"=<": constraintLessThanEqual,
+		"~":  constraintTilde,
+		"~>": constraintTilde,
+		"^":  constraintCaret,
+	}
+
+	constraintMsg = map[string]string{
+		"":   "%s is not equal to %s",
+		"=":  "%s is not equal to %s",
+		"!=": "%s is equal to %s",
+		">":  "%s is less than or equal to %s",
+		"<":  "%s is greater than or equal to %s",
+		">=": "%s is less than %s",
+		"=>": "%s is less than %s",
+		"<=": "%s is greater than %s",
+		"=<": "%s is greater than %s",
+		"~":  "%s does not have same major and minor version as %s",
+		"~>": "%s does not have same major and minor version as %s",
+		"^":  "%s does not have same major version as %s",
+	}
+
+	ops := make([]string, 0, len(constraintOps))
+	for k := range constraintOps {
+		ops = append(ops, regexp.QuoteMeta(k))
+	}
+
+	constraintRegex = regexp.MustCompile(fmt.Sprintf(
+		`^\s*(%s)\s*(%s)\s*$`,
+		strings.Join(ops, "|"),
+		cvRegex))
+
+	constraintRangeRegex = regexp.MustCompile(fmt.Sprintf(
+		`\s*(%s)\s+-\s+(%s)\s*`,
+		cvRegex, cvRegex))
+}
+
+// An individual constraint
+type constraint struct {
+	// The callback function for the restraint. It performs the logic for
+	// the constraint.
+	function cfunc
+
+	msg string
+
+	// The version used in the constraint check. For example, if a constraint
+	// is '<= 2.0.0' the con a version instance representing 2.0.0.
+	con *Version
+
+	// The original parsed version (e.g., 4.x from != 4.x)
+	orig string
+
+	// When an x is used as part of the version (e.g., 1.x)
+	minorDirty bool
+	dirty      bool
+	patchDirty bool
+}
+
+// Check if a version meets the constraint
+func (c *constraint) check(v *Version) bool {
+	return c.function(v, c)
+}
+
+type cfunc func(v *Version, c *constraint) bool
+
+func parseConstraint(c string) (*constraint, error) {
+	m := constraintRegex.FindStringSubmatch(c)
+	if m == nil {
+		return nil, fmt.Errorf("improper constraint: %s", c)
+	}
+
+	ver := m[2]
+	orig := ver
+	minorDirty := false
+	patchDirty := false
+	dirty := false
+	if isX(m[3]) {
+		ver = "0.0.0"
+		dirty = true
+	} else if isX(strings.TrimPrefix(m[4], ".")) || m[4] == "" {
+		minorDirty = true
+		dirty = true
+		ver = fmt.Sprintf("%s.0.0%s", m[3], m[6])
+	} else if isX(strings.TrimPrefix(m[5], ".")) {
+		dirty = true
+		patchDirty = true
+		ver = fmt.Sprintf("%s%s.0%s", m[3], m[4], m[6])
+	}
+
+	con, err := NewVersion(ver)
+	if err != nil {
+
+		// The constraintRegex should catch any regex parsing errors. So,
+		// we should never get here.
+		return nil, errors.New("constraint Parser Error")
+	}
+
+	cs := &constraint{
+		function:   constraintOps[m[1]],
+		msg:        constraintMsg[m[1]],
+		con:        con,
+		orig:       orig,
+		minorDirty: minorDirty,
+		patchDirty: patchDirty,
+		dirty:      dirty,
+	}
+	return cs, nil
+}
+
+// Constraint functions
+func constraintNotEqual(v *Version, c *constraint) bool {
+	if c.dirty {
+
+		// If there is a pre-release on the version but the constraint isn't looking
+		// for them assume that pre-releases are not compatible. See issue 21 for
+		// more details.
+		if v.Prerelease() != "" && c.con.Prerelease() == "" {
+			return false
+		}
+
+		if c.con.Major() != v.Major() {
+			return true
+		}
+		if c.con.Minor() != v.Minor() && !c.minorDirty {
+			return true
+		} else if c.minorDirty {
+			return false
+		}
+
+		return false
+	}
+
+	return !v.Equal(c.con)
+}
+
+func constraintGreaterThan(v *Version, c *constraint) bool {
+
+	// An edge case the constraint is 0.0.0 and the version is 0.0.0-someprerelease
+	// exists. This that case.
+	if !isNonZero(c.con) && isNonZero(v) {
+		return true
+	}
+
+	// If there is a pre-release on the version but the constraint isn't looking
+	// for them assume that pre-releases are not compatible. See issue 21 for
+	// more details.
+	if v.Prerelease() != "" && c.con.Prerelease() == "" {
+		return false
+	}
+
+	return v.Compare(c.con) == 1
+}
+
+func constraintLessThan(v *Version, c *constraint) bool {
+	// If there is a pre-release on the version but the constraint isn't looking
+	// for them assume that pre-releases are not compatible. See issue 21 for
+	// more details.
+	if v.Prerelease() != "" && c.con.Prerelease() == "" {
+		return false
+	}
+
+	if !c.dirty {
+		return v.Compare(c.con) < 0
+	}
+
+	if v.Major() > c.con.Major() {
+		return false
+	} else if v.Minor() > c.con.Minor() && !c.minorDirty {
+		return false
+	}
+
+	return true
+}
+
+func constraintGreaterThanEqual(v *Version, c *constraint) bool {
+	// An edge case the constraint is 0.0.0 and the version is 0.0.0-someprerelease
+	// exists. This that case.
+	if !isNonZero(c.con) && isNonZero(v) {
+		return true
+	}
+
+	// If there is a pre-release on the version but the constraint isn't looking
+	// for them assume that pre-releases are not compatible. See issue 21 for
+	// more details.
+	if v.Prerelease() != "" && c.con.Prerelease() == "" {
+		return false
+	}
+
+	return v.Compare(c.con) >= 0
+}
+
+func constraintLessThanEqual(v *Version, c *constraint) bool {
+	// If there is a pre-release on the version but the constraint isn't looking
+	// for them assume that pre-releases are not compatible. See issue 21 for
+	// more details.
+	if v.Prerelease() != "" && c.con.Prerelease() == "" {
+		return false
+	}
+
+	if !c.dirty {
+		return v.Compare(c.con) <= 0
+	}
+
+	if v.Major() > c.con.Major() {
+		return false
+	} else if v.Minor() > c.con.Minor() && !c.minorDirty {
+		return false
+	}
+
+	return true
+}
+
+// ~*, ~>* --> >= 0.0.0 (any)
+// ~2, ~2.x, ~2.x.x, ~>2, ~>2.x ~>2.x.x --> >=2.0.0, <3.0.0
+// ~2.0, ~2.0.x, ~>2.0, ~>2.0.x --> >=2.0.0, <2.1.0
+// ~1.2, ~1.2.x, ~>1.2, ~>1.2.x --> >=1.2.0, <1.3.0
+// ~1.2.3, ~>1.2.3 --> >=1.2.3, <1.3.0
+// ~1.2.0, ~>1.2.0 --> >=1.2.0, <1.3.0
+func constraintTilde(v *Version, c *constraint) bool {
+	// If there is a pre-release on the version but the constraint isn't looking
+	// for them assume that pre-releases are not compatible. See issue 21 for
+	// more details.
+	if v.Prerelease() != "" && c.con.Prerelease() == "" {
+		return false
+	}
+
+	if v.LessThan(c.con) {
+		return false
+	}
+
+	// ~0.0.0 is a special case where all constraints are accepted. It's
+	// equivalent to >= 0.0.0.
+	if c.con.Major() == 0 && c.con.Minor() == 0 && c.con.Patch() == 0 &&
+		!c.minorDirty && !c.patchDirty {
+		return true
+	}
+
+	if v.Major() != c.con.Major() {
+		return false
+	}
+
+	if v.Minor() != c.con.Minor() && !c.minorDirty {
+		return false
+	}
+
+	return true
+}
+
+// When there is a .x (dirty) status it automatically opts in to ~. Otherwise
+// it's a straight =
+func constraintTildeOrEqual(v *Version, c *constraint) bool {
+	// If there is a pre-release on the version but the constraint isn't looking
+	// for them assume that pre-releases are not compatible. See issue 21 for
+	// more details.
+	if v.Prerelease() != "" && c.con.Prerelease() == "" {
+		return false
+	}
+
+	if c.dirty {
+		c.msg = constraintMsg["~"]
+		return constraintTilde(v, c)
+	}
+
+	return v.Equal(c.con)
+}
+
+// ^* --> (any)
+// ^2, ^2.x, ^2.x.x --> >=2.0.0, <3.0.0
+// ^2.0, ^2.0.x --> >=2.0.0, <3.0.0
+// ^1.2, ^1.2.x --> >=1.2.0, <2.0.0
+// ^1.2.3 --> >=1.2.3, <2.0.0
+// ^1.2.0 --> >=1.2.0, <2.0.0
+func constraintCaret(v *Version, c *constraint) bool {
+	// If there is a pre-release on the version but the constraint isn't looking
+	// for them assume that pre-releases are not compatible. See issue 21 for
+	// more details.
+	if v.Prerelease() != "" && c.con.Prerelease() == "" {
+		return false
+	}
+
+	if v.LessThan(c.con) {
+		return false
+	}
+
+	if v.Major() != c.con.Major() {
+		return false
+	}
+
+	return true
+}
+
+var constraintRangeRegex *regexp.Regexp
+
+const cvRegex string = `v?([0-9|x|X|\*]+)(\.[0-9|x|X|\*]+)?(\.[0-9|x|X|\*]+)?` +
+	`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
+	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?`
+
+func isX(x string) bool {
+	switch x {
+	case "x", "*", "X":
+		return true
+	default:
+		return false
+	}
+}
+
+func rewriteRange(i string) string {
+	m := constraintRangeRegex.FindAllStringSubmatch(i, -1)
+	if m == nil {
+		return i
+	}
+	o := i
+	for _, v := range m {
+		t := fmt.Sprintf(">= %s, <= %s", v[1], v[11])
+		o = strings.Replace(o, v[0], t, 1)
+	}
+
+	return o
+}
+
+// Detect if a version is not zero (0.0.0)
+func isNonZero(v *Version) bool {
+	if v.Major() != 0 || v.Minor() != 0 || v.Patch() != 0 || v.Prerelease() != "" {
+		return true
+	}
+
+	return false
+}

--- a/vendor/github.com/Masterminds/semver/constraints_test.go
+++ b/vendor/github.com/Masterminds/semver/constraints_test.go
@@ -1,0 +1,465 @@
+package semver
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseConstraint(t *testing.T) {
+	tests := []struct {
+		in  string
+		f   cfunc
+		v   string
+		err bool
+	}{
+		{">= 1.2", constraintGreaterThanEqual, "1.2.0", false},
+		{"1.0", constraintTildeOrEqual, "1.0.0", false},
+		{"foo", nil, "", true},
+		{"<= 1.2", constraintLessThanEqual, "1.2.0", false},
+		{"=< 1.2", constraintLessThanEqual, "1.2.0", false},
+		{"=> 1.2", constraintGreaterThanEqual, "1.2.0", false},
+		{"v1.2", constraintTildeOrEqual, "1.2.0", false},
+		{"=1.5", constraintTildeOrEqual, "1.5.0", false},
+		{"> 1.3", constraintGreaterThan, "1.3.0", false},
+		{"< 1.4.1", constraintLessThan, "1.4.1", false},
+	}
+
+	for _, tc := range tests {
+		c, err := parseConstraint(tc.in)
+		if tc.err && err == nil {
+			t.Errorf("Expected error for %s didn't occur", tc.in)
+		} else if !tc.err && err != nil {
+			t.Errorf("Unexpected error for %s", tc.in)
+		}
+
+		// If an error was expected continue the loop and don't try the other
+		// tests as they will cause errors.
+		if tc.err {
+			continue
+		}
+
+		if tc.v != c.con.String() {
+			t.Errorf("Incorrect version found on %s", tc.in)
+		}
+
+		f1 := reflect.ValueOf(tc.f)
+		f2 := reflect.ValueOf(c.function)
+		if f1 != f2 {
+			t.Errorf("Wrong constraint found for %s", tc.in)
+		}
+	}
+}
+
+func TestConstraintCheck(t *testing.T) {
+	tests := []struct {
+		constraint string
+		version    string
+		check      bool
+	}{
+		{"= 2.0", "1.2.3", false},
+		{"= 2.0", "2.0.0", true},
+		{"4.1", "4.1.0", true},
+		{"!=4.1", "4.1.0", false},
+		{"!=4.1", "5.1.0", true},
+		{">1.1", "4.1.0", true},
+		{">1.1", "1.1.0", false},
+		{"<1.1", "0.1.0", true},
+		{"<1.1", "1.1.0", false},
+		{"<1.1", "1.1.1", false},
+		{">=1.1", "4.1.0", true},
+		{">=1.1", "1.1.0", true},
+		{">=1.1", "0.0.9", false},
+		{"<=1.1", "0.1.0", true},
+		{"<=1.1", "1.1.0", true},
+		{"<=1.1", "1.1.1", false},
+		{">0", "0.0.1-alpha", true},
+		{">=0", "0.0.1-alpha", true},
+		{">0", "0", false},
+		{">=0", "0", true},
+		{"=0", "1", false},
+	}
+
+	for _, tc := range tests {
+		c, err := parseConstraint(tc.constraint)
+		if err != nil {
+			t.Errorf("err: %s", err)
+			continue
+		}
+
+		v, err := NewVersion(tc.version)
+		if err != nil {
+			t.Errorf("err: %s", err)
+			continue
+		}
+
+		a := c.check(v)
+		if a != tc.check {
+			t.Errorf("Constraint %q failing with %q", tc.constraint, tc.version)
+		}
+	}
+}
+
+func TestNewConstraint(t *testing.T) {
+	tests := []struct {
+		input string
+		ors   int
+		count int
+		err   bool
+	}{
+		{">= 1.1", 1, 1, false},
+		{"2.0", 1, 1, false},
+		{"v2.3.5-20161202202307-sha.e8fc5e5", 1, 1, false},
+		{">= bar", 0, 0, true},
+		{">= 1.2.3, < 2.0", 1, 2, false},
+		{">= 1.2.3, < 2.0 || => 3.0, < 4", 2, 2, false},
+
+		// The 3 - 4 should be broken into 2 by the range rewriting
+		{"3 - 4 || => 3.0, < 4", 2, 2, false},
+	}
+
+	for _, tc := range tests {
+		v, err := NewConstraint(tc.input)
+		if tc.err && err == nil {
+			t.Errorf("expected but did not get error for: %s", tc.input)
+			continue
+		} else if !tc.err && err != nil {
+			t.Errorf("unexpectederror for input %s: %s", tc.input, err)
+			continue
+		}
+		if tc.err {
+			continue
+		}
+
+		l := len(v.constraints)
+		if tc.ors != l {
+			t.Errorf("Expected %s to have %d ORs but got %d",
+				tc.input, tc.ors, l)
+		}
+
+		l = len(v.constraints[0])
+		if tc.count != l {
+			t.Errorf("Expected %s to have %d constraints but got %d",
+				tc.input, tc.count, l)
+		}
+	}
+}
+
+func TestConstraintsCheck(t *testing.T) {
+	tests := []struct {
+		constraint string
+		version    string
+		check      bool
+	}{
+		{"*", "1.2.3", true},
+		{"~0.0.0", "1.2.3", true},
+		{"0.x.x", "1.2.3", false},
+		{"0.0.x", "1.2.3", false},
+		{"0.0.0", "1.2.3", false},
+		{"*", "1.2.3", true},
+		{"^0.0.0", "1.2.3", false},
+		{"= 2.0", "1.2.3", false},
+		{"= 2.0", "2.0.0", true},
+		{"4.1", "4.1.0", true},
+		{"4.1.x", "4.1.3", true},
+		{"1.x", "1.4", true},
+		{"!=4.1", "4.1.0", false},
+		{"!=4.1-alpha", "4.1.0-alpha", false},
+		{"!=4.1-alpha", "4.1.0", true},
+		{"!=4.1", "5.1.0", true},
+		{"!=4.x", "5.1.0", true},
+		{"!=4.x", "4.1.0", false},
+		{"!=4.1.x", "4.2.0", true},
+		{"!=4.2.x", "4.2.3", false},
+		{">1.1", "4.1.0", true},
+		{">1.1", "1.1.0", false},
+		{"<1.1", "0.1.0", true},
+		{"<1.1", "1.1.0", false},
+		{"<1.1", "1.1.1", false},
+		{"<1.x", "1.1.1", true},
+		{"<1.x", "2.1.1", false},
+		{"<1.1.x", "1.2.1", false},
+		{"<1.1.x", "1.1.500", true},
+		{"<1.2.x", "1.1.1", true},
+		{">=1.1", "4.1.0", true},
+		{">=1.1", "4.1.0-beta", false},
+		{">=1.1", "1.1.0", true},
+		{">=1.1", "0.0.9", false},
+		{"<=1.1", "0.1.0", true},
+		{"<=1.1", "0.1.0-alpha", false},
+		{"<=1.1-a", "0.1.0-alpha", true},
+		{"<=1.1", "1.1.0", true},
+		{"<=1.x", "1.1.0", true},
+		{"<=2.x", "3.1.0", false},
+		{"<=1.1", "1.1.1", false},
+		{"<=1.1.x", "1.2.500", false},
+		{">1.1, <2", "1.1.1", true},
+		{">1.1, <3", "4.3.2", false},
+		{">=1.1, <2, !=1.2.3", "1.2.3", false},
+		{">=1.1, <2, !=1.2.3 || > 3", "3.1.2", true},
+		{">=1.1, <2, !=1.2.3 || >= 3", "3.0.0", true},
+		{">=1.1, <2, !=1.2.3 || > 3", "3.0.0", false},
+		{">=1.1, <2, !=1.2.3 || > 3", "1.2.3", false},
+		{"1.1 - 2", "1.1.1", true},
+		{"1.1-3", "4.3.2", false},
+		{"^1.1", "1.1.1", true},
+		{"^1.1", "4.3.2", false},
+		{"^1.x", "1.1.1", true},
+		{"^2.x", "1.1.1", false},
+		{"^1.x", "2.1.1", false},
+		{"^1.x", "1.1.1-beta1", false},
+		{"^1.1.2-alpha", "1.2.1-beta1", true},
+		{"^1.2.x-alpha", "1.1.1-beta1", false},
+		{"~*", "2.1.1", true},
+		{"~1", "2.1.1", false},
+		{"~1", "1.3.5", true},
+		{"~1", "1.4", true},
+		{"~1.x", "2.1.1", false},
+		{"~1.x", "1.3.5", true},
+		{"~1.x", "1.4", true},
+		{"~1.1", "1.1.1", true},
+		{"~1.1", "1.1.1-alpha", false},
+		{"~1.1-alpha", "1.1.1-beta", true},
+		{"~1.1.1-beta", "1.1.1-alpha", false},
+		{"~1.1.1-beta", "1.1.1", true},
+		{"~1.2.3", "1.2.5", true},
+		{"~1.2.3", "1.2.2", false},
+		{"~1.2.3", "1.3.2", false},
+		{"~1.1", "1.2.3", false},
+		{"~1.3", "2.4.5", false},
+	}
+
+	for _, tc := range tests {
+		c, err := NewConstraint(tc.constraint)
+		if err != nil {
+			t.Errorf("err: %s", err)
+			continue
+		}
+
+		v, err := NewVersion(tc.version)
+		if err != nil {
+			t.Errorf("err: %s", err)
+			continue
+		}
+
+		a := c.Check(v)
+		if a != tc.check {
+			t.Errorf("Constraint '%s' failing with '%s'", tc.constraint, tc.version)
+		}
+	}
+}
+
+func TestRewriteRange(t *testing.T) {
+	tests := []struct {
+		c  string
+		nc string
+	}{
+		{"2 - 3", ">= 2, <= 3"},
+		{"2 - 3, 2 - 3", ">= 2, <= 3,>= 2, <= 3"},
+		{"2 - 3, 4.0.0 - 5.1", ">= 2, <= 3,>= 4.0.0, <= 5.1"},
+	}
+
+	for _, tc := range tests {
+		o := rewriteRange(tc.c)
+
+		if o != tc.nc {
+			t.Errorf("Range %s rewritten incorrectly as '%s'", tc.c, o)
+		}
+	}
+}
+
+func TestIsX(t *testing.T) {
+	tests := []struct {
+		t string
+		c bool
+	}{
+		{"A", false},
+		{"%", false},
+		{"X", true},
+		{"x", true},
+		{"*", true},
+	}
+
+	for _, tc := range tests {
+		a := isX(tc.t)
+		if a != tc.c {
+			t.Errorf("Function isX error on %s", tc.t)
+		}
+	}
+}
+
+func TestConstraintsValidate(t *testing.T) {
+	tests := []struct {
+		constraint string
+		version    string
+		check      bool
+	}{
+		{"*", "1.2.3", true},
+		{"~0.0.0", "1.2.3", true},
+		{"= 2.0", "1.2.3", false},
+		{"= 2.0", "2.0.0", true},
+		{"4.1", "4.1.0", true},
+		{"4.1.x", "4.1.3", true},
+		{"1.x", "1.4", true},
+		{"!=4.1", "4.1.0", false},
+		{"!=4.1", "5.1.0", true},
+		{"!=4.x", "5.1.0", true},
+		{"!=4.x", "4.1.0", false},
+		{"!=4.1.x", "4.2.0", true},
+		{"!=4.2.x", "4.2.3", false},
+		{">1.1", "4.1.0", true},
+		{">1.1", "1.1.0", false},
+		{"<1.1", "0.1.0", true},
+		{"<1.1", "1.1.0", false},
+		{"<1.1", "1.1.1", false},
+		{"<1.x", "1.1.1", true},
+		{"<1.x", "2.1.1", false},
+		{"<1.1.x", "1.2.1", false},
+		{"<1.1.x", "1.1.500", true},
+		{"<1.2.x", "1.1.1", true},
+		{">=1.1", "4.1.0", true},
+		{">=1.1", "1.1.0", true},
+		{">=1.1", "0.0.9", false},
+		{"<=1.1", "0.1.0", true},
+		{"<=1.1", "1.1.0", true},
+		{"<=1.x", "1.1.0", true},
+		{"<=2.x", "3.1.0", false},
+		{"<=1.1", "1.1.1", false},
+		{"<=1.1.x", "1.2.500", false},
+		{">1.1, <2", "1.1.1", true},
+		{">1.1, <3", "4.3.2", false},
+		{">=1.1, <2, !=1.2.3", "1.2.3", false},
+		{">=1.1, <2, !=1.2.3 || > 3", "3.1.2", true},
+		{">=1.1, <2, !=1.2.3 || >= 3", "3.0.0", true},
+		{">=1.1, <2, !=1.2.3 || > 3", "3.0.0", false},
+		{">=1.1, <2, !=1.2.3 || > 3", "1.2.3", false},
+		{"1.1 - 2", "1.1.1", true},
+		{"1.1-3", "4.3.2", false},
+		{"^1.1", "1.1.1", true},
+		{"^1.1", "1.1.1-alpha", false},
+		{"^1.1.1-alpha", "1.1.1-beta", true},
+		{"^1.1.1-beta", "1.1.1-alpha", false},
+		{"^1.1", "4.3.2", false},
+		{"^1.x", "1.1.1", true},
+		{"^2.x", "1.1.1", false},
+		{"^1.x", "2.1.1", false},
+		{"~*", "2.1.1", true},
+		{"~1", "2.1.1", false},
+		{"~1", "1.3.5", true},
+		{"~1", "1.3.5-beta", false},
+		{"~1.x", "2.1.1", false},
+		{"~1.x", "1.3.5", true},
+		{"~1.x", "1.3.5-beta", false},
+		{"~1.3.6-alpha", "1.3.5-beta", false},
+		{"~1.3.5-alpha", "1.3.5-beta", true},
+		{"~1.3.5-beta", "1.3.5-alpha", false},
+		{"~1.x", "1.4", true},
+		{"~1.1", "1.1.1", true},
+		{"~1.2.3", "1.2.5", true},
+		{"~1.2.3", "1.2.2", false},
+		{"~1.2.3", "1.3.2", false},
+		{"~1.1", "1.2.3", false},
+		{"~1.3", "2.4.5", false},
+	}
+
+	for _, tc := range tests {
+		c, err := NewConstraint(tc.constraint)
+		if err != nil {
+			t.Errorf("err: %s", err)
+			continue
+		}
+
+		v, err := NewVersion(tc.version)
+		if err != nil {
+			t.Errorf("err: %s", err)
+			continue
+		}
+
+		a, msgs := c.Validate(v)
+		if a != tc.check {
+			t.Errorf("Constraint '%s' failing with '%s'", tc.constraint, tc.version)
+		} else if !a && len(msgs) == 0 {
+			t.Errorf("%q failed with %q but no errors returned", tc.constraint, tc.version)
+		}
+
+		// if a == false {
+		// 	for _, m := range msgs {
+		// 		t.Errorf("%s", m)
+		// 	}
+		// }
+	}
+
+	v, err := NewVersion("1.2.3")
+	if err != nil {
+		t.Errorf("err: %s", err)
+	}
+
+	c, err := NewConstraint("!= 1.2.5, ^2, <= 1.1.x")
+	if err != nil {
+		t.Errorf("err: %s", err)
+	}
+
+	_, msgs := c.Validate(v)
+	if len(msgs) != 2 {
+		t.Error("Invalid number of validations found")
+	}
+	e := msgs[0].Error()
+	if e != "1.2.3 does not have same major version as 2" {
+		t.Error("Did not get expected message: 1.2.3 does not have same major version as 2")
+	}
+	e = msgs[1].Error()
+	if e != "1.2.3 is greater than 1.1.x" {
+		t.Error("Did not get expected message: 1.2.3 is greater than 1.1.x")
+	}
+
+	tests2 := []struct {
+		constraint, version, msg string
+	}{
+		{"= 2.0", "1.2.3", "1.2.3 is not equal to 2.0"},
+		{"!=4.1", "4.1.0", "4.1.0 is equal to 4.1"},
+		{"!=4.x", "4.1.0", "4.1.0 is equal to 4.x"},
+		{"!=4.2.x", "4.2.3", "4.2.3 is equal to 4.2.x"},
+		{">1.1", "1.1.0", "1.1.0 is less than or equal to 1.1"},
+		{"<1.1", "1.1.0", "1.1.0 is greater than or equal to 1.1"},
+		{"<1.1", "1.1.1", "1.1.1 is greater than or equal to 1.1"},
+		{"<1.x", "2.1.1", "2.1.1 is greater than or equal to 1.x"},
+		{"<1.1.x", "1.2.1", "1.2.1 is greater than or equal to 1.1.x"},
+		{">=1.1", "0.0.9", "0.0.9 is less than 1.1"},
+		{"<=2.x", "3.1.0", "3.1.0 is greater than 2.x"},
+		{"<=1.1", "1.1.1", "1.1.1 is greater than 1.1"},
+		{"<=1.1.x", "1.2.500", "1.2.500 is greater than 1.1.x"},
+		{">1.1, <3", "4.3.2", "4.3.2 is greater than or equal to 3"},
+		{">=1.1, <2, !=1.2.3", "1.2.3", "1.2.3 is equal to 1.2.3"},
+		{">=1.1, <2, !=1.2.3 || > 3", "3.0.0", "3.0.0 is greater than or equal to 2"},
+		{">=1.1, <2, !=1.2.3 || > 3", "1.2.3", "1.2.3 is equal to 1.2.3"},
+		{"1.1 - 3", "4.3.2", "4.3.2 is greater than 3"},
+		{"^1.1", "4.3.2", "4.3.2 does not have same major version as 1.1"},
+		{"^2.x", "1.1.1", "1.1.1 does not have same major version as 2.x"},
+		{"^1.x", "2.1.1", "2.1.1 does not have same major version as 1.x"},
+		{"~1", "2.1.2", "2.1.2 does not have same major and minor version as 1"},
+		{"~1.x", "2.1.1", "2.1.1 does not have same major and minor version as 1.x"},
+		{"~1.2.3", "1.2.2", "1.2.2 does not have same major and minor version as 1.2.3"},
+		{"~1.2.3", "1.3.2", "1.3.2 does not have same major and minor version as 1.2.3"},
+		{"~1.1", "1.2.3", "1.2.3 does not have same major and minor version as 1.1"},
+		{"~1.3", "2.4.5", "2.4.5 does not have same major and minor version as 1.3"},
+	}
+
+	for _, tc := range tests2 {
+		c, err := NewConstraint(tc.constraint)
+		if err != nil {
+			t.Errorf("err: %s", err)
+			continue
+		}
+
+		v, err := NewVersion(tc.version)
+		if err != nil {
+			t.Errorf("err: %s", err)
+			continue
+		}
+
+		_, msgs := c.Validate(v)
+		e := msgs[0].Error()
+		if e != tc.msg {
+			t.Errorf("Did not get expected message %q: %s", tc.msg, e)
+		}
+	}
+}

--- a/vendor/github.com/Masterminds/semver/doc.go
+++ b/vendor/github.com/Masterminds/semver/doc.go
@@ -1,0 +1,115 @@
+/*
+Package semver provides the ability to work with Semantic Versions (http://semver.org) in Go.
+
+Specifically it provides the ability to:
+
+    * Parse semantic versions
+    * Sort semantic versions
+    * Check if a semantic version fits within a set of constraints
+    * Optionally work with a `v` prefix
+
+Parsing Semantic Versions
+
+To parse a semantic version use the `NewVersion` function. For example,
+
+    v, err := semver.NewVersion("1.2.3-beta.1+build345")
+
+If there is an error the version wasn't parseable. The version object has methods
+to get the parts of the version, compare it to other versions, convert the
+version back into a string, and get the original string. For more details
+please see the documentation at https://godoc.org/github.com/Masterminds/semver.
+
+Sorting Semantic Versions
+
+A set of versions can be sorted using the `sort` package from the standard library.
+For example,
+
+    raw := []string{"1.2.3", "1.0", "1.3", "2", "0.4.2",}
+    vs := make([]*semver.Version, len(raw))
+	for i, r := range raw {
+		v, err := semver.NewVersion(r)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		vs[i] = v
+	}
+
+	sort.Sort(semver.Collection(vs))
+
+Checking Version Constraints
+
+Checking a version against version constraints is one of the most featureful
+parts of the package.
+
+    c, err := semver.NewConstraint(">= 1.2.3")
+    if err != nil {
+        // Handle constraint not being parseable.
+    }
+
+    v, _ := semver.NewVersion("1.3")
+    if err != nil {
+        // Handle version not being parseable.
+    }
+    // Check if the version meets the constraints. The a variable will be true.
+    a := c.Check(v)
+
+Basic Comparisons
+
+There are two elements to the comparisons. First, a comparison string is a list
+of comma separated and comparisons. These are then separated by || separated or
+comparisons. For example, `">= 1.2, < 3.0.0 || >= 4.2.3"` is looking for a
+comparison that's greater than or equal to 1.2 and less than 3.0.0 or is
+greater than or equal to 4.2.3.
+
+The basic comparisons are:
+
+    * `=`: equal (aliased to no operator)
+    * `!=`: not equal
+    * `>`: greater than
+    * `<`: less than
+    * `>=`: greater than or equal to
+    * `<=`: less than or equal to
+
+Hyphen Range Comparisons
+
+There are multiple methods to handle ranges and the first is hyphens ranges.
+These look like:
+
+    * `1.2 - 1.4.5` which is equivalent to `>= 1.2, <= 1.4.5`
+    * `2.3.4 - 4.5` which is equivalent to `>= 2.3.4, <= 4.5`
+
+Wildcards In Comparisons
+
+The `x`, `X`, and `*` characters can be used as a wildcard character. This works
+for all comparison operators. When used on the `=` operator it falls
+back to the pack level comparison (see tilde below). For example,
+
+    * `1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
+    * `>= 1.2.x` is equivalent to `>= 1.2.0`
+    * `<= 2.x` is equivalent to `<= 3`
+    * `*` is equivalent to `>= 0.0.0`
+
+Tilde Range Comparisons (Patch)
+
+The tilde (`~`) comparison operator is for patch level ranges when a minor
+version is specified and major level changes when the minor number is missing.
+For example,
+
+    * `~1.2.3` is equivalent to `>= 1.2.3, < 1.3.0`
+    * `~1` is equivalent to `>= 1, < 2`
+    * `~2.3` is equivalent to `>= 2.3, < 2.4`
+    * `~1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
+    * `~1.x` is equivalent to `>= 1, < 2`
+
+Caret Range Comparisons (Major)
+
+The caret (`^`) comparison operator is for major level changes. This is useful
+when comparisons of API versions as a major change is API breaking. For example,
+
+    * `^1.2.3` is equivalent to `>= 1.2.3, < 2.0.0`
+    * `^1.2.x` is equivalent to `>= 1.2.0, < 2.0.0`
+    * `^2.3` is equivalent to `>= 2.3, < 3`
+    * `^2.x` is equivalent to `>= 2.0.0, < 3`
+*/
+package semver

--- a/vendor/github.com/Masterminds/semver/version.go
+++ b/vendor/github.com/Masterminds/semver/version.go
@@ -1,0 +1,422 @@
+package semver
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// The compiled version of the regex created at init() is cached here so it
+// only needs to be created once.
+var versionRegex *regexp.Regexp
+var validPrereleaseRegex *regexp.Regexp
+
+var (
+	// ErrInvalidSemVer is returned a version is found to be invalid when
+	// being parsed.
+	ErrInvalidSemVer = errors.New("Invalid Semantic Version")
+
+	// ErrInvalidMetadata is returned when the metadata is an invalid format
+	ErrInvalidMetadata = errors.New("Invalid Metadata string")
+
+	// ErrInvalidPrerelease is returned when the pre-release is an invalid format
+	ErrInvalidPrerelease = errors.New("Invalid Prerelease string")
+)
+
+// SemVerRegex is the regular expression used to parse a semantic version.
+const SemVerRegex string = `v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?` +
+	`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
+	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?`
+
+// ValidPrerelease is the regular expression which validates
+// both prerelease and metadata values.
+const ValidPrerelease string = `^([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*)`
+
+// Version represents a single semantic version.
+type Version struct {
+	major, minor, patch int64
+	pre                 string
+	metadata            string
+	original            string
+}
+
+func init() {
+	versionRegex = regexp.MustCompile("^" + SemVerRegex + "$")
+	validPrereleaseRegex = regexp.MustCompile(ValidPrerelease)
+}
+
+// NewVersion parses a given version and returns an instance of Version or
+// an error if unable to parse the version.
+func NewVersion(v string) (*Version, error) {
+	m := versionRegex.FindStringSubmatch(v)
+	if m == nil {
+		return nil, ErrInvalidSemVer
+	}
+
+	sv := &Version{
+		metadata: m[8],
+		pre:      m[5],
+		original: v,
+	}
+
+	var temp int64
+	temp, err := strconv.ParseInt(m[1], 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing version segment: %s", err)
+	}
+	sv.major = temp
+
+	if m[2] != "" {
+		temp, err = strconv.ParseInt(strings.TrimPrefix(m[2], "."), 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing version segment: %s", err)
+		}
+		sv.minor = temp
+	} else {
+		sv.minor = 0
+	}
+
+	if m[3] != "" {
+		temp, err = strconv.ParseInt(strings.TrimPrefix(m[3], "."), 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing version segment: %s", err)
+		}
+		sv.patch = temp
+	} else {
+		sv.patch = 0
+	}
+
+	return sv, nil
+}
+
+// MustParse parses a given version and panics on error.
+func MustParse(v string) *Version {
+	sv, err := NewVersion(v)
+	if err != nil {
+		panic(err)
+	}
+	return sv
+}
+
+// String converts a Version object to a string.
+// Note, if the original version contained a leading v this version will not.
+// See the Original() method to retrieve the original value. Semantic Versions
+// don't contain a leading v per the spec. Instead it's optional on
+// impelementation.
+func (v *Version) String() string {
+	var buf bytes.Buffer
+
+	fmt.Fprintf(&buf, "%d.%d.%d", v.major, v.minor, v.patch)
+	if v.pre != "" {
+		fmt.Fprintf(&buf, "-%s", v.pre)
+	}
+	if v.metadata != "" {
+		fmt.Fprintf(&buf, "+%s", v.metadata)
+	}
+
+	return buf.String()
+}
+
+// Original returns the original value passed in to be parsed.
+func (v *Version) Original() string {
+	return v.original
+}
+
+// Major returns the major version.
+func (v *Version) Major() int64 {
+	return v.major
+}
+
+// Minor returns the minor version.
+func (v *Version) Minor() int64 {
+	return v.minor
+}
+
+// Patch returns the patch version.
+func (v *Version) Patch() int64 {
+	return v.patch
+}
+
+// Prerelease returns the pre-release version.
+func (v *Version) Prerelease() string {
+	return v.pre
+}
+
+// Metadata returns the metadata on the version.
+func (v *Version) Metadata() string {
+	return v.metadata
+}
+
+// originalVPrefix returns the original 'v' prefix if any.
+func (v *Version) originalVPrefix() string {
+
+	// Note, only lowercase v is supported as a prefix by the parser.
+	if v.original != "" && v.original[:1] == "v" {
+		return v.original[:1]
+	}
+	return ""
+}
+
+// IncPatch produces the next patch version.
+// If the current version does not have prerelease/metadata information,
+// it unsets metadata and prerelease values, increments patch number.
+// If the current version has any of prerelease or metadata information,
+// it unsets both values and keeps curent patch value
+func (v Version) IncPatch() Version {
+	vNext := v
+	// according to http://semver.org/#spec-item-9
+	// Pre-release versions have a lower precedence than the associated normal version.
+	// according to http://semver.org/#spec-item-10
+	// Build metadata SHOULD be ignored when determining version precedence.
+	if v.pre != "" {
+		vNext.metadata = ""
+		vNext.pre = ""
+	} else {
+		vNext.metadata = ""
+		vNext.pre = ""
+		vNext.patch = v.patch + 1
+	}
+	vNext.original = v.originalVPrefix() + "" + vNext.String()
+	return vNext
+}
+
+// IncMinor produces the next minor version.
+// Sets patch to 0.
+// Increments minor number.
+// Unsets metadata.
+// Unsets prerelease status.
+func (v Version) IncMinor() Version {
+	vNext := v
+	vNext.metadata = ""
+	vNext.pre = ""
+	vNext.patch = 0
+	vNext.minor = v.minor + 1
+	vNext.original = v.originalVPrefix() + "" + vNext.String()
+	return vNext
+}
+
+// IncMajor produces the next major version.
+// Sets patch to 0.
+// Sets minor to 0.
+// Increments major number.
+// Unsets metadata.
+// Unsets prerelease status.
+func (v Version) IncMajor() Version {
+	vNext := v
+	vNext.metadata = ""
+	vNext.pre = ""
+	vNext.patch = 0
+	vNext.minor = 0
+	vNext.major = v.major + 1
+	vNext.original = v.originalVPrefix() + "" + vNext.String()
+	return vNext
+}
+
+// SetPrerelease defines the prerelease value.
+// Value must not include the required 'hypen' prefix.
+func (v Version) SetPrerelease(prerelease string) (Version, error) {
+	vNext := v
+	if len(prerelease) > 0 && !validPrereleaseRegex.MatchString(prerelease) {
+		return vNext, ErrInvalidPrerelease
+	}
+	vNext.pre = prerelease
+	vNext.original = v.originalVPrefix() + "" + vNext.String()
+	return vNext, nil
+}
+
+// SetMetadata defines metadata value.
+// Value must not include the required 'plus' prefix.
+func (v Version) SetMetadata(metadata string) (Version, error) {
+	vNext := v
+	if len(metadata) > 0 && !validPrereleaseRegex.MatchString(metadata) {
+		return vNext, ErrInvalidMetadata
+	}
+	vNext.metadata = metadata
+	vNext.original = v.originalVPrefix() + "" + vNext.String()
+	return vNext, nil
+}
+
+// LessThan tests if one version is less than another one.
+func (v *Version) LessThan(o *Version) bool {
+	return v.Compare(o) < 0
+}
+
+// GreaterThan tests if one version is greater than another one.
+func (v *Version) GreaterThan(o *Version) bool {
+	return v.Compare(o) > 0
+}
+
+// Equal tests if two versions are equal to each other.
+// Note, versions can be equal with different metadata since metadata
+// is not considered part of the comparable version.
+func (v *Version) Equal(o *Version) bool {
+	return v.Compare(o) == 0
+}
+
+// Compare compares this version to another one. It returns -1, 0, or 1 if
+// the version smaller, equal, or larger than the other version.
+//
+// Versions are compared by X.Y.Z. Build metadata is ignored. Prerelease is
+// lower than the version without a prerelease.
+func (v *Version) Compare(o *Version) int {
+	// Compare the major, minor, and patch version for differences. If a
+	// difference is found return the comparison.
+	if d := compareSegment(v.Major(), o.Major()); d != 0 {
+		return d
+	}
+	if d := compareSegment(v.Minor(), o.Minor()); d != 0 {
+		return d
+	}
+	if d := compareSegment(v.Patch(), o.Patch()); d != 0 {
+		return d
+	}
+
+	// At this point the major, minor, and patch versions are the same.
+	ps := v.pre
+	po := o.Prerelease()
+
+	if ps == "" && po == "" {
+		return 0
+	}
+	if ps == "" {
+		return 1
+	}
+	if po == "" {
+		return -1
+	}
+
+	return comparePrerelease(ps, po)
+}
+
+// UnmarshalJSON implements JSON.Unmarshaler interface.
+func (v *Version) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	temp, err := NewVersion(s)
+	if err != nil {
+		return err
+	}
+	v.major = temp.major
+	v.minor = temp.minor
+	v.patch = temp.patch
+	v.pre = temp.pre
+	v.metadata = temp.metadata
+	v.original = temp.original
+	temp = nil
+	return nil
+}
+
+// MarshalJSON implements JSON.Marshaler interface.
+func (v *Version) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.String())
+}
+
+func compareSegment(v, o int64) int {
+	if v < o {
+		return -1
+	}
+	if v > o {
+		return 1
+	}
+
+	return 0
+}
+
+func comparePrerelease(v, o string) int {
+
+	// split the prelease versions by their part. The separator, per the spec,
+	// is a .
+	sparts := strings.Split(v, ".")
+	oparts := strings.Split(o, ".")
+
+	// Find the longer length of the parts to know how many loop iterations to
+	// go through.
+	slen := len(sparts)
+	olen := len(oparts)
+
+	l := slen
+	if olen > slen {
+		l = olen
+	}
+
+	// Iterate over each part of the prereleases to compare the differences.
+	for i := 0; i < l; i++ {
+		// Since the lentgh of the parts can be different we need to create
+		// a placeholder. This is to avoid out of bounds issues.
+		stemp := ""
+		if i < slen {
+			stemp = sparts[i]
+		}
+
+		otemp := ""
+		if i < olen {
+			otemp = oparts[i]
+		}
+
+		d := comparePrePart(stemp, otemp)
+		if d != 0 {
+			return d
+		}
+	}
+
+	// Reaching here means two versions are of equal value but have different
+	// metadata (the part following a +). They are not identical in string form
+	// but the version comparison finds them to be equal.
+	return 0
+}
+
+func comparePrePart(s, o string) int {
+	// Fastpath if they are equal
+	if s == o {
+		return 0
+	}
+
+	// When s or o are empty we can use the other in an attempt to determine
+	// the response.
+	if o == "" {
+		_, n := strconv.ParseInt(s, 10, 64)
+		if n != nil {
+			return -1
+		}
+		return 1
+	}
+	if s == "" {
+		_, n := strconv.ParseInt(o, 10, 64)
+		if n != nil {
+			return 1
+		}
+		return -1
+	}
+
+	// When comparing strings "99" is greater than "103". To handle
+	// cases like this we need to detect numbers and compare them.
+
+	oi, n1 := strconv.ParseInt(o, 10, 64)
+	si, n2 := strconv.ParseInt(s, 10, 64)
+
+	// The case where both are strings compare the strings
+	if n1 != nil && n2 != nil {
+		if s > o {
+			return 1
+		}
+		return -1
+	} else if n1 != nil {
+		// o is a string and s is a number
+		return -1
+	} else if n2 != nil {
+		// s is a string and o is a number
+		return 1
+	}
+	// Both are numbers
+	if si > oi {
+		return 1
+	}
+	return -1
+
+}

--- a/vendor/github.com/Masterminds/semver/version_test.go
+++ b/vendor/github.com/Masterminds/semver/version_test.go
@@ -1,0 +1,487 @@
+package semver
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestNewVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		err     bool
+	}{
+		{"1.2.3", false},
+		{"v1.2.3", false},
+		{"1.0", false},
+		{"v1.0", false},
+		{"1", false},
+		{"v1", false},
+		{"1.2.beta", true},
+		{"v1.2.beta", true},
+		{"foo", true},
+		{"1.2-5", false},
+		{"v1.2-5", false},
+		{"1.2-beta.5", false},
+		{"v1.2-beta.5", false},
+		{"\n1.2", true},
+		{"\nv1.2", true},
+		{"1.2.0-x.Y.0+metadata", false},
+		{"v1.2.0-x.Y.0+metadata", false},
+		{"1.2.0-x.Y.0+metadata-width-hypen", false},
+		{"v1.2.0-x.Y.0+metadata-width-hypen", false},
+		{"1.2.3-rc1-with-hypen", false},
+		{"v1.2.3-rc1-with-hypen", false},
+		{"1.2.3.4", true},
+		{"v1.2.3.4", true},
+	}
+
+	for _, tc := range tests {
+		_, err := NewVersion(tc.version)
+		if tc.err && err == nil {
+			t.Fatalf("expected error for version: %s", tc.version)
+		} else if !tc.err && err != nil {
+			t.Fatalf("error for version %s: %s", tc.version, err)
+		}
+	}
+}
+
+func TestOriginal(t *testing.T) {
+	tests := []string{
+		"1.2.3",
+		"v1.2.3",
+		"1.0",
+		"v1.0",
+		"1",
+		"v1",
+		"1.2-5",
+		"v1.2-5",
+		"1.2-beta.5",
+		"v1.2-beta.5",
+		"1.2.0-x.Y.0+metadata",
+		"v1.2.0-x.Y.0+metadata",
+		"1.2.0-x.Y.0+metadata-width-hypen",
+		"v1.2.0-x.Y.0+metadata-width-hypen",
+		"1.2.3-rc1-with-hypen",
+		"v1.2.3-rc1-with-hypen",
+	}
+
+	for _, tc := range tests {
+		v, err := NewVersion(tc)
+		if err != nil {
+			t.Errorf("Error parsing version %s", tc)
+		}
+
+		o := v.Original()
+		if o != tc {
+			t.Errorf("Error retrieving originl. Expected '%s' but got '%s'", tc, v)
+		}
+	}
+}
+
+func TestParts(t *testing.T) {
+	v, err := NewVersion("1.2.3-beta.1+build.123")
+	if err != nil {
+		t.Error("Error parsing version 1.2.3-beta.1+build.123")
+	}
+
+	if v.Major() != 1 {
+		t.Error("Major() returning wrong value")
+	}
+	if v.Minor() != 2 {
+		t.Error("Minor() returning wrong value")
+	}
+	if v.Patch() != 3 {
+		t.Error("Patch() returning wrong value")
+	}
+	if v.Prerelease() != "beta.1" {
+		t.Error("Prerelease() returning wrong value")
+	}
+	if v.Metadata() != "build.123" {
+		t.Error("Metadata() returning wrong value")
+	}
+}
+
+func TestString(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected string
+	}{
+		{"1.2.3", "1.2.3"},
+		{"v1.2.3", "1.2.3"},
+		{"1.0", "1.0.0"},
+		{"v1.0", "1.0.0"},
+		{"1", "1.0.0"},
+		{"v1", "1.0.0"},
+		{"1.2-5", "1.2.0-5"},
+		{"v1.2-5", "1.2.0-5"},
+		{"1.2-beta.5", "1.2.0-beta.5"},
+		{"v1.2-beta.5", "1.2.0-beta.5"},
+		{"1.2.0-x.Y.0+metadata", "1.2.0-x.Y.0+metadata"},
+		{"v1.2.0-x.Y.0+metadata", "1.2.0-x.Y.0+metadata"},
+		{"1.2.0-x.Y.0+metadata-width-hypen", "1.2.0-x.Y.0+metadata-width-hypen"},
+		{"v1.2.0-x.Y.0+metadata-width-hypen", "1.2.0-x.Y.0+metadata-width-hypen"},
+		{"1.2.3-rc1-with-hypen", "1.2.3-rc1-with-hypen"},
+		{"v1.2.3-rc1-with-hypen", "1.2.3-rc1-with-hypen"},
+	}
+
+	for _, tc := range tests {
+		v, err := NewVersion(tc.version)
+		if err != nil {
+			t.Errorf("Error parsing version %s", tc)
+		}
+
+		s := v.String()
+		if s != tc.expected {
+			t.Errorf("Error generating string. Expected '%s' but got '%s'", tc.expected, s)
+		}
+	}
+}
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		v1       string
+		v2       string
+		expected int
+	}{
+		{"1.2.3", "1.5.1", -1},
+		{"2.2.3", "1.5.1", 1},
+		{"2.2.3", "2.2.2", 1},
+		{"3.2-beta", "3.2-beta", 0},
+		{"1.3", "1.1.4", 1},
+		{"4.2", "4.2-beta", 1},
+		{"4.2-beta", "4.2", -1},
+		{"4.2-alpha", "4.2-beta", -1},
+		{"4.2-alpha", "4.2-alpha", 0},
+		{"4.2-beta.2", "4.2-beta.1", 1},
+		{"4.2-beta2", "4.2-beta1", 1},
+		{"4.2-beta", "4.2-beta.2", -1},
+		{"4.2-beta", "4.2-beta.foo", 1},
+		{"4.2-beta.2", "4.2-beta", 1},
+		{"4.2-beta.foo", "4.2-beta", -1},
+		{"1.2+bar", "1.2+baz", 0},
+	}
+
+	for _, tc := range tests {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		v2, err := NewVersion(tc.v2)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		a := v1.Compare(v2)
+		e := tc.expected
+		if a != e {
+			t.Errorf(
+				"Comparison of '%s' and '%s' failed. Expected '%d', got '%d'",
+				tc.v1, tc.v2, e, a,
+			)
+		}
+	}
+}
+
+func TestLessThan(t *testing.T) {
+	tests := []struct {
+		v1       string
+		v2       string
+		expected bool
+	}{
+		{"1.2.3", "1.5.1", true},
+		{"2.2.3", "1.5.1", false},
+		{"3.2-beta", "3.2-beta", false},
+	}
+
+	for _, tc := range tests {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		v2, err := NewVersion(tc.v2)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		a := v1.LessThan(v2)
+		e := tc.expected
+		if a != e {
+			t.Errorf(
+				"Comparison of '%s' and '%s' failed. Expected '%t', got '%t'",
+				tc.v1, tc.v2, e, a,
+			)
+		}
+	}
+}
+
+func TestGreaterThan(t *testing.T) {
+	tests := []struct {
+		v1       string
+		v2       string
+		expected bool
+	}{
+		{"1.2.3", "1.5.1", false},
+		{"2.2.3", "1.5.1", true},
+		{"3.2-beta", "3.2-beta", false},
+		{"3.2.0-beta.1", "3.2.0-beta.5", false},
+		{"3.2-beta.4", "3.2-beta.2", true},
+		{"7.43.0-SNAPSHOT.99", "7.43.0-SNAPSHOT.103", false},
+		{"7.43.0-SNAPSHOT.FOO", "7.43.0-SNAPSHOT.103", true},
+		{"7.43.0-SNAPSHOT.99", "7.43.0-SNAPSHOT.BAR", false},
+	}
+
+	for _, tc := range tests {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		v2, err := NewVersion(tc.v2)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		a := v1.GreaterThan(v2)
+		e := tc.expected
+		if a != e {
+			t.Errorf(
+				"Comparison of '%s' and '%s' failed. Expected '%t', got '%t'",
+				tc.v1, tc.v2, e, a,
+			)
+		}
+	}
+}
+
+func TestEqual(t *testing.T) {
+	tests := []struct {
+		v1       string
+		v2       string
+		expected bool
+	}{
+		{"1.2.3", "1.5.1", false},
+		{"2.2.3", "1.5.1", false},
+		{"3.2-beta", "3.2-beta", true},
+		{"3.2-beta+foo", "3.2-beta+bar", true},
+	}
+
+	for _, tc := range tests {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		v2, err := NewVersion(tc.v2)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		a := v1.Equal(v2)
+		e := tc.expected
+		if a != e {
+			t.Errorf(
+				"Comparison of '%s' and '%s' failed. Expected '%t', got '%t'",
+				tc.v1, tc.v2, e, a,
+			)
+		}
+	}
+}
+
+func TestInc(t *testing.T) {
+	tests := []struct {
+		v1               string
+		expected         string
+		how              string
+		expectedOriginal string
+	}{
+		{"1.2.3", "1.2.4", "patch", "1.2.4"},
+		{"v1.2.4", "1.2.5", "patch", "v1.2.5"},
+		{"1.2.3", "1.3.0", "minor", "1.3.0"},
+		{"v1.2.4", "1.3.0", "minor", "v1.3.0"},
+		{"1.2.3", "2.0.0", "major", "2.0.0"},
+		{"v1.2.4", "2.0.0", "major", "v2.0.0"},
+		{"1.2.3+meta", "1.2.4", "patch", "1.2.4"},
+		{"1.2.3-beta+meta", "1.2.3", "patch", "1.2.3"},
+		{"v1.2.4-beta+meta", "1.2.4", "patch", "v1.2.4"},
+		{"1.2.3-beta+meta", "1.3.0", "minor", "1.3.0"},
+		{"v1.2.4-beta+meta", "1.3.0", "minor", "v1.3.0"},
+		{"1.2.3-beta+meta", "2.0.0", "major", "2.0.0"},
+		{"v1.2.4-beta+meta", "2.0.0", "major", "v2.0.0"},
+	}
+
+	for _, tc := range tests {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+		var v2 Version
+		switch tc.how {
+		case "patch":
+			v2 = v1.IncPatch()
+		case "minor":
+			v2 = v1.IncMinor()
+		case "major":
+			v2 = v1.IncMajor()
+		}
+
+		a := v2.String()
+		e := tc.expected
+		if a != e {
+			t.Errorf(
+				"Inc %q failed. Expected %q got %q",
+				tc.how, e, a,
+			)
+		}
+
+		a = v2.Original()
+		e = tc.expectedOriginal
+		if a != e {
+			t.Errorf(
+				"Inc %q failed. Expected original %q got %q",
+				tc.how, e, a,
+			)
+		}
+	}
+}
+
+func TestSetPrerelease(t *testing.T) {
+	tests := []struct {
+		v1                 string
+		prerelease         string
+		expectedVersion    string
+		expectedPrerelease string
+		expectedOriginal   string
+		expectedErr        error
+	}{
+		{"1.2.3", "**", "1.2.3", "", "1.2.3", ErrInvalidPrerelease},
+		{"1.2.3", "beta", "1.2.3-beta", "beta", "1.2.3-beta", nil},
+		{"v1.2.4", "beta", "1.2.4-beta", "beta", "v1.2.4-beta", nil},
+	}
+
+	for _, tc := range tests {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		v2, err := v1.SetPrerelease(tc.prerelease)
+		if err != tc.expectedErr {
+			t.Errorf("Expected to get err=%s, but got err=%s", tc.expectedErr, err)
+		}
+
+		a := v2.Prerelease()
+		e := tc.expectedPrerelease
+		if a != e {
+			t.Errorf("Expected prerelease value=%q, but got %q", e, a)
+		}
+
+		a = v2.String()
+		e = tc.expectedVersion
+		if a != e {
+			t.Errorf("Expected version string=%q, but got %q", e, a)
+		}
+
+		a = v2.Original()
+		e = tc.expectedOriginal
+		if a != e {
+			t.Errorf("Expected version original=%q, but got %q", e, a)
+		}
+	}
+}
+
+func TestSetMetadata(t *testing.T) {
+	tests := []struct {
+		v1               string
+		metadata         string
+		expectedVersion  string
+		expectedMetadata string
+		expectedOriginal string
+		expectedErr      error
+	}{
+		{"1.2.3", "**", "1.2.3", "", "1.2.3", ErrInvalidMetadata},
+		{"1.2.3", "meta", "1.2.3+meta", "meta", "1.2.3+meta", nil},
+		{"v1.2.4", "meta", "1.2.4+meta", "meta", "v1.2.4+meta", nil},
+	}
+
+	for _, tc := range tests {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		v2, err := v1.SetMetadata(tc.metadata)
+		if err != tc.expectedErr {
+			t.Errorf("Expected to get err=%s, but got err=%s", tc.expectedErr, err)
+		}
+
+		a := v2.Metadata()
+		e := tc.expectedMetadata
+		if a != e {
+			t.Errorf("Expected metadata value=%q, but got %q", e, a)
+		}
+
+		a = v2.String()
+		e = tc.expectedVersion
+		if e != a {
+			t.Errorf("Expected version string=%q, but got %q", e, a)
+		}
+
+		a = v2.Original()
+		e = tc.expectedOriginal
+		if a != e {
+			t.Errorf("Expected version original=%q, but got %q", e, a)
+		}
+	}
+}
+
+func TestOriginalVPrefix(t *testing.T) {
+	tests := []struct {
+		version string
+		vprefix string
+	}{
+		{"1.2.3", ""},
+		{"v1.2.4", "v"},
+	}
+
+	for _, tc := range tests {
+		v1, _ := NewVersion(tc.version)
+		a := v1.originalVPrefix()
+		e := tc.vprefix
+		if a != e {
+			t.Errorf("Expected vprefix=%q, but got %q", e, a)
+		}
+	}
+}
+
+func TestJsonMarshal(t *testing.T) {
+	sVer := "1.1.1"
+	x, err := NewVersion(sVer)
+	if err != nil {
+		t.Errorf("Error creating version: %s", err)
+	}
+	out, err2 := json.Marshal(x)
+	if err2 != nil {
+		t.Errorf("Error marshaling version: %s", err2)
+	}
+	got := string(out)
+	want := fmt.Sprintf("%q", sVer)
+	if got != want {
+		t.Errorf("Error marshaling unexpected marshaled content: got=%q want=%q", got, want)
+	}
+}
+
+func TestJsonUnmarshal(t *testing.T) {
+	sVer := "1.1.1"
+	ver := &Version{}
+	err := json.Unmarshal([]byte(fmt.Sprintf("%q", sVer)), ver)
+	if err != nil {
+		t.Errorf("Error unmarshaling version: %s", err)
+	}
+	got := ver.String()
+	want := sVer
+	if got != want {
+		t.Errorf("Error unmarshaling unexpected object content: got=%q want=%q", got, want)
+	}
+}

--- a/vendor/github.com/Masterminds/sprig/.gitignore
+++ b/vendor/github.com/Masterminds/sprig/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+/.glide

--- a/vendor/github.com/Masterminds/sprig/.travis.yml
+++ b/vendor/github.com/Masterminds/sprig/.travis.yml
@@ -1,0 +1,24 @@
+language: go
+
+go:
+  - 1.6
+  - 1.7
+  - 1.8
+  - tip
+
+# Setting sudo access to false will let Travis CI use containers rather than
+# VMs to run the tests. For more details see:
+# - http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+# - http://docs.travis-ci.com/user/workers/standard-infrastructure/
+sudo: false
+
+script:
+  - make setup test
+
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/06e3328629952dabe3e0
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: never     # options: [always|never|change] default: always

--- a/vendor/github.com/Masterminds/sprig/CHANGELOG.md
+++ b/vendor/github.com/Masterminds/sprig/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Release 1.2.0 (2016-02-01)
+
+- Added quote and squote
+- Added b32enc and b32dec
+- add now takes varargs
+- biggest now takes varargs
+
+# Release 1.1.0 (2015-12-29)
+
+- Added #4: Added contains function. strings.Contains, but with the arguments
+  switched to simplify common pipelines. (thanks krancour)
+- Added Travis-CI testing support
+
+# Release 1.0.0 (2015-12-23)
+
+- Initial release

--- a/vendor/github.com/Masterminds/sprig/LICENSE.txt
+++ b/vendor/github.com/Masterminds/sprig/LICENSE.txt
@@ -1,0 +1,20 @@
+Sprig
+Copyright (C) 2013 Masterminds
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/Masterminds/sprig/Makefile
+++ b/vendor/github.com/Masterminds/sprig/Makefile
@@ -1,0 +1,13 @@
+
+HAS_GLIDE := $(shell command -v glide;)
+
+.PHONY: test
+test:
+	go test -v .
+
+.PHONY: setup
+setup:
+ifndef HAS_GLIDE
+	go get -u github.com/Masterminds/glide
+endif
+	glide install

--- a/vendor/github.com/Masterminds/sprig/README.md
+++ b/vendor/github.com/Masterminds/sprig/README.md
@@ -1,0 +1,81 @@
+# Sprig: Template functions for Go templates
+[![Stability: Sustained](https://masterminds.github.io/stability/sustained.svg)](https://masterminds.github.io/stability/sustained.html)
+[![Build Status](https://travis-ci.org/Masterminds/sprig.svg?branch=master)](https://travis-ci.org/Masterminds/sprig)
+
+The Go language comes with a [built-in template
+language](http://golang.org/pkg/text/template/), but not
+very many template functions. This library provides a group of commonly
+used template functions.
+
+It is inspired by the template functions found in
+[Twig](http://twig.sensiolabs.org/documentation) and also in various
+JavaScript libraries, such as [underscore.js](http://underscorejs.org/).
+
+## Usage
+
+Template developers can read the [Sprig function documentation](http://masterminds.github.io/sprig/) to
+learn about the >100 template functions available.
+
+For Go developers wishing to include Sprig as a library in their programs,
+API documentation is available [at GoDoc.org](http://godoc.org/github.com/Masterminds/sprig), but
+read on for standard usage.
+
+### Load the Sprig library
+
+To load the Sprig `FuncMap`:
+
+```go
+
+import (
+  "github.com/Masterminds/sprig"
+  "html/template"
+)
+
+// This example illustrates that the FuncMap *must* be set before the
+// templates themselves are loaded.
+tpl := template.Must(
+  template.New("base").Funcs(sprig.FuncMap()).ParseGlob("*.html")
+)
+
+
+```
+
+### Call the functions inside of templates
+
+By convention, all functions are lowercase. This seems to follow the Go
+idiom for template functions (as opposed to template methods, which are
+TitleCase).
+
+
+Example:
+
+```
+{{ "hello!" | upper | repeat 5 }}
+```
+
+Produces:
+
+```
+HELLO!HELLO!HELLO!HELLO!HELLO!
+```
+
+## Principles:
+
+The following principles were used in deciding on which functions to add, and
+determining how to implement them.
+
+- Template functions should be used to build layout. Therefore, the following
+  types of operations are within the domain of template functions:
+  - Formatting
+  - Layout
+  - Simple type conversions
+  - Utilities that assist in handling common formatting and layout needs (e.g. arithmetic)
+- Template functions should not return errors unless there is no way to print
+  a sensible value. For example, converting a string to an integer should not
+  produce an error if conversion fails. Instead, it should display a default
+  value that can be displayed.
+- Simple math is necessary for grid layouts, pagers, and so on. Complex math
+  (anything other than arithmetic) should be done outside of templates.
+- Template functions only deal with the data passed into them. They never retrieve
+  data from a source.
+- Finally, do not override core Go template functions.

--- a/vendor/github.com/Masterminds/sprig/crypto.go
+++ b/vendor/github.com/Masterminds/sprig/crypto.go
@@ -1,0 +1,148 @@
+package sprig
+
+import (
+	"bytes"
+	"crypto/dsa"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+
+	uuid "github.com/satori/go.uuid"
+	"golang.org/x/crypto/scrypt"
+)
+
+func sha256sum(input string) string {
+	hash := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(hash[:])
+}
+
+// uuidv4 provides a safe and secure UUID v4 implementation
+func uuidv4() string {
+	return fmt.Sprintf("%s", uuid.NewV4())
+}
+
+var master_password_seed = "com.lyndir.masterpassword"
+
+var password_type_templates = map[string][][]byte{
+	"maximum": {[]byte("anoxxxxxxxxxxxxxxxxx"), []byte("axxxxxxxxxxxxxxxxxno")},
+	"long": {[]byte("CvcvnoCvcvCvcv"), []byte("CvcvCvcvnoCvcv"), []byte("CvcvCvcvCvcvno"), []byte("CvccnoCvcvCvcv"), []byte("CvccCvcvnoCvcv"),
+		[]byte("CvccCvcvCvcvno"), []byte("CvcvnoCvccCvcv"), []byte("CvcvCvccnoCvcv"), []byte("CvcvCvccCvcvno"), []byte("CvcvnoCvcvCvcc"),
+		[]byte("CvcvCvcvnoCvcc"), []byte("CvcvCvcvCvccno"), []byte("CvccnoCvccCvcv"), []byte("CvccCvccnoCvcv"), []byte("CvccCvccCvcvno"),
+		[]byte("CvcvnoCvccCvcc"), []byte("CvcvCvccnoCvcc"), []byte("CvcvCvccCvccno"), []byte("CvccnoCvcvCvcc"), []byte("CvccCvcvnoCvcc"),
+		[]byte("CvccCvcvCvccno")},
+	"medium": {[]byte("CvcnoCvc"), []byte("CvcCvcno")},
+	"short":  {[]byte("Cvcn")},
+	"basic":  {[]byte("aaanaaan"), []byte("aannaaan"), []byte("aaannaaa")},
+	"pin":    {[]byte("nnnn")},
+}
+
+var template_characters = map[byte]string{
+	'V': "AEIOU",
+	'C': "BCDFGHJKLMNPQRSTVWXYZ",
+	'v': "aeiou",
+	'c': "bcdfghjklmnpqrstvwxyz",
+	'A': "AEIOUBCDFGHJKLMNPQRSTVWXYZ",
+	'a': "AEIOUaeiouBCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxyz",
+	'n': "0123456789",
+	'o': "@&%?,=[]_:-+*$#!'^~;()/.",
+	'x': "AEIOUaeiouBCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxyz0123456789!@#$%^&*()",
+}
+
+func derivePassword(counter uint32, password_type, password, user, site string) string {
+	var templates = password_type_templates[password_type]
+	if templates == nil {
+		return fmt.Sprintf("cannot find password template %s", password_type)
+	}
+
+	var buffer bytes.Buffer
+	buffer.WriteString(master_password_seed)
+	binary.Write(&buffer, binary.BigEndian, uint32(len(user)))
+	buffer.WriteString(user)
+
+	salt := buffer.Bytes()
+	key, err := scrypt.Key([]byte(password), salt, 32768, 8, 2, 64)
+	if err != nil {
+		return fmt.Sprintf("failed to derive password: %s", err)
+	}
+
+	buffer.Truncate(len(master_password_seed))
+	binary.Write(&buffer, binary.BigEndian, uint32(len(site)))
+	buffer.WriteString(site)
+	binary.Write(&buffer, binary.BigEndian, counter)
+
+	var hmacv = hmac.New(sha256.New, key)
+	hmacv.Write(buffer.Bytes())
+	var seed = hmacv.Sum(nil)
+	var temp = templates[int(seed[0])%len(templates)]
+
+	buffer.Truncate(0)
+	for i, element := range temp {
+		pass_chars := template_characters[element]
+		pass_char := pass_chars[int(seed[i+1])%len(pass_chars)]
+		buffer.WriteByte(pass_char)
+	}
+
+	return buffer.String()
+}
+
+func generatePrivateKey(typ string) string {
+	var priv interface{}
+	var err error
+	switch typ {
+	case "", "rsa":
+		// good enough for government work
+		priv, err = rsa.GenerateKey(rand.Reader, 4096)
+	case "dsa":
+		key := new(dsa.PrivateKey)
+		// again, good enough for government work
+		if err = dsa.GenerateParameters(&key.Parameters, rand.Reader, dsa.L2048N256); err != nil {
+			return fmt.Sprintf("failed to generate dsa params: %s", err)
+		}
+		err = dsa.GenerateKey(key, rand.Reader)
+		priv = key
+	case "ecdsa":
+		// again, good enough for government work
+		priv, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	default:
+		return "Unknown type " + typ
+	}
+	if err != nil {
+		return fmt.Sprintf("failed to generate private key: %s", err)
+	}
+
+	return string(pem.EncodeToMemory(pemBlockForKey(priv)))
+}
+
+type DSAKeyFormat struct {
+	Version       int
+	P, Q, G, Y, X *big.Int
+}
+
+func pemBlockForKey(priv interface{}) *pem.Block {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}
+	case *dsa.PrivateKey:
+		val := DSAKeyFormat{
+			P: k.P, Q: k.Q, G: k.G,
+			Y: k.Y, X: k.X,
+		}
+		bytes, _ := asn1.Marshal(val)
+		return &pem.Block{Type: "DSA PRIVATE KEY", Bytes: bytes}
+	case *ecdsa.PrivateKey:
+		b, _ := x509.MarshalECPrivateKey(k)
+		return &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}
+	default:
+		return nil
+	}
+}

--- a/vendor/github.com/Masterminds/sprig/crypto_test.go
+++ b/vendor/github.com/Masterminds/sprig/crypto_test.go
@@ -1,0 +1,110 @@
+package sprig
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSha256Sum(t *testing.T) {
+	tpl := `{{"abc" | sha256sum}}`
+	if err := runt(tpl, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestDerivePassword(t *testing.T) {
+	expectations := map[string]string{
+		`{{derivePassword 1 "long" "password" "user" "example.com"}}`:    "ZedaFaxcZaso9*",
+		`{{derivePassword 2 "long" "password" "user" "example.com"}}`:    "Fovi2@JifpTupx",
+		`{{derivePassword 1 "maximum" "password" "user" "example.com"}}`: "pf4zS1LjCg&LjhsZ7T2~",
+		`{{derivePassword 1 "medium" "password" "user" "example.com"}}`:  "ZedJuz8$",
+		`{{derivePassword 1 "basic" "password" "user" "example.com"}}`:   "pIS54PLs",
+		`{{derivePassword 1 "short" "password" "user" "example.com"}}`:   "Zed5",
+		`{{derivePassword 1 "pin" "password" "user" "example.com"}}`:     "6685",
+	}
+
+	for tpl, result := range expectations {
+		out, err := runRaw(tpl, nil)
+		if err != nil {
+			t.Error(err)
+		}
+		if 0 != strings.Compare(out, result) {
+			t.Error("Generated password does not match for", tpl)
+		}
+	}
+}
+
+// NOTE(bacongobbler): this test is really _slow_ because of how long it takes to compute
+// and generate a new crypto key.
+func TestGenPrivateKey(t *testing.T) {
+	// test that calling by default generates an RSA private key
+	tpl := `{{genPrivateKey ""}}`
+	out, err := runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !strings.Contains(out, "RSA PRIVATE KEY") {
+		t.Error("Expected RSA PRIVATE KEY")
+	}
+	// test all acceptable arguments
+	tpl = `{{genPrivateKey "rsa"}}`
+	out, err = runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !strings.Contains(out, "RSA PRIVATE KEY") {
+		t.Error("Expected RSA PRIVATE KEY")
+	}
+	tpl = `{{genPrivateKey "dsa"}}`
+	out, err = runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !strings.Contains(out, "DSA PRIVATE KEY") {
+		t.Error("Expected DSA PRIVATE KEY")
+	}
+	tpl = `{{genPrivateKey "ecdsa"}}`
+	out, err = runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !strings.Contains(out, "EC PRIVATE KEY") {
+		t.Error("Expected EC PRIVATE KEY")
+	}
+	// test bad
+	tpl = `{{genPrivateKey "bad"}}`
+	out, err = runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if out != "Unknown type bad" {
+		t.Error("Expected type 'bad' to be an unknown crypto algorithm")
+	}
+	// ensure that we can base64 encode the string
+	tpl = `{{genPrivateKey "rsa" | b64enc}}`
+	out, err = runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestUUIDGeneration(t *testing.T) {
+	tpl := `{{uuidv4}}`
+	out, err := runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(out) != 36 {
+		t.Error("Expected UUID of length 36")
+	}
+
+	out2, err := runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if out == out2 {
+		t.Error("Expected subsequent UUID generations to be different")
+	}
+}

--- a/vendor/github.com/Masterminds/sprig/date.go
+++ b/vendor/github.com/Masterminds/sprig/date.go
@@ -1,0 +1,53 @@
+package sprig
+
+import (
+	"time"
+)
+
+// Given a format and a date, format the date string.
+//
+// Date can be a `time.Time` or an `int, int32, int64`.
+// In the later case, it is treated as seconds since UNIX
+// epoch.
+func date(fmt string, date interface{}) string {
+	return dateInZone(fmt, date, "Local")
+}
+
+func htmlDate(date interface{}) string {
+	return dateInZone("2006-01-02", date, "Local")
+}
+
+func htmlDateInZone(date interface{}, zone string) string {
+	return dateInZone("2006-01-02", date, zone)
+}
+
+func dateInZone(fmt string, date interface{}, zone string) string {
+	var t time.Time
+	switch date := date.(type) {
+	default:
+		t = time.Now()
+	case time.Time:
+		t = date
+	case int64:
+		t = time.Unix(date, 0)
+	case int:
+		t = time.Unix(int64(date), 0)
+	case int32:
+		t = time.Unix(int64(date), 0)
+	}
+
+	loc, err := time.LoadLocation(zone)
+	if err != nil {
+		loc, _ = time.LoadLocation("UTC")
+	}
+
+	return t.In(loc).Format(fmt)
+}
+
+func dateModify(fmt string, date time.Time) time.Time {
+	d, err := time.ParseDuration(fmt)
+	if err != nil {
+		return date
+	}
+	return date.Add(d)
+}

--- a/vendor/github.com/Masterminds/sprig/date_test.go
+++ b/vendor/github.com/Masterminds/sprig/date_test.go
@@ -1,0 +1,13 @@
+package sprig
+
+import (
+	"testing"
+)
+
+func TestHtmlDate(t *testing.T) {
+	t.Skip()
+	tpl := `{{ htmlDate 0}}`
+	if err := runt(tpl, "1970-01-01"); err != nil {
+		t.Error(err)
+	}
+}

--- a/vendor/github.com/Masterminds/sprig/defaults.go
+++ b/vendor/github.com/Masterminds/sprig/defaults.go
@@ -1,0 +1,75 @@
+package sprig
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+// dfault checks whether `given` is set, and returns default if not set.
+//
+// This returns `d` if `given` appears not to be set, and `given` otherwise.
+//
+// For numeric types 0 is unset.
+// For strings, maps, arrays, and slices, len() = 0 is considered unset.
+// For bool, false is unset.
+// Structs are never considered unset.
+//
+// For everything else, including pointers, a nil value is unset.
+func dfault(d interface{}, given ...interface{}) interface{} {
+
+	if empty(given) || empty(given[0]) {
+		return d
+	}
+	return given[0]
+}
+
+// empty returns true if the given value has the zero value for its type.
+func empty(given interface{}) bool {
+	g := reflect.ValueOf(given)
+	if !g.IsValid() {
+		return true
+	}
+
+	// Basically adapted from text/template.isTrue
+	switch g.Kind() {
+	default:
+		return g.IsNil()
+	case reflect.Array, reflect.Slice, reflect.Map, reflect.String:
+		return g.Len() == 0
+	case reflect.Bool:
+		return g.Bool() == false
+	case reflect.Complex64, reflect.Complex128:
+		return g.Complex() == 0
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return g.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return g.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return g.Float() == 0
+	case reflect.Struct:
+		return false
+	}
+	return true
+}
+
+// coalesce returns the first non-empty value.
+func coalesce(v ...interface{}) interface{} {
+	for _, val := range v {
+		if !empty(val) {
+			return val
+		}
+	}
+	return nil
+}
+
+// toJson encodes an item into a JSON string
+func toJson(v interface{}) string {
+	output, _ := json.Marshal(v)
+	return string(output)
+}
+
+// toPrettyJson encodes an item into a pretty (indented) JSON string
+func toPrettyJson(v interface{}) string {
+	output, _ := json.MarshalIndent(v, "", "  ")
+	return string(output)
+}

--- a/vendor/github.com/Masterminds/sprig/defaults_test.go
+++ b/vendor/github.com/Masterminds/sprig/defaults_test.go
@@ -1,0 +1,107 @@
+package sprig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefault(t *testing.T) {
+	tpl := `{{"" | default "foo"}}`
+	if err := runt(tpl, "foo"); err != nil {
+		t.Error(err)
+	}
+	tpl = `{{default "foo" 234}}`
+	if err := runt(tpl, "234"); err != nil {
+		t.Error(err)
+	}
+	tpl = `{{default "foo" 2.34}}`
+	if err := runt(tpl, "2.34"); err != nil {
+		t.Error(err)
+	}
+
+	tpl = `{{ .Nothing | default "123" }}`
+	if err := runt(tpl, "123"); err != nil {
+		t.Error(err)
+	}
+	tpl = `{{ default "123" }}`
+	if err := runt(tpl, "123"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestEmpty(t *testing.T) {
+	tpl := `{{if empty 1}}1{{else}}0{{end}}`
+	if err := runt(tpl, "0"); err != nil {
+		t.Error(err)
+	}
+
+	tpl = `{{if empty 0}}1{{else}}0{{end}}`
+	if err := runt(tpl, "1"); err != nil {
+		t.Error(err)
+	}
+	tpl = `{{if empty ""}}1{{else}}0{{end}}`
+	if err := runt(tpl, "1"); err != nil {
+		t.Error(err)
+	}
+	tpl = `{{if empty 0.0}}1{{else}}0{{end}}`
+	if err := runt(tpl, "1"); err != nil {
+		t.Error(err)
+	}
+	tpl = `{{if empty false}}1{{else}}0{{end}}`
+	if err := runt(tpl, "1"); err != nil {
+		t.Error(err)
+	}
+
+	dict := map[string]interface{}{"top": map[string]interface{}{}}
+	tpl = `{{if empty .top.NoSuchThing}}1{{else}}0{{end}}`
+	if err := runtv(tpl, "1", dict); err != nil {
+		t.Error(err)
+	}
+	tpl = `{{if empty .bottom.NoSuchThing}}1{{else}}0{{end}}`
+	if err := runtv(tpl, "1", dict); err != nil {
+		t.Error(err)
+	}
+}
+func TestCoalesce(t *testing.T) {
+	tests := map[string]string{
+		`{{ coalesce 1 }}`:                            "1",
+		`{{ coalesce "" 0 nil 2 }}`:                   "2",
+		`{{ $two := 2 }}{{ coalesce "" 0 nil $two }}`: "2",
+		`{{ $two := 2 }}{{ coalesce "" $two 0 0 0 }}`: "2",
+		`{{ $two := 2 }}{{ coalesce "" $two 3 4 5 }}`: "2",
+		`{{ coalesce }}`:                              "<no value>",
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+
+	dict := map[string]interface{}{"top": map[string]interface{}{}}
+	tpl := `{{ coalesce .top.NoSuchThing .bottom .bottom.dollar "airplane"}}`
+	if err := runtv(tpl, "airplane", dict); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestToJson(t *testing.T) {
+	dict := map[string]interface{}{"Top": map[string]interface{}{"bool": true, "string": "test", "number": 42}}
+
+	tpl := `{{.Top | toJson}}`
+	expected := `{"bool":true,"number":42,"string":"test"}`
+	if err := runtv(tpl, expected, dict); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestToPrettyJson(t *testing.T) {
+	dict := map[string]interface{}{"Top": map[string]interface{}{"bool": true, "string": "test", "number": 42}}
+	tpl := `{{.Top | toPrettyJson}}`
+	expected := `{
+  "bool": true,
+  "number": 42,
+  "string": "test"
+}`
+	if err := runtv(tpl, expected, dict); err != nil {
+		t.Error(err)
+	}
+}

--- a/vendor/github.com/Masterminds/sprig/dict.go
+++ b/vendor/github.com/Masterminds/sprig/dict.go
@@ -1,0 +1,84 @@
+package sprig
+
+import "github.com/imdario/mergo"
+
+func set(d map[string]interface{}, key string, value interface{}) map[string]interface{} {
+	d[key] = value
+	return d
+}
+
+func unset(d map[string]interface{}, key string) map[string]interface{} {
+	delete(d, key)
+	return d
+}
+
+func hasKey(d map[string]interface{}, key string) bool {
+	_, ok := d[key]
+	return ok
+}
+
+func pluck(key string, d ...map[string]interface{}) []interface{} {
+	res := []interface{}{}
+	for _, dict := range d {
+		if val, ok := dict[key]; ok {
+			res = append(res, val)
+		}
+	}
+	return res
+}
+
+func keys(dict map[string]interface{}) []string {
+	k := []string{}
+	for key := range dict {
+		k = append(k, key)
+	}
+	return k
+}
+
+func pick(dict map[string]interface{}, keys ...string) map[string]interface{} {
+	res := map[string]interface{}{}
+	for _, k := range keys {
+		if v, ok := dict[k]; ok {
+			res[k] = v
+		}
+	}
+	return res
+}
+
+func omit(dict map[string]interface{}, keys ...string) map[string]interface{} {
+	res := map[string]interface{}{}
+
+	omit := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		omit[k] = true
+	}
+
+	for k, v := range dict {
+		if _, ok := omit[k]; !ok {
+			res[k] = v
+		}
+	}
+	return res
+}
+
+func dict(v ...interface{}) map[string]interface{} {
+	dict := map[string]interface{}{}
+	lenv := len(v)
+	for i := 0; i < lenv; i += 2 {
+		key := strval(v[i])
+		if i+1 >= lenv {
+			dict[key] = ""
+			continue
+		}
+		dict[key] = v[i+1]
+	}
+	return dict
+}
+
+func merge(dst map[string]interface{}, src map[string]interface{}) interface{} {
+	if err := mergo.Merge(&dst, src); err != nil {
+		// Swallow errors inside of a template.
+		return ""
+	}
+	return dst
+}

--- a/vendor/github.com/Masterminds/sprig/dict_test.go
+++ b/vendor/github.com/Masterminds/sprig/dict_test.go
@@ -1,0 +1,174 @@
+package sprig
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDict(t *testing.T) {
+	tpl := `{{$d := dict 1 2 "three" "four" 5}}{{range $k, $v := $d}}{{$k}}{{$v}}{{end}}`
+	out, err := runRaw(tpl, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(out) != 12 {
+		t.Errorf("Expected length 12, got %d", len(out))
+	}
+	// dict does not guarantee ordering because it is backed by a map.
+	if !strings.Contains(out, "12") {
+		t.Error("Expected grouping 12")
+	}
+	if !strings.Contains(out, "threefour") {
+		t.Error("Expected grouping threefour")
+	}
+	if !strings.Contains(out, "5") {
+		t.Error("Expected 5")
+	}
+	tpl = `{{$t := dict "I" "shot" "the" "albatross"}}{{$t.the}} {{$t.I}}`
+	if err := runt(tpl, "albatross shot"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestUnset(t *testing.T) {
+	tpl := `{{- $d := dict "one" 1 "two" 222222 -}}
+	{{- $_ := unset $d "two" -}}
+	{{- range $k, $v := $d}}{{$k}}{{$v}}{{- end -}}
+	`
+
+	expect := "one1"
+	if err := runt(tpl, expect); err != nil {
+		t.Error(err)
+	}
+}
+func TestHasKey(t *testing.T) {
+	tpl := `{{- $d := dict "one" 1 "two" 222222 -}}
+	{{- if hasKey $d "one" -}}1{{- end -}}
+	`
+
+	expect := "1"
+	if err := runt(tpl, expect); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestPluck(t *testing.T) {
+	tpl := `
+	{{- $d := dict "one" 1 "two" 222222 -}}
+	{{- $d2 := dict "one" 1 "two" 33333 -}}
+	{{- $d3 := dict "one" 1 -}}
+	{{- $d4 := dict "one" 1 "two" 4444 -}}
+	{{- pluck "two" $d $d2 $d3 $d4 -}}
+	`
+
+	expect := "[222222 33333 4444]"
+	if err := runt(tpl, expect); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestKeys(t *testing.T) {
+	tests := map[string]string{
+		`{{ dict "foo" 1 "bar" 2 | keys | sortAlpha }}`: "[bar foo]",
+		`{{ dict | keys }}`:                             "[]",
+	}
+	for tpl, expect := range tests {
+		if err := runt(tpl, expect); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestPick(t *testing.T) {
+	tests := map[string]string{
+		`{{- $d := dict "one" 1 "two" 222222 }}{{ pick $d "two" | len -}}`:               "1",
+		`{{- $d := dict "one" 1 "two" 222222 }}{{ pick $d "two" -}}`:                     "map[two:222222]",
+		`{{- $d := dict "one" 1 "two" 222222 }}{{ pick $d "one" "two" | len -}}`:         "2",
+		`{{- $d := dict "one" 1 "two" 222222 }}{{ pick $d "one" "two" "three" | len -}}`: "2",
+		`{{- $d := dict }}{{ pick $d "two" | len -}}`:                                    "0",
+	}
+	for tpl, expect := range tests {
+		if err := runt(tpl, expect); err != nil {
+			t.Error(err)
+		}
+	}
+}
+func TestOmit(t *testing.T) {
+	tests := map[string]string{
+		`{{- $d := dict "one" 1 "two" 222222 }}{{ omit $d "one" | len -}}`:         "1",
+		`{{- $d := dict "one" 1 "two" 222222 }}{{ omit $d "one" -}}`:               "map[two:222222]",
+		`{{- $d := dict "one" 1 "two" 222222 }}{{ omit $d "one" "two" | len -}}`:   "0",
+		`{{- $d := dict "one" 1 "two" 222222 }}{{ omit $d "two" "three" | len -}}`: "1",
+		`{{- $d := dict }}{{ omit $d "two" | len -}}`:                              "0",
+	}
+	for tpl, expect := range tests {
+		if err := runt(tpl, expect); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestSet(t *testing.T) {
+	tpl := `{{- $d := dict "one" 1 "two" 222222 -}}
+	{{- $_ := set $d "two" 2 -}}
+	{{- $_ := set $d "three" 3 -}}
+	{{- if hasKey $d "one" -}}{{$d.one}}{{- end -}}
+	{{- if hasKey $d "two" -}}{{$d.two}}{{- end -}}
+	{{- if hasKey $d "three" -}}{{$d.three}}{{- end -}}
+	`
+
+	expect := "123"
+	if err := runt(tpl, expect); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestCompact(t *testing.T) {
+	tests := map[string]string{
+		`{{ list 1 0 "" "hello" | compact }}`: `[1 hello]`,
+		`{{ list "" "" | compact }}`:          `[]`,
+		`{{ list | compact }}`:                `[]`,
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+}
+
+func TestMerge(t *testing.T) {
+	dict := map[string]interface{}{
+		"src": map[string]interface{}{
+			"a": 1,
+			"b": 2,
+			"d": map[string]interface{}{
+				"e": "four",
+			},
+			"g": []int{6, 7},
+		},
+		"dst": map[string]interface{}{
+			"a": "one",
+			"c": 3,
+			"d": map[string]interface{}{
+				"f": 5,
+			},
+			"g": []int{8, 9},
+		},
+	}
+	tpl := `{{merge .dst .src}}`
+	_, err := runRaw(tpl, dict)
+	if err != nil {
+		t.Error(err)
+	}
+	expected := map[string]interface{}{
+		"a": "one", // key overridden
+		"b": 2,     // merged from src
+		"c": 3,     // merged from dst
+		"d": map[string]interface{}{ // deep merge
+			"e": "four",
+			"f": 5,
+		},
+		"g": []int{8, 9}, // overridden - arrays are not merged
+	}
+	assert.Equal(t, expected, dict["dst"])
+}

--- a/vendor/github.com/Masterminds/sprig/doc.go
+++ b/vendor/github.com/Masterminds/sprig/doc.go
@@ -1,0 +1,225 @@
+/*
+Sprig: Template functions for Go.
+
+This package contains a number of utility functions for working with data
+inside of Go `html/template` and `text/template` files.
+
+To add these functions, use the `template.Funcs()` method:
+
+	t := templates.New("foo").Funcs(sprig.FuncMap())
+
+Note that you should add the function map before you parse any template files.
+
+	In several cases, Sprig reverses the order of arguments from the way they
+	appear in the standard library. This is to make it easier to pipe
+	arguments into functions.
+
+Date Functions
+
+	- date FORMAT TIME: Format a date, where a date is an integer type or a time.Time type, and
+	  format is a time.Format formatting string.
+	- dateModify: Given a date, modify it with a duration: `date_modify "-1.5h" now`. If the duration doesn't
+	  parse, it returns the time unaltered. See `time.ParseDuration` for info on duration strings.
+	- now: Current time.Time, for feeding into date-related functions.
+	- htmlDate TIME: Format a date for use in the value field of an HTML "date" form element.
+	- dateInZone FORMAT TIME TZ: Like date, but takes three arguments: format, timestamp,
+	  timezone.
+	- htmlDateInZone TIME TZ: Like htmlDate, but takes two arguments: timestamp,
+	  timezone.
+
+String Functions
+
+	- abbrev: Truncate a string with ellipses. `abbrev 5 "hello world"` yields "he..."
+	- abbrevboth: Abbreviate from both sides, yielding "...lo wo..."
+	- trunc: Truncate a string (no suffix). `trunc 5 "Hello World"` yields "hello".
+	- trim: strings.TrimSpace
+	- trimAll: strings.Trim, but with the argument order reversed `trimAll "$" "$5.00"` or `"$5.00 | trimAll "$"`
+	- trimSuffix: strings.TrimSuffix, but with the argument order reversed: `trimSuffix "-" "ends-with-"`
+	- trimPrefix: strings.TrimPrefix, but with the argument order reversed `trimPrefix "$" "$5"`
+	- upper: strings.ToUpper
+	- lower: strings.ToLower
+	- nospace: Remove all space characters from a string. `nospace "h e l l o"` becomes "hello"
+	- title: strings.Title
+	- untitle: Remove title casing
+	- repeat: strings.Repeat, but with the arguments switched: `repeat count str`. (This simplifies common pipelines)
+	- substr: Given string, start, and length, return a substr.
+	- initials: Given a multi-word string, return the initials. `initials "Matt Butcher"` returns "MB"
+	- randAlphaNum: Given a length, generate a random alphanumeric sequence
+	- randAlpha: Given a length, generate an alphabetic string
+	- randAscii: Given a length, generate a random ASCII string (symbols included)
+	- randNumeric: Given a length, generate a string of digits.
+	- wrap: Force a line wrap at the given width. `wrap 80 "imagine a longer string"`
+	- wrapWith: Wrap a line at the given length, but using 'sep' instead of a newline. `wrapWith 50, "<br>", $html`
+	- contains: strings.Contains, but with the arguments switched: `contains substr str`. (This simplifies common pipelines)
+	- hasPrefix: strings.hasPrefix, but with the arguments switched
+	- hasSuffix: strings.hasSuffix, but with the arguments switched
+	- quote: Wrap string(s) in double quotation marks, escape the contents by adding '\' before '"'.
+	- squote: Wrap string(s) in double quotation marks, does not escape content.
+	- cat: Concatenate strings, separating them by spaces. `cat $a $b $c`.
+	- indent: Indent a string using space characters. `indent 4 "foo\nbar"` produces "    foo\n    bar"
+	- replace: Replace an old with a new in a string: `$name | replace " " "-"`
+	- plural: Choose singular or plural based on length: `len $fish | plural "one anchovy" "many anchovies"`
+	- sha256sum: Generate a hex encoded sha256 hash of the input
+	- toString: Convert something to a string
+
+String Slice Functions:
+
+	- join: strings.Join, but as `join SEP SLICE`
+	- split: strings.Split, but as `split SEP STRING`. The results are returned
+	  as a map with the indexes set to _N, where N is an integer starting from 0.
+	  Use it like this: `{{$v := "foo/bar/baz" | split "/"}}{{$v._0}}` (Prints `foo`)
+	- splitList: strings.Split, but as `split SEP STRING`. The results are returned
+	  as an array.
+	- toStrings: convert a list to a list of strings. 'list 1 2 3 | toStrings' produces '["1" "2" "3"]'
+	- sortAlpha: sort a list lexicographically.
+
+Integer Slice Functions:
+
+	- until: Given an integer, returns a slice of counting integers from 0 to one
+	  less than the given integer: `range $i, $e := until 5`
+	- untilStep: Given start, stop, and step, return an integer slice starting at
+	  'start', stopping at `stop`, and incrementing by 'step. This is the same
+	  as Python's long-form of 'range'.
+
+Conversions:
+
+	- atoi: Convert a string to an integer. 0 if the integer could not be parsed.
+	- in64: Convert a string or another numeric type to an int64.
+	- int: Convert a string or another numeric type to an int.
+	- float64: Convert a string or another numeric type to a float64.
+
+Defaults:
+
+	- default: Give a default value. Used like this: trim "   "| default "empty".
+	  Since trim produces an empty string, the default value is returned. For
+	  things with a length (strings, slices, maps), len(0) will trigger the default.
+	  For numbers, the value 0 will trigger the default. For booleans, false will
+	  trigger the default. For structs, the default is never returned (there is
+	  no clear empty condition). For everything else, nil value triggers a default.
+	- empty: Return true if the given value is the zero value for its type.
+	  Caveats: structs are always non-empty. This should match the behavior of
+	  {{if pipeline}}, but can be used inside of a pipeline.
+	- coalesce: Given a list of items, return the first non-empty one.
+	  This follows the same rules as 'empty'. '{{ coalesce .someVal 0 "hello" }}`
+	  will return `.someVal` if set, or else return "hello". The 0 is skipped
+	  because it is an empty value.
+	- compact: Return a copy of a list with all of the empty values removed.
+	  'list 0 1 2 "" | compact' will return '[1 2]'
+
+OS:
+	- env: Resolve an environment variable
+	- expandenv: Expand a string through the environment
+
+File Paths:
+	- base: Return the last element of a path. https://golang.org/pkg/path#Base
+	- dir: Remove the last element of a path. https://golang.org/pkg/path#Dir
+	- clean: Clean a path to the shortest equivalent name.  (e.g. remove "foo/.."
+	  from "foo/../bar.html") https://golang.org/pkg/path#Clean
+	- ext: https://golang.org/pkg/path#Ext
+	- isAbs: https://golang.org/pkg/path#IsAbs
+
+Encoding:
+	- b64enc: Base 64 encode a string.
+	- b64dec: Base 64 decode a string.
+
+Reflection:
+
+	- typeOf: Takes an interface and returns a string representation of the type.
+	  For pointers, this will return a type prefixed with an asterisk(`*`). So
+	  a pointer to type `Foo` will be `*Foo`.
+	- typeIs: Compares an interface with a string name, and returns true if they match.
+	  Note that a pointer will not match a reference. For example `*Foo` will not
+	  match `Foo`.
+	- typeIsLike: Compares an interface with a string name and returns true if
+	  the interface is that `name` or that `*name`. In other words, if the given
+	  value matches the given type or is a pointer to the given type, this returns
+	  true.
+	- kindOf: Takes an interface and returns a string representation of its kind.
+	- kindIs: Returns true if the given string matches the kind of the given interface.
+
+	Note: None of these can test whether or not something implements a given
+	interface, since doing so would require compiling the interface in ahead of
+	time.
+
+Data Structures:
+
+	- tuple: Takes an arbitrary list of items and returns a slice of items. Its
+	  tuple-ish properties are mainly gained through the template idiom, and not
+	  through an API provided here. WARNING: The implementation of tuple will
+	  change in the future.
+	- list: An arbitrary ordered list of items. (This is prefered over tuple.)
+	- dict: Takes a list of name/values and returns a map[string]interface{}.
+	  The first parameter is converted to a string and stored as a key, the
+	  second parameter is treated as the value. And so on, with odds as keys and
+	  evens as values. If the function call ends with an odd, the last key will
+	  be assigned the empty string. Non-string keys are converted to strings as
+	  follows: []byte are converted, fmt.Stringers will have String() called.
+	  errors will have Error() called. All others will be passed through
+	  fmt.Sprtinf("%v").
+
+Lists Functions:
+
+These are used to manipulate lists: '{{ list 1 2 3 | reverse | first }}'
+
+	- first: Get the first item in a 'list'. 'list 1 2 3 | first' prints '1'
+	- last: Get the last item in a 'list': 'list 1 2 3 | last ' prints '3'
+	- rest: Get all but the first item in a list: 'list 1 2 3 | rest' returns '[2 3]'
+	- initial: Get all but the last item in a list: 'list 1 2 3 | initial' returns '[1 2]'
+	- append: Add an item to the end of a list: 'append $list 4' adds '4' to the end of '$list'
+	- prepend: Add an item to the beginning of a list: 'prepend $list 4' puts 4 at the beginning of the list.
+	- reverse: Reverse the items in a list.
+	- uniq: Remove duplicates from a list.
+	- without: Return a list with the given values removed: 'without (list 1 2 3) 1' would return '[2 3]'
+	- has: Return 'true' if the item is found in the list: 'has "foo" $list' will return 'true' if the list contains "foo"
+
+Dict Functions:
+
+These are used to manipulate dicts.
+
+	- set: Takes a dict, a key, and a value, and sets that key/value pair in
+	  the dict. `set $dict $key $value`. For convenience, it returns the dict,
+	  even though the dict was modified in place.
+	- unset: Takes a dict and a key, and deletes that key/value pair from the
+	  dict. `unset $dict $key`. This returns the dict for convenience.
+	- hasKey: Takes a dict and a key, and returns boolean true if the key is in
+	  the dict.
+	- pluck: Given a key and one or more maps, get all of the values for that key.
+	- keys: Get an array of all of the keys in a dict.
+	- pick: Select just the given keys out of the dict, and return a new dict.
+	- omit: Return a dict without the given keys.
+
+Math Functions:
+
+Integer functions will convert integers of any width to `int64`. If a
+string is passed in, functions will attempt to convert with
+`strconv.ParseInt(s, 1064)`. If this fails, the value will be treated as 0.
+
+	- add1: Increment an integer by 1
+	- add: Sum an arbitrary number of integers
+	- sub: Subtract the second integer from the first
+	- div: Divide the first integer by the second
+	- mod: Module of first integer divided by second
+	- mul: Multiply integers
+	- max: Return the biggest of a series of one or more integers
+	- min: Return the smallest of a series of one or more integers
+	- biggest: DEPRECATED. Return the biggest of a series of one or more integers
+
+Crypto Functions:
+
+	- genPrivateKey: Generate a private key for the given cryptosystem. If no
+	  argument is supplied, by default it will generate a private key using
+	  the RSA algorithm. Accepted values are `rsa`, `dsa`, and `ecdsa`.
+	- derivePassword: Derive a password from the given parameters according to the ["Master Password" algorithm](http://masterpasswordapp.com/algorithm.html)
+	  Given parameters (in order) are:
+          `counter` (starting with 1), `password_type` (maximum, long, medium, short, basic, or pin), `password`,
+           `user`, and `site`
+
+SemVer Functions:
+
+These functions provide version parsing and comparisons for SemVer 2 version
+strings.
+
+	- semver: Parse a semantic version and return a Version object.
+	- semverCompare: Compare a SemVer range to a particular version.
+*/
+package sprig

--- a/vendor/github.com/Masterminds/sprig/docs/_config.yml
+++ b/vendor/github.com/Masterminds/sprig/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-slate

--- a/vendor/github.com/Masterminds/sprig/docs/conversion.md
+++ b/vendor/github.com/Masterminds/sprig/docs/conversion.md
@@ -1,0 +1,25 @@
+# Type Conversion Functions
+
+The following type conversion functions are provided by Sprig:
+
+- `atoi`: Convert a string to an integer
+- `float64`: Convert to a float64
+- `int`: Convert to an `int` at the system's width.
+- `int64`: Convert to an `int64`
+- `toString`: Convert to a string
+- `toStrings`: Convert a list, slice, or array to a list of strings.
+
+Only `atoi` requires that the input be a specific type. The others will attempt
+to convert from any type to the destination type. For example, `int64` can convert
+floats to ints, and it can also convert strings to ints.
+
+## toStrings
+
+Given a list-like collection, produce a slice of strings.
+
+```
+list 1 2 3 | toStrings
+```
+
+The above converts `1` to `"1"`, `2` to `"2"`, and so on, and then returns
+them as a list.

--- a/vendor/github.com/Masterminds/sprig/docs/crypto.md
+++ b/vendor/github.com/Masterminds/sprig/docs/crypto.md
@@ -1,0 +1,37 @@
+# Cryptographic and Security Functions
+
+Sprig provides a couple of advanced cryptographic functions.
+
+## sha256sum
+
+The `sha256sum` function receives a string, and computes it's SHA256 digest.
+
+```
+sha256sum "Hello world!"
+```
+
+The above will compute the SHA 256 sum in an "ASCII armored" format that is
+safe to print.
+
+## derivePassword
+
+The `derivePassword` function can be used to derive a specific password based on
+some shared "master password" constraints. The algorithm for this is
+[well specified](http://masterpasswordapp.com/algorithm.html).
+
+```
+derivePassword 1 "long" "password" "user" "example.com"
+```
+
+Note that it is considered insecure to store the parts directly in the template.
+
+## generatePrivateKey
+
+The `generatePrivateKey` function generates a new private key encoded into a PEM
+block.
+
+It takes one of the values for its first param:
+
+- `ecdsa`: Generate an elyptical curve DSA key (P256)
+- `dsa`: Generate a DSA key (L2048N256)
+- `rsa`: Generate an RSA 4096 key

--- a/vendor/github.com/Masterminds/sprig/docs/date.md
+++ b/vendor/github.com/Masterminds/sprig/docs/date.md
@@ -1,0 +1,62 @@
+# Date Functions
+
+## now
+
+The current date/time. Use this in conjunction with other date functions.
+
+## date
+
+The `date` function formats a date.
+
+
+Format the date to YEAR-MONTH-DAY:
+```
+now | date "2006-01-02"
+```
+
+Date formatting in Go is a [little bit different](https://pauladamsmith.com/blog/2011/05/go_time.html).
+
+In short, take this as the base date:
+
+```
+Mon Jan 2 15:04:05 MST 2006
+```
+
+Write it in the format you want. Above, `2006-01-02` is the same date, but
+in the format we want.
+
+## dateInZone
+
+Same as `date`, but with a timezone.
+
+```
+date "2006-01-02" (now) "UTC"
+```
+
+## dateModify
+
+The `dateModify` takes a modification and a date and returns the timestamp.
+
+Subtract an hour and thirty minutes from the current time:
+
+```
+now | date_modify "-1.5h"
+```
+
+## htmlDate
+
+The `htmlDate` function formates a date for inserting into an HTML date picker
+input field.
+
+```
+now | htmlDate
+```
+
+## htmlDateInZone
+
+Same as htmlDate, but with a timezone.
+
+```
+htmlDate (now) "UTC"
+```
+

--- a/vendor/github.com/Masterminds/sprig/docs/defaults.md
+++ b/vendor/github.com/Masterminds/sprig/docs/defaults.md
@@ -1,0 +1,59 @@
+# Default Functions
+
+Sprig provides tools for setting default values for templates.
+
+## default
+
+To set a simple default value, use `default`:
+
+```
+default "foo" .Bar
+```
+
+In the above, if `.Bar` evaluates to a non-empty value, it will be used. But if
+it is empty, `foo` will be returned instead.
+
+The definition of "empty" depends on type:
+
+- Numeric: 0
+- String: ""
+- Lists: `[]`
+- Dicts: `{}`
+- Boolean: `false`
+- And always `nil` (aka null)
+
+For structs, there is no definition of empty, so a struct will never return the
+default.
+
+## empty
+
+The `empty` function returns `true` if the given value is considered empty, and
+`false` otherwise. The empty values are listed in the `default` section.
+
+```
+empty .Foo
+```
+
+Note that in Go template conditionals, emptiness is calculated for you. Thus,
+you rarely need `if empty .Foo`. Instead, just use `if .Foo`.
+
+## coalesce
+
+The `coalesce` function takes a list of values and returns the first non-empty
+one.
+
+```
+coalesce 0 1 2
+```
+
+The above returns `1`.
+
+This function is useful for scanning through multiple variables or values:
+
+```
+coalesce .name .parent.name "Matt"
+```
+
+The above will first check to see if `.name` is empty. If it is not, it will return
+that value. If it _is_ empty, `coalesce` will evaluate `.parent.name` for emptiness.
+Finally, if both `.name` and `.parent.name` are empty, it will return `Matt`.

--- a/vendor/github.com/Masterminds/sprig/docs/dicts.md
+++ b/vendor/github.com/Masterminds/sprig/docs/dicts.md
@@ -1,0 +1,124 @@
+# Dictionaries and Dict Functions
+
+Sprig provides a key/value storage type called a `dict` (short for "dictionary",
+as in Python). A `dict` is an _unorder_ type.
+
+The key to a dictionary **must be a string**. However, the value can be any
+type, even another `dict` or `list`.
+
+Unlike `list`s, `dict`s are not immutable. The `set` and `unset` functions will
+modify the contents of a dictionary.
+
+## dict
+
+Creating dictionaries is done by calling the `dict` function and passing it a
+list of pairs.
+
+The following creates a dictionary with three items:
+
+```
+$myDict := dict "name1" "value1" "name2" "value2" "name3" "value 3"
+```
+
+## set
+
+Use `set` to add a new key/value pair to a dictionary.
+
+```
+$_ := set $myDict "name4" "value4"
+```
+
+Note that `set` _returns the dictionary_ (a requirement of Go template functions),
+so you may need to trap the value as done above with the `$_` assignment.
+
+## unset
+
+Given a map and a key, delete the key from the map.
+
+```
+$_ := unset $myDict "name4"
+```
+
+As with `set`, this returns the dictionary.
+
+Note that if the key is not found, this operation will simply return. No error
+will be generated.
+
+## hasKey
+
+The `hasKey` function returns `true` if the given dict contains the given key.
+
+```
+hasKey $myDict "name1"
+```
+
+If the key is not found, this returns `false`.
+
+## pluck
+
+The `pluck` function makes it possible to give one key and multiple maps, and
+get a list of all of the matches:
+
+```
+pluck "name1" $myDict $myOtherDict
+```
+
+The above will return a `list` containing every found value (`[value1 otherValue1]`).
+
+If the give key is _not found_ in a map, that map will not have an item in the
+list (and the length of the returned list will be less than the number of dicts
+in the call to `pluck`.
+
+If the key is _found_ but the value is an empty value, that value will be
+inserted.
+
+A common idiom in Sprig templates is to uses `pluck... | first` to get the first
+matching key out of a collection of dictionaries.
+
+## merge
+
+Merge two dictionaries into one, giving precedence to the dest dictionary:
+
+```
+$newdict := merge $dest $source
+```
+
+This is a deep merge operation.
+
+## keys
+
+The `keys` function will return a `list` of all of the keys in a `dict`. Since
+a dictionary is _unordered_, the keys will not be in a predictable order. They
+can be sorted with `sortAlpha`.
+
+```
+keys $myDict | sortAlpha
+```
+
+## pick
+
+The `pick` function selects just the given keys out of a dictionary, creating a
+new `dict`.
+
+```
+$new := pick $myDict "name1" "name3"
+```
+
+The above returns `{name1: value1, name2: value2}`
+
+## omit
+
+The `omit` function is similar to `pick`, except it returns a new `dict` with all
+the keys that _do not_ match the given keys.
+
+```
+$new := omit $myDict "name1" "name3"
+```
+
+The above returns `{name2: value2}`
+
+## A Note on Dict Internals
+
+A `dict` is implemented in Go as a `map[string]interface{}`. Go developers can
+pass `map[string]interface{}` values into the context to make them available
+to templates as `dict`s.

--- a/vendor/github.com/Masterminds/sprig/docs/encoding.md
+++ b/vendor/github.com/Masterminds/sprig/docs/encoding.md
@@ -1,0 +1,6 @@
+# Encoding Functions
+
+Sprig has the following encoding and decoding functions:
+
+- `b64enc`/`b64dec`: Encode or decode with Base64
+- `b32enc`/`b32dec`: Encode or decode with Base32

--- a/vendor/github.com/Masterminds/sprig/docs/flow_control.md
+++ b/vendor/github.com/Masterminds/sprig/docs/flow_control.md
@@ -1,0 +1,11 @@
+# Flow Control Functions
+
+## fail
+
+Unconditionally returns an empty `string` and an `error` with the specified
+text. This is useful in scenarios where other conditionals have determined that
+template rendering should fail.
+
+```
+fail "Please accept the end user license agreement"
+```

--- a/vendor/github.com/Masterminds/sprig/docs/index.md
+++ b/vendor/github.com/Masterminds/sprig/docs/index.md
@@ -1,0 +1,23 @@
+# Sprig Function Documentation
+
+The Sprig library provides over 70 template functions for Go's template language.
+
+- [String Functions](strings.md): `trim`, `wrap`, `randAlpha`, `plural`, etc.
+  - [String List Functions](string_slice.md): `splitList`, `sortAlpha`, etc.
+- [Math Functions](math.md): `add`, `max`, `mul`, etc.
+  - [Integer Slice Functions](integer_slice.md): `until`, `untilStep`
+- [Date Functions](date.md): `now`, `date`, etc.
+- [Defaults Functions](defaults.md): `default`, `empty`, `coalesce`
+- [Encoding Functions](encoding.md): `b64enc`, `b64dec`, etc.
+- [Lists and List Functions](lists.md): `list`, `first`, `uniq`, etc.
+- [Dictionaries and Dict Functions](dicts.md): `dict`, `hasKey`, `pluck`, etc.
+- [Type Conversion Functions](conversion.md): `atoi`, `int64`, `toString`, etc.
+- [File Path Functions](paths.md): `base`, `dir`, `ext`, `clean`, `isAbs`
+- [Flow Control Functions](flow_control.md): `fail`
+- Advanced Functions
+  - [UUID Functions](uuid.md): `uuidv4`
+  - [OS Functions](os.md): `env`, `expandenv`
+  - [Version Comparison Functions](semver.md): `semver`, `semverCompare`
+  - [Reflection](reflection.md): `typeOf`, `kindIs`, `typeIsLike`, etc.
+  - [Cryptographic and Security Functions](crypto.md): `derivePassword`, `sha256sum`, `genPrivateKey`
+

--- a/vendor/github.com/Masterminds/sprig/docs/integer_slice.md
+++ b/vendor/github.com/Masterminds/sprig/docs/integer_slice.md
@@ -1,0 +1,25 @@
+# Integer Slice Functions
+
+## until
+
+The `until` function builds a range of integers.
+
+```
+until 5
+```
+
+The above generates the list `[0, 1, 2, 3, 4]`.
+
+This is useful for looping with `range $i, $e := until 5`.
+
+## untilStep
+
+Like `until`, `untilStep` generates a list of counting integers. But it allows
+you to define a start, stop, and step:
+
+```
+untilStep 3 6 2
+```
+
+The above will produce `[3 5]` by starting with 3, and adding 2 until it is equal
+or greater than 6. This is similar to Python's `range` function.

--- a/vendor/github.com/Masterminds/sprig/docs/lists.md
+++ b/vendor/github.com/Masterminds/sprig/docs/lists.md
@@ -1,0 +1,111 @@
+# Lists and List Functions
+
+Sprig provides a simple `list` type that can contain arbitrary sequential lists
+of data. This is similar to arrays or slices, but lists are designed to be used
+as immutable data types.
+
+Create a list of integers:
+
+```
+$myList := list 1 2 3 4 5
+```
+
+The above creates a list of `[1 2 3 4 5]`.
+
+## first
+
+To get the head item on a list, use `first`.
+
+`first $myList` returns `1`
+
+## rest
+
+To get the tail of the list (everything but the first item), use `rest`.
+
+`rest $myList` returns `[2 3 4 5]`
+
+## last
+
+To get the last item on a list, use `last`:
+
+`last $myList` returns `5`. This is roughly analogous to reversing a list and
+then calling `first`.
+
+## initial
+
+This compliments `last` by returning all _but_ the last element.
+`initial $myList` returns `[1 2 3 4]`.
+
+## append
+
+Append a new item to an existing list, creating a new list.
+
+```
+$new = append $myList 6
+```
+
+The above would set `$new` to `[1 2 3 4 5 6]`. `$myList` would remain unaltered.
+
+## prepend
+
+Push an alement onto the front of a list, creating a new list.
+
+```
+prepend $myList 0
+```
+
+The above would produce `[0 1 2 3 4 5]`. `$myList` would remain unaltered.
+
+## reverse
+
+Produce a new list with the reversed elements of the given list.
+
+```
+reverse $myList
+```
+
+The above would generate the list `[5 4 3 2 1]`.
+
+## uniq
+
+Generate a list with all of the duplicates removed.
+
+```
+list 1 1 1 2 | uniq
+```
+
+The above would produce `[1 2]`
+
+## without
+
+The `without` function filters items out of a list.
+
+```
+without $myList 3
+```
+
+The above would produce `[1 2 4 5]`
+
+Without can take more than one filter:
+
+```
+without $myList 1 3 5
+```
+
+That would produce `[2 4]`
+
+##  has
+
+Test to see if a list has a particular element.
+
+```
+has $myList 4
+```
+
+The above would return `true`, while `has $myList "hello"` would return false.
+
+## A Note on List Internals
+
+A list is implemented in Go as a `[]interface{}`. For Go developers embedding
+Sprig, you may pass `[]interface{}` items into your template context and be
+able to use all of the `list` functions on those items.

--- a/vendor/github.com/Masterminds/sprig/docs/math.md
+++ b/vendor/github.com/Masterminds/sprig/docs/math.md
@@ -1,0 +1,63 @@
+# Math Functions
+
+All math functions operate on `int64` values unless specified otherwise.
+
+(In the future, these will be extended to handle floats as well)
+
+## add
+
+Sum numbers with `add`
+
+## add1
+
+To increment by 1, use `add1`
+
+## sub
+
+To subtract, use `sub`
+
+## div
+
+Perform integer division with `div`
+
+## mod
+
+Modulo with `mod`
+
+## mul
+
+Multiply with `mul`
+
+## max
+
+Return the largest of a series of integers:
+
+This will return `3`:
+
+```
+max 1 2 3
+```
+
+## min
+
+Return the smallest of a series of integers.
+
+`min 1 2 3` will return `1`.
+
+## floor
+
+Returns the greatest float value less than or equal to input value
+
+`floor 123.9999` will return `123.0`
+
+## ceil
+
+Returns the greatest float value greater than or equal to input value
+
+`ceil 123.001` will return `124.0`
+
+## round
+
+Returns a float value with the remainder rounded to the given number to digits after the decimal point.
+
+`round 123.555555` will return `123.556`

--- a/vendor/github.com/Masterminds/sprig/docs/os.md
+++ b/vendor/github.com/Masterminds/sprig/docs/os.md
@@ -1,0 +1,24 @@
+# OS Functions
+
+_WARNING:_ These functions can lead to information leakage if not used
+appropriately.
+
+_WARNING:_ Some notable implementations of Sprig (such as 
+[Kubernetes Helm](http://helm.sh) _do not provide these functions for security
+reasons_.
+
+## env
+
+The `env` function reads an environment variable:
+
+```
+env "HOME"
+```
+
+## expandenv
+
+To substitute environment variables in a string, use `expandenv`:
+
+```
+expandenv "Your path is set to $PATH"
+```

--- a/vendor/github.com/Masterminds/sprig/docs/paths.md
+++ b/vendor/github.com/Masterminds/sprig/docs/paths.md
@@ -1,0 +1,43 @@
+# File Path Functions
+
+While Sprig does not grant access to the filesystem, it does provide functions
+for working with strings that follow file path conventions.
+
+# base
+
+Return the last element of a path.
+
+```
+base "foo/bar/baz"
+```
+
+The above prints "baz"
+
+# dir
+
+Return the directory, stripping the last part of the path. So `dir "foo/bar/baz"`
+returns `foo/bar`
+
+# clean
+
+Clean up a path.
+
+```
+clean "foo/bar/../baz"
+```
+
+The above resolves the `..` and returns `foo/baz`
+
+# ext
+
+Return the file extension.
+
+```
+ext "foo.bar"
+```
+
+The above returns `.bar`.
+
+# isAbs
+
+To check whether a file path is absolute, use `isAbs`.

--- a/vendor/github.com/Masterminds/sprig/docs/reflection.md
+++ b/vendor/github.com/Masterminds/sprig/docs/reflection.md
@@ -1,0 +1,38 @@
+# Reflection Functions
+
+Sprig provides rudimentary reflection tools. These help advanced template
+developers understand the underlying Go type information for a particular value.
+
+Go has several primitive _kinds_, like `string`, `slice`, `int64`, and `bool`.
+
+Go has an open _type_ system that allows developers to create their own types.
+
+Sprig provides a set of functions for each.
+
+## Kind Functions
+
+There are two Kind functions: `kindOf` returns the kind of an object.
+
+```
+kindOf "hello"
+```
+
+The above would return `string`. For simple tests (like in `if` blocks), the
+`isKind` function will let you verify that a value is a particular kind:
+
+```
+kindIs "int" 123
+```
+
+The above will return `true`
+
+## Type Functions
+
+Types are slightly harder to work with, so there are three different functions:
+
+- `typeOf` returns the underlying type of a value: `typeOf $foo`
+- `typeIs` is like `kindIs`, but for types: `typeIs "*io.Buffer" $myVal`
+- `typeIsLike` works as `kindIs`, except that it also dereferences pointers.
+
+**Note:** None of these can test whether or not something implements a given
+interface, since doing so would require compiling the interface in ahead of time.

--- a/vendor/github.com/Masterminds/sprig/docs/semver.md
+++ b/vendor/github.com/Masterminds/sprig/docs/semver.md
@@ -1,0 +1,124 @@
+# Semantic Version Functions
+
+Some version schemes are easily parseable and comparable. Sprig provides functions
+for working with [SemVer 2](http://semver.org) versions.
+
+## semver
+
+The `semver` function parses a string into a Semantic Version:
+
+```
+$version := semver "1.2.3-alpha.1+123"
+```
+
+_If the parser fails, it will cause template execution to halt with an error._
+
+At this point, `$version` is a pointer to a `Version` object with the following
+properties:
+
+- `$version.Major`: The major number (`1` above)
+- `$version.Minor`: The minor number (`2` above)
+- `$version.Patch`: The patch number (`3` above)
+- `$version.Prerelease`: The prerelease (`alpha.1` above)
+- `$version.Metadata`: The build metadata (`123` above)
+- `$version.Original`: The original version as a string
+
+Additionally, you can compare a `Version` to another `version` using the `Compare`
+function:
+
+```
+semver "1.4.3" | (semver "1.2.3").Compare
+```
+
+The above will return `-1`.
+
+The return values are:
+
+- `-1` if the given semver is greater than the semver whose `Compare` method was called
+- `1` if the version who's `Compare` function was called is greater.
+- `0` if they are the same version
+
+(Note that in SemVer, the `Metadata` field is not compared during version
+comparison operations.)
+
+
+## semverCompare
+
+A more robust comparison function is provided as `semverCompare`. This version
+supports version ranges:
+
+- `semverCompare "1.2.3" "1.2.3"` checks for an exact match
+- `semverCompare "^1.2.0" "1.2.3"` checks that the major and minor versions match, and that the patch 
+  number of the second version is _greater than or equal to_ the first parameter.
+
+The SemVer functions use the [Masterminds semver library](https://github.com/Masterminds/semver),
+from the creators of Sprig.
+
+
+## Basic Comparisons
+
+There are two elements to the comparisons. First, a comparison string is a list
+of comma separated and comparisons. These are then separated by || separated or
+comparisons. For example, `">= 1.2, < 3.0.0 || >= 4.2.3"` is looking for a
+comparison that's greater than or equal to 1.2 and less than 3.0.0 or is
+greater than or equal to 4.2.3.
+
+The basic comparisons are:
+
+* `=`: equal (aliased to no operator)
+* `!=`: not equal
+* `>`: greater than
+* `<`: less than
+* `>=`: greater than or equal to
+* `<=`: less than or equal to
+
+_Note, according to the Semantic Version specification pre-releases may not be
+API compliant with their release counterpart. It says,_
+
+> _A pre-release version indicates that the version is unstable and might not satisfy the intended compatibility requirements as denoted by its associated normal version._
+
+_SemVer comparisons without a pre-release value will skip pre-release versions.
+For example, `>1.2.3` will skip pre-releases when looking at a list of values
+while `>1.2.3-alpha.1` will evaluate pre-releases._
+
+## Hyphen Range Comparisons
+
+There are multiple methods to handle ranges and the first is hyphens ranges.
+These look like:
+
+* `1.2 - 1.4.5` which is equivalent to `>= 1.2, <= 1.4.5`
+* `2.3.4 - 4.5` which is equivalent to `>= 2.3.4, <= 4.5`
+
+## Wildcards In Comparisons
+
+The `x`, `X`, and `*` characters can be used as a wildcard character. This works
+for all comparison operators. When used on the `=` operator it falls
+back to the pack level comparison (see tilde below). For example,
+
+* `1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
+* `>= 1.2.x` is equivalent to `>= 1.2.0`
+* `<= 2.x` is equivalent to `<= 3`
+* `*` is equivalent to `>= 0.0.0`
+
+## Tilde Range Comparisons (Patch)
+
+The tilde (`~`) comparison operator is for patch level ranges when a minor
+version is specified and major level changes when the minor number is missing.
+For example,
+
+* `~1.2.3` is equivalent to `>= 1.2.3, < 1.3.0`
+* `~1` is equivalent to `>= 1, < 2`
+* `~2.3` is equivalent to `>= 2.3, < 2.4`
+* `~1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
+* `~1.x` is equivalent to `>= 1, < 2`
+
+## Caret Range Comparisons (Major)
+
+The caret (`^`) comparison operator is for major level changes. This is useful
+when comparisons of API versions as a major change is API breaking. For example,
+
+* `^1.2.3` is equivalent to `>= 1.2.3, < 2.0.0`
+* `^1.2.x` is equivalent to `>= 1.2.0, < 2.0.0`
+* `^2.3` is equivalent to `>= 2.3, < 3`
+* `^2.x` is equivalent to `>= 2.0.0, < 3`
+

--- a/vendor/github.com/Masterminds/sprig/docs/string_slice.md
+++ b/vendor/github.com/Masterminds/sprig/docs/string_slice.md
@@ -1,0 +1,55 @@
+# String Slice Functions
+
+These function operate on or generate slices of strings. In Go, a slice is a
+growable array. In Sprig, it's a special case of a `list`.
+
+## join
+
+Join a list of strings into a single string, with the given separator.
+
+```
+list "hello" "world" | join "_"
+```
+
+The above will produce `hello_world`
+
+`join` will try to convert non-strings to a string value:
+
+```
+list 1 2 3 | join "+"
+```
+
+The above will produce `1+2+3`
+
+## splitList and split
+
+Split a string into a list of strings:
+
+```
+splitList "$" "foo$bar$baz"
+```
+
+The above will return `[foo bar baz]`
+
+The older `split` function splits a string into a `dict`. It is designed to make
+it easy to use template dot notation for accessing members:
+
+```
+$a := split "$" "foo$bar$baz"
+```
+
+The above produces a map with index keys. `{_0: foo, _1: bar, _2: baz}`
+
+```
+$a._0
+```
+
+The above produces `foo`
+
+## sortAlpha
+
+The `sortAlpha` function sorts a list of strings into alphabetical (lexicographical)
+order.
+
+It does _not_ sort in place, but returns a sorted copy of the list, in keeping
+with the immutability of lists.

--- a/vendor/github.com/Masterminds/sprig/docs/strings.md
+++ b/vendor/github.com/Masterminds/sprig/docs/strings.md
@@ -1,0 +1,385 @@
+# String Functions
+
+Sprig has a number of string manipulation functions.
+
+## trim
+
+The `trim` function removes space from either side of a string:
+
+```
+trim "   hello    "
+```
+
+The above produces `hello`
+
+## trimAll
+
+Remove given characters from the front or back of a string:
+
+```
+trimAll "$" "$5.00"
+```
+
+The above returns `5.00` (as a string).
+
+## trimSuffix
+
+Trim just the suffix from a string:
+
+```
+trimSuffix "-" "hello-"
+```
+
+The above returns `hello`
+
+## upper
+
+Convert the entire string to uppercase:
+
+```
+upper "hello"
+```
+
+The above returns `HELLO`
+
+## lower
+
+Convert the entire string to lowercase:
+
+```
+lower "HELLO"
+```
+
+The above returns `hello`
+
+## title
+
+Convert to title case:
+
+```
+title "hello world"
+```
+
+The above returns `Hello World`
+
+## untitle
+
+Remove title casing. `untitle "Hello World"` produces `hello world`.
+
+## repeat
+
+Repeat a string multiple times:
+
+```
+repeat 3 "hello"
+```
+
+The above returns `hellohellohello`
+
+## substr
+
+Get a substring from a string. It takes three parameters:
+
+- start (int)
+- length (int)
+- string (string)
+
+```
+substr 0 5 "hello world"
+```
+
+The above returns `hello`
+
+## nospace
+
+Remove all whitespace from a string.
+
+```
+nospace "hello w o r l d"
+```
+
+The above returns `helloworld`
+
+## trunc
+
+Truncate a string (and add no suffix)
+
+```
+trunc 5 "hello world"
+```
+
+The above produces `hello`.
+
+## abbrev
+
+Truncate a string with ellipses (`...`)
+
+Parameters: 
+- max length
+- the string
+
+```
+abbrev 5 "hello world"
+```
+
+The above returns `he...`, since it counts the width of the ellipses against the
+maximum length.
+
+## abbrevboth
+
+Abbreviate both sides:
+
+```
+abbrevboth 5 10 "1234 5678 9123"
+```
+
+the above produces `...5678...`
+
+It takes:
+
+- left offset
+- max length
+- the string
+
+## initials
+
+Given multiple words, take the first letter of each word and combine.
+
+```
+initials "First Try"
+```
+
+The above returns `FT`
+
+## randAlphaNum, randAlpha, randNumeric, and randAscii
+
+These four functions generate random strings, but with different base character
+sets:
+
+- `randAlphaNum` uses `0-9a-zA-Z`
+- `randAlpha` uses `a-zA-Z`
+- `randNumeric` uses `0-9`
+- `randAscii` uses all printable ASCII characters
+
+Each of them takes one parameter: the integer length of the string.
+
+```
+randNumeric 3
+```
+
+The above will produce a random string with three digits.
+
+## wrap
+
+Wrap text at a given column count:
+
+```
+wrap 80 $someText
+```
+
+The above will wrap the string in `$someText` at 80 columns.
+
+## wrapWith
+
+`wrapWith` works as `wrap`, but lets you specify the string to wrap with.
+(`wrap` uses `\n`)
+
+```
+wrapWith 5 "\t" "Hello World"
+```
+
+The above produces `hello world` (where the whitespace is an ASCII tab
+character)
+
+## contains
+
+Test to see if one string is contained inside of another:
+
+```
+contains "cat" "catch"
+```
+
+The above returns `true` because `catch` contains `cat`.
+
+## hasPrefix and hasSuffix
+
+The `hasPrefix` and `hasSuffix` functions test whether a string has a given
+prefix or suffix:
+
+```
+hasPrefix "cat" "catch"
+```
+
+The above returns `true` because `catch` has the prefix `cat`.
+
+## quote and squote
+
+These functions wrap a string in double quotes (`quote`) or single quotes
+(`squote`).
+
+## cat
+
+The `cat` function concatenates multiple strings together into one, separating
+them with spaces:
+
+```
+cat "hello" "beautiful" "world"
+```
+
+The above produces `hello beautiful world`
+
+## indent
+
+The `indent` function indents every line in a given string to the specified
+indent width. This is useful when aligning multi-line strings:
+
+```
+indent 4 $lots_of_text
+```
+
+The above will indent every line of text by 4 space characters.
+
+## replace
+
+Perform simple string replacement.
+
+It takes three arguments:
+
+- string to replace
+- string to replace with
+- source string
+
+```
+"I Am Henry VIII" | replace " " "-"
+```
+
+The above will produce `I-Am-Henry-VIII`
+
+## plural
+
+Pluralize a string.
+
+```
+len $fish | plural "one anchovy" "many anchovies"
+```
+
+In the above, if the length of the string is 1, the first argument will be
+printed (`one anchovy`). Otherwise, the second argument will be printed 
+(`many anchovies`).
+
+The arguments are:
+
+- singular string
+- plural string
+- length integer
+
+NOTE: Sprig does not currently support languages with more complex pluralization
+rules. And `0` is considered a plural because the English language treats it
+as such (`zero anchovies`). The Sprig developers are working on a solution for
+better internationalization.
+
+## snakecase
+
+Convert string from camelCase to snake_case.
+
+Introduced in 2.12.0.
+
+```
+snakecase "FirstName"
+```
+
+This above will produce `first_name`.
+
+## camelcase
+
+Convert string from snake_case to CamelCase
+
+Introduced in 2.12.0.
+
+```
+camelcase "http_server"
+```
+
+This above will produce `HttpServer`.
+
+## shuffle
+
+Shuffle a string.
+
+Introduced in 2.12.0.
+
+
+```
+shuffle "hello"
+```
+
+The above will randomize the letters in `hello`, perhaps producing `oelhl`.
+
+## regexMatch
+
+Returns true if the input string mratches the regular expression.
+
+```
+regexMatch "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}" "test@acme.com"
+```
+
+The above produces `true`
+
+## regexFindAll
+
+Returns a slice of all matches of the regular expression in the input string
+
+```
+regexFindAll "[2,4,6,8]" "123456789 
+```
+
+The above produces `[2 4 6 8]`
+
+## regexFind
+
+Return the first (left most) match of the regular expression in the input string
+
+```
+regexFind "[a-zA-Z][1-9]" "abcd1234"
+```
+
+The above produces `d1`
+
+## regexReplaceAll
+
+Returns a copy of the input string, replacing matches of the Regexp with the replacement string replacement.
+Inside string replacement, $ signs are interpreted as in Expand, so for instance $1 represents the text of the first submatch
+
+```
+regexReplaceAll "a(x*)b" "-ab-axxb-" "${1}W"
+```
+
+The above produces `-W-xxW-`
+
+## regexReplaceAllLiteral
+
+Returns a copy of the input string, replacing matches of the Regexp with the replacement string replacement
+The replacement string is substituted directly, without using Expand
+
+```
+regexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "${1}"
+```
+
+The above produces `-${1}-${1}-`
+
+## regexSplit
+
+Slices the input string into substrings separated by the expression and returns a slice of the substrings between those expression matches. The last parameter `n` determines the number of substrings to return, where `-1` means return all matches
+
+```
+regexSplit "z+" "pizza" -1
+```
+
+The above produces `[pi a]`
+
+## See Also...
+
+The [Conversion Functions](conversion.html) contain functions for converting
+strings. The [String Slice Functions](string_slice.html) contains functions
+for working with an array of strings.
+

--- a/vendor/github.com/Masterminds/sprig/docs/uuid.md
+++ b/vendor/github.com/Masterminds/sprig/docs/uuid.md
@@ -1,0 +1,9 @@
+# UUID Functions
+
+Sprig can generate UUID v4 universally unique IDs.
+
+```
+uuidv4
+```
+
+The above returns a new UUID of the v4 (randomly generated) type.

--- a/vendor/github.com/Masterminds/sprig/example_test.go
+++ b/vendor/github.com/Masterminds/sprig/example_test.go
@@ -1,0 +1,25 @@
+package sprig
+
+import (
+	"fmt"
+	"os"
+	"text/template"
+)
+
+func Example() {
+	// Set up variables and template.
+	vars := map[string]interface{}{"Name": "  John Jacob Jingleheimer Schmidt "}
+	tpl := `Hello {{.Name | trim | lower}}`
+
+	// Get the Sprig function map.
+	fmap := TxtFuncMap()
+	t := template.Must(template.New("test").Funcs(fmap).Parse(tpl))
+
+	err := t.Execute(os.Stdout, vars)
+	if err != nil {
+		fmt.Printf("Error during template execution: %s", err)
+		return
+	}
+	// Output:
+	// Hello john jacob jingleheimer schmidt
+}

--- a/vendor/github.com/Masterminds/sprig/flow_control_test.go
+++ b/vendor/github.com/Masterminds/sprig/flow_control_test.go
@@ -1,0 +1,16 @@
+package sprig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFail(t *testing.T) {
+	const msg = "This is an error!"
+	tpl := fmt.Sprintf(`{{fail "%s"}}`, msg)
+	_, err := runRaw(tpl, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), msg)
+}

--- a/vendor/github.com/Masterminds/sprig/functions.go
+++ b/vendor/github.com/Masterminds/sprig/functions.go
@@ -1,0 +1,272 @@
+package sprig
+
+import (
+	"errors"
+	"html/template"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	ttemplate "text/template"
+	"time"
+
+	util "github.com/aokoli/goutils"
+	"github.com/huandu/xstrings"
+)
+
+// Produce the function map.
+//
+// Use this to pass the functions into the template engine:
+//
+// 	tpl := template.New("foo").Funcs(sprig.FuncMap()))
+//
+func FuncMap() template.FuncMap {
+	return HtmlFuncMap()
+}
+
+// HermeticTextFuncMap returns a 'text/template'.FuncMap with only repeatable functions.
+func HermeticTxtFuncMap() ttemplate.FuncMap {
+	r := TxtFuncMap()
+	for _, name := range nonhermeticFunctions {
+		delete(r, name)
+	}
+	return r
+}
+
+// HermeticHtmlFuncMap returns an 'html/template'.Funcmap with only repeatable functions.
+func HermeticHtmlFuncMap() template.FuncMap {
+	r := HtmlFuncMap()
+	for _, name := range nonhermeticFunctions {
+		delete(r, name)
+	}
+	return r
+}
+
+// TextFuncMap returns a 'text/template'.FuncMap
+func TxtFuncMap() ttemplate.FuncMap {
+	return ttemplate.FuncMap(GenericFuncMap())
+}
+
+// HtmlFuncMap returns an 'html/template'.Funcmap
+func HtmlFuncMap() template.FuncMap {
+	return template.FuncMap(GenericFuncMap())
+}
+
+// GenericFuncMap returns a copy of the basic function map as a map[string]interface{}.
+func GenericFuncMap() map[string]interface{} {
+	gfm := make(map[string]interface{}, len(genericMap))
+	for k, v := range genericMap {
+		gfm[k] = v
+	}
+	return gfm
+}
+
+// These functions are not guaranteed to evaluate to the same result for given input, because they
+// refer to the environemnt or global state.
+var nonhermeticFunctions = []string{
+	// Date functions
+	"date",
+	"date_in_zone",
+	"date_modify",
+	"now",
+	"htmlDate",
+	"htmlDateInZone",
+	"dateInZone",
+	"dateModify",
+
+	// Strings
+	"randAlphaNum",
+	"randAlpha",
+	"randAscii",
+	"randNumeric",
+	"uuidv4",
+
+	// OS
+	"env",
+	"expandenv",
+}
+
+var genericMap = map[string]interface{}{
+	"hello": func() string { return "Hello!" },
+
+	// Date functions
+	"date":           date,
+	"date_in_zone":   dateInZone,
+	"date_modify":    dateModify,
+	"now":            func() time.Time { return time.Now() },
+	"htmlDate":       htmlDate,
+	"htmlDateInZone": htmlDateInZone,
+	"dateInZone":     dateInZone,
+	"dateModify":     dateModify,
+
+	// Strings
+	"abbrev":     abbrev,
+	"abbrevboth": abbrevboth,
+	"trunc":      trunc,
+	"trim":       strings.TrimSpace,
+	"upper":      strings.ToUpper,
+	"lower":      strings.ToLower,
+	"title":      strings.Title,
+	"untitle":    untitle,
+	"substr":     substring,
+	// Switch order so that "foo" | repeat 5
+	"repeat": func(count int, str string) string { return strings.Repeat(str, count) },
+	// Deprecated: Use trimAll.
+	"trimall": func(a, b string) string { return strings.Trim(b, a) },
+	// Switch order so that "$foo" | trimall "$"
+	"trimAll":      func(a, b string) string { return strings.Trim(b, a) },
+	"trimSuffix":   func(a, b string) string { return strings.TrimSuffix(b, a) },
+	"trimPrefix":   func(a, b string) string { return strings.TrimPrefix(b, a) },
+	"nospace":      util.DeleteWhiteSpace,
+	"initials":     initials,
+	"randAlphaNum": randAlphaNumeric,
+	"randAlpha":    randAlpha,
+	"randAscii":    randAscii,
+	"randNumeric":  randNumeric,
+	"swapcase":     util.SwapCase,
+	"shuffle":      xstrings.Shuffle,
+	"snakecase":    xstrings.ToSnakeCase,
+	"camelcase":    xstrings.ToCamelCase,
+	"wrap":         func(l int, s string) string { return util.Wrap(s, l) },
+	"wrapWith":     func(l int, sep, str string) string { return util.WrapCustom(str, l, sep, true) },
+	// Switch order so that "foobar" | contains "foo"
+	"contains":  func(substr string, str string) bool { return strings.Contains(str, substr) },
+	"hasPrefix": func(substr string, str string) bool { return strings.HasPrefix(str, substr) },
+	"hasSuffix": func(substr string, str string) bool { return strings.HasSuffix(str, substr) },
+	"quote":     quote,
+	"squote":    squote,
+	"cat":       cat,
+	"indent":    indent,
+	"replace":   replace,
+	"plural":    plural,
+	"sha256sum": sha256sum,
+	"toString":  strval,
+
+	// Wrap Atoi to stop errors.
+	"atoi":    func(a string) int { i, _ := strconv.Atoi(a); return i },
+	"int64":   toInt64,
+	"int":     toInt,
+	"float64": toFloat64,
+
+	//"gt": func(a, b int) bool {return a > b},
+	//"gte": func(a, b int) bool {return a >= b},
+	//"lt": func(a, b int) bool {return a < b},
+	//"lte": func(a, b int) bool {return a <= b},
+
+	// split "/" foo/bar returns map[int]string{0: foo, 1: bar}
+	"split":     split,
+	"splitList": func(sep, orig string) []string { return strings.Split(orig, sep) },
+	"toStrings": strslice,
+
+	"until":     until,
+	"untilStep": untilStep,
+
+	// VERY basic arithmetic.
+	"add1": func(i interface{}) int64 { return toInt64(i) + 1 },
+	"add": func(i ...interface{}) int64 {
+		var a int64 = 0
+		for _, b := range i {
+			a += toInt64(b)
+		}
+		return a
+	},
+	"sub": func(a, b interface{}) int64 { return toInt64(a) - toInt64(b) },
+	"div": func(a, b interface{}) int64 { return toInt64(a) / toInt64(b) },
+	"mod": func(a, b interface{}) int64 { return toInt64(a) % toInt64(b) },
+	"mul": func(a interface{}, v ...interface{}) int64 {
+		val := toInt64(a)
+		for _, b := range v {
+			val = val * toInt64(b)
+		}
+		return val
+	},
+	"biggest": max,
+	"max":     max,
+	"min":     min,
+	"ceil":    ceil,
+	"floor":   floor,
+	"round":   round,
+
+	// string slices. Note that we reverse the order b/c that's better
+	// for template processing.
+	"join":      join,
+	"sortAlpha": sortAlpha,
+
+	// Defaults
+	"default":      dfault,
+	"empty":        empty,
+	"coalesce":     coalesce,
+	"compact":      compact,
+	"toJson":       toJson,
+	"toPrettyJson": toPrettyJson,
+
+	// Reflection
+	"typeOf":     typeOf,
+	"typeIs":     typeIs,
+	"typeIsLike": typeIsLike,
+	"kindOf":     kindOf,
+	"kindIs":     kindIs,
+
+	// OS:
+	"env":       func(s string) string { return os.Getenv(s) },
+	"expandenv": func(s string) string { return os.ExpandEnv(s) },
+
+	// File Paths:
+	"base":  path.Base,
+	"dir":   path.Dir,
+	"clean": path.Clean,
+	"ext":   path.Ext,
+	"isAbs": path.IsAbs,
+
+	// Encoding:
+	"b64enc": base64encode,
+	"b64dec": base64decode,
+	"b32enc": base32encode,
+	"b32dec": base32decode,
+
+	// Data Structures:
+	"tuple":  list, // FIXME: with the addition of append/prepend these are no longer immutable.
+	"list":   list,
+	"dict":   dict,
+	"set":    set,
+	"unset":  unset,
+	"hasKey": hasKey,
+	"pluck":  pluck,
+	"keys":   keys,
+	"pick":   pick,
+	"omit":   omit,
+	"merge":  merge,
+
+	"append": push, "push": push,
+	"prepend": prepend,
+	"first":   first,
+	"rest":    rest,
+	"last":    last,
+	"initial": initial,
+	"reverse": reverse,
+	"uniq":    uniq,
+	"without": without,
+	"has":     func(needle interface{}, haystack []interface{}) bool { return inList(haystack, needle) },
+
+	// Crypto:
+	"genPrivateKey":  generatePrivateKey,
+	"derivePassword": derivePassword,
+
+	// UUIDs:
+	"uuidv4": uuidv4,
+
+	// SemVer:
+	"semver":        semver,
+	"semverCompare": semverCompare,
+
+	// Flow Control:
+	"fail": func(msg string) (string, error) { return "", errors.New(msg) },
+
+	// Regex
+	"regexMatch": regexMatch,
+	"regexFindAll": regexFindAll,
+	"regexFind": regexFind,
+	"regexReplaceAll": regexReplaceAll,
+	"regexReplaceAllLiteral": regexReplaceAllLiteral,
+	"regexSplit": regexSplit,
+}

--- a/vendor/github.com/Masterminds/sprig/functions_test.go
+++ b/vendor/github.com/Masterminds/sprig/functions_test.go
@@ -1,0 +1,108 @@
+package sprig
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+	"text/template"
+
+	"github.com/aokoli/goutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnv(t *testing.T) {
+	os.Setenv("FOO", "bar")
+	tpl := `{{env "FOO"}}`
+	if err := runt(tpl, "bar"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestExpandEnv(t *testing.T) {
+	os.Setenv("FOO", "bar")
+	tpl := `{{expandenv "Hello $FOO"}}`
+	if err := runt(tpl, "Hello bar"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestBase(t *testing.T) {
+	assert.NoError(t, runt(`{{ base "foo/bar" }}`, "bar"))
+}
+
+func TestDir(t *testing.T) {
+	assert.NoError(t, runt(`{{ dir "foo/bar/baz" }}`, "foo/bar"))
+}
+
+func TestIsAbs(t *testing.T) {
+	assert.NoError(t, runt(`{{ isAbs "/foo" }}`, "true"))
+	assert.NoError(t, runt(`{{ isAbs "foo" }}`, "false"))
+}
+
+func TestClean(t *testing.T) {
+	assert.NoError(t, runt(`{{ clean "/foo/../foo/../bar" }}`, "/bar"))
+}
+
+func TestExt(t *testing.T) {
+	assert.NoError(t, runt(`{{ ext "/foo/bar/baz.txt" }}`, ".txt"))
+}
+
+func TestSnakeCase(t *testing.T) {
+	assert.NoError(t, runt(`{{ snakecase "FirstName" }}`, "first_name"))
+	assert.NoError(t, runt(`{{ snakecase "HTTPServer" }}`, "http_server"))
+	assert.NoError(t, runt(`{{ snakecase "NoHTTPS" }}`, "no_https"))
+	assert.NoError(t, runt(`{{ snakecase "GO_PATH" }}`, "go_path"))
+	assert.NoError(t, runt(`{{ snakecase "GO PATH" }}`, "go_path"))
+	assert.NoError(t, runt(`{{ snakecase "GO-PATH" }}`, "go_path"))
+}
+
+func TestCamelCase(t *testing.T) {
+	assert.NoError(t, runt(`{{ camelcase "http_server" }}`, "HttpServer"))
+	assert.NoError(t, runt(`{{ camelcase "_camel_case" }}`, "_CamelCase"))
+	assert.NoError(t, runt(`{{ camelcase "no_https" }}`, "NoHttps"))
+	assert.NoError(t, runt(`{{ camelcase "_complex__case_" }}`, "_Complex_Case_"))
+	assert.NoError(t, runt(`{{ camelcase "all" }}`, "All"))
+}
+
+func TestShuffle(t *testing.T) {
+	goutils.RANDOM = rand.New(rand.NewSource(1))
+	// Because we're using a random number generator, we need these to go in
+	// a predictable sequence:
+	assert.NoError(t, runt(`{{ shuffle "Hello World" }}`, "rldo HWlloe"))
+}
+
+// runt runs a template and checks that the output exactly matches the expected string.
+func runt(tpl, expect string) error {
+	return runtv(tpl, expect, map[string]string{})
+}
+
+// runtv takes a template, and expected return, and values for substitution.
+//
+// It runs the template and verifies that the output is an exact match.
+func runtv(tpl, expect string, vars interface{}) error {
+	fmap := TxtFuncMap()
+	t := template.Must(template.New("test").Funcs(fmap).Parse(tpl))
+	var b bytes.Buffer
+	err := t.Execute(&b, vars)
+	if err != nil {
+		return err
+	}
+	if expect != b.String() {
+		return fmt.Errorf("Expected '%s', got '%s'", expect, b.String())
+	}
+	return nil
+}
+
+// runRaw runs a template with the given variables and returns the result.
+func runRaw(tpl string, vars interface{}) (string, error) {
+	fmap := TxtFuncMap()
+	t := template.Must(template.New("test").Funcs(fmap).Parse(tpl))
+	var b bytes.Buffer
+	err := t.Execute(&b, vars)
+	if err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}

--- a/vendor/github.com/Masterminds/sprig/glide.lock
+++ b/vendor/github.com/Masterminds/sprig/glide.lock
@@ -1,0 +1,33 @@
+hash: b9cc40bfd6dde74a94103b96700df1a9ab29a7fff5650216cf5a05f4fe72fb73
+updated: 2017-05-02T16:01:04.617727646-06:00
+imports:
+- name: github.com/aokoli/goutils
+  version: 9c37978a95bd5c709a15883b6242714ea6709e64
+- name: github.com/huandu/xstrings
+  version: 3959339b333561bf62a38b424fd41517c2c90f40
+- name: github.com/imdario/mergo
+  version: 3e95a51e0639b4cf372f2ccf74c86749d747fbdc
+- name: github.com/Masterminds/goutils
+  version: 45307ec16e3cd47cd841506c081f7afd8237d210
+- name: github.com/Masterminds/semver
+  version: 59c29afe1a994eacb71c833025ca7acf874bb1da
+- name: github.com/satori/go.uuid
+  version: 879c5887cd475cd7864858769793b2ceb0d44feb
+- name: github.com/stretchr/testify
+  version: e3a8ff8ce36581f87a15341206f205b1da467059
+  subpackages:
+  - assert
+- name: golang.org/x/crypto
+  version: d172538b2cfce0c13cee31e647d0367aa8cd2486
+  subpackages:
+  - pbkdf2
+  - scrypt
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib

--- a/vendor/github.com/Masterminds/sprig/glide.yaml
+++ b/vendor/github.com/Masterminds/sprig/glide.yaml
@@ -1,0 +1,15 @@
+package: github.com/Masterminds/sprig
+import:
+- package: github.com/Masterminds/goutils
+  version: ^1.0.0
+- package: github.com/satori/go.uuid
+  version: ^1.1.0
+- package: golang.org/x/crypto
+  subpackages:
+  - scrypt
+- package: github.com/Masterminds/semver
+  version: v1.2.2
+- package: github.com/stretchr/testify
+- package: github.com/imdario/mergo
+  version: ~0.2.2
+- package: github.com/huandu/xstrings

--- a/vendor/github.com/Masterminds/sprig/list.go
+++ b/vendor/github.com/Masterminds/sprig/list.go
@@ -1,0 +1,109 @@
+package sprig
+
+import (
+	"reflect"
+	"sort"
+)
+
+func list(v ...interface{}) []interface{} {
+	return v
+}
+
+func push(list []interface{}, v interface{}) []interface{} {
+	return append(list, v)
+}
+
+func prepend(list []interface{}, v interface{}) []interface{} {
+	return append([]interface{}{v}, list...)
+}
+
+func last(list []interface{}) interface{} {
+	l := len(list)
+	if l == 0 {
+		return nil
+	}
+	return list[l-1]
+}
+
+func first(list []interface{}) interface{} {
+	if len(list) == 0 {
+		return nil
+	}
+	return list[0]
+}
+
+func rest(list []interface{}) []interface{} {
+	if len(list) == 0 {
+		return list
+	}
+	return list[1:]
+}
+
+func initial(list []interface{}) []interface{} {
+	l := len(list)
+	if l == 0 {
+		return list
+	}
+	return list[:l-1]
+}
+
+func sortAlpha(list interface{}) []string {
+	k := reflect.Indirect(reflect.ValueOf(list)).Kind()
+	switch k {
+	case reflect.Slice, reflect.Array:
+		a := strslice(list)
+		s := sort.StringSlice(a)
+		s.Sort()
+		return s
+	}
+	return []string{strval(list)}
+}
+
+func reverse(v []interface{}) []interface{} {
+	// We do not sort in place because the incomming array should not be altered.
+	l := len(v)
+	c := make([]interface{}, l)
+	for i := 0; i < l; i++ {
+		c[l-i-1] = v[i]
+	}
+	return c
+}
+
+func compact(list []interface{}) []interface{} {
+	res := []interface{}{}
+	for _, item := range list {
+		if !empty(item) {
+			res = append(res, item)
+		}
+	}
+	return res
+}
+
+func uniq(list []interface{}) []interface{} {
+	dest := []interface{}{}
+	for _, item := range list {
+		if !inList(dest, item) {
+			dest = append(dest, item)
+		}
+	}
+	return dest
+}
+
+func inList(haystack []interface{}, needle interface{}) bool {
+	for _, h := range haystack {
+		if reflect.DeepEqual(needle, h) {
+			return true
+		}
+	}
+	return false
+}
+
+func without(list []interface{}, omit ...interface{}) []interface{} {
+	res := []interface{}{}
+	for _, i := range list {
+		if !inList(omit, i) {
+			res = append(res, i)
+		}
+	}
+	return res
+}

--- a/vendor/github.com/Masterminds/sprig/list_test.go
+++ b/vendor/github.com/Masterminds/sprig/list_test.go
@@ -1,0 +1,135 @@
+package sprig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTuple(t *testing.T) {
+	tpl := `{{$t := tuple 1 "a" "foo"}}{{index $t 2}}{{index $t 0 }}{{index $t 1}}`
+	if err := runt(tpl, "foo1a"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestList(t *testing.T) {
+	tpl := `{{$t := list 1 "a" "foo"}}{{index $t 2}}{{index $t 0 }}{{index $t 1}}`
+	if err := runt(tpl, "foo1a"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestPush(t *testing.T) {
+	// Named `append` in the function map
+	tests := map[string]string{
+		`{{ $t := tuple 1 2 3  }}{{ append $t 4 | len }}`:        "4",
+		`{{ $t := tuple 1 2 3 4  }}{{ append $t 5 | join "-" }}`: "1-2-3-4-5",
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+}
+func TestPrepend(t *testing.T) {
+	tests := map[string]string{
+		`{{ $t := tuple 1 2 3  }}{{ prepend $t 0 | len }}`:        "4",
+		`{{ $t := tuple 1 2 3 4  }}{{ prepend $t 0 | join "-" }}`: "0-1-2-3-4",
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+}
+
+func TestFirst(t *testing.T) {
+	tests := map[string]string{
+		`{{ list 1 2 3 | first }}`: "1",
+		`{{ list | first }}`:       "<no value>",
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+}
+func TestLast(t *testing.T) {
+	tests := map[string]string{
+		`{{ list 1 2 3 | last }}`: "3",
+		`{{ list | last }}`:       "<no value>",
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+}
+
+func TestInitial(t *testing.T) {
+	tests := map[string]string{
+		`{{ list 1 2 3 | initial | len }}`:   "2",
+		`{{ list 1 2 3 | initial | last }}`:  "2",
+		`{{ list 1 2 3 | initial | first }}`: "1",
+		`{{ list | initial }}`:               "[]",
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+}
+
+func TestRest(t *testing.T) {
+	tests := map[string]string{
+		`{{ list 1 2 3 | rest | len }}`:   "2",
+		`{{ list 1 2 3 | rest | last }}`:  "3",
+		`{{ list 1 2 3 | rest | first }}`: "2",
+		`{{ list | rest }}`:               "[]",
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+}
+
+func TestReverse(t *testing.T) {
+	tests := map[string]string{
+		`{{ list 1 2 3 | reverse | first }}`:        "3",
+		`{{ list 1 2 3 | reverse | rest | first }}`: "2",
+		`{{ list 1 2 3 | reverse | last }}`:         "1",
+		`{{ list 1 2 3 4 | reverse }}`:              "[4 3 2 1]",
+		`{{ list 1 | reverse }}`:                    "[1]",
+		`{{ list | reverse }}`:                      "[]",
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+}
+
+func TestUniq(t *testing.T) {
+	tests := map[string]string{
+		`{{ list 1 2 3 4 | uniq }}`:                   `[1 2 3 4]`,
+		`{{ list "a" "b" "c" "d" | uniq }}`:           `[a b c d]`,
+		`{{ list 1 1 1 1 2 2 2 2 | uniq }}`:           `[1 2]`,
+		`{{ list "foo" 1 1 1 1 "foo" "foo" | uniq }}`: `[foo 1]`,
+		`{{ list | uniq }}`:                           `[]`,
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+}
+
+func TestWithout(t *testing.T) {
+	tests := map[string]string{
+		`{{ without (list 1 2 3 4) 1 }}`:           `[2 3 4]`,
+		`{{ without (list "a" "b" "c" "d") "a" }}`: `[b c d]`,
+		`{{ without (list 1 1 1 1 2) 1 }}`:         `[2]`,
+		`{{ without (list) 1 }}`:                   `[]`,
+		`{{ without (list 1 2 3) }}`:               `[1 2 3]`,
+		`{{ without list }}`:                       `[]`,
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+}
+
+func TestHas(t *testing.T) {
+	tests := map[string]string{
+		`{{ list 1 2 3 | has 1 }}`: `true`,
+		`{{ list 1 2 3 | has 4 }}`: `false`,
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+}

--- a/vendor/github.com/Masterminds/sprig/numeric.go
+++ b/vendor/github.com/Masterminds/sprig/numeric.go
@@ -1,0 +1,159 @@
+package sprig
+
+import (
+	"math"
+	"reflect"
+	"strconv"
+)
+
+// toFloat64 converts 64-bit floats
+func toFloat64(v interface{}) float64 {
+	if str, ok := v.(string); ok {
+		iv, err := strconv.ParseFloat(str, 64)
+		if err != nil {
+			return 0
+		}
+		return iv
+	}
+
+	val := reflect.Indirect(reflect.ValueOf(v))
+	switch val.Kind() {
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+		return float64(val.Int())
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32:
+		return float64(val.Uint())
+	case reflect.Uint, reflect.Uint64:
+		return float64(val.Uint())
+	case reflect.Float32, reflect.Float64:
+		return val.Float()
+	case reflect.Bool:
+		if val.Bool() == true {
+			return 1
+		}
+		return 0
+	default:
+		return 0
+	}
+}
+
+func toInt(v interface{}) int {
+	//It's not optimal. Bud I don't want duplicate toInt64 code.
+	return int(toInt64(v))
+}
+
+// toInt64 converts integer types to 64-bit integers
+func toInt64(v interface{}) int64 {
+	if str, ok := v.(string); ok {
+		iv, err := strconv.ParseInt(str, 10, 64)
+		if err != nil {
+			return 0
+		}
+		return iv
+	}
+
+	val := reflect.Indirect(reflect.ValueOf(v))
+	switch val.Kind() {
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+		return val.Int()
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32:
+		return int64(val.Uint())
+	case reflect.Uint, reflect.Uint64:
+		tv := val.Uint()
+		if tv <= math.MaxInt64 {
+			return int64(tv)
+		}
+		// TODO: What is the sensible thing to do here?
+		return math.MaxInt64
+	case reflect.Float32, reflect.Float64:
+		return int64(val.Float())
+	case reflect.Bool:
+		if val.Bool() == true {
+			return 1
+		}
+		return 0
+	default:
+		return 0
+	}
+}
+
+func max(a interface{}, i ...interface{}) int64 {
+	aa := toInt64(a)
+	for _, b := range i {
+		bb := toInt64(b)
+		if bb > aa {
+			aa = bb
+		}
+	}
+	return aa
+}
+
+func min(a interface{}, i ...interface{}) int64 {
+	aa := toInt64(a)
+	for _, b := range i {
+		bb := toInt64(b)
+		if bb < aa {
+			aa = bb
+		}
+	}
+	return aa
+}
+
+func until(count int) []int {
+	step := 1
+	if count < 0 {
+		step = -1
+	}
+	return untilStep(0, count, step)
+}
+
+func untilStep(start, stop, step int) []int {
+	v := []int{}
+
+	if stop < start {
+		if step >= 0 {
+			return v
+		}
+		for i := start; i > stop; i += step {
+			v = append(v, i)
+		}
+		return v
+	}
+
+	if step <= 0 {
+		return v
+	}
+	for i := start; i < stop; i += step {
+		v = append(v, i)
+	}
+	return v
+}
+
+func floor(a interface{}) float64 {
+	aa := toFloat64(a)
+	return math.Floor(aa)
+}
+
+func ceil(a interface{}) float64 {
+	aa := toFloat64(a)
+	return math.Ceil(aa)
+}
+
+func round(a interface{}, p int, r_opt ...float64) float64 {
+	roundOn := .5
+	if len(r_opt) > 0 {
+		roundOn = r_opt[0]
+	}
+	val := toFloat64(a)
+	places := toFloat64(p)
+
+	var round float64
+	pow := math.Pow(10, places)
+	digit := pow * val
+	_, div := math.Modf(digit)
+	if div >= roundOn {
+		round = math.Ceil(digit)
+	} else {
+		round = math.Floor(digit)
+	}
+	return round / pow
+}

--- a/vendor/github.com/Masterminds/sprig/numeric_test.go
+++ b/vendor/github.com/Masterminds/sprig/numeric_test.go
@@ -1,0 +1,205 @@
+package sprig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUntil(t *testing.T) {
+	tests := map[string]string{
+		`{{range $i, $e := until 5}}{{$i}}{{$e}}{{end}}`:   "0011223344",
+		`{{range $i, $e := until -5}}{{$i}}{{$e}} {{end}}`: "00 1-1 2-2 3-3 4-4 ",
+	}
+	for tpl, expect := range tests {
+		if err := runt(tpl, expect); err != nil {
+			t.Error(err)
+		}
+	}
+}
+func TestUntilStep(t *testing.T) {
+	tests := map[string]string{
+		`{{range $i, $e := untilStep 0 5 1}}{{$i}}{{$e}}{{end}}`:     "0011223344",
+		`{{range $i, $e := untilStep 3 6 1}}{{$i}}{{$e}}{{end}}`:     "031425",
+		`{{range $i, $e := untilStep 0 -10 -2}}{{$i}}{{$e}} {{end}}`: "00 1-2 2-4 3-6 4-8 ",
+		`{{range $i, $e := untilStep 3 0 1}}{{$i}}{{$e}}{{end}}`:     "",
+		`{{range $i, $e := untilStep 3 99 0}}{{$i}}{{$e}}{{end}}`:    "",
+		`{{range $i, $e := untilStep 3 99 -1}}{{$i}}{{$e}}{{end}}`:   "",
+		`{{range $i, $e := untilStep 3 0 0}}{{$i}}{{$e}}{{end}}`:     "",
+	}
+	for tpl, expect := range tests {
+		if err := runt(tpl, expect); err != nil {
+			t.Error(err)
+		}
+	}
+
+}
+func TestBiggest(t *testing.T) {
+	tpl := `{{ biggest 1 2 3 345 5 6 7}}`
+	if err := runt(tpl, `345`); err != nil {
+		t.Error(err)
+	}
+
+	tpl = `{{ max 345}}`
+	if err := runt(tpl, `345`); err != nil {
+		t.Error(err)
+	}
+}
+func TestMin(t *testing.T) {
+	tpl := `{{ min 1 2 3 345 5 6 7}}`
+	if err := runt(tpl, `1`); err != nil {
+		t.Error(err)
+	}
+
+	tpl = `{{ min 345}}`
+	if err := runt(tpl, `345`); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestToFloat64(t *testing.T) {
+	target := float64(102)
+	if target != toFloat64(int8(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toFloat64(int(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toFloat64(int32(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toFloat64(int16(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toFloat64(int64(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toFloat64("102") {
+		t.Errorf("Expected 102")
+	}
+	if 0 != toFloat64("frankie") {
+		t.Errorf("Expected 0")
+	}
+	if target != toFloat64(uint16(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toFloat64(uint64(102)) {
+		t.Errorf("Expected 102")
+	}
+	if 102.1234 != toFloat64(float64(102.1234)) {
+		t.Errorf("Expected 102.1234")
+	}
+	if 1 != toFloat64(true) {
+		t.Errorf("Expected 102")
+	}
+}
+func TestToInt64(t *testing.T) {
+	target := int64(102)
+	if target != toInt64(int8(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toInt64(int(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toInt64(int32(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toInt64(int16(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toInt64(int64(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toInt64("102") {
+		t.Errorf("Expected 102")
+	}
+	if 0 != toInt64("frankie") {
+		t.Errorf("Expected 0")
+	}
+	if target != toInt64(uint16(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toInt64(uint64(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toInt64(float64(102.1234)) {
+		t.Errorf("Expected 102")
+	}
+	if 1 != toInt64(true) {
+		t.Errorf("Expected 102")
+	}
+}
+
+func TestToInt(t *testing.T) {
+	target := int(102)
+	if target != toInt(int8(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toInt(int(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toInt(int32(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toInt(int16(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toInt(int64(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toInt("102") {
+		t.Errorf("Expected 102")
+	}
+	if 0 != toInt("frankie") {
+		t.Errorf("Expected 0")
+	}
+	if target != toInt(uint16(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toInt(uint64(102)) {
+		t.Errorf("Expected 102")
+	}
+	if target != toInt(float64(102.1234)) {
+		t.Errorf("Expected 102")
+	}
+	if 1 != toInt(true) {
+		t.Errorf("Expected 102")
+	}
+}
+
+func TestAdd(t *testing.T) {
+	tpl := `{{ 3 | add 1 2}}`
+	if err := runt(tpl, `6`); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestMul(t *testing.T) {
+	tpl := `{{ 1 | mul "2" 3 "4"}}`
+	if err := runt(tpl, `24`); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestCeil(t *testing.T){
+	assert.Equal(t, 123.0, ceil(123))
+	assert.Equal(t, 123.0, ceil("123"))
+	assert.Equal(t, 124.0, ceil(123.01))
+	assert.Equal(t, 124.0, ceil("123.01"))
+}
+
+func TestFloor(t *testing.T){
+	assert.Equal(t, 123.0, floor(123))
+	assert.Equal(t, 123.0, floor("123"))
+	assert.Equal(t, 123.0, floor(123.9999))
+	assert.Equal(t, 123.0, floor("123.9999"))
+}
+
+func TestRound(t *testing.T){
+	assert.Equal(t, 123.556, round(123.5555, 3))
+	assert.Equal(t, 123.556, round("123.55555", 3))
+	assert.Equal(t, 124.0, round(123.500001, 0))
+	assert.Equal(t, 123.0, round(123.49999999, 0))
+	assert.Equal(t, 123.23, round(123.2329999, 2, .3))
+	assert.Equal(t, 123.24, round(123.233, 2, .3))
+}

--- a/vendor/github.com/Masterminds/sprig/reflect.go
+++ b/vendor/github.com/Masterminds/sprig/reflect.go
@@ -1,0 +1,28 @@
+package sprig
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// typeIs returns true if the src is the type named in target.
+func typeIs(target string, src interface{}) bool {
+	return target == typeOf(src)
+}
+
+func typeIsLike(target string, src interface{}) bool {
+	t := typeOf(src)
+	return target == t || "*"+target == t
+}
+
+func typeOf(src interface{}) string {
+	return fmt.Sprintf("%T", src)
+}
+
+func kindIs(target string, src interface{}) bool {
+	return target == kindOf(src)
+}
+
+func kindOf(src interface{}) string {
+	return reflect.ValueOf(src).Kind().String()
+}

--- a/vendor/github.com/Masterminds/sprig/reflect_test.go
+++ b/vendor/github.com/Masterminds/sprig/reflect_test.go
@@ -1,0 +1,73 @@
+package sprig
+
+import (
+	"testing"
+)
+
+type fixtureTO struct {
+	Name, Value string
+}
+
+func TestTypeOf(t *testing.T) {
+	f := &fixtureTO{"hello", "world"}
+	tpl := `{{typeOf .}}`
+	if err := runtv(tpl, "*sprig.fixtureTO", f); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestKindOf(t *testing.T) {
+	tpl := `{{kindOf .}}`
+
+	f := fixtureTO{"hello", "world"}
+	if err := runtv(tpl, "struct", f); err != nil {
+		t.Error(err)
+	}
+
+	f2 := []string{"hello"}
+	if err := runtv(tpl, "slice", f2); err != nil {
+		t.Error(err)
+	}
+
+	var f3 *fixtureTO = nil
+	if err := runtv(tpl, "ptr", f3); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTypeIs(t *testing.T) {
+	f := &fixtureTO{"hello", "world"}
+	tpl := `{{if typeIs "*sprig.fixtureTO" .}}t{{else}}f{{end}}`
+	if err := runtv(tpl, "t", f); err != nil {
+		t.Error(err)
+	}
+
+	f2 := "hello"
+	if err := runtv(tpl, "f", f2); err != nil {
+		t.Error(err)
+	}
+}
+func TestTypeIsLike(t *testing.T) {
+	f := "foo"
+	tpl := `{{if typeIsLike "string" .}}t{{else}}f{{end}}`
+	if err := runtv(tpl, "t", f); err != nil {
+		t.Error(err)
+	}
+
+	// Now make a pointer. Should still match.
+	f2 := &f
+	if err := runtv(tpl, "t", f2); err != nil {
+		t.Error(err)
+	}
+}
+func TestKindIs(t *testing.T) {
+	f := &fixtureTO{"hello", "world"}
+	tpl := `{{if kindIs "ptr" .}}t{{else}}f{{end}}`
+	if err := runtv(tpl, "t", f); err != nil {
+		t.Error(err)
+	}
+	f2 := "hello"
+	if err := runtv(tpl, "f", f2); err != nil {
+		t.Error(err)
+	}
+}

--- a/vendor/github.com/Masterminds/sprig/regex.go
+++ b/vendor/github.com/Masterminds/sprig/regex.go
@@ -1,0 +1,35 @@
+package sprig
+
+import (
+	"regexp"
+)
+
+func regexMatch(regex string, s string) bool {
+	match, _ := regexp.MatchString(regex, s)
+	return match
+}
+
+func regexFindAll(regex string, s string, n int) []string {
+	r := regexp.MustCompile(regex)
+	return r.FindAllString(s, n)
+}
+
+func regexFind(regex string, s string) string {
+	r := regexp.MustCompile(regex)
+	return r.FindString(s)
+}
+
+func regexReplaceAll(regex string, s string, repl string) string {
+	r := regexp.MustCompile(regex)
+	return r.ReplaceAllString(s, repl)
+}
+
+func regexReplaceAllLiteral(regex string, s string, repl string) string {
+	r := regexp.MustCompile(regex)
+	return r.ReplaceAllLiteralString(s, repl)
+}
+
+func regexSplit(regex string, s string, n int) []string {
+	r := regexp.MustCompile(regex)
+	return r.Split(s, n)
+}

--- a/vendor/github.com/Masterminds/sprig/regex_test.go
+++ b/vendor/github.com/Masterminds/sprig/regex_test.go
@@ -1,0 +1,61 @@
+package sprig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegexMatch(t *testing.T) {
+	regex := "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"
+
+	assert.True(t, regexMatch(regex, "test@acme.com"))
+	assert.True(t, regexMatch(regex, "Test@Acme.Com"))
+	assert.False(t, regexMatch(regex, "test"))
+	assert.False(t, regexMatch(regex, "test.com"))
+	assert.False(t, regexMatch(regex, "test@acme"))
+}
+
+func TestRegexFindAll(t *testing.T){
+	regex := "a{2}"
+	assert.Equal(t, 1, len(regexFindAll(regex, "aa", -1)))
+	assert.Equal(t, 1, len(regexFindAll(regex, "aaaaaaaa", 1)))
+	assert.Equal(t, 2, len(regexFindAll(regex, "aaaa", -1)))
+	assert.Equal(t, 0, len(regexFindAll(regex, "none", -1)))
+}
+
+func TestRegexFindl(t *testing.T){
+	regex := "fo.?"
+	assert.Equal(t, "foo", regexFind(regex, "foorbar"))
+	assert.Equal(t, "foo", regexFind(regex, "foo foe fome"))
+	assert.Equal(t, "", regexFind(regex, "none"))
+}
+
+func TestRegexReplaceAll(t *testing.T){
+	regex := "a(x*)b"
+	assert.Equal(t, "-T-T-", regexReplaceAll(regex,"-ab-axxb-", "T"))
+	assert.Equal(t, "--xx-", regexReplaceAll(regex,"-ab-axxb-", "$1"))
+	assert.Equal(t, "---", regexReplaceAll(regex,"-ab-axxb-", "$1W"))
+	assert.Equal(t, "-W-xxW-", regexReplaceAll(regex,"-ab-axxb-", "${1}W"))
+}
+
+func TestRegexReplaceAllLiteral(t *testing.T){
+	regex := "a(x*)b"
+	assert.Equal(t, "-T-T-", regexReplaceAllLiteral(regex,"-ab-axxb-", "T"))
+	assert.Equal(t, "-$1-$1-", regexReplaceAllLiteral(regex,"-ab-axxb-", "$1"))
+	assert.Equal(t, "-${1}-${1}-", regexReplaceAllLiteral(regex,"-ab-axxb-", "${1}"))
+}
+
+func TestRegexSplit(t *testing.T){
+	regex := "a"
+	assert.Equal(t, 4, len(regexSplit(regex,"banana", -1)))
+	assert.Equal(t, 0, len(regexSplit(regex,"banana", 0)))
+	assert.Equal(t, 1, len(regexSplit(regex,"banana", 1)))
+	assert.Equal(t, 2, len(regexSplit(regex,"banana", 2)))
+
+	regex = "z+"
+	assert.Equal(t, 2, len(regexSplit(regex,"pizza", -1)))
+	assert.Equal(t, 0, len(regexSplit(regex,"pizza", 0)))
+	assert.Equal(t, 1, len(regexSplit(regex,"pizza", 1)))
+	assert.Equal(t, 2, len(regexSplit(regex,"pizza", 2)))
+}

--- a/vendor/github.com/Masterminds/sprig/semver.go
+++ b/vendor/github.com/Masterminds/sprig/semver.go
@@ -1,0 +1,23 @@
+package sprig
+
+import (
+	sv2 "github.com/Masterminds/semver"
+)
+
+func semverCompare(constraint, version string) (bool, error) {
+	c, err := sv2.NewConstraint(constraint)
+	if err != nil {
+		return false, err
+	}
+
+	v, err := sv2.NewVersion(version)
+	if err != nil {
+		return false, err
+	}
+
+	return c.Check(v), nil
+}
+
+func semver(version string) (*sv2.Version, error) {
+	return sv2.NewVersion(version)
+}

--- a/vendor/github.com/Masterminds/sprig/semver_test.go
+++ b/vendor/github.com/Masterminds/sprig/semver_test.go
@@ -1,0 +1,31 @@
+package sprig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSemverCompare(t *testing.T) {
+	tests := map[string]string{
+		`{{ semverCompare "1.2.3" "1.2.3" }}`:  `true`,
+		`{{ semverCompare "^1.2.0" "1.2.3" }}`: `true`,
+		`{{ semverCompare "^1.2.0" "2.2.3" }}`: `false`,
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+}
+
+func TestSemver(t *testing.T) {
+	tests := map[string]string{
+		`{{ $s := semver "1.2.3-beta.1+c0ff33" }}{{ $s.Prerelease }}`: "beta.1",
+		`{{ $s := semver "1.2.3-beta.1+c0ff33" }}{{ $s.Major}}`:       "1",
+		`{{ semver "1.2.3" | (semver "1.2.3").Compare }}`:             `0`,
+		`{{ semver "1.2.3" | (semver "1.3.3").Compare }}`:             `1`,
+		`{{ semver "1.4.3" | (semver "1.2.3").Compare }}`:             `-1`,
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+}

--- a/vendor/github.com/Masterminds/sprig/strings.go
+++ b/vendor/github.com/Masterminds/sprig/strings.go
@@ -1,0 +1,197 @@
+package sprig
+
+import (
+	"encoding/base32"
+	"encoding/base64"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	util "github.com/aokoli/goutils"
+)
+
+func base64encode(v string) string {
+	return base64.StdEncoding.EncodeToString([]byte(v))
+}
+
+func base64decode(v string) string {
+	data, err := base64.StdEncoding.DecodeString(v)
+	if err != nil {
+		return err.Error()
+	}
+	return string(data)
+}
+
+func base32encode(v string) string {
+	return base32.StdEncoding.EncodeToString([]byte(v))
+}
+
+func base32decode(v string) string {
+	data, err := base32.StdEncoding.DecodeString(v)
+	if err != nil {
+		return err.Error()
+	}
+	return string(data)
+}
+
+func abbrev(width int, s string) string {
+	if width < 4 {
+		return s
+	}
+	r, _ := util.Abbreviate(s, width)
+	return r
+}
+
+func abbrevboth(left, right int, s string) string {
+	if right < 4 || left > 0 && right < 7 {
+		return s
+	}
+	r, _ := util.AbbreviateFull(s, left, right)
+	return r
+}
+func initials(s string) string {
+	// Wrap this just to eliminate the var args, which templates don't do well.
+	return util.Initials(s)
+}
+
+func randAlphaNumeric(count int) string {
+	// It is not possible, it appears, to actually generate an error here.
+	r, _ := util.RandomAlphaNumeric(count)
+	return r
+}
+
+func randAlpha(count int) string {
+	r, _ := util.RandomAlphabetic(count)
+	return r
+}
+
+func randAscii(count int) string {
+	r, _ := util.RandomAscii(count)
+	return r
+}
+
+func randNumeric(count int) string {
+	r, _ := util.RandomNumeric(count)
+	return r
+}
+
+func untitle(str string) string {
+	return util.Uncapitalize(str)
+}
+
+func quote(str ...interface{}) string {
+	out := make([]string, len(str))
+	for i, s := range str {
+		out[i] = fmt.Sprintf("%q", strval(s))
+	}
+	return strings.Join(out, " ")
+}
+
+func squote(str ...interface{}) string {
+	out := make([]string, len(str))
+	for i, s := range str {
+		out[i] = fmt.Sprintf("'%v'", s)
+	}
+	return strings.Join(out, " ")
+}
+
+func cat(v ...interface{}) string {
+	r := strings.TrimSpace(strings.Repeat("%v ", len(v)))
+	return fmt.Sprintf(r, v...)
+}
+
+func indent(spaces int, v string) string {
+	pad := strings.Repeat(" ", spaces)
+	return pad + strings.Replace(v, "\n", "\n"+pad, -1)
+}
+
+func replace(old, new, src string) string {
+	return strings.Replace(src, old, new, -1)
+}
+
+func plural(one, many string, count int) string {
+	if count == 1 {
+		return one
+	}
+	return many
+}
+
+func strslice(v interface{}) []string {
+	switch v := v.(type) {
+	case []string:
+		return v
+	case []interface{}:
+		l := len(v)
+		b := make([]string, l)
+		for i := 0; i < l; i++ {
+			b[i] = strval(v[i])
+		}
+		return b
+	default:
+		val := reflect.ValueOf(v)
+		switch val.Kind() {
+		case reflect.Array, reflect.Slice:
+			l := val.Len()
+			b := make([]string, l)
+			for i := 0; i < l; i++ {
+				b[i] = strval(val.Index(i).Interface())
+			}
+			return b
+		default:
+			return []string{strval(v)}
+		}
+	}
+}
+
+func strval(v interface{}) string {
+	switch v := v.(type) {
+	case string:
+		return v
+	case []byte:
+		return string(v)
+	case error:
+		return v.Error()
+	case fmt.Stringer:
+		return v.String()
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+func trunc(c int, s string) string {
+	if len(s) <= c {
+		return s
+	}
+	return s[0:c]
+}
+
+func join(sep string, v interface{}) string {
+	return strings.Join(strslice(v), sep)
+}
+
+func split(sep, orig string) map[string]string {
+	parts := strings.Split(orig, sep)
+	res := make(map[string]string, len(parts))
+	for i, v := range parts {
+		res["_"+strconv.Itoa(i)] = v
+	}
+	return res
+}
+
+// substring creates a substring of the given string.
+//
+// If start is < 0, this calls string[:length].
+//
+// If start is >= 0 and length < 0, this calls string[start:]
+//
+// Otherwise, this calls string[start, length].
+func substring(start, length int, s string) string {
+	if start < 0 {
+		return s[:length]
+	}
+	if length < 0 {
+		return s[start:]
+	}
+	return s[start:length]
+}

--- a/vendor/github.com/Masterminds/sprig/strings_test.go
+++ b/vendor/github.com/Masterminds/sprig/strings_test.go
@@ -1,0 +1,220 @@
+package sprig
+
+import (
+	"encoding/base32"
+	"encoding/base64"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/aokoli/goutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubstr(t *testing.T) {
+	tpl := `{{"fooo" | substr 0 3 }}`
+	if err := runt(tpl, "foo"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTrunc(t *testing.T) {
+	tpl := `{{ "foooooo" | trunc 3 }}`
+	if err := runt(tpl, "foo"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestQuote(t *testing.T) {
+	tpl := `{{quote "a" "b" "c"}}`
+	if err := runt(tpl, `"a" "b" "c"`); err != nil {
+		t.Error(err)
+	}
+	tpl = `{{quote "\"a\"" "b" "c"}}`
+	if err := runt(tpl, `"\"a\"" "b" "c"`); err != nil {
+		t.Error(err)
+	}
+	tpl = `{{quote 1 2 3 }}`
+	if err := runt(tpl, `"1" "2" "3"`); err != nil {
+		t.Error(err)
+	}
+}
+func TestSquote(t *testing.T) {
+	tpl := `{{squote "a" "b" "c"}}`
+	if err := runt(tpl, `'a' 'b' 'c'`); err != nil {
+		t.Error(err)
+	}
+	tpl = `{{squote 1 2 3 }}`
+	if err := runt(tpl, `'1' '2' '3'`); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestContains(t *testing.T) {
+	// Mainly, we're just verifying the paramater order swap.
+	tests := []string{
+		`{{if contains "cat" "fair catch"}}1{{end}}`,
+		`{{if hasPrefix "cat" "catch"}}1{{end}}`,
+		`{{if hasSuffix "cat" "ducat"}}1{{end}}`,
+	}
+	for _, tt := range tests {
+		if err := runt(tt, "1"); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestTrim(t *testing.T) {
+	tests := []string{
+		`{{trim "   5.00   "}}`,
+		`{{trimAll "$" "$5.00$"}}`,
+		`{{trimPrefix "$" "$5.00"}}`,
+		`{{trimSuffix "$" "5.00$"}}`,
+	}
+	for _, tt := range tests {
+		if err := runt(tt, "5.00"); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestSplit(t *testing.T) {
+	tpl := `{{$v := "foo$bar$baz" | split "$"}}{{$v._0}}`
+	if err := runt(tpl, "foo"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestToString(t *testing.T) {
+	tpl := `{{ toString 1 | kindOf }}`
+	assert.NoError(t, runt(tpl, "string"))
+}
+
+func TestToStrings(t *testing.T) {
+	tpl := `{{ $s := list 1 2 3 | toStrings }}{{ index $s 1 | kindOf }}`
+	assert.NoError(t, runt(tpl, "string"))
+}
+
+func TestJoin(t *testing.T) {
+	assert.NoError(t, runt(`{{ tuple "a" "b" "c" | join "-" }}`, "a-b-c"))
+	assert.NoError(t, runt(`{{ tuple 1 2 3 | join "-" }}`, "1-2-3"))
+	assert.NoError(t, runtv(`{{ join "-" .V }}`, "a-b-c", map[string]interface{}{"V": []string{"a", "b", "c"}}))
+	assert.NoError(t, runtv(`{{ join "-" .V }}`, "abc", map[string]interface{}{"V": "abc"}))
+	assert.NoError(t, runtv(`{{ join "-" .V }}`, "1-2-3", map[string]interface{}{"V": []int{1, 2, 3}}))
+}
+
+func TestSortAlpha(t *testing.T) {
+	// Named `append` in the function map
+	tests := map[string]string{
+		`{{ list "c" "a" "b" | sortAlpha | join "" }}`: "abc",
+		`{{ list 2 1 4 3 | sortAlpha | join "" }}`:     "1234",
+	}
+	for tpl, expect := range tests {
+		assert.NoError(t, runt(tpl, expect))
+	}
+}
+func TestBase64EncodeDecode(t *testing.T) {
+	magicWord := "coffee"
+	expect := base64.StdEncoding.EncodeToString([]byte(magicWord))
+
+	if expect == magicWord {
+		t.Fatal("Encoder doesn't work.")
+	}
+
+	tpl := `{{b64enc "coffee"}}`
+	if err := runt(tpl, expect); err != nil {
+		t.Error(err)
+	}
+	tpl = fmt.Sprintf("{{b64dec %q}}", expect)
+	if err := runt(tpl, magicWord); err != nil {
+		t.Error(err)
+	}
+}
+func TestBase32EncodeDecode(t *testing.T) {
+	magicWord := "coffee"
+	expect := base32.StdEncoding.EncodeToString([]byte(magicWord))
+
+	if expect == magicWord {
+		t.Fatal("Encoder doesn't work.")
+	}
+
+	tpl := `{{b32enc "coffee"}}`
+	if err := runt(tpl, expect); err != nil {
+		t.Error(err)
+	}
+	tpl = fmt.Sprintf("{{b32dec %q}}", expect)
+	if err := runt(tpl, magicWord); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGoutils(t *testing.T) {
+	tests := map[string]string{
+		`{{abbrev 5 "hello world"}}`:           "he...",
+		`{{abbrevboth 5 10 "1234 5678 9123"}}`: "...5678...",
+		`{{nospace "h e l l o "}}`:             "hello",
+		`{{untitle "First Try"}}`:              "first try", //https://youtu.be/44-RsrF_V_w
+		`{{initials "First Try"}}`:             "FT",
+		`{{wrap 5 "Hello World"}}`:             "Hello\nWorld",
+		`{{wrapWith 5 "\t" "Hello World"}}`:    "Hello\tWorld",
+	}
+	for k, v := range tests {
+		t.Log(k)
+		if err := runt(k, v); err != nil {
+			t.Errorf("Error on tpl %s: %s", err)
+		}
+	}
+}
+
+func TestRandom(t *testing.T) {
+	// One of the things I love about Go:
+	goutils.RANDOM = rand.New(rand.NewSource(1))
+
+	// Because we're using a random number generator, we need these to go in
+	// a predictable sequence:
+	if err := runt(`{{randAlphaNum 5}}`, "9bzRv"); err != nil {
+		t.Errorf("Error on tpl %s: %s", err)
+	}
+	if err := runt(`{{randAlpha 5}}`, "VjwGe"); err != nil {
+		t.Errorf("Error on tpl %s: %s", err)
+	}
+	if err := runt(`{{randAscii 5}}`, "1KA5p"); err != nil {
+		t.Errorf("Error on tpl %s: %s", err)
+	}
+	if err := runt(`{{randNumeric 5}}`, "26018"); err != nil {
+		t.Errorf("Error on tpl %s: %s", err)
+	}
+
+}
+
+func TestCat(t *testing.T) {
+	tpl := `{{$b := "b"}}{{"c" | cat "a" $b}}`
+	if err := runt(tpl, "a b c"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestIndent(t *testing.T) {
+	tpl := `{{indent 4 "a\nb\nc"}}`
+	if err := runt(tpl, "    a\n    b\n    c"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestReplace(t *testing.T) {
+	tpl := `{{"I Am Henry VIII" | replace " " "-"}}`
+	if err := runt(tpl, "I-Am-Henry-VIII"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestPlural(t *testing.T) {
+	tpl := `{{$num := len "two"}}{{$num}} {{$num | plural "1 char" "chars"}}`
+	if err := runt(tpl, "3 chars"); err != nil {
+		t.Error(err)
+	}
+	tpl = `{{len "t" | plural "cheese" "%d chars"}}`
+	if err := runt(tpl, "cheese"); err != nil {
+		t.Error(err)
+	}
+}

--- a/vendor/github.com/aokoli/goutils/.travis.yml
+++ b/vendor/github.com/aokoli/goutils/.travis.yml
@@ -1,0 +1,18 @@
+language: go
+
+go:
+  - 1.6
+  - 1.7
+  - 1.8
+  - tip
+
+script:
+  - go test -v
+
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/06e3328629952dabe3e0
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: never     # options: [always|never|change] default: always

--- a/vendor/github.com/aokoli/goutils/CHANGELOG.md
+++ b/vendor/github.com/aokoli/goutils/CHANGELOG.md
@@ -1,0 +1,8 @@
+# 1.0.1 (2017-05-31)
+
+## Fixed
+- #21: Fix generation of alphanumeric strings (thanks @dbarranco)
+
+# 1.0.0 (2014-04-30)
+
+- Initial release.

--- a/vendor/github.com/aokoli/goutils/LICENSE.txt
+++ b/vendor/github.com/aokoli/goutils/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/aokoli/goutils/README.md
+++ b/vendor/github.com/aokoli/goutils/README.md
@@ -1,0 +1,70 @@
+GoUtils
+===========
+[![Stability: Maintenance](https://masterminds.github.io/stability/maintenance.svg)](https://masterminds.github.io/stability/maintenance.html)
+[![GoDoc](https://godoc.org/github.com/Masterminds/goutils?status.png)](https://godoc.org/github.com/Masterminds/goutils) [![Build Status](https://travis-ci.org/Masterminds/goutils.svg?branch=master)](https://travis-ci.org/Masterminds/goutils) [![Build status](https://ci.appveyor.com/api/projects/status/sc2b1ew0m7f0aiju?svg=true)](https://ci.appveyor.com/project/mattfarina/goutils)
+
+
+GoUtils provides users with utility functions to manipulate strings in various ways. It is a Go implementation of some
+string manipulation libraries of Java Apache Commons. GoUtils includes the following Java Apache Commons classes:
+* WordUtils    
+* RandomStringUtils  
+* StringUtils (partial implementation)
+
+## Installation
+If you have Go set up on your system, from the GOPATH directory within the command line/terminal, enter this:
+
+	go get github.com/Masterminds/goutils
+
+If you do not have Go set up on your system, please follow the [Go installation directions from the documenation](http://golang.org/doc/install), and then follow the instructions above to install GoUtils.
+
+
+## Documentation
+GoUtils doc is available here: [![GoDoc](https://godoc.org/github.com/Masterminds/goutils?status.png)](https://godoc.org/github.com/Masterminds/goutils)
+
+
+## Usage
+The code snippets below show examples of how to use GoUtils. Some functions return errors while others do not. The first instance below, which does not return an error, is the `Initials` function (located within the `wordutils.go` file).
+
+    package main
+
+    import (
+        "fmt"
+    	"github.com/Masterminds/goutils"
+    )
+
+    func main() {
+
+    	// EXAMPLE 1: A goutils function which returns no errors
+        fmt.Println (goutils.Initials("John Doe Foo")) // Prints out "JDF"
+
+    }
+Some functions return errors mainly due to illegal arguements used as parameters. The code example below illustrates how to deal with function that returns an error. In this instance, the function is the `Random` function (located within the `randomstringutils.go` file).
+
+    package main
+
+    import (
+        "fmt"
+        "github.com/Masterminds/goutils"
+    )
+
+    func main() {
+
+        // EXAMPLE 2: A goutils function which returns an error
+        rand1, err1 := goutils.Random (-1, 0, 0, true, true)  
+
+        if err1 != nil {
+			fmt.Println(err1) // Prints out error message because -1 was entered as the first parameter in goutils.Random(...)
+		} else {
+			fmt.Println(rand1)
+		}
+
+    }
+
+## License
+GoUtils is licensed under the Apache License, Version 2.0. Please check the LICENSE.txt file or visit http://www.apache.org/licenses/LICENSE-2.0 for a copy of the license.
+
+## Issue Reporting
+Make suggestions or report issues using the Git issue tracker: https://github.com/Masterminds/goutils/issues
+
+## Website
+* [GoUtils webpage](http://Masterminds.github.io/goutils/)

--- a/vendor/github.com/aokoli/goutils/appveyor.yml
+++ b/vendor/github.com/aokoli/goutils/appveyor.yml
@@ -1,0 +1,21 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\Masterminds\goutils
+shallow_clone: true
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+build: off
+
+install:
+  - go version
+  - go env
+
+test_script:
+  - go test -v
+
+deploy: off

--- a/vendor/github.com/aokoli/goutils/randomstringutils.go
+++ b/vendor/github.com/aokoli/goutils/randomstringutils.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2014 Alexander Okoli
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package goutils
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"regexp"
+	"time"
+	"unicode"
+)
+
+// RANDOM provides the time-based seed used to generate random numbers
+var RANDOM = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+/*
+RandomNonAlphaNumeric creates a random string whose length is the number of characters specified.
+Characters will be chosen from the set of all characters (ASCII/Unicode values between 0 to 2,147,483,647 (math.MaxInt32)).
+
+Parameter:
+	count - the length of random string to create
+
+Returns:
+	string - the random string
+	error - an error stemming from an invalid parameter within underlying function, RandomSeed(...)
+*/
+func RandomNonAlphaNumeric(count int) (string, error) {
+	return RandomAlphaNumericCustom(count, false, false)
+}
+
+/*
+RandomAscii creates a random string whose length is the number of characters specified.
+Characters will be chosen from the set of characters whose ASCII value is between 32 and 126 (inclusive).
+
+Parameter:
+	count - the length of random string to create
+
+Returns:
+	string - the random string
+	error - an error stemming from an invalid parameter within underlying function, RandomSeed(...)
+*/
+func RandomAscii(count int) (string, error) {
+	return Random(count, 32, 127, false, false)
+}
+
+/*
+RandomNumeric creates a random string whose length is the number of characters specified.
+Characters will be chosen from the set of numeric characters.
+
+Parameter:
+	count - the length of random string to create
+
+Returns:
+	string - the random string
+	error - an error stemming from an invalid parameter within underlying function, RandomSeed(...)
+*/
+func RandomNumeric(count int) (string, error) {
+	return Random(count, 0, 0, false, true)
+}
+
+/*
+RandomAlphabetic creates a random string whose length is the number of characters specified.
+Characters will be chosen from the set of alpha-numeric characters as indicated by the arguments.
+
+Parameters:
+	count - the length of random string to create
+	letters - if true, generated string may include alphabetic characters
+	numbers - if true, generated string may include numeric characters
+
+Returns:
+	string - the random string
+	error - an error stemming from an invalid parameter within underlying function, RandomSeed(...)
+*/
+func RandomAlphabetic(count int) (string, error) {
+	return Random(count, 0, 0, true, false)
+}
+
+/*
+RandomAlphaNumeric creates a random string whose length is the number of characters specified.
+Characters will be chosen from the set of alpha-numeric characters.
+
+Parameter:
+	count - the length of random string to create
+
+Returns:
+	string - the random string
+	error - an error stemming from an invalid parameter within underlying function, RandomSeed(...)
+*/
+func RandomAlphaNumeric(count int) (string, error) {
+	RandomString, err := Random(count, 0, 0, true, true)
+	if err != nil {
+		return "", fmt.Errorf("Error: %s", err)
+	}
+	match, err := regexp.MatchString("([0-9]+)", RandomString)
+	if err != nil {
+		panic(err)
+	}
+
+	if !match {
+		//Get the position between 0 and the length of the string-1  to insert a random number
+		position := rand.Intn(count)
+		//Insert a random number between [0-9] in the position
+		RandomString = RandomString[:position] + string('0'+rand.Intn(10)) + RandomString[position+1:]
+		return RandomString, err
+	}
+	return RandomString, err
+
+}
+
+/*
+RandomAlphaNumericCustom creates a random string whose length is the number of characters specified.
+Characters will be chosen from the set of alpha-numeric characters as indicated by the arguments.
+
+Parameters:
+	count - the length of random string to create
+	letters - if true, generated string may include alphabetic characters
+	numbers - if true, generated string may include numeric characters
+
+Returns:
+	string - the random string
+	error - an error stemming from an invalid parameter within underlying function, RandomSeed(...)
+*/
+func RandomAlphaNumericCustom(count int, letters bool, numbers bool) (string, error) {
+	return Random(count, 0, 0, letters, numbers)
+}
+
+/*
+Random creates a random string based on a variety of options, using default source of randomness.
+This method has exactly the same semantics as RandomSeed(int, int, int, bool, bool, []char, *rand.Rand), but
+instead of using an externally supplied source of randomness, it uses the internal *rand.Rand instance.
+
+Parameters:
+	count - the length of random string to create
+	start - the position in set of chars (ASCII/Unicode int) to start at
+	end - the position in set of chars (ASCII/Unicode int) to end before
+	letters - if true, generated string may include alphabetic characters
+	numbers - if true, generated string may include numeric characters
+	chars - the set of chars to choose randoms from. If nil, then it will use the set of all chars.
+
+Returns:
+	string - the random string
+	error - an error stemming from an invalid parameter within underlying function, RandomSeed(...)
+*/
+func Random(count int, start int, end int, letters bool, numbers bool, chars ...rune) (string, error) {
+	return RandomSeed(count, start, end, letters, numbers, chars, RANDOM)
+}
+
+/*
+RandomSeed creates a random string based on a variety of options, using supplied source of randomness.
+If the parameters start and end are both 0, start and end are set to ' ' and 'z', the ASCII printable characters, will be used,
+unless letters and numbers are both false, in which case, start and end are set to 0 and math.MaxInt32, respectively.
+If chars is not nil, characters stored in chars that are between start and end are chosen.
+This method accepts a user-supplied *rand.Rand instance to use as a source of randomness. By seeding a single *rand.Rand instance
+with a fixed seed and using it for each call, the same random sequence of strings can be generated repeatedly and predictably.
+
+Parameters:
+	count - the length of random string to create
+	start - the position in set of chars (ASCII/Unicode decimals) to start at
+	end - the position in set of chars (ASCII/Unicode decimals) to end before
+	letters - if true, generated string may include alphabetic characters
+	numbers - if true, generated string may include numeric characters
+	chars - the set of chars to choose randoms from. If nil, then it will use the set of all chars.
+	random - a source of randomness.
+
+Returns:
+	string - the random string
+	error - an error stemming from invalid parameters: if count < 0; or the provided chars array is empty; or end <= start; or end > len(chars)
+*/
+func RandomSeed(count int, start int, end int, letters bool, numbers bool, chars []rune, random *rand.Rand) (string, error) {
+
+	if count == 0 {
+		return "", nil
+	} else if count < 0 {
+		err := fmt.Errorf("randomstringutils illegal argument: Requested random string length %v is less than 0.", count) // equiv to err := errors.New("...")
+		return "", err
+	}
+	if chars != nil && len(chars) == 0 {
+		err := fmt.Errorf("randomstringutils illegal argument: The chars array must not be empty")
+		return "", err
+	}
+
+	if start == 0 && end == 0 {
+		if chars != nil {
+			end = len(chars)
+		} else {
+			if !letters && !numbers {
+				end = math.MaxInt32
+			} else {
+				end = 'z' + 1
+				start = ' '
+			}
+		}
+	} else {
+		if end <= start {
+			err := fmt.Errorf("randomstringutils illegal argument: Parameter end (%v) must be greater than start (%v)", end, start)
+			return "", err
+		}
+
+		if chars != nil && end > len(chars) {
+			err := fmt.Errorf("randomstringutils illegal argument: Parameter end (%v) cannot be greater than len(chars) (%v)", end, len(chars))
+			return "", err
+		}
+	}
+
+	buffer := make([]rune, count)
+	gap := end - start
+
+	// high-surrogates range, (\uD800-\uDBFF) = 55296 - 56319
+	//  low-surrogates range, (\uDC00-\uDFFF) = 56320 - 57343
+
+	for count != 0 {
+		count--
+		var ch rune
+		if chars == nil {
+			ch = rune(random.Intn(gap) + start)
+		} else {
+			ch = chars[random.Intn(gap)+start]
+		}
+
+		if letters && unicode.IsLetter(ch) || numbers && unicode.IsDigit(ch) || !letters && !numbers {
+			if ch >= 56320 && ch <= 57343 { // low surrogate range
+				if count == 0 {
+					count++
+				} else {
+					// Insert low surrogate
+					buffer[count] = ch
+					count--
+					// Insert high surrogate
+					buffer[count] = rune(55296 + random.Intn(128))
+				}
+			} else if ch >= 55296 && ch <= 56191 { // High surrogates range (Partial)
+				if count == 0 {
+					count++
+				} else {
+					// Insert low surrogate
+					buffer[count] = rune(56320 + random.Intn(128))
+					count--
+					// Insert high surrogate
+					buffer[count] = ch
+				}
+			} else if ch >= 56192 && ch <= 56319 {
+				// private high surrogate, skip it
+				count++
+			} else {
+				// not one of the surrogates*
+				buffer[count] = ch
+			}
+		} else {
+			count++
+		}
+	}
+	return string(buffer), nil
+}

--- a/vendor/github.com/aokoli/goutils/randomstringutils_test.go
+++ b/vendor/github.com/aokoli/goutils/randomstringutils_test.go
@@ -1,0 +1,78 @@
+package goutils
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+// ****************************** TESTS ********************************************
+
+func TestRandomSeed(t *testing.T) {
+
+	// count, start, end, letters, numbers := 5, 0, 0, true, true
+	random := rand.New(rand.NewSource(10))
+	out := "3ip9v"
+
+	// Test 1: Simulating RandomAlphaNumeric(count int)
+	if x, _ := RandomSeed(5, 0, 0, true, true, nil, random); x != out {
+		t.Errorf("RandomSeed(%v, %v, %v, %v, %v, %v, %v) = %v, want %v", 5, 0, 0, true, true, nil, random, x, out)
+	}
+
+	// Test 2: Simulating RandomAlphabetic(count int)
+	out = "MBrbj"
+
+	if x, _ := RandomSeed(5, 0, 0, true, false, nil, random); x != out {
+		t.Errorf("RandomSeed(%v, %v, %v, %v, %v, %v, %v) = %v, want %v", 5, 0, 0, true, false, nil, random, x, out)
+	}
+
+	// Test 3: Simulating RandomNumeric(count int)
+	out = "88935"
+
+	if x, _ := RandomSeed(5, 0, 0, false, true, nil, random); x != out {
+		t.Errorf("RandomSeed(%v, %v, %v, %v, %v, %v, %v) = %v, want %v", 5, 0, 0, false, true, nil, random, x, out)
+	}
+
+	// Test 4: Simulating RandomAscii(count int)
+	out = "H_I;E"
+
+	if x, _ := RandomSeed(5, 32, 127, false, false, nil, random); x != out {
+		t.Errorf("RandomSeed(%v, %v, %v, %v, %v, %v, %v) = %v, want %v", 5, 32, 127, false, false, nil, random, x, out)
+	}
+
+	// Test 5: Simulating RandomSeed(...) with custom chars
+	chars := []rune{'1', '2', '3', 'a', 'b', 'c'}
+	out = "2b2ca"
+
+	if x, _ := RandomSeed(5, 0, 0, false, false, chars, random); x != out {
+		t.Errorf("RandomSeed(%v, %v, %v, %v, %v, %v, %v) = %v, want %v", 5, 0, 0, false, false, chars, random, x, out)
+	}
+
+}
+
+// ****************************** EXAMPLES ********************************************
+
+func ExampleRandomSeed() {
+
+	var seed int64 = 10 // If you change this seed #, the random sequence below will change
+	random := rand.New(rand.NewSource(seed))
+	chars := []rune{'1', '2', '3', 'a', 'b', 'c'}
+
+	rand1, _ := RandomSeed(5, 0, 0, true, true, nil, random)      // RandomAlphaNumeric (Alphabets and numbers possible)
+	rand2, _ := RandomSeed(5, 0, 0, true, false, nil, random)     // RandomAlphabetic (Only alphabets)
+	rand3, _ := RandomSeed(5, 0, 0, false, true, nil, random)     // RandomNumeric (Only numbers)
+	rand4, _ := RandomSeed(5, 32, 127, false, false, nil, random) // RandomAscii (Alphabets, numbers, and other ASCII chars)
+	rand5, _ := RandomSeed(5, 0, 0, true, true, chars, random)    // RandomSeed with custom characters
+
+	fmt.Println(rand1)
+	fmt.Println(rand2)
+	fmt.Println(rand3)
+	fmt.Println(rand4)
+	fmt.Println(rand5)
+	// Output:
+	// 3ip9v
+	// MBrbj
+	// 88935
+	// H_I;E
+	// 2b2ca
+}

--- a/vendor/github.com/aokoli/goutils/stringutils.go
+++ b/vendor/github.com/aokoli/goutils/stringutils.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2014 Alexander Okoli
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package goutils
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// Typically returned by functions where a searched item cannot be found
+const INDEX_NOT_FOUND = -1
+
+/*
+Abbreviate abbreviates a string using ellipses. This will turn  the string "Now is the time for all good men" into "Now is the time for..."
+
+Specifically, the algorithm is as follows:
+
+    - If str is less than maxWidth characters long, return it.
+    - Else abbreviate it to (str[0:maxWidth - 3] + "...").
+    - If maxWidth is less than 4, return an illegal argument error.
+    - In no case will it return a string of length greater than maxWidth.
+
+Parameters:
+    str -  the string to check
+    maxWidth - maximum length of result string, must be at least 4
+
+Returns:
+    string - abbreviated string
+    error - if the width is too small
+*/
+func Abbreviate(str string, maxWidth int) (string, error) {
+	return AbbreviateFull(str, 0, maxWidth)
+}
+
+/*
+AbbreviateFull abbreviates a string using ellipses. This will turn the string "Now is the time for all good men" into "...is the time for..."
+This function works like Abbreviate(string, int), but allows you to specify a "left edge" offset. Note that this left edge is not
+necessarily going to be the leftmost character in the result, or the first character following the ellipses, but it will appear
+somewhere in the result.
+In no case will it return a string of length greater than maxWidth.
+
+Parameters:
+    str - the string to check
+    offset - left edge of source string
+    maxWidth - maximum length of result string, must be at least 4
+
+Returns:
+    string - abbreviated string
+    error - if the width is too small
+*/
+func AbbreviateFull(str string, offset int, maxWidth int) (string, error) {
+	if str == "" {
+		return "", nil
+	}
+	if maxWidth < 4 {
+		err := fmt.Errorf("stringutils illegal argument: Minimum abbreviation width is 4")
+		return "", err
+	}
+	if len(str) <= maxWidth {
+		return str, nil
+	}
+	if offset > len(str) {
+		offset = len(str)
+	}
+	if len(str)-offset < (maxWidth - 3) { // 15 - 5 < 10 - 3 =  10 < 7
+		offset = len(str) - (maxWidth - 3)
+	}
+	abrevMarker := "..."
+	if offset <= 4 {
+		return str[0:maxWidth-3] + abrevMarker, nil // str.substring(0, maxWidth - 3) + abrevMarker;
+	}
+	if maxWidth < 7 {
+		err := fmt.Errorf("stringutils illegal argument: Minimum abbreviation width with offset is 7")
+		return "", err
+	}
+	if (offset + maxWidth - 3) < len(str) { // 5 + (10-3) < 15 = 12 < 15
+		abrevStr, _ := Abbreviate(str[offset:len(str)], (maxWidth - 3))
+		return abrevMarker + abrevStr, nil // abrevMarker + abbreviate(str.substring(offset), maxWidth - 3);
+	}
+	return abrevMarker + str[(len(str)-(maxWidth-3)):len(str)], nil // abrevMarker + str.substring(str.length() - (maxWidth - 3));
+}
+
+/*
+DeleteWhiteSpace deletes all whitespaces from a string as defined by unicode.IsSpace(rune).
+It returns the string without whitespaces.
+
+Parameter:
+    str - the string to delete whitespace from, may be nil
+
+Returns:
+    the string without whitespaces
+*/
+func DeleteWhiteSpace(str string) string {
+	if str == "" {
+		return str
+	}
+	sz := len(str)
+	var chs bytes.Buffer
+	count := 0
+	for i := 0; i < sz; i++ {
+		ch := rune(str[i])
+		if !unicode.IsSpace(ch) {
+			chs.WriteRune(ch)
+			count++
+		}
+	}
+	if count == sz {
+		return str
+	}
+	return chs.String()
+}
+
+/*
+IndexOfDifference compares two strings, and returns the index at which the strings begin to differ.
+
+Parameters:
+    str1 - the first string
+    str2 - the second string
+
+Returns:
+    the index where str1 and str2 begin to differ; -1 if they are equal
+*/
+func IndexOfDifference(str1 string, str2 string) int {
+	if str1 == str2 {
+		return INDEX_NOT_FOUND
+	}
+	if IsEmpty(str1) || IsEmpty(str2) {
+		return 0
+	}
+	var i int
+	for i = 0; i < len(str1) && i < len(str2); i++ {
+		if rune(str1[i]) != rune(str2[i]) {
+			break
+		}
+	}
+	if i < len(str2) || i < len(str1) {
+		return i
+	}
+	return INDEX_NOT_FOUND
+}
+
+/*
+IsBlank checks if a string is whitespace or empty (""). Observe the following behavior:
+
+    goutils.IsBlank("")        = true
+    goutils.IsBlank(" ")       = true
+    goutils.IsBlank("bob")     = false
+    goutils.IsBlank("  bob  ") = false
+
+Parameter:
+    str - the string to check
+
+Returns:
+    true - if the string is whitespace or empty ("")
+*/
+func IsBlank(str string) bool {
+	strLen := len(str)
+	if str == "" || strLen == 0 {
+		return true
+	}
+	for i := 0; i < strLen; i++ {
+		if unicode.IsSpace(rune(str[i])) == false {
+			return false
+		}
+	}
+	return true
+}
+
+/*
+IndexOf returns the index of the first instance of sub in str, with the search beginning from the
+index start point specified. -1 is returned if sub is not present in str.
+
+An empty string ("") will return -1 (INDEX_NOT_FOUND). A negative start position is treated as zero.
+A start position greater than the string length returns -1.
+
+Parameters:
+    str - the string to check
+    sub - the substring to find
+    start - the start position; negative treated as zero
+
+Returns:
+    the first index where the sub string was found  (always >= start)
+*/
+func IndexOf(str string, sub string, start int) int {
+
+	if start < 0 {
+		start = 0
+	}
+
+	if len(str) < start {
+		return INDEX_NOT_FOUND
+	}
+
+	if IsEmpty(str) || IsEmpty(sub) {
+		return INDEX_NOT_FOUND
+	}
+
+	partialIndex := strings.Index(str[start:len(str)], sub)
+	if partialIndex == -1 {
+		return INDEX_NOT_FOUND
+	}
+	return partialIndex + start
+}
+
+// IsEmpty checks if a string is empty (""). Returns true if empty, and false otherwise.
+func IsEmpty(str string) bool {
+	return len(str) == 0
+}

--- a/vendor/github.com/aokoli/goutils/stringutils_test.go
+++ b/vendor/github.com/aokoli/goutils/stringutils_test.go
@@ -1,0 +1,309 @@
+package goutils
+
+import (
+	"fmt"
+	"testing"
+)
+
+// ****************************** TESTS ********************************************
+
+func TestAbbreviate(t *testing.T) {
+
+	// Test 1
+	in := "abcdefg"
+	out := "abc..."
+	maxWidth := 6
+
+	if x, _ := Abbreviate(in, maxWidth); x != out {
+		t.Errorf("Abbreviate(%v, %v) = %v, want %v", in, maxWidth, x, out)
+	}
+
+	// Test 2
+	out = "abcdefg"
+	maxWidth = 7
+
+	if x, _ := Abbreviate(in, maxWidth); x != out {
+		t.Errorf("Abbreviate(%v, %v) = %v, want %v", in, maxWidth, x, out)
+	}
+
+	// Test 3
+	out = "a..."
+	maxWidth = 4
+
+	if x, _ := Abbreviate(in, maxWidth); x != out {
+		t.Errorf("Abbreviate(%v, %v) = %v, want %v", in, maxWidth, x, out)
+	}
+}
+
+func TestAbbreviateFull(t *testing.T) {
+
+	// Test 1
+	in := "abcdefghijklmno"
+	out := "abcdefg..."
+	offset := -1
+	maxWidth := 10
+
+	if x, _ := AbbreviateFull(in, offset, maxWidth); x != out {
+		t.Errorf("AbbreviateFull(%v, %v, %v) = %v, want %v", in, offset, maxWidth, x, out)
+	}
+
+	// Test 2
+	out = "...fghi..."
+	offset = 5
+	maxWidth = 10
+
+	if x, _ := AbbreviateFull(in, offset, maxWidth); x != out {
+		t.Errorf("AbbreviateFull(%v, %v, %v) = %v, want %v", in, offset, maxWidth, x, out)
+	}
+
+	// Test 3
+	out = "...ijklmno"
+	offset = 12
+	maxWidth = 10
+
+	if x, _ := AbbreviateFull(in, offset, maxWidth); x != out {
+		t.Errorf("AbbreviateFull(%v, %v, %v) = %v, want %v", in, offset, maxWidth, x, out)
+	}
+}
+
+func TestIndexOf(t *testing.T) {
+
+	// Test 1
+	str := "abcafgka"
+	sub := "a"
+	start := 0
+	out := 0
+
+	if x := IndexOf(str, sub, start); x != out {
+		t.Errorf("IndexOf(%v, %v, %v) = %v, want %v", str, sub, start, x, out)
+	}
+
+	// Test 2
+	start = 1
+	out = 3
+
+	if x := IndexOf(str, sub, start); x != out {
+		t.Errorf("IndexOf(%v, %v, %v) = %v, want %v", str, sub, start, x, out)
+	}
+
+	// Test 3
+	start = 4
+	out = 7
+
+	if x := IndexOf(str, sub, start); x != out {
+		t.Errorf("IndexOf(%v, %v, %v) = %v, want %v", str, sub, start, x, out)
+	}
+
+	// Test 4
+	sub = "z"
+	out = -1
+
+	if x := IndexOf(str, sub, start); x != out {
+		t.Errorf("IndexOf(%v, %v, %v) = %v, want %v", str, sub, start, x, out)
+	}
+
+}
+
+func TestIsBlank(t *testing.T) {
+
+	// Test 1
+	str := ""
+	out := true
+
+	if x := IsBlank(str); x != out {
+		t.Errorf("IndexOf(%v) = %v, want %v", str, x, out)
+	}
+
+	// Test 2
+	str = "   "
+	out = true
+
+	if x := IsBlank(str); x != out {
+		t.Errorf("IndexOf(%v) = %v, want %v", str, x, out)
+	}
+
+	// Test 3
+	str = " abc "
+	out = false
+
+	if x := IsBlank(str); x != out {
+		t.Errorf("IndexOf(%v) = %v, want %v", str, x, out)
+	}
+}
+
+func TestDeleteWhiteSpace(t *testing.T) {
+
+	// Test 1
+	str := " a b c "
+	out := "abc"
+
+	if x := DeleteWhiteSpace(str); x != out {
+		t.Errorf("IndexOf(%v) = %v, want %v", str, x, out)
+	}
+
+	// Test 2
+	str = "    "
+	out = ""
+
+	if x := DeleteWhiteSpace(str); x != out {
+		t.Errorf("IndexOf(%v) = %v, want %v", str, x, out)
+	}
+}
+
+func TestIndexOfDifference(t *testing.T) {
+
+	str1 := "abc"
+	str2 := "a_c"
+	out := 1
+
+	if x := IndexOfDifference(str1, str2); x != out {
+		t.Errorf("IndexOfDifference(%v, %v) = %v, want %v", str1, str2, x, out)
+	}
+}
+
+// ****************************** EXAMPLES ********************************************
+
+func ExampleAbbreviate() {
+
+	str := "abcdefg"
+	out1, _ := Abbreviate(str, 6)
+	out2, _ := Abbreviate(str, 7)
+	out3, _ := Abbreviate(str, 8)
+	out4, _ := Abbreviate(str, 4)
+	_, err1 := Abbreviate(str, 3)
+
+	fmt.Println(out1)
+	fmt.Println(out2)
+	fmt.Println(out3)
+	fmt.Println(out4)
+	fmt.Println(err1)
+	// Output:
+	// abc...
+	// abcdefg
+	// abcdefg
+	// a...
+	// stringutils illegal argument: Minimum abbreviation width is 4
+}
+
+func ExampleAbbreviateFull() {
+
+	str := "abcdefghijklmno"
+	str2 := "abcdefghij"
+	out1, _ := AbbreviateFull(str, -1, 10)
+	out2, _ := AbbreviateFull(str, 0, 10)
+	out3, _ := AbbreviateFull(str, 1, 10)
+	out4, _ := AbbreviateFull(str, 4, 10)
+	out5, _ := AbbreviateFull(str, 5, 10)
+	out6, _ := AbbreviateFull(str, 6, 10)
+	out7, _ := AbbreviateFull(str, 8, 10)
+	out8, _ := AbbreviateFull(str, 10, 10)
+	out9, _ := AbbreviateFull(str, 12, 10)
+	_, err1 := AbbreviateFull(str2, 0, 3)
+	_, err2 := AbbreviateFull(str2, 5, 6)
+
+	fmt.Println(out1)
+	fmt.Println(out2)
+	fmt.Println(out3)
+	fmt.Println(out4)
+	fmt.Println(out5)
+	fmt.Println(out6)
+	fmt.Println(out7)
+	fmt.Println(out8)
+	fmt.Println(out9)
+	fmt.Println(err1)
+	fmt.Println(err2)
+	// Output:
+	// abcdefg...
+	// abcdefg...
+	// abcdefg...
+	// abcdefg...
+	// ...fghi...
+	// ...ghij...
+	// ...ijklmno
+	// ...ijklmno
+	// ...ijklmno
+	// stringutils illegal argument: Minimum abbreviation width is 4
+	// stringutils illegal argument: Minimum abbreviation width with offset is 7
+}
+
+func ExampleIsBlank() {
+
+	out1 := IsBlank("")
+	out2 := IsBlank(" ")
+	out3 := IsBlank("bob")
+	out4 := IsBlank("  bob  ")
+
+	fmt.Println(out1)
+	fmt.Println(out2)
+	fmt.Println(out3)
+	fmt.Println(out4)
+	// Output:
+	// true
+	// true
+	// false
+	// false
+}
+
+func ExampleDeleteWhiteSpace() {
+
+	out1 := DeleteWhiteSpace(" ")
+	out2 := DeleteWhiteSpace("bob")
+	out3 := DeleteWhiteSpace("bob   ")
+	out4 := DeleteWhiteSpace("  b  o    b  ")
+
+	fmt.Println(out1)
+	fmt.Println(out2)
+	fmt.Println(out3)
+	fmt.Println(out4)
+	// Output:
+	//
+	// bob
+	// bob
+	// bob
+}
+
+func ExampleIndexOf() {
+
+	str := "abcdefgehije"
+	out1 := IndexOf(str, "e", 0)
+	out2 := IndexOf(str, "e", 5)
+	out3 := IndexOf(str, "e", 8)
+	out4 := IndexOf(str, "eh", 0)
+	out5 := IndexOf(str, "eh", 22)
+	out6 := IndexOf(str, "z", 0)
+	out7 := IndexOf(str, "", 0)
+
+	fmt.Println(out1)
+	fmt.Println(out2)
+	fmt.Println(out3)
+	fmt.Println(out4)
+	fmt.Println(out5)
+	fmt.Println(out6)
+	fmt.Println(out7)
+	// Output:
+	// 4
+	// 7
+	// 11
+	// 7
+	// -1
+	// -1
+	// -1
+}
+
+func ExampleIndexOfDifference() {
+
+	out1 := IndexOfDifference("abc", "abc")
+	out2 := IndexOfDifference("ab", "abxyz")
+	out3 := IndexOfDifference("", "abc")
+	out4 := IndexOfDifference("abcde", "abxyz")
+
+	fmt.Println(out1)
+	fmt.Println(out2)
+	fmt.Println(out3)
+	fmt.Println(out4)
+	// Output:
+	// -1
+	// 2
+	// 0
+	// 2
+}

--- a/vendor/github.com/aokoli/goutils/wordutils.go
+++ b/vendor/github.com/aokoli/goutils/wordutils.go
@@ -1,0 +1,356 @@
+/*
+Copyright 2014 Alexander Okoli
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package goutils provides utility functions to manipulate strings in various ways.
+The code snippets below show examples of how to use goutils. Some functions return
+errors while others do not, so usage would vary as a result.
+
+Example:
+
+    package main
+
+    import (
+        "fmt"
+        "github.com/aokoli/goutils"
+    )
+
+    func main() {
+
+        // EXAMPLE 1: A goutils function which returns no errors
+        fmt.Println (goutils.Initials("John Doe Foo")) // Prints out "JDF"
+
+
+
+        // EXAMPLE 2: A goutils function which returns an error
+        rand1, err1 := goutils.Random (-1, 0, 0, true, true)
+
+        if err1 != nil {
+            fmt.Println(err1) // Prints out error message because -1 was entered as the first parameter in goutils.Random(...)
+        } else {
+            fmt.Println(rand1)
+        }
+    }
+*/
+package goutils
+
+import (
+	"bytes"
+	"strings"
+	"unicode"
+)
+
+// VERSION indicates the current version of goutils
+const VERSION = "1.0.0"
+
+/*
+Wrap wraps a single line of text, identifying words by ' '.
+New lines will be separated by '\n'. Very long words, such as URLs will not be wrapped.
+Leading spaces on a new line are stripped. Trailing spaces are not stripped.
+
+Parameters:
+    str - the string to be word wrapped
+    wrapLength - the column (a column can fit only one character) to wrap the words at, less than 1 is treated as 1
+
+Returns:
+    a line with newlines inserted
+*/
+func Wrap(str string, wrapLength int) string {
+	return WrapCustom(str, wrapLength, "", false)
+}
+
+/*
+WrapCustom wraps a single line of text, identifying words by ' '.
+Leading spaces on a new line are stripped. Trailing spaces are not stripped.
+
+Parameters:
+    str - the string to be word wrapped
+    wrapLength - the column number (a column can fit only one character) to wrap the words at, less than 1 is treated as 1
+    newLineStr - the string to insert for a new line, "" uses '\n'
+    wrapLongWords - true if long words (such as URLs) should be wrapped
+
+Returns:
+    a line with newlines inserted
+*/
+func WrapCustom(str string, wrapLength int, newLineStr string, wrapLongWords bool) string {
+
+	if str == "" {
+		return ""
+	}
+	if newLineStr == "" {
+		newLineStr = "\n" // TODO Assumes "\n" is seperator. Explore SystemUtils.LINE_SEPARATOR from Apache Commons
+	}
+	if wrapLength < 1 {
+		wrapLength = 1
+	}
+
+	inputLineLength := len(str)
+	offset := 0
+
+	var wrappedLine bytes.Buffer
+
+	for inputLineLength-offset > wrapLength {
+
+		if rune(str[offset]) == ' ' {
+			offset++
+			continue
+		}
+
+		end := wrapLength + offset + 1
+		spaceToWrapAt := strings.LastIndex(str[offset:end], " ") + offset
+
+		if spaceToWrapAt >= offset {
+			// normal word (not longer than wrapLength)
+			wrappedLine.WriteString(str[offset:spaceToWrapAt])
+			wrappedLine.WriteString(newLineStr)
+			offset = spaceToWrapAt + 1
+
+		} else {
+			// long word or URL
+			if wrapLongWords {
+				end := wrapLength + offset
+				// long words are wrapped one line at a time
+				wrappedLine.WriteString(str[offset:end])
+				wrappedLine.WriteString(newLineStr)
+				offset += wrapLength
+			} else {
+				// long words aren't wrapped, just extended beyond limit
+				end := wrapLength + offset
+				spaceToWrapAt = strings.IndexRune(str[end:len(str)], ' ') + end
+				if spaceToWrapAt >= 0 {
+					wrappedLine.WriteString(str[offset:spaceToWrapAt])
+					wrappedLine.WriteString(newLineStr)
+					offset = spaceToWrapAt + 1
+				} else {
+					wrappedLine.WriteString(str[offset:len(str)])
+					offset = inputLineLength
+				}
+			}
+		}
+	}
+
+	wrappedLine.WriteString(str[offset:len(str)])
+
+	return wrappedLine.String()
+
+}
+
+/*
+Capitalize capitalizes all the delimiter separated words in a string. Only the first letter of each word is changed.
+To convert the rest of each word to lowercase at the same time, use CapitalizeFully(str string, delimiters ...rune).
+The delimiters represent a set of characters understood to separate words. The first string character
+and the first non-delimiter character after a delimiter will be capitalized. A "" input string returns "".
+Capitalization uses the Unicode title case, normally equivalent to upper case.
+
+Parameters:
+    str - the string to capitalize
+    delimiters - set of characters to determine capitalization, exclusion of this parameter means whitespace would be delimeter
+
+Returns:
+    capitalized string
+*/
+func Capitalize(str string, delimiters ...rune) string {
+
+	var delimLen int
+
+	if delimiters == nil {
+		delimLen = -1
+	} else {
+		delimLen = len(delimiters)
+	}
+
+	if str == "" || delimLen == 0 {
+		return str
+	}
+
+	buffer := []rune(str)
+	capitalizeNext := true
+	for i := 0; i < len(buffer); i++ {
+		ch := buffer[i]
+		if isDelimiter(ch, delimiters...) {
+			capitalizeNext = true
+		} else if capitalizeNext {
+			buffer[i] = unicode.ToTitle(ch)
+			capitalizeNext = false
+		}
+	}
+	return string(buffer)
+
+}
+
+/*
+CapitalizeFully converts all the delimiter separated words in a string into capitalized words, that is each word is made up of a
+titlecase character and then a series of lowercase characters. The delimiters represent a set of characters understood
+to separate words. The first string character and the first non-delimiter character after a delimiter will be capitalized.
+Capitalization uses the Unicode title case, normally equivalent to upper case.
+
+Parameters:
+    str - the string to capitalize fully
+    delimiters - set of characters to determine capitalization, exclusion of this parameter means whitespace would be delimeter
+
+Returns:
+    capitalized string
+*/
+func CapitalizeFully(str string, delimiters ...rune) string {
+
+	var delimLen int
+
+	if delimiters == nil {
+		delimLen = -1
+	} else {
+		delimLen = len(delimiters)
+	}
+
+	if str == "" || delimLen == 0 {
+		return str
+	}
+	str = strings.ToLower(str)
+	return Capitalize(str, delimiters...)
+}
+
+/*
+Uncapitalize uncapitalizes all the whitespace separated words in a string. Only the first letter of each word is changed.
+The delimiters represent a set of characters understood to separate words. The first string character and the first non-delimiter
+character after a delimiter will be uncapitalized. Whitespace is defined by unicode.IsSpace(char).
+
+Parameters:
+    str - the string to uncapitalize fully
+    delimiters - set of characters to determine capitalization, exclusion of this parameter means whitespace would be delimeter
+
+Returns:
+    uncapitalized string
+*/
+func Uncapitalize(str string, delimiters ...rune) string {
+
+	var delimLen int
+
+	if delimiters == nil {
+		delimLen = -1
+	} else {
+		delimLen = len(delimiters)
+	}
+
+	if str == "" || delimLen == 0 {
+		return str
+	}
+
+	buffer := []rune(str)
+	uncapitalizeNext := true // TODO Always makes capitalize/un apply to first char.
+	for i := 0; i < len(buffer); i++ {
+		ch := buffer[i]
+		if isDelimiter(ch, delimiters...) {
+			uncapitalizeNext = true
+		} else if uncapitalizeNext {
+			buffer[i] = unicode.ToLower(ch)
+			uncapitalizeNext = false
+		}
+	}
+	return string(buffer)
+}
+
+/*
+SwapCase swaps the case of a string using a word based algorithm.
+
+Conversion algorithm:
+
+    Upper case character converts to Lower case
+    Title case character converts to Lower case
+    Lower case character after Whitespace or at start converts to Title case
+    Other Lower case character converts to Upper case
+    Whitespace is defined by unicode.IsSpace(char).
+
+Parameters:
+    str - the string to swap case
+
+Returns:
+    the changed string
+*/
+func SwapCase(str string) string {
+	if str == "" {
+		return str
+	}
+	buffer := []rune(str)
+
+	whitespace := true
+
+	for i := 0; i < len(buffer); i++ {
+		ch := buffer[i]
+		if unicode.IsUpper(ch) {
+			buffer[i] = unicode.ToLower(ch)
+			whitespace = false
+		} else if unicode.IsTitle(ch) {
+			buffer[i] = unicode.ToLower(ch)
+			whitespace = false
+		} else if unicode.IsLower(ch) {
+			if whitespace {
+				buffer[i] = unicode.ToTitle(ch)
+				whitespace = false
+			} else {
+				buffer[i] = unicode.ToUpper(ch)
+			}
+		} else {
+			whitespace = unicode.IsSpace(ch)
+		}
+	}
+	return string(buffer)
+}
+
+/*
+Initials extracts the initial letters from each word in the string. The first letter of the string and all first
+letters after the defined delimiters are returned as a new string. Their case is not changed. If the delimiters
+parameter is excluded, then Whitespace is used. Whitespace is defined by unicode.IsSpacea(char). An empty delimiter array returns an empty string.
+
+Parameters:
+    str - the string to get initials from
+    delimiters - set of characters to determine words, exclusion of this parameter means whitespace would be delimeter
+Returns:
+    string of initial letters
+*/
+func Initials(str string, delimiters ...rune) string {
+	if str == "" {
+		return str
+	}
+	if delimiters != nil && len(delimiters) == 0 {
+		return ""
+	}
+	strLen := len(str)
+	var buf bytes.Buffer
+	lastWasGap := true
+	for i := 0; i < strLen; i++ {
+		ch := rune(str[i])
+
+		if isDelimiter(ch, delimiters...) {
+			lastWasGap = true
+		} else if lastWasGap {
+			buf.WriteRune(ch)
+			lastWasGap = false
+		}
+	}
+	return buf.String()
+}
+
+// private function (lower case func name)
+func isDelimiter(ch rune, delimiters ...rune) bool {
+	if delimiters == nil {
+		return unicode.IsSpace(ch)
+	}
+	for _, delimiter := range delimiters {
+		if ch == delimiter {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/aokoli/goutils/wordutils_test.go
+++ b/vendor/github.com/aokoli/goutils/wordutils_test.go
@@ -1,0 +1,225 @@
+package goutils
+
+import (
+	"fmt"
+	"testing"
+)
+
+// ****************************** TESTS ********************************************
+
+func TestWrapNormalWord(t *testing.T) {
+
+	in := "Bob Manuel Bob Manuel"
+	out := "Bob Manuel\nBob Manuel"
+	wrapLength := 10
+
+	if x := Wrap(in, wrapLength); x != out {
+		t.Errorf("Wrap(%v) = %v, want %v", in, x, out)
+	}
+}
+
+func TestWrapCustomLongWordFalse(t *testing.T) {
+
+	in := "BobManuelBob Bob"
+	out := "BobManuelBob<br\\>Bob"
+	wrapLength := 10
+	newLineStr := "<br\\>"
+	wrapLongWords := false
+
+	if x := WrapCustom(in, wrapLength, newLineStr, wrapLongWords); x != out {
+		t.Errorf("Wrap(%v) = %v, want %v", in, x, out)
+	}
+}
+
+func TestWrapCustomLongWordTrue(t *testing.T) {
+
+	in := "BobManuelBob Bob"
+	out := "BobManuelB<br\\>ob Bob"
+	wrapLength := 10
+	newLineStr := "<br\\>"
+	wrapLongWords := true
+
+	if x := WrapCustom(in, wrapLength, newLineStr, wrapLongWords); x != out {
+		t.Errorf("WrapCustom(%v) = %v, want %v", in, x, out)
+	}
+}
+
+func TestCapitalize(t *testing.T) {
+
+	// Test 1: Checks if function works with 1 parameter, and default whitespace delimiter
+	in := "test is going.well.thank.you.for inquiring"
+	out := "Test Is Going.well.thank.you.for Inquiring"
+
+	if x := Capitalize(in); x != out {
+		t.Errorf("Capitalize(%v) = %v, want %v", in, x, out)
+	}
+
+	// Test 2: Checks if function works with both parameters, with param 2 containing whitespace and '.'
+	out = "Test Is Going.Well.Thank.You.For Inquiring"
+	delimiters := []rune{' ', '.'}
+
+	if x := Capitalize(in, delimiters...); x != out {
+		t.Errorf("Capitalize(%v) = %v, want %v", in, x, out)
+	}
+}
+
+func TestCapitalizeFully(t *testing.T) {
+
+	// Test 1
+	in := "tEsT iS goiNG.wELL.tHaNk.yOU.for inqUIrING"
+	out := "Test Is Going.well.thank.you.for Inquiring"
+
+	if x := CapitalizeFully(in); x != out {
+		t.Errorf("CapitalizeFully(%v) = %v, want %v", in, x, out)
+	}
+
+	// Test 2
+	out = "Test Is Going.Well.Thank.You.For Inquiring"
+	delimiters := []rune{' ', '.'}
+
+	if x := CapitalizeFully(in, delimiters...); x != out {
+		t.Errorf("CapitalizeFully(%v) = %v, want %v", in, x, out)
+	}
+}
+
+func TestUncapitalize(t *testing.T) {
+
+	// Test 1: Checks if function works with 1 parameter, and default whitespace delimiter
+	in := "This Is A.Test"
+	out := "this is a.Test"
+
+	if x := Uncapitalize(in); x != out {
+		t.Errorf("Uncapitalize(%v) = %v, want %v", in, x, out)
+	}
+
+	// Test 2: Checks if function works with both parameters, with param 2 containing whitespace and '.'
+	out = "this is a.test"
+	delimiters := []rune{' ', '.'}
+
+	if x := Uncapitalize(in, delimiters...); x != out {
+		t.Errorf("Uncapitalize(%v) = %v, want %v", in, x, out)
+	}
+}
+
+func TestSwapCase(t *testing.T) {
+
+	in := "This Is A.Test"
+	out := "tHIS iS a.tEST"
+
+	if x := SwapCase(in); x != out {
+		t.Errorf("SwapCase(%v) = %v, want %v", in, x, out)
+	}
+}
+
+func TestInitials(t *testing.T) {
+
+	// Test 1
+	in := "John Doe.Ray"
+	out := "JD"
+
+	if x := Initials(in); x != out {
+		t.Errorf("Initials(%v) = %v, want %v", in, x, out)
+	}
+
+	// Test 2
+	out = "JDR"
+	delimiters := []rune{' ', '.'}
+
+	if x := Initials(in, delimiters...); x != out {
+		t.Errorf("Initials(%v) = %v, want %v", in, x, out)
+	}
+
+}
+
+// ****************************** EXAMPLES ********************************************
+
+func ExampleWrap() {
+
+	in := "Bob Manuel Bob Manuel"
+	wrapLength := 10
+
+	fmt.Println(Wrap(in, wrapLength))
+	// Output:
+	// Bob Manuel
+	// Bob Manuel
+}
+
+func ExampleWrapCustom_1() {
+
+	in := "BobManuelBob Bob"
+	wrapLength := 10
+	newLineStr := "<br\\>"
+	wrapLongWords := false
+
+	fmt.Println(WrapCustom(in, wrapLength, newLineStr, wrapLongWords))
+	// Output:
+	// BobManuelBob<br\>Bob
+}
+
+func ExampleWrapCustom_2() {
+
+	in := "BobManuelBob Bob"
+	wrapLength := 10
+	newLineStr := "<br\\>"
+	wrapLongWords := true
+
+	fmt.Println(WrapCustom(in, wrapLength, newLineStr, wrapLongWords))
+	// Output:
+	// BobManuelB<br\>ob Bob
+}
+
+func ExampleCapitalize() {
+
+	in := "test is going.well.thank.you.for inquiring" // Compare input to CapitalizeFully example
+	delimiters := []rune{' ', '.'}
+
+	fmt.Println(Capitalize(in))
+	fmt.Println(Capitalize(in, delimiters...))
+	// Output:
+	// Test Is Going.well.thank.you.for Inquiring
+	// Test Is Going.Well.Thank.You.For Inquiring
+}
+
+func ExampleCapitalizeFully() {
+
+	in := "tEsT iS goiNG.wELL.tHaNk.yOU.for inqUIrING" // Notice scattered capitalization
+	delimiters := []rune{' ', '.'}
+
+	fmt.Println(CapitalizeFully(in))
+	fmt.Println(CapitalizeFully(in, delimiters...))
+	// Output:
+	// Test Is Going.well.thank.you.for Inquiring
+	// Test Is Going.Well.Thank.You.For Inquiring
+}
+
+func ExampleUncapitalize() {
+
+	in := "This Is A.Test"
+	delimiters := []rune{' ', '.'}
+
+	fmt.Println(Uncapitalize(in))
+	fmt.Println(Uncapitalize(in, delimiters...))
+	// Output:
+	// this is a.Test
+	// this is a.test
+}
+
+func ExampleSwapCase() {
+
+	in := "This Is A.Test"
+	fmt.Println(SwapCase(in))
+	// Output:
+	// tHIS iS a.tEST
+}
+
+func ExampleInitials() {
+
+	in := "John Doe.Ray"
+	delimiters := []rune{' ', '.'}
+
+	fmt.Println(Initials(in))
+	fmt.Println(Initials(in, delimiters...))
+	// Output:
+	// JD
+	// JDR
+}

--- a/vendor/github.com/huandu/xstrings/.gitignore
+++ b/vendor/github.com/huandu/xstrings/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/huandu/xstrings/.travis.yml
+++ b/vendor/github.com/huandu/xstrings/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/vendor/github.com/huandu/xstrings/CONTRIBUTING.md
+++ b/vendor/github.com/huandu/xstrings/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing #
+
+Thanks for your contribution in advance. No matter what you will contribute to this project, pull request or bug report or feature discussion, it's always highly appreciated.
+
+## New API or feature ##
+
+I want to speak more about how to add new functions to this package.
+
+Package `xstring` is a collection of useful string functions which should be implemented in Go. It's a bit subject to say which function should be included and which should not. I set up following rules in order to make it clear and as objective as possible.
+
+* Rule 1: Only string algorithm, which takes string as input, can be included.
+* Rule 2: If a function has been implemented in package `string`, it must not be included.
+* Rule 3: If a function is not language neutral, it must not be included.
+* Rule 4: If a function is a part of standard library in other languages, it can be included.
+* Rule 5: If a function is quite useful in some famous framework or library, it can be included.
+
+New function must be discussed in project issues before submitting any code. If a pull request with new functions is sent without any ref issue, it will be rejected.
+
+## Pull request ##
+
+Pull request is always welcome. Just make sure you have run `go fmt` and all test cases passed before submit.
+
+If the pull request is to add a new API or feature, don't forget to update README.md and add new API in function list.

--- a/vendor/github.com/huandu/xstrings/LICENSE
+++ b/vendor/github.com/huandu/xstrings/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Huan Du
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/huandu/xstrings/README.md
+++ b/vendor/github.com/huandu/xstrings/README.md
@@ -1,0 +1,114 @@
+# xstrings #
+
+[![Build Status](https://travis-ci.org/huandu/xstrings.png?branch=master)](https://travis-ci.org/huandu/xstrings)
+[![GoDoc](https://godoc.org/github.com/huandu/xstrings?status.svg)](https://godoc.org/github.com/huandu/xstrings)
+
+Go package [xstrings](https://godoc.org/github.com/huandu/xstrings) is a collection of string functions, which are widely used in other languages but absent in Go package [strings](http://golang.org/pkg/strings).
+
+All functions are well tested and carefully tuned for performance.
+
+## Propose a new function ##
+
+Please review [contributing guideline](CONTRIBUTING.md) and [create new issue](https://github.com/huandu/xstrings/issues) to state why it should be included.
+
+## Install ##
+
+Use `go get` to install this library.
+
+	go get github.com/huandu/xstrings
+
+## API document ##
+
+See [GoDoc](https://godoc.org/github.com/huandu/xstrings) for full document.
+
+## Function list ##
+
+Go functions have a unique naming style. One, who has experience in other language but new in Go, may have difficulties to find out right string function to use.
+
+Here is a list of functions in [strings](http://golang.org/pkg/strings) and [xstrings](https://godoc.org/github.com/huandu/xstrings) with enough extra information about how to map these functions to their friends in other languages. Hope this list could be helpful for fresh gophers.
+
+### Package `xstrings` functions ###
+
+*Keep this table sorted by Function in ascending order.*
+
+| Function | Friends | # |
+| -------- | ------- | --- |
+| [Center](https://godoc.org/github.com/huandu/xstrings#Center) | `str.center` in Python; `String#center` in Ruby | [#30](https://github.com/huandu/xstrings/issues/30) |
+| [Count](https://godoc.org/github.com/huandu/xstrings#Count) | `String#count` in Ruby | [#16](https://github.com/huandu/xstrings/issues/16) |
+| [Delete](https://godoc.org/github.com/huandu/xstrings#Delete) | `String#delete` in Ruby | [#17](https://github.com/huandu/xstrings/issues/17) |
+| [ExpandTabs](https://godoc.org/github.com/huandu/xstrings#ExpandTabs) | `str.expandtabs` in Python | [#27](https://github.com/huandu/xstrings/issues/27) |
+| [FirstRuneToLower](https://godoc.org/github.com/huandu/xstrings#FirstRuneToLower) | `lcfirst` in PHP or Perl | [#15](https://github.com/huandu/xstrings/issues/15) |
+| [FirstRuneToUpper](https://godoc.org/github.com/huandu/xstrings#FirstRuneToUpper) | `String#capitalize` in Ruby; `ucfirst` in PHP or Perl | [#15](https://github.com/huandu/xstrings/issues/15) |
+| [Insert](https://godoc.org/github.com/huandu/xstrings#Insert) | `String#insert` in Ruby | [#18](https://github.com/huandu/xstrings/issues/18) |
+| [LastPartition](https://godoc.org/github.com/huandu/xstrings#LastPartition) | `str.rpartition` in Python; `String#rpartition` in Ruby | [#19](https://github.com/huandu/xstrings/issues/19) |
+| [LeftJustify](https://godoc.org/github.com/huandu/xstrings#LeftJustify) | `str.ljust` in Python; `String#ljust` in Ruby | [#28](https://github.com/huandu/xstrings/issues/28) |
+| [Len](https://godoc.org/github.com/huandu/xstrings#Len) | `mb_strlen` in PHP | [#23](https://github.com/huandu/xstrings/issues/23) |
+| [Partition](https://godoc.org/github.com/huandu/xstrings#Partition) | `str.partition` in Python; `String#partition` in Ruby | [#10](https://github.com/huandu/xstrings/issues/10) |
+| [Reverse](https://godoc.org/github.com/huandu/xstrings#Reverse) | `String#reverse` in Ruby; `strrev` in PHP; `reverse` in Perl | [#7](https://github.com/huandu/xstrings/issues/7) |
+| [RightJustify](https://godoc.org/github.com/huandu/xstrings#RightJustify) | `str.rjust` in Python; `String#rjust` in Ruby | [#29](https://github.com/huandu/xstrings/issues/29) |
+| [RuneWidth](https://godoc.org/github.com/huandu/xstrings#RuneWidth) | - | [#27](https://github.com/huandu/xstrings/issues/27) |
+| [Scrub](https://godoc.org/github.com/huandu/xstrings#Scrub) | `String#scrub` in Ruby | [#20](https://github.com/huandu/xstrings/issues/20) |
+| [Shuffle](https://godoc.org/github.com/huandu/xstrings#Shuffle) | `str_shuffle` in PHP | [#13](https://github.com/huandu/xstrings/issues/13) |
+| [ShuffleSource](https://godoc.org/github.com/huandu/xstrings#ShuffleSource) | `str_shuffle` in PHP | [#13](https://github.com/huandu/xstrings/issues/13) |
+| [Slice](https://godoc.org/github.com/huandu/xstrings#Slice) | `mb_substr` in PHP | [#9](https://github.com/huandu/xstrings/issues/9) |
+| [Squeeze](https://godoc.org/github.com/huandu/xstrings#Squeeze) | `String#squeeze` in Ruby | [#11](https://github.com/huandu/xstrings/issues/11) |
+| [Successor](https://godoc.org/github.com/huandu/xstrings#Successor) | `String#succ` or `String#next` in Ruby | [#22](https://github.com/huandu/xstrings/issues/22) |
+| [SwapCase](https://godoc.org/github.com/huandu/xstrings#SwapCase) | `str.swapcase` in Python; `String#swapcase` in Ruby | [#12](https://github.com/huandu/xstrings/issues/12) |
+| [ToCamelCase](https://godoc.org/github.com/huandu/xstrings#ToCamelCase) | `String#camelize` in RoR | [#1](https://github.com/huandu/xstrings/issues/1) |
+| [ToSnakeCase](https://godoc.org/github.com/huandu/xstrings#ToSnakeCase) | `String#underscore` in RoR | [#1](https://github.com/huandu/xstrings/issues/1) |
+| [Translate](https://godoc.org/github.com/huandu/xstrings#Translate) | `str.translate` in Python; `String#tr` in Ruby; `strtr` in PHP; `tr///` in Perl | [#21](https://github.com/huandu/xstrings/issues/21) |
+| [Width](https://godoc.org/github.com/huandu/xstrings#Width) | `mb_strwidth` in PHP | [#26](https://github.com/huandu/xstrings/issues/26) |
+| [WordCount](https://godoc.org/github.com/huandu/xstrings#WordCount) | `str_word_count` in PHP | [#14](https://github.com/huandu/xstrings/issues/14) |
+| [WordSplit](https://godoc.org/github.com/huandu/xstrings#WordSplit) | - | [#14](https://github.com/huandu/xstrings/issues/14) |
+
+### Package `strings` functions ###
+
+*Keep this table sorted by Function in ascending order.*
+
+| Function | Friends |
+| -------- | ------- |
+| [Contains](http://golang.org/pkg/strings/#Contains) | `String#include?` in Ruby |
+| [ContainsAny](http://golang.org/pkg/strings/#ContainsAny) | - |
+| [ContainsRune](http://golang.org/pkg/strings/#ContainsRune) | - |
+| [Count](http://golang.org/pkg/strings/#Count) | `str.count` in Python; `substr_count` in PHP |
+| [EqualFold](http://golang.org/pkg/strings/#EqualFold) | `stricmp` in PHP; `String#casecmp` in Ruby |
+| [Fields](http://golang.org/pkg/strings/#Fields) | `str.split` in Python; `split` in Perl; `String#split` in Ruby |
+| [FieldsFunc](http://golang.org/pkg/strings/#FieldsFunc) | - |
+| [HasPrefix](http://golang.org/pkg/strings/#HasPrefix) | `str.startswith` in Python; `String#start_with?` in Ruby |
+| [HasSuffix](http://golang.org/pkg/strings/#HasSuffix) | `str.endswith` in Python; `String#end_with?` in Ruby |
+| [Index](http://golang.org/pkg/strings/#Index) | `str.index` in Python; `String#index` in Ruby; `strpos` in PHP; `index` in Perl |
+| [IndexAny](http://golang.org/pkg/strings/#IndexAny) | - |
+| [IndexByte](http://golang.org/pkg/strings/#IndexByte) | - |
+| [IndexFunc](http://golang.org/pkg/strings/#IndexFunc) | - |
+| [IndexRune](http://golang.org/pkg/strings/#IndexRune) | - |
+| [Join](http://golang.org/pkg/strings/#Join) | `str.join` in Python; `Array#join` in Ruby; `implode` in PHP; `join` in Perl |
+| [LastIndex](http://golang.org/pkg/strings/#LastIndex) | `str.rindex` in Python; `String#rindex`; `strrpos` in PHP; `rindex` in Perl |
+| [LastIndexAny](http://golang.org/pkg/strings/#LastIndexAny) | - |
+| [LastIndexFunc](http://golang.org/pkg/strings/#LastIndexFunc) | - |
+| [Map](http://golang.org/pkg/strings/#Map) | `String#each_codepoint` in Ruby |
+| [Repeat](http://golang.org/pkg/strings/#Repeat) | operator `*` in Python and Ruby; `str_repeat` in PHP |
+| [Replace](http://golang.org/pkg/strings/#Replace) | `str.replace` in Python; `String#sub` in Ruby; `str_replace` in PHP |
+| [Split](http://golang.org/pkg/strings/#Split) | `str.split` in Python; `String#split` in Ruby; `explode` in PHP; `split` in Perl |
+| [SplitAfter](http://golang.org/pkg/strings/#SplitAfter) | - |
+| [SplitAfterN](http://golang.org/pkg/strings/#SplitAfterN) | - |
+| [SplitN](http://golang.org/pkg/strings/#SplitN) | `str.split` in Python; `String#split` in Ruby; `explode` in PHP; `split` in Perl |
+| [Title](http://golang.org/pkg/strings/#Title) | `str.title` in Python |
+| [ToLower](http://golang.org/pkg/strings/#ToLower) | `str.lower` in Python; `String#downcase` in Ruby; `strtolower` in PHP; `lc` in Perl |
+| [ToLowerSpecial](http://golang.org/pkg/strings/#ToLowerSpecial) | - |
+| [ToTitle](http://golang.org/pkg/strings/#ToTitle) | - |
+| [ToTitleSpecial](http://golang.org/pkg/strings/#ToTitleSpecial) | - |
+| [ToUpper](http://golang.org/pkg/strings/#ToUpper) | `str.upper` in Python; `String#upcase` in Ruby; `strtoupper` in PHP; `uc` in Perl |
+| [ToUpperSpecial](http://golang.org/pkg/strings/#ToUpperSpecial) | - |
+| [Trim](http://golang.org/pkg/strings/#Trim) | `str.strip` in Python; `String#strip` in Ruby; `trim` in PHP |
+| [TrimFunc](http://golang.org/pkg/strings/#TrimFunc) | - |
+| [TrimLeft](http://golang.org/pkg/strings/#TrimLeft) | `str.lstrip` in Python; `String#lstrip` in Ruby; `ltrim` in PHP |
+| [TrimLeftFunc](http://golang.org/pkg/strings/#TrimLeftFunc) | - |
+| [TrimPrefix](http://golang.org/pkg/strings/#TrimPrefix) | - |
+| [TrimRight](http://golang.org/pkg/strings/#TrimRight) | `str.rstrip` in Python; `String#rstrip` in Ruby; `rtrim` in PHP |
+| [TrimRightFunc](http://golang.org/pkg/strings/#TrimRightFunc) | - |
+| [TrimSpace](http://golang.org/pkg/strings/#TrimSpace) | `str.strip` in Python; `String#strip` in Ruby; `trim` in PHP |
+| [TrimSuffix](http://golang.org/pkg/strings/#TrimSuffix) | `String#chomp` in Ruby; `chomp` in Perl |
+
+## License ##
+
+This library is licensed under MIT license. See LICENSE for details.

--- a/vendor/github.com/huandu/xstrings/common.go
+++ b/vendor/github.com/huandu/xstrings/common.go
@@ -1,0 +1,25 @@
+// Copyright 2015 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package xstrings
+
+import (
+	"bytes"
+)
+
+const _BUFFER_INIT_GROW_SIZE_MAX = 2048
+
+// Lazy initialize a buffer.
+func allocBuffer(orig, cur string) *bytes.Buffer {
+	output := &bytes.Buffer{}
+	maxSize := len(orig) * 4
+
+	// Avoid to reserve too much memory at once.
+	if maxSize > _BUFFER_INIT_GROW_SIZE_MAX {
+		maxSize = _BUFFER_INIT_GROW_SIZE_MAX
+	}
+
+	output.Grow(maxSize)
+	output.WriteString(orig[:len(orig)-len(cur)])
+	return output
+}

--- a/vendor/github.com/huandu/xstrings/convert.go
+++ b/vendor/github.com/huandu/xstrings/convert.go
@@ -1,0 +1,357 @@
+// Copyright 2015 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package xstrings
+
+import (
+	"bytes"
+	"math/rand"
+	"unicode"
+	"unicode/utf8"
+)
+
+// ToCamelCase can convert all lower case characters behind underscores
+// to upper case character.
+// Underscore character will be removed in result except following cases.
+//     * More than 1 underscore.
+//           "a__b" => "A_B"
+//     * At the beginning of string.
+//           "_a" => "_A"
+//     * At the end of string.
+//           "ab_" => "Ab_"
+func ToCamelCase(str string) string {
+	if len(str) == 0 {
+		return ""
+	}
+
+	buf := &bytes.Buffer{}
+	var r0, r1 rune
+	var size int
+
+	// leading '_' will appear in output.
+	for len(str) > 0 {
+		r0, size = utf8.DecodeRuneInString(str)
+		str = str[size:]
+
+		if r0 != '_' {
+			break
+		}
+
+		buf.WriteRune(r0)
+	}
+
+	if len(str) == 0 {
+		return buf.String()
+	}
+
+	buf.WriteRune(unicode.ToUpper(r0))
+	r0, size = utf8.DecodeRuneInString(str)
+	str = str[size:]
+
+	for len(str) > 0 {
+		r1 = r0
+		r0, size = utf8.DecodeRuneInString(str)
+		str = str[size:]
+
+		if r1 == '_' && r0 != '_' {
+			r0 = unicode.ToUpper(r0)
+		} else {
+			buf.WriteRune(r1)
+		}
+	}
+
+	buf.WriteRune(r0)
+	return buf.String()
+}
+
+// ToSnakeCase can convert all upper case characters in a string to
+// underscore format.
+//
+// Some samples.
+//     "FirstName"  => "first_name"
+//     "HTTPServer" => "http_server"
+//     "NoHTTPS"    => "no_https"
+//     "GO_PATH"    => "go_path"
+//     "GO PATH"    => "go_path"      // space is converted to underscore.
+//     "GO-PATH"    => "go_path"      // hyphen is converted to underscore.
+func ToSnakeCase(str string) string {
+	if len(str) == 0 {
+		return ""
+	}
+
+	buf := &bytes.Buffer{}
+	var prev, r0, r1 rune
+	var size int
+
+	r0 = '_'
+
+	for len(str) > 0 {
+		prev = r0
+		r0, size = utf8.DecodeRuneInString(str)
+		str = str[size:]
+
+		switch {
+		case r0 == utf8.RuneError:
+			buf.WriteByte(byte(str[0]))
+
+		case unicode.IsUpper(r0):
+			if prev != '_' {
+				buf.WriteRune('_')
+			}
+
+			buf.WriteRune(unicode.ToLower(r0))
+
+			if len(str) == 0 {
+				break
+			}
+
+			r0, size = utf8.DecodeRuneInString(str)
+			str = str[size:]
+
+			if !unicode.IsUpper(r0) {
+				buf.WriteRune(r0)
+				break
+			}
+
+			// find next non-upper-case character and insert `_` properly.
+			// it's designed to convert `HTTPServer` to `http_server`.
+			// if there are more than 2 adjacent upper case characters in a word,
+			// treat them as an abbreviation plus a normal word.
+			for len(str) > 0 {
+				r1 = r0
+				r0, size = utf8.DecodeRuneInString(str)
+				str = str[size:]
+
+				if r0 == utf8.RuneError {
+					buf.WriteRune(unicode.ToLower(r1))
+					buf.WriteByte(byte(str[0]))
+					break
+				}
+
+				if !unicode.IsUpper(r0) {
+					if r0 == '_' || r0 == ' ' || r0 == '-' {
+						r0 = '_'
+
+						buf.WriteRune(unicode.ToLower(r1))
+					} else {
+						buf.WriteRune('_')
+						buf.WriteRune(unicode.ToLower(r1))
+						buf.WriteRune(r0)
+					}
+
+					break
+				}
+
+				buf.WriteRune(unicode.ToLower(r1))
+			}
+
+			if len(str) == 0 || r0 == '_' {
+				buf.WriteRune(unicode.ToLower(r0))
+				break
+			}
+
+		default:
+			if r0 == ' ' || r0 == '-' {
+				r0 = '_'
+			}
+
+			buf.WriteRune(r0)
+		}
+	}
+
+	return buf.String()
+}
+
+// SwapCase will swap characters case from upper to lower or lower to upper.
+func SwapCase(str string) string {
+	var r rune
+	var size int
+
+	buf := &bytes.Buffer{}
+
+	for len(str) > 0 {
+		r, size = utf8.DecodeRuneInString(str)
+
+		switch {
+		case unicode.IsUpper(r):
+			buf.WriteRune(unicode.ToLower(r))
+
+		case unicode.IsLower(r):
+			buf.WriteRune(unicode.ToUpper(r))
+
+		default:
+			buf.WriteRune(r)
+		}
+
+		str = str[size:]
+	}
+
+	return buf.String()
+}
+
+// FirstRuneToUpper converts first rune to upper case if necessary.
+func FirstRuneToUpper(str string) string {
+	if str == "" {
+		return str
+	}
+
+	r, size := utf8.DecodeRuneInString(str)
+
+	if !unicode.IsLower(r) {
+		return str
+	}
+
+	buf := &bytes.Buffer{}
+	buf.WriteRune(unicode.ToUpper(r))
+	buf.WriteString(str[size:])
+	return buf.String()
+}
+
+// FirstRuneToLower converts first rune to lower case if necessary.
+func FirstRuneToLower(str string) string {
+	if str == "" {
+		return str
+	}
+
+	r, size := utf8.DecodeRuneInString(str)
+
+	if !unicode.IsUpper(r) {
+		return str
+	}
+
+	buf := &bytes.Buffer{}
+	buf.WriteRune(unicode.ToLower(r))
+	buf.WriteString(str[size:])
+	return buf.String()
+}
+
+// Shuffle randomizes runes in a string and returns the result.
+// It uses default random source in `math/rand`.
+func Shuffle(str string) string {
+	if str == "" {
+		return str
+	}
+
+	runes := []rune(str)
+	index := 0
+
+	for i := len(runes) - 1; i > 0; i-- {
+		index = rand.Intn(i + 1)
+
+		if i != index {
+			runes[i], runes[index] = runes[index], runes[i]
+		}
+	}
+
+	return string(runes)
+}
+
+// ShuffleSource randomizes runes in a string with given random source.
+func ShuffleSource(str string, src rand.Source) string {
+	if str == "" {
+		return str
+	}
+
+	runes := []rune(str)
+	index := 0
+	r := rand.New(src)
+
+	for i := len(runes) - 1; i > 0; i-- {
+		index = r.Intn(i + 1)
+
+		if i != index {
+			runes[i], runes[index] = runes[index], runes[i]
+		}
+	}
+
+	return string(runes)
+}
+
+// Successor returns the successor to string.
+//
+// If there is one alphanumeric rune is found in string, increase the rune by 1.
+// If increment generates a "carry", the rune to the left of it is incremented.
+// This process repeats until there is no carry, adding an additional rune if necessary.
+//
+// If there is no alphanumeric rune, the rightmost rune will be increased by 1
+// regardless whether the result is a valid rune or not.
+//
+// Only following characters are alphanumeric.
+//     * a - z
+//     * A - Z
+//     * 0 - 9
+//
+// Samples (borrowed from ruby's String#succ document):
+//     "abcd"      => "abce"
+//     "THX1138"   => "THX1139"
+//     "<<koala>>" => "<<koalb>>"
+//     "1999zzz"   => "2000aaa"
+//     "ZZZ9999"   => "AAAA0000"
+//     "***"       => "**+"
+func Successor(str string) string {
+	if str == "" {
+		return str
+	}
+
+	var r rune
+	var i int
+	carry := ' '
+	runes := []rune(str)
+	l := len(runes)
+	lastAlphanumeric := l
+
+	for i = l - 1; i >= 0; i-- {
+		r = runes[i]
+
+		if ('a' <= r && r <= 'y') ||
+			('A' <= r && r <= 'Y') ||
+			('0' <= r && r <= '8') {
+			runes[i]++
+			carry = ' '
+			lastAlphanumeric = i
+			break
+		}
+
+		switch r {
+		case 'z':
+			runes[i] = 'a'
+			carry = 'a'
+			lastAlphanumeric = i
+
+		case 'Z':
+			runes[i] = 'A'
+			carry = 'A'
+			lastAlphanumeric = i
+
+		case '9':
+			runes[i] = '0'
+			carry = '0'
+			lastAlphanumeric = i
+		}
+	}
+
+	// Needs to add one character for carry.
+	if i < 0 && carry != ' ' {
+		buf := &bytes.Buffer{}
+		buf.Grow(l + 4) // Reserve enough space for write.
+
+		if lastAlphanumeric != 0 {
+			buf.WriteString(str[:lastAlphanumeric])
+		}
+
+		buf.WriteRune(carry)
+
+		for _, r = range runes[lastAlphanumeric:] {
+			buf.WriteRune(r)
+		}
+
+		return buf.String()
+	}
+
+	// No alphanumeric character. Simply increase last rune's value.
+	if lastAlphanumeric == l {
+		runes[l-1]++
+	}
+
+	return string(runes)
+}

--- a/vendor/github.com/huandu/xstrings/convert_test.go
+++ b/vendor/github.com/huandu/xstrings/convert_test.go
@@ -1,0 +1,163 @@
+// Copyright 2015 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package xstrings
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestToSnakeCase(t *testing.T) {
+	runTestCases(t, ToSnakeCase, _M{
+		"HTTPServer":         "http_server",
+		"_camelCase":         "_camel_case",
+		"NoHTTPS":            "no_https",
+		"Wi_thF":             "wi_th_f",
+		"_AnotherTES_TCaseP": "_another_tes_t_case_p",
+		"ALL":                "all",
+		"_HELLO_WORLD_":      "_hello_world_",
+		"HELLO_WORLD":        "hello_world",
+		"HELLO____WORLD":     "hello____world",
+		"TW":                 "tw",
+		"_C":                 "_c",
+
+		"  sentence case  ":                                    "__sentence_case__",
+		" Mixed-hyphen case _and SENTENCE_case and UPPER-case": "_mixed_hyphen_case__and_sentence_case_and_upper_case",
+	})
+}
+
+func TestToCamelCase(t *testing.T) {
+	runTestCases(t, ToCamelCase, _M{
+		"http_server":     "HttpServer",
+		"_camel_case":     "_CamelCase",
+		"no_https":        "NoHttps",
+		"_complex__case_": "_Complex_Case_",
+		"all":             "All",
+	})
+}
+
+func TestSwapCase(t *testing.T) {
+	runTestCases(t, SwapCase, _M{
+		"swapCase": "SWAPcASE",
+		"Θ~λa云Ξπ":  "θ~ΛA云ξΠ",
+	})
+}
+
+func TestFirstRuneToUpper(t *testing.T) {
+	runTestCases(t, FirstRuneToUpper, _M{
+		"hello, world!": "Hello, world!",
+		"Hello, world!": "Hello, world!",
+		"你好，世界！":        "你好，世界！",
+	})
+}
+
+func TestFirstRuneToLower(t *testing.T) {
+	runTestCases(t, FirstRuneToLower, _M{
+		"hello, world!": "hello, world!",
+		"Hello, world!": "hello, world!",
+		"你好，世界！":        "你好，世界！",
+	})
+}
+
+func TestShuffle(t *testing.T) {
+	// It seems there is no reliable way to test shuffled string.
+	// Runner just make sure shuffled string has the same runes as origin string.
+	runner := func(str string) string {
+		s := Shuffle(str)
+		slice := sort.StringSlice(strings.Split(s, ""))
+		slice.Sort()
+		return strings.Join(slice, "")
+	}
+
+	runTestCases(t, runner, _M{
+		"":            "",
+		"facgbheidjk": "abcdefghijk",
+		"尝试中文":        "中尝文试",
+		"zh英文hun排":    "hhnuz排文英",
+	})
+}
+
+type testShuffleSource int
+
+// A generated random number sequance just for testing.
+var testShuffleTable = []int64{
+	1874068156324778273,
+	3328451335138149956,
+	5263531936693774911,
+	7955079406183515637,
+	2703501726821866378,
+	2740103009342231109,
+	6941261091797652072,
+	1905388747193831650,
+	7981306761429961588,
+	6426100070888298971,
+	4831389563158288344,
+	261049867304784443,
+	1460320609597786623,
+	5600924393587988459,
+	8995016276575641803,
+	732830328053361739,
+	5486140987150761883,
+	545291762129038907,
+	6382800227808658932,
+	2781055864473387780,
+	1598098976185383115,
+	4990765271833742716,
+	5018949295715050020,
+	2568779411109623071,
+	3902890183311134652,
+	4893789450120281907,
+	2338498362660772719,
+	2601737961087659062,
+	7273596521315663110,
+	3337066551442961397,
+	8121576815539813105,
+	2740376916591569721,
+	8249030965139585917,
+	898860202204764712,
+	9010467728050264449,
+	685213522303989579,
+	2050257992909156333,
+	6281838661429879825,
+	2227583514184312746,
+	2873287401706343734,
+}
+
+func (src testShuffleSource) Int63() int64 {
+	n := testShuffleTable[int(src)%len(testShuffleTable)]
+	src++
+	return n
+}
+
+func (src testShuffleSource) Seed(int64) {}
+
+func TestShuffleSource(t *testing.T) {
+	var src testShuffleSource
+	runner := func(str string) string {
+		return ShuffleSource(str, src)
+	}
+
+	runTestCases(t, runner, _M{
+		"":            "",
+		"facgbheidjk": "bakefjgichd",
+		"尝试中文怎么样":     "怎试中样尝么文",
+		"zh英文hun排":    "hh英nzu文排",
+	})
+}
+
+func TestSuccessor(t *testing.T) {
+	runTestCases(t, Successor, _M{
+		"":          "",
+		"abcd":      "abce",
+		"THX1138":   "THX1139",
+		"<<koala>>": "<<koalb>>",
+		"1999zzz":   "2000aaa",
+		"ZZZ9999":   "AAAA0000",
+		"***":       "**+",
+
+		"来点中文试试":               "来点中文试诖",
+		"中cZ英ZZ文zZ混9zZ9杂99进z位": "中dA英AA文aA混0aA0杂00进a位",
+	})
+}

--- a/vendor/github.com/huandu/xstrings/count.go
+++ b/vendor/github.com/huandu/xstrings/count.go
@@ -1,0 +1,120 @@
+// Copyright 2015 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package xstrings
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// Get str's utf8 rune length.
+func Len(str string) int {
+	return utf8.RuneCountInString(str)
+}
+
+// Count number of words in a string.
+//
+// Word is defined as a locale dependent string containing alphabetic characters,
+// which may also contain but not start with `'` and `-` characters.
+func WordCount(str string) int {
+	var r rune
+	var size, n int
+
+	inWord := false
+
+	for len(str) > 0 {
+		r, size = utf8.DecodeRuneInString(str)
+
+		switch {
+		case isAlphabet(r):
+			if !inWord {
+				inWord = true
+				n++
+			}
+
+		case inWord && (r == '\'' || r == '-'):
+			// Still in word.
+
+		default:
+			inWord = false
+		}
+
+		str = str[size:]
+	}
+
+	return n
+}
+
+const minCJKCharacter = '\u3400'
+
+// Checks r is a letter but not CJK character.
+func isAlphabet(r rune) bool {
+	if !unicode.IsLetter(r) {
+		return false
+	}
+
+	switch {
+	// Quick check for non-CJK character.
+	case r < minCJKCharacter:
+		return true
+
+	// Common CJK characters.
+	case r >= '\u4E00' && r <= '\u9FCC':
+		return false
+
+	// Rare CJK characters.
+	case r >= '\u3400' && r <= '\u4D85':
+		return false
+
+	// Rare and historic CJK characters.
+	case r >= '\U00020000' && r <= '\U0002B81D':
+		return false
+	}
+
+	return true
+}
+
+// Width returns string width in monotype font.
+// Multi-byte characters are usually twice the width of single byte characters.
+//
+// Algorithm comes from `mb_strwidth` in PHP.
+// http://php.net/manual/en/function.mb-strwidth.php
+func Width(str string) int {
+	var r rune
+	var size, n int
+
+	for len(str) > 0 {
+		r, size = utf8.DecodeRuneInString(str)
+		n += RuneWidth(r)
+		str = str[size:]
+	}
+
+	return n
+}
+
+// RuneWidth returns character width in monotype font.
+// Multi-byte characters are usually twice the width of single byte characters.
+//
+// Algorithm comes from `mb_strwidth` in PHP.
+// http://php.net/manual/en/function.mb-strwidth.php
+func RuneWidth(r rune) int {
+	switch {
+	case r == utf8.RuneError || r < '\x20':
+		return 0
+
+	case '\x20' <= r && r < '\u2000':
+		return 1
+
+	case '\u2000' <= r && r < '\uFF61':
+		return 2
+
+	case '\uFF61' <= r && r < '\uFFA0':
+		return 1
+
+	case '\uFFA0' <= r:
+		return 2
+	}
+
+	return 0
+}

--- a/vendor/github.com/huandu/xstrings/count_test.go
+++ b/vendor/github.com/huandu/xstrings/count_test.go
@@ -1,0 +1,62 @@
+// Copyright 2015 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package xstrings
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestLen(t *testing.T) {
+	runner := func(str string) string {
+		return fmt.Sprint(Len(str))
+	}
+
+	runTestCases(t, runner, _M{
+		"abcdef":    "6",
+		"中文":        "2",
+		"中yin文hun排": "9",
+		"":          "0",
+	})
+}
+
+func TestWordCount(t *testing.T) {
+	runner := func(str string) string {
+		return fmt.Sprint(WordCount(str))
+	}
+
+	runTestCases(t, runner, _M{
+		"one word: λ":             "3",
+		"中文":                      "0",
+		"你好，sekai！":               "1",
+		"oh, it's super-fancy!!a": "4",
+		"":        "0",
+		"-":       "0",
+		"it's-'s": "1",
+	})
+}
+
+func TestWidth(t *testing.T) {
+	runner := func(str string) string {
+		return fmt.Sprint(Width(str))
+	}
+
+	runTestCases(t, runner, _M{
+		"abcd\t0123\n7890": "12",
+		"中zh英eng文混排":       "15",
+		"": "0",
+	})
+}
+
+func TestRuneWidth(t *testing.T) {
+	runner := func(str string) string {
+		return fmt.Sprint(RuneWidth([]rune(str)[0]))
+	}
+
+	runTestCases(t, runner, _M{
+		"a":    "1",
+		"中":    "2",
+		"\x11": "0",
+	})
+}

--- a/vendor/github.com/huandu/xstrings/doc.go
+++ b/vendor/github.com/huandu/xstrings/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2015 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+// Package `xstrings` is to provide string algorithms which are useful but not included in `strings` package.
+// See project home page for details. https://github.com/huandu/xstrings
+//
+// Package `xstrings` assumes all strings are encoded in utf8.
+package xstrings

--- a/vendor/github.com/huandu/xstrings/format.go
+++ b/vendor/github.com/huandu/xstrings/format.go
@@ -1,0 +1,170 @@
+// Copyright 2015 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package xstrings
+
+import (
+	"bytes"
+	"unicode/utf8"
+)
+
+// ExpandTabs can expand tabs ('\t') rune in str to one or more spaces dpending on
+// current column and tabSize.
+// The column number is reset to zero after each newline ('\n') occurring in the str.
+//
+// ExpandTabs uses RuneWidth to decide rune's width.
+// For example, CJK characters will be treated as two characters.
+//
+// If tabSize <= 0, ExpandTabs panics with error.
+//
+// Samples:
+//     ExpandTabs("a\tbc\tdef\tghij\tk", 4) => "a   bc  def ghij    k"
+//     ExpandTabs("abcdefg\thij\nk\tl", 4)  => "abcdefg hij\nk   l"
+//     ExpandTabs("z中\t文\tw", 4)           => "z中 文  w"
+func ExpandTabs(str string, tabSize int) string {
+	if tabSize <= 0 {
+		panic("tab size must be positive")
+	}
+
+	var r rune
+	var i, size, column, expand int
+	var output *bytes.Buffer
+
+	orig := str
+
+	for len(str) > 0 {
+		r, size = utf8.DecodeRuneInString(str)
+
+		if r == '\t' {
+			expand = tabSize - column%tabSize
+
+			if output == nil {
+				output = allocBuffer(orig, str)
+			}
+
+			for i = 0; i < expand; i++ {
+				output.WriteByte(byte(' '))
+			}
+
+			column += expand
+		} else {
+			if r == '\n' {
+				column = 0
+			} else {
+				column += RuneWidth(r)
+			}
+
+			if output != nil {
+				output.WriteRune(r)
+			}
+		}
+
+		str = str[size:]
+	}
+
+	if output == nil {
+		return orig
+	}
+
+	return output.String()
+}
+
+// LeftJustify returns a string with pad string at right side if str's rune length is smaller than length.
+// If str's rune length is larger than length, str itself will be returned.
+//
+// If pad is an empty string, str will be returned.
+//
+// Samples:
+//     LeftJustify("hello", 4, " ")    => "hello"
+//     LeftJustify("hello", 10, " ")   => "hello     "
+//     LeftJustify("hello", 10, "123") => "hello12312"
+func LeftJustify(str string, length int, pad string) string {
+	l := Len(str)
+
+	if l >= length || pad == "" {
+		return str
+	}
+
+	remains := length - l
+	padLen := Len(pad)
+
+	output := &bytes.Buffer{}
+	output.Grow(len(str) + (remains/padLen+1)*len(pad))
+	output.WriteString(str)
+	writePadString(output, pad, padLen, remains)
+	return output.String()
+}
+
+// RightJustify returns a string with pad string at left side if str's rune length is smaller than length.
+// If str's rune length is larger than length, str itself will be returned.
+//
+// If pad is an empty string, str will be returned.
+//
+// Samples:
+//     RightJustify("hello", 4, " ")    => "hello"
+//     RightJustify("hello", 10, " ")   => "     hello"
+//     RightJustify("hello", 10, "123") => "12312hello"
+func RightJustify(str string, length int, pad string) string {
+	l := Len(str)
+
+	if l >= length || pad == "" {
+		return str
+	}
+
+	remains := length - l
+	padLen := Len(pad)
+
+	output := &bytes.Buffer{}
+	output.Grow(len(str) + (remains/padLen+1)*len(pad))
+	writePadString(output, pad, padLen, remains)
+	output.WriteString(str)
+	return output.String()
+}
+
+// Center returns a string with pad string at both side if str's rune length is smaller than length.
+// If str's rune length is larger than length, str itself will be returned.
+//
+// If pad is an empty string, str will be returned.
+//
+// Samples:
+//     Center("hello", 4, " ")    => "hello"
+//     Center("hello", 10, " ")   => "  hello   "
+//     Center("hello", 10, "123") => "12hello123"
+func Center(str string, length int, pad string) string {
+	l := Len(str)
+
+	if l >= length || pad == "" {
+		return str
+	}
+
+	remains := length - l
+	padLen := Len(pad)
+
+	output := &bytes.Buffer{}
+	output.Grow(len(str) + (remains/padLen+1)*len(pad))
+	writePadString(output, pad, padLen, remains/2)
+	output.WriteString(str)
+	writePadString(output, pad, padLen, (remains+1)/2)
+	return output.String()
+}
+
+func writePadString(output *bytes.Buffer, pad string, padLen, remains int) {
+	var r rune
+	var size int
+
+	repeats := remains / padLen
+
+	for i := 0; i < repeats; i++ {
+		output.WriteString(pad)
+	}
+
+	remains = remains % padLen
+
+	if remains != 0 {
+		for i := 0; i < remains; i++ {
+			r, size = utf8.DecodeRuneInString(pad)
+			output.WriteRune(r)
+			pad = pad[size:]
+		}
+	}
+}

--- a/vendor/github.com/huandu/xstrings/format_test.go
+++ b/vendor/github.com/huandu/xstrings/format_test.go
@@ -1,0 +1,100 @@
+// Copyright 2015 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package xstrings
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestExpandTabs(t *testing.T) {
+	runner := func(str string) (result string) {
+		defer func() {
+			if e := recover(); e != nil {
+				result = e.(string)
+			}
+		}()
+
+		input := strings.Split(str, separator)
+		n, _ := strconv.Atoi(input[1])
+		return ExpandTabs(input[0], n)
+	}
+
+	runTestCases(t, runner, _M{
+		sep("a\tbc\tdef\tghij\tk", "4"): "a   bc  def ghij    k",
+		sep("abcdefg\thij\nk\tl", "4"):  "abcdefg hij\nk   l",
+		sep("z中\t文\tw", "4"):            "z中 文  w",
+		sep("abcdef", "4"):              "abcdef",
+
+		sep("abc\td\tef\tghij\nk\tl", "3"): "abc   d  ef ghij\nk  l",
+		sep("abc\td\tef\tghij\nk\tl", "1"): "abc d ef ghij\nk l",
+
+		sep("abc", "0"):  "tab size must be positive",
+		sep("abc", "-1"): "tab size must be positive",
+	})
+}
+
+func TestLeftJustify(t *testing.T) {
+	runner := func(str string) string {
+		input := strings.Split(str, separator)
+		n, _ := strconv.Atoi(input[1])
+		return LeftJustify(input[0], n, input[2])
+	}
+
+	runTestCases(t, runner, _M{
+		sep("hello", "4", " "):    "hello",
+		sep("hello", "10", " "):   "hello     ",
+		sep("hello", "10", "123"): "hello12312",
+
+		sep("hello中文test", "4", " "):    "hello中文test",
+		sep("hello中文test", "12", " "):   "hello中文test ",
+		sep("hello中文test", "18", "测试！"): "hello中文test测试！测试！测",
+
+		sep("hello中文test", "0", "123"): "hello中文test",
+		sep("hello中文test", "18", ""):   "hello中文test",
+	})
+}
+
+func TestRightJustify(t *testing.T) {
+	runner := func(str string) string {
+		input := strings.Split(str, separator)
+		n, _ := strconv.Atoi(input[1])
+		return RightJustify(input[0], n, input[2])
+	}
+
+	runTestCases(t, runner, _M{
+		sep("hello", "4", " "):    "hello",
+		sep("hello", "10", " "):   "     hello",
+		sep("hello", "10", "123"): "12312hello",
+
+		sep("hello中文test", "4", " "):    "hello中文test",
+		sep("hello中文test", "12", " "):   " hello中文test",
+		sep("hello中文test", "18", "测试！"): "测试！测试！测hello中文test",
+
+		sep("hello中文test", "0", "123"): "hello中文test",
+		sep("hello中文test", "18", ""):   "hello中文test",
+	})
+}
+
+func TestCenter(t *testing.T) {
+	runner := func(str string) string {
+		input := strings.Split(str, separator)
+		n, _ := strconv.Atoi(input[1])
+		return Center(input[0], n, input[2])
+	}
+
+	runTestCases(t, runner, _M{
+		sep("hello", "4", " "):    "hello",
+		sep("hello", "10", " "):   "  hello   ",
+		sep("hello", "10", "123"): "12hello123",
+
+		sep("hello中文test", "4", " "):    "hello中文test",
+		sep("hello中文test", "12", " "):   "hello中文test ",
+		sep("hello中文test", "18", "测试！"): "测试！hello中文test测试！测",
+
+		sep("hello中文test", "0", "123"): "hello中文test",
+		sep("hello中文test", "18", ""):   "hello中文test",
+	})
+}

--- a/vendor/github.com/huandu/xstrings/manipulate.go
+++ b/vendor/github.com/huandu/xstrings/manipulate.go
@@ -1,0 +1,217 @@
+// Copyright 2015 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package xstrings
+
+import (
+	"bytes"
+	"strings"
+	"unicode/utf8"
+)
+
+// Reverse a utf8 encoded string.
+func Reverse(str string) string {
+	var size int
+
+	tail := len(str)
+	buf := make([]byte, tail)
+	s := buf
+
+	for len(str) > 0 {
+		_, size = utf8.DecodeRuneInString(str)
+		tail -= size
+		s = append(s[:tail], []byte(str[:size])...)
+		str = str[size:]
+	}
+
+	return string(buf)
+}
+
+// Slice a string by rune.
+//
+// Start must satisfy 0 <= start <= rune length.
+//
+// End can be positive, zero or negative.
+// If end >= 0, start and end must satisfy start <= end <= rune length.
+// If end < 0, it means slice to the end of string.
+//
+// Otherwise, Slice will panic as out of range.
+func Slice(str string, start, end int) string {
+	var size, startPos, endPos int
+
+	origin := str
+
+	if start < 0 || end > len(str) || (end >= 0 && start > end) {
+		panic("out of range")
+	}
+
+	if end >= 0 {
+		end -= start
+	}
+
+	for start > 0 && len(str) > 0 {
+		_, size = utf8.DecodeRuneInString(str)
+		start--
+		startPos += size
+		str = str[size:]
+	}
+
+	if end < 0 {
+		return origin[startPos:]
+	}
+
+	endPos = startPos
+
+	for end > 0 && len(str) > 0 {
+		_, size = utf8.DecodeRuneInString(str)
+		end--
+		endPos += size
+		str = str[size:]
+	}
+
+	if len(str) == 0 && (start > 0 || end > 0) {
+		panic("out of range")
+	}
+
+	return origin[startPos:endPos]
+}
+
+// Partition splits a string by sep into three parts.
+// The return value is a slice of strings with head, match and tail.
+//
+// If str contains sep, for example "hello" and "l", Partition returns
+//     "he", "l", "lo"
+//
+// If str doesn't contain sep, for example "hello" and "x", Partition returns
+//     "hello", "", ""
+func Partition(str, sep string) (head, match, tail string) {
+	index := strings.Index(str, sep)
+
+	if index == -1 {
+		head = str
+		return
+	}
+
+	head = str[:index]
+	match = str[index : index+len(sep)]
+	tail = str[index+len(sep):]
+	return
+}
+
+// LastPartition splits a string by last instance of sep into three parts.
+// The return value is a slice of strings with head, match and tail.
+//
+// If str contains sep, for example "hello" and "l", LastPartition returns
+//     "hel", "l", "o"
+//
+// If str doesn't contain sep, for example "hello" and "x", LastPartition returns
+//     "", "", "hello"
+func LastPartition(str, sep string) (head, match, tail string) {
+	index := strings.LastIndex(str, sep)
+
+	if index == -1 {
+		tail = str
+		return
+	}
+
+	head = str[:index]
+	match = str[index : index+len(sep)]
+	tail = str[index+len(sep):]
+	return
+}
+
+// Insert src into dst at given rune index.
+// Index is counted by runes instead of bytes.
+//
+// If index is out of range of dst, panic with out of range.
+func Insert(dst, src string, index int) string {
+	return Slice(dst, 0, index) + src + Slice(dst, index, -1)
+}
+
+// Scrubs invalid utf8 bytes with repl string.
+// Adjacent invalid bytes are replaced only once.
+func Scrub(str, repl string) string {
+	var buf *bytes.Buffer
+	var r rune
+	var size, pos int
+	var hasError bool
+
+	origin := str
+
+	for len(str) > 0 {
+		r, size = utf8.DecodeRuneInString(str)
+
+		if r == utf8.RuneError {
+			if !hasError {
+				if buf == nil {
+					buf = &bytes.Buffer{}
+				}
+
+				buf.WriteString(origin[:pos])
+				hasError = true
+			}
+		} else if hasError {
+			hasError = false
+			buf.WriteString(repl)
+
+			origin = origin[pos:]
+			pos = 0
+		}
+
+		pos += size
+		str = str[size:]
+	}
+
+	if buf != nil {
+		buf.WriteString(origin)
+		return buf.String()
+	}
+
+	// No invalid byte.
+	return origin
+}
+
+// Splits a string into words. Returns a slice of words.
+// If there is no word in a string, return nil.
+//
+// Word is defined as a locale dependent string containing alphabetic characters,
+// which may also contain but not start with `'` and `-` characters.
+func WordSplit(str string) []string {
+	var word string
+	var words []string
+	var r rune
+	var size, pos int
+
+	inWord := false
+
+	for len(str) > 0 {
+		r, size = utf8.DecodeRuneInString(str)
+
+		switch {
+		case isAlphabet(r):
+			if !inWord {
+				inWord = true
+				word = str
+				pos = 0
+			}
+
+		case inWord && (r == '\'' || r == '-'):
+			// Still in word.
+
+		default:
+			if inWord {
+				inWord = false
+				words = append(words, word[:pos])
+			}
+		}
+
+		pos += size
+		str = str[size:]
+	}
+
+	if inWord {
+		words = append(words, word[:pos])
+	}
+
+	return words
+}

--- a/vendor/github.com/huandu/xstrings/manipulate_test.go
+++ b/vendor/github.com/huandu/xstrings/manipulate_test.go
@@ -1,0 +1,142 @@
+// Copyright 2015 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package xstrings
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestReverse(t *testing.T) {
+	runTestCases(t, Reverse, _M{
+		"reverse string": "gnirts esrever",
+		"中文如何？":          "？何如文中",
+		"中en文混~排怎样？a":    "a？样怎排~混文ne中",
+	})
+}
+
+func TestSlice(t *testing.T) {
+	runner := func(str string) (result string) {
+		defer func() {
+			if e := recover(); e != nil {
+				result = e.(string)
+			}
+		}()
+
+		strs := split(str)
+		start, _ := strconv.ParseInt(strs[1], 10, 0)
+		end, _ := strconv.ParseInt(strs[2], 10, 0)
+
+		result = Slice(strs[0], int(start), int(end))
+		return
+	}
+
+	runTestCases(t, runner, _M{
+		sep("abcdefghijk", "3", "8"):      "defgh",
+		sep("来点中文如何？", "2", "7"):          "中文如何？",
+		sep("中en文混~排总是少不了的a", "2", "8"):   "n文混~排总",
+		sep("中en文混~排总是少不了的a", "0", "0"):   "",
+		sep("中en文混~排总是少不了的a", "14", "14"): "",
+		sep("中en文混~排总是少不了的a", "5", "-1"):  "~排总是少不了的a",
+		sep("中en文混~排总是少不了的a", "14", "-1"): "",
+
+		sep("let us slice out of range", "-3", "3"): "out of range",
+		sep("超出范围哦", "2", "6"):                      "out of range",
+		sep("don't do this", "3", "2"):              "out of range",
+		sep("千gan万de不piao要liang", "19", "19"):       "out of range",
+	})
+}
+
+func TestPartition(t *testing.T) {
+	runner := func(str string) string {
+		input := strings.Split(str, separator)
+		head, match, tail := Partition(input[0], input[1])
+		return sep(head, match, tail)
+	}
+
+	runTestCases(t, runner, _M{
+		sep("hello", "l"):           sep("he", "l", "lo"),
+		sep("中文总少不了", "少"):          sep("中文总", "少", "不了"),
+		sep("z这个zh英文混排hao不", "h英文"): sep("z这个z", "h英文", "混排hao不"),
+		sep("边界tiao件zen能忘", "边界"):   sep("", "边界", "tiao件zen能忘"),
+		sep("尾巴ye别忘le", "忘le"):      sep("尾巴ye别", "忘le", ""),
+
+		sep("hello", "x"):     sep("hello", "", ""),
+		sep("不是晩香玉", "晚"):     sep("不是晩香玉", "", ""), // Hint: 晩 is not 晚 :)
+		sep("来ge混排ba", "e 混"): sep("来ge混排ba", "", ""),
+	})
+}
+
+func TestLastPartition(t *testing.T) {
+	runner := func(str string) string {
+		input := strings.Split(str, separator)
+		head, match, tail := LastPartition(input[0], input[1])
+		return sep(head, match, tail)
+	}
+
+	runTestCases(t, runner, _M{
+		sep("hello", "l"):               sep("hel", "l", "o"),
+		sep("少量中文总少不了", "少"):            sep("少量中文总", "少", "不了"),
+		sep("z这个zh英文ch英文混排hao不", "h英文"): sep("z这个zh英文c", "h英文", "混排hao不"),
+		sep("边界tiao件zen能忘边界", "边界"):     sep("边界tiao件zen能忘", "边界", ""),
+		sep("尾巴ye别忘le", "尾巴"):           sep("", "尾巴", "ye别忘le"),
+
+		sep("hello", "x"):     sep("", "", "hello"),
+		sep("不是晩香玉", "晚"):     sep("", "", "不是晩香玉"), // Hint: 晩 is not 晚 :)
+		sep("来ge混排ba", "e 混"): sep("", "", "来ge混排ba"),
+	})
+}
+
+func TestInsert(t *testing.T) {
+	runner := func(str string) (result string) {
+		defer func() {
+			if e := recover(); e != nil {
+				result = e.(string)
+			}
+		}()
+
+		strs := split(str)
+		index, _ := strconv.ParseInt(strs[2], 10, 0)
+		result = Insert(strs[0], strs[1], int(index))
+		return
+	}
+
+	runTestCases(t, runner, _M{
+		sep("abcdefg", "hi", "3"):    "abchidefg",
+		sep("少量中文是必须的", "混pai", "4"): "少量中文混pai是必须的",
+		sep("zh英文hun排", "~！", "5"):   "zh英文h~！un排",
+		sep("插在begining", "我", "0"):  "我插在begining",
+		sep("插在ending", "我", "8"):    "插在ending我",
+
+		sep("超tian出yuan边tu界po", "foo", "-1"): "out of range",
+		sep("超tian出yuan边tu界po", "foo", "17"): "out of range",
+	})
+}
+
+func TestScrub(t *testing.T) {
+	runner := func(str string) string {
+		strs := split(str)
+		return Scrub(strs[0], strs[1])
+	}
+
+	runTestCases(t, runner, _M{
+		sep("ab\uFFFDcd\xFF\xCEefg\xFF\xFC\xFD\xFAhijk", "*"): "ab*cd*efg*hijk",
+		sep("no错误です", "*"):                                    "no错误です",
+		sep("", "*"):                                          "",
+	})
+}
+
+func TestWordSplit(t *testing.T) {
+	runner := func(str string) string {
+		return sep(WordSplit(str)...)
+	}
+
+	runTestCases(t, runner, _M{
+		"one word":                   sep("one", "word"),
+		"一个字：把他给我拿下！":                "",
+		"it's a super-fancy one!!!a": sep("it's", "a", "super-fancy", "one", "a"),
+		"a -b-c' 'd'e":               sep("a", "b-c'", "d'e"),
+	})
+}

--- a/vendor/github.com/huandu/xstrings/translate.go
+++ b/vendor/github.com/huandu/xstrings/translate.go
@@ -1,0 +1,545 @@
+// Copyright 2015 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package xstrings
+
+import (
+	"bytes"
+	"unicode"
+	"unicode/utf8"
+)
+
+type runeRangeMap struct {
+	FromLo rune // Lower bound of range map.
+	FromHi rune // An inclusive higher bound of range map.
+	ToLo   rune
+	ToHi   rune
+}
+
+type runeDict struct {
+	Dict [unicode.MaxASCII + 1]rune
+}
+
+type runeMap map[rune]rune
+
+// Translator can translate string with pre-compiled from and to patterns.
+// If a from/to pattern pair needs to be used more than once, it's recommended
+// to create a Translator and reuse it.
+type Translator struct {
+	quickDict  *runeDict       // A quick dictionary to look up rune by index. Only availabe for latin runes.
+	runeMap    runeMap         // Rune map for translation.
+	ranges     []*runeRangeMap // Ranges of runes.
+	mappedRune rune            // If mappedRune >= 0, all matched runes are translated to the mappedRune.
+	reverted   bool            // If to pattern is empty, all matched characters will be deleted.
+	hasPattern bool
+}
+
+// NewTranslator creates new Translator through a from/to pattern pair.
+func NewTranslator(from, to string) *Translator {
+	tr := &Translator{}
+
+	if from == "" {
+		return tr
+	}
+
+	reverted := from[0] == '^'
+	deletion := len(to) == 0
+
+	if reverted {
+		from = from[1:]
+	}
+
+	var fromStart, fromEnd, fromRangeStep rune
+	var toStart, toEnd, toRangeStep rune
+	var fromRangeSize, toRangeSize rune
+	var singleRunes []rune
+
+	// Update the to rune range.
+	updateRange := func() {
+		// No more rune to read in the to rune pattern.
+		if toEnd == utf8.RuneError {
+			return
+		}
+
+		if toRangeStep == 0 {
+			to, toStart, toEnd, toRangeStep = nextRuneRange(to, toEnd)
+			return
+		}
+
+		// Current range is not empty. Consume 1 rune from start.
+		if toStart != toEnd {
+			toStart += toRangeStep
+			return
+		}
+
+		// No more rune. Repeat the last rune.
+		if to == "" {
+			toEnd = utf8.RuneError
+			return
+		}
+
+		// Both start and end are used. Read two more runes from the to pattern.
+		to, toStart, toEnd, toRangeStep = nextRuneRange(to, utf8.RuneError)
+	}
+
+	if deletion {
+		toStart = utf8.RuneError
+		toEnd = utf8.RuneError
+	} else {
+		// If from pattern is reverted, only the last rune in the to pattern will be used.
+		if reverted {
+			var size int
+
+			for len(to) > 0 {
+				toStart, size = utf8.DecodeRuneInString(to)
+				to = to[size:]
+			}
+
+			toEnd = utf8.RuneError
+		} else {
+			to, toStart, toEnd, toRangeStep = nextRuneRange(to, utf8.RuneError)
+		}
+	}
+
+	fromEnd = utf8.RuneError
+
+	for len(from) > 0 {
+		from, fromStart, fromEnd, fromRangeStep = nextRuneRange(from, fromEnd)
+
+		// fromStart is a single character. Just map it with a rune in the to pattern.
+		if fromRangeStep == 0 {
+			singleRunes = tr.addRune(fromStart, toStart, singleRunes)
+			updateRange()
+			continue
+		}
+
+		for toEnd != utf8.RuneError && fromStart != fromEnd {
+			// If mapped rune is a single character instead of a range, simply shift first
+			// rune in the range.
+			if toRangeStep == 0 {
+				singleRunes = tr.addRune(fromStart, toStart, singleRunes)
+				updateRange()
+				fromStart += fromRangeStep
+				continue
+			}
+
+			fromRangeSize = (fromEnd - fromStart) * fromRangeStep
+			toRangeSize = (toEnd - toStart) * toRangeStep
+
+			// Not enough runes in the to pattern. Need to read more.
+			if fromRangeSize > toRangeSize {
+				fromStart, toStart = tr.addRuneRange(fromStart, fromStart+toRangeSize*fromRangeStep, toStart, toEnd, singleRunes)
+				fromStart += fromRangeStep
+				updateRange()
+
+				// Edge case: If fromRangeSize == toRangeSize + 1, the last fromStart value needs be considered
+				// as a single rune.
+				if fromStart == fromEnd {
+					singleRunes = tr.addRune(fromStart, toStart, singleRunes)
+					updateRange()
+				}
+
+				continue
+			}
+
+			fromStart, toStart = tr.addRuneRange(fromStart, fromEnd, toStart, toStart+fromRangeSize*toRangeStep, singleRunes)
+			updateRange()
+			break
+		}
+
+		if fromStart == fromEnd {
+			fromEnd = utf8.RuneError
+			continue
+		}
+
+		fromStart, toStart = tr.addRuneRange(fromStart, fromEnd, toStart, toStart, singleRunes)
+		fromEnd = utf8.RuneError
+	}
+
+	if fromEnd != utf8.RuneError {
+		singleRunes = tr.addRune(fromEnd, toStart, singleRunes)
+	}
+
+	tr.reverted = reverted
+	tr.mappedRune = -1
+	tr.hasPattern = true
+
+	// Translate RuneError only if in deletion or reverted mode.
+	if deletion || reverted {
+		tr.mappedRune = toStart
+	}
+
+	return tr
+}
+
+func (tr *Translator) addRune(from, to rune, singleRunes []rune) []rune {
+	if from <= unicode.MaxASCII {
+		if tr.quickDict == nil {
+			tr.quickDict = &runeDict{}
+		}
+
+		tr.quickDict.Dict[from] = to
+	} else {
+		if tr.runeMap == nil {
+			tr.runeMap = make(runeMap)
+		}
+
+		tr.runeMap[from] = to
+	}
+
+	singleRunes = append(singleRunes, from)
+	return singleRunes
+}
+
+func (tr *Translator) addRuneRange(fromLo, fromHi, toLo, toHi rune, singleRunes []rune) (rune, rune) {
+	var r rune
+	var rrm *runeRangeMap
+
+	if fromLo < fromHi {
+		rrm = &runeRangeMap{
+			FromLo: fromLo,
+			FromHi: fromHi,
+			ToLo:   toLo,
+			ToHi:   toHi,
+		}
+	} else {
+		rrm = &runeRangeMap{
+			FromLo: fromHi,
+			FromHi: fromLo,
+			ToLo:   toHi,
+			ToHi:   toLo,
+		}
+	}
+
+	// If there is any single rune conflicts with this rune range, clear single rune record.
+	for _, r = range singleRunes {
+		if rrm.FromLo <= r && r <= rrm.FromHi {
+			if r <= unicode.MaxASCII {
+				tr.quickDict.Dict[r] = 0
+			} else {
+				delete(tr.runeMap, r)
+			}
+		}
+	}
+
+	tr.ranges = append(tr.ranges, rrm)
+	return fromHi, toHi
+}
+
+func nextRuneRange(str string, last rune) (remaining string, start, end rune, rangeStep rune) {
+	var r rune
+	var size int
+
+	remaining = str
+	escaping := false
+	isRange := false
+
+	for len(remaining) > 0 {
+		r, size = utf8.DecodeRuneInString(remaining)
+		remaining = remaining[size:]
+
+		// Parse special characters.
+		if !escaping {
+			if r == '\\' {
+				escaping = true
+				continue
+			}
+
+			if r == '-' {
+				// Ignore slash at beginning of string.
+				if last == utf8.RuneError {
+					continue
+				}
+
+				start = last
+				isRange = true
+				continue
+			}
+		}
+
+		escaping = false
+
+		if last != utf8.RuneError {
+			// This is a range which start and end are the same.
+			// Considier it as a normal character.
+			if isRange && last == r {
+				isRange = false
+				continue
+			}
+
+			start = last
+			end = r
+
+			if isRange {
+				if start < end {
+					rangeStep = 1
+				} else {
+					rangeStep = -1
+				}
+			}
+
+			return
+		}
+
+		last = r
+	}
+
+	start = last
+	end = utf8.RuneError
+	return
+}
+
+// Translate str with a from/to pattern pair.
+//
+// See comment in Translate function for usage and samples.
+func (tr *Translator) Translate(str string) string {
+	if !tr.hasPattern || str == "" {
+		return str
+	}
+
+	var r rune
+	var size int
+	var needTr bool
+
+	orig := str
+
+	var output *bytes.Buffer
+
+	for len(str) > 0 {
+		r, size = utf8.DecodeRuneInString(str)
+		r, needTr = tr.TranslateRune(r)
+
+		if needTr && output == nil {
+			output = allocBuffer(orig, str)
+		}
+
+		if r != utf8.RuneError && output != nil {
+			output.WriteRune(r)
+		}
+
+		str = str[size:]
+	}
+
+	// No character is translated.
+	if output == nil {
+		return orig
+	}
+
+	return output.String()
+}
+
+// TranslateRune return translated rune and true if r matches the from pattern.
+// If r doesn't match the pattern, original r is returned and translated is false.
+func (tr *Translator) TranslateRune(r rune) (result rune, translated bool) {
+	switch {
+	case tr.quickDict != nil:
+		if r <= unicode.MaxASCII {
+			result = tr.quickDict.Dict[r]
+
+			if result != 0 {
+				translated = true
+
+				if tr.mappedRune >= 0 {
+					result = tr.mappedRune
+				}
+
+				break
+			}
+		}
+
+		fallthrough
+
+	case tr.runeMap != nil:
+		var ok bool
+
+		if result, ok = tr.runeMap[r]; ok {
+			translated = true
+
+			if tr.mappedRune >= 0 {
+				result = tr.mappedRune
+			}
+
+			break
+		}
+
+		fallthrough
+
+	default:
+		var rrm *runeRangeMap
+		ranges := tr.ranges
+
+		for i := len(ranges) - 1; i >= 0; i-- {
+			rrm = ranges[i]
+
+			if rrm.FromLo <= r && r <= rrm.FromHi {
+				translated = true
+
+				if tr.mappedRune >= 0 {
+					result = tr.mappedRune
+					break
+				}
+
+				if rrm.ToLo < rrm.ToHi {
+					result = rrm.ToLo + r - rrm.FromLo
+				} else if rrm.ToLo > rrm.ToHi {
+					// ToHi can be smaller than ToLo if range is from higher to lower.
+					result = rrm.ToLo - r + rrm.FromLo
+				} else {
+					result = rrm.ToLo
+				}
+
+				break
+			}
+		}
+	}
+
+	if tr.reverted {
+		if !translated {
+			result = tr.mappedRune
+		}
+
+		translated = !translated
+	}
+
+	if !translated {
+		result = r
+	}
+
+	return
+}
+
+// HasPattern returns true if Translator has one pattern at least.
+func (tr *Translator) HasPattern() bool {
+	return tr.hasPattern
+}
+
+// Translate str with the characters defined in from replaced by characters defined in to.
+//
+// From and to are patterns representing a set of characters. Pattern is defined as following.
+//
+//     * Special characters
+//       * '-' means a range of runes, e.g.
+//         * "a-z" means all characters from 'a' to 'z' inclusive;
+//         * "z-a" means all characters from 'z' to 'a' inclusive.
+//       * '^' as first character means a set of all runes excepted listed, e.g.
+//         * "^a-z" means all characters except 'a' to 'z' inclusive.
+//       * '\' escapes special characters.
+//     * Normal character represents itself, e.g. "abc" is a set including 'a', 'b' and 'c'.
+//
+// Translate will try to find a 1:1 mapping from from to to.
+// If to is smaller than from, last rune in to will be used to map "out of range" characters in from.
+//
+// Note that '^' only works in the from pattern. It will be considered as a normal character in the to pattern.
+//
+// If the to pattern is an empty string, Translate works exactly the same as Delete.
+//
+// Samples:
+//     Translate("hello", "aeiou", "12345")    => "h2ll4"
+//     Translate("hello", "a-z", "A-Z")        => "HELLO"
+//     Translate("hello", "z-a", "a-z")        => "svool"
+//     Translate("hello", "aeiou", "*")        => "h*ll*"
+//     Translate("hello", "^l", "*")           => "**ll*"
+//     Translate("hello ^ world", `\^lo`, "*") => "he*** * w*r*d"
+func Translate(str, from, to string) string {
+	tr := NewTranslator(from, to)
+	return tr.Translate(str)
+}
+
+// Delete runes in str matching the pattern.
+// Pattern is defined in Translate function.
+//
+// Samples:
+//     Delete("hello", "aeiou") => "hll"
+//     Delete("hello", "a-k")   => "llo"
+//     Delete("hello", "^a-k")  => "he"
+func Delete(str, pattern string) string {
+	tr := NewTranslator(pattern, "")
+	return tr.Translate(str)
+}
+
+// Count how many runes in str match the pattern.
+// Pattern is defined in Translate function.
+//
+// Samples:
+//     Count("hello", "aeiou") => 3
+//     Count("hello", "a-k")   => 3
+//     Count("hello", "^a-k")  => 2
+func Count(str, pattern string) int {
+	if pattern == "" || str == "" {
+		return 0
+	}
+
+	var r rune
+	var size int
+	var matched bool
+
+	tr := NewTranslator(pattern, "")
+	cnt := 0
+
+	for len(str) > 0 {
+		r, size = utf8.DecodeRuneInString(str)
+		str = str[size:]
+
+		if _, matched = tr.TranslateRune(r); matched {
+			cnt++
+		}
+	}
+
+	return cnt
+}
+
+// Squeeze deletes adjacent repeated runes in str.
+// If pattern is not empty, only runes matching the pattern will be squeezed.
+//
+// Samples:
+//     Squeeze("hello", "")    => "helo"
+//     Squeeze("hello", "m-z") => "hello"
+func Squeeze(str, pattern string) string {
+	var last, r rune
+	var size int
+	var skipSqueeze, matched bool
+	var tr *Translator
+	var output *bytes.Buffer
+
+	orig := str
+	last = -1
+
+	if len(pattern) > 0 {
+		tr = NewTranslator(pattern, "")
+	}
+
+	for len(str) > 0 {
+		r, size = utf8.DecodeRuneInString(str)
+
+		// Need to squeeze the str.
+		if last == r && !skipSqueeze {
+			if tr != nil {
+				if _, matched = tr.TranslateRune(r); !matched {
+					skipSqueeze = true
+				}
+			}
+
+			if output == nil {
+				output = allocBuffer(orig, str)
+			}
+
+			if skipSqueeze {
+				output.WriteRune(r)
+			}
+		} else {
+			if output != nil {
+				output.WriteRune(r)
+			}
+
+			last = r
+		}
+
+		str = str[size:]
+	}
+
+	if output == nil {
+		return orig
+	}
+
+	return output.String()
+}

--- a/vendor/github.com/huandu/xstrings/translate_test.go
+++ b/vendor/github.com/huandu/xstrings/translate_test.go
@@ -1,0 +1,92 @@
+// Copyright 2015 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package xstrings
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestTranslate(t *testing.T) {
+	runner := func(str string) string {
+		input := strings.Split(str, separator)
+		return Translate(input[0], input[1], input[2])
+	}
+
+	runTestCases(t, runner, _M{
+		sep("hello", "aeiou", "12345"):    "h2ll4",
+		sep("hello", "aeiou", ""):         "hll",
+		sep("hello", "a-z", "A-Z"):        "HELLO",
+		sep("hello", "z-a", "a-z"):        "svool",
+		sep("hello", "aeiou", "*"):        "h*ll*",
+		sep("hello", "^l", "*"):           "**ll*",
+		sep("hello", "p-z", "*"):          "hello",
+		sep("hello ^ world", `\^lo`, "*"): "he*** * w*r*d",
+
+		sep("中文字符测试", "文中谁敢试？", "123456"):  "21字符测5",
+		sep("中文字符测试", "^文中谁敢试？", "123456"): "中文666试",
+		sep("中文字符测试", "字-试", "0-9"):        "中90999",
+
+		sep("h1e2l3l4o, w5o6r7l8d", "a-z,0-9", `A-Z\-a-czk-p`):       "HbEcLzLkO- WlOmRnLoD",
+		sep("h1e2l3l4o, w5o6r7l8d", "a-zoh-n", "b-zakt-z"):           "t1f2x3x4k, x5k6s7x8e",
+		sep("h1e2l3l4o, w5o6r7l8d", "helloa-zoh-n", "99999b-zakt-z"): "t1f2x3x4k, x5k6s7x8e",
+
+		sep("hello", "e-", "p"):        "hpllo",
+		sep("hello", "-e-", "p"):       "hpllo",
+		sep("hello", "----e---", "p"):  "hpllo",
+		sep("hello", "^---e----", "p"): "peppp",
+
+		sep("hel\uFFFDlo", "\uFFFD", "H"):    "helHlo",
+		sep("hel\uFFFDlo", "^\uFFFD", "H"):   "HHHHH",
+		sep("hel\uFFFDlo", "o-\uFFFDh", "H"): "HelHlH",
+	})
+}
+
+func TestDelete(t *testing.T) {
+	runner := func(str string) string {
+		input := strings.Split(str, separator)
+		return Delete(input[0], input[1])
+	}
+
+	runTestCases(t, runner, _M{
+		sep("hello", "aeiou"): "hll",
+		sep("hello", "a-k"):   "llo",
+		sep("hello", "^a-k"):  "he",
+
+		sep("中文字符测试", "文中谁敢试？"): "字符测",
+	})
+}
+
+func TestCount(t *testing.T) {
+	runner := func(str string) string {
+		input := strings.Split(str, separator)
+		return fmt.Sprint(Count(input[0], input[1]))
+	}
+
+	runTestCases(t, runner, _M{
+		sep("hello", "aeiou"): "2",
+		sep("hello", "a-k"):   "2",
+		sep("hello", "^a-k"):  "3",
+
+		sep("中文字符测试", "文中谁敢试？"): "3",
+	})
+}
+
+func TestSqueeze(t *testing.T) {
+	runner := func(str string) string {
+		input := strings.Split(str, separator)
+		return Squeeze(input[0], input[1])
+	}
+
+	runTestCases(t, runner, _M{
+		sep("hello", ""):     "helo",
+		sep("hello", "a-k"):  "hello",
+		sep("hello", "^a-k"): "helo",
+		sep("hello", "^a-l"): "hello",
+
+		sep("打打打打个劫！！", ""):  "打个劫！",
+		sep("打打打打个劫！！", "打"): "打个劫！！",
+	})
+}

--- a/vendor/github.com/huandu/xstrings/util_test.go
+++ b/vendor/github.com/huandu/xstrings/util_test.go
@@ -1,0 +1,33 @@
+// Copyright 2015 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package xstrings
+
+import (
+	"strings"
+	"testing"
+)
+
+type _M map[string]string
+
+const (
+	separator = " ¶ "
+)
+
+func runTestCases(t *testing.T, converter func(string) string, cases map[string]string) {
+	for k, v := range cases {
+		s := converter(k)
+
+		if s != v {
+			t.Fatalf("case fails. [case:%v]\nshould => %#v\nactual => %#v", k, v, s)
+		}
+	}
+}
+
+func sep(strs ...string) string {
+	return strings.Join(strs, separator)
+}
+
+func split(str string) []string {
+	return strings.Split(str, separator)
+}

--- a/vendor/github.com/satori/go.uuid/.travis.yml
+++ b/vendor/github.com/satori/go.uuid/.travis.yml
@@ -1,0 +1,22 @@
+language: go
+sudo: false
+go:
+    - 1.2
+    - 1.3
+    - 1.4
+    - 1.5
+    - 1.6
+    - 1.7
+    - 1.8
+    - tip
+matrix:
+    allow_failures:
+        - go: tip
+    fast_finish: true
+before_install:
+    - go get github.com/mattn/goveralls
+    - go get golang.org/x/tools/cmd/cover
+script:
+    - $HOME/gopath/bin/goveralls -service=travis-ci
+notifications:
+    email: false

--- a/vendor/github.com/satori/go.uuid/LICENSE
+++ b/vendor/github.com/satori/go.uuid/LICENSE
@@ -1,0 +1,20 @@
+Copyright (C) 2013-2016 by Maxim Bublis <b@codemonkey.ru>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/satori/go.uuid/README.md
+++ b/vendor/github.com/satori/go.uuid/README.md
@@ -1,0 +1,65 @@
+# UUID package for Go language
+
+[![Build Status](https://travis-ci.org/satori/go.uuid.png?branch=master)](https://travis-ci.org/satori/go.uuid)
+[![Coverage Status](https://coveralls.io/repos/github/satori/go.uuid/badge.svg?branch=master)](https://coveralls.io/github/satori/go.uuid)
+[![GoDoc](http://godoc.org/github.com/satori/go.uuid?status.png)](http://godoc.org/github.com/satori/go.uuid)
+
+This package provides pure Go implementation of Universally Unique Identifier (UUID). Supported both creation and parsing of UUIDs.
+
+With 100% test coverage and benchmarks out of box.
+
+Supported versions:
+* Version 1, based on timestamp and MAC address (RFC 4122)
+* Version 2, based on timestamp, MAC address and POSIX UID/GID (DCE 1.1)
+* Version 3, based on MD5 hashing (RFC 4122)
+* Version 4, based on random numbers (RFC 4122)
+* Version 5, based on SHA-1 hashing (RFC 4122)
+
+## Installation
+
+Use the `go` command:
+
+	$ go get github.com/satori/go.uuid
+
+## Requirements
+
+UUID package requires Go >= 1.2.
+
+## Example
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/satori/go.uuid"
+)
+
+func main() {
+	// Creating UUID Version 4
+	u1 := uuid.NewV4()
+	fmt.Printf("UUIDv4: %s\n", u1)
+
+	// Parsing UUID from string input
+	u2, err := uuid.FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	if err != nil {
+		fmt.Printf("Something gone wrong: %s", err)
+	}
+	fmt.Printf("Successfully parsed: %s", u2)
+}
+```
+
+## Documentation
+
+[Documentation](http://godoc.org/github.com/satori/go.uuid) is hosted at GoDoc project.
+
+## Links
+* [RFC 4122](http://tools.ietf.org/html/rfc4122)
+* [DCE 1.1: Authentication and Security Services](http://pubs.opengroup.org/onlinepubs/9696989899/chap5.htm#tagcjh_08_02_01_01)
+
+## Copyright
+
+Copyright (C) 2013-2016 by Maxim Bublis <b@codemonkey.ru>.
+
+UUID package released under MIT License.
+See [LICENSE](https://github.com/satori/go.uuid/blob/master/LICENSE) for details.

--- a/vendor/github.com/satori/go.uuid/benchmarks_test.go
+++ b/vendor/github.com/satori/go.uuid/benchmarks_test.go
@@ -1,0 +1,123 @@
+// Copyright (C) 2013-2015 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	"testing"
+)
+
+func BenchmarkFromBytes(b *testing.B) {
+	bytes := []byte{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	for i := 0; i < b.N; i++ {
+		FromBytes(bytes)
+	}
+}
+
+func BenchmarkFromString(b *testing.B) {
+	s := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	for i := 0; i < b.N; i++ {
+		FromString(s)
+	}
+}
+
+func BenchmarkFromStringUrn(b *testing.B) {
+	s := "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	for i := 0; i < b.N; i++ {
+		FromString(s)
+	}
+}
+
+func BenchmarkFromStringWithBrackets(b *testing.B) {
+	s := "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}"
+	for i := 0; i < b.N; i++ {
+		FromString(s)
+	}
+}
+
+func BenchmarkNewV1(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewV1()
+	}
+}
+
+func BenchmarkNewV2(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewV2(DomainPerson)
+	}
+}
+
+func BenchmarkNewV3(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewV3(NamespaceDNS, "www.example.com")
+	}
+}
+
+func BenchmarkNewV4(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewV4()
+	}
+}
+
+func BenchmarkNewV5(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewV5(NamespaceDNS, "www.example.com")
+	}
+}
+
+func BenchmarkMarshalBinary(b *testing.B) {
+	u := NewV4()
+	for i := 0; i < b.N; i++ {
+		u.MarshalBinary()
+	}
+}
+
+func BenchmarkMarshalText(b *testing.B) {
+	u := NewV4()
+	for i := 0; i < b.N; i++ {
+		u.MarshalText()
+	}
+}
+
+func BenchmarkUnmarshalBinary(b *testing.B) {
+	bytes := []byte{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	u := UUID{}
+	for i := 0; i < b.N; i++ {
+		u.UnmarshalBinary(bytes)
+	}
+}
+
+func BenchmarkUnmarshalText(b *testing.B) {
+	bytes := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	u := UUID{}
+	for i := 0; i < b.N; i++ {
+		u.UnmarshalText(bytes)
+	}
+}
+
+var sink string
+
+func BenchmarkMarshalToString(b *testing.B) {
+	u := NewV4()
+	for i := 0; i < b.N; i++ {
+		sink = u.String()
+	}
+}

--- a/vendor/github.com/satori/go.uuid/uuid.go
+++ b/vendor/github.com/satori/go.uuid/uuid.go
@@ -1,0 +1,481 @@
+// Copyright (C) 2013-2015 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Package uuid provides implementation of Universally Unique Identifier (UUID).
+// Supported versions are 1, 3, 4 and 5 (as specified in RFC 4122) and
+// version 2 (as specified in DCE 1.1).
+package uuid
+
+import (
+	"bytes"
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha1"
+	"database/sql/driver"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"net"
+	"os"
+	"sync"
+	"time"
+)
+
+// UUID layout variants.
+const (
+	VariantNCS = iota
+	VariantRFC4122
+	VariantMicrosoft
+	VariantFuture
+)
+
+// UUID DCE domains.
+const (
+	DomainPerson = iota
+	DomainGroup
+	DomainOrg
+)
+
+// Difference in 100-nanosecond intervals between
+// UUID epoch (October 15, 1582) and Unix epoch (January 1, 1970).
+const epochStart = 122192928000000000
+
+// Used in string method conversion
+const dash byte = '-'
+
+// UUID v1/v2 storage.
+var (
+	storageMutex  sync.Mutex
+	storageOnce   sync.Once
+	epochFunc     = unixTimeFunc
+	clockSequence uint16
+	lastTime      uint64
+	hardwareAddr  [6]byte
+	posixUID      = uint32(os.Getuid())
+	posixGID      = uint32(os.Getgid())
+)
+
+// String parse helpers.
+var (
+	urnPrefix  = []byte("urn:uuid:")
+	byteGroups = []int{8, 4, 4, 4, 12}
+)
+
+func initClockSequence() {
+	buf := make([]byte, 2)
+	safeRandom(buf)
+	clockSequence = binary.BigEndian.Uint16(buf)
+}
+
+func initHardwareAddr() {
+	interfaces, err := net.Interfaces()
+	if err == nil {
+		for _, iface := range interfaces {
+			if len(iface.HardwareAddr) >= 6 {
+				copy(hardwareAddr[:], iface.HardwareAddr)
+				return
+			}
+		}
+	}
+
+	// Initialize hardwareAddr randomly in case
+	// of real network interfaces absence
+	safeRandom(hardwareAddr[:])
+
+	// Set multicast bit as recommended in RFC 4122
+	hardwareAddr[0] |= 0x01
+}
+
+func initStorage() {
+	initClockSequence()
+	initHardwareAddr()
+}
+
+func safeRandom(dest []byte) {
+	if _, err := rand.Read(dest); err != nil {
+		panic(err)
+	}
+}
+
+// Returns difference in 100-nanosecond intervals between
+// UUID epoch (October 15, 1582) and current time.
+// This is default epoch calculation function.
+func unixTimeFunc() uint64 {
+	return epochStart + uint64(time.Now().UnixNano()/100)
+}
+
+// UUID representation compliant with specification
+// described in RFC 4122.
+type UUID [16]byte
+
+// NullUUID can be used with the standard sql package to represent a
+// UUID value that can be NULL in the database
+type NullUUID struct {
+	UUID  UUID
+	Valid bool
+}
+
+// The nil UUID is special form of UUID that is specified to have all
+// 128 bits set to zero.
+var Nil = UUID{}
+
+// Predefined namespace UUIDs.
+var (
+	NamespaceDNS, _  = FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	NamespaceURL, _  = FromString("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
+	NamespaceOID, _  = FromString("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
+	NamespaceX500, _ = FromString("6ba7b814-9dad-11d1-80b4-00c04fd430c8")
+)
+
+// And returns result of binary AND of two UUIDs.
+func And(u1 UUID, u2 UUID) UUID {
+	u := UUID{}
+	for i := 0; i < 16; i++ {
+		u[i] = u1[i] & u2[i]
+	}
+	return u
+}
+
+// Or returns result of binary OR of two UUIDs.
+func Or(u1 UUID, u2 UUID) UUID {
+	u := UUID{}
+	for i := 0; i < 16; i++ {
+		u[i] = u1[i] | u2[i]
+	}
+	return u
+}
+
+// Equal returns true if u1 and u2 equals, otherwise returns false.
+func Equal(u1 UUID, u2 UUID) bool {
+	return bytes.Equal(u1[:], u2[:])
+}
+
+// Version returns algorithm version used to generate UUID.
+func (u UUID) Version() uint {
+	return uint(u[6] >> 4)
+}
+
+// Variant returns UUID layout variant.
+func (u UUID) Variant() uint {
+	switch {
+	case (u[8] & 0x80) == 0x00:
+		return VariantNCS
+	case (u[8]&0xc0)|0x80 == 0x80:
+		return VariantRFC4122
+	case (u[8]&0xe0)|0xc0 == 0xc0:
+		return VariantMicrosoft
+	}
+	return VariantFuture
+}
+
+// Bytes returns bytes slice representation of UUID.
+func (u UUID) Bytes() []byte {
+	return u[:]
+}
+
+// Returns canonical string representation of UUID:
+// xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
+func (u UUID) String() string {
+	buf := make([]byte, 36)
+
+	hex.Encode(buf[0:8], u[0:4])
+	buf[8] = dash
+	hex.Encode(buf[9:13], u[4:6])
+	buf[13] = dash
+	hex.Encode(buf[14:18], u[6:8])
+	buf[18] = dash
+	hex.Encode(buf[19:23], u[8:10])
+	buf[23] = dash
+	hex.Encode(buf[24:], u[10:])
+
+	return string(buf)
+}
+
+// SetVersion sets version bits.
+func (u *UUID) SetVersion(v byte) {
+	u[6] = (u[6] & 0x0f) | (v << 4)
+}
+
+// SetVariant sets variant bits as described in RFC 4122.
+func (u *UUID) SetVariant() {
+	u[8] = (u[8] & 0xbf) | 0x80
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+// The encoding is the same as returned by String.
+func (u UUID) MarshalText() (text []byte, err error) {
+	text = []byte(u.String())
+	return
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+// Following formats are supported:
+// "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+// "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+// "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+func (u *UUID) UnmarshalText(text []byte) (err error) {
+	if len(text) < 32 {
+		err = fmt.Errorf("uuid: UUID string too short: %s", text)
+		return
+	}
+
+	t := text[:]
+	braced := false
+
+	if bytes.Equal(t[:9], urnPrefix) {
+		t = t[9:]
+	} else if t[0] == '{' {
+		braced = true
+		t = t[1:]
+	}
+
+	b := u[:]
+
+	for i, byteGroup := range byteGroups {
+		if i > 0 {
+			if t[0] != '-' {
+				err = fmt.Errorf("uuid: invalid string format")
+				return
+			}
+			t = t[1:]
+		}
+
+		if len(t) < byteGroup {
+			err = fmt.Errorf("uuid: UUID string too short: %s", text)
+			return
+		}
+
+		if i == 4 && len(t) > byteGroup &&
+			((braced && t[byteGroup] != '}') || len(t[byteGroup:]) > 1 || !braced) {
+			err = fmt.Errorf("uuid: UUID string too long: %s", text)
+			return
+		}
+
+		_, err = hex.Decode(b[:byteGroup/2], t[:byteGroup])
+		if err != nil {
+			return
+		}
+
+		t = t[byteGroup:]
+		b = b[byteGroup/2:]
+	}
+
+	return
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface.
+func (u UUID) MarshalBinary() (data []byte, err error) {
+	data = u.Bytes()
+	return
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+// It will return error if the slice isn't 16 bytes long.
+func (u *UUID) UnmarshalBinary(data []byte) (err error) {
+	if len(data) != 16 {
+		err = fmt.Errorf("uuid: UUID must be exactly 16 bytes long, got %d bytes", len(data))
+		return
+	}
+	copy(u[:], data)
+
+	return
+}
+
+// Value implements the driver.Valuer interface.
+func (u UUID) Value() (driver.Value, error) {
+	return u.String(), nil
+}
+
+// Scan implements the sql.Scanner interface.
+// A 16-byte slice is handled by UnmarshalBinary, while
+// a longer byte slice or a string is handled by UnmarshalText.
+func (u *UUID) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		if len(src) == 16 {
+			return u.UnmarshalBinary(src)
+		}
+		return u.UnmarshalText(src)
+
+	case string:
+		return u.UnmarshalText([]byte(src))
+	}
+
+	return fmt.Errorf("uuid: cannot convert %T to UUID", src)
+}
+
+// Value implements the driver.Valuer interface.
+func (u NullUUID) Value() (driver.Value, error) {
+	if !u.Valid {
+		return nil, nil
+	}
+	// Delegate to UUID Value function
+	return u.UUID.Value()
+}
+
+// Scan implements the sql.Scanner interface.
+func (u *NullUUID) Scan(src interface{}) error {
+	if src == nil {
+		u.UUID, u.Valid = Nil, false
+		return nil
+	}
+
+	// Delegate to UUID Scan function
+	u.Valid = true
+	return u.UUID.Scan(src)
+}
+
+// FromBytes returns UUID converted from raw byte slice input.
+// It will return error if the slice isn't 16 bytes long.
+func FromBytes(input []byte) (u UUID, err error) {
+	err = u.UnmarshalBinary(input)
+	return
+}
+
+// FromBytesOrNil returns UUID converted from raw byte slice input.
+// Same behavior as FromBytes, but returns a Nil UUID on error.
+func FromBytesOrNil(input []byte) UUID {
+	uuid, err := FromBytes(input)
+	if err != nil {
+		return Nil
+	}
+	return uuid
+}
+
+// FromString returns UUID parsed from string input.
+// Input is expected in a form accepted by UnmarshalText.
+func FromString(input string) (u UUID, err error) {
+	err = u.UnmarshalText([]byte(input))
+	return
+}
+
+// FromStringOrNil returns UUID parsed from string input.
+// Same behavior as FromString, but returns a Nil UUID on error.
+func FromStringOrNil(input string) UUID {
+	uuid, err := FromString(input)
+	if err != nil {
+		return Nil
+	}
+	return uuid
+}
+
+// Returns UUID v1/v2 storage state.
+// Returns epoch timestamp, clock sequence, and hardware address.
+func getStorage() (uint64, uint16, []byte) {
+	storageOnce.Do(initStorage)
+
+	storageMutex.Lock()
+	defer storageMutex.Unlock()
+
+	timeNow := epochFunc()
+	// Clock changed backwards since last UUID generation.
+	// Should increase clock sequence.
+	if timeNow <= lastTime {
+		clockSequence++
+	}
+	lastTime = timeNow
+
+	return timeNow, clockSequence, hardwareAddr[:]
+}
+
+// NewV1 returns UUID based on current timestamp and MAC address.
+func NewV1() UUID {
+	u := UUID{}
+
+	timeNow, clockSeq, hardwareAddr := getStorage()
+
+	binary.BigEndian.PutUint32(u[0:], uint32(timeNow))
+	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
+	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
+	binary.BigEndian.PutUint16(u[8:], clockSeq)
+
+	copy(u[10:], hardwareAddr)
+
+	u.SetVersion(1)
+	u.SetVariant()
+
+	return u
+}
+
+// NewV2 returns DCE Security UUID based on POSIX UID/GID.
+func NewV2(domain byte) UUID {
+	u := UUID{}
+
+	timeNow, clockSeq, hardwareAddr := getStorage()
+
+	switch domain {
+	case DomainPerson:
+		binary.BigEndian.PutUint32(u[0:], posixUID)
+	case DomainGroup:
+		binary.BigEndian.PutUint32(u[0:], posixGID)
+	}
+
+	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
+	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
+	binary.BigEndian.PutUint16(u[8:], clockSeq)
+	u[9] = domain
+
+	copy(u[10:], hardwareAddr)
+
+	u.SetVersion(2)
+	u.SetVariant()
+
+	return u
+}
+
+// NewV3 returns UUID based on MD5 hash of namespace UUID and name.
+func NewV3(ns UUID, name string) UUID {
+	u := newFromHash(md5.New(), ns, name)
+	u.SetVersion(3)
+	u.SetVariant()
+
+	return u
+}
+
+// NewV4 returns random generated UUID.
+func NewV4() UUID {
+	u := UUID{}
+	safeRandom(u[:])
+	u.SetVersion(4)
+	u.SetVariant()
+
+	return u
+}
+
+// NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.
+func NewV5(ns UUID, name string) UUID {
+	u := newFromHash(sha1.New(), ns, name)
+	u.SetVersion(5)
+	u.SetVariant()
+
+	return u
+}
+
+// Returns UUID based on hashing of namespace UUID and name.
+func newFromHash(h hash.Hash, ns UUID, name string) UUID {
+	u := UUID{}
+	h.Write(ns[:])
+	h.Write([]byte(name))
+	copy(u[:], h.Sum(nil))
+
+	return u
+}

--- a/vendor/github.com/satori/go.uuid/uuid_test.go
+++ b/vendor/github.com/satori/go.uuid/uuid_test.go
@@ -1,0 +1,633 @@
+// Copyright (C) 2013, 2015 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestBytes(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	bytes1 := []byte{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	if !bytes.Equal(u.Bytes(), bytes1) {
+		t.Errorf("Incorrect bytes representation for UUID: %s", u)
+	}
+}
+
+func TestString(t *testing.T) {
+	if NamespaceDNS.String() != "6ba7b810-9dad-11d1-80b4-00c04fd430c8" {
+		t.Errorf("Incorrect string representation for UUID: %s", NamespaceDNS.String())
+	}
+}
+
+func TestEqual(t *testing.T) {
+	if !Equal(NamespaceDNS, NamespaceDNS) {
+		t.Errorf("Incorrect comparison of %s and %s", NamespaceDNS, NamespaceDNS)
+	}
+
+	if Equal(NamespaceDNS, NamespaceURL) {
+		t.Errorf("Incorrect comparison of %s and %s", NamespaceDNS, NamespaceURL)
+	}
+}
+
+func TestOr(t *testing.T) {
+	u1 := UUID{0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff}
+	u2 := UUID{0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00}
+
+	u := UUID{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+
+	if !Equal(u, Or(u1, u2)) {
+		t.Errorf("Incorrect bitwise OR result %s", Or(u1, u2))
+	}
+}
+
+func TestAnd(t *testing.T) {
+	u1 := UUID{0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff}
+	u2 := UUID{0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00}
+
+	u := UUID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+	if !Equal(u, And(u1, u2)) {
+		t.Errorf("Incorrect bitwise AND result %s", And(u1, u2))
+	}
+}
+
+func TestVersion(t *testing.T) {
+	u := UUID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+	if u.Version() != 1 {
+		t.Errorf("Incorrect version for UUID: %d", u.Version())
+	}
+}
+
+func TestSetVersion(t *testing.T) {
+	u := UUID{}
+	u.SetVersion(4)
+
+	if u.Version() != 4 {
+		t.Errorf("Incorrect version for UUID after u.setVersion(4): %d", u.Version())
+	}
+}
+
+func TestVariant(t *testing.T) {
+	u1 := UUID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+	if u1.Variant() != VariantNCS {
+		t.Errorf("Incorrect variant for UUID variant %d: %d", VariantNCS, u1.Variant())
+	}
+
+	u2 := UUID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+	if u2.Variant() != VariantRFC4122 {
+		t.Errorf("Incorrect variant for UUID variant %d: %d", VariantRFC4122, u2.Variant())
+	}
+
+	u3 := UUID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+	if u3.Variant() != VariantMicrosoft {
+		t.Errorf("Incorrect variant for UUID variant %d: %d", VariantMicrosoft, u3.Variant())
+	}
+
+	u4 := UUID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+	if u4.Variant() != VariantFuture {
+		t.Errorf("Incorrect variant for UUID variant %d: %d", VariantFuture, u4.Variant())
+	}
+}
+
+func TestSetVariant(t *testing.T) {
+	u := new(UUID)
+	u.SetVariant()
+
+	if u.Variant() != VariantRFC4122 {
+		t.Errorf("Incorrect variant for UUID after u.setVariant(): %d", u.Variant())
+	}
+}
+
+func TestFromBytes(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	u1, err := FromBytes(b1)
+	if err != nil {
+		t.Errorf("Error parsing UUID from bytes: %s", err)
+	}
+
+	if !Equal(u, u1) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u1)
+	}
+
+	b2 := []byte{}
+
+	_, err = FromBytes(b2)
+	if err == nil {
+		t.Errorf("Should return error parsing from empty byte slice, got %s", err)
+	}
+}
+
+func TestMarshalBinary(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	b2, err := u.MarshalBinary()
+	if err != nil {
+		t.Errorf("Error marshaling UUID: %s", err)
+	}
+
+	if !bytes.Equal(b1, b2) {
+		t.Errorf("Marshaled UUID should be %s, got %s", b1, b2)
+	}
+}
+
+func TestUnmarshalBinary(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	u1 := UUID{}
+	err := u1.UnmarshalBinary(b1)
+	if err != nil {
+		t.Errorf("Error unmarshaling UUID: %s", err)
+	}
+
+	if !Equal(u, u1) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u1)
+	}
+
+	b2 := []byte{}
+	u2 := UUID{}
+
+	err = u2.UnmarshalBinary(b2)
+	if err == nil {
+		t.Errorf("Should return error unmarshalling from empty byte slice, got %s", err)
+	}
+}
+
+func TestFromString(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	s1 := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	s2 := "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}"
+	s3 := "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+	_, err := FromString("")
+	if err == nil {
+		t.Errorf("Should return error trying to parse empty string, got %s", err)
+	}
+
+	u1, err := FromString(s1)
+	if err != nil {
+		t.Errorf("Error parsing UUID from string: %s", err)
+	}
+
+	if !Equal(u, u1) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u1)
+	}
+
+	u2, err := FromString(s2)
+	if err != nil {
+		t.Errorf("Error parsing UUID from string: %s", err)
+	}
+
+	if !Equal(u, u2) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u2)
+	}
+
+	u3, err := FromString(s3)
+	if err != nil {
+		t.Errorf("Error parsing UUID from string: %s", err)
+	}
+
+	if !Equal(u, u3) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u3)
+	}
+}
+
+func TestFromStringShort(t *testing.T) {
+	// Invalid 35-character UUID string
+	s1 := "6ba7b810-9dad-11d1-80b4-00c04fd430c"
+
+	for i := len(s1); i >= 0; i-- {
+		_, err := FromString(s1[:i])
+		if err == nil {
+			t.Errorf("Should return error trying to parse too short string, got %s", err)
+		}
+	}
+}
+
+func TestFromStringLong(t *testing.T) {
+	// Invalid 37+ character UUID string
+	s := []string{
+		"6ba7b810-9dad-11d1-80b4-00c04fd430c8=",
+		"6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+		"{6ba7b810-9dad-11d1-80b4-00c04fd430c8}f",
+		"6ba7b810-9dad-11d1-80b4-00c04fd430c800c04fd430c8",
+	}
+
+	for _, str := range s {
+		_, err := FromString(str)
+		if err == nil {
+			t.Errorf("Should return error trying to parse too long string, passed %s", str)
+		}
+	}
+}
+
+func TestFromStringInvalid(t *testing.T) {
+	// Invalid UUID string formats
+	s := []string{
+		"6ba7b8109dad11d180b400c04fd430c8",
+		"6ba7b8109dad11d180b400c04fd430c86ba7b8109dad11d180b400c04fd430c8",
+		"urn:uuid:{6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+		"6ba7b8109-dad-11d1-80b4-00c04fd430c8",
+		"6ba7b810-9dad1-1d1-80b4-00c04fd430c8",
+		"6ba7b810-9dad-11d18-0b4-00c04fd430c8",
+		"6ba7b810-9dad-11d1-80b40-0c04fd430c8",
+		"6ba7b810+9dad+11d1+80b4+00c04fd430c8",
+		"6ba7b810-9dad11d180b400c04fd430c8",
+		"6ba7b8109dad-11d180b400c04fd430c8",
+		"6ba7b8109dad11d1-80b400c04fd430c8",
+		"6ba7b8109dad11d180b4-00c04fd430c8",
+	}
+
+	for _, str := range s {
+		_, err := FromString(str)
+		if err == nil {
+			t.Errorf("Should return error trying to parse invalid string, passed %s", str)
+		}
+	}
+}
+
+func TestFromStringOrNil(t *testing.T) {
+	u := FromStringOrNil("")
+	if u != Nil {
+		t.Errorf("Should return Nil UUID on parse failure, got %s", u)
+	}
+}
+
+func TestFromBytesOrNil(t *testing.T) {
+	b := []byte{}
+	u := FromBytesOrNil(b)
+	if u != Nil {
+		t.Errorf("Should return Nil UUID on parse failure, got %s", u)
+	}
+}
+
+func TestMarshalText(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+	b2, err := u.MarshalText()
+	if err != nil {
+		t.Errorf("Error marshaling UUID: %s", err)
+	}
+
+	if !bytes.Equal(b1, b2) {
+		t.Errorf("Marshaled UUID should be %s, got %s", b1, b2)
+	}
+}
+
+func TestUnmarshalText(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+	u1 := UUID{}
+	err := u1.UnmarshalText(b1)
+	if err != nil {
+		t.Errorf("Error unmarshaling UUID: %s", err)
+	}
+
+	if !Equal(u, u1) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u1)
+	}
+
+	b2 := []byte("")
+	u2 := UUID{}
+
+	err = u2.UnmarshalText(b2)
+	if err == nil {
+		t.Errorf("Should return error trying to unmarshal from empty string")
+	}
+}
+
+func TestValue(t *testing.T) {
+	u, err := FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	if err != nil {
+		t.Errorf("Error parsing UUID from string: %s", err)
+	}
+
+	val, err := u.Value()
+	if err != nil {
+		t.Errorf("Error getting UUID value: %s", err)
+	}
+
+	if val != u.String() {
+		t.Errorf("Wrong value returned, should be equal: %s and %s", val, u)
+	}
+}
+
+func TestValueNil(t *testing.T) {
+	u := UUID{}
+
+	val, err := u.Value()
+	if err != nil {
+		t.Errorf("Error getting UUID value: %s", err)
+	}
+
+	if val != Nil.String() {
+		t.Errorf("Wrong value returned, should be equal to UUID.Nil: %s", val)
+	}
+}
+
+func TestNullUUIDValueNil(t *testing.T) {
+	u := NullUUID{}
+
+	val, err := u.Value()
+	if err != nil {
+		t.Errorf("Error getting UUID value: %s", err)
+	}
+
+	if val != nil {
+		t.Errorf("Wrong value returned, should be nil: %s", val)
+	}
+}
+
+func TestScanBinary(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	u1 := UUID{}
+	err := u1.Scan(b1)
+	if err != nil {
+		t.Errorf("Error unmarshaling UUID: %s", err)
+	}
+
+	if !Equal(u, u1) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u1)
+	}
+
+	b2 := []byte{}
+	u2 := UUID{}
+
+	err = u2.Scan(b2)
+	if err == nil {
+		t.Errorf("Should return error unmarshalling from empty byte slice, got %s", err)
+	}
+}
+
+func TestScanString(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	s1 := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+	u1 := UUID{}
+	err := u1.Scan(s1)
+	if err != nil {
+		t.Errorf("Error unmarshaling UUID: %s", err)
+	}
+
+	if !Equal(u, u1) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u1)
+	}
+
+	s2 := ""
+	u2 := UUID{}
+
+	err = u2.Scan(s2)
+	if err == nil {
+		t.Errorf("Should return error trying to unmarshal from empty string")
+	}
+}
+
+func TestScanText(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+	u1 := UUID{}
+	err := u1.Scan(b1)
+	if err != nil {
+		t.Errorf("Error unmarshaling UUID: %s", err)
+	}
+
+	if !Equal(u, u1) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u1)
+	}
+
+	b2 := []byte("")
+	u2 := UUID{}
+
+	err = u2.Scan(b2)
+	if err == nil {
+		t.Errorf("Should return error trying to unmarshal from empty string")
+	}
+}
+
+func TestScanUnsupported(t *testing.T) {
+	u := UUID{}
+
+	err := u.Scan(true)
+	if err == nil {
+		t.Errorf("Should return error trying to unmarshal from bool")
+	}
+}
+
+func TestScanNil(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	err := u.Scan(nil)
+	if err == nil {
+		t.Errorf("Error UUID shouldn't allow unmarshalling from nil")
+	}
+}
+
+func TestNullUUIDScanValid(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	s1 := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+	u1 := NullUUID{}
+	err := u1.Scan(s1)
+	if err != nil {
+		t.Errorf("Error unmarshaling NullUUID: %s", err)
+	}
+
+	if !u1.Valid {
+		t.Errorf("NullUUID should be valid")
+	}
+
+	if !Equal(u, u1.UUID) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u1.UUID)
+	}
+}
+
+func TestNullUUIDScanNil(t *testing.T) {
+	u := NullUUID{UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}, true}
+
+	err := u.Scan(nil)
+	if err != nil {
+		t.Errorf("Error unmarshaling NullUUID: %s", err)
+	}
+
+	if u.Valid {
+		t.Errorf("NullUUID should not be valid")
+	}
+
+	if !Equal(u.UUID, Nil) {
+		t.Errorf("NullUUID value should be equal to Nil: %v", u)
+	}
+}
+
+func TestNewV1(t *testing.T) {
+	u := NewV1()
+
+	if u.Version() != 1 {
+		t.Errorf("UUIDv1 generated with incorrect version: %d", u.Version())
+	}
+
+	if u.Variant() != VariantRFC4122 {
+		t.Errorf("UUIDv1 generated with incorrect variant: %d", u.Variant())
+	}
+
+	u1 := NewV1()
+	u2 := NewV1()
+
+	if Equal(u1, u2) {
+		t.Errorf("UUIDv1 generated two equal UUIDs: %s and %s", u1, u2)
+	}
+
+	oldFunc := epochFunc
+	epochFunc = func() uint64 { return 0 }
+
+	u3 := NewV1()
+	u4 := NewV1()
+
+	if Equal(u3, u4) {
+		t.Errorf("UUIDv1 generated two equal UUIDs: %s and %s", u3, u4)
+	}
+
+	epochFunc = oldFunc
+}
+
+func TestNewV2(t *testing.T) {
+	u1 := NewV2(DomainPerson)
+
+	if u1.Version() != 2 {
+		t.Errorf("UUIDv2 generated with incorrect version: %d", u1.Version())
+	}
+
+	if u1.Variant() != VariantRFC4122 {
+		t.Errorf("UUIDv2 generated with incorrect variant: %d", u1.Variant())
+	}
+
+	u2 := NewV2(DomainGroup)
+
+	if u2.Version() != 2 {
+		t.Errorf("UUIDv2 generated with incorrect version: %d", u2.Version())
+	}
+
+	if u2.Variant() != VariantRFC4122 {
+		t.Errorf("UUIDv2 generated with incorrect variant: %d", u2.Variant())
+	}
+}
+
+func TestNewV3(t *testing.T) {
+	u := NewV3(NamespaceDNS, "www.example.com")
+
+	if u.Version() != 3 {
+		t.Errorf("UUIDv3 generated with incorrect version: %d", u.Version())
+	}
+
+	if u.Variant() != VariantRFC4122 {
+		t.Errorf("UUIDv3 generated with incorrect variant: %d", u.Variant())
+	}
+
+	if u.String() != "5df41881-3aed-3515-88a7-2f4a814cf09e" {
+		t.Errorf("UUIDv3 generated incorrectly: %s", u.String())
+	}
+
+	u = NewV3(NamespaceDNS, "python.org")
+
+	if u.String() != "6fa459ea-ee8a-3ca4-894e-db77e160355e" {
+		t.Errorf("UUIDv3 generated incorrectly: %s", u.String())
+	}
+
+	u1 := NewV3(NamespaceDNS, "golang.org")
+	u2 := NewV3(NamespaceDNS, "golang.org")
+	if !Equal(u1, u2) {
+		t.Errorf("UUIDv3 generated different UUIDs for same namespace and name: %s and %s", u1, u2)
+	}
+
+	u3 := NewV3(NamespaceDNS, "example.com")
+	if Equal(u1, u3) {
+		t.Errorf("UUIDv3 generated same UUIDs for different names in same namespace: %s and %s", u1, u2)
+	}
+
+	u4 := NewV3(NamespaceURL, "golang.org")
+	if Equal(u1, u4) {
+		t.Errorf("UUIDv3 generated same UUIDs for sane names in different namespaces: %s and %s", u1, u4)
+	}
+}
+
+func TestNewV4(t *testing.T) {
+	u := NewV4()
+
+	if u.Version() != 4 {
+		t.Errorf("UUIDv4 generated with incorrect version: %d", u.Version())
+	}
+
+	if u.Variant() != VariantRFC4122 {
+		t.Errorf("UUIDv4 generated with incorrect variant: %d", u.Variant())
+	}
+}
+
+func TestNewV5(t *testing.T) {
+	u := NewV5(NamespaceDNS, "www.example.com")
+
+	if u.Version() != 5 {
+		t.Errorf("UUIDv5 generated with incorrect version: %d", u.Version())
+	}
+
+	if u.Variant() != VariantRFC4122 {
+		t.Errorf("UUIDv5 generated with incorrect variant: %d", u.Variant())
+	}
+
+	u = NewV5(NamespaceDNS, "python.org")
+
+	if u.String() != "886313e1-3b8a-5372-9b90-0c9aee199e5d" {
+		t.Errorf("UUIDv5 generated incorrectly: %s", u.String())
+	}
+
+	u1 := NewV5(NamespaceDNS, "golang.org")
+	u2 := NewV5(NamespaceDNS, "golang.org")
+	if !Equal(u1, u2) {
+		t.Errorf("UUIDv5 generated different UUIDs for same namespace and name: %s and %s", u1, u2)
+	}
+
+	u3 := NewV5(NamespaceDNS, "example.com")
+	if Equal(u1, u3) {
+		t.Errorf("UUIDv5 generated same UUIDs for different names in same namespace: %s and %s", u1, u2)
+	}
+
+	u4 := NewV5(NamespaceURL, "golang.org")
+	if Equal(u1, u4) {
+		t.Errorf("UUIDv3 generated same UUIDs for sane names in different namespaces: %s and %s", u1, u4)
+	}
+}


### PR DESCRIPTION
Extending the current implementation of toolbox template to include multiple files and snippets. Note, I've removed the requirements for defaults as I think people should be forced to specifically pass them

- allowing the users to use a snippets directory for reusable templates
- allows the users to specify multiple templates files via multiple --template <path>, use a directory or both
- allows the users to specify multiple configuration files via multiple --values <path>,  use a directory or both
- adding a safety check to ensure templates don't reference an unknown values
- fixing the vetting issues to the method YamlToJson -> YAMLToJSON
- as usual anything a saw on the journey which doesn't comply with go-vet got changed

Examples of a snippet

```YAML
hooks:
  - name: some_service.service
    manifest: |
      {{ include "some_service.service" . | indent 6 }}
```
We currently use something similar to template our cluster and instances group documents, handling the differences between prod, ci and ephemeral
