### PR TITLE
Warn if SSH fingerprint is obviously bad

### DIFF
--- a/upup/pkg/fi/vfs_castore.go
+++ b/upup/pkg/fi/vfs_castore.go
@@ -634,20 +634,22 @@ func formatFingerprint(data []byte) string {
 }
 
 func insertFingerprintColons(id string) string {
-	var buf bytes.Buffer
+	remaining := id
 
+	var buf bytes.Buffer
 	for {
-		if id == "" {
+		if remaining == "" {
 			break
 		}
 		if buf.Len() != 0 {
 			buf.WriteString(":")
 		}
-		if len(id) < 2 {
-			buf.WriteString(id)
+		if len(remaining) < 2 {
+			glog.Warningf("unexpected format for SSH public key id: %q", id)
+			buf.WriteString(remaining)
 		} else {
-			buf.WriteString(id[0:2])
-			id = id[2:]
+			buf.WriteString(remaining[0:2])
+			remaining = remaining[2:]
 		}
 	}
 	return buf.String()


### PR DESCRIPTION
In particular this catches double-encoding