### PR TITLE
Makefile: use hack/.packages instead of go list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ GOBINDATA=$(LOCAL)/go-bindata
 NODEUP=$(LOCAL)/nodeup
 UID:=$(shell id -u)
 GID:=$(shell id -g)
-TESTABLE_PACKAGES:=$(shell go list ./... | egrep -v "k8s.io/kops/cloudmock|k8s.io/kops/vendor")
+TESTABLE_PACKAGES:=$(cat hack/.packages | egrep -v "k8s.io/kops/cloudmock|k8s.io/kops/vendor")
 
 # See http://stackoverflow.com/questions/18136918/how-to-get-current-relative-directory-of-your-makefile
 MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))


### PR DESCRIPTION
go list is slow, so we memoize the list of packages in hack/.packages.