### PR TITLE
baremetal: relax validation on subnets & networking

### DIFF
--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -244,6 +244,7 @@ func FindKopsVersionSpec(versions []KopsVersionSpec, version semver.Version) *Ko
 type CloudProviderID string
 
 const CloudProviderAWS CloudProviderID = "aws"
+const CloudProviderBareMetal CloudProviderID = "baremetal"
 const CloudProviderGCE CloudProviderID = "gce"
 const CloudProviderDO CloudProviderID = "digitalocean"
 const CloudProviderVSphere CloudProviderID = "vsphere"


### PR DESCRIPTION
For baremetal, we don't require that subnets or the network CIDR is
specified.