### PR TITLE
ETCD container mount /etc/hosts file

### DIFF
--- a/protokube/pkg/protokube/etcd_manifest.go
+++ b/protokube/pkg/protokube/etcd_manifest.go
@@ -86,6 +86,11 @@ func BuildEtcdManifest(c *EtcdCluster) *v1.Pod {
 			MountPath: "/var/log/etcd.log",
 			ReadOnly:  false,
 		})
+		container.VolumeMounts = append(container.VolumeMounts, v1.VolumeMount{
+			Name:      "hosts",
+			MountPath: "/etc/hosts",
+			ReadOnly:  true,
+		})
 		// add the host path mount to the pod spec
 		pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
 			Name: "varetcdata",
@@ -103,7 +108,14 @@ func BuildEtcdManifest(c *EtcdCluster) *v1.Pod {
 				},
 			},
 		})
-
+		pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+			Name: "hosts",
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
+					Path: "/etc/hosts",
+				},
+			},
+		})
 		// @check if tls is enabled and mount the directory. It might be worth considering
 		// if we you use our own directory in /srv i.e /srv/etcd rather than the default /src/kubernetes
 		if c.isTLS() {


### PR DESCRIPTION
This PR just volume mounts the /etc/hosts file from the masters into the etcd-server containers. I'm not 100% sure if this is the right approach to fixing this problem, but I was running into the issue of the etcd servers no longer being able to discover each other after performing a rolling-update. I'm running this version of protokube locally and it's fixed my issues of the etcd containers not being able to discover each other after an update.

I saw that the kube-proxy manifest was already volume mounting the /etc/hosts file, so I figured this was kosher. 