### PR TITLE
Additional Kubelet Options

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -142,6 +142,10 @@ type KubeletConfigSpec struct {
 	SystemReservedCgroup string `json:"systemReservedCgroup,omitempty" flag:"system-reserved-cgroup"`
 	// Enforce Allocatable across pods whenever the overall usage across all pods exceeds Allocatable.
 	EnforceNodeAllocatable string `json:"enforceNodeAllocatable,omitempty" flag:"enforce-node-allocatable"`
+	// RuntimeRequestTimeout is timeout for runtime requests on - pull, logs, exec and attach
+	RuntimeRequestTimeout *metav1.Duration `json:"runtimeRequestTimeout,omitempty" flag:"runtime-request-timeout"`
+	// VolumeStatsAggPeriod is the interval for kubelet to calculate and cache the volume disk usage for all pods and volumes
+	VolumeStatsAggPeriod *metav1.Duration `json:"volumeStatsAggPeriod,omitempty" flag:"volume-stats-agg-period"`
 }
 
 // KubeProxyConfig defined the configuration for a proxy

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -142,6 +142,10 @@ type KubeletConfigSpec struct {
 	SystemReservedCgroup string `json:"systemReservedCgroup,omitempty" flag:"system-reserved-cgroup"`
 	// Enforce Allocatable across pods whenever the overall usage across all pods exceeds Allocatable.
 	EnforceNodeAllocatable string `json:"enforceNodeAllocatable,omitempty" flag:"enforce-node-allocatable"`
+	// RuntimeRequestTimeout is timeout for runtime requests on - pull, logs, exec and attach
+	RuntimeRequestTimeout *metav1.Duration `json:"runtimeRequestTimeout,omitempty" flag:"runtime-request-timeout"`
+	// VolumeStatsAggPeriod is the interval for kubelet to calculate and cache the volume disk usage for all pods and volumes
+	VolumeStatsAggPeriod *metav1.Duration `json:"volumeStatsAggPeriod,omitempty" flag:"volume-stats-agg-period"`
 }
 
 // KubeProxyConfig defined the configuration for a proxy

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1944,6 +1944,8 @@ func autoConvert_v1alpha1_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.SystemReserved = in.SystemReserved
 	out.SystemReservedCgroup = in.SystemReservedCgroup
 	out.EnforceNodeAllocatable = in.EnforceNodeAllocatable
+	out.RuntimeRequestTimeout = in.RuntimeRequestTimeout
+	out.VolumeStatsAggPeriod = in.VolumeStatsAggPeriod
 	return nil
 }
 
@@ -2004,6 +2006,8 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha1_KubeletConfigSpec(in *kops.K
 	out.SystemReserved = in.SystemReserved
 	out.SystemReservedCgroup = in.SystemReservedCgroup
 	out.EnforceNodeAllocatable = in.EnforceNodeAllocatable
+	out.RuntimeRequestTimeout = in.RuntimeRequestTimeout
+	out.VolumeStatsAggPeriod = in.VolumeStatsAggPeriod
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -142,6 +142,10 @@ type KubeletConfigSpec struct {
 	SystemReservedCgroup string `json:"systemReservedCgroup,omitempty" flag:"system-reserved-cgroup"`
 	// Enforce Allocatable across pods whenever the overall usage across all pods exceeds Allocatable.
 	EnforceNodeAllocatable string `json:"enforceNodeAllocatable,omitempty" flag:"enforce-node-allocatable"`
+	// RuntimeRequestTimeout is timeout for runtime requests on - pull, logs, exec and attach
+	RuntimeRequestTimeout *metav1.Duration `json:"runtimeRequestTimeout,omitempty" flag:"runtime-request-timeout"`
+	// VolumeStatsAggPeriod is the interval for kubelet to calculate and cache the volume disk usage for all pods and volumes
+	VolumeStatsAggPeriod *metav1.Duration `json:"volumeStatsAggPeriod,omitempty" flag:"volume-stats-agg-period"`
 }
 
 // KubeProxyConfig defined the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2052,6 +2052,8 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.SystemReserved = in.SystemReserved
 	out.SystemReservedCgroup = in.SystemReservedCgroup
 	out.EnforceNodeAllocatable = in.EnforceNodeAllocatable
+	out.RuntimeRequestTimeout = in.RuntimeRequestTimeout
+	out.VolumeStatsAggPeriod = in.VolumeStatsAggPeriod
 	return nil
 }
 
@@ -2112,6 +2114,8 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.SystemReserved = in.SystemReserved
 	out.SystemReservedCgroup = in.SystemReservedCgroup
 	out.EnforceNodeAllocatable = in.EnforceNodeAllocatable
+	out.RuntimeRequestTimeout = in.RuntimeRequestTimeout
+	out.VolumeStatsAggPeriod = in.VolumeStatsAggPeriod
 	return nil
 }
 


### PR DESCRIPTION
This PR add additional options to the kubelet spec allowing users to set the --runtime-request-timeout and -volume-stats-agg-period

In related to issue https://github.com/kubernetes/kops/issues/3265