### PR TITLE
refactor resource tracker to be usable across packages

### DIFF
--- a/cmd/kops/delete_cluster.go
+++ b/cmd/kops/delete_cluster.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kops/pkg/apis/kops/registry"
 	"k8s.io/kops/pkg/kubeconfig"
 	"k8s.io/kops/pkg/resources"
+	"k8s.io/kops/pkg/resources/tracker"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
@@ -148,7 +149,7 @@ func RunDeleteCluster(f *util.Factory, out io.Writer, options *DeleteClusterOpti
 			return err
 		}
 
-		clusterResources := make(map[string]*resources.ResourceTracker)
+		clusterResources := make(map[string]*tracker.Resource)
 		for k, resource := range allResources {
 			if resource.Shared {
 				continue
@@ -162,16 +163,16 @@ func RunDeleteCluster(f *util.Factory, out io.Writer, options *DeleteClusterOpti
 			wouldDeleteCloudResources = true
 
 			t := &tables.Table{}
-			t.AddColumn("TYPE", func(r *resources.ResourceTracker) string {
+			t.AddColumn("TYPE", func(r *tracker.Resource) string {
 				return r.Type
 			})
-			t.AddColumn("ID", func(r *resources.ResourceTracker) string {
+			t.AddColumn("ID", func(r *tracker.Resource) string {
 				return r.ID
 			})
-			t.AddColumn("NAME", func(r *resources.ResourceTracker) string {
+			t.AddColumn("NAME", func(r *tracker.Resource) string {
 				return r.Name
 			})
-			var l []*resources.ResourceTracker
+			var l []*tracker.Resource
 			for _, v := range clusterResources {
 				l = append(l, v)
 			}

--- a/hack/.packages
+++ b/hack/.packages
@@ -77,6 +77,7 @@ k8s.io/kops/pkg/pretty
 k8s.io/kops/pkg/resources
 k8s.io/kops/pkg/resources/digitalocean
 k8s.io/kops/pkg/resources/digitalocean/dns
+k8s.io/kops/pkg/resources/tracker
 k8s.io/kops/pkg/systemd
 k8s.io/kops/pkg/templates
 k8s.io/kops/pkg/testutils

--- a/pkg/resources/aws.go
+++ b/pkg/resources/aws.go
@@ -32,6 +32,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kops/pkg/dns"
+	"k8s.io/kops/pkg/resources/tracker"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 )
@@ -43,12 +44,12 @@ const (
 	TypeLoadBalancer            = "load-balancer"
 )
 
-type listFn func(fi.Cloud, string) ([]*ResourceTracker, error)
+type listFn func(fi.Cloud, string) ([]*tracker.Resource, error)
 
-func (c *ClusterResources) listResourcesAWS() (map[string]*ResourceTracker, error) {
+func (c *ClusterResources) listResourcesAWS() (map[string]*tracker.Resource, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
-	resources := make(map[string]*ResourceTracker)
+	resources := make(map[string]*tracker.Resource)
 
 	// These are the functions that are used for looking up
 	// cluster resources by their tags.
@@ -80,11 +81,11 @@ func (c *ClusterResources) listResourcesAWS() (map[string]*ResourceTracker, erro
 		ListIAMRoles,
 	}
 	for _, fn := range listFunctions {
-		trackers, err := fn(cloud, c.ClusterName)
+		resourceTrackers, err := fn(cloud, c.ClusterName)
 		if err != nil {
 			return nil, err
 		}
-		for _, t := range trackers {
+		for _, t := range resourceTrackers {
 			resources[t.Type+":"+t.ID] = t
 		}
 	}
@@ -108,11 +109,11 @@ func (c *ClusterResources) listResourcesAWS() (map[string]*ResourceTracker, erro
 				}
 				vpc := resources["vpc:"+vpcID]
 				if vpc != nil && resources["internet-gateway:"+igwID] == nil {
-					resources["internet-gateway:"+igwID] = &ResourceTracker{
+					resources["internet-gateway:"+igwID] = &tracker.Resource{
 						Name:    FindName(igw.Tags),
 						ID:      igwID,
 						Type:    "internet-gateway",
-						deleter: DeleteInternetGateway,
+						Deleter: DeleteInternetGateway,
 						Shared:  vpc.Shared, // Shared iff the VPC is shared
 					}
 				}
@@ -146,7 +147,7 @@ func (c *ClusterResources) listResourcesAWS() (map[string]*ResourceTracker, erro
 
 	{
 		// We delete a NAT gateway if it is linked to our route table
-		routeTableIds := make(map[string]*ResourceTracker)
+		routeTableIds := make(map[string]*tracker.Resource)
 		for _, resource := range resources {
 			if resource.Type != ec2.ResourceTypeRouteTable {
 				continue
@@ -165,7 +166,7 @@ func (c *ClusterResources) listResourcesAWS() (map[string]*ResourceTracker, erro
 	}
 
 	for k, t := range resources {
-		if t.done {
+		if t.Done {
 			delete(resources, k)
 		}
 	}
@@ -184,7 +185,7 @@ func BuildEC2Filters(cloud fi.Cloud) []*ec2.Filter {
 	return filters
 }
 
-func addUntaggedRouteTables(cloud awsup.AWSCloud, clusterName string, resources map[string]*ResourceTracker) error {
+func addUntaggedRouteTables(cloud awsup.AWSCloud, clusterName string, resources map[string]*tracker.Resource) error {
 	// We sometimes have trouble tagging the route table (eventual consistency, e.g. #597)
 	// If we are deleting the VPC, we should delete the route table
 	// (no real reason not to; easy to recreate; no real state etc)
@@ -364,7 +365,7 @@ func matchesElbTags(tags map[string]string, actual []*elb.Tag) bool {
 //	Delete(cloud fi.Cloud) error
 //}
 
-func DeleteInstance(cloud fi.Cloud, t *ResourceTracker) error {
+func DeleteInstance(cloud fi.Cloud, t *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	id := t.ID
@@ -383,7 +384,7 @@ func DeleteInstance(cloud fi.Cloud, t *ResourceTracker) error {
 	return nil
 }
 
-func DeleteCloudFormationStack(cloud fi.Cloud, t *ResourceTracker) error {
+func DeleteCloudFormationStack(cloud fi.Cloud, t *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	id := t.ID
@@ -399,16 +400,16 @@ func DeleteCloudFormationStack(cloud fi.Cloud, t *ResourceTracker) error {
 	return nil
 }
 
-func DumpCloudFormationStack(r *ResourceTracker) (interface{}, error) {
+func DumpCloudFormationStack(r *tracker.Resource) (interface{}, error) {
 	data := make(map[string]interface{})
 	data["id"] = r.ID
 	data["type"] = r.Type
-	data["raw"] = r.obj
+	data["raw"] = r.Obj
 	return data, nil
 }
 
-func ListCloudFormationStacks(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
-	var trackers []*ResourceTracker
+func ListCloudFormationStacks(cloud fi.Cloud, clusterName string) ([]*tracker.Resource, error) {
+	var resourceTrackers []*tracker.Resource
 	request := &cloudformation.ListStacksInput{}
 	c := cloud.(awsup.AWSCloud)
 	response, err := c.CloudFormation().ListStacks(request)
@@ -417,22 +418,22 @@ func ListCloudFormationStacks(cloud fi.Cloud, clusterName string) ([]*ResourceTr
 	}
 	for _, stack := range response.StackSummaries {
 		if *stack.StackName == clusterName {
-			tracker := &ResourceTracker{
+			resourceTracker := &tracker.Resource{
 				Name:    *stack.StackName,
 				ID:      *stack.StackId,
 				Type:    "cloud-formation",
-				deleter: DeleteCloudFormationStack,
+				Deleter: DeleteCloudFormationStack,
 				Dumper:  DumpCloudFormationStack,
-				obj:     stack,
+				Obj:     stack,
 			}
-			trackers = append(trackers, tracker)
+			resourceTrackers = append(resourceTrackers, resourceTracker)
 		}
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
-func ListInstances(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
+func ListInstances(cloud fi.Cloud, clusterName string) ([]*tracker.Resource, error) {
 	c := cloud.(awsup.AWSCloud)
 
 	glog.V(2).Infof("Querying EC2 instances")
@@ -440,7 +441,7 @@ func ListInstances(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, erro
 		Filters: BuildEC2Filters(cloud),
 	}
 
-	var trackers []*ResourceTracker
+	var resourceTrackers []*tracker.Resource
 
 	err := c.EC2().DescribeInstancesPages(request, func(p *ec2.DescribeInstancesOutput, lastPage bool) bool {
 		for _, reservation := range p.Reservations {
@@ -462,13 +463,13 @@ func ListInstances(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, erro
 					}
 				}
 
-				tracker := &ResourceTracker{
+				resourceTracker := &tracker.Resource{
 					Name:    FindName(instance.Tags),
 					ID:      id,
 					Type:    ec2.ResourceTypeInstance,
-					deleter: DeleteInstance,
+					Deleter: DeleteInstance,
 					Dumper:  DumpInstance,
-					obj:     instance,
+					Obj:     instance,
 				}
 
 				var blocks []string
@@ -486,9 +487,9 @@ func ListInstances(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, erro
 				blocks = append(blocks, "subnet:"+aws.StringValue(instance.SubnetId))
 				blocks = append(blocks, "vpc:"+aws.StringValue(instance.VpcId))
 
-				tracker.blocks = blocks
+				resourceTracker.Blocks = blocks
 
-				trackers = append(trackers, tracker)
+				resourceTrackers = append(resourceTrackers, resourceTracker)
 
 			}
 		}
@@ -498,18 +499,18 @@ func ListInstances(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, erro
 		return nil, fmt.Errorf("error describing instances: %v", err)
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
-func DumpInstance(r *ResourceTracker) (interface{}, error) {
+func DumpInstance(r *tracker.Resource) (interface{}, error) {
 	data := make(map[string]interface{})
 	data["id"] = r.ID
 	data["type"] = ec2.ResourceTypeInstance
-	data["raw"] = r.obj
+	data["raw"] = r.Obj
 	return data, nil
 }
 
-func DeleteSecurityGroup(cloud fi.Cloud, t *ResourceTracker) error {
+func DeleteSecurityGroup(cloud fi.Cloud, t *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	id := t.ID
@@ -564,41 +565,41 @@ func DeleteSecurityGroup(cloud fi.Cloud, t *ResourceTracker) error {
 	return nil
 }
 
-func DumpSecurityGroup(r *ResourceTracker) (interface{}, error) {
+func DumpSecurityGroup(r *tracker.Resource) (interface{}, error) {
 	data := make(map[string]interface{})
 	data["id"] = r.ID
 	data["type"] = ec2.ResourceTypeSecurityGroup
-	data["raw"] = r.obj
+	data["raw"] = r.Obj
 	return data, nil
 }
 
-func ListSecurityGroups(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
+func ListSecurityGroups(cloud fi.Cloud, clusterName string) ([]*tracker.Resource, error) {
 	groups, err := DescribeSecurityGroups(cloud)
 	if err != nil {
 		return nil, err
 	}
 
-	var trackers []*ResourceTracker
+	var resourceTrackers []*tracker.Resource
 
 	for _, sg := range groups {
-		tracker := &ResourceTracker{
+		resourceTracker := &tracker.Resource{
 			Name:    FindName(sg.Tags),
 			ID:      aws.StringValue(sg.GroupId),
 			Type:    "security-group",
-			deleter: DeleteSecurityGroup,
+			Deleter: DeleteSecurityGroup,
 			Dumper:  DumpSecurityGroup,
-			obj:     sg,
+			Obj:     sg,
 		}
 
 		var blocks []string
 		blocks = append(blocks, "vpc:"+aws.StringValue(sg.VpcId))
 
-		tracker.blocks = blocks
+		resourceTracker.Blocks = blocks
 
-		trackers = append(trackers, tracker)
+		resourceTrackers = append(resourceTrackers, resourceTracker)
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
 func DescribeSecurityGroups(cloud fi.Cloud) ([]*ec2.SecurityGroup, error) {
@@ -616,7 +617,7 @@ func DescribeSecurityGroups(cloud fi.Cloud) ([]*ec2.SecurityGroup, error) {
 	return response.SecurityGroups, nil
 }
 
-func DeleteVolume(cloud fi.Cloud, r *ResourceTracker) error {
+func DeleteVolume(cloud fi.Cloud, r *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	id := r.ID
@@ -639,32 +640,32 @@ func DeleteVolume(cloud fi.Cloud, r *ResourceTracker) error {
 	return nil
 }
 
-func ListVolumes(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
+func ListVolumes(cloud fi.Cloud, clusterName string) ([]*tracker.Resource, error) {
 	c := cloud.(awsup.AWSCloud)
 
 	volumes, err := DescribeVolumes(cloud)
 	if err != nil {
 		return nil, err
 	}
-	var trackers []*ResourceTracker
+	var resourceTrackers []*tracker.Resource
 
 	elasticIPs := make(map[string]bool)
 	for _, volume := range volumes {
 		id := aws.StringValue(volume.VolumeId)
 
-		tracker := &ResourceTracker{
+		resourceTracker := &tracker.Resource{
 			Name:    FindName(volume.Tags),
 			ID:      id,
 			Type:    "volume",
-			deleter: DeleteVolume,
+			Deleter: DeleteVolume,
 		}
 
 		var blocks []string
 		//blocks = append(blocks, "vpc:" + aws.StringValue(rt.VpcId))
 
-		tracker.blocks = blocks
+		resourceTracker.Blocks = blocks
 
-		trackers = append(trackers, tracker)
+		resourceTrackers = append(resourceTrackers, resourceTracker)
 
 		// Check for an elastic IP tag
 		for _, tag := range volume.Tags {
@@ -694,19 +695,19 @@ func ListVolumes(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error)
 				continue
 			}
 
-			tracker := &ResourceTracker{
+			resourceTracker := &tracker.Resource{
 				Name:    ip,
 				ID:      aws.StringValue(address.AllocationId),
 				Type:    TypeElasticIp,
-				deleter: DeleteElasticIP,
+				Deleter: DeleteElasticIP,
 			}
 
-			trackers = append(trackers, tracker)
+			resourceTrackers = append(resourceTrackers, resourceTracker)
 
 		}
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
 func DescribeVolumes(cloud fi.Cloud) ([]*ec2.Volume, error) {
@@ -732,7 +733,7 @@ func DescribeVolumes(cloud fi.Cloud) ([]*ec2.Volume, error) {
 	return volumes, nil
 }
 
-func DeleteKeypair(cloud fi.Cloud, r *ResourceTracker) error {
+func DeleteKeypair(cloud fi.Cloud, r *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	name := r.Name
@@ -748,7 +749,7 @@ func DeleteKeypair(cloud fi.Cloud, r *ResourceTracker) error {
 	return nil
 }
 
-func ListKeypairs(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
+func ListKeypairs(cloud fi.Cloud, clusterName string) ([]*tracker.Resource, error) {
 	if !strings.Contains(clusterName, ".") {
 		glog.Infof("cluster %q is legacy (kube-up) cluster; won't delete keypairs", clusterName)
 		return nil, nil
@@ -768,24 +769,24 @@ func ListKeypairs(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error
 		return nil, fmt.Errorf("error listing KeyPairs: %v", err)
 	}
 
-	var trackers []*ResourceTracker
+	var resourceTrackers []*tracker.Resource
 
 	for _, keypair := range response.KeyPairs {
 		name := aws.StringValue(keypair.KeyName)
 		if name != keypairName && !strings.HasPrefix(name, keypairName+"-") {
 			continue
 		}
-		tracker := &ResourceTracker{
+		resourceTracker := &tracker.Resource{
 			Name:    name,
 			ID:      name,
 			Type:    "keypair",
-			deleter: DeleteKeypair,
+			Deleter: DeleteKeypair,
 		}
 
-		trackers = append(trackers, tracker)
+		resourceTrackers = append(resourceTrackers, resourceTracker)
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
 func IsDependencyViolation(err error) bool {
@@ -801,7 +802,7 @@ func IsDependencyViolation(err error) bool {
 	}
 }
 
-func DeleteSubnet(cloud fi.Cloud, tracker *ResourceTracker) error {
+func DeleteSubnet(cloud fi.Cloud, tracker *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	id := tracker.ID
@@ -823,14 +824,14 @@ func DeleteSubnet(cloud fi.Cloud, tracker *ResourceTracker) error {
 	return nil
 }
 
-func ListSubnets(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
+func ListSubnets(cloud fi.Cloud, clusterName string) ([]*tracker.Resource, error) {
 	c := cloud.(awsup.AWSCloud)
 	subnets, err := DescribeSubnets(cloud)
 	if err != nil {
 		return nil, fmt.Errorf("error listing subnets: %v", err)
 	}
 
-	var trackers []*ResourceTracker
+	var resourceTrackers []*tracker.Resource
 	elasticIPs := sets.NewString()
 	ownedElasticIPs := sets.NewString()
 	natGatewayIds := sets.NewString()
@@ -839,15 +840,15 @@ func ListSubnets(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error)
 		subnetID := aws.StringValue(subnet.SubnetId)
 
 		shared := HasSharedTag("subnet:"+subnetID, subnet.Tags, clusterName)
-		tracker := &ResourceTracker{
+		resourceTracker := &tracker.Resource{
 			Name:    FindName(subnet.Tags),
 			ID:      subnetID,
 			Type:    "subnet",
-			deleter: DeleteSubnet,
+			Deleter: DeleteSubnet,
 			Shared:  shared,
 		}
-		tracker.blocks = append(tracker.blocks, "vpc:"+aws.StringValue(subnet.VpcId))
-		trackers = append(trackers, tracker)
+		resourceTracker.Blocks = append(resourceTracker.Blocks, "vpc:"+aws.StringValue(subnet.VpcId))
+		resourceTrackers = append(resourceTrackers, resourceTracker)
 
 		// Get tags and append with EIPs/NGWs as needed
 		for _, tag := range subnet.Tags {
@@ -890,14 +891,14 @@ func ListSubnets(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error)
 				continue
 			}
 
-			tracker := &ResourceTracker{
+			resourceTracker := &tracker.Resource{
 				Name:    ip,
 				ID:      aws.StringValue(address.AllocationId),
 				Type:    TypeElasticIp,
-				deleter: DeleteElasticIP,
+				Deleter: DeleteElasticIP,
 				Shared:  !ownedElasticIPs.Has(ip),
 			}
-			trackers = append(trackers, tracker)
+			resourceTrackers = append(resourceTrackers, resourceTracker)
 		}
 	}
 
@@ -940,26 +941,26 @@ func ListSubnets(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error)
 				continue
 			}
 
-			tracker := &ResourceTracker{
+			resourceTracker := &tracker.Resource{
 				Name:    id,
 				ID:      id,
 				Type:    TypeNatGateway,
-				deleter: DeleteNatGateway,
+				Deleter: DeleteNatGateway,
 				Shared:  sharedNgwIds.Has(id) || !ownedNatGatewayIds.Has(id),
 			}
 
 			// The NAT gateway blocks deletion of any associated Elastic IPs
 			for _, address := range ngw.NatGatewayAddresses {
 				if address.AllocationId != nil {
-					tracker.blocks = append(tracker.blocks, TypeElasticIp+":"+aws.StringValue(address.AllocationId))
+					resourceTracker.Blocks = append(resourceTracker.Blocks, TypeElasticIp+":"+aws.StringValue(address.AllocationId))
 				}
 			}
 
-			trackers = append(trackers, tracker)
+			resourceTrackers = append(resourceTrackers, resourceTracker)
 		}
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
 func DescribeSubnets(cloud fi.Cloud) ([]*ec2.Subnet, error) {
@@ -977,7 +978,7 @@ func DescribeSubnets(cloud fi.Cloud) ([]*ec2.Subnet, error) {
 	return response.Subnets, nil
 }
 
-func DeleteRouteTable(cloud fi.Cloud, r *ResourceTracker) error {
+func DeleteRouteTable(cloud fi.Cloud, r *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	id := r.ID
@@ -1031,28 +1032,28 @@ func DescribeRouteTables(cloud fi.Cloud) ([]*ec2.RouteTable, error) {
 	return response.RouteTables, nil
 }
 
-func ListRouteTables(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
+func ListRouteTables(cloud fi.Cloud, clusterName string) ([]*tracker.Resource, error) {
 	routeTables, err := DescribeRouteTables(cloud)
 	if err != nil {
 		return nil, err
 	}
 
-	var trackers []*ResourceTracker
+	var resourceTrackers []*tracker.Resource
 
 	for _, rt := range routeTables {
-		tracker := buildTrackerForRouteTable(rt)
-		trackers = append(trackers, tracker)
+		resourceTracker := buildTrackerForRouteTable(rt)
+		resourceTrackers = append(resourceTrackers, resourceTracker)
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
-func buildTrackerForRouteTable(rt *ec2.RouteTable) *ResourceTracker {
-	tracker := &ResourceTracker{
+func buildTrackerForRouteTable(rt *ec2.RouteTable) *tracker.Resource {
+	resourceTracker := &tracker.Resource{
 		Name:    FindName(rt.Tags),
 		ID:      aws.StringValue(rt.RouteTableId),
 		Type:    ec2.ResourceTypeRouteTable,
-		deleter: DeleteRouteTable,
+		Deleter: DeleteRouteTable,
 	}
 
 	var blocks []string
@@ -1064,13 +1065,13 @@ func buildTrackerForRouteTable(rt *ec2.RouteTable) *ResourceTracker {
 		blocked = append(blocked, "subnet:"+aws.StringValue(a.SubnetId))
 	}
 
-	tracker.blocks = blocks
-	tracker.blocked = blocked
+	resourceTracker.Blocks = blocks
+	resourceTracker.Blocked = blocked
 
-	return tracker
+	return resourceTracker
 }
 
-func DeleteDhcpOptions(cloud fi.Cloud, r *ResourceTracker) error {
+func DeleteDhcpOptions(cloud fi.Cloud, r *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	id := r.ID
@@ -1089,30 +1090,30 @@ func DeleteDhcpOptions(cloud fi.Cloud, r *ResourceTracker) error {
 	return nil
 }
 
-func ListDhcpOptions(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
+func ListDhcpOptions(cloud fi.Cloud, clusterName string) ([]*tracker.Resource, error) {
 	dhcpOptions, err := DescribeDhcpOptions(cloud)
 	if err != nil {
 		return nil, err
 	}
 
-	var trackers []*ResourceTracker
+	var resourceTrackers []*tracker.Resource
 
 	for _, o := range dhcpOptions {
-		tracker := &ResourceTracker{
+		resourceTracker := &tracker.Resource{
 			Name:    FindName(o.Tags),
 			ID:      aws.StringValue(o.DhcpOptionsId),
 			Type:    "dhcp-options",
-			deleter: DeleteDhcpOptions,
+			Deleter: DeleteDhcpOptions,
 		}
 
 		var blocks []string
 
-		tracker.blocks = blocks
+		resourceTracker.Blocks = blocks
 
-		trackers = append(trackers, tracker)
+		resourceTrackers = append(resourceTrackers, resourceTracker)
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
 func DescribeDhcpOptions(cloud fi.Cloud) ([]*ec2.DhcpOptions, error) {
@@ -1130,7 +1131,7 @@ func DescribeDhcpOptions(cloud fi.Cloud) ([]*ec2.DhcpOptions, error) {
 	return response.DhcpOptions, nil
 }
 
-func DeleteInternetGateway(cloud fi.Cloud, r *ResourceTracker) error {
+func DeleteInternetGateway(cloud fi.Cloud, r *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	id := r.ID
@@ -1194,20 +1195,20 @@ func DeleteInternetGateway(cloud fi.Cloud, r *ResourceTracker) error {
 	return nil
 }
 
-func ListInternetGateways(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
+func ListInternetGateways(cloud fi.Cloud, clusterName string) ([]*tracker.Resource, error) {
 	gateways, err := DescribeInternetGateways(cloud)
 	if err != nil {
 		return nil, err
 	}
 
-	var trackers []*ResourceTracker
+	var resourceTrackers []*tracker.Resource
 
 	for _, o := range gateways {
-		tracker := &ResourceTracker{
+		resourceTracker := &tracker.Resource{
 			Name:    FindName(o.Tags),
 			ID:      aws.StringValue(o.InternetGatewayId),
 			Type:    "internet-gateway",
-			deleter: DeleteInternetGateway,
+			Deleter: DeleteInternetGateway,
 		}
 
 		var blocks []string
@@ -1216,12 +1217,12 @@ func ListInternetGateways(cloud fi.Cloud, clusterName string) ([]*ResourceTracke
 				blocks = append(blocks, "vpc:"+aws.StringValue(a.VpcId))
 			}
 		}
-		tracker.blocks = blocks
+		resourceTracker.Blocks = blocks
 
-		trackers = append(trackers, tracker)
+		resourceTrackers = append(resourceTrackers, resourceTracker)
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
 func DescribeInternetGateways(cloud fi.Cloud) ([]*ec2.InternetGateway, error) {
@@ -1266,7 +1267,7 @@ func DescribeInternetGatewaysIgnoreTags(cloud fi.Cloud) ([]*ec2.InternetGateway,
 	return gateways, nil
 }
 
-func DeleteVPC(cloud fi.Cloud, r *ResourceTracker) error {
+func DeleteVPC(cloud fi.Cloud, r *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	id := r.ID
@@ -1285,11 +1286,11 @@ func DeleteVPC(cloud fi.Cloud, r *ResourceTracker) error {
 	return nil
 }
 
-func DumpVPC(r *ResourceTracker) (interface{}, error) {
+func DumpVPC(r *tracker.Resource) (interface{}, error) {
 	data := make(map[string]interface{})
 	data["id"] = r.ID
 	data["type"] = ec2.ResourceTypeVpc
-	data["raw"] = r.obj
+	data["raw"] = r.Obj
 	return data, nil
 }
 
@@ -1308,38 +1309,38 @@ func DescribeVPCs(cloud fi.Cloud) ([]*ec2.Vpc, error) {
 	return response.Vpcs, nil
 }
 
-func ListVPCs(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
+func ListVPCs(cloud fi.Cloud, clusterName string) ([]*tracker.Resource, error) {
 	vpcs, err := DescribeVPCs(cloud)
 	if err != nil {
 		return nil, err
 	}
 
-	var trackers []*ResourceTracker
+	var resourceTrackers []*tracker.Resource
 	for _, v := range vpcs {
 		vpcID := aws.StringValue(v.VpcId)
 
-		tracker := &ResourceTracker{
+		resourceTracker := &tracker.Resource{
 			Name:    FindName(v.Tags),
 			ID:      vpcID,
 			Type:    ec2.ResourceTypeVpc,
-			deleter: DeleteVPC,
+			Deleter: DeleteVPC,
 			Dumper:  DumpVPC,
-			obj:     v,
+			Obj:     v,
 			Shared:  HasSharedTag(ec2.ResourceTypeVpc+":"+vpcID, v.Tags, clusterName),
 		}
 
 		var blocks []string
 		blocks = append(blocks, "dhcp-options:"+aws.StringValue(v.DhcpOptionsId))
 
-		tracker.blocks = blocks
+		resourceTracker.Blocks = blocks
 
-		trackers = append(trackers, tracker)
+		resourceTrackers = append(resourceTrackers, resourceTracker)
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
-func DeleteAutoScalingGroup(cloud fi.Cloud, r *ResourceTracker) error {
+func DeleteAutoScalingGroup(cloud fi.Cloud, r *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	id := r.ID
@@ -1359,7 +1360,7 @@ func DeleteAutoScalingGroup(cloud fi.Cloud, r *ResourceTracker) error {
 	return nil
 }
 
-func ListAutoScalingGroups(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
+func ListAutoScalingGroups(cloud fi.Cloud, clusterName string) ([]*tracker.Resource, error) {
 	c := cloud.(awsup.AWSCloud)
 
 	tags := c.Tags()
@@ -1369,14 +1370,14 @@ func ListAutoScalingGroups(cloud fi.Cloud, clusterName string) ([]*ResourceTrack
 		return nil, err
 	}
 
-	var trackers []*ResourceTracker
+	var resourceTrackers []*tracker.Resource
 
 	for _, asg := range asgs {
-		tracker := &ResourceTracker{
+		resourceTracker := &tracker.Resource{
 			Name:    FindASGName(asg.Tags),
 			ID:      aws.StringValue(asg.AutoScalingGroupName),
 			Type:    "autoscaling-group",
-			deleter: DeleteAutoScalingGroup,
+			Deleter: DeleteAutoScalingGroup,
 		}
 
 		var blocks []string
@@ -1389,20 +1390,20 @@ func ListAutoScalingGroups(cloud fi.Cloud, clusterName string) ([]*ResourceTrack
 		}
 		blocks = append(blocks, TypeAutoscalingLaunchConfig+":"+aws.StringValue(asg.LaunchConfigurationName))
 
-		tracker.blocks = blocks
+		resourceTracker.Blocks = blocks
 
-		trackers = append(trackers, tracker)
+		resourceTrackers = append(resourceTrackers, resourceTracker)
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
-func FindAutoScalingLaunchConfigurations(cloud fi.Cloud, securityGroups sets.String) ([]*ResourceTracker, error) {
+func FindAutoScalingLaunchConfigurations(cloud fi.Cloud, securityGroups sets.String) ([]*tracker.Resource, error) {
 	c := cloud.(awsup.AWSCloud)
 
 	glog.V(2).Infof("Finding all Autoscaling LaunchConfigurations by security group")
 
-	var trackers []*ResourceTracker
+	var resourceTrackers []*tracker.Resource
 
 	request := &autoscaling.DescribeLaunchConfigurationsInput{}
 	err := c.Autoscaling().DescribeLaunchConfigurationsPages(request, func(p *autoscaling.DescribeLaunchConfigurationsOutput, lastPage bool) bool {
@@ -1418,19 +1419,19 @@ func FindAutoScalingLaunchConfigurations(cloud fi.Cloud, securityGroups sets.Str
 				continue
 			}
 
-			tracker := &ResourceTracker{
+			resourceTracker := &tracker.Resource{
 				Name:    aws.StringValue(t.LaunchConfigurationName),
 				ID:      aws.StringValue(t.LaunchConfigurationName),
 				Type:    TypeAutoscalingLaunchConfig,
-				deleter: DeleteAutoscalingLaunchConfiguration,
+				Deleter: DeleteAutoscalingLaunchConfiguration,
 			}
 
 			var blocks []string
 			//blocks = append(blocks, TypeAutoscalingLaunchConfig + ":" + aws.StringValue(asg.LaunchConfigurationName))
 
-			tracker.blocks = blocks
+			resourceTracker.Blocks = blocks
 
-			trackers = append(trackers, tracker)
+			resourceTrackers = append(resourceTrackers, resourceTracker)
 		}
 		return true
 	})
@@ -1438,10 +1439,10 @@ func FindAutoScalingLaunchConfigurations(cloud fi.Cloud, securityGroups sets.Str
 		return nil, fmt.Errorf("error listing autoscaling LaunchConfigurations: %v", err)
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
-func FindNatGateways(cloud fi.Cloud, routeTables map[string]*ResourceTracker) ([]*ResourceTracker, error) {
+func FindNatGateways(cloud fi.Cloud, routeTables map[string]*tracker.Resource) ([]*tracker.Resource, error) {
 	if len(routeTables) == 0 {
 		return nil, nil
 	}
@@ -1488,7 +1489,7 @@ func FindNatGateways(cloud fi.Cloud, routeTables map[string]*ResourceTracker) ([
 		}
 	}
 
-	var trackers []*ResourceTracker
+	var resourceTrackers []*tracker.Resource
 	if len(natGatewayIds) != 0 {
 		request := &ec2.DescribeNatGatewaysInput{}
 		for natGatewayId := range natGatewayIds {
@@ -1505,14 +1506,14 @@ func FindNatGateways(cloud fi.Cloud, routeTables map[string]*ResourceTracker) ([
 
 		for _, t := range response.NatGateways {
 			natGatewayId := aws.StringValue(t.NatGatewayId)
-			ngwTracker := &ResourceTracker{
+			ngwTracker := &tracker.Resource{
 				Name:    natGatewayId,
 				ID:      natGatewayId,
 				Type:    TypeNatGateway,
-				deleter: DeleteNatGateway,
+				Deleter: DeleteNatGateway,
 				Shared:  !ownedNatGatewayIds.Has(natGatewayId),
 			}
-			trackers = append(trackers, ngwTracker)
+			resourceTrackers = append(resourceTrackers, ngwTracker)
 
 			// If we're deleting the NatGateway, we should delete the ElasticIP also
 			for _, address := range t.NatGatewayAddresses {
@@ -1525,22 +1526,22 @@ func FindNatGateways(cloud fi.Cloud, routeTables map[string]*ResourceTracker) ([
 						name = aws.StringValue(address.AllocationId)
 					}
 
-					eipTracker := &ResourceTracker{
+					eipTracker := &tracker.Resource{
 						Name:    name,
 						ID:      aws.StringValue(address.AllocationId),
 						Type:    TypeElasticIp,
-						deleter: DeleteElasticIP,
+						Deleter: DeleteElasticIP,
 						Shared:  !ownedNatGatewayIds.Has(natGatewayId),
 					}
-					trackers = append(trackers, eipTracker)
+					resourceTrackers = append(resourceTrackers, eipTracker)
 
-					ngwTracker.blocks = append(ngwTracker.blocks, eipTracker.Type+":"+eipTracker.ID)
+					ngwTracker.Blocks = append(ngwTracker.Blocks, eipTracker.Type+":"+eipTracker.ID)
 				}
 			}
 		}
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
 // extractClusterName performs string-matching / parsing to determine the ClusterName in some instance-data
@@ -1590,7 +1591,7 @@ func extractClusterName(userData string) string {
 	return clusterName
 
 }
-func DeleteAutoscalingLaunchConfiguration(cloud fi.Cloud, r *ResourceTracker) error {
+func DeleteAutoscalingLaunchConfiguration(cloud fi.Cloud, r *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	id := r.ID
@@ -1605,7 +1606,7 @@ func DeleteAutoscalingLaunchConfiguration(cloud fi.Cloud, r *ResourceTracker) er
 	return nil
 }
 
-func DeleteELB(cloud fi.Cloud, r *ResourceTracker) error {
+func DeleteELB(cloud fi.Cloud, r *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	id := r.ID
@@ -1624,30 +1625,30 @@ func DeleteELB(cloud fi.Cloud, r *ResourceTracker) error {
 	return nil
 }
 
-func DumpELB(r *ResourceTracker) (interface{}, error) {
+func DumpELB(r *tracker.Resource) (interface{}, error) {
 	data := make(map[string]interface{})
 	data["id"] = r.ID
 	data["type"] = TypeLoadBalancer
-	data["raw"] = r.obj
+	data["raw"] = r.Obj
 	return data, nil
 }
 
-func ListELBs(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
+func ListELBs(cloud fi.Cloud, clusterName string) ([]*tracker.Resource, error) {
 	elbs, elbTags, err := DescribeELBs(cloud)
 	if err != nil {
 		return nil, err
 	}
 
-	var trackers []*ResourceTracker
+	var resourceTrackers []*tracker.Resource
 	for _, elb := range elbs {
 		id := aws.StringValue(elb.LoadBalancerName)
-		tracker := &ResourceTracker{
+		resourceTracker := &tracker.Resource{
 			Name:    FindELBName(elbTags[id]),
 			ID:      id,
 			Type:    TypeLoadBalancer,
-			deleter: DeleteELB,
+			Deleter: DeleteELB,
 			Dumper:  DumpELB,
-			obj:     elb,
+			Obj:     elb,
 		}
 
 		var blocks []string
@@ -1659,12 +1660,12 @@ func ListELBs(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
 		}
 		blocks = append(blocks, "vpc:"+aws.StringValue(elb.VPCId))
 
-		tracker.blocks = blocks
+		resourceTracker.Blocks = blocks
 
-		trackers = append(trackers, tracker)
+		resourceTrackers = append(resourceTrackers, resourceTracker)
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
 func DescribeELBs(cloud fi.Cloud) ([]*elb.LoadBalancerDescription, map[string][]*elb.Tag, error) {
@@ -1726,7 +1727,7 @@ func DescribeELBs(cloud fi.Cloud) ([]*elb.LoadBalancerDescription, map[string][]
 	return elbs, elbTags, nil
 }
 
-func DeleteElasticIP(cloud fi.Cloud, t *ResourceTracker) error {
+func DeleteElasticIP(cloud fi.Cloud, t *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	id := t.ID
@@ -1750,7 +1751,7 @@ func DeleteElasticIP(cloud fi.Cloud, t *ResourceTracker) error {
 	return nil
 }
 
-func DeleteNatGateway(cloud fi.Cloud, t *ResourceTracker) error {
+func DeleteNatGateway(cloud fi.Cloud, t *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	id := t.ID
@@ -1769,16 +1770,16 @@ func DeleteNatGateway(cloud fi.Cloud, t *ResourceTracker) error {
 	return nil
 }
 
-func deleteRoute53Records(cloud fi.Cloud, zone *route53.HostedZone, trackers []*ResourceTracker) error {
+func deleteRoute53Records(cloud fi.Cloud, zone *route53.HostedZone, resourceTrackers []*tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	var changes []*route53.Change
 	var names []string
-	for _, tracker := range trackers {
-		names = append(names, tracker.Name)
+	for _, resourceTracker := range resourceTrackers {
+		names = append(names, resourceTracker.Name)
 		changes = append(changes, &route53.Change{
 			Action:            aws.String("DELETE"),
-			ResourceRecordSet: tracker.obj.(*route53.ResourceRecordSet),
+			ResourceRecordSet: resourceTracker.Obj.(*route53.ResourceRecordSet),
 		})
 	}
 	human := strings.Join(names, ", ")
@@ -1798,11 +1799,11 @@ func deleteRoute53Records(cloud fi.Cloud, zone *route53.HostedZone, trackers []*
 	return nil
 }
 
-func ListRoute53Records(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
-	var trackers []*ResourceTracker
+func ListRoute53Records(cloud fi.Cloud, clusterName string) ([]*tracker.Resource, error) {
+	var resourceTrackers []*tracker.Resource
 
 	if dns.IsGossipHostname(clusterName) {
-		return trackers, nil
+		return resourceTrackers, nil
 	}
 
 	c := cloud.(awsup.AWSCloud)
@@ -1868,17 +1869,17 @@ func ListRoute53Records(cloud fi.Cloud, clusterName string) ([]*ResourceTracker,
 					continue
 				}
 
-				tracker := &ResourceTracker{
+				resourceTracker := &tracker.Resource{
 					Name:     aws.StringValue(rrs.Name),
 					ID:       hostedZoneID + "/" + aws.StringValue(rrs.Name),
 					Type:     "route53-record",
-					groupKey: hostedZoneID,
-					groupDeleter: func(cloud fi.Cloud, trackers []*ResourceTracker) error {
-						return deleteRoute53Records(cloud, zone, trackers)
+					GroupKey: hostedZoneID,
+					GroupDeleter: func(cloud fi.Cloud, resourceTrackers []*tracker.Resource) error {
+						return deleteRoute53Records(cloud, zone, resourceTrackers)
 					},
-					obj: rrs,
+					Obj: rrs,
 				}
-				trackers = append(trackers, tracker)
+				resourceTrackers = append(resourceTrackers, resourceTracker)
 			}
 			return true
 		})
@@ -1887,10 +1888,10 @@ func ListRoute53Records(cloud fi.Cloud, clusterName string) ([]*ResourceTracker,
 		}
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
-func DeleteIAMRole(cloud fi.Cloud, r *ResourceTracker) error {
+func DeleteIAMRole(cloud fi.Cloud, r *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
 	roleName := r.Name
@@ -1942,7 +1943,7 @@ func DeleteIAMRole(cloud fi.Cloud, r *ResourceTracker) error {
 	return nil
 }
 
-func ListIAMRoles(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
+func ListIAMRoles(cloud fi.Cloud, clusterName string) ([]*tracker.Resource, error) {
 	c := cloud.(awsup.AWSCloud)
 
 	remove := make(map[string]bool)
@@ -1968,26 +1969,26 @@ func ListIAMRoles(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error
 		}
 	}
 
-	var trackers []*ResourceTracker
+	var resourceTrackers []*tracker.Resource
 
 	for _, role := range roles {
 		name := aws.StringValue(role.RoleName)
-		tracker := &ResourceTracker{
+		resourceTracker := &tracker.Resource{
 			Name:    name,
 			ID:      name,
 			Type:    "iam-role",
-			deleter: DeleteIAMRole,
+			Deleter: DeleteIAMRole,
 		}
-		trackers = append(trackers, tracker)
+		resourceTrackers = append(resourceTrackers, resourceTracker)
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
-func DeleteIAMInstanceProfile(cloud fi.Cloud, r *ResourceTracker) error {
+func DeleteIAMInstanceProfile(cloud fi.Cloud, r *tracker.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
-	profile := r.obj.(*iam.InstanceProfile)
+	profile := r.Obj.(*iam.InstanceProfile)
 	name := aws.StringValue(profile.InstanceProfileName)
 
 	// Remove roles
@@ -2020,7 +2021,7 @@ func DeleteIAMInstanceProfile(cloud fi.Cloud, r *ResourceTracker) error {
 	return nil
 }
 
-func ListIAMInstanceProfiles(cloud fi.Cloud, clusterName string) ([]*ResourceTracker, error) {
+func ListIAMInstanceProfiles(cloud fi.Cloud, clusterName string) ([]*tracker.Resource, error) {
 	c := cloud.(awsup.AWSCloud)
 
 	remove := make(map[string]bool)
@@ -2044,22 +2045,22 @@ func ListIAMInstanceProfiles(cloud fi.Cloud, clusterName string) ([]*ResourceTra
 		return nil, fmt.Errorf("error listing IAM instance profiles: %v", err)
 	}
 
-	var trackers []*ResourceTracker
+	var resourceTrackers []*tracker.Resource
 
 	for _, profile := range profiles {
 		name := aws.StringValue(profile.InstanceProfileName)
-		tracker := &ResourceTracker{
+		resourceTracker := &tracker.Resource{
 			Name:    name,
 			ID:      name,
 			Type:    "iam-instance-profile",
-			deleter: DeleteIAMInstanceProfile,
-			obj:     profile,
+			Deleter: DeleteIAMInstanceProfile,
+			Obj:     profile,
 		}
 
-		trackers = append(trackers, tracker)
+		resourceTrackers = append(resourceTrackers, resourceTracker)
 	}
 
-	return trackers, nil
+	return resourceTrackers, nil
 }
 
 func FindName(tags []*ec2.Tag) string {

--- a/pkg/resources/aws_test.go
+++ b/pkg/resources/aws_test.go
@@ -24,12 +24,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/kops/cloudmock/aws/mockec2"
+	"k8s.io/kops/pkg/resources/tracker"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 )
 
 func TestAddUntaggedRouteTables(t *testing.T) {
 	cloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
-	resources := make(map[string]*ResourceTracker)
+	resources := make(map[string]*tracker.Resource)
 
 	clusterName := "me.example.com"
 
@@ -71,7 +72,7 @@ func TestAddUntaggedRouteTables(t *testing.T) {
 		RouteTableId: aws.String("rt-5555"),
 	})
 
-	resources["vpc:vpc-1234"] = &ResourceTracker{}
+	resources["vpc:vpc-1234"] = &tracker.Resource{}
 
 	err := addUntaggedRouteTables(cloud, clusterName, resources)
 	if err != nil {

--- a/pkg/resources/digitalocean/resources.go
+++ b/pkg/resources/digitalocean/resources.go
@@ -14,18 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package digitalocean
 
 import (
-	"k8s.io/kops/pkg/resources/digitalocean"
 	"k8s.io/kops/pkg/resources/tracker"
+	"k8s.io/kops/upup/pkg/fi"
 )
 
-func (c *ClusterResources) listResourcesDO() (map[string]*tracker.Resource, error) {
-	r := digitalocean.Resources{
-		Cloud:       c.Cloud,
-		ClusterName: c.ClusterName,
-	}
+type Resources struct {
+	Cloud       fi.Cloud
+	ClusterName string
+}
 
-	return r.ListResources()
+// ListResources fetches all digitalocean resources into tracker.Resources
+func (r *Resources) ListResources() (map[string]*tracker.Resource, error) {
+	return nil, nil
+}
+
+// DeleteResources deletes all resources passed in the form in tracker.Resources
+func (r *Resources) DeleteResources(resources map[string]*tracker.Resource) error {
+	return nil
 }

--- a/pkg/resources/tracker/tracker.go
+++ b/pkg/resources/tracker/tracker.go
@@ -14,18 +14,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package tracker
 
 import (
-	"k8s.io/kops/pkg/resources/digitalocean"
-	"k8s.io/kops/pkg/resources/tracker"
+	"k8s.io/kops/upup/pkg/fi"
 )
 
-func (c *ClusterResources) listResourcesDO() (map[string]*tracker.Resource, error) {
-	r := digitalocean.Resources{
-		Cloud:       c.Cloud,
-		ClusterName: c.ClusterName,
-	}
+type Resource struct {
+	Name string
+	Type string
+	ID   string
 
-	return r.ListResources()
+	// If true, this resource is not owned by the cluster
+	Shared bool
+
+	Blocks  []string
+	Blocked []string
+	Done    bool
+
+	Deleter      func(cloud fi.Cloud, tracker *Resource) error
+	GroupKey     string
+	GroupDeleter func(cloud fi.Cloud, trackers []*Resource) error
+
+	Dumper func(r *Resource) (interface{}, error)
+
+	Obj interface{}
 }

--- a/pkg/resources/vsphere.go
+++ b/pkg/resources/vsphere.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
+	"k8s.io/kops/pkg/resources/tracker"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/vsphere"
 )
@@ -35,12 +36,12 @@ type clusterDiscoveryVSphere struct {
 	clusterName  string
 }
 
-type vsphereListFn func() ([]*ResourceTracker, error)
+type vsphereListFn func() ([]*tracker.Resource, error)
 
-func (c *ClusterResources) listResourcesVSphere() (map[string]*ResourceTracker, error) {
+func (c *ClusterResources) listResourcesVSphere() (map[string]*tracker.Resource, error) {
 	vsphereCloud := c.Cloud.(*vsphere.VSphereCloud)
 
-	resources := make(map[string]*ResourceTracker)
+	resources := make(map[string]*tracker.Resource)
 
 	d := &clusterDiscoveryVSphere{
 		cloud:        c.Cloud,
@@ -65,7 +66,7 @@ func (c *ClusterResources) listResourcesVSphere() (map[string]*ResourceTracker, 
 	return resources, nil
 }
 
-func (d *clusterDiscoveryVSphere) listVMs() ([]*ResourceTracker, error) {
+func (d *clusterDiscoveryVSphere) listVMs() ([]*tracker.Resource, error) {
 	c := d.vsphereCloud
 
 	regexForMasterVMs := "*" + "." + "masters" + "." + d.clusterName + "*"
@@ -79,25 +80,25 @@ func (d *clusterDiscoveryVSphere) listVMs() ([]*ResourceTracker, error) {
 		glog.Warning(err)
 	}
 
-	var trackers []*ResourceTracker
+	var trackers []*tracker.Resource
 	for _, vm := range vms {
-		tracker := &ResourceTracker{
+		tracker := &tracker.Resource{
 			Name:    vm.Name(),
 			ID:      vm.Name(),
 			Type:    typeVM,
-			deleter: deleteVM,
+			Deleter: deleteVM,
 			Dumper:  DumpVMInfo,
-			obj:     vm,
+			Obj:     vm,
 		}
 		trackers = append(trackers, tracker)
 	}
 	return trackers, nil
 }
 
-func deleteVM(cloud fi.Cloud, r *ResourceTracker) error {
+func deleteVM(cloud fi.Cloud, r *tracker.Resource) error {
 	vsphereCloud := cloud.(*vsphere.VSphereCloud)
 
-	vm := r.obj.(*object.VirtualMachine)
+	vm := r.Obj.(*object.VirtualMachine)
 
 	task, err := vm.PowerOff(context.TODO())
 	if err != nil {
@@ -120,14 +121,14 @@ func deleteVM(cloud fi.Cloud, r *ResourceTracker) error {
 	return nil
 }
 
-func DumpVMInfo(r *ResourceTracker) (interface{}, error) {
+func DumpVMInfo(r *tracker.Resource) (interface{}, error) {
 	data := make(map[string]interface{})
 	data["id"] = r.ID
 	data["type"] = r.Type
-	data["raw"] = r.obj
+	data["raw"] = r.Obj
 	return data, nil
 }
 
-func GetResourceTrackerKey(t *ResourceTracker) string {
+func GetResourceTrackerKey(t *tracker.Resource) string {
 	return t.Type + ":" + t.ID
 }


### PR DESCRIPTION
Puts ResourceTracker into its own package `pkg/resources/tracker` so it can be called from different packges without hitting import cycle e.g. `pkg/reources/digitalocean/resource.go`. This is so that we can group cloud specific code into their own packages (`pkg/resources/aws/`. `pkg/resources/gce/`, etc) rather than dump all the resource code from all clouds into `pkg/resources` 