### PR TITLE
Prevent Docker build environments from creating root-owned artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ UNIQUE:=$(shell date +%s)
 GOVERSION=1.8.3
 BINDATA_TARGETS=upup/models/bindata.go federation/model/bindata.go
 BUILD=${GOPATH_1ST}/src/k8s.io/kops/.build
+UID:=$(shell id -u)
+GID:=$(shell id -g)
 
 # See http://stackoverflow.com/questions/18136918/how-to-get-current-relative-directory-of-your-makefile
 MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))
@@ -312,7 +314,7 @@ protokube-builder-image:
 
 .PHONY: protokube-build-in-docker
 protokube-build-in-docker: protokube-builder-image
-	docker run -t -e VERSION=${VERSION} -v `pwd`:/src protokube-builder /onbuild.sh
+	docker run -t -e VERSION=${VERSION} -e HOST_UID=${UID} -e HOST_GID=${GID} -v `pwd`:/src protokube-builder /onbuild.sh
 
 .PHONY: protokube-image
 protokube-image: protokube-build-in-docker
@@ -357,7 +359,7 @@ dns-controller-builder-image:
 
 .PHONY: dns-controller-build-in-docker
 dns-controller-build-in-docker: dns-controller-builder-image
-	docker run -t -v `pwd`:/src dns-controller-builder /onbuild.sh
+	docker run -t -e HOST_UID=${UID} -e HOST_GID=${GID} -v `pwd`:/src dns-controller-builder /onbuild.sh
 
 .PHONY: dns-controller-image
 dns-controller-image: dns-controller-build-in-docker

--- a/images/dns-controller-builder/onbuild.sh
+++ b/images/dns-controller-builder/onbuild.sh
@@ -26,3 +26,5 @@ make dns-controller-gocode
 
 mkdir -p /src/.build/artifacts/
 cp /go/bin/dns-controller /src/.build/artifacts/
+
+chown -R $HOST_UID:$HOST_GID /src/.build/artifacts

--- a/images/protokube-builder/onbuild.sh
+++ b/images/protokube-builder/onbuild.sh
@@ -36,3 +36,5 @@ cp /go/bin/channels /src/.build/artifacts/
 cd /src/.build/artifacts/
 curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.6.6/bin/linux/amd64/kubectl
 chmod +x kubectl
+
+chown -R $HOST_UID:$HOST_GID /src/.build/artifacts


### PR DESCRIPTION
The binaries in `.build/artifacts` are built in Docker containers and are owned by the root user.

I've created HOST_UID and HOST_GID variables in the Makefile that are passed in to the Docker build containers so that artifacts can be chowned to the proper user and group IDs.

Previously, it was impossible to `make clean` or `rm -rf .build` without root privileges.