### PR TITLE
DNS Controller Limitation

### DIFF
--- a/dns-controller/cmd/dns-controller/main.go
+++ b/dns-controller/cmd/dns-controller/main.go
@@ -24,64 +24,50 @@ import (
 	"os"
 	"strings"
 
-	"github.com/golang/glog"
-	"github.com/spf13/pflag"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/kops/dns-controller/pkg/dns"
 	"k8s.io/kops/dns-controller/pkg/watchers"
 	"k8s.io/kops/protokube/pkg/gossip"
 	gossipdns "k8s.io/kops/protokube/pkg/gossip/dns"
 	gossipdnsprovider "k8s.io/kops/protokube/pkg/gossip/dns/provider"
-	"k8s.io/kubernetes/federation/pkg/dnsprovider"
-
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/kops/protokube/pkg/gossip/mesh"
+
+	"github.com/golang/glog"
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	_ "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/aws/route53"
 	k8scoredns "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/coredns"
 	_ "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns"
 )
 
 var (
-	flags = pflag.NewFlagSet("", pflag.ExitOnError)
-
-	// value overwritten during build. This can be used to resolve issues.
+	flags        = pflag.NewFlagSet("", pflag.ExitOnError)
 	BuildVersion = "0.1"
 )
 
 func main() {
 	fmt.Printf("dns-controller version %s\n", BuildVersion)
+	var dnsServer, dnsProviderID, gossipListen, gossipSecret, watchNamespace string
+	var gossipSeeds, zones []string
+	var watchIngress bool
 
 	// Be sure to get the glog flags
 	glog.Flush()
 
-	dnsProviderId := "aws-route53"
-	flags.StringVar(&dnsProviderId, "dns", dnsProviderId, "DNS provider we should use (aws-route53, google-clouddns, coredns, gossip)")
-
-	gossipListen := "0.0.0.0:3998"
-	flags.StringVar(&gossipListen, "gossip-listen", gossipListen, "The address on which to listen if gossip is enabled")
-
-	var gossipSeeds []string
+	flag.StringVar(&dnsServer, "dns-server", "", "DNS Server")
+	flags.BoolVar(&watchIngress, "watch-ingress", true, "Configure hostnames found in ingress resources")
 	flags.StringSliceVar(&gossipSeeds, "gossip-seed", gossipSeeds, "If set, will enable gossip zones and seed using the provided addresses")
-
-	var gossipSecret string
-	flags.StringVar(&gossipSecret, "gossip-secret", gossipSecret, "Secret to use to secure gossip")
-
-	var zones []string
 	flags.StringSliceVarP(&zones, "zone", "z", []string{}, "Configure permitted zones and their mappings")
-
-	watchIngress := true
-	flags.BoolVar(&watchIngress, "watch-ingress", watchIngress, "Configure hostnames found in ingress resources")
-
-	dnsServer := ""
-	flag.StringVar(&dnsServer, "dns-server", dnsServer, "DNS Server")
-
+	flags.StringVar(&dnsProviderID, "dns", "aws-route53", "DNS provider we should use (aws-route53, google-clouddns, coredns, gossip)")
+	flags.StringVar(&gossipListen, "gossip-listen", "0.0.0.0:3998", "The address on which to listen if gossip is enabled")
+	flags.StringVar(&gossipSecret, "gossip-secret", gossipSecret, "Secret to use to secure gossip")
+	flags.StringVar(&watchNamespace, "watch-namespace", "", "Limits the functionality for pods, services and ingress to specific namespace, by default all")
 	// Trick to avoid 'logging before flag.Parse' warning
 	flag.CommandLine.Parse([]string{})
 
 	flag.Set("logtostderr", "true")
-
 	flags.AddGoFlagSet(flag.CommandLine)
-
 	flags.Parse(os.Args)
 
 	zoneRules, err := dns.ParseZoneRules(zones)
@@ -96,33 +82,28 @@ func main() {
 		os.Exit(1)
 	}
 
-	kubeClient, err := kubernetes.NewForConfig(config)
+	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		glog.Fatalf("error building REST client: %v", err)
 	}
 
-	//kubeExtensionsClient, err := client_extensions.NewForConfig(config)
-	//if err != nil {
-	//	glog.Fatalf("error building extensions REST client: %v", err)
-	//}
-
 	var dnsProviders []dnsprovider.Interface
