### PR TITLE
Makefile clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ LATEST_FILE?=latest-ci.txt
 GOPATH_1ST=$(shell go env | grep GOPATH | cut -f 2 -d \")
 UNIQUE:=$(shell date +%s)
 GOVERSION=1.8.3
+BINDATA_TARGETS=upup/models/bindata.go federation/model/bindata.go
+BUILD=${GOPATH_1ST}/src/k8s.io/kops/.build
 
 # See http://stackoverflow.com/questions/18136918/how-to-get-current-relative-directory-of-your-makefile
 MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))
@@ -106,6 +108,10 @@ help: # Show this help
 	| sed 's/^/    /'               `: indent`; \
 	echo ''; \
 	} 1>&2; \
+
+clean: # Remove build directory and bindata-generated files
+	if test -e ${BUILD}; then rm -rf ${BUILD}; fi
+	for t in ${BINDATA_TARGETS}; do if test -e $$t; then rm $$t; fi; done 
 
 kops: kops-gobindata # Install kops
 	go install ${EXTRA_BUILDFLAGS} -ldflags "-X k8s.io/kops.Version=${VERSION} -X k8s.io/kops.GitVersion=${GITSHA} ${EXTRA_LDFLAGS}" k8s.io/kops/cmd/kops/...

--- a/Makefile
+++ b/Makefile
@@ -109,9 +109,10 @@ help: # Show this help
 	echo ''; \
 	} 1>&2; \
 
+.PHONY: clean
 clean: # Remove build directory and bindata-generated files
+	for t in ${BINDATA_TARGETS}; do if test -e $$t; then rm -f $$t; fi; done 
 	if test -e ${BUILD}; then rm -rf ${BUILD}; fi
-	for t in ${BINDATA_TARGETS}; do if test -e $$t; then rm $$t; fi; done 
 
 kops: kops-gobindata # Install kops
 	go install ${EXTRA_BUILDFLAGS} -ldflags "-X k8s.io/kops.Version=${VERSION} -X k8s.io/kops.GitVersion=${GITSHA} ${EXTRA_LDFLAGS}" k8s.io/kops/cmd/kops/...
@@ -121,12 +122,12 @@ gobindata-tool:
 	go build ${EXTRA_BUILDFLAGS} -ldflags "${EXTRA_LDFLAGS}" -o ${GOPATH_1ST}/bin/go-bindata k8s.io/kops/vendor/github.com/jteeuwen/go-bindata/go-bindata
 
 .PHONY: kops-gobindata
-kops-gobindata: ${BINDATA_TARGETS}
+kops-gobindata: gobindata-tool ${BINDATA_TARGETS}
 
-upup/models/bindata.go: gobindata-tool
+upup/models/bindata.go:
 	cd ${GOPATH_1ST}/src/k8s.io/kops; ${GOPATH_1ST}/bin/go-bindata -o $@ -pkg models -ignore="\\.DS_Store" -ignore="bindata\\.go" -ignore="vfs\\.go" -prefix upup/models/ upup/models/...
 
-federation/model/bindata.go: gobindata-tool
+federation/model/bindata.go:
 	cd ${GOPATH_1ST}/src/k8s.io/kops; ${GOPATH_1ST}/bin/go-bindata -o $@ -pkg model -ignore="\\.DS_Store" -ignore="bindata\\.go" -prefix federation/model/ federation/model/...
 
 # Build in a docker container with golang 1.X

--- a/Makefile
+++ b/Makefile
@@ -121,9 +121,13 @@ gobindata-tool:
 	go build ${EXTRA_BUILDFLAGS} -ldflags "${EXTRA_LDFLAGS}" -o ${GOPATH_1ST}/bin/go-bindata k8s.io/kops/vendor/github.com/jteeuwen/go-bindata/go-bindata
 
 .PHONY: kops-gobindata
-kops-gobindata: gobindata-tool
-	cd ${GOPATH_1ST}/src/k8s.io/kops; ${GOPATH_1ST}/bin/go-bindata -o upup/models/bindata.go -pkg models -ignore="\\.DS_Store" -ignore="bindata\\.go" -ignore="vfs\\.go" -prefix upup/models/ upup/models/...
-	cd ${GOPATH_1ST}/src/k8s.io/kops; ${GOPATH_1ST}/bin/go-bindata -o federation/model/bindata.go -pkg model -ignore="\\.DS_Store" -ignore="bindata\\.go" -prefix federation/model/ federation/model/...
+kops-gobindata: ${BINDATA_TARGETS}
+
+upup/models/bindata.go: gobindata-tool
+	cd ${GOPATH_1ST}/src/k8s.io/kops; ${GOPATH_1ST}/bin/go-bindata -o $@ -pkg models -ignore="\\.DS_Store" -ignore="bindata\\.go" -ignore="vfs\\.go" -prefix upup/models/ upup/models/...
+
+federation/model/bindata.go: gobindata-tool
+	cd ${GOPATH_1ST}/src/k8s.io/kops; ${GOPATH_1ST}/bin/go-bindata -o $@ -pkg model -ignore="\\.DS_Store" -ignore="bindata\\.go" -prefix federation/model/ federation/model/...
 
 # Build in a docker container with golang 1.X
 # Used to test we have not broken 1.X


### PR DESCRIPTION
I'm interested in tightening up the kops Makefile.

This first step adds a "clean" recipe for deleting the .build directory and any files generated by go-bindatatool.

The two files generated by go-bindatatool get their own  recipes, so now make can keep track of when they have been built and will not need to regenerate.