### PR TITLE
Makefile protokube target creates binary under ~/.build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ IMAGES=$(DIST)/images
 GOBINDATA=$(LOCAL)/go-bindata
 CHANNELS=$(LOCAL)/channels
 NODEUP=$(LOCAL)/nodeup
+PROTOKUBE=$(LOCAL)/protokube
 UPLOAD=$(BUILD)/upload
 UID:=$(shell id -u)
 GID:=$(shell id -g)
@@ -94,7 +95,7 @@ ifndef SHASUMCMD
 endif
 
 .PHONY: all
-all: ${KOPS} ${NODEUP} ${CHANNELS}
+all: ${KOPS} ${NODEUP} ${CHANNELS} ${PROTOKUBE}
 
 .PHONY: help
 help: # Show this help
@@ -133,6 +134,7 @@ install: all
 	cp ${KOPS} ${GOPATH_1ST}/bin
 	cp ${NODEUP} ${GOPATH_1ST}/bin
 	cp ${CHANNELS} ${GOPATH_1ST}/bin
+	cp ${PROTOKUBE} ${GOPATH_1ST}/bin
 
 .PHONY: kops
 kops: ${KOPS}
@@ -330,9 +332,11 @@ push-gce-run: push
 push-aws-run: push
 	ssh -t ${TARGET} sudo SKIP_PACKAGE_UPDATE=1 /tmp/nodeup --conf=/var/cache/kubernetes-install/kube_env.yaml --v=8
 
-.PHONY: protokube-gocode
-protokube-gocode:
-	go install -tags 'peer_name_alternative peer_name_hash' k8s.io/kops/protokube/cmd/protokube
+${PROTOKUBE}:
+	go build -tags 'peer_name_alternative peer_name_hash' -o $@  k8s.io/kops/protokube/cmd/protokube
+
+.PHONY: protokube
+protokube: ${PROTOKUBE}
 
 .PHONY: protokube-builder-image
 protokube-builder-image:

--- a/images/protokube-builder/onbuild.sh
+++ b/images/protokube-builder/onbuild.sh
@@ -23,10 +23,10 @@ ln -s /src/ /go/src/k8s.io/kops
 ls -lR  /go/src/k8s.io/kops/protokube/cmd/
 
 cd /go/src/k8s.io/kops/
-make protokube-gocode
+make protokube
 
 mkdir -p /src/.build/artifacts/
-cp /go/bin/protokube /src/.build/artifacts/
+cp /src/.build/local/protokube /src/.build/artifacts/
 
 # Applying channels calls out to the channels tool
 make channels


### PR DESCRIPTION
This PR changes the Makefile to drop the `protokube` binary in .build/local as with the other kops binary artifacts. `protokube` can be installed to `$GOPATH/bin` along with the other binaries by invoking `make install`.