### PR TITLE
GCE: move file assets to writeable location

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"k8s.io/kops/nodeup/pkg/distros"
 	"k8s.io/kops/pkg/apis/kops"
@@ -69,6 +70,11 @@ func (c *NodeupModelContext) PathSrvKubernetes() string {
 	default:
 		return "/srv/kubernetes"
 	}
+}
+
+// FileAssetsDefaultPath is the default location for assets which have no path
+func (c *NodeupModelContext) FileAssetsDefaultPath() string {
+	return filepath.Join(c.PathSrvKubernetes(), "assets")
 }
 
 // PathSrvSshproxy returns the path for the SSL proxy

--- a/nodeup/pkg/model/file_assets.go
+++ b/nodeup/pkg/model/file_assets.go
@@ -28,11 +28,6 @@ import (
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 )
 
-const (
-	// FileAssetsDefaultPath is the default location for assets which have no path
-	FileAssetsDefaultPath string = "/srv/kubernetes/assets"
-)
-
 // FileAssetsBuilder configures the hooks
 type FileAssetsBuilder struct {
 	*NodeupModelContext
@@ -46,7 +41,7 @@ func (f *FileAssetsBuilder) Build(c *fi.ModelBuilderContext) error {
 	tracker := make(map[string]bool, 0)
 	// ensure the default path exists
 	c.AddTask(&nodetasks.File{
-		Path: FileAssetsDefaultPath,
+		Path: f.FileAssetsDefaultPath(),
 		Type: nodetasks.FileType_Directory,
 		Mode: s("0755"),
 	})
@@ -75,7 +70,7 @@ func (f *FileAssetsBuilder) buildFileAssets(c *fi.ModelBuilderContext, assets []
 		// @check if e have a path and if not use the default path
 		assetPath := asset.Path
 		if assetPath == "" {
-			assetPath = fmt.Sprintf("%s/%s", FileAssetsDefaultPath, asset.Name)
+			assetPath = filepath.Join(f.FileAssetsDefaultPath(), asset.Name)
 		}
 		// @check if the file has already been done and skip
 		if _, found := tracker[assetPath]; found {


### PR DESCRIPTION
On container OS, the /srv/kubernetes location is not writeable, so we
use /etc/srv/kubernetes instead.