### PR TITLE
Makefile protokube and install default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,6 @@ kops: ${KOPS}
 ${KOPS}: ${BINDATA_TARGETS}
 	go build ${EXTRA_BUILDFLAGS} -ldflags "-X k8s.io/kops.Version=${VERSION} -X k8s.io/kops.GitVersion=${GITSHA} ${EXTRA_LDFLAGS}" -o $@ k8s.io/kops/cmd/kops/
 
-.PHONY: ${GOBINDATA}
 ${GOBINDATA}:
 	mkdir -p ${LOCAL}
 	go build ${EXTRA_BUILDFLAGS} -ldflags "${EXTRA_LDFLAGS}" -o $@ k8s.io/kops/vendor/github.com/jteeuwen/go-bindata/go-bindata

--- a/images/protokube-builder/onbuild.sh
+++ b/images/protokube-builder/onbuild.sh
@@ -23,10 +23,10 @@ ln -s /src/ /go/src/k8s.io/kops
 ls -lR  /go/src/k8s.io/kops/protokube/cmd/
 
 cd /go/src/k8s.io/kops/
-make protokube-gocode
+make protokube
 
 mkdir -p /src/.build/artifacts/
-cp /go/bin/protokube /src/.build/artifacts/
+cp /src/.build/local/protokube /src/.build/artifacts/protokube
 
 # Applying channels calls out to the channels tool
 make channels


### PR DESCRIPTION
HI, guys.

Here's what I'm up to with the Makefile:

A Makefile looks like the world's most stunted scripting environment, and perhaps it is. What a Makefile is really good at is creating a dependency graph. I've been replacing PHONY targets with targets that create an in-tree artifact so that `make` can do its job and keep track of what has been built, and then only build the things that don't exist or are older than the other artifacts that they depend on.

In the near-term this fixes the Makefile targets that wouldn't build unless you'd manually run some other `make` directive first.

In the longer-term it gets `kops` to the point where you can run `make` with the `-j` flag and run multiple concurrent `make` processes simultaneously, so targets that are CPU dependent aren't waiting for targets that are slowed by a network bottleneck.

I've pulled the recent @justinsb Makefile change out, because the `kops-dev` target drops a binary out-of-tree where `make` can't keep track of it, and it changes `make all` to only built kops instead of all the binaries.

It looked like the important thing in the recent commit was to have the development build of kops land in `$GOPATH/bin` automatically. In this PR I change `install` to be the first target in the Makefile, so kops, nodeup, channels, and protokube all get built and copied into `$GOPATH/bin` by default.

This is a little weird, because usually with a Makefile you do everything within your local directory structure, and then save `make install` for the one target that can wander off and clobber stuff on the rest of the system. I'm happy for it to be the default if that's what you guys prefer.

This PR also adds the `${PROTOKUBE}` target to the PHONY `make all`.

Once this passes CI I plan on assigning it to @justinsb so as to be sure there are no surprises.