### PR TITLE
Implementing GCE as an interface - modelling aws cloud provider

### DIFF
--- a/cmd/kops/status_discovery.go
+++ b/cmd/kops/status_discovery.go
@@ -39,7 +39,7 @@ func (s *cloudDiscoveryStatusStore) GetApiIngressStatus(cluster *kops.Cluster) (
 		return nil, err
 	}
 
-	if gceCloud, ok := cloud.(*gce.GCECloud); ok {
+	if gceCloud, ok := cloud.(gce.GCECloud); ok {
 		return gceCloud.GetApiIngressStatus(cluster)
 	}
 

--- a/pkg/resources/gce.go
+++ b/pkg/resources/gce.go
@@ -45,9 +45,9 @@ const (
 )
 
 func (c *ClusterResources) listResourcesGCE() (map[string]*ResourceTracker, error) {
-	gceCloud := c.Cloud.(*gce.GCECloud)
+	gceCloud := c.Cloud.(gce.GCECloud)
 	if c.Region == "" {
-		c.Region = gceCloud.Region
+		c.Region = gceCloud.Region()
 	}
 
 	resources := make(map[string]*ResourceTracker)
@@ -60,7 +60,7 @@ func (c *ClusterResources) listResourcesGCE() (map[string]*ResourceTracker, erro
 
 	{
 		// TODO: Only zones in api.Cluster object, if we have one?
-		gceZones, err := d.gceCloud.Compute.Zones.List(d.gceCloud.Project).Do()
+		gceZones, err := d.gceCloud.Compute().Zones.List(d.gceCloud.Project()).Do()
 		if err != nil {
 			return nil, fmt.Errorf("error listing zones: %v", err)
 		}
@@ -123,7 +123,7 @@ func (c *ClusterResources) listResourcesGCE() (map[string]*ResourceTracker, erro
 
 type clusterDiscoveryGCE struct {
 	cloud       fi.Cloud
-	gceCloud    *gce.GCECloud
+	gceCloud    gce.GCECloud
 	clusterName string
 
 	instanceTemplates []*compute.InstanceTemplate
@@ -147,7 +147,7 @@ func (d *clusterDiscoveryGCE) findInstanceTemplates() ([]*compute.InstanceTempla
 
 	ctx := context.Background()
 
-	err := c.Compute.InstanceTemplates.List(c.Project).Pages(ctx, func(page *compute.InstanceTemplateList) error {
+	err := c.Compute().InstanceTemplates.List(c.Project()).Pages(ctx, func(page *compute.InstanceTemplateList) error {
 		for _, t := range page.Items {
 			match := false
 			for _, item := range t.Properties.Metadata.Items {
@@ -202,7 +202,7 @@ func (d *clusterDiscoveryGCE) listGCEInstanceTemplates() ([]*ResourceTracker, er
 }
 
 func deleteGCEInstanceTemplate(cloud fi.Cloud, r *ResourceTracker) error {
-	c := cloud.(*gce.GCECloud)
+	c := cloud.(gce.GCECloud)
 	t := r.obj.(*compute.InstanceTemplate)
 
 	glog.V(2).Infof("Deleting GCE InstanceTemplate %s", t.SelfLink)
@@ -211,7 +211,7 @@ func deleteGCEInstanceTemplate(cloud fi.Cloud, r *ResourceTracker) error {
 		return err
 	}
 
-	op, err := c.Compute.InstanceTemplates.Delete(u.Project, u.Name).Do()
+	op, err := c.Compute().InstanceTemplates.Delete(u.Project, u.Name).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			glog.Infof("instancetemplate not found, assuming deleted: %q", t.SelfLink)
@@ -225,7 +225,7 @@ func deleteGCEInstanceTemplate(cloud fi.Cloud, r *ResourceTracker) error {
 
 func (d *clusterDiscoveryGCE) listInstanceGroupManagersAndInstances() ([]*ResourceTracker, error) {
 	c := d.gceCloud
-	project := c.Project
+	project := c.Project()
 
 	var trackers []*ResourceTracker
 
@@ -243,7 +243,7 @@ func (d *clusterDiscoveryGCE) listInstanceGroupManagersAndInstances() ([]*Resour
 	ctx := context.Background()
 
 	for _, zoneName := range d.zones {
-		err := c.Compute.InstanceGroupManagers.List(project, zoneName).Pages(ctx, func(page *compute.InstanceGroupManagerList) error {
+		err := c.Compute().InstanceGroupManagers.List(project, zoneName).Pages(ctx, func(page *compute.InstanceGroupManagerList) error {
 			for _, mig := range page.Items {
 				instanceTemplate := instanceTemplates[mig.InstanceTemplate]
 				if instanceTemplate == nil {
@@ -282,7 +282,7 @@ func (d *clusterDiscoveryGCE) listInstanceGroupManagersAndInstances() ([]*Resour
 }
 
 func deleteInstanceGroupManager(cloud fi.Cloud, r *ResourceTracker) error {
-	c := cloud.(*gce.GCECloud)
+	c := cloud.(gce.GCECloud)
 	t := r.obj.(*compute.InstanceGroupManager)
 
 	glog.V(2).Infof("Deleting GCE InstanceGroupManager %s", t.SelfLink)
@@ -293,7 +293,7 @@ func deleteInstanceGroupManager(cloud fi.Cloud, r *ResourceTracker) error {
 
 	//glog.Infof("MIG: %s", fi.DebugAsJsonString(t))
 
-	op, err := c.Compute.InstanceGroupManagers.Delete(u.Project, u.Zone, u.Name).Do()
+	op, err := c.Compute().InstanceGroupManagers.Delete(u.Project, u.Zone, u.Name).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			glog.Infof("InstanceGroupManager not found, assuming deleted: %q", t.SelfLink)
@@ -307,14 +307,14 @@ func deleteInstanceGroupManager(cloud fi.Cloud, r *ResourceTracker) error {
 
 func (d *clusterDiscoveryGCE) listManagedInstances(igm *compute.InstanceGroupManager) ([]*ResourceTracker, error) {
 	c := d.gceCloud
-	project := c.Project
+	project := c.Project()
 
 	var trackers []*ResourceTracker
 
 	zoneName := gce.LastComponent(igm.Zone)
 
 	// This call is not paginated
-	instances, err := c.Compute.InstanceGroupManagers.ListManagedInstances(project, zoneName, igm.Name).Do()
+	instances, err := c.Compute().InstanceGroupManagers.ListManagedInstances(project, zoneName, igm.Name).Do()
 	if err != nil {
 		return nil, fmt.Errorf("error listing ManagedInstances in %s: %v", igm.Name, err)
 	}
@@ -351,7 +351,7 @@ func (d *clusterDiscoveryGCE) findGCEDisks() ([]*compute.Disk, error) {
 
 	// TODO: Push down tag filter?
 
-	err := c.Compute.Disks.AggregatedList(c.Project).Pages(ctx, func(page *compute.DiskAggregatedList) error {
+	err := c.Compute().Disks.AggregatedList(c.Project()).Pages(ctx, func(page *compute.DiskAggregatedList) error {
 		for _, list := range page.Items {
 			for _, d := range list.Disks {
 				match := false
@@ -411,7 +411,7 @@ func (d *clusterDiscoveryGCE) listGCEDisks() ([]*ResourceTracker, error) {
 }
 
 func deleteGCEDisk(cloud fi.Cloud, r *ResourceTracker) error {
-	c := cloud.(*gce.GCECloud)
+	c := cloud.(gce.GCECloud)
 	t := r.obj.(*compute.Disk)
 
 	glog.V(2).Infof("Deleting GCE Disk %s", t.SelfLink)
@@ -420,7 +420,7 @@ func deleteGCEDisk(cloud fi.Cloud, r *ResourceTracker) error {
 		return err
 	}
 
-	op, err := c.Compute.Disks.Delete(u.Project, u.Zone, u.Name).Do()
+	op, err := c.Compute().Disks.Delete(u.Project, u.Zone, u.Name).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			glog.Infof("disk not found, assuming deleted: %q", t.SelfLink)
@@ -439,7 +439,7 @@ func (d *clusterDiscoveryGCE) listTargetPools() ([]*ResourceTracker, error) {
 
 	ctx := context.Background()
 
-	err := c.Compute.TargetPools.List(c.Project, c.Region).Pages(ctx, func(page *compute.TargetPoolList) error {
+	err := c.Compute().TargetPools.List(c.Project(), c.Region()).Pages(ctx, func(page *compute.TargetPoolList) error {
 		for _, tp := range page.Items {
 			if !d.matchesClusterName(tp.Name) {
 				continue
@@ -467,7 +467,7 @@ func (d *clusterDiscoveryGCE) listTargetPools() ([]*ResourceTracker, error) {
 }
 
 func deleteTargetPool(cloud fi.Cloud, r *ResourceTracker) error {
-	c := cloud.(*gce.GCECloud)
+	c := cloud.(gce.GCECloud)
 	t := r.obj.(*compute.TargetPool)
 
 	glog.V(2).Infof("Deleting GCE TargetPool %s", t.SelfLink)
@@ -478,7 +478,7 @@ func deleteTargetPool(cloud fi.Cloud, r *ResourceTracker) error {
 
 	glog.Infof("TargetPool: %s", fi.DebugAsJsonString(t))
 
-	op, err := c.Compute.TargetPools.Delete(u.Project, u.Region, u.Name).Do()
+	op, err := c.Compute().TargetPools.Delete(u.Project, u.Region, u.Name).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			glog.Infof("TargetPool not found, assuming deleted: %q", t.SelfLink)
@@ -497,7 +497,7 @@ func (d *clusterDiscoveryGCE) listForwardingRules() ([]*ResourceTracker, error) 
 
 	ctx := context.Background()
 
-	err := c.Compute.ForwardingRules.List(c.Project, c.Region).Pages(ctx, func(page *compute.ForwardingRuleList) error {
+	err := c.Compute().ForwardingRules.List(c.Project(), c.Region()).Pages(ctx, func(page *compute.ForwardingRuleList) error {
 		for _, fr := range page.Items {
 			if !d.matchesClusterName(fr.Name) {
 				continue
@@ -532,7 +532,7 @@ func (d *clusterDiscoveryGCE) listForwardingRules() ([]*ResourceTracker, error) 
 }
 
 func deleteForwardingRule(cloud fi.Cloud, r *ResourceTracker) error {
-	c := cloud.(*gce.GCECloud)
+	c := cloud.(gce.GCECloud)
 	t := r.obj.(*compute.ForwardingRule)
 
 	glog.V(2).Infof("Deleting GCE ForwardingRule %s", t.SelfLink)
@@ -541,7 +541,7 @@ func deleteForwardingRule(cloud fi.Cloud, r *ResourceTracker) error {
 		return err
 	}
 
-	op, err := c.Compute.ForwardingRules.Delete(u.Project, u.Region, u.Name).Do()
+	op, err := c.Compute().ForwardingRules.Delete(u.Project, u.Region, u.Name).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			glog.Infof("ForwardingRule not found, assuming deleted: %q", t.SelfLink)
@@ -554,7 +554,7 @@ func deleteForwardingRule(cloud fi.Cloud, r *ResourceTracker) error {
 }
 
 func deleteManagedInstance(cloud fi.Cloud, r *ResourceTracker) error {
-	c := cloud.(*gce.GCECloud)
+	c := cloud.(gce.GCECloud)
 	selfLink := r.obj.(string)
 
 	glog.V(2).Infof("Deleting GCE Instance %s", selfLink)
@@ -563,7 +563,7 @@ func deleteManagedInstance(cloud fi.Cloud, r *ResourceTracker) error {
 		return err
 	}
 
-	op, err := c.Compute.Instances.Delete(u.Project, u.Zone, u.Name).Do()
+	op, err := c.Compute().Instances.Delete(u.Project, u.Zone, u.Name).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			glog.Infof("Instance not found, assuming deleted: %q", selfLink)
@@ -592,7 +592,7 @@ func (d *clusterDiscoveryGCE) listRoutes(resources map[string]*ResourceTracker) 
 	ctx := context.Background()
 
 	// TODO: Push-down prefix?
-	err := c.Compute.Routes.List(c.Project).Pages(ctx, func(page *compute.RouteList) error {
+	err := c.Compute().Routes.List(c.Project()).Pages(ctx, func(page *compute.RouteList) error {
 		for _, r := range page.Items {
 			if !strings.HasPrefix(r.Name, prefix) {
 				continue
@@ -646,7 +646,7 @@ func (d *clusterDiscoveryGCE) listRoutes(resources map[string]*ResourceTracker) 
 }
 
 func deleteRoute(cloud fi.Cloud, r *ResourceTracker) error {
-	c := cloud.(*gce.GCECloud)
+	c := cloud.(gce.GCECloud)
 	t := r.obj.(*compute.Route)
 
 	glog.V(2).Infof("Deleting GCE Route %s", t.SelfLink)
@@ -655,7 +655,7 @@ func deleteRoute(cloud fi.Cloud, r *ResourceTracker) error {
 		return err
 	}
 
-	op, err := c.Compute.Routes.Delete(u.Project, u.Name).Do()
+	op, err := c.Compute().Routes.Delete(u.Project, u.Name).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			glog.Infof("Route not found, assuming deleted: %q", t.SelfLink)
@@ -674,7 +674,7 @@ func (d *clusterDiscoveryGCE) listAddresses() ([]*ResourceTracker, error) {
 
 	ctx := context.Background()
 
-	err := c.Compute.Addresses.List(c.Project, c.Region).Pages(ctx, func(page *compute.AddressList) error {
+	err := c.Compute().Addresses.List(c.Project(), c.Region()).Pages(ctx, func(page *compute.AddressList) error {
 		for _, a := range page.Items {
 			if !d.matchesClusterName(a.Name) {
 				glog.V(8).Infof("Skipping Address with name %q", a.Name)
@@ -702,7 +702,7 @@ func (d *clusterDiscoveryGCE) listAddresses() ([]*ResourceTracker, error) {
 }
 
 func deleteAddress(cloud fi.Cloud, r *ResourceTracker) error {
-	c := cloud.(*gce.GCECloud)
+	c := cloud.(gce.GCECloud)
 	t := r.obj.(*compute.Address)
 
 	glog.V(2).Infof("Deleting GCE Address %s", t.SelfLink)
@@ -711,7 +711,7 @@ func deleteAddress(cloud fi.Cloud, r *ResourceTracker) error {
 		return err
 	}
 
-	op, err := c.Compute.Addresses.Delete(u.Project, u.Region, u.Name).Do()
+	op, err := c.Compute().Addresses.Delete(u.Project, u.Region, u.Name).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			glog.Infof("Address not found, assuming deleted: %q", t.SelfLink)

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -310,9 +310,9 @@ func (c *ApplyClusterCmd) Run() error {
 	switch kops.CloudProviderID(cluster.Spec.CloudProvider) {
 	case kops.CloudProviderGCE:
 		{
-			gceCloud := cloud.(*gce.GCECloud)
-			region = gceCloud.Region
-			project = gceCloud.Project
+			gceCloud := cloud.(gce.GCECloud)
+			region = gceCloud.Region()
+			project = gceCloud.Project()
 
 			if !AlphaAllowGCE.Enabled() {
 				return fmt.Errorf("GCE support is currently alpha, and is feature-gated.  export KOPS_FEATURE_FLAGS=AlphaAllowGCE")
@@ -706,7 +706,7 @@ func (c *ApplyClusterCmd) Run() error {
 	case TargetDirect:
 		switch cluster.Spec.CloudProvider {
 		case "gce":
-			target = gce.NewGCEAPITarget(cloud.(*gce.GCECloud))
+			target = gce.NewGCEAPITarget(cloud.(gce.GCECloud))
 		case "aws":
 			target = awsup.NewAWSAPITarget(cloud.(awsup.AWSCloud))
 		case "digitalocean":

--- a/upup/pkg/fi/cloudup/gce/gce_apitarget.go
+++ b/upup/pkg/fi/cloudup/gce/gce_apitarget.go
@@ -21,12 +21,12 @@ import (
 )
 
 type GCEAPITarget struct {
-	Cloud *GCECloud
+	Cloud GCECloud
 }
 
 var _ fi.Target = &GCEAPITarget{}
 
-func NewGCEAPITarget(cloud *GCECloud) *GCEAPITarget {
+func NewGCEAPITarget(cloud GCECloud) *GCEAPITarget {
 	return &GCEAPITarget{
 		Cloud: cloud,
 	}

--- a/upup/pkg/fi/cloudup/gcetasks/address.go
+++ b/upup/pkg/fi/cloudup/gcetasks/address.go
@@ -34,7 +34,7 @@ type Address struct {
 }
 
 func (e *Address) Find(c *fi.Context) (*Address, error) {
-	actual, err := e.find(c.Cloud.(*gce.GCECloud))
+	actual, err := e.find(c.Cloud.(gce.GCECloud))
 	if actual != nil && err == nil {
 		if e.IPAddress == nil {
 			e.IPAddress = actual.IPAddress
@@ -43,9 +43,9 @@ func (e *Address) Find(c *fi.Context) (*Address, error) {
 	return actual, err
 }
 
-func findAddressByIP(cloud *gce.GCECloud, ip string) (*Address, error) {
+func findAddressByIP(cloud gce.GCECloud, ip string) (*Address, error) {
 	// Technically this is a regex, but it doesn't matter...
-	r, err := cloud.Compute.Addresses.List(cloud.Project, cloud.Region).Filter("address eq " + ip).Do()
+	r, err := cloud.Compute().Addresses.List(cloud.Project(), cloud.Region()).Filter("address eq " + ip).Do()
 	if err != nil {
 		return nil, fmt.Errorf("error listing IPAddresss: %v", err)
 	}
@@ -64,8 +64,8 @@ func findAddressByIP(cloud *gce.GCECloud, ip string) (*Address, error) {
 	return actual, nil
 }
 
-func (e *Address) find(cloud *gce.GCECloud) (*Address, error) {
-	r, err := cloud.Compute.Addresses.Get(cloud.Project, cloud.Region, *e.Name).Do()
+func (e *Address) find(cloud gce.GCECloud) (*Address, error) {
+	r, err := cloud.Compute().Addresses.Get(cloud.Project(), cloud.Region(), *e.Name).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			return nil, nil
@@ -84,7 +84,7 @@ func (e *Address) find(cloud *gce.GCECloud) (*Address, error) {
 var _ fi.HasAddress = &Address{}
 
 func (e *Address) FindIPAddress(context *fi.Context) (*string, error) {
-	actual, err := e.find(context.Cloud.(*gce.GCECloud))
+	actual, err := e.find(context.Cloud.(gce.GCECloud))
 	if err != nil {
 		return nil, fmt.Errorf("error querying for IPAddress: %v", err)
 	}
@@ -110,22 +110,23 @@ func (_ *Address) CheckChanges(a, e, changes *Address) error {
 	return nil
 }
 
-func (_ *Address) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Address) error {
+func (_ *Address) RenderGCE(t gce.GCEAPITarget, a, e, changes *Address) error {
+	cloud := t.Cloud
 	addr := &compute.Address{
 		Name:    *e.Name,
 		Address: fi.StringValue(e.IPAddress),
-		Region:  t.Cloud.Region,
+		Region:  cloud.Region(),
 	}
 
 	if a == nil {
 		glog.Infof("GCE creating address: %q", addr.Name)
 
-		op, err := t.Cloud.Compute.Addresses.Insert(t.Cloud.Project, t.Cloud.Region, addr).Do()
+		op, err := cloud.Compute().Addresses.Insert(cloud.Project(), cloud.Region(), addr).Do()
 		if err != nil {
 			return fmt.Errorf("error creating IPAddress: %v", err)
 		}
 
-		if err := t.Cloud.WaitForOp(op); err != nil {
+		if err := cloud.WaitForOp(op); err != nil {
 			return fmt.Errorf("error waiting for IPAddress: %v", err)
 		}
 	} else {

--- a/upup/pkg/fi/cloudup/gcetasks/disk.go
+++ b/upup/pkg/fi/cloudup/gcetasks/disk.go
@@ -45,9 +45,9 @@ func (e *Disk) CompareWithID() *string {
 }
 
 func (e *Disk) Find(c *fi.Context) (*Disk, error) {
-	cloud := c.Cloud.(*gce.GCECloud)
+	cloud := c.Cloud.(gce.GCECloud)
 
-	r, err := cloud.Compute.Disks.Get(cloud.Project, *e.Zone, *e.Name).Do()
+	r, err := cloud.Compute().Disks.Get(cloud.Project(), *e.Zone, *e.Name).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			return nil, nil
@@ -100,8 +100,9 @@ func (_ *Disk) CheckChanges(a, e, changes *Disk) error {
 }
 
 func (_ *Disk) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Disk) error {
+	cloud := t.Cloud
 	typeURL := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/diskTypes/%s",
-		t.Cloud.Project,
+		cloud.Project(),
 		*e.Zone,
 		*e.VolumeType)
 
@@ -112,14 +113,14 @@ func (_ *Disk) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Disk) error {
 	}
 
 	if a == nil {
-		_, err := t.Cloud.Compute.Disks.Insert(t.Cloud.Project, *e.Zone, disk).Do()
+		_, err := cloud.Compute().Disks.Insert(t.Cloud.Project(), *e.Zone, disk).Do()
 		if err != nil {
 			return fmt.Errorf("error creating Disk: %v", err)
 		}
 	}
 
 	if changes.Labels != nil {
-		d, err := t.Cloud.Compute.Disks.Get(t.Cloud.Project, *e.Zone, disk.Name).Do()
+		d, err := cloud.Compute().Disks.Get(t.Cloud.Project(), *e.Zone, disk.Name).Do()
 		if err != nil {
 			return fmt.Errorf("error reading created Disk: %v", err)
 		}
@@ -142,7 +143,7 @@ func (_ *Disk) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Disk) error {
 			labelsRequest.Labels[k] = v
 		}
 		glog.V(2).Infof("Setting labels on disk %q: %v", disk.Name, labelsRequest.Labels)
-		_, err = t.Cloud.Compute.Disks.SetLabels(t.Cloud.Project, *e.Zone, disk.Name, labelsRequest).Do()
+		_, err = t.Cloud.Compute().Disks.SetLabels(t.Cloud.Project(), *e.Zone, disk.Name, labelsRequest).Do()
 		if err != nil {
 			return fmt.Errorf("error setting labels on created Disk: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/gcetasks/firewallrule.go
+++ b/upup/pkg/fi/cloudup/gcetasks/firewallrule.go
@@ -45,9 +45,9 @@ func (e *FirewallRule) CompareWithID() *string {
 }
 
 func (e *FirewallRule) Find(c *fi.Context) (*FirewallRule, error) {
-	cloud := c.Cloud.(*gce.GCECloud)
+	cloud := c.Cloud.(gce.GCECloud)
 
-	r, err := cloud.Compute.Firewalls.Get(cloud.Project, *e.Name).Do()
+	r, err := cloud.Compute().Firewalls.Get(cloud.Project(), *e.Name).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			return nil, nil
@@ -132,18 +132,19 @@ func (e *FirewallRule) mapToGCE(project string) (*compute.Firewall, error) {
 }
 
 func (_ *FirewallRule) RenderGCE(t *gce.GCEAPITarget, a, e, changes *FirewallRule) error {
-	firewall, err := e.mapToGCE(t.Cloud.Project)
+	cloud := t.Cloud
+	firewall, err := e.mapToGCE(cloud.Project())
 	if err != nil {
 		return err
 	}
 
 	if a == nil {
-		_, err := t.Cloud.Compute.Firewalls.Insert(t.Cloud.Project, firewall).Do()
+		_, err := t.Cloud.Compute().Firewalls.Insert(t.Cloud.Project(), firewall).Do()
 		if err != nil {
 			return fmt.Errorf("error creating FirewallRule: %v", err)
 		}
 	} else {
-		_, err := t.Cloud.Compute.Firewalls.Update(t.Cloud.Project, *e.Name, firewall).Do()
+		_, err := t.Cloud.Compute().Firewalls.Update(t.Cloud.Project(), *e.Name, firewall).Do()
 		if err != nil {
 			return fmt.Errorf("error creating FirewallRule: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/gcetasks/forwardingrule.go
+++ b/upup/pkg/fi/cloudup/gcetasks/forwardingrule.go
@@ -44,10 +44,10 @@ func (e *ForwardingRule) CompareWithID() *string {
 }
 
 func (e *ForwardingRule) Find(c *fi.Context) (*ForwardingRule, error) {
-	cloud := c.Cloud.(*gce.GCECloud)
+	cloud := c.Cloud.(gce.GCECloud)
 	name := fi.StringValue(e.Name)
 
-	r, err := cloud.Compute.ForwardingRules.Get(cloud.Project, cloud.Region, name).Do()
+	r, err := cloud.Compute().ForwardingRules.Get(cloud.Project(), cloud.Region(), name).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			return nil, nil
@@ -121,7 +121,7 @@ func (_ *ForwardingRule) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Forwardin
 	if a == nil {
 		glog.V(4).Infof("Creating ForwardingRule %q", o.Name)
 
-		_, err := t.Cloud.Compute.ForwardingRules.Insert(t.Cloud.Project, t.Cloud.Region, o).Do()
+		_, err := t.Cloud.Compute().ForwardingRules.Insert(t.Cloud.Project(), t.Cloud.Region(), o).Do()
 		if err != nil {
 			return fmt.Errorf("error creating ForwardingRule %q: %v", o.Name, err)
 		}

--- a/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager.go
@@ -45,9 +45,9 @@ func (e *InstanceGroupManager) CompareWithID() *string {
 }
 
 func (e *InstanceGroupManager) Find(c *fi.Context) (*InstanceGroupManager, error) {
-	cloud := c.Cloud.(*gce.GCECloud)
+	cloud := c.Cloud.(gce.GCECloud)
 
-	r, err := cloud.Compute.InstanceGroupManagers.Get(cloud.Project, *e.Zone, *e.Name).Do()
+	r, err := cloud.Compute().InstanceGroupManagers.Get(cloud.Project(), *e.Zone, *e.Name).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			return nil, nil
@@ -81,7 +81,7 @@ func (_ *InstanceGroupManager) CheckChanges(a, e, changes *InstanceGroupManager)
 }
 
 func (_ *InstanceGroupManager) RenderGCE(t *gce.GCEAPITarget, a, e, changes *InstanceGroupManager) error {
-	project := t.Cloud.Project
+	project := t.Cloud.Project()
 
 	instanceTemplateURL, err := e.InstanceTemplate.URL(project)
 	if err != nil {
@@ -102,7 +102,7 @@ func (_ *InstanceGroupManager) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Ins
 
 	if a == nil {
 		//for {
-		op, err := t.Cloud.Compute.InstanceGroupManagers.Insert(t.Cloud.Project, *e.Zone, i).Do()
+		op, err := t.Cloud.Compute().InstanceGroupManagers.Insert(t.Cloud.Project(), *e.Zone, i).Do()
 		if err != nil {
 			return fmt.Errorf("error creating InstanceGroupManager: %v", err)
 		}
@@ -115,7 +115,7 @@ func (_ *InstanceGroupManager) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Ins
 			request := &compute.InstanceGroupManagersSetTargetPoolsRequest{
 				TargetPools: i.TargetPools,
 			}
-			op, err := t.Cloud.Compute.InstanceGroupManagers.SetTargetPools(t.Cloud.Project, *e.Zone, i.Name, request).Do()
+			op, err := t.Cloud.Compute().InstanceGroupManagers.SetTargetPools(t.Cloud.Project(), *e.Zone, i.Name, request).Do()
 			if err != nil {
 				return fmt.Errorf("error updating TargetPools for InstanceGroupManager: %v", err)
 			}
@@ -131,7 +131,7 @@ func (_ *InstanceGroupManager) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Ins
 			request := &compute.InstanceGroupManagersSetInstanceTemplateRequest{
 				InstanceTemplate: instanceTemplateURL,
 			}
-			op, err := t.Cloud.Compute.InstanceGroupManagers.SetInstanceTemplate(t.Cloud.Project, *e.Zone, i.Name, request).Do()
+			op, err := t.Cloud.Compute().InstanceGroupManagers.SetInstanceTemplate(t.Cloud.Project(), *e.Zone, i.Name, request).Do()
 			if err != nil {
 				return fmt.Errorf("error updating InstanceTemplate for InstanceGroupManager: %v", err)
 			}

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -67,9 +67,9 @@ func (e *InstanceTemplate) CompareWithID() *string {
 }
 
 func (e *InstanceTemplate) Find(c *fi.Context) (*InstanceTemplate, error) {
-	cloud := c.Cloud.(*gce.GCECloud)
+	cloud := c.Cloud.(gce.GCECloud)
 
-	response, err := cloud.Compute.InstanceTemplates.List(cloud.Project).Do()
+	response, err := cloud.Compute().InstanceTemplates.List(cloud.Project()).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			return nil, nil
@@ -77,7 +77,7 @@ func (e *InstanceTemplate) Find(c *fi.Context) (*InstanceTemplate, error) {
 		return nil, fmt.Errorf("error listing InstanceTemplates: %v", err)
 	}
 
-	expected, err := e.mapToGCE(cloud.Project)
+	expected, err := e.mapToGCE(cloud.Project())
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (e *InstanceTemplate) Find(c *fi.Context) (*InstanceTemplate, error) {
 		actual.MachineType = fi.String(lastComponent(p.MachineType))
 		actual.CanIPForward = &p.CanIpForward
 
-		bootDiskImage, err := ShortenImageURL(cloud.Project, p.Disks[0].InitializeParams.SourceImage)
+		bootDiskImage, err := ShortenImageURL(cloud.Project(), p.Disks[0].InitializeParams.SourceImage)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing source image URL: %v", err)
 		}
@@ -342,7 +342,7 @@ func (e *InstanceTemplate) URL(project string) (string, error) {
 }
 
 func (_ *InstanceTemplate) RenderGCE(t *gce.GCEAPITarget, a, e, changes *InstanceTemplate) error {
-	project := t.Cloud.Project
+	project := t.Cloud.Project()
 
 	i, err := e.mapToGCE(project)
 	if err != nil {
@@ -356,7 +356,7 @@ func (_ *InstanceTemplate) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Instanc
 		e.ID = &name
 		i.Name = name
 
-		op, err := t.Cloud.Compute.InstanceTemplates.Insert(t.Cloud.Project, i).Do()
+		op, err := t.Cloud.Compute().InstanceTemplates.Insert(t.Cloud.Project(), i).Do()
 		if err != nil {
 			return fmt.Errorf("error creating InstanceTemplate: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/gcetasks/network.go
+++ b/upup/pkg/fi/cloudup/gcetasks/network.go
@@ -40,9 +40,9 @@ func (e *Network) CompareWithID() *string {
 }
 
 func (e *Network) Find(c *fi.Context) (*Network, error) {
-	cloud := c.Cloud.(*gce.GCECloud)
+	cloud := c.Cloud.(gce.GCECloud)
 
-	r, err := cloud.Compute.Networks.Get(cloud.Project, *e.Name).Do()
+	r, err := cloud.Compute().Networks.Get(cloud.Project(), *e.Name).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			return nil, nil
@@ -54,8 +54,8 @@ func (e *Network) Find(c *fi.Context) (*Network, error) {
 	actual.Name = &r.Name
 	actual.CIDR = &r.IPv4Range
 
-	if r.SelfLink != e.URL(cloud.Project) {
-		glog.Warningf("SelfLink did not match URL: %q vs %q", r.SelfLink, e.URL(cloud.Project))
+	if r.SelfLink != e.URL(cloud.Project()) {
+		glog.Warningf("SelfLink did not match URL: %q vs %q", r.SelfLink, e.URL(cloud.Project()))
 	}
 
 	return actual, nil
@@ -98,7 +98,7 @@ func (_ *Network) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Network) error {
 
 			Name: *e.Name,
 		}
-		_, err := t.Cloud.Compute.Networks.Insert(t.Cloud.Project, network).Do()
+		_, err := t.Cloud.Compute().Networks.Insert(t.Cloud.Project(), network).Do()
 		if err != nil {
 			return fmt.Errorf("error creating Network: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/gcetasks/subnet.go
+++ b/upup/pkg/fi/cloudup/gcetasks/subnet.go
@@ -42,9 +42,9 @@ func (e *Subnet) CompareWithID() *string {
 }
 
 func (e *Subnet) Find(c *fi.Context) (*Subnet, error) {
-	cloud := c.Cloud.(*gce.GCECloud)
+	cloud := c.Cloud.(gce.GCECloud)
 
-	s, err := cloud.Compute.Subnetworks.Get(cloud.Project, cloud.Region, *e.Name).Do()
+	s, err := cloud.Compute().Subnetworks.Get(cloud.Project(), cloud.Region(), *e.Name).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			return nil, nil
@@ -78,7 +78,7 @@ func (_ *Subnet) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Subnet) error {
 			Name:        *e.Name,
 			Network:     *e.Network.Name,
 		}
-		_, err := t.Cloud.Compute.Subnetworks.Insert(t.Cloud.Project, t.Cloud.Region, subnet).Do()
+		_, err := t.Cloud.Compute().Subnetworks.Insert(t.Cloud.Project(), t.Cloud.Region(), subnet).Do()
 		if err != nil {
 			return fmt.Errorf("error creating Subnet: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/gcetasks/targetpool.go
+++ b/upup/pkg/fi/cloudup/gcetasks/targetpool.go
@@ -39,10 +39,10 @@ func (e *TargetPool) CompareWithID() *string {
 }
 
 func (e *TargetPool) Find(c *fi.Context) (*TargetPool, error) {
-	cloud := c.Cloud.(*gce.GCECloud)
+	cloud := c.Cloud.(gce.GCECloud)
 	name := fi.StringValue(e.Name)
 
-	r, err := cloud.Compute.TargetPools.Get(cloud.Project, cloud.Region, name).Do()
+	r, err := cloud.Compute().TargetPools.Get(cloud.Project(), cloud.Region(), name).Do()
 	if err != nil {
 		if gce.IsNotFound(err) {
 			return nil, nil
@@ -67,10 +67,10 @@ func (_ *TargetPool) CheckChanges(a, e, changes *TargetPool) error {
 	return nil
 }
 
-func (e *TargetPool) URL(cloud *gce.GCECloud) string {
+func (e *TargetPool) URL(cloud gce.GCECloud) string {
 	name := fi.StringValue(e.Name)
 
-	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/targetPools/%s", cloud.Project, cloud.Region, name)
+	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/targetPools/%s", cloud.Project(), cloud.Region(), name)
 }
 
 func (_ *TargetPool) RenderGCE(t *gce.GCEAPITarget, a, e, changes *TargetPool) error {
@@ -83,7 +83,7 @@ func (_ *TargetPool) RenderGCE(t *gce.GCEAPITarget, a, e, changes *TargetPool) e
 	if a == nil {
 		glog.V(4).Infof("Creating TargetPool %q", o.Name)
 
-		op, err := t.Cloud.Compute.TargetPools.Insert(t.Cloud.Project, t.Cloud.Region, o).Do()
+		op, err := t.Cloud.Compute().TargetPools.Insert(t.Cloud.Project(), t.Cloud.Region(), o).Do()
 		if err != nil {
 			return fmt.Errorf("error creating TargetPool %q: %v", name, err)
 		}


### PR DESCRIPTION
GCE and other cloud providers are structs instead of an interface.  AWS cloud provider implements an interface.  This PR refactors `GCECloud` as an interface, and creates `gceCloudImplementation`.

- [x] Need to e2e test