### PR TITLE
Add external-dns as addon.

### DIFF
--- a/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/README.md
+++ b/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/README.md
@@ -1,0 +1,26 @@
+# ExternalDNS
+
+ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
+
+## What it does
+
+Inspired by [Kubernetes DNS](https://github.com/kubernetes/dns), Kubernetes' cluster-internal DNS server, ExternalDNS makes Kubernetes resources discoverable via public DNS servers. Like KubeDNS, it retrieves a list of resources (Services, Ingresses, etc.) from the [Kubernetes API](https://kubernetes.io/docs/api/) to determine a desired list of DNS records. *Unlike* KubeDNS, however, it's not a DNS server itself, but merely configures other DNS providers accordingly—e.g. [AWS Route 53](https://aws.amazon.com/route53/) or [Google CloudDNS](https://cloud.google.com/dns/docs/).
+
+In a broader sense, ExternalDNS allows you to control DNS records dynamically via Kubernetes resources in a DNS provider-agnostic way.
+
+## Deploying to a Cluster
+
+The following tutorials are provided:
+
+* [AWS](https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/aws.md)
+* [Azure](https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/azure.md)
+* [Cloudflare](https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/cloudflare.md)
+* [DigitalOcean](https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/digitalocean.md)
+* Google Container Engine
+	* [Using Google's Default Ingress Controller](https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/gke.md)
+	* [Using the Nginx Ingress Controller](https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/nginx-ingress.md)
+* [FAQ](https://github.com/kubernetes-incubator/external-dns/blob/master/docs/faq.md)
+
+## Github repository
+
+Source code is managed under kubernetes-incubator at [external-dns](https://github.com/kubernetes-incubator/external-dns).

--- a/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-addon: external-dns.addons.k8s.io
     k8s-app: external-dns
-    version: v0.3.0
+    version: v0.4.4
 spec:
   replicas: 1
   selector:
@@ -17,7 +17,7 @@ spec:
       labels:
         k8s-addon: external-dns.addons.k8s.io
         k8s-app: external-dns
-        version: v0.3.0
+        version: v0.4.4
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         # For 1.6, we keep the old tolerations in case of a downgrade to 1.5
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.3.0
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.4
         args:
 {{ range $arg := ExternalDnsArgv }}
         - "{{ $arg }}"

--- a/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-addon: external-dns.addons.k8s.io
     k8s-app: external-dns
-    version: v0.3.0
+    version: v0.4.4
 spec:
   replicas: 1
   selector:
@@ -17,7 +17,7 @@ spec:
       labels:
         k8s-addon: external-dns.addons.k8s.io
         k8s-app: external-dns
-        version: v0.3.0
+        version: v0.4.4
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key": "dedicated", "value": "master"}]'
@@ -28,7 +28,7 @@ spec:
       hostNetwork: true
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.3.0
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.4
         args:
 {{ range $arg := ExternalDnsArgv }}
         - "{{ $arg }}"

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -202,7 +202,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 	if featureflag.EnableExternalDNS.Enabled() {
 		{
 			key := "external-dns.addons.k8s.io"
-			version := "0.3.0"
+			version := "0.4.4"
 
 			{
 				location := key + "/pre-k8s-1.6.yaml"


### PR DESCRIPTION
This superseeds route53mapper as it has multicloud support documentation and YAML taken from https://github.com/kubernetes-incubator/external-dns 