### PR TITLE
Revision to IAM Policies created by Kops

### DIFF
--- a/pkg/model/iam.go
+++ b/pkg/model/iam.go
@@ -19,14 +19,15 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"strings"
+	"text/template"
+
 	"github.com/golang/glog"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/model/iam"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
-	"reflect"
-	"strings"
-	"text/template"
 )
 
 // IAMModelBuilder configures IAM objects
@@ -87,8 +88,8 @@ func (b *IAMModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		}
 
 		{
-			iamPolicy := &iam.IAMPolicyResource{
-				Builder: &iam.IAMPolicyBuilder{
+			iamPolicy := &iam.PolicyResource{
+				Builder: &iam.PolicyBuilder{
 					Cluster: b.Cluster,
 					Role:    role,
 					Region:  b.Region,
@@ -156,11 +157,11 @@ func (b *IAMModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			}
 
 			if additionalPolicy != "" {
-				p := &iam.IAMPolicy{
-					Version: iam.IAMPolicyDefaultVersion,
+				p := &iam.Policy{
+					Version: iam.PolicyDefaultVersion,
 				}
 
-				statements := make([]*iam.IAMStatement, 0)
+				statements := make([]*iam.Statement, 0)
 				json.Unmarshal([]byte(additionalPolicy), &statements)
 				p.Statement = append(p.Statement, statements...)
 

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// TODO: We have a couple different code paths until we do lifecycles, and
+// TODO: when we have a cluster or refactor some s3 code.  The only code that
+// TODO: is not shared by the different path is the s3 / state store stuff.
+
+// TODO: Initial work has been done to lock down IAM actions based on resources
+// TODO: and condition keys, but this can be extended further (with thorough testing).
+
 package iam
 
 import (
@@ -24,44 +31,60 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"k8s.io/apimachinery/pkg/util/sets"
-	api "k8s.io/kops/pkg/apis/kops"
+
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/util/stringorslice"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
 	"k8s.io/kops/util/pkg/vfs"
 )
 
-const IAMPolicyDefaultVersion = "2012-10-17"
+// PolicyDefaultVersion is the default version included in all policy documents
+const PolicyDefaultVersion = "2012-10-17"
 
-type IAMPolicy struct {
+// Policy Struct is a collection of fields that form a valid AWS policy document
+type Policy struct {
 	Version   string
-	Statement []*IAMStatement
+	Statement []*Statement
 }
 
-func (p *IAMPolicy) AsJSON() (string, error) {
+// AsJSON converts the policy document to JSON format (parsable by AWS)
+func (p *Policy) AsJSON() (string, error) {
 	j, err := json.MarshalIndent(p, "", "  ")
 	if err != nil {
-		return "", fmt.Errorf("error marshaling policy to JSON: %v", err)
+		return "", fmt.Errorf("error marshalling policy to JSON: %v", err)
 	}
 	return string(j), nil
 }
 
-type IAMStatementEffect string
+// SID (Statement ID) is an optional identifier for the policy statement
+type SID string
 
-const IAMStatementEffectAllow IAMStatementEffect = "Allow"
-const IAMStatementEffectDeny IAMStatementEffect = "Deny"
+// StatementEffect is required and specifies what type of access the statement results in
+type StatementEffect string
 
+// StatementEffectAllow allows access for the given resources in the statement (based on conditions)
+const StatementEffectAllow StatementEffect = "Allow"
+
+// StatementEffectDeny allows access for the given resources in the statement (based on conditions)
+const StatementEffectDeny StatementEffect = "Deny"
+
+// Condition is a map of Conditions to be evaluated for a given IAM Statement
 type Condition map[string]interface{}
 
-type IAMStatement struct {
-	Effect    IAMStatementEffect
+// Statement is an AWS IAM Policy Statement Object:
+// http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#Statement
+type Statement struct {
+	Sid       SID
+	Effect    StatementEffect
 	Action    stringorslice.StringOrSlice
 	Resource  stringorslice.StringOrSlice
 	Condition Condition `json:",omitempty"`
 }
 
-func (l *IAMStatement) Equal(r *IAMStatement) bool {
+// Equal compares two IAM Statements and returns a bool
+// TODO: Extend to support Condition Keys
+func (l *Statement) Equal(r *Statement) bool {
 	if l.Effect != r.Effect {
 		return false
 	}
@@ -74,116 +97,159 @@ func (l *IAMStatement) Equal(r *IAMStatement) bool {
 	return true
 }
 
-type IAMPolicyBuilder struct {
-	Cluster      *api.Cluster
-	Role         api.InstanceGroupRole
-	Region       string
-	HostedZoneID string
+// PolicyBuilder struct defines all valid fields to be used when building the
+// AWS IAM policy document for a given instance group role.
+type PolicyBuilder struct {
+	Cluster        *kops.Cluster
+	CreateECRPerms bool
+	HostedZoneID   string
+	KMSKeys        []string
+	Region         string
+	ResourceARN    *string
+	Role           kops.InstanceGroupRole
 }
 
-// BuildAWSIAMPolicy builds a set of IAM policy statements based on the
-// instance group type and IAM Strict setting within the Cluster Spec
-func (b *IAMPolicyBuilder) BuildAWSIAMPolicy() (*IAMPolicy, error) {
-	wildcard := stringorslice.Slice([]string{"*"})
-	iamPrefix := b.IAMPrefix()
+// BuildAWSPolicy builds a set of IAM policy statements based on the
+// instance group type and IAM Legacy flag within the Cluster Spec
+func (b *PolicyBuilder) BuildAWSPolicy() (*Policy, error) {
+	var p *Policy
+	var err error
 
-	// The Legacy IAM setting deploys an open policy (prior to the hardening PRs)
-	legacyIAM := false
-	if b.Cluster.Spec.IAM != nil {
-		legacyIAM = b.Cluster.Spec.IAM.Legacy
-	}
-
-	p := &IAMPolicy{
-		Version: IAMPolicyDefaultVersion,
-	}
-
-	// Don't give bastions any permissions (yet)
-	if b.Role == api.InstanceGroupRoleBastion {
-		p.Statement = append(p.Statement, &IAMStatement{
-			// We grant a trivial (?) permission (DescribeRegions), because empty policies are not allowed
-			Effect:   IAMStatementEffectAllow,
-			Action:   stringorslice.Slice([]string{"ec2:DescribeRegions"}),
-			Resource: wildcard,
-		})
-
-		return p, nil
-	}
-
-	addEC2Permissions(p, iamPrefix, b, wildcard, legacyIAM)
-
-	{
-		// We provide ECR access on the nodes (naturally), but we also provide access on the master.
-		// We shouldn't be running lots of pods on the master, but it is perfectly reasonable to run
-		// a private logging pod or similar.
-		p.Statement = append(p.Statement, &IAMStatement{
-			Effect: IAMStatementEffectAllow,
-			Action: stringorslice.Of(
-				"ecr:GetAuthorizationToken",
-				"ecr:BatchCheckLayerAvailability",
-				"ecr:GetDownloadUrlForLayer",
-				"ecr:GetRepositoryPolicy",
-				"ecr:DescribeRepositories",
-				"ecr:ListImages",
-				"ecr:BatchGetImage",
-			),
-			Resource: wildcard,
-		})
-	}
-
-	if b.Role == api.InstanceGroupRoleMaster {
-		p.Statement = append(p.Statement, &IAMStatement{
-			Effect:   IAMStatementEffectAllow,
-			Action:   stringorslice.Slice([]string{"elasticloadbalancing:*"}),
-			Resource: wildcard,
-		})
-
-		p.Statement = append(p.Statement, &IAMStatement{
-			Effect: IAMStatementEffectAllow,
-			Action: stringorslice.Of(
-				"autoscaling:DescribeAutoScalingGroups",
-				"autoscaling:DescribeAutoScalingInstances",
-				"autoscaling:DescribeLaunchConfigurations",
-				"autoscaling:SetDesiredCapacity",
-				"autoscaling:TerminateInstanceInAutoScalingGroup",
-			),
-			Resource: wildcard,
-		})
-
-		// Restrict the KMS permissions to only the keys that are being used
-		kmsKeyIDs := sets.NewString()
-		for _, e := range b.Cluster.Spec.EtcdClusters {
-			for _, m := range e.Members {
-				if m.KmsKeyId != nil {
-					kmsKeyIDs.Insert(*m.KmsKeyId)
-				}
+	// Retrieve all the KMS Keys in use
+	for _, e := range b.Cluster.Spec.EtcdClusters {
+		for _, m := range e.Members {
+			if m.KmsKeyId != nil {
+				b.KMSKeys = append(b.KMSKeys, *m.KmsKeyId)
 			}
 		}
+	}
 
-		if kmsKeyIDs.Len() > 0 {
-			p.Statement = append(p.Statement, &IAMStatement{
-				Effect: IAMStatementEffectAllow,
-				Action: stringorslice.Of(
-					"kms:Encrypt",
-					"kms:Decrypt",
-					"kms:ReEncrypt*",
-					"kms:GenerateDataKey*",
-					"kms:DescribeKey",
-					"kms:CreateGrant",
-					"kms:ListGrants",
-					"kms:RevokeGrant",
-				),
-				Resource: stringorslice.Slice(kmsKeyIDs.List()),
-			})
+	switch b.Role {
+	case kops.InstanceGroupRoleBastion:
+		p, err = b.BuildAWSPolicyBastion()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate AWS IAM Policy for Bastion Instance Group: %v", err)
 		}
+	case kops.InstanceGroupRoleNode:
+		p, err = b.BuildAWSPolicyNode()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate AWS IAM Policy for Node Instance Group: %v", err)
+		}
+	case kops.InstanceGroupRoleMaster:
+		p, err = b.BuildAWSPolicyMaster()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate AWS IAM Policy for Master Instance Group: %v", err)
+		}
+	default:
+		return nil, fmt.Errorf("unrecognised instance group type: %s", b.Role)
+	}
+
+	return p, nil
+}
+
+// BuildAWSPolicyMaster generates a custom policy for a Kubernetes master.
+func (b *PolicyBuilder) BuildAWSPolicyMaster() (*Policy, error) {
+	resource := createResource(b)
+
+	p := &Policy{
+		Version: PolicyDefaultVersion,
+	}
+
+	addMasterEC2Policies(p, resource, b.Cluster.Spec.IAM.Legacy, b.Cluster.GetName())
+	addMasterASPolicies(p, resource, b.Cluster.Spec.IAM.Legacy, b.Cluster.GetName())
+	addMasterELBPolicies(p, resource, b.Cluster.Spec.IAM.Legacy)
+	addCertIAMPolicies(p, resource)
+
+	var err error
+	if p, err = b.AddS3Permissions(p); err != nil {
+		return nil, fmt.Errorf("failed to generate AWS IAM S3 access statements: %v", err)
+	}
+
+	if b.KMSKeys != nil && len(b.KMSKeys) != 0 {
+		addKMSIAMPolicies(p, stringorslice.Slice(b.KMSKeys), b.Cluster.Spec.IAM.Legacy)
+	}
+
+	if b.Cluster.Spec.IAM.Legacy || b.CreateECRPerms {
+		addECRPermissions(p)
 	}
 
 	if b.HostedZoneID != "" {
 		addRoute53Permissions(p, b.HostedZoneID)
 	}
-	// dns-controller currently assumes it can list the hosted zones, even when using gossip
-	addRoute53ListHostedZonesPermission(p)
 
-	// For S3 IAM permissions, we grant permissions to subtrees.  So find the parents;
+	if b.Cluster.Spec.IAM.Legacy {
+		addRoute53ListHostedZonesPermission(p)
+	}
+
+	return p, nil
+}
+
+// BuildAWSPolicyNode generates a custom policy for a Kubernetes node.
+func (b *PolicyBuilder) BuildAWSPolicyNode() (*Policy, error) {
+	resource := createResource(b)
+
+	p := &Policy{
+		Version: PolicyDefaultVersion,
+	}
+
+	addNodeEC2Policies(p, resource)
+
+	var err error
+	if p, err = b.AddS3Permissions(p); err != nil {
+		return nil, fmt.Errorf("failed to generate AWS IAM S3 access statements: %v", err)
+	}
+
+	if b.Cluster.Spec.IAM.Legacy || b.CreateECRPerms {
+		addECRPermissions(p)
+	}
+
+	if b.Cluster.Spec.IAM.Legacy {
+		if b.HostedZoneID != "" {
+			addRoute53Permissions(p, b.HostedZoneID)
+		}
+		addRoute53ListHostedZonesPermission(p)
+	}
+
+	return p, nil
+}
+
+// BuildAWSPolicyBastion generates a custom policy for a bastion host.
+func (b *PolicyBuilder) BuildAWSPolicyBastion() (*Policy, error) {
+	resource := createResource(b)
+
+	p := &Policy{
+		Version: PolicyDefaultVersion,
+	}
+
+	// Bastion hosts currently don't require any specific permissions.
+	// A trivial permission is granted, because empty policies are not allowed.
+	p.Statement = append(p.Statement, &Statement{
+		Sid:      "kopsK8sBastion",
+		Effect:   StatementEffectAllow,
+		Action:   stringorslice.Slice([]string{"ec2:DescribeRegions"}),
+		Resource: resource,
+	})
+
+	return p, nil
+}
+
+// IAMPrefix returns the prefix for AWS ARNs in the current region, for use with IAM
+// it is arn:aws everywhere but in cn-north and us-gov-west-1
+func (b *PolicyBuilder) IAMPrefix() string {
+	switch b.Region {
+	case "cn-north-1":
+		return "arn:aws-cn"
+	case "us-gov-west-1":
+		return "arn:aws-us-gov"
+	default:
+		return "arn:aws"
+	}
+}
+
+// AddS3Permissions updates an IAM Policy with statements granting tailored
+// access to S3 assets, depending on the instance group role
+func (b *PolicyBuilder) AddS3Permissions(p *Policy) (*Policy, error) {
+	// For S3 IAM permissions we grant permissions to subtrees, so find the parents;
 	// we don't need to grant mypath and mypath/child.
 	var roots []string
 	{
@@ -229,12 +295,62 @@ func (b *IAMPolicyBuilder) BuildAWSIAMPolicy() (*IAMPolicy, error) {
 		}
 
 		if s3Path, ok := vfsPath.(*vfs.S3Path); ok {
-			addS3Permissions(p, iamPrefix, s3Path, b.Role, legacyIAM)
+			iamS3Path := s3Path.Bucket() + "/" + s3Path.Key()
+			iamS3Path = strings.TrimSuffix(iamS3Path, "/")
+
+			p.Statement = append(p.Statement, &Statement{
+				Sid:    "kopsK8sS3GetListBucket",
+				Effect: StatementEffectAllow,
+				Action: stringorslice.Of("s3:GetBucketLocation", "s3:ListBucket"),
+				Resource: stringorslice.Slice([]string{
+					strings.Join([]string{b.IAMPrefix(), ":s3:::", s3Path.Bucket()}, ""),
+				}),
+			})
+
+			if b.Cluster.Spec.IAM.Legacy {
+				p.Statement = append(p.Statement, &Statement{
+					Sid:    "kopsK8sS3BucketFullAccess",
+					Effect: StatementEffectAllow,
+					Action: stringorslice.Slice([]string{"s3:*"}),
+					Resource: stringorslice.Of(
+						strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/*"}, ""),
+					),
+				})
+			} else {
+				if b.Role == kops.InstanceGroupRoleMaster {
+					p.Statement = append(p.Statement, &Statement{
+						Sid:    "kopsK8sS3MasterBucketFullGet",
+						Effect: StatementEffectAllow,
+						Action: stringorslice.Slice([]string{"s3:Get*"}),
+						Resource: stringorslice.Of(
+							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/*"}, ""),
+						),
+					})
+				} else if b.Role == kops.InstanceGroupRoleNode {
+					p.Statement = append(p.Statement, &Statement{
+						Sid:    "kopsK8sS3NodeBucketSelectiveGet",
+						Effect: StatementEffectAllow,
+						Action: stringorslice.Slice([]string{"s3:Get*"}),
+						Resource: stringorslice.Of(
+							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/addons/*"}, ""),
+							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/cluster.spec"}, ""),
+							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/config"}, ""),
+							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/instancegroup/*"}, ""),
+							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/pki/issued/*"}, ""),
+							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/pki/private/kube-proxy/*"}, ""),
+							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/pki/private/kubelet/*"}, ""),
+							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/pki/ssh/*"}, ""),
+							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/secrets/dockerconfig"}, ""),
+						),
+					})
+				}
+			}
 		} else if _, ok := vfsPath.(*vfs.MemFSPath); ok {
 			// Tests -ignore - nothing we can do in terms of IAM policy
 			glog.Warningf("ignoring memfs path %q for IAM policy builder", vfsPath)
 		} else {
-			// We could implement this approach, but it seems better to get all clouds using cluster-readable storage
+			// We could implement this approach, but it seems better to
+			// get all clouds using cluster-readable storage
 			return nil, fmt.Errorf("path is not cluster readable: %v", root)
 		}
 	}
@@ -242,192 +358,18 @@ func (b *IAMPolicyBuilder) BuildAWSIAMPolicy() (*IAMPolicy, error) {
 	return p, nil
 }
 
-// addEC2Permissions updates the IAM Policy with statements granting tailored
-// access to EC2 resources, depending on the instance role
-func addEC2Permissions(p *IAMPolicy, iamPrefix string, b *IAMPolicyBuilder, wildcard stringorslice.StringOrSlice, legacyIAM bool) {
-	if (b.Role == api.InstanceGroupRoleNode) || (b.Role == api.InstanceGroupRoleMaster) {
-		// Describe* calls don't support any additional IAM restrictions
-		p.Statement = append(p.Statement, &IAMStatement{
-			Effect:   IAMStatementEffectAllow,
-			Action:   stringorslice.Slice([]string{"ec2:Describe*"}),
-			Resource: wildcard,
-		})
-	}
-
-	if b.Role == api.InstanceGroupRoleMaster {
-		if legacyIAM {
-			p.Statement = append(p.Statement,
-				&IAMStatement{
-					Effect:   IAMStatementEffectAllow,
-					Action:   stringorslice.Slice([]string{"ec2:*"}),
-					Resource: wildcard,
-				},
-			)
-		} else {
-			// The non-Describe* ec2 calls support different types of filtering:
-			// http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ec2-api-permissions.html
-			// We try to lock down the permissions here in non-legacy mode,
-			// but there are still some improvements possible
-
-			// AttachVolume - supports filtering on tags
-			// DetachVolume - supports filtering on tags
-			// CreateVolume - supports filtering on tags, but we need to switch to pass tags to CreateVolume
-			// DeleteVolume - supports filtering on tags
-
-			// CreateSecurityGroup - no filtering
-			// DeleteSecurityGroup - supports filtering on VPC & tags
-			// AuthorizeSecurityGroupIngress - supports filtering on VPC & tags
-			// RevokeSecurityGroupIngress - supports filtering on VPC & tags
-
-			// CreateTags - supports filtering on existing tags.  Also supports filtering on VPC for some resources (e.g. security groups)
-
-			// CreateRoute - supports no filtering
-			// DeleteRoute - supports filtering on tags (of the route table) and of the VPC
-
-			// ModifyInstanceAttribute - supports no filtering
-
-			p.Statement = append(p.Statement,
-				&IAMStatement{
-					Effect: IAMStatementEffectAllow,
-					Action: stringorslice.Slice([]string{
-						"ec2:CreateRoute",
-						"ec2:CreateSecurityGroup",
-						"ec2:CreateTags",
-						"ec2:CreateVolume",
-						"ec2:DeleteVolume",
-						"ec2:ModifyInstanceAttribute",
-					}),
-					Resource: wildcard,
-				},
-				&IAMStatement{
-					Effect:   IAMStatementEffectAllow,
-					Action:   stringorslice.Slice([]string{"ec2:*"}),
-					Resource: wildcard,
-					Condition: Condition{
-						"StringEquals": map[string]string{
-							"ec2:ResourceTag/KubernetesCluster": b.Cluster.GetName(),
-						},
-					},
-				},
-			)
-		}
-	}
-}
-
-func addRoute53Permissions(p *IAMPolicy, hostedZoneID string) {
-	// Remove /hostedzone/ prefix (if present)
-	hostedZoneID = strings.TrimPrefix(hostedZoneID, "/")
-	hostedZoneID = strings.TrimPrefix(hostedZoneID, "hostedzone/")
-
-	p.Statement = append(p.Statement, &IAMStatement{
-		Effect: IAMStatementEffectAllow,
-		Action: stringorslice.Of("route53:ChangeResourceRecordSets",
-			"route53:ListResourceRecordSets",
-			"route53:GetHostedZone"),
-		Resource: stringorslice.Slice([]string{"arn:aws:route53:::hostedzone/" + hostedZoneID}),
-	})
-
-	p.Statement = append(p.Statement, &IAMStatement{
-		Effect:   IAMStatementEffectAllow,
-		Action:   stringorslice.Slice([]string{"route53:GetChange"}),
-		Resource: stringorslice.Slice([]string{"arn:aws:route53:::change/*"}),
-	})
-}
-
-func addRoute53ListHostedZonesPermission(p *IAMPolicy) {
-	wildcard := stringorslice.Slice([]string{"*"})
-	p.Statement = append(p.Statement, &IAMStatement{
-		Effect:   IAMStatementEffectAllow,
-		Action:   stringorslice.Slice([]string{"route53:ListHostedZones"}),
-		Resource: wildcard,
-	})
-}
-
-// addS3Permissions updates the IAM Policy with statements granting tailored
-// access to S3 assets, depending on the instance role
-func addS3Permissions(p *IAMPolicy, iamPrefix string, s3Path *vfs.S3Path, role api.InstanceGroupRole, legacyIAM bool) {
-	// Note that the config store may itself be a subdirectory of a bucket
-	iamS3Path := s3Path.Bucket() + "/" + s3Path.Key()
-	iamS3Path = strings.TrimSuffix(iamS3Path, "/")
-
-	p.Statement = append(p.Statement, &IAMStatement{
-		Effect: IAMStatementEffectAllow,
-		Action: stringorslice.Of("s3:GetBucketLocation", "s3:ListBucket"),
-		Resource: stringorslice.Slice([]string{
-			strings.Join([]string{iamPrefix, ":s3:::", s3Path.Bucket()}, ""),
-		}),
-	})
-
-	p.Statement = append(p.Statement, &IAMStatement{
-		Effect: IAMStatementEffectAllow,
-		Action: stringorslice.Slice([]string{"s3:List*"}),
-		Resource: stringorslice.Of(
-			strings.Join([]string{iamPrefix, ":s3:::", iamS3Path}, ""),
-			strings.Join([]string{iamPrefix, ":s3:::", iamS3Path, "/*"}, ""),
-		),
-	})
-
-	if legacyIAM {
-		if role == api.InstanceGroupRoleMaster || role == api.InstanceGroupRoleNode {
-			p.Statement = append(p.Statement, &IAMStatement{
-				Effect: IAMStatementEffectAllow,
-				Action: stringorslice.Slice([]string{"s3:*"}),
-				Resource: stringorslice.Of(
-					strings.Join([]string{iamPrefix, ":s3:::", iamS3Path, "/*"}, ""),
-				),
-			})
-		}
-	} else {
-		if role == api.InstanceGroupRoleMaster {
-			p.Statement = append(p.Statement, &IAMStatement{
-				Effect: IAMStatementEffectAllow,
-				Action: stringorslice.Slice([]string{"s3:Get*"}),
-				Resource: stringorslice.Of(
-					strings.Join([]string{iamPrefix, ":s3:::", iamS3Path, "/*"}, ""),
-				),
-			})
-		} else if role == api.InstanceGroupRoleNode {
-			p.Statement = append(p.Statement, &IAMStatement{
-				Effect: IAMStatementEffectAllow,
-				Action: stringorslice.Slice([]string{"s3:Get*"}),
-				Resource: stringorslice.Of(
-					strings.Join([]string{iamPrefix, ":s3:::", iamS3Path, "/addons/*"}, ""),
-					strings.Join([]string{iamPrefix, ":s3:::", iamS3Path, "/cluster.spec"}, ""),
-					strings.Join([]string{iamPrefix, ":s3:::", iamS3Path, "/config"}, ""),
-					strings.Join([]string{iamPrefix, ":s3:::", iamS3Path, "/instancegroup/*"}, ""),
-					strings.Join([]string{iamPrefix, ":s3:::", iamS3Path, "/pki/issued/*"}, ""),
-					strings.Join([]string{iamPrefix, ":s3:::", iamS3Path, "/pki/private/kube-proxy/*"}, ""),
-					strings.Join([]string{iamPrefix, ":s3:::", iamS3Path, "/pki/private/kubelet/*"}, ""),
-					strings.Join([]string{iamPrefix, ":s3:::", iamS3Path, "/pki/ssh/*"}, ""),
-					strings.Join([]string{iamPrefix, ":s3:::", iamS3Path, "/secrets/dockerconfig"}, ""),
-				),
-			})
-		}
-	}
-}
-
-// IAMPrefix returns the prefix for AWS ARNs in the current region, for use with IAM
-// it is arn:aws everywhere but in cn-north and us-gov-west-1
-func (b *IAMPolicyBuilder) IAMPrefix() string {
-	switch b.Region {
-	case "cn-north-1":
-		return "arn:aws-cn"
-	case "us-gov-west-1":
-		return "arn:aws-us-gov"
-	default:
-		return "arn:aws"
-	}
-}
-
-type IAMPolicyResource struct {
-	Builder *IAMPolicyBuilder
+// PolicyResource defines the PolicyBuilder and DNSZone to use when building the
+// IAM policy document for a given instance group role
+type PolicyResource struct {
+	Builder *PolicyBuilder
 	DNSZone *awstasks.DNSZone
 }
 
-var _ fi.Resource = &IAMPolicyResource{}
-var _ fi.HasDependencies = &IAMPolicyResource{}
+var _ fi.Resource = &PolicyResource{}
+var _ fi.HasDependencies = &PolicyResource{}
 
-func (b *IAMPolicyResource) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+// GetDependencies adds the DNSZone task to the list of dependencies if set
+func (b *PolicyResource) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 	var deps []fi.Task
 	if b.DNSZone != nil {
 		deps = append(deps, b.DNSZone)
@@ -436,7 +378,7 @@ func (b *IAMPolicyResource) GetDependencies(tasks map[string]fi.Task) []fi.Task 
 }
 
 // Open produces the AWS IAM policy for the given role
-func (b *IAMPolicyResource) Open() (io.Reader, error) {
+func (b *PolicyResource) Open() (io.Reader, error) {
 	// Defensive copy before mutation
 	pb := *b.Builder
 
@@ -449,13 +391,296 @@ func (b *IAMPolicyResource) Open() (io.Reader, error) {
 		pb.HostedZoneID = hostedZoneID
 	}
 
-	policy, err := pb.BuildAWSIAMPolicy()
+	policy, err := pb.BuildAWSPolicy()
 	if err != nil {
 		return nil, fmt.Errorf("error building IAM policy: %v", err)
 	}
-	json, err := policy.AsJSON()
+	j, err := policy.AsJSON()
 	if err != nil {
 		return nil, fmt.Errorf("error building IAM policy: %v", err)
 	}
-	return bytes.NewReader([]byte(json)), nil
+	return bytes.NewReader([]byte(j)), nil
+}
+
+func addECRPermissions(p *Policy) {
+	// TODO - I think we can just have GetAuthorizationToken here, as we are not
+	// TODO - making any API calls except for GetAuthorizationToken.
+
+	// We provide ECR access on the nodes (naturally), but we also provide access on the master.
+	// We shouldn't be running lots of pods on the master, but it is perfectly reasonable to run
+	// a private logging pod or similar.
+	// At this point we allow all regions with ECR, since ECR is region specific.
+	p.Statement = append(p.Statement, &Statement{
+		Sid:    "kopsK8sECR",
+		Effect: StatementEffectAllow,
+		Action: stringorslice.Of(
+			"ecr:GetAuthorizationToken",
+			"ecr:BatchCheckLayerAvailability",
+			"ecr:GetDownloadUrlForLayer",
+			"ecr:GetRepositoryPolicy",
+			"ecr:DescribeRepositories",
+			"ecr:ListImages",
+			"ecr:BatchGetImage",
+		),
+		Resource: stringorslice.Slice([]string{"*"}),
+	})
+}
+
+func addRoute53Permissions(p *Policy, hostedZoneID string) {
+
+	// TODO: Route53 currently not supported in China, need to check and fail/return
+
+	// Remove /hostedzone/ prefix (if present)
+	hostedZoneID = strings.TrimPrefix(hostedZoneID, "/")
+	hostedZoneID = strings.TrimPrefix(hostedZoneID, "hostedzone/")
+
+	p.Statement = append(p.Statement, &Statement{
+		Sid:    "kopsK8sRoute53Change",
+		Effect: StatementEffectAllow,
+		Action: stringorslice.Of("route53:ChangeResourceRecordSets",
+			"route53:ListResourceRecordSets",
+			"route53:GetHostedZone"),
+		Resource: stringorslice.Slice([]string{"arn:aws:route53:::hostedzone/" + hostedZoneID}),
+	})
+
+	p.Statement = append(p.Statement, &Statement{
+		Sid:      "kopsK8sRoute53GetChanges",
+		Effect:   StatementEffectAllow,
+		Action:   stringorslice.Slice([]string{"route53:GetChange"}),
+		Resource: stringorslice.Slice([]string{"arn:aws:route53:::change/*"}),
+	})
+
+	wildcard := stringorslice.Slice([]string{"*"})
+	p.Statement = append(p.Statement, &Statement{
+		Sid:      "kopsK8sRoute53ListZones",
+		Effect:   StatementEffectAllow,
+		Action:   stringorslice.Slice([]string{"route53:ListHostedZones"}),
+		Resource: wildcard,
+	})
+}
+
+func addKMSIAMPolicies(p *Policy, resource stringorslice.StringOrSlice, legacyIAM bool) {
+	if legacyIAM {
+		p.Statement = append(p.Statement, &Statement{
+			Sid:    "kopsK8sKMSEncryptedVolumesLegacyPerms",
+			Effect: StatementEffectAllow,
+			Action: stringorslice.Of(
+				"kms:ListGrants",
+				"kms:RevokeGrant",
+			),
+			Resource: resource,
+		})
+	}
+
+	// TODO could use "kms:ViaService" Condition Key here?
+	p.Statement = append(p.Statement, &Statement{
+		Sid:    "kopsK8sKMSEncryptedVolumes",
+		Effect: StatementEffectAllow,
+		Action: stringorslice.Of(
+			"kms:CreateGrant",
+			"kms:Decrypt",
+			"kms:DescribeKey",
+			"kms:Encrypt",
+			"kms:GenerateDataKey*",
+			"kms:ReEncrypt*",
+		),
+		Resource: resource,
+	})
+}
+
+func addNodeEC2Policies(p *Policy, resource stringorslice.StringOrSlice) {
+	// Protokube makes a DescribeInstances call
+	p.Statement = append(p.Statement, &Statement{
+		Sid:      "kopsK8sEC2NodePerms",
+		Effect:   StatementEffectAllow,
+		Action:   stringorslice.Slice([]string{"ec2:DescribeInstances"}),
+		Resource: resource,
+	})
+}
+
+func addMasterEC2Policies(p *Policy, resource stringorslice.StringOrSlice, legacyIAM bool, clusterName string) {
+	if legacyIAM {
+		p.Statement = append(p.Statement,
+			&Statement{
+				Sid:      "kopsK8sEC2MasterPermsFullAccess",
+				Effect:   StatementEffectAllow,
+				Action:   stringorslice.Slice([]string{"ec2:*"}),
+				Resource: resource,
+			},
+		)
+	} else {
+
+		// Describe* calls don't support any additional IAM restrictions
+		// The non-Describe* ec2 calls support different types of filtering:
+		// http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ec2-api-permissions.html
+		// We try to lock down the permissions here in non-legacy mode,
+		// but there are still some improvements we can make:
+
+		// CreateVolume - supports filtering on tags, but we need to switch to pass tags to CreateVolume
+		// CreateTags - supports filtering on existing tags. Also supports filtering on VPC for some resources (e.g. security groups)
+		// Network Routing Permissions - May not be required with the CNI Networking provider
+
+		// Comments are which cloudprovider code file makes the call
+		p.Statement = append(p.Statement,
+			&Statement{
+				Sid:    "kopsK8sEC2MasterPermsDescribeResources",
+				Effect: StatementEffectAllow,
+				Action: stringorslice.Slice([]string{
+					"ec2:DescribeInstances",      // aws.go
+					"ec2:DescribeRouteTables",    // aws.go
+					"ec2:DescribeSecurityGroups", // aws.go
+					"ec2:DescribeSubnets",        // aws.go
+					"ec2:DescribeVolumes",        // aws.go
+				}),
+				Resource: resource,
+			},
+			&Statement{
+				Sid:    "kopsK8sEC2MasterPermsAllResources",
+				Effect: StatementEffectAllow,
+				Action: stringorslice.Slice([]string{
+					"ec2:CreateRoute",             // aws.go
+					"ec2:CreateSecurityGroup",     // aws.go
+					"ec2:CreateTags",              // aws.go, tag.go
+					"ec2:CreateVolume",            // aws.go
+					"ec2:ModifyInstanceAttribute", // aws.go
+				}),
+				Resource: resource,
+			},
+			&Statement{
+				Sid:    "kopsK8sEC2MasterPermsTaggedResources",
+				Effect: StatementEffectAllow,
+				Action: stringorslice.Of(
+					"ec2:AttachVolume",                  // aws.go
+					"ec2:AuthorizeSecurityGroupIngress", // aws.go
+					"ec2:DeleteRoute",                   // aws.go
+					"ec2:DeleteSecurityGroup",           // aws.go
+					"ec2:DeleteVolume",                  // aws.go
+					"ec2:DetachVolume",                  // aws.go
+					"ec2:RevokeSecurityGroupIngress",    // aws.go
+				),
+				Resource: resource,
+				Condition: Condition{
+					"StringEquals": map[string]string{
+						"ec2:ResourceTag/KubernetesCluster": clusterName,
+					},
+				},
+			},
+		)
+	}
+}
+
+func addMasterELBPolicies(p *Policy, resource stringorslice.StringOrSlice, legacyIAM bool) {
+	if legacyIAM {
+		p.Statement = append(p.Statement, &Statement{
+			Sid:      "kopsK8sELBMasterPermsFullAccess",
+			Effect:   StatementEffectAllow,
+			Action:   stringorslice.Slice([]string{"elasticloadbalancing:*"}),
+			Resource: resource,
+		})
+	} else {
+		// Comments are which cloudprovider code file makes the call
+		p.Statement = append(p.Statement, &Statement{
+			Sid:    "kopsK8sELBMasterPermsRestrictive",
+			Effect: StatementEffectAllow,
+			Action: stringorslice.Of(
+				"elasticloadbalancing:AttachLoadBalancerToSubnets",             // aws_loadbalancer.go
+				"elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",       // aws_loadbalancer.go
+				"elasticloadbalancing:CreateLoadBalancer",                      // aws_loadbalancer.go
+				"elasticloadbalancing:CreateLoadBalancerPolicy",                // aws_loadbalancer.go
+				"elasticloadbalancing:CreateLoadBalancerListeners",             // aws_loadbalancer.go
+				"elasticloadbalancing:ConfigureHealthCheck",                    // aws_loadbalancer.go
+				"elasticloadbalancing:DeleteLoadBalancer",                      // aws.go
+				"elasticloadbalancing:DeleteLoadBalancerListeners",             // aws_loadbalancer.go
+				"elasticloadbalancing:DescribeLoadBalancers",                   // aws.go
+				"elasticloadbalancing:DescribeLoadBalancerAttributes",          // aws.go
+				"elasticloadbalancing:DetachLoadBalancerFromSubnets",           // aws_loadbalancer.go
+				"elasticloadbalancing:DeregisterInstancesFromLoadBalancer",     // aws_loadbalancer.go
+				"elasticloadbalancing:ModifyLoadBalancerAttributes",            // aws_loadbalancer.go
+				"elasticloadbalancing:RegisterInstancesWithLoadBalancer",       // aws_loadbalancer.go
+				"elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer", // aws_loadbalancer.go
+			),
+			Resource: resource,
+		})
+	}
+}
+
+func addMasterASPolicies(p *Policy, resource stringorslice.StringOrSlice, legacyIAM bool, clusterName string) {
+	if legacyIAM {
+		p.Statement = append(p.Statement, &Statement{
+			Sid:    "kopsK8sASMasterPerms",
+			Effect: StatementEffectAllow,
+			Action: stringorslice.Slice([]string{
+				"autoscaling:DescribeAutoScalingGroups",
+				"autoscaling:DescribeAutoScalingInstances",
+				"autoscaling:DescribeLaunchConfigurations",
+				"autoscaling:GetAsgForInstance",
+				"autoscaling:SetDesiredCapacity",
+				"autoscaling:TerminateInstanceInAutoScalingGroup",
+				"autoscaling:UpdateAutoScalingGroup",
+			}),
+			Resource: resource,
+		})
+	} else {
+		// Comments are which cloudprovider / autoscaler code file makes the call
+		// TODO: Make optional only if using autoscalers
+		p.Statement = append(p.Statement,
+			&Statement{
+				Sid:    "kopsK8sASMasterPermsAllResources",
+				Effect: StatementEffectAllow,
+				Action: stringorslice.Of(
+					"autoscaling:DescribeAutoScalingGroups",    // aws_instancegroups.go
+					"autoscaling:DescribeLaunchConfigurations", // aws.go
+					"autoscaling:GetAsgForInstance",            // aws_manager.go
+				),
+				Resource: resource,
+			},
+			&Statement{
+				Sid:    "kopsK8sASMasterPermsTaggedResources",
+				Effect: StatementEffectAllow,
+				Action: stringorslice.Of(
+					"autoscaling:SetDesiredCapacity",                  // aws_manager.go
+					"autoscaling:TerminateInstanceInAutoScalingGroup", // aws_manager.go
+					"autoscaling:UpdateAutoScalingGroup",              // aws_instancegroups.go
+				),
+				Resource: resource,
+				Condition: Condition{
+					"StringEquals": map[string]string{
+						"ec2:ResourceTag/KubernetesCluster": clusterName,
+					},
+				},
+			},
+		)
+	}
+}
+
+func addCertIAMPolicies(p *Policy, resource stringorslice.StringOrSlice) {
+	// TODO: Make optional only if using IAM SSL Certs on ELBs
+	p.Statement = append(p.Statement, &Statement{
+		Sid:    "kopsMasterCertIAMPerms",
+		Effect: StatementEffectAllow,
+		Action: stringorslice.Of(
+			"iam:ListServerCertificates",
+			"iam:GetServerCertificate",
+		),
+		Resource: resource,
+	})
+}
+
+func addRoute53ListHostedZonesPermission(p *Policy) {
+	wildcard := stringorslice.Slice([]string{"*"})
+	p.Statement = append(p.Statement, &Statement{
+		Effect:   StatementEffectAllow,
+		Action:   stringorslice.Slice([]string{"route53:ListHostedZones"}),
+		Resource: wildcard,
+	})
+}
+
+func createResource(b *PolicyBuilder) stringorslice.StringOrSlice {
+	var resource stringorslice.StringOrSlice
+	if b.ResourceARN != nil {
+		resource = stringorslice.Slice([]string{*b.ResourceARN})
+	} else {
+		resource = stringorslice.Slice([]string{"*"})
+	}
+	return resource
 }

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -18,34 +18,39 @@ package iam
 
 import (
 	"encoding/json"
+	"io/ioutil"
+	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
 
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/diff"
 	"k8s.io/kops/pkg/util/stringorslice"
-	"k8s.io/kops/util/pkg/vfs"
 )
 
 func TestRoundTrip(t *testing.T) {
 	grid := []struct {
-		IAM  *IAMStatement
+		IAM  *Statement
 		JSON string
 	}{
 		{
-			IAM: &IAMStatement{
-				Effect:   IAMStatementEffectAllow,
+			IAM: &Statement{
+				Effect:   StatementEffectAllow,
 				Action:   stringorslice.Of("ec2:DescribeRegions"),
 				Resource: stringorslice.Of("*"),
+				Sid:      "foo",
 			},
-			JSON: "{\"Effect\":\"Allow\",\"Action\":\"ec2:DescribeRegions\",\"Resource\":\"*\"}",
+			JSON: "{\"Sid\":\"foo\",\"Effect\":\"Allow\",\"Action\":\"ec2:DescribeRegions\",\"Resource\":\"*\"}",
 		},
 		{
-			IAM: &IAMStatement{
-				Effect:   IAMStatementEffectDeny,
+			IAM: &Statement{
+				Effect:   StatementEffectDeny,
 				Action:   stringorslice.Of("ec2:DescribeRegions", "ec2:DescribeInstances"),
 				Resource: stringorslice.Of("a", "b"),
+				Sid:      "foo",
 			},
-			JSON: "{\"Effect\":\"Deny\",\"Action\":[\"ec2:DescribeRegions\",\"ec2:DescribeInstances\"],\"Resource\":[\"a\",\"b\"]}",
+			JSON: "{\"Sid\":\"foo\",\"Effect\":\"Deny\",\"Action\":[\"ec2:DescribeRegions\",\"ec2:DescribeInstances\"],\"Resource\":[\"a\",\"b\"]}",
 		},
 	}
 	for _, g := range grid {
@@ -58,7 +63,7 @@ func TestRoundTrip(t *testing.T) {
 			t.Errorf("Unexpected JSON encoding.  Actual=%q, Expected=%q", string(actualJSON), g.JSON)
 		}
 
-		parsed := &IAMStatement{}
+		parsed := &Statement{}
 		err = json.Unmarshal([]byte(g.JSON), parsed)
 		if err != nil {
 			t.Errorf("error decoding IAM %s to json: %v", g.JSON, err)
@@ -71,271 +76,103 @@ func TestRoundTrip(t *testing.T) {
 	}
 }
 
-func TestS3PolicyGeneration(t *testing.T) {
-	defaultS3Statements := []*IAMStatement{
-		{
-			Effect: IAMStatementEffectAllow,
-			Action: stringorslice.Of(
-				"s3:GetBucketLocation",
-				"s3:ListBucket",
-			),
-			Resource: stringorslice.Slice([]string{
-				"arn:aws:s3:::bucket-name",
-			}),
-		},
-		{
-			Effect: IAMStatementEffectAllow,
-			Action: stringorslice.Slice([]string{
-				"s3:List*",
-			}),
-			Resource: stringorslice.Slice([]string{
-				"arn:aws:s3:::bucket-name/cluster-name.k8s.local",
-				"arn:aws:s3:::bucket-name/cluster-name.k8s.local/*",
-			}),
-		},
-	}
-
+func TestPolicyGeneration(t *testing.T) {
 	grid := []struct {
 		Role      kops.InstanceGroupRole
 		LegacyIAM bool
-		IAMPolicy IAMPolicy
+		Policy    string
 	}{
 		{
 			Role:      "Master",
-			LegacyIAM: false,
-			IAMPolicy: IAMPolicy{
-				Statement: append(defaultS3Statements, &IAMStatement{
-					Effect: IAMStatementEffectAllow,
-					Action: stringorslice.Slice([]string{
-						"s3:Get*",
-					}),
-					Resource: stringorslice.Of(
-						"arn:aws:s3:::bucket-name/cluster-name.k8s.local/*",
-					),
-				}),
-			},
+			LegacyIAM: true,
+			Policy:    "tests/iam_builder_master_legacy.json",
 		},
 		{
 			Role:      "Master",
-			LegacyIAM: true,
-			IAMPolicy: IAMPolicy{
-				Statement: append(defaultS3Statements, &IAMStatement{
-					Effect: IAMStatementEffectAllow,
-					Action: stringorslice.Slice([]string{
-						"s3:*",
-					}),
-					Resource: stringorslice.Of(
-						"arn:aws:s3:::bucket-name/cluster-name.k8s.local/*",
-					),
-				}),
-			},
-		},
-		{
-			Role:      "Node",
 			LegacyIAM: false,
-			IAMPolicy: IAMPolicy{
-				Statement: append(defaultS3Statements, &IAMStatement{
-					Effect: IAMStatementEffectAllow,
-					Action: stringorslice.Slice([]string{
-						"s3:Get*",
-					}),
-					Resource: stringorslice.Slice([]string{
-						"arn:aws:s3:::bucket-name/cluster-name.k8s.local/addons/*",
-						"arn:aws:s3:::bucket-name/cluster-name.k8s.local/cluster.spec",
-						"arn:aws:s3:::bucket-name/cluster-name.k8s.local/config",
-						"arn:aws:s3:::bucket-name/cluster-name.k8s.local/instancegroup/*",
-						"arn:aws:s3:::bucket-name/cluster-name.k8s.local/pki/issued/*",
-						"arn:aws:s3:::bucket-name/cluster-name.k8s.local/pki/private/kube-proxy/*",
-						"arn:aws:s3:::bucket-name/cluster-name.k8s.local/pki/private/kubelet/*",
-						"arn:aws:s3:::bucket-name/cluster-name.k8s.local/pki/ssh/*",
-						"arn:aws:s3:::bucket-name/cluster-name.k8s.local/secrets/dockerconfig",
-					}),
-				}),
-			},
+			Policy:    "tests/iam_builder_master_strict.json",
 		},
 		{
 			Role:      "Node",
 			LegacyIAM: true,
-			IAMPolicy: IAMPolicy{
-				Statement: append(defaultS3Statements, &IAMStatement{
-					Effect: IAMStatementEffectAllow,
-					Action: stringorslice.Slice([]string{
-						"s3:*",
-					}),
-					Resource: stringorslice.Of(
-						"arn:aws:s3:::bucket-name/cluster-name.k8s.local/*",
-					),
-				}),
-			},
+			Policy:    "tests/iam_builder_node_legacy.json",
 		},
 		{
-			Role:      "Bastion",
+			Role:      "Node",
 			LegacyIAM: false,
-			IAMPolicy: IAMPolicy{
-				Statement: defaultS3Statements,
-			},
+			Policy:    "tests/iam_builder_node_strict.json",
 		},
 		{
 			Role:      "Bastion",
 			LegacyIAM: true,
-			IAMPolicy: IAMPolicy{
-				Statement: defaultS3Statements,
-			},
+			Policy:    "tests/iam_builder_bastion.json",
+		},
+		{
+			Role:      "Bastion",
+			LegacyIAM: false,
+			Policy:    "tests/iam_builder_bastion.json",
 		},
 	}
 
 	for i, x := range grid {
-		ip := &IAMPolicy{}
-
-		vfsPath, err := vfs.Context.BuildVfsPath("s3://bucket-name/cluster-name.k8s.local")
-		if err != nil {
-			t.Errorf("case %d failed to build Vfs Path. error: %s", i, err)
-			continue
-		}
-		s3Path, ok := vfsPath.(*vfs.S3Path)
-		if !ok {
-			t.Errorf("case %d failed to build S3 Path.", i)
-			continue
-		}
-
-		addS3Permissions(ip, "arn:aws", s3Path, x.Role, x.LegacyIAM)
-
-		expectedPolicy, err := x.IAMPolicy.AsJSON()
-		if err != nil {
-			t.Errorf("case %d failed to convert expected IAM Policy to JSON. Error: %q", i, err)
-			continue
-		}
-		actualPolicy, err := ip.AsJSON()
-		if err != nil {
-			t.Errorf("case %d failed to convert generated IAM Policy to JSON. Error: %q", i, err)
-			continue
-		}
-
-		if expectedPolicy != actualPolicy {
-			diffString := diff.FormatDiff(expectedPolicy, actualPolicy)
-			t.Logf("diff:\n%s\n", diffString)
-			t.Errorf("case %d failed, policy output differed from expected.", i)
-			continue
-		}
-	}
-}
-
-func TestEC2PolicyGeneration(t *testing.T) {
-	wildcard := stringorslice.Slice([]string{"*"})
-	clusterName := "my-cluster.k8s.local"
-	defaultEC2Statements := []*IAMStatement{
-		{
-			Effect:   IAMStatementEffectAllow,
-			Action:   stringorslice.Slice([]string{"ec2:Describe*"}),
-			Resource: wildcard,
-		},
-	}
-
-	grid := []struct {
-		Role      kops.InstanceGroupRole
-		LegacyIAM bool
-		IAMPolicy IAMPolicy
-	}{
-		{
-			Role:      "Node",
-			LegacyIAM: false,
-			IAMPolicy: IAMPolicy{
-				Statement: defaultEC2Statements,
-			},
-		},
-		{
-			Role:      "Node",
-			LegacyIAM: true,
-			IAMPolicy: IAMPolicy{
-				Statement: defaultEC2Statements,
-			},
-		},
-		{
-			Role:      "Master",
-			LegacyIAM: false,
-			IAMPolicy: IAMPolicy{
-				Statement: append(
-					defaultEC2Statements,
-					&IAMStatement{
-						Effect: IAMStatementEffectAllow,
-						Action: stringorslice.Slice([]string{
-							"ec2:CreateRoute",
-							"ec2:CreateSecurityGroup",
-							"ec2:CreateTags",
-							"ec2:CreateVolume",
-							"ec2:DeleteVolume",
-							"ec2:ModifyInstanceAttribute",
-						}),
-						Resource: wildcard,
+		b := &PolicyBuilder{
+			Cluster: &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					ConfigStore: "s3://kops-tests/iam-builder-test.k8s.local",
+					IAM: &kops.IAMSpec{
+						Legacy: x.LegacyIAM,
 					},
-					&IAMStatement{
-						Effect:   IAMStatementEffectAllow,
-						Action:   stringorslice.Slice([]string{"ec2:*"}),
-						Resource: wildcard,
-						Condition: Condition{
-							"StringEquals": map[string]string{
-								"ec2:ResourceTag/KubernetesCluster": clusterName,
+					EtcdClusters: []*kops.EtcdClusterSpec{
+						{
+							Members: []*kops.EtcdMemberSpec{
+								{
+									KmsKeyId: aws.String("key-id-1"),
+								},
+								{
+									KmsKeyId: aws.String("key-id-2"),
+								},
+							},
+						},
+						{
+							Members: []*kops.EtcdMemberSpec{},
+						},
+						{
+							Members: []*kops.EtcdMemberSpec{
+								{
+									KmsKeyId: aws.String("key-id-3"),
+								},
 							},
 						},
 					},
-				),
+				},
 			},
-		},
-		{
-			Role:      "Master",
-			LegacyIAM: true,
-			IAMPolicy: IAMPolicy{
-				Statement: append(
-					defaultEC2Statements,
-					&IAMStatement{
-						Effect:   IAMStatementEffectAllow,
-						Action:   stringorslice.Slice([]string{"ec2:*"}),
-						Resource: wildcard,
-					},
-				),
-			},
-		},
-		{
-			Role:      "Bastion",
-			LegacyIAM: false,
-			IAMPolicy: IAMPolicy{
-				Statement: nil,
-			},
-		},
-		{
-			Role:      "Bastion",
-			LegacyIAM: true,
-			IAMPolicy: IAMPolicy{
-				Statement: nil,
-			},
-		},
-	}
-
-	for i, x := range grid {
-		ip := &IAMPolicy{}
-		b := IAMPolicyBuilder{
-			Role:    x.Role,
-			Cluster: &kops.Cluster{},
+			Role: x.Role,
 		}
-		b.Cluster.SetName(clusterName)
+		b.Cluster.SetName("iam-builder-test.k8s.local")
 
-		addEC2Permissions(ip, "arn:aws", &b, wildcard, x.LegacyIAM)
-
-		expectedPolicy, err := x.IAMPolicy.AsJSON()
+		p, err := b.BuildAWSPolicy()
 		if err != nil {
-			t.Errorf("case %d failed to convert expected IAM Policy to JSON. Error: %q", i, err)
+			t.Errorf("case %d failed to build an AWS IAM policy. Error: %v", i, err)
 			continue
 		}
-		actualPolicy, err := ip.AsJSON()
+
+		actualPolicy, err := p.AsJSON()
 		if err != nil {
-			t.Errorf("case %d failed to convert generated IAM Policy to JSON. Error: %q", i, err)
+			t.Errorf("case %d failed to convert generated IAM Policy to JSON. Error: %v", i, err)
 			continue
 		}
+		actualPolicy = strings.TrimSpace(actualPolicy)
+
+		expectedPolicyBytes, err := ioutil.ReadFile(x.Policy)
+		if err != nil {
+			t.Fatalf("unexpected error reading IAM Policy from file %q: %v", x.Policy, err)
+		}
+		expectedPolicy := strings.TrimSpace(string(expectedPolicyBytes))
 
 		if expectedPolicy != actualPolicy {
 			diffString := diff.FormatDiff(expectedPolicy, actualPolicy)
 			t.Logf("diff:\n%s\n", diffString)
-			t.Errorf("case %d failed, policy output differed from expected.", i)
+			t.Errorf("case %d failed, policy output differed from expected (%s).", i, x.Policy)
 			continue
 		}
 	}

--- a/pkg/model/iam/tests/iam_builder_bastion.json
+++ b/pkg/model/iam/tests/iam_builder_bastion.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "kopsK8sBastion",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeRegions"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}

--- a/pkg/model/iam/tests/iam_builder_master_legacy.json
+++ b/pkg/model/iam/tests/iam_builder_master_legacy.json
@@ -1,0 +1,127 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "kopsK8sEC2MasterPermsFullAccess",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:*"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "kopsK8sASMasterPerms",
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeAutoScalingInstances",
+        "autoscaling:DescribeLaunchConfigurations",
+        "autoscaling:GetAsgForInstance",
+        "autoscaling:SetDesiredCapacity",
+        "autoscaling:TerminateInstanceInAutoScalingGroup",
+        "autoscaling:UpdateAutoScalingGroup"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "kopsK8sELBMasterPermsFullAccess",
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:*"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "kopsMasterCertIAMPerms",
+      "Effect": "Allow",
+      "Action": [
+        "iam:ListServerCertificates",
+        "iam:GetServerCertificate"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "kopsK8sS3GetListBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::kops-tests"
+      ]
+    },
+    {
+      "Sid": "kopsK8sS3BucketFullAccess",
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
+    },
+    {
+      "Sid": "kopsK8sKMSEncryptedVolumesLegacyPerms",
+      "Effect": "Allow",
+      "Action": [
+        "kms:ListGrants",
+        "kms:RevokeGrant"
+      ],
+      "Resource": [
+        "key-id-1",
+        "key-id-2",
+        "key-id-3"
+      ]
+    },
+    {
+      "Sid": "kopsK8sKMSEncryptedVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "kms:CreateGrant",
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Resource": [
+        "key-id-1",
+        "key-id-2",
+        "key-id-3"
+      ]
+    },
+    {
+      "Sid": "kopsK8sECR",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:GetRepositoryPolicy",
+        "ecr:DescribeRepositories",
+        "ecr:ListImages",
+        "ecr:BatchGetImage"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "route53:ListHostedZones"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}

--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -1,0 +1,154 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "kopsK8sEC2MasterPermsDescribeResources",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVolumes"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "kopsK8sEC2MasterPermsAllResources",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateRoute",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateTags",
+        "ec2:CreateVolume",
+        "ec2:ModifyInstanceAttribute"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "kopsK8sEC2MasterPermsTaggedResources",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AttachVolume",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:DeleteRoute",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DeleteVolume",
+        "ec2:DetachVolume",
+        "ec2:RevokeSecurityGroupIngress"
+      ],
+      "Resource": [
+        "*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/KubernetesCluster": "iam-builder-test.k8s.local"
+        }
+      }
+    },
+    {
+      "Sid": "kopsK8sASMasterPermsAllResources",
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeLaunchConfigurations",
+        "autoscaling:GetAsgForInstance"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "kopsK8sASMasterPermsTaggedResources",
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:SetDesiredCapacity",
+        "autoscaling:TerminateInstanceInAutoScalingGroup",
+        "autoscaling:UpdateAutoScalingGroup"
+      ],
+      "Resource": [
+        "*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/KubernetesCluster": "iam-builder-test.k8s.local"
+        }
+      }
+    },
+    {
+      "Sid": "kopsK8sELBMasterPermsRestrictive",
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:AttachLoadBalancerToSubnets",
+        "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateLoadBalancerPolicy",
+        "elasticloadbalancing:CreateLoadBalancerListeners",
+        "elasticloadbalancing:ConfigureHealthCheck",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:DeleteLoadBalancerListeners",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DetachLoadBalancerFromSubnets",
+        "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+        "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "kopsMasterCertIAMPerms",
+      "Effect": "Allow",
+      "Action": [
+        "iam:ListServerCertificates",
+        "iam:GetServerCertificate"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "kopsK8sS3GetListBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::kops-tests"
+      ]
+    },
+    {
+      "Sid": "kopsK8sS3MasterBucketFullGet",
+      "Effect": "Allow",
+      "Action": [
+        "s3:Get*"
+      ],
+      "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
+    },
+    {
+      "Sid": "kopsK8sKMSEncryptedVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "kms:CreateGrant",
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Resource": [
+        "key-id-1",
+        "key-id-2",
+        "key-id-3"
+      ]
+    }
+  ]
+}

--- a/pkg/model/iam/tests/iam_builder_node_legacy.json
+++ b/pkg/model/iam/tests/iam_builder_node_legacy.json
@@ -1,0 +1,60 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "kopsK8sEC2NodePerms",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "kopsK8sS3GetListBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::kops-tests"
+      ]
+    },
+    {
+      "Sid": "kopsK8sS3BucketFullAccess",
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
+    },
+    {
+      "Sid": "kopsK8sECR",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:GetRepositoryPolicy",
+        "ecr:DescribeRepositories",
+        "ecr:ListImages",
+        "ecr:BatchGetImage"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "route53:ListHostedZones"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}

--- a/pkg/model/iam/tests/iam_builder_node_strict.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict.json
@@ -1,0 +1,44 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "kopsK8sEC2NodePerms",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "kopsK8sS3GetListBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::kops-tests"
+      ]
+    },
+    {
+      "Sid": "kopsK8sS3NodeBucketSelectiveGet",
+      "Effect": "Allow",
+      "Action": [
+        "s3:Get*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/addons/*",
+        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/cluster.spec",
+        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/config",
+        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/instancegroup/*",
+        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/issued/*",
+        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kube-proxy/*",
+        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kubelet/*",
+        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/ssh/*",
+        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/secrets/dockerconfig"
+      ]
+    }
+  ]
+}

--- a/tests/integration/minimal/cloudformation.json
+++ b/tests/integration/minimal/cloudformation.json
@@ -536,21 +536,50 @@
           "Statement": [
             {
               "Action": [
-                "ec2:Describe*"
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                "*"
-              ]
-            },
-            {
-              "Action": [
                 "ec2:*"
               ],
               "Effect": "Allow",
               "Resource": [
                 "*"
-              ]
+              ],
+              "Sid": "kopsK8sEC2MasterPermsFullAccess"
+            },
+            {
+              "Action": [
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeLaunchConfigurations",
+                "autoscaling:GetAsgForInstance",
+                "autoscaling:SetDesiredCapacity",
+                "autoscaling:TerminateInstanceInAutoScalingGroup",
+                "autoscaling:UpdateAutoScalingGroup"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ],
+              "Sid": "kopsK8sASMasterPerms"
+            },
+            {
+              "Action": [
+                "elasticloadbalancing:*"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ],
+              "Sid": "kopsK8sELBMasterPermsFullAccess"
+            },
+            {
+              "Action": [
+                "iam:ListServerCertificates",
+                "iam:GetServerCertificate"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ],
+              "Sid": "kopsMasterCertIAMPerms"
             },
             {
               "Action": [
@@ -565,29 +594,8 @@
               "Effect": "Allow",
               "Resource": [
                 "*"
-              ]
-            },
-            {
-              "Action": [
-                "elasticloadbalancing:*"
               ],
-              "Effect": "Allow",
-              "Resource": [
-                "*"
-              ]
-            },
-            {
-              "Action": [
-                "autoscaling:DescribeAutoScalingGroups",
-                "autoscaling:DescribeAutoScalingInstances",
-                "autoscaling:DescribeLaunchConfigurations",
-                "autoscaling:SetDesiredCapacity",
-                "autoscaling:TerminateInstanceInAutoScalingGroup"
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                "*"
-              ]
+              "Sid": "kopsK8sECR"
             },
             {
               "Action": [
@@ -598,7 +606,8 @@
               "Effect": "Allow",
               "Resource": [
                 "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
-              ]
+              ],
+              "Sid": "kopsK8sRoute53Change"
             },
             {
               "Action": [
@@ -607,7 +616,8 @@
               "Effect": "Allow",
               "Resource": [
                 "arn:aws:route53:::change/*"
-              ]
+              ],
+              "Sid": "kopsK8sRoute53GetChanges"
             },
             {
               "Action": [
@@ -616,7 +626,18 @@
               "Effect": "Allow",
               "Resource": [
                 "*"
-              ]
+              ],
+              "Sid": "kopsK8sRoute53ListZones"
+            },
+            {
+              "Action": [
+                "route53:ListHostedZones"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ],
+              "Sid": ""
             }
           ],
           "Version": "2012-10-17"
@@ -636,12 +657,13 @@
           "Statement": [
             {
               "Action": [
-                "ec2:Describe*"
+                "ec2:DescribeInstances"
               ],
               "Effect": "Allow",
               "Resource": [
                 "*"
-              ]
+              ],
+              "Sid": "kopsK8sEC2NodePerms"
             },
             {
               "Action": [
@@ -656,7 +678,8 @@
               "Effect": "Allow",
               "Resource": [
                 "*"
-              ]
+              ],
+              "Sid": "kopsK8sECR"
             },
             {
               "Action": [
@@ -667,7 +690,8 @@
               "Effect": "Allow",
               "Resource": [
                 "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
-              ]
+              ],
+              "Sid": "kopsK8sRoute53Change"
             },
             {
               "Action": [
@@ -676,7 +700,8 @@
               "Effect": "Allow",
               "Resource": [
                 "arn:aws:route53:::change/*"
-              ]
+              ],
+              "Sid": "kopsK8sRoute53GetChanges"
             },
             {
               "Action": [
@@ -685,7 +710,18 @@
               "Effect": "Allow",
               "Resource": [
                 "*"
-              ]
+              ],
+              "Sid": "kopsK8sRoute53ListZones"
+            },
+            {
+              "Action": [
+                "route53:ListHostedZones"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ],
+              "Sid": ""
             }
           ],
           "Version": "2012-10-17"


### PR DESCRIPTION
Based off of the work done by @chrislovecnm in PR #2497.

This PR tightens down the IAM policies created for Master & Node instance groups. The Cluster Spec `IAMSpec.Legacy` flag is used to control application of stricter policy rules, which is defaulted to true for existing clusters (to limit potential regression impact), and false for new cluster creation.