### PR TITLE
Check actual EbsOptimized status during cluster update

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
@@ -111,15 +111,16 @@ func (e *LaunchConfiguration) Find(c *fi.Context) (*LaunchConfiguration, error) 
 	glog.V(2).Infof("found existing AutoscalingLaunchConfiguration: %q", *lc.LaunchConfigurationName)
 
 	actual := &LaunchConfiguration{
-		Name:               e.Name,
-		ID:                 lc.LaunchConfigurationName,
-		ImageID:            lc.ImageId,
-		InstanceType:       lc.InstanceType,
-		SSHKey:             &SSHKey{Name: lc.KeyName},
-		AssociatePublicIP:  lc.AssociatePublicIpAddress,
-		IAMInstanceProfile: &IAMInstanceProfile{Name: lc.IamInstanceProfile},
-		SpotPrice:          aws.StringValue(lc.SpotPrice),
-		Tenancy:            lc.PlacementTenancy,
+		Name:                   e.Name,
+		ID:                     lc.LaunchConfigurationName,
+		ImageID:                lc.ImageId,
+		InstanceType:           lc.InstanceType,
+		SSHKey:                 &SSHKey{Name: lc.KeyName},
+		AssociatePublicIP:      lc.AssociatePublicIpAddress,
+		IAMInstanceProfile:     &IAMInstanceProfile{Name: lc.IamInstanceProfile},
+		SpotPrice:              aws.StringValue(lc.SpotPrice),
+		Tenancy:                lc.PlacementTenancy,
+		RootVolumeOptimization: lc.EbsOptimized,
 	}
 
 	securityGroups := []*SecurityGroup{}


### PR DESCRIPTION
Fixes #3313.

It seems like the actual EbsOptimized state of the LaunchConfiguration is not read during `kops update cluster` and always trigges a modification of instance-groups that have `rootVolumeOptimization: true`.

If any meaningful test can be created for this, please let me know.