### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ BINDATA_TARGETS=upup/models/bindata.go federation/model/bindata.go
 ARTIFACTS=$(BUILD)/artifacts
 DIST=$(BUILD)/dist
 GOBINDATA=$(LOCAL)/go-bindata
+NODEUP=$(LOCAL)/nodeup
 UID:=$(shell id -u)
 GID:=$(shell id -g)
 TESTABLE_PACKAGES:=$(shell go list ./... | egrep -v "k8s.io/kops/cloudmock|k8s.io/kops/vendor")
@@ -127,6 +128,7 @@ clean: # Remove build directory and bindata-generated files
 .PHONY: install
 install: ${KOPS}
 	cp ${KOPS} ${GOPATH_1ST}/bin
+	cp ${NODEUP} ${GOPATH_1ST}/bin
 
 .PHONY: kops
 kops: ${KOPS}
@@ -357,9 +359,11 @@ protokube-push: protokube-image
 .PHONY: nodeup
 nodeup: nodeup-dist
 
+${NODEUP}: ${BINDATA_TARGETS}
+	go build ${EXTRA_BUILDFLAGS} -ldflags "${EXTRA_LDFLAGS} -X k8s.io/kops.Version=${VERSION} -X k8s.io/kops.GitVersion=${GITSHA}" -o $@ k8s.io/kops/cmd/nodeup
+
 .PHONY: nodeup-gocode
-nodeup-gocode: kops-gobindata
-	go install ${EXTRA_BUILDFLAGS} -ldflags "${EXTRA_LDFLAGS} -X k8s.io/kops.Version=${VERSION} -X k8s.io/kops.GitVersion=${GITSHA}" k8s.io/kops/cmd/nodeup
+nodeup-gocode: ${NODEUP}
 
 .PHONY: nodeup-dist
 nodeup-dist:

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ hooks: # Install Git hooks
 
 .PHONY: test
 test: ${BINDATA_TARGETS}  # Run tests locally
-	go test ${TESTABLE_PACKAGES} -v -logtostderr
+	for t in ${TESTABLE_PACKAGES}; do go test -v  $$t 2>&1; done 
 
 ${DIST}/linux/amd64/nodeup: ${BINDATA_TARGETS}
 	mkdir -p ${DIST}

--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,7 @@ nodeup-dist:
 	mkdir -p ${DIST}
 	docker pull golang:${GOVERSION} # Keep golang image up to date
 	docker run --name=nodeup-build-${UNIQUE} -e STATIC_BUILD=yes -e VERSION=${VERSION} -v ${MAKEDIR}:/go/src/k8s.io/kops golang:${GOVERSION} make -f /go/src/k8s.io/kops/Makefile nodeup-gocode
-	docker cp nodeup-build-${UNIQUE}:/go/bin/nodeup .build/dist/
+	docker cp nodeup-build-${UNIQUE}:/go/src/k8s.io/kops/.build/local/nodeup .build/dist/
 	(${SHASUMCMD} .build/dist/nodeup | cut -d' ' -f1) > .build/dist/nodeup.sha1
 
 .PHONY: dns-controller-gocode

--- a/Makefile
+++ b/Makefile
@@ -212,9 +212,9 @@ crossbuild: ${DIST}/darwin/amd64/kops ${DIST}/linux/amd64/kops
 .PHONY: crossbuild-in-docker
 crossbuild-in-docker:
 	docker pull golang:${GOVERSION} # Keep golang image up to date
-	docker run -it --name=kops-build-${UNIQUE} -e STATIC_BUILD=yes -e VERSION=${VERSION} -v ${MAKEDIR}:/go/src/k8s.io/kops golang:${GOVERSION} make -f /go/src/k8s.io/kops/Makefile crossbuild
+	docker run --name=kops-build-${UNIQUE} -e STATIC_BUILD=yes -e VERSION=${VERSION} -v ${MAKEDIR}:/go/src/k8s.io/kops golang:${GOVERSION} make -f /go/src/k8s.io/kops/Makefile crossbuild
 	docker start kops-build-${UNIQUE}
-	docker exec -it kops-build-${UNIQUE} chown -R ${UID}:${GID} /go/src/k8s.io/kops/.build
+	docker exec kops-build-${UNIQUE} chown -R ${UID}:${GID} /go/src/k8s.io/kops/.build
 	docker cp kops-build-${UNIQUE}:/go/src/k8s.io/kops/.build .
 	docker kill kops-build-${UNIQUE}
 	docker rm kops-build-${UNIQUE}


### PR DESCRIPTION
Makefile separate install directive from kops

Makefile TESTABLE_PACKAGES variable to opt-out of testing

Makefile .build/local to keep development kops and go-bindata out of PATH

Makefile fewer PHONY targets that actually generate artifacts

Makefile prevent root-owned artifacts