### PR TITLE
Support additional config options for Canal Networking

### DIFF
--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -44,28 +44,28 @@ type KubenetNetworkingSpec struct {
 type ExternalNetworkingSpec struct {
 }
 
-// CNI is the specification for networking that is implemented by a Daemonset
+// CNINetworkingSpec is the specification for networking that is implemented by a Daemonset
 // Networking is not managed by kops - we can create options here that directly configure e.g. weave
 // but this is useful for arbitrary network modes or for modes that don't need additional configuration.
 type CNINetworkingSpec struct {
 }
 
-// Kopeio declares that we want Kopeio networking
+// KopeioNetworkingSpec declares that we want Kopeio networking
 type KopeioNetworkingSpec struct {
 }
 
-// Weave declares that we want Weave networking
+// WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
 	MTU *int32 `json:"mtu,omitempty"`
 }
 
-// Flannel declares that we want Flannel networking
+// FlannelNetworkingSpec declares that we want Flannel networking
 type FlannelNetworkingSpec struct {
 	// Backend is the backend overlay type we want to use (vxlan or udp)
 	Backend string `json:"backend,omitempty"`
 }
 
-// Calico declares that we want Calico networking
+// CalicoNetworkingSpec declares that we want Calico networking
 type CalicoNetworkingSpec struct {
 	CrossSubnet bool `json:"crossSubnet,omitempty"` // Enables Calico's cross-subnet mode when set to true
 }
@@ -76,13 +76,27 @@ type CanalNetworkingSpec struct {
 	// for traffic between pod to host after calico rules have been processed.
 	// Default: ACCEPT (other options: DROP, RETURN)
 	DefaultEndpointToHostAction string `json:"defaultEndpointToHostAction,omitempty"`
+	// ChainInsertMode controls whether Felix inserts rules to the top of iptables chains, or
+	// appends to the bottom. Leaving the default option is safest to prevent accidentally
+	// breaking connectivity. Default: 'insert' (other options: 'append')
+	ChainInsertMode string `json:"chainInsertMode,omitempty"`
+	// PrometheusMetricsEnabled can be set to enable the experimental Prometheus
+	// metrics server (default: false)
+	PrometheusMetricsEnabled bool `json:"prometheusMetricsEnabled,omitempty"`
+	// PrometheusMetricsPort is the TCP port that the experimental Prometheus
+	// metrics server should bind to (default: 9091)
+	PrometheusMetricsPort int32 `json:"prometheusMetricsPort,omitempty"`
+	// PrometheusGoMetricsEnabled enables Prometheus Go runtime metrics collection
+	PrometheusGoMetricsEnabled bool `json:"prometheusGoMetricsEnabled,omitempty"`
+	// PrometheusProcessMetricsEnabled enables Prometheus process metrics collection
+	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 }
 
-// Kuberouter declares that we want Kube-router networking
+// KuberouterNetworkingSpec declares that we want Kube-router networking
 type KuberouterNetworkingSpec struct {
 }
 
