### PR TITLE
AWS mock provider should use the AWS cloudprovider id

### DIFF
--- a/tests/integration/complex/kubernetes.tf
+++ b/tests/integration/complex/kubernetes.tf
@@ -38,6 +38,10 @@ output "vpc_id" {
   value = "${aws_vpc.complex-example-com.id}"
 }
 
+provider "aws" {
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-complex-example-com" {
   name                 = "master-us-test-1a.masters.complex.example.com"
   launch_configuration = "${aws_launch_configuration.master-us-test-1a-masters-complex-example-com.id}"

--- a/tests/integration/ha/kubernetes.tf
+++ b/tests/integration/ha/kubernetes.tf
@@ -38,6 +38,10 @@ output "vpc_id" {
   value = "${aws_vpc.ha-example-com.id}"
 }
 
+provider "aws" {
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-ha-example-com" {
   name                 = "master-us-test-1a.masters.ha.example.com"
   launch_configuration = "${aws_launch_configuration.master-us-test-1a-masters-ha-example-com.id}"

--- a/tests/integration/minimal-141/kubernetes.tf
+++ b/tests/integration/minimal-141/kubernetes.tf
@@ -38,6 +38,10 @@ output "vpc_id" {
   value = "${aws_vpc.minimal-141-example-com.id}"
 }
 
+provider "aws" {
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-141-example-com" {
   name                 = "master-us-test-1a.masters.minimal-141.example.com"
   launch_configuration = "${aws_launch_configuration.master-us-test-1a-masters-minimal-141-example-com.id}"

--- a/tests/integration/minimal/kubernetes.tf
+++ b/tests/integration/minimal/kubernetes.tf
@@ -38,6 +38,10 @@ output "vpc_id" {
   value = "${aws_vpc.minimal-example-com.id}"
 }
 
+provider "aws" {
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com" {
   name                 = "master-us-test-1a.masters.minimal.example.com"
   launch_configuration = "${aws_launch_configuration.master-us-test-1a-masters-minimal-example-com.id}"

--- a/tests/integration/privatecalico/kubernetes.tf
+++ b/tests/integration/privatecalico/kubernetes.tf
@@ -50,6 +50,10 @@ output "vpc_id" {
   value = "${aws_vpc.privatecalico-example-com.id}"
 }
 
+provider "aws" {
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_attachment" "bastion-privatecalico-example-com" {
   elb                    = "${aws_elb.bastion-privatecalico-example-com.id}"
   autoscaling_group_name = "${aws_autoscaling_group.bastion-privatecalico-example-com.id}"

--- a/tests/integration/privatecanal/kubernetes.tf
+++ b/tests/integration/privatecanal/kubernetes.tf
@@ -50,6 +50,10 @@ output "vpc_id" {
   value = "${aws_vpc.privatecanal-example-com.id}"
 }
 
+provider "aws" {
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_attachment" "bastion-privatecanal-example-com" {
   elb                    = "${aws_elb.bastion-privatecanal-example-com.id}"
   autoscaling_group_name = "${aws_autoscaling_group.bastion-privatecanal-example-com.id}"

--- a/tests/integration/privatedns1/kubernetes.tf
+++ b/tests/integration/privatedns1/kubernetes.tf
@@ -50,6 +50,10 @@ output "vpc_id" {
   value = "${aws_vpc.privatedns1-example-com.id}"
 }
 
+provider "aws" {
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_attachment" "bastion-privatedns1-example-com" {
   elb                    = "${aws_elb.bastion-privatedns1-example-com.id}"
   autoscaling_group_name = "${aws_autoscaling_group.bastion-privatedns1-example-com.id}"

--- a/tests/integration/privatedns2/kubernetes.tf
+++ b/tests/integration/privatedns2/kubernetes.tf
@@ -50,6 +50,10 @@ output "vpc_id" {
   value = "vpc-123"
 }
 
+provider "aws" {
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_attachment" "bastion-privatedns2-example-com" {
   elb                    = "${aws_elb.bastion-privatedns2-example-com.id}"
   autoscaling_group_name = "${aws_autoscaling_group.bastion-privatedns2-example-com.id}"

--- a/tests/integration/privateflannel/kubernetes.tf
+++ b/tests/integration/privateflannel/kubernetes.tf
@@ -50,6 +50,10 @@ output "vpc_id" {
   value = "${aws_vpc.privateflannel-example-com.id}"
 }
 
+provider "aws" {
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_attachment" "bastion-privateflannel-example-com" {
   elb                    = "${aws_elb.bastion-privateflannel-example-com.id}"
   autoscaling_group_name = "${aws_autoscaling_group.bastion-privateflannel-example-com.id}"

--- a/tests/integration/privatekopeio/kubernetes.tf
+++ b/tests/integration/privatekopeio/kubernetes.tf
@@ -50,6 +50,10 @@ output "vpc_id" {
   value = "${aws_vpc.privatekopeio-example-com.id}"
 }
 
+provider "aws" {
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_attachment" "bastion-privatekopeio-example-com" {
   elb                    = "${aws_elb.bastion-privatekopeio-example-com.id}"
   autoscaling_group_name = "${aws_autoscaling_group.bastion-privatekopeio-example-com.id}"

--- a/tests/integration/privateweave/kubernetes.tf
+++ b/tests/integration/privateweave/kubernetes.tf
@@ -50,6 +50,10 @@ output "vpc_id" {
   value = "${aws_vpc.privateweave-example-com.id}"
 }
 
+provider "aws" {
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_attachment" "bastion-privateweave-example-com" {
   elb                    = "${aws_elb.bastion-privateweave-example-com.id}"
   autoscaling_group_name = "${aws_autoscaling_group.bastion-privateweave-example-com.id}"

--- a/tests/integration/shared_subnet/kubernetes.tf
+++ b/tests/integration/shared_subnet/kubernetes.tf
@@ -42,6 +42,10 @@ output "vpc_id" {
   value = "vpc-12345678"
 }
 
+provider "aws" {
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-sharedsubnet-example-com" {
   name                 = "master-us-test-1a.masters.sharedsubnet.example.com"
   launch_configuration = "${aws_launch_configuration.master-us-test-1a-masters-sharedsubnet-example-com.id}"

--- a/tests/integration/shared_vpc/kubernetes.tf
+++ b/tests/integration/shared_vpc/kubernetes.tf
@@ -38,6 +38,10 @@ output "vpc_id" {
   value = "vpc-12345678"
 }
 
+provider "aws" {
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-sharedvpc-example-com" {
   name                 = "master-us-test-1a.masters.sharedvpc.example.com"
   launch_configuration = "${aws_launch_configuration.master-us-test-1a-masters-sharedvpc-example-com.id}"

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -74,7 +74,7 @@ type MockCloud struct {
 }
 
 func (c *MockCloud) ProviderID() kops.CloudProviderID {
-	return "mock"
+	return kops.CloudProviderAWS
 }
 
 func (c *MockCloud) DNS() (dnsprovider.Interface, error) {


### PR DESCRIPTION
Otherwise our tests get a little confused; for example they weren't
outputing the Terraform provider block.