### PR TITLE
Add Zones field to InstanceGroup

### DIFF
--- a/cmd/kops/get_cluster.go
+++ b/cmd/kops/get_cluster.go
@@ -197,7 +197,9 @@ func clusterOutputTable(clusters []*api.Cluster, out io.Writer) error {
 	t.AddColumn("ZONES", func(c *api.Cluster) string {
 		zones := sets.NewString()
 		for _, s := range c.Spec.Subnets {
-			zones.Insert(s.Zone)
+			if s.Zone != "" {
+				zones.Insert(s.Zone)
+			}
 		}
 		return strings.Join(zones.List(), ",")
 	})

--- a/hack/.packages
+++ b/hack/.packages
@@ -25,6 +25,7 @@ k8s.io/kops/nodeup/pkg/model
 k8s.io/kops/nodeup/pkg/model/resources
 k8s.io/kops/pkg/apis/kops
 k8s.io/kops/pkg/apis/kops/install
+k8s.io/kops/pkg/apis/kops/model
 k8s.io/kops/pkg/apis/kops/registry
 k8s.io/kops/pkg/apis/kops/util
 k8s.io/kops/pkg/apis/kops/v1alpha1

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -61,7 +61,9 @@ type ClusterSpec struct {
 	MasterPublicName string `json:"masterPublicName,omitempty"`
 	// MasterInternalName is the internal DNS name for the master nodes
 	MasterInternalName string `json:"masterInternalName,omitempty"`
-	// NetworkCIDR is used by the AWS VPC / GCE Network, or otherwise allocated to k8s. This is a real CIDR, not the internal k8s network
+	// NetworkCIDR is the CIDR used for the AWS VPC / GCE Network, or otherwise allocated to k8s
+	// This is a real CIDR, not the internal k8s network
+	// On AWS, it maps to the VPC CIDR.  It is not required on GCE.
 	NetworkCIDR string `json:"networkCIDR,omitempty"`
 	// NetworkID is an identifier of a network, if we want to reuse/share an existing network (e.g. an AWS VPC)
 	NetworkID string `json:"networkID,omitempty"`
@@ -323,8 +325,10 @@ type ClusterSubnetSpec struct {
 	Name string `json:"name,omitempty"`
 	// CIDR is the network cidr of the subnet
 	CIDR string `json:"cidr,omitempty"`
-	// Zone is the zone the subnet resides
+	// Zone is the zone the subnet is in, set for subnets that are zonally scoped
 	Zone string `json:"zone,omitempty"`
+	// Region is the region the subnet is in, set for subnets that are regionally scoped
+	Region string `json:"region,omitempty"`
 	// ProviderID is the cloud provider id for the objects associated with the zone (the subnet on AWS)
 	ProviderID string `json:"id,omitempty"`
 	// Egress defines the method of traffic egress for this subnet

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -82,6 +82,9 @@ type InstanceGroupSpec struct {
 	RootVolumeOptimization *bool `json:"rootVolumeOptimization,omitempty"`
 	// Subnets is the names of the Subnets (as specified in the Cluster) where machines in this instance group should be placed
 	Subnets []string `json:"subnets,omitempty"`
+	// Zones is the names of the Zones where machines in this instance group should be placed
+	// This is needed for regional subnets (e.g. GCE), to restrict placement to particular zones
+	Zones []string `json:"zones,omitempty"`
 	// Hooks is a list of hooks for this instanceGroup, note: these can override the cluster wide ones if required
 	Hooks []HookSpec `json:"hooks,omitempty"`
 	// MaxPrice indicates this is a spot-pricing group, with the specified value as our max-price bid

--- a/pkg/apis/kops/model/utils.go
+++ b/pkg/apis/kops/model/utils.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kops/pkg/apis/kops"
+)
+
+// FindSubnet returns the subnet with the specified name, or returns nil
+func FindSubnet(c *kops.Cluster, subnetName string) *kops.ClusterSubnetSpec {
+	for i := range c.Spec.Subnets {
+		if c.Spec.Subnets[i].Name == subnetName {
+			return &c.Spec.Subnets[i]
+		}
+	}
+	return nil
+}
+
+// FindZonesForInstanceGroup computes the zones for an instance group, which are the zones directly declared in the InstanceGroup, or the subnet zones
+func FindZonesForInstanceGroup(c *kops.Cluster, ig *kops.InstanceGroup) ([]string, error) {
+	zones := sets.NewString(ig.Spec.Zones...)
+	for _, subnetName := range ig.Spec.Subnets {
+		subnet := FindSubnet(c, subnetName)
+		if subnet == nil {
+			return nil, fmt.Errorf("cannot find subnet %q (declared in instance group %q, not found in cluster)", subnetName, ig.ObjectMeta.Name)
+		}
+
+		if subnet.Zone != "" {
+			zones.Insert(subnet.Zone)
+		}
+	}
+	return zones.List(), nil
+}

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -60,8 +60,9 @@ type ClusterSpec struct {
 	MasterPublicName string `json:"masterPublicName,omitempty"`
 	// MasterInternalName is the internal DNS name for the master nodes
 	MasterInternalName string `json:"masterInternalName,omitempty"`
-	// The CIDR used for the AWS VPC / GCE Network, or otherwise allocated to k8s
+	// NetworkCIDR is the CIDR used for the AWS VPC Network, or otherwise allocated to k8s
 	// This is a real CIDR, not the internal k8s network
+	// On AWS, it maps to the VPC CIDR.  It is not required on GCE.
 	NetworkCIDR string `json:"networkCIDR,omitempty"`
 	// NetworkID is an identifier of a network, if we want to reuse/share an existing network (e.g. an AWS VPC)
 	NetworkID string `json:"networkID,omitempty"`

--- a/pkg/apis/kops/v1alpha1/conversion.go
+++ b/pkg/apis/kops/v1alpha1/conversion.go
@@ -235,15 +235,25 @@ func Convert_kops_EtcdMemberSpec_To_v1alpha1_EtcdMemberSpec(in *kops.EtcdMemberS
 }
 
 func Convert_v1alpha1_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *InstanceGroupSpec, out *kops.InstanceGroupSpec, s conversion.Scope) error {
+	err := autoConvert_v1alpha1_InstanceGroupSpec_To_kops_InstanceGroupSpec(in, out, s)
+	if err != nil {
+		return err
+	}
+
 	out.Subnets = in.Zones
 
-	return autoConvert_v1alpha1_InstanceGroupSpec_To_kops_InstanceGroupSpec(in, out, s)
+	return nil
 }
 
 func Convert_kops_InstanceGroupSpec_To_v1alpha1_InstanceGroupSpec(in *kops.InstanceGroupSpec, out *InstanceGroupSpec, s conversion.Scope) error {
+	err := autoConvert_kops_InstanceGroupSpec_To_v1alpha1_InstanceGroupSpec(in, out, s)
+	if err != nil {
+		return err
+	}
+
 	out.Zones = in.Subnets
 
-	return autoConvert_kops_InstanceGroupSpec_To_v1alpha1_InstanceGroupSpec(in, out, s)
+	return nil
 }
 
 func Convert_v1alpha1_TopologySpec_To_kops_TopologySpec(in *TopologySpec, out *kops.TopologySpec, s conversion.Scope) error {

--- a/pkg/apis/kops/v1alpha1/instancegroup.go
+++ b/pkg/apis/kops/v1alpha1/instancegroup.go
@@ -86,6 +86,7 @@ type InstanceGroupSpec struct {
 	Kubelet *KubeletConfigSpec `json:"kubelet,omitempty"`
 	// Taints indicates the kubernetes taints for nodes in this group
 	Taints []string `json:"taints,omitempty"`
-	// @should this be here??
+	// Zones is the names of the Zones where machines in this instance group should be placed
+	// This is needed for regional subnets (e.g. GCE), to restrict placement to particular zones
 	Zones []string `json:"zones,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1619,7 +1619,7 @@ func autoConvert_v1alpha1_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 		out.Kubelet = nil
 	}
 	out.Taints = in.Taints
-	// WARNING: in.Zones requires manual conversion: does not exist in peer-type
+	out.Zones = in.Zones
 	return nil
 }
 
@@ -1634,6 +1634,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha1_InstanceGroupSpec(in *kops.I
 	out.RootVolumeIops = in.RootVolumeIops
 	out.RootVolumeOptimization = in.RootVolumeOptimization
 	// WARNING: in.Subnets requires manual conversion: does not exist in peer-type
+	out.Zones = in.Zones
 	if in.Hooks != nil {
 		in, out := &in.Hooks, &out.Hooks
 		*out = make([]HookSpec, len(*in))

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -58,8 +58,9 @@ type ClusterSpec struct {
 	MasterPublicName string `json:"masterPublicName,omitempty"`
 	// MasterInternalName is the internal DNS name for the master nodes
 	MasterInternalName string `json:"masterInternalName,omitempty"`
-	// The CIDR used for the AWS VPC / GCE Network, or otherwise allocated to k8s
+	// NetworkCIDR is the CIDR used for the AWS VPC / GCE Network, or otherwise allocated to k8s
 	// This is a real CIDR, not the internal k8s network
+	// On AWS, it maps to the VPC CIDR.  It is not required on GCE.
 	NetworkCIDR string `json:"networkCIDR,omitempty"`
 	// NetworkID is an identifier of a network, if we want to reuse/share an existing network (e.g. an AWS VPC)
 	NetworkID string `json:"networkID,omitempty"`
@@ -315,7 +316,10 @@ const (
 type ClusterSubnetSpec struct {
 	Name string `json:"name,omitempty"`
 
+	// Zone is the zone the subnet is in, set for subnets that are zonally scoped
 	Zone string `json:"zone,omitempty"`
+	// Region is the region the subnet is in, set for subnets that are regionally scoped
+	Region string `json:"region,omitempty"`
 
 	CIDR string `json:"cidr,omitempty"`
 

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -74,6 +74,9 @@ type InstanceGroupSpec struct {
 	RootVolumeOptimization *bool `json:"rootVolumeOptimization,omitempty"`
 	// Subnets is the names of the Subnets (as specified in the Cluster) where machines in this instance group should be placed
 	Subnets []string `json:"subnets,omitempty"`
+	// Zones is the names of the Zones where machines in this instance group should be placed
+	// This is needed for regional subnets (e.g. GCE), to restrict placement to particular zones
+	Zones []string `json:"zones,omitempty"`
 	// Hooks is a list of hooks for this instanceGroup, note: these can override the cluster wide ones if required
 	Hooks []HookSpec `json:"hooks,omitempty"`
 	// MaxPrice indicates this is a spot-pricing group, with the specified value as our max-price bid

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1063,6 +1063,7 @@ func Convert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, out 
 func autoConvert_v1alpha2_ClusterSubnetSpec_To_kops_ClusterSubnetSpec(in *ClusterSubnetSpec, out *kops.ClusterSubnetSpec, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Zone = in.Zone
+	out.Region = in.Region
 	out.CIDR = in.CIDR
 	out.ProviderID = in.ProviderID
 	out.Egress = in.Egress
@@ -1079,6 +1080,7 @@ func autoConvert_kops_ClusterSubnetSpec_To_v1alpha2_ClusterSubnetSpec(in *kops.C
 	out.Name = in.Name
 	out.CIDR = in.CIDR
 	out.Zone = in.Zone
+	out.Region = in.Region
 	out.ProviderID = in.ProviderID
 	out.Egress = in.Egress
 	out.Type = SubnetType(in.Type)

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1691,6 +1691,7 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	out.RootVolumeIops = in.RootVolumeIops
 	out.RootVolumeOptimization = in.RootVolumeOptimization
 	out.Subnets = in.Subnets
+	out.Zones = in.Zones
 	if in.Hooks != nil {
 		in, out := &in.Hooks, &out.Hooks
 		*out = make([]kops.HookSpec, len(*in))
@@ -1748,6 +1749,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	out.RootVolumeIops = in.RootVolumeIops
 	out.RootVolumeOptimization = in.RootVolumeOptimization
 	out.Subnets = in.Subnets
+	out.Zones = in.Zones
 	if in.Hooks != nil {
 		in, out := &in.Hooks, &out.Hooks
 		*out = make([]HookSpec, len(*in))

--- a/pkg/apis/kops/validation/gce.go
+++ b/pkg/apis/kops/validation/gce.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/kops/pkg/apis/kops"
+)
+
+func gceValidateCluster(c *kops.Cluster) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	fieldSpec := field.NewPath("spec")
+
+	regions := sets.NewString()
+	for i, subnet := range c.Spec.Subnets {
+		f := fieldSpec.Child("Subnets").Index(i)
+		if subnet.Zone != "" {
+			allErrs = append(allErrs, field.Invalid(f.Child("Zone"), subnet.Zone, "zones should not be specified for GCE subnets, as GCE subnets are regional"))
+		}
+		if subnet.Region == "" {
+			allErrs = append(allErrs, field.Required(f.Child("Region"), "region must be specified for GCE subnets"))
+		} else {
+			regions.Insert(subnet.Region)
+		}
+	}
+
+	if len(regions) > 1 {
+		allErrs = append(allErrs, field.Invalid(fieldSpec.Child("Subnets"), strings.Join(regions.List(), ","), "clusters cannot span GCE regions"))
+	}
+
+	return nil
+}

--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -56,15 +56,15 @@ func ValidateInstanceGroup(g *kops.InstanceGroup) error {
 	return nil
 }
 
-// CrossValidate performs validation of the instance group, including that it is consistent with the Cluster
-// It calls Validate, so all that validation is included.
+// CrossValidateInstanceGroup performs validation of the instance group, including that it is consistent with the Cluster
+// It calls ValidateInstanceGroup, so all that validation is included.
 func CrossValidateInstanceGroup(g *kops.InstanceGroup, cluster *kops.Cluster, strict bool) error {
 	err := ValidateInstanceGroup(g)
 	if err != nil {
 		return err
 	}
 
-	// Check that instance groups are defined in valid zones
+	// Check that instance groups are defined in subnets that are defined in the cluster
 	{
 		clusterSubnets := make(map[string]*kops.ClusterSubnetSpec)
 		for i := range cluster.Spec.Subnets {

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -39,6 +39,15 @@ func ValidateDockerConfig(config *kops.DockerConfig, fldPath *field.Path) field.
 func newValidateCluster(cluster *kops.Cluster) field.ErrorList {
 	allErrs := validation.ValidateObjectMeta(&cluster.ObjectMeta, false, validation.NameIsDNSSubdomain, field.NewPath("metadata"))
 	allErrs = append(allErrs, validateClusterSpec(&cluster.Spec, field.NewPath("spec"))...)
+
+	// Additional cloud-specific validation rules
+	switch kops.CloudProviderID(cluster.Spec.CloudProvider) {
+	case kops.CloudProviderAWS:
+		allErrs = append(allErrs, awsValidateCluster(cluster)...)
+	case kops.CloudProviderGCE:
+		allErrs = append(allErrs, gceValidateCluster(cluster)...)
+	}
+
 	return allErrs
 }
 

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/glog"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/model"
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/model/components"
@@ -132,13 +133,12 @@ func (m *KopsModelContext) FindInstanceGroup(name string) *kops.InstanceGroup {
 
 // FindSubnet returns the subnet with the matching Name (or nil if not found)
 func (m *KopsModelContext) FindSubnet(name string) *kops.ClusterSubnetSpec {
-	for i := range m.Cluster.Spec.Subnets {
-		s := &m.Cluster.Spec.Subnets[i]
-		if s.Name == name {
-			return s
-		}
-	}
-	return nil
+	return model.FindSubnet(m.Cluster, name)
+}
+
+// FindZonesForInstanceGroup finds the zones for an InstanceGroup
+func (m *KopsModelContext) FindZonesForInstanceGroup(ig *kops.InstanceGroup) ([]string, error) {
+	return model.FindZonesForInstanceGroup(m.Cluster, ig)
 }
 
 // MasterInstanceGroups returns InstanceGroups with the master role

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/model"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
@@ -60,21 +61,17 @@ func (b *MasterVolumeBuilder) Build(c *fi.ModelBuilderContext) error {
 				return fmt.Errorf("InstanceGroup not found (for etcd %s/%s): %q", m.Name, etcd.Name, igName)
 			}
 
-			if len(ig.Spec.Subnets) == 0 {
-				return fmt.Errorf("Must specify a subnet for instancegroup %q used by etcd %s/%s", igName, m.Name, etcd.Name)
+			zones, err := model.FindZonesForInstanceGroup(b.Cluster, ig)
+			if err != nil {
+				return err
 			}
-			if len(ig.Spec.Subnets) != 1 {
-				return fmt.Errorf("Must specify a unique subnet for instancegroup %q used by etcd %s/%s", igName, m.Name, etcd.Name)
+			if len(zones) == 0 {
+				return fmt.Errorf("must specify a zone for instancegroup %q used by etcd %s/%s", igName, m.Name, etcd.Name)
 			}
-
-			subnet := b.FindSubnet(ig.Spec.Subnets[0])
-			if subnet == nil {
-				return fmt.Errorf("Subnet %q not found (specified by instancegroup %q)", ig.Spec.Subnets[0], igName)
+			if len(zones) != 1 {
+				return fmt.Errorf("must specify a unique zone for instancegroup %q used by etcd %s/%s", igName, m.Name, etcd.Name)
 			}
-
-			if subnet.Zone == "" {
-				return fmt.Errorf("Subnet %q did not specify a zone", subnet.Name)
-			}
+			zone := zones[0]
 
 			volumeSize := fi.Int32Value(m.VolumeSize)
 			if volumeSize == 0 {
@@ -89,13 +86,13 @@ func (b *MasterVolumeBuilder) Build(c *fi.ModelBuilderContext) error {
 
 			switch kops.CloudProviderID(b.Cluster.Spec.CloudProvider) {
 			case kops.CloudProviderAWS:
-				b.addAWSVolume(c, name, volumeSize, subnet, etcd, m, allMembers)
+				b.addAWSVolume(c, name, volumeSize, zone, etcd, m, allMembers)
 			case kops.CloudProviderDO:
-				b.addDOVolume(c, name, volumeSize, subnet, etcd, m, allMembers)
+				b.addDOVolume(c, name, volumeSize, zone, etcd, m, allMembers)
 			case kops.CloudProviderGCE:
-				b.addGCEVolume(c, name, volumeSize, subnet, etcd, m, allMembers)
+				b.addGCEVolume(c, name, volumeSize, zone, etcd, m, allMembers)
 			case kops.CloudProviderVSphere:
-				b.addVSphereVolume(c, name, volumeSize, subnet, etcd, m, allMembers)
+				b.addVSphereVolume(c, name, volumeSize, zone, etcd, m, allMembers)
 			case kops.CloudProviderBareMetal:
 				glog.Fatalf("BareMetal not implemented")
 			default:
@@ -106,7 +103,7 @@ func (b *MasterVolumeBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-func (b *MasterVolumeBuilder) addAWSVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, subnet *kops.ClusterSubnetSpec, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) {
+func (b *MasterVolumeBuilder) addAWSVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) {
 	volumeType := fi.StringValue(m.VolumeType)
 	if volumeType == "" {
 		volumeType = DefaultAWSEtcdVolumeType
@@ -132,7 +129,7 @@ func (b *MasterVolumeBuilder) addAWSVolume(c *fi.ModelBuilderContext, name strin
 		Name:      s(name),
 		Lifecycle: b.Lifecycle,
 
-		AvailabilityZone: s(subnet.Zone),
+		AvailabilityZone: s(zone),
 		SizeGB:           fi.Int64(int64(volumeSize)),
 		VolumeType:       s(volumeType),
 		KmsKeyId:         m.KmsKeyId,
@@ -143,7 +140,7 @@ func (b *MasterVolumeBuilder) addAWSVolume(c *fi.ModelBuilderContext, name strin
 	c.AddTask(t)
 }
 
-func (b *MasterVolumeBuilder) addDOVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, subnet *kops.ClusterSubnetSpec, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) {
+func (b *MasterVolumeBuilder) addDOVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) {
 	// required that names start with a lower case and only contains letters, numbers and hyphens
 	name = "kops-" + strings.Replace(name, ".", "-", -1)
 
@@ -156,13 +153,13 @@ func (b *MasterVolumeBuilder) addDOVolume(c *fi.ModelBuilderContext, name string
 		Name:      s(name),
 		Lifecycle: b.Lifecycle,
 		SizeGB:    fi.Int64(int64(volumeSize)),
-		Region:    s(subnet.Zone),
+		Region:    s(zone),
 	}
 
 	c.AddTask(t)
 }
 
-func (b *MasterVolumeBuilder) addGCEVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, subnet *kops.ClusterSubnetSpec, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) {
+func (b *MasterVolumeBuilder) addGCEVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) {
 	volumeType := fi.StringValue(m.VolumeType)
 	if volumeType == "" {
 		volumeType = DefaultGCEEtcdVolumeType
@@ -196,7 +193,7 @@ func (b *MasterVolumeBuilder) addGCEVolume(c *fi.ModelBuilderContext, name strin
 		Name:      s(name),
 		Lifecycle: b.Lifecycle,
 
-		Zone:       s(subnet.Zone),
+		Zone:       s(zone),
 		SizeGB:     fi.Int64(int64(volumeSize)),
 		VolumeType: s(volumeType),
 		Labels:     tags,
@@ -205,6 +202,6 @@ func (b *MasterVolumeBuilder) addGCEVolume(c *fi.ModelBuilderContext, name strin
 	c.AddTask(t)
 }
 
-func (b *MasterVolumeBuilder) addVSphereVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, subnet *kops.ClusterSubnetSpec, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) {
+func (b *MasterVolumeBuilder) addVSphereVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) {
 	fmt.Print("addVSphereVolume to be implemented")
 }

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -32,9 +32,8 @@ spec:
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.8.0
+  kubernetesVersion: v1.8.0-beta.1
   masterPublicName: api.ha-gce.example.com
-  networkCIDR: 172.20.0.0/16
   networking:
     kubenet: {}
   nonMasqueradeCIDR: 100.64.0.0/10
@@ -42,18 +41,9 @@ spec:
   sshAccess:
   - 0.0.0.0/0
   subnets:
-  - cidr: 172.20.32.0/19
-    name: us-test1-a
+  - name: us-test1
+    region: us-test1
     type: Public
-    zone: us-test1-a
-  - cidr: 172.20.64.0/19
-    name: us-test1-b
-    type: Public
-    zone: us-test1-b
-  - cidr: 172.20.96.0/19
-    name: us-test1-c
-    type: Public
-    zone: us-test1-c
   topology:
     dns:
       type: Public
@@ -76,7 +66,7 @@ spec:
   minSize: 1
   role: Master
   subnets:
-  - us-test1-a
+  - us-test1
 
 ---
 
@@ -94,7 +84,7 @@ spec:
   minSize: 1
   role: Master
   subnets:
-  - us-test1-b
+  - us-test1
 
 ---
 
@@ -112,7 +102,7 @@ spec:
   minSize: 1
   role: Master
   subnets:
-  - us-test1-c
+  - us-test1
 
 ---
 
@@ -130,6 +120,4 @@ spec:
   minSize: 2
   role: Node
   subnets:
-  - us-test1-a
-  - us-test1-b
-  - us-test1-c
+  - us-test1

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -67,6 +67,8 @@ spec:
   role: Master
   subnets:
   - us-test1
+  zones:
+  - us-test1-a
 
 ---
 
@@ -85,6 +87,8 @@ spec:
   role: Master
   subnets:
   - us-test1
+  zones:
+  - us-test1-b
 
 ---
 
@@ -103,6 +107,8 @@ spec:
   role: Master
   subnets:
   - us-test1
+  zones:
+  - us-test1-c
 
 ---
 
@@ -121,3 +127,7 @@ spec:
   role: Node
   subnets:
   - us-test1
+  zones:
+  - us-test1-a
+  - us-test1-b
+  - us-test1-c

--- a/tests/integration/create_cluster/ha_gce/options.yaml
+++ b/tests/integration/create_cluster/ha_gce/options.yaml
@@ -8,5 +8,5 @@ MasterZones:
 - us-test1-b
 - us-test1-c
 Cloud: gce
-KubernetesVersion: v1.8.0
+KubernetesVersion: v1.8.0-beta.1
 Project: testproject

--- a/tests/integration/ha_gce/in-v1alpha2.yaml
+++ b/tests/integration/ha_gce/in-v1alpha2.yaml
@@ -67,6 +67,8 @@ spec:
   role: Master
   subnets:
   - us-test1
+  zones:
+  - us-test1-a
 
 ---
 
@@ -85,6 +87,8 @@ spec:
   role: Master
   subnets:
   - us-test1
+  zones:
+  - us-test1-b
 
 ---
 
@@ -103,6 +107,8 @@ spec:
   role: Master
   subnets:
   - us-test1
+  zones:
+  - us-test1-c
 
 ---
 
@@ -121,3 +127,7 @@ spec:
   role: Node
   subnets:
   - us-test1
+  zones:
+  - us-test1-a
+  - us-test1-b
+  - us-test1-c

--- a/tests/integration/ha_gce/in-v1alpha2.yaml
+++ b/tests/integration/ha_gce/in-v1alpha2.yaml
@@ -32,9 +32,8 @@ spec:
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.7.5
+  kubernetesVersion: v1.8.0-beta.1
   masterPublicName: api.ha-gce.example.com
-  networkCIDR: 172.20.0.0/16
   networking:
     kubenet: {}
   nonMasqueradeCIDR: 100.64.0.0/10
@@ -42,18 +41,9 @@ spec:
   sshAccess:
   - 0.0.0.0/0
   subnets:
-  - cidr: 172.20.32.0/19
-    name: us-test1-a
+  - name: us-test1
+    region: us-test1
     type: Public
-    zone: us-test1-a
-  - cidr: 172.20.64.0/19
-    name: us-test1-b
-    type: Public
-    zone: us-test1-b
-  - cidr: 172.20.96.0/19
-    name: us-test1-c
-    type: Public
-    zone: us-test1-c
   topology:
     dns:
       type: Public
@@ -76,7 +66,7 @@ spec:
   minSize: 1
   role: Master
   subnets:
-  - us-test1-a
+  - us-test1
 
 ---
 
@@ -94,7 +84,7 @@ spec:
   minSize: 1
   role: Master
   subnets:
-  - us-test1-b
+  - us-test1
 
 ---
 
@@ -112,7 +102,7 @@ spec:
   minSize: 1
   role: Master
   subnets:
-  - us-test1-c
+  - us-test1
 
 ---
 
@@ -130,6 +120,4 @@ spec:
   minSize: 2
   role: Node
   subnets:
-  - us-test1-a
-  - us-test1-b
-  - us-test1-c
+  - us-test1

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/model"
 	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
@@ -1003,19 +1004,11 @@ func (c *awsCloudImplementation) DefaultInstanceType(cluster *kops.Cluster, ig *
 	}
 
 	// Find the AZs the InstanceGroup targets
-	igZones := sets.NewString()
-	for _, subnetName := range ig.Spec.Subnets {
-		var subnet *kops.ClusterSubnetSpec
-		for i := range cluster.Spec.Subnets {
-			if cluster.Spec.Subnets[i].Name == subnetName {
-				subnet = &cluster.Spec.Subnets[i]
-			}
-		}
-		if subnet == nil {
-			return "", fmt.Errorf("subnet %q is not defined in cluster", subnetName)
-		}
-		igZones.Insert(subnet.Zone)
+	igZones, err := model.FindZonesForInstanceGroup(cluster, ig)
+	if err != nil {
+		return "", err
 	}
+	igZonesSet := sets.NewString(igZones...)
 
 	// TODO: Validate that instance type exists in all AZs, but skip AZs that don't support any VPC stuff
 	for _, instanceType := range candidates {
@@ -1023,7 +1016,7 @@ func (c *awsCloudImplementation) DefaultInstanceType(cluster *kops.Cluster, ig *
 		if err != nil {
 			return "", err
 		}
-		if zones.IsSuperset(igZones) {
+		if zones.IsSuperset(igZonesSet) {
 			return instanceType, nil
 		} else {
 			glog.V(2).Infof("can't use instance type %q, available in zones %v but need %v", instanceType, zones, igZones)

--- a/upup/pkg/fi/cloudup/gce/utils.go
+++ b/upup/pkg/fi/cloudup/gce/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"fmt"
 	"google.golang.org/api/googleapi"
 	"strings"
 )
@@ -60,7 +61,7 @@ func SafeObjectName(name string, clusterName string) string {
 	return SafeClusterName(gceName)
 }
 
-// Returns the last component of a URL, i.e. anything after the last slash
+// LastComponent returns the last component of a URL, i.e. anything after the last slash
 // If there is no slash, returns the whole string
 func LastComponent(s string) string {
 	lastSlash := strings.LastIndex(s, "/")
@@ -68,4 +69,14 @@ func LastComponent(s string) string {
 		s = s[lastSlash+1:]
 	}
 	return s
+}
+
+// ZoneToRegion maps a GCE zone name to a GCE region name, returning an error if it cannot be mapped
+func ZoneToRegion(zone string) (string, error) {
+	tokens := strings.Split(zone, "-")
+	if len(tokens) <= 2 {
+		return "", fmt.Errorf("invalid GCE Zone: %v", zone)
+	}
+	region := tokens[0] + "-" + tokens[1]
+	return region, nil
 }

--- a/upup/pkg/fi/cloudup/utils.go
+++ b/upup/pkg/fi/cloudup/utils.go
@@ -40,20 +40,13 @@ func BuildCloud(cluster *kops.Cluster) (fi.Cloud, error) {
 	switch kops.CloudProviderID(cluster.Spec.CloudProvider) {
 	case kops.CloudProviderGCE:
 		{
-			nodeZones := make(map[string]bool)
 			for _, subnet := range cluster.Spec.Subnets {
-				nodeZones[subnet.Zone] = true
-
-				tokens := strings.Split(subnet.Zone, "-")
-				if len(tokens) <= 2 {
-					return nil, fmt.Errorf("Invalid GCE Zone: %v", subnet.Zone)
+				if subnet.Region != "" {
+					region = subnet.Region
 				}
-				zoneRegion := tokens[0] + "-" + tokens[1]
-				if region != "" && zoneRegion != region {
-					return nil, fmt.Errorf("Clusters cannot span multiple regions (found zone %q, but region is %q)", subnet.Zone, region)
-				}
-
-				region = zoneRegion
+			}
+			if region == "" {
+				return nil, fmt.Errorf("on GCE, subnets must include Regions")
 			}
 
 			project = cluster.Spec.Project


### PR DESCRIPTION
The Zones field can specify zones where they are not specified on a
Subnet, for example on GCE where we have regional subnets.