### PR TITLE
Allow cluster autoscaler addon to read statefulsets

### DIFF
--- a/addons/cluster-autoscaler/v1.6.0.yaml
+++ b/addons/cluster-autoscaler/v1.6.0.yaml
@@ -66,6 +66,13 @@ rules:
   verbs:
   - watch
   - list
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - watch
+  - list
 
 ---
 


### PR DESCRIPTION
Cluster autoscaler addon was unable to list/watch statefulsets when RBAC is enabled because it wasn't granted permission. fixes #3363