### PR TITLE
GCS: Don't reuse same error message

### DIFF
--- a/util/pkg/vfs/gsfs.go
+++ b/util/pkg/vfs/gsfs.go
@@ -213,7 +213,7 @@ func (p *GSPath) ReadTree() ([]Path, error) {
 		if isGCSNotFound(err) {
 			return nil, os.ErrNotExist
 		}
-		return nil, fmt.Errorf("error listing %s: %v", p, err)
+		return nil, fmt.Errorf("error listing tree %s: %v", p, err)
 	}
 	return paths, nil
 }


### PR DESCRIPTION
We had exactly the same error message for two code paths, which made
figuring out the cause harder.