### PR TITLE
small docs improvement

### DIFF
--- a/docs/ns.md
+++ b/docs/ns.md
@@ -3,7 +3,7 @@
  - Note your hosted zone ID
 
 ```bash
-aws route53 list-hosted-zones | jq '.HostedZones[] | select(.Name=="subdomain.example.com.") | .Id'
+HZC=$(aws route53 list-hosted-zones | jq -r '.HostedZones[] | select(.Name=="subdomain.example.com.") | .Id' | tee /dev/stderr)
 
 ```
 


### PR DESCRIPTION
Make cmd1 populate the var for cmd2

Using `tee /dev/stderr` allows the user to still get output if they copy-pasta the first command. The other changes prepare the HZC variable so it can be used if they copy-pasta the second command.