### PR TITLE
WIP: Makefile lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: go
+sudo: required
+dist: trusty
+
 go:
   - 1.8
   - 1.9
@@ -7,7 +10,7 @@ go:
 go_import_path: k8s.io/kops
 
 script:
-  - make ci
+  - make -j2 ci
 
 git:
   submodules: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ go:
 
 go_import_path: k8s.io/kops
 
+install:
+  - make -j2 ci-setup
+
 script:
   - make -j2 ci
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ go:
 go_import_path: k8s.io/kops
 
 install:
-  - make -j2 ci-setup
+  - make ci-setup
 
 script:
   - make -j2 ci

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LATEST_FILE?=latest-ci.txt
 GOPATH_1ST=$(shell go env | grep GOPATH | cut -f 2 -d \")
 UNIQUE:=$(shell date +%s)
 GOVERSION=1.8.3
-PACKAGES:=$(shell go list ./... | egrep -v "\/vendor\/|\/cloudmock\/")
+PACKAGES:=$(shell go list ./... | egrep -v "\/vendor\/|\/cloudmock\/|\/kops\/federation\/model")
 #
 # See http://stackoverflow.com/questions/18136918/how-to-get-current-relative-directory-of-your-makefile
 MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))
@@ -456,7 +456,7 @@ verify-gendocs: kops
 # verify-package has to be after verify-gendoc, because with .gitignore for federation bindata
 # it bombs in travis. verify-gendoc generates the bindata file.
 .PHONY: ci
-ci: govet verify-gofmt verify-boilerplate nodeup-gocode | codegen verify-gendocs test examples verify-packages lint
+ci: govet verify-gofmt verify-boilerplate nodeup-gocode test examples lint | verify-gendocs verify-packages
 	echo "Done!"
 
 # --------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -456,7 +456,7 @@ verify-gendocs: kops
 # verify-package has to be after verify-gendoc, because with .gitignore for federation bindata
 # it bombs in travis. verify-gendoc generates the bindata file.
 .PHONY: ci
-ci: govet verify-gofmt verify-boilerplate nodeup-gocode examples test | verify-gendocs verify-packages lint
+ci: govet verify-gofmt verify-boilerplate nodeup-gocode | verify-gendocs test examples verify-packages lint
 	echo "Done!"
 
 # --------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -456,7 +456,7 @@ verify-gendocs: kops
 # verify-package has to be after verify-gendoc, because with .gitignore for federation bindata
 # it bombs in travis. verify-gendoc generates the bindata file.
 .PHONY: ci
-ci: govet verify-gofmt verify-boilerplate nodeup-gocode examples test lint | verify-gendocs verify-packages
+ci: govet verify-gofmt verify-boilerplate nodeup-gocode examples test | verify-gendocs verify-packages lint
 	echo "Done!"
 
 # --------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -407,25 +407,38 @@ govet:
 # --------------------------------------------------
 # Continuous integration targets
 
+
+.PHONY: ci-setup
+ci-setup: simple-setup staticcheck-setup unused-setup codegen
+
 .PHONY: lint
-lint: staticcheck unused simple | codegen
+lint: staticcheck unused simple
+
+.PHONY: simple-setup
+simple-setup:
+	go get honnef.co/go/tools/cmd/gosimple
 
 .PHONY: simple
 simple:
 	@echo "** linting with 'simple'"
-	go get honnef.co/go/tools/cmd/gosimple
 	-gosimple $(PACKAGES)
+
+.PHONY: staticcheck-setup
+staticcheck-setup:
+	go get honnef.co/go/tools/cmd/staticcheck
 
 .PHONY: staticcheck
 staticcheck:
 	@echo "** linting with 'staticcheck'"
-	go get honnef.co/go/tools/cmd/staticcheck
 	-staticcheck $(PACKAGES)
+
+.PHONY: unused-setup
+unused-setup:
+	go get honnef.co/go/tools/cmd/unused
 
 .PHONY: unused
 unused:
 	@echo "** linting with 'unused'"
-	go get honnef.co/go/tools/cmd/unused
 	-unused $(PACKAGES)
 
 .PHONY: verify-boilerplate
@@ -460,7 +473,7 @@ verify-gendocs: kops
 # verify-package has to be after verify-gendoc, because with .gitignore for federation bindata
 # it bombs in travis. verify-gendoc generates the bindata file.
 .PHONY: ci
-ci: govet verify-gofmt verify-boilerplate nodeup-gocode test-travis examples lint | verify-gendocs verify-packages
+ci: govet verify-gofmt verify-boilerplate nodeup-gocode test examples lint | verify-gendocs verify-packages
 	echo "Done!"
 
 # --------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -456,7 +456,7 @@ verify-gendocs: kops
 # verify-package has to be after verify-gendoc, because with .gitignore for federation bindata
 # it bombs in travis. verify-gendoc generates the bindata file.
 .PHONY: ci
-ci: govet verify-gofmt verify-boilerplate nodeup-gocode | verify-gendocs test examples verify-packages lint
+ci: govet verify-gofmt verify-boilerplate nodeup-gocode | codegen verify-gendocs test examples verify-packages lint
 	echo "Done!"
 
 # --------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LATEST_FILE?=latest-ci.txt
 GOPATH_1ST=$(shell go env | grep GOPATH | cut -f 2 -d \")
 UNIQUE:=$(shell date +%s)
 GOVERSION=1.8.3
-PACKAGES:=$(shell go list ./... | egrep -v "\/vendor\/|\/cloudmock\/|\/kops\/federation\/model")
+PACKAGES:=$(shell go list ./... | egrep -v "\/vendor\/|\/cloudmock\/")
 #
 # See http://stackoverflow.com/questions/18136918/how-to-get-current-relative-directory-of-your-makefile
 MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))
@@ -154,6 +154,10 @@ hooks: # Install Git hooks
 
 .PHONY: test
 test: # Run tests locally
+	go test $(PACKAGES) -args -v=1 -logtostderr
+
+.PHONY: test-travis
+test-travis: codegen
 	go test $(PACKAGES) -args -v=1 -logtostderr
 
 .PHONY: crossbuild-nodeup
@@ -404,7 +408,7 @@ govet:
 # Continuous integration targets
 
 .PHONY: lint
-lint: staticcheck unused simple
+lint: staticcheck unused simple | codegen
 
 .PHONY: simple
 simple:
@@ -456,7 +460,7 @@ verify-gendocs: kops
 # verify-package has to be after verify-gendoc, because with .gitignore for federation bindata
 # it bombs in travis. verify-gendoc generates the bindata file.
 .PHONY: ci
-ci: govet verify-gofmt verify-boilerplate nodeup-gocode test examples lint | verify-gendocs verify-packages
+ci: govet verify-gofmt verify-boilerplate nodeup-gocode test-travis examples lint | verify-gendocs verify-packages
 	echo "Done!"
 
 # --------------------------------------------------


### PR DESCRIPTION
This PR adds a "lint" recipe to the Makefile that uses some honnef.co utilities. These utilities can use a lot of RAM, so I've modified .travis.yml to use a VM with 7.5GB of RAM instead of a 4GB container. This will slow test runs.

To compensate, I've configured .travis.yml to run two parallel jobs when running `make ci`.

I've changed the Makefile to use `go list ./...` and some exclusions to determine which packages get tested and linted instead of listing them explicitly in each recipe. This should prevent the previous errors of omission in testing.