### PR TITLE
Add file assets to node user data scripts, fingerprint fileAssets and hooks content.

### DIFF
--- a/pkg/model/tests/data/bootstrapscript_0.txt
+++ b/pkg/model/tests/data/bootstrapscript_0.txt
@@ -167,10 +167,12 @@ masterKubelet:
 __EOF_CLUSTER_SPEC
 
 cat > ig_spec.yaml << '__EOF_IG_SPEC'
+fileAssets:
+- content: tre8+iQw12cCsccJY3cQk4HQV3g= (fingerprint)
+  name: tokens
+  path: /kube/tokens.csv
 hooks:
-- manifest: |-
-    Type=oneshot
-    ExecStart=/usr/bin/systemctl start apply-to-all.service
+- manifest: FdicqEXLciSI1yRjQxsrye3QivU= (fingerprint)
   name: apply-to-all.service
 kubelet:
   kubeconfigPath: /etc/kubernetes/igconfig.txt

--- a/pkg/model/tests/data/bootstrapscript_1.txt
+++ b/pkg/model/tests/data/bootstrapscript_1.txt
@@ -149,15 +149,15 @@ cloudConfig:
   nodeTags: something
 docker:
   logLevel: INFO
+fileAssets:
+- content: 4/KwQntXJBIluh/8K2f+zWTQdhM= (fingerprint)
+  name: iptables-restore
+  path: /var/lib/iptables/rules-save
 hooks:
 - execContainer:
     command:
-    - sh
-    - -c
-    - chroot /rootfs apt-get update && chroot /rootfs apt-get install -y ceph-common
+    - ChIIt0bv6sTY/wwaEWTBNaObBgM= (fingerprint)
     image: busybox
-  roles:
-  - Master
 kubeAPIServer:
   image: CoreOS
 kubeControllerManager:
@@ -176,19 +176,20 @@ masterKubelet:
 __EOF_CLUSTER_SPEC
 
 cat > ig_spec.yaml << '__EOF_IG_SPEC'
+fileAssets:
+- content: 4/KwQntXJBIluh/8K2f+zWTQdhM= (fingerprint)
+  name: iptables-restore
+  path: /var/lib/iptables/rules-save
+- content: tre8+iQw12cCsccJY3cQk4HQV3g= (fingerprint)
+  name: tokens
+  path: /kube/tokens.csv
 hooks:
 - before:
   - update-engine.service
   - kubelet.service
-  manifest: |-
-    Type=oneshot
-    ExecStart=/usr/bin/systemctl stop update-engine.service
+  manifest: LSdpmOQebIkYoG0lRv8AUHCBIyg= (fingerprint)
   name: disable-update-engine.service
-  roles:
-  - Master
-- manifest: |-
-    Type=oneshot
-    ExecStart=/usr/bin/systemctl start apply-to-all.service
+- manifest: FdicqEXLciSI1yRjQxsrye3QivU= (fingerprint)
   name: apply-to-all.service
 kubelet:
   kubeconfigPath: /etc/kubernetes/igconfig.txt

--- a/pkg/model/tests/data/bootstrapscript_2.txt
+++ b/pkg/model/tests/data/bootstrapscript_2.txt
@@ -149,16 +149,15 @@ cloudConfig:
   nodeTags: something
 docker:
   logLevel: INFO
+fileAssets:
+- content: 4/KwQntXJBIluh/8K2f+zWTQdhM= (fingerprint)
+  name: iptables-restore
+  path: /var/lib/iptables/rules-save
 hooks:
 - execContainer:
     command:
-    - sh
-    - -c
-    - chroot /rootfs apt-get update && chroot /rootfs apt-get install -y ceph-common
+    - ChIIt0bv6sTY/wwaEWTBNaObBgM= (fingerprint)
     image: busybox
-  roles:
-  - Master
-  - Node
 kubeAPIServer:
   image: CoreOS
 kubeControllerManager:
@@ -177,20 +176,20 @@ masterKubelet:
 __EOF_CLUSTER_SPEC
 
 cat > ig_spec.yaml << '__EOF_IG_SPEC'
+fileAssets:
+- content: 4/KwQntXJBIluh/8K2f+zWTQdhM= (fingerprint)
+  name: iptables-restore
+  path: /var/lib/iptables/rules-save
+- content: tre8+iQw12cCsccJY3cQk4HQV3g= (fingerprint)
+  name: tokens
+  path: /kube/tokens.csv
 hooks:
 - before:
   - update-engine.service
   - kubelet.service
-  manifest: |-
-    Type=oneshot
-    ExecStart=/usr/bin/systemctl stop update-engine.service
+  manifest: LSdpmOQebIkYoG0lRv8AUHCBIyg= (fingerprint)
   name: disable-update-engine.service
-  roles:
-  - Master
-  - Node
-- manifest: |-
-    Type=oneshot
-    ExecStart=/usr/bin/systemctl start apply-to-all.service
+- manifest: FdicqEXLciSI1yRjQxsrye3QivU= (fingerprint)
   name: apply-to-all.service
 kubelet:
   kubeconfigPath: /etc/kubernetes/igconfig.txt

