### PR TITLE
Kubelet Readonly Port

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -58,6 +58,8 @@ type KubeletConfigSpec struct {
 	KubeletCgroups string `json:"kubeletCgroups,omitempty" flag:"kubelet-cgroups"`
 	// Cgroups that container runtime is expected to be isolated in.
 	RuntimeCgroups string `json:"runtimeCgroups,omitempty" flag:"runtime-cgroups"`
+	// ReadOnlyPort is the port used by the kubelet api for read-only access (default 10255)
+	ReadOnlyPort *int32 `json:"readOnlyPort,omitempty" flag:"read-only-port"`
 	// SystemCgroups is absolute name of cgroups in which to place
 	// all non-kernel processes that are not already in a container. Empty
 	// for no container. Rolling back the flag requires a reboot.

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -58,6 +58,8 @@ type KubeletConfigSpec struct {
 	KubeletCgroups string `json:"kubeletCgroups,omitempty" flag:"kubelet-cgroups"`
 	// Cgroups that container runtime is expected to be isolated in.
 	RuntimeCgroups string `json:"runtimeCgroups,omitempty" flag:"runtime-cgroups"`
+	// ReadOnlyPort is the port used by the kubelet api for read-only access (default 10255)
+	ReadOnlyPort *int32 `json:"readOnlyPort,omitempty" flag:"read-only-port"`
 	// SystemCgroups is absolute name of cgroups in which to place
 	// all non-kernel processes that are not already in a container. Empty
 	// for no container. Rolling back the flag requires a reboot.

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1912,6 +1912,7 @@ func autoConvert_v1alpha1_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.CloudProvider = in.CloudProvider
 	out.KubeletCgroups = in.KubeletCgroups
 	out.RuntimeCgroups = in.RuntimeCgroups
+	out.ReadOnlyPort = in.ReadOnlyPort
 	out.SystemCgroups = in.SystemCgroups
 	out.CgroupRoot = in.CgroupRoot
 	out.ConfigureCBR0 = in.ConfigureCBR0
@@ -1972,6 +1973,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha1_KubeletConfigSpec(in *kops.K
 	out.CloudProvider = in.CloudProvider
 	out.KubeletCgroups = in.KubeletCgroups
 	out.RuntimeCgroups = in.RuntimeCgroups
+	out.ReadOnlyPort = in.ReadOnlyPort
 	out.SystemCgroups = in.SystemCgroups
 	out.CgroupRoot = in.CgroupRoot
 	out.ConfigureCBR0 = in.ConfigureCBR0

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -58,6 +58,8 @@ type KubeletConfigSpec struct {
 	KubeletCgroups string `json:"kubeletCgroups,omitempty" flag:"kubelet-cgroups"`
 	// Cgroups that container runtime is expected to be isolated in.
 	RuntimeCgroups string `json:"runtimeCgroups,omitempty" flag:"runtime-cgroups"`
+	// ReadOnlyPort is the port used by the kubelet api for read-only access (default 10255)
+	ReadOnlyPort *int32 `json:"readOnlyPort,omitempty" flag:"read-only-port"`
 	// SystemCgroups is absolute name of cgroups in which to place
 	// all non-kernel processes that are not already in a container. Empty
 	// for no container. Rolling back the flag requires a reboot.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2020,6 +2020,7 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.CloudProvider = in.CloudProvider
 	out.KubeletCgroups = in.KubeletCgroups
 	out.RuntimeCgroups = in.RuntimeCgroups
+	out.ReadOnlyPort = in.ReadOnlyPort
 	out.SystemCgroups = in.SystemCgroups
 	out.CgroupRoot = in.CgroupRoot
 	out.ConfigureCBR0 = in.ConfigureCBR0
@@ -2080,6 +2081,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.CloudProvider = in.CloudProvider
 	out.KubeletCgroups = in.KubeletCgroups
 	out.RuntimeCgroups = in.RuntimeCgroups
+	out.ReadOnlyPort = in.ReadOnlyPort
 	out.SystemCgroups = in.SystemCgroups
 	out.CgroupRoot = in.CgroupRoot
 	out.ConfigureCBR0 = in.ConfigureCBR0


### PR DESCRIPTION
The current implementation does not permit the user to specify the kubelet read-only port (which unset defaults to 10255). For security reasons we need this port switched off i.e. 0. This PR retains the default behavior but adds the readOnlyPort as an option for those whom need to override.

```shell
   podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
   podManifestPath: /etc/kubernetes/manifests
+  readOnlyPort: 0
   registerSchedulable: false
   requireKubeconfig: true
```
And tested on the box
```shell
core@ip-10-250-34-23 ~ $ egrep -o 'read-only-port=[0-9]+' /etc/sysconfig/kubelet 
read-only-port=0
```
