### PR TITLE
Fix broken link in aws.md

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -80,10 +80,10 @@ export AWS_SECRET_ACCESS_KEY=<secret key>
 
 ## Configure DNS
 
-Note: If you are using Kops 1.6.2 or later, then DNS configuration is 
-optional. Instead, a gossip-based cluster can be easily created. The 
-only requirement to trigger this is to have the cluster name end with 
-`.k8s.local`. If a gossip-based cluster is created then you can skip 
+Note: If you are using Kops 1.6.2 or later, then DNS configuration is
+optional. Instead, a gossip-based cluster can be easily created. The
+only requirement to trigger this is to have the cluster name end with
+`.k8s.local`. If a gossip-based cluster is created then you can skip
 this section.
 
 In order to build a Kubernetes cluster with `kops`, we need to prepare
@@ -316,8 +316,9 @@ aws ec2 describe-availability-zones --region us-west-2
 ```
 
 Below is a create cluster command.  We'll use the most basic example possible,
-with more verbose examples in [advanced creation](advanced_create.md).  The
-below command will generate a cluster configuration, but not start building it. Make sure that you have generated SSH key pair before creating the cluster.
+with more verbose examples in [high availability](high_availability.md#advanced-example).
+The below command will generate a cluster configuration, but not start building
+it. Make sure that you have generated SSH key pair before creating the cluster.
 
 ```bash
 kops create cluster \


### PR DESCRIPTION
aws.md linked to advanced_create.md which was deleted in
https://github.com/kubernetes/kops/pull/2725. Its contents were added to
high_availability.md. Update the link to point to the relevant section in
high_availability.md.