--- a/pkg/model/tests/data/bootstrapscript_3.txt
+++ b/pkg/model/tests/data/bootstrapscript_3.txt
@@ -159,10 +159,12 @@ kubelet:
 __EOF_CLUSTER_SPEC
 
 cat > ig_spec.yaml << '__EOF_IG_SPEC'
+fileAssets:
+- content: tre8+iQw12cCsccJY3cQk4HQV3g= (fingerprint)
+  name: tokens
+  path: /kube/tokens.csv
 hooks:
-- manifest: |-
-    Type=oneshot
-    ExecStart=/usr/bin/systemctl start apply-to-all.service
+- manifest: FdicqEXLciSI1yRjQxsrye3QivU= (fingerprint)
   name: apply-to-all.service
 kubelet:
   kubeconfigPath: /etc/kubernetes/igconfig.txt

--- a/pkg/model/tests/data/bootstrapscript_4.txt
+++ b/pkg/model/tests/data/bootstrapscript_4.txt
@@ -149,15 +149,15 @@ cloudConfig:
   nodeTags: something
 docker:
   logLevel: INFO
+fileAssets:
+- content: 4/KwQntXJBIluh/8K2f+zWTQdhM= (fingerprint)
+  name: iptables-restore
+  path: /var/lib/iptables/rules-save
 hooks:
 - execContainer:
     command:
-    - sh
-    - -c
-    - chroot /rootfs apt-get update && chroot /rootfs apt-get install -y ceph-common
+    - ChIIt0bv6sTY/wwaEWTBNaObBgM= (fingerprint)
     image: busybox
-  roles:
-  - Node
 kubeProxy:
   cpuRequest: 30m
   featureGates:
@@ -168,19 +168,20 @@ kubelet:
 __EOF_CLUSTER_SPEC
 
 cat > ig_spec.yaml << '__EOF_IG_SPEC'
+fileAssets:
+- content: 4/KwQntXJBIluh/8K2f+zWTQdhM= (fingerprint)
+  name: iptables-restore
+  path: /var/lib/iptables/rules-save
+- content: tre8+iQw12cCsccJY3cQk4HQV3g= (fingerprint)
+  name: tokens
+  path: /kube/tokens.csv
 hooks:
 - before:
   - update-engine.service
   - kubelet.service
-  manifest: |-
-    Type=oneshot
-    ExecStart=/usr/bin/systemctl stop update-engine.service
+  manifest: LSdpmOQebIkYoG0lRv8AUHCBIyg= (fingerprint)
   name: disable-update-engine.service
-  roles:
-  - Node
-- manifest: |-
-    Type=oneshot
-    ExecStart=/usr/bin/systemctl start apply-to-all.service
+- manifest: FdicqEXLciSI1yRjQxsrye3QivU= (fingerprint)
   name: apply-to-all.service
 kubelet:
   kubeconfigPath: /etc/kubernetes/igconfig.txt

--- a/pkg/model/tests/data/bootstrapscript_5.txt
+++ b/pkg/model/tests/data/bootstrapscript_5.txt
@@ -149,16 +149,15 @@ cloudConfig:
   nodeTags: something
 docker:
   logLevel: INFO
+fileAssets:
+- content: 4/KwQntXJBIluh/8K2f+zWTQdhM= (fingerprint)
+  name: iptables-restore
+  path: /var/lib/iptables/rules-save
 hooks:
 - execContainer:
     command:
-    - sh
-    - -c
-    - chroot /rootfs apt-get update && chroot /rootfs apt-get install -y ceph-common
+    - ChIIt0bv6sTY/wwaEWTBNaObBgM= (fingerprint)
     image: busybox
-  roles:
-  - Master
-  - Node
 kubeProxy:
   cpuRequest: 30m
   featureGates:
@@ -169,20 +168,20 @@ kubelet:
 __EOF_CLUSTER_SPEC
 
 cat > ig_spec.yaml << '__EOF_IG_SPEC'
+fileAssets:
+- content: 4/KwQntXJBIluh/8K2f+zWTQdhM= (fingerprint)
+  name: iptables-restore
+  path: /var/lib/iptables/rules-save
+- content: tre8+iQw12cCsccJY3cQk4HQV3g= (fingerprint)
+  name: tokens
+  path: /kube/tokens.csv
 hooks:
 - before:
   - update-engine.service
   - kubelet.service
-  manifest: |-
-    Type=oneshot
-    ExecStart=/usr/bin/systemctl stop update-engine.service
+  manifest: LSdpmOQebIkYoG0lRv8AUHCBIyg= (fingerprint)
   name: disable-update-engine.service
-  roles:
-  - Master
-  - Node
-- manifest: |-
-    Type=oneshot
-    ExecStart=/usr/bin/systemctl start apply-to-all.service
+- manifest: FdicqEXLciSI1yRjQxsrye3QivU= (fingerprint)
   name: apply-to-all.service
 kubelet:
   kubeconfigPath: /etc/kubernetes/igconfig.txt


### PR DESCRIPTION
**Changes made:**
- Include FileAssets in the bootstrapscript (user-data for all nodes), selectively dependent on the roles specified for each asset.
- Fingerprint the sections of the FileAssets (Content) and Hooks (Manifests, ExecContainer Commands) Specs within the bootstrap script to reduce size (otherwise this can very quickly hit the 16KB user data limit with AWS).