-	if dnsProviderId != "gossip" {
+	if dnsProviderID != "gossip" {
 		var file io.Reader
-		if dnsProviderId == k8scoredns.ProviderName {
+		if dnsProviderID == k8scoredns.ProviderName {
 			var lines []string
 			lines = append(lines, "etcd-endpoints = "+dnsServer)
 			lines = append(lines, "zones = "+zones[0])
 			config := "[global]\n" + strings.Join(lines, "\n") + "\n"
 			file = bytes.NewReader([]byte(config))
 		}
-		dnsProvider, err := dnsprovider.GetDnsProvider(dnsProviderId, file)
+		dnsProvider, err := dnsprovider.GetDnsProvider(dnsProviderID, file)
 		if err != nil {
-			glog.Errorf("Error initializing DNS provider %q: %v", dnsProviderId, err)
+			glog.Errorf("Error initializing DNS provider %q: %v", dnsProviderID, err)
 			os.Exit(1)
 		}
 		if dnsProvider == nil {
-			glog.Errorf("DNS provider was nil %q: %v", dnsProviderId, err)
+			glog.Errorf("DNS provider was nil %q: %v", dnsProviderID, err)
 			os.Exit(1)
 		}
 		dnsProviders = append(dnsProviders, dnsProvider)
@@ -172,30 +153,40 @@ func main() {
 		os.Exit(1)
 	}
 
-	nodeController, err := watchers.NewNodeController(kubeClient, dnsController)
-	if err != nil {
-		glog.Errorf("Error building node controller: %v", err)
+	// @step: initialize the watchers
+	if err := initializeWatchers(client, dnsController, watchNamespace, watchIngress); err != nil {
+		glog.Errorf("%s", err)
 		os.Exit(1)
 	}
 
-	podController, err := watchers.NewPodController(kubeClient, dnsController)
+	// start and wait on the dns controller
+	dnsController.Run()
+}
+
+// initializeWatchers is responsible for creating the watchers
+func initializeWatchers(client kubernetes.Interface, dnsctl *dns.DNSController, namespace string, watchIngress bool) error {
+	glog.V(1).Info("initializing the watch controllers, namespace: %q", namespace)
+
+	nodeController, err := watchers.NewNodeController(client, dnsctl)
 	if err != nil {
-		glog.Errorf("Error building pod controller: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to initialize the node controller, error: %v", err)
 	}
 
-	serviceController, err := watchers.NewServiceController(kubeClient, dnsController)
+	podController, err := watchers.NewPodController(client, dnsctl, namespace)
 	if err != nil {
-		glog.Errorf("Error building service controller: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to initialize the pod controller, error: %v", err)
+	}
+
+	serviceController, err := watchers.NewServiceController(client, dnsctl, namespace)
+	if err != nil {
+		return fmt.Errorf("failed to initialize the service controller, error: %v", err)
 	}
 
 	var ingressController *watchers.IngressController
 	if watchIngress {
-		ingressController, err = watchers.NewIngressController(kubeClient, dnsController)
+		ingressController, err = watchers.NewIngressController(client, dnsctl, namespace)
 		if err != nil {
-			glog.Errorf("Error building ingress controller: %v", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to initialize the ingress controller, error: %v", err)
 		}
 	} else {
 		glog.Infof("Ingress controller disabled")
@@ -205,9 +196,9 @@ func main() {
 	go podController.Run()
 	go serviceController.Run()
 
-	if ingressController != nil {
+	if watchIngress {
 		go ingressController.Run()
 	}
 
-	dnsController.Run()
+	return nil
 }

--- a/dns-controller/pkg/watchers/annotations.go
+++ b/dns-controller/pkg/watchers/annotations.go
@@ -16,10 +16,10 @@ limitations under the License.
 
 package watchers
 
-// AnnotationNameDnsExternal is used to set up a DNS name for accessing the resource from outside the cluster
+// AnnotationNameDNSExternal is used to set up a DNS name for accessing the resource from outside the cluster
 // For a service of Type=LoadBalancer, it would map to the external LB hostname or IP
-const AnnotationNameDnsExternal = "dns.alpha.kubernetes.io/external"
+const AnnotationNameDNSExternal = "dns.alpha.kubernetes.io/external"
 
-// AnnotationNameDnsInternal is used to set up a DNS name for accessing the resource from inside the cluster
+// AnnotationNameDNSInternal is used to set up a DNS name for accessing the resource from inside the cluster
 // This is only supported on Pods currently, and maps to the Internal address
-const AnnotationNameDnsInternal = "dns.alpha.kubernetes.io/internal"
+const AnnotationNameDNSInternal = "dns.alpha.kubernetes.io/internal"

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -98,7 +98,6 @@ type ClusterSpec struct {
 	EgressProxy *EgressProxySpec `json:"egressProxy,omitempty"`
 	// SSHKeyName specifies a preexisting SSH key to use
 	SSHKeyName string `json:"sshKeyName,omitempty"`
-
 	// KubernetesAPIAccess is a list of the CIDRs that can access the Kubernetes API endpoint (master HTTPS)
 	KubernetesAPIAccess []string `json:"kubernetesApiAccess,omitempty"`
 	// IsolatesMasters determines whether we should lock down masters so that they are not on the pod network.
@@ -268,8 +267,12 @@ type KubeDNSConfig struct {
 	ServerIP string `json:"serverIP,omitempty"`
 }
 
+// ExternalDNSConfig are options of the dns-controller
 type ExternalDNSConfig struct {
+	// WatchIngress indicates you want the dns-controller to watch and create dns entries for ingress resources
 	WatchIngress *bool `json:"watchIngress,omitempty"`
+	// WatchNamespace is namespace to watch, detaults to all (use to control whom can creates dns entries)
+	WatchNamespace string `json:"watchNamespace,omitempty"`
 }
 
 // EtcdClusterSpec is the etcd cluster specification

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -22,6 +22,7 @@ import (
 
 // +genclient=true
 
+// Cluster is a specific cluster wrapper
 type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -30,6 +31,7 @@ type Cluster struct {
 	Spec ClusterSpec `json:"spec,omitempty"`
 }
 
+// ClusterList is a list of clusters
 type ClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -37,53 +39,42 @@ type ClusterList struct {
 	Items []Cluster `json:"items"`
 }
 
+// ClusterSpec defines the configuration for a cluster
 type ClusterSpec struct {
 	// The Channel we are following
 	Channel string `json:"channel,omitempty"`
-
 	// ConfigBase is the path where we store configuration for the cluster
 	// This might be different that the location when the cluster spec itself is stored,
 	// both because this must be accessible to the cluster,
 	// and because it might be on a different cloud or storage system (etcd vs S3)
 	ConfigBase string `json:"configBase,omitempty"`
-
 	// The CloudProvider to use (aws or gce)
 	CloudProvider string `json:"cloudProvider,omitempty"`
-
 	// The version of kubernetes to install (optional, and can be a "spec" like stable)
 	KubernetesVersion string `json:"kubernetesVersion,omitempty"`
-
 	// Configuration of zones we are targeting
 	Zones []*ClusterZoneSpec `json:"zones,omitempty"`
-	//Region                        string        `json:",omitempty"`
-
 	// Project is the cloud project we should use, required on GCE
 	Project string `json:"project,omitempty"`
-
 	// MasterPublicName is the external DNS name for the master nodes
 	MasterPublicName string `json:"masterPublicName,omitempty"`
 	// MasterInternalName is the internal DNS name for the master nodes
 	MasterInternalName string `json:"masterInternalName,omitempty"`
-
 	// The CIDR used for the AWS VPC / GCE Network, or otherwise allocated to k8s
 	// This is a real CIDR, not the internal k8s network
 	NetworkCIDR string `json:"networkCIDR,omitempty"`
-
 	// NetworkID is an identifier of a network, if we want to reuse/share an existing network (e.g. an AWS VPC)
 	NetworkID string `json:"networkID,omitempty"`
-
 	// Topology defines the type of network topology to use on the cluster - default public
 	// This is heavily weighted towards AWS for the time being, but should also be agnostic enough
 	// to port out to GCE later if needed
 	Topology *TopologySpec `json:"topology,omitempty"`
-
 	// SecretStore is the VFS path to where secrets are stored
 	SecretStore string `json:"secretStore,omitempty"`
 	// KeyStore is the VFS path to where SSL keys and certificates are stored
 	KeyStore string `json:"keyStore,omitempty"`
 	// ConfigStore is the VFS path to where the configuration (Cluster, InstanceGroupss etc) is stored
 	ConfigStore string `json:"configStore,omitempty"`
-
 	// DNSZone is the DNS zone we should use when configuring DNS
 	// This is because some clouds let us define a managed zone foo.bar, and then have
 	// kubernetes.dev.foo.bar, without needing to define dev.foo.bar as a hosted zone.
@@ -91,31 +82,19 @@ type ClusterSpec struct {
 	// Note that DNSZone can either by the host name of the zone (containing dots),
 	// or can be an identifier for the zone.
 	DNSZone string `json:"dnsZone,omitempty"`
-
 	// ClusterDNSDomain is the suffix we use for internal DNS names (normally cluster.local)
 	ClusterDNSDomain string `json:"clusterDNSDomain,omitempty"`
-
-	//InstancePrefix                string `json:",omitempty"`
-
 	// ClusterName is a unique identifier for the cluster, and currently must be a DNS name
 	//ClusterName       string `json:",omitempty"`
-
 	Multizone *bool `json:"multizone,omitempty"`
-
-	//ClusterIPRange                string `json:",omitempty"`
-
 	// ServiceClusterIPRange is the CIDR, from the internal network, where we allocate IPs for services
 	ServiceClusterIPRange string `json:"serviceClusterIPRange,omitempty"`
-	//MasterIPRange                 string `json:",omitempty"`
-
 	// NonMasqueradeCIDR is the CIDR for the internal k8s network (on which pods & services live)
 	// It cannot overlap ServiceClusterIPRange
 	NonMasqueradeCIDR string `json:"nonMasqueradeCIDR,omitempty"`
-
 	// AdminAccess determines the permitted access to the admin endpoints (SSH & master HTTPS)
 	// Currently only a single CIDR is supported (though a richer grammar could be added in future)
 	AdminAccess []string `json:"adminAccess,omitempty"`
-
 	// IsolatesMasters determines whether we should lock down masters so that they are not on the pod network.
 	// true is the kube-up behaviour, but it is very surprising: it means that daemonsets only work on the master
 	// if they have hostNetwork=true.
@@ -124,106 +103,21 @@ type ClusterSpec struct {
 	//  * run kube-proxy on the master
 	//  * enable debugging handlers on the master, so kubectl logs works
 	IsolateMasters *bool `json:"isolateMasters,omitempty"`
-
 	// UpdatePolicy determines the policy for applying upgrades automatically.
 	// Valid values:
 	//   'external' do not apply updates automatically - they are applied manually or by an external system
 	//   missing: default policy (currently OS security upgrades that do not require a reboot)
 	UpdatePolicy *string `json:"updatePolicy,omitempty"`
-
 	// Additional policies to add for roles
 	AdditionalPolicies *map[string]string `json:"additionalPolicies,omitempty"`
-
 	// A collection of files assets for deployed cluster wide
 	FileAssets []FileAssetSpec `json:"fileAssets,omitempty"`
-
-	//HairpinMode                   string `json:",omitempty"`
-	//
-	//OpencontrailTag               string `json:",omitempty"`
-	//OpencontrailKubernetesTag     string `json:",omitempty"`
-	//OpencontrailPublicSubnet      string `json:",omitempty"`
-	//
-	//EnableClusterMonitoring       string `json:",omitempty"`
-	//EnableL7LoadBalancing         string `json:",omitempty"`
-	//EnableClusterUI               *bool  `json:",omitempty"`
-	//
-	//EnableClusterDNS              *bool  `json:",omitempty"`
-	//DNSReplicas                   int    `json:",omitempty"`
-	//DNSServerIP                   string `json:",omitempty"`
-
-	//EnableClusterLogging          *bool  `json:",omitempty"`
-	//EnableNodeLogging             *bool  `json:",omitempty"`
-	//LoggingDestination            string `json:",omitempty"`
-	//ElasticsearchLoggingReplicas  int    `json:",omitempty"`
-	//
-	//EnableClusterRegistry         *bool  `json:",omitempty"`
-	//ClusterRegistryDisk           string `json:",omitempty"`
-	//ClusterRegistryDiskSize       int    `json:",omitempty"`
-	//
-	//EnableCustomMetrics           *bool `json:",omitempty"`
-	//
-	//RegisterMasterKubelet         *bool  `json:",omitempty"`
-
-	//// Image is the default image spec to use for the cluster
-	//Image                     string `json:",omitempty"`
-
-	//KubeUser                      string `json:",omitempty"`
-	//
-	//// These are moved to CAStore / SecretStore
-	////KubePassword			string
-	////KubeletToken                  string
-	////KubeProxyToken                string
-	////BearerToken                   string
-	////CACert                        []byte
-	////CAKey                         []byte
-	////KubeletCert                   []byte
-	////KubeletKey                    []byte
-	////MasterCert                    []byte
-	////MasterKey                     []byte
-	////KubecfgCert                   []byte
-	////KubecfgKey                    []byte
-	//
-	//AdmissionControl              string `json:",omitempty"`
-	//
-	//KubeImageTag                  string `json:",omitempty"`
-	//KubeDockerRegistry            string `json:",omitempty"`
-	//KubeAddonRegistry             string `json:",omitempty"`
-	//
-	//KubeletPort                   int `json:",omitempty"`
-	//
-	//KubeApiserverRequestTimeout   int `json:",omitempty"`
-	//
-	//TerminatedPodGcThreshold      string `json:",omitempty"`
-	//
-	//EnableManifestURL             *bool  `json:",omitempty"`
-	//ManifestURL                   string `json:",omitempty"`
-	//ManifestURLHeader             string `json:",omitempty"`
-	//
-	//TestCluster                   string `json:",omitempty"`
-	//
-	//E2EStorageTestEnvironment     string `json:",omitempty"`
-	//KubeletTestArgs               string `json:",omitempty"`
-	//KubeletTestLogLevel           string `json:",omitempty"`
-	//DockerTestArgs                string `json:",omitempty"`
-	//DockerTestLogLevel            string `json:",omitempty"`
-	//ApiserverTestArgs             string `json:",omitempty"`
-	//ApiserverTestLogLevel         string `json:",omitempty"`
-	//ControllerManagerTestArgs     string `json:",omitempty"`
-	//ControllerManagerTestLogLevel string `json:",omitempty"`
-	//SchedulerTestArgs             string `json:",omitempty"`
-	//SchedulerTestLogLevel         string `json:",omitempty"`
-	//KubeProxyTestArgs             string `json:",omitempty"`
-	//KubeProxyTestLogLevel         string `json:",omitempty"`
-
 	// HTTPProxy defines connection information to support use of a private cluster behind an forward HTTP Proxy
 	EgressProxy *EgressProxySpec `json:"egressProxy,omitempty"`
-
 	// SSHKeyName specifies a preexisting SSH key to use
 	SSHKeyName string `json:"sshKeyName,omitempty"`
-
 	// EtcdClusters stores the configuration for each cluster
 	EtcdClusters []*EtcdClusterSpec `json:"etcdClusters,omitempty"`
-
 	// Component configurations
 	Docker                *DockerConfig                `json:"docker,omitempty"`
 	KubeDNS               *KubeDNSConfig               `json:"kubeDNS,omitempty"`
@@ -238,25 +132,18 @@ type ClusterSpec struct {
 
 	// Networking configuration
 	Networking *NetworkingSpec `json:"networking,omitempty"`
-
 	// API field controls how the API is exposed outside the cluster
 	API *AccessSpec `json:"api,omitempty"`
-
 	// Authentication field controls how the cluster is configured for authentication
 	Authentication *AuthenticationSpec `json:"authentication,omitempty"`
-
 	// Authorization field controls how the cluster is configured for authorization
 	Authorization *AuthorizationSpec `json:"authorization,omitempty"`
-
 	// Tags for AWS instance groups
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`
-
 	// Hooks for custom actions e.g. on first installation
 	Hooks []HookSpec `json:"hooks,omitempty"`
-
 	// Alternative locations for files and containers
 	Assets *Assets `json:"assets,omitempty"`
-
 	// IAM field adds control over the IAM security policies applied to resources
 	IAM *IAMSpec `json:"iam,omitempty"`
 }
@@ -364,17 +251,24 @@ type LoadBalancerAccessSpec struct {
 	IdleTimeoutSeconds *int64           `json:"idleTimeoutSeconds,omitempty"`
 }
 
+// KubeDNSConfig defines the kube dns configuration
 type KubeDNSConfig struct {
 	// Image is the name of the docker image to run
 	Image string `json:"image,omitempty"`
-
-	Replicas int    `json:"replicas,omitempty"`
-	Domain   string `json:"domain,omitempty"`
+	// Replicas is the number of pod replicas
+	Replicas int `json:"replicas,omitempty"`
+	// Domain is the dns domain
+	Domain string `json:"domain,omitempty"`
+	// ServerIP is the server ip
 	ServerIP string `json:"serverIP,omitempty"`
 }
 
+// ExternalDNSConfig are options of the dns-controller
 type ExternalDNSConfig struct {
+	// WatchIngress indicates you want the dns-controller to watch and create dns entries for ingress resources
 	WatchIngress *bool `json:"watchIngress,omitempty"`
+	// WatchNamespace is namespace to watch, detaults to all (use to control whom can creates dns entries)
+	WatchNamespace string `json:"watchNamespace,omitempty"`
 }
 
 // EtcdClusterSpec is the etcd cluster specification

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1181,6 +1181,7 @@ func Convert_kops_ExecContainerAction_To_v1alpha1_ExecContainerAction(in *kops.E
 
 func autoConvert_v1alpha1_ExternalDNSConfig_To_kops_ExternalDNSConfig(in *ExternalDNSConfig, out *kops.ExternalDNSConfig, s conversion.Scope) error {
 	out.WatchIngress = in.WatchIngress
+	out.WatchNamespace = in.WatchNamespace
 	return nil
 }
 
@@ -1191,6 +1192,7 @@ func Convert_v1alpha1_ExternalDNSConfig_To_kops_ExternalDNSConfig(in *ExternalDN
 
 func autoConvert_kops_ExternalDNSConfig_To_v1alpha1_ExternalDNSConfig(in *kops.ExternalDNSConfig, out *ExternalDNSConfig, s conversion.Scope) error {
 	out.WatchIngress = in.WatchIngress
+	out.WatchNamespace = in.WatchNamespace
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -290,8 +290,12 @@ type KubeDNSConfig struct {
 	ServerIP string `json:"serverIP,omitempty"`
 }
 
+// ExternalDNSConfig are options of the dns-controller
 type ExternalDNSConfig struct {
+	// WatchIngress indicates you want the dns-controller to watch and create dns entries for ingress resources
 	WatchIngress *bool `json:"watchIngress,omitempty"`
+	// WatchNamespace is namespace to watch, detaults to all (use to control whom can creates dns entries)
+	WatchNamespace string `json:"watchNamespace,omitempty"`
 }
 
 // EtcdClusterSpec is the etcd cluster specification

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1288,6 +1288,7 @@ func Convert_kops_ExecContainerAction_To_v1alpha2_ExecContainerAction(in *kops.E
 
 func autoConvert_v1alpha2_ExternalDNSConfig_To_kops_ExternalDNSConfig(in *ExternalDNSConfig, out *kops.ExternalDNSConfig, s conversion.Scope) error {
 	out.WatchIngress = in.WatchIngress
+	out.WatchNamespace = in.WatchNamespace
 	return nil
 }
 
@@ -1298,6 +1299,7 @@ func Convert_v1alpha2_ExternalDNSConfig_To_kops_ExternalDNSConfig(in *ExternalDN
 
 func autoConvert_kops_ExternalDNSConfig_To_v1alpha2_ExternalDNSConfig(in *kops.ExternalDNSConfig, out *ExternalDNSConfig, s conversion.Scope) error {
 	out.WatchIngress = in.WatchIngress
+	out.WatchNamespace = in.WatchNamespace
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -510,7 +510,6 @@ func (c *ApplyClusterCmd) Run() error {
 
 				l.Builders = append(l.Builders,
 					&model.MasterVolumeBuilder{KopsModelContext: modelContext, Lifecycle: clusterLifecycle},
-
 					&awsmodel.APILoadBalancerBuilder{AWSModelContext: awsModelContext, Lifecycle: networkLifecycle},
 					&model.BastionModelBuilder{KopsModelContext: modelContext, Lifecycle: networkLifecycle},
 					&model.DNSModelBuilder{KopsModelContext: modelContext, Lifecycle: networkLifecycle},

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kops/nodeup/pkg/distros"
 	"k8s.io/kops/nodeup/pkg/model"
 	api "k8s.io/kops/pkg/apis/kops"
@@ -41,6 +40,7 @@ import (
 	"k8s.io/kops/util/pkg/vfs"
 
 	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // We should probably retry for a long time - there is not really any great fallback


### PR DESCRIPTION
The current implementation does not place any limitation on the dns annontation which the dns-controller can consume. In a multi-tenented environment we have to ensure certain safe guards are met, so users can't by accident or intentionally alter our internal dns. Note; the current behaviour has not been changed;

- added the --watch-namespace option to the dns controller and WatchNamespace to the spec
- cleaned up area of the code where possible or related
- fixed an vetting issues that i came across on the journey
- renamed the dns-controller watcher files