-// Romana declares that we want Romana networking
+// RomanaNetworkingSpec declares that we want Romana networking
 type RomanaNetworkingSpec struct {
 	// DaemonServiceIP is the Kubernetes Service IP for the romana-daemon pod
 	DaemonServiceIP string `json:"daemonServiceIP,omitempty"`

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -44,28 +44,28 @@ type KubenetNetworkingSpec struct {
 type ExternalNetworkingSpec struct {
 }
 
-// CNI is the specification for networking that is implemented by a Daemonset
+// CNINetworkingSpec is the specification for networking that is implemented by a Daemonset
 // Networking is not managed by kops - we can create options here that directly configure e.g. weave
 // but this is useful for arbitrary network modes or for modes that don't need additional configuration.
 type CNINetworkingSpec struct {
 }
 
-// Kopeio declares that we want Kopeio networking
+// KopeioNetworkingSpec declares that we want Kopeio networking
 type KopeioNetworkingSpec struct {
 }
 
-// Weave declares that we want Weave networking
+// WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
 	MTU *int32 `json:"mtu,omitempty"`
 }
 
-// Flannel declares that we want Flannel networking
+// FlannelNetworkingSpec declares that we want Flannel networking
 type FlannelNetworkingSpec struct {
 	// Backend is the backend overlay type we want to use (vxlan or udp)
 	Backend string `json:"backend,omitempty"`
 }
 
-// Calico declares that we want Calico networking
+// CalicoNetworkingSpec declares that we want Calico networking
 type CalicoNetworkingSpec struct {
 	CrossSubnet bool `json:"crossSubnet,omitempty"` // Enables Calico's cross-subnet mode when set to true
 }
@@ -76,13 +76,27 @@ type CanalNetworkingSpec struct {
 	// for traffic between pod to host after calico rules have been processed.
 	// Default: ACCEPT (other options: DROP, RETURN)
 	DefaultEndpointToHostAction string `json:"defaultEndpointToHostAction,omitempty"`
+	// ChainInsertMode controls whether Felix inserts rules to the top of iptables chains, or
+	// appends to the bottom. Leaving the default option is safest to prevent accidentally
+	// breaking connectivity. Default: 'insert' (other options: 'append')
+	ChainInsertMode string `json:"chainInsertMode,omitempty"`
+	// PrometheusMetricsEnabled can be set to enable the experimental Prometheus
+	// metrics server (default: false)
+	PrometheusMetricsEnabled bool `json:"prometheusMetricsEnabled,omitempty"`
+	// PrometheusMetricsPort is the TCP port that the experimental Prometheus
+	// metrics server should bind to (default: 9091)
+	PrometheusMetricsPort int32 `json:"prometheusMetricsPort,omitempty"`
+	// PrometheusGoMetricsEnabled enables Prometheus Go runtime metrics collection
+	PrometheusGoMetricsEnabled bool `json:"prometheusGoMetricsEnabled,omitempty"`
+	// PrometheusProcessMetricsEnabled enables Prometheus process metrics collection
+	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 }
 
-// Kuberouter declares that we want Canal networking
+// KuberouterNetworkingSpec declares that we want Kube-router networking
 type KuberouterNetworkingSpec struct {
 }
 
-// Romana declares that we want Romana networking
+// RomanaNetworkingSpec declares that we want Romana networking
 type RomanaNetworkingSpec struct {
 	// DaemonServiceIP is the Kubernetes Service IP for the romana-daemon pod
 	DaemonServiceIP string `json:"daemonServiceIP,omitempty"`

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -366,6 +366,11 @@ func Convert_kops_CalicoNetworkingSpec_To_v1alpha1_CalicoNetworkingSpec(in *kops
 
 func autoConvert_v1alpha1_CanalNetworkingSpec_To_kops_CanalNetworkingSpec(in *CanalNetworkingSpec, out *kops.CanalNetworkingSpec, s conversion.Scope) error {
 	out.DefaultEndpointToHostAction = in.DefaultEndpointToHostAction
+	out.ChainInsertMode = in.ChainInsertMode
+	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
+	out.PrometheusMetricsPort = in.PrometheusMetricsPort
+	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
+	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	return nil
 }
 
@@ -376,6 +381,11 @@ func Convert_v1alpha1_CanalNetworkingSpec_To_kops_CanalNetworkingSpec(in *CanalN
 
 func autoConvert_kops_CanalNetworkingSpec_To_v1alpha1_CanalNetworkingSpec(in *kops.CanalNetworkingSpec, out *CanalNetworkingSpec, s conversion.Scope) error {
 	out.DefaultEndpointToHostAction = in.DefaultEndpointToHostAction
+	out.ChainInsertMode = in.ChainInsertMode
+	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
+	out.PrometheusMetricsPort = in.PrometheusMetricsPort
+	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
+	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -44,28 +44,28 @@ type KubenetNetworkingSpec struct {
 type ExternalNetworkingSpec struct {
 }
 
-// CNI is the specification for networking that is implemented by a Daemonset
+// CNINetworkingSpec is the specification for networking that is implemented by a Daemonset
 // Networking is not managed by kops - we can create options here that directly configure e.g. weave
 // but this is useful for arbitrary network modes or for modes that don't need additional configuration.
 type CNINetworkingSpec struct {
 }
 
-// Kopeio declares that we want Kopeio networking
+// KopeioNetworkingSpec declares that we want Kopeio networking
 type KopeioNetworkingSpec struct {
 }
 
-// Weave declares that we want Weave networking
+// WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
 	MTU *int32 `json:"mtu,omitempty"`
 }
 
-// Flannel declares that we want Flannel networking
+// FlannelNetworkingSpec declares that we want Flannel networking
 type FlannelNetworkingSpec struct {
 	// Backend is the backend overlay type we want to use (vxlan or udp)
 	Backend string `json:"backend,omitempty"`
 }
 
-// Calico declares that we want Calico networking
+// CalicoNetworkingSpec declares that we want Calico networking
 type CalicoNetworkingSpec struct {
 	CrossSubnet bool `json:"crossSubnet,omitempty"` // Enables Calico's cross-subnet mode when set to true
 }
@@ -76,13 +76,27 @@ type CanalNetworkingSpec struct {
 	// for traffic between pod to host after calico rules have been processed.
 	// Default: ACCEPT (other options: DROP, RETURN)
 	DefaultEndpointToHostAction string `json:"defaultEndpointToHostAction,omitempty"`
+	// ChainInsertMode controls whether Felix inserts rules to the top of iptables chains, or
+	// appends to the bottom. Leaving the default option is safest to prevent accidentally
+	// breaking connectivity. Default: 'insert' (other options: 'append')
+	ChainInsertMode string `json:"chainInsertMode,omitempty"`
+	// PrometheusMetricsEnabled can be set to enable the experimental Prometheus
+	// metrics server (default: false)
+	PrometheusMetricsEnabled bool `json:"prometheusMetricsEnabled,omitempty"`
+	// PrometheusMetricsPort is the TCP port that the experimental Prometheus
+	// metrics server should bind to (default: 9091)
+	PrometheusMetricsPort int32 `json:"prometheusMetricsPort,omitempty"`
+	// PrometheusGoMetricsEnabled enables Prometheus Go runtime metrics collection
+	PrometheusGoMetricsEnabled bool `json:"prometheusGoMetricsEnabled,omitempty"`
+	// PrometheusProcessMetricsEnabled enables Prometheus process metrics collection
+	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 }
 
-// Kuberouter declares that we want Canal networking
+// KuberouterNetworkingSpec declares that we want Kube-router networking
 type KuberouterNetworkingSpec struct {
 }
 
-// Romana declares that we want Romana networking
+// RomanaNetworkingSpec declares that we want Romana networking
 type RomanaNetworkingSpec struct {
 	// DaemonServiceIP is the Kubernetes Service IP for the romana-daemon pod
 	DaemonServiceIP string `json:"daemonServiceIP,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -402,6 +402,11 @@ func Convert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *kops
 
 func autoConvert_v1alpha2_CanalNetworkingSpec_To_kops_CanalNetworkingSpec(in *CanalNetworkingSpec, out *kops.CanalNetworkingSpec, s conversion.Scope) error {
 	out.DefaultEndpointToHostAction = in.DefaultEndpointToHostAction
+	out.ChainInsertMode = in.ChainInsertMode
+	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
+	out.PrometheusMetricsPort = in.PrometheusMetricsPort
+	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
+	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	return nil
 }
 
@@ -412,6 +417,11 @@ func Convert_v1alpha2_CanalNetworkingSpec_To_kops_CanalNetworkingSpec(in *CanalN
 
 func autoConvert_kops_CanalNetworkingSpec_To_v1alpha2_CanalNetworkingSpec(in *kops.CanalNetworkingSpec, out *CanalNetworkingSpec, s conversion.Scope) error {
 	out.DefaultEndpointToHostAction = in.DefaultEndpointToHostAction
+	out.ChainInsertMode = in.ChainInsertMode
+	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
+	out.PrometheusMetricsPort = in.PrometheusMetricsPort
+	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
+	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	return nil
 }
 

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -198,6 +198,13 @@ func ValidateCluster(c *kops.Cluster, strict bool) *field.Error {
 		default:
 			return field.Invalid(fieldSpec.Child("Networking", "Canal", "DefaultEndpointToHostAction"), action, fmt.Sprintf("Unsupported value: %s, supports ACCEPT, DROP or RETURN", action))
 		}
+
+		chainInsertMode := c.Spec.Networking.Canal.ChainInsertMode
+		switch chainInsertMode {
+		case "", "insert", "append":
+		default:
+			return field.Invalid(fieldSpec.Child("Networking", "Canal", "ChainInsertMode"), action, fmt.Sprintf("Unsupported value: %s, supports 'insert' or 'append'", chainInsertMode))
+		}
 	}
 
 	// Check ClusterCIDR

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.6.yaml.template
@@ -120,6 +120,21 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "{{- or .Networking.Canal.DefaultEndpointToHostAction "ACCEPT" }}"
+            # Controls whether Felix inserts rules to the top of iptables chains, or appends to the bottom
+            - name: FELIX_CHAININSERTMODE
+              value: "{{- or .Networking.Canal.ChainInsertMode "insert" }}"
+            # Set to enable the experimental Prometheus metrics server
+            - name: FELIX_PROMETHEUSMETRICSENABLED
+              value: "{{- or .Networking.Canal.PrometheusMetricsEnabled "false" }}"
+            # TCP port that the Prometheus metrics server should bind to
+            - name: FELIX_PROMETHEUSMETRICSPORT
+              value: "{{- or .Networking.Canal.PrometheusMetricsPort "9091" }}"
+            # Enable Prometheus Go runtime metrics collection
+            - name: FELIX_PROMETHEUSGOMETRICSENABLED
+              value: "{{- or .Networking.Canal.PrometheusGoMetricsEnabled "true" }}"
+            # Enable Prometheus process metrics collection
+            - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
+              value: "{{- or .Networking.Canal.PrometheusProcessMetricsEnabled "true" }}"
           securityContext:
             privileged: true
           resources:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/pre-k8s-1.6.yaml.template
@@ -112,6 +112,21 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "{{- or .Networking.Canal.DefaultEndpointToHostAction "ACCEPT" }}"
+            # Controls whether Felix inserts rules to the top of iptables chains, or appends to the bottom
+            - name: FELIX_CHAININSERTMODE
+              value: "{{- or .Networking.Canal.ChainInsertMode "insert" }}"
+            # Set to enable the experimental Prometheus metrics server
+            - name: FELIX_PROMETHEUSMETRICSENABLED
+              value: "{{- or .Networking.Canal.PrometheusMetricsEnabled "false" }}"
+            # TCP port that the Prometheus metrics server should bind to
+            - name: FELIX_PROMETHEUSMETRICSPORT
+              value: "{{- or .Networking.Canal.PrometheusMetricsPort "9091" }}"
+            # Enable Prometheus Go runtime metrics collection
+            - name: FELIX_PROMETHEUSGOMETRICSENABLED
+              value: "{{- or .Networking.Canal.PrometheusGoMetricsEnabled "true" }}"
+            # Enable Prometheus process metrics collection
+            - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
+              value: "{{- or .Networking.Canal.PrometheusProcessMetricsEnabled "true" }}"
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
Add support for additional global and iptables configuration options within the Canal Networking Spec: https://docs.projectcalico.org/v2.4/reference/felix/configuration

- **ChainInsertMode:** Controls whether Felix inserts rules to the top of iptables chains, or appends to the bottom. Leaving the default option is safest to prevent accidentally breaking connectivity. Default: 'insert' (other options: 'append')
- **PrometheusMetricsEnabled:** Set to enable the experimental Prometheus metrics server (default: false)
- **PrometheusMetricsPort:** TCP port that the experimental Prometheus metrics server should bind to (default: 9091)
- **PrometheusGoMetricsEnabled:** Enable Prometheus Go runtime metrics collection
- **PrometheusProcessMetricsEnabled:** Enable Prometheus process metrics collection