### PR TITLE
Add permissions for cluster autoscaler addon to scale down

### DIFF
--- a/addons/cluster-autoscaler/v1.6.0.yaml
+++ b/addons/cluster-autoscaler/v1.6.0.yaml
@@ -27,6 +27,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - pods/status
   verbs:
   - update
@@ -43,6 +49,14 @@ rules:
   - ""
   resources:
   - nodes
+  verbs:
+  - watch
+  - list
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
   - pods
   - services
   - replicationcontrollers
@@ -51,6 +65,7 @@ rules:
   verbs:
   - watch
   - list
+  - get
 - apiGroups:
   - extensions
   resources:
@@ -59,6 +74,7 @@ rules:
   verbs:
   - watch
   - list
+  - get
 - apiGroups:
   - policy
   resources:


### PR DESCRIPTION
Cluster autoscaler had insufficient permissions for the actions to scale down. fixes #3418