### PR TITLE
Fixes #3321 handle aws path object detection

### DIFF
--- a/pkg/apis/kops/registry/registry.go
+++ b/pkg/apis/kops/registry/registry.go
@@ -39,6 +39,9 @@ func DeleteAllClusterState(basePath vfs.Path) error {
 	}
 
 	for _, path := range paths {
+		if path.Base() == basePath.Base() {
+			continue
+		}
 		relativePath, err := vfs.RelativePath(basePath, path)
 		if err != nil {
 			return err


### PR DESCRIPTION
This check allows properly handle aws path objects(objects that have a forward slash "/" character as the last character in the key name)