### PR TITLE
GCE: Prevent instancetemplate spurious mismatches

### DIFF
--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -227,6 +227,7 @@ func (e *InstanceTemplate) mapToGCE(project string) (*compute.InstanceTemplate, 
 
 	var networkInterfaces []*compute.NetworkInterface
 	ni := &compute.NetworkInterface{
+		Kind: "compute#networkInterface",
 		AccessConfigs: []*compute.AccessConfig{{
 			Kind: "compute#accessConfig",
 			//NatIP: *e.IPAddress.Address,


### PR DESCRIPTION
The lack of a Kind on the networkInterface was causing the
InstanceTemplate to be considered dirty.