### PR TITLE
AWS delete and find methods for instancegroups and rolling-updates

### DIFF
--- a/pkg/resources/digitalocean/cloud.go
+++ b/pkg/resources/digitalocean/cloud.go
@@ -21,8 +21,12 @@ import (
 	"os"
 
 	"github.com/digitalocean/godo"
+	"github.com/golang/glog"
 	"golang.org/x/oauth2"
 
+	"fmt"
+
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/resources/digitalocean/dns"
 	"k8s.io/kops/upup/pkg/fi"
@@ -74,6 +78,24 @@ func NewCloud(region string) (*Cloud, error) {
 		dns:    dns.NewProvider(client),
 		Region: region,
 	}, nil
+}
+
+// GetCloudGroups is not implemented yet, that needs to return the instances and groups that back a kops cluster.
+func (c *Cloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+	glog.V(8).Infof("digitalocean cloud provider GetCloudGroups not implemented yet")
+	return nil, fmt.Errorf("digital ocean cloud provider does not support getting cloud groups at this time.")
+}
+
+// DeleteGroup is not implemented yet, is a func that needs to delete a DO instance group.
+func (c *Cloud) DeleteGroup(name string, template string) error {
+	glog.V(8).Infof("digitalocean cloud provider DeleteGroup not implemented yet")
+	return fmt.Errorf("digital ocean cloud provider does not support deleting cloud groups at this time.")
+}
+
+// DeleteInstance is not implemented yet, is func needs to delete a DO instance.
+func (c *Cloud) DeleteInstance(id *string) error {
+	glog.V(8).Infof("digitalocean cloud provider DeleteInstance not implemented yet")
+	return fmt.Errorf("digital ocean cloud provider does not support deleting cloud instances at this time.")
 }
 
 // ProviderID returns the kops api identifier for DigitalOcean cloud provider

--- a/upup/pkg/fi/cloud.go
+++ b/upup/pkg/fi/cloud.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fi
 
 import (
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 )
@@ -28,6 +29,15 @@ type Cloud interface {
 
 	// FindVPCInfo looks up the specified VPC by id, returning info if found, otherwise (nil, nil)
 	FindVPCInfo(id string) (*VPCInfo, error)
+
+	// DeleteInstance deletes a cloud instance
+	DeleteInstance(id *string) error
+
+	// DeleteGroup delete a group of cloud instances
+	DeleteGroup(name string, template string) error
+
+	// GetCloudGroups returns a map of cloud instances that back a kops cluster
+	GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*CloudGroup, error)
 }
 
 type VPCInfo struct {
@@ -42,6 +52,24 @@ type SubnetInfo struct {
 	ID   string
 	Zone string
 	CIDR string
+}
+
+// CloudInstanceGroup is the cloud backing of InstanceGroup.
+type CloudGroup struct {
+	InstanceGroup     *kops.InstanceGroup
+	GroupName         string
+	GroupTemplateName string
+	Status            string
+	Ready             []*CloudGroupInstance
+	NeedUpdate        []*CloudGroupInstance
+	MinSize           int
+	MaxSize           int
+}
+
+// CloudInstanceGroupInstance describes an instance in an autoscaling group.
+type CloudGroupInstance struct {
+	ID   *string
+	Node *v1.Node
 }
 
 // zonesToCloud allows us to infer from certain well-known zones to a cloud

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/golang/glog"
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
@@ -71,6 +72,20 @@ type MockCloud struct {
 	MockCloudFormation *cloudformation.CloudFormation
 	MockEC2            ec2iface.EC2API
 	MockRoute53        route53iface.Route53API
+}
+
+func (c *MockAWSCloud) DeleteGroup(name string, template string) error {
+	// TODO implement
+	return nil
+}
+
+func (c *MockAWSCloud) DeleteInstance(id *string) error {
+	// TODO implement
+	return nil
+}
+
+func (c *MockAWSCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+	return nil, fmt.Errorf("not implemented yet")
 }
 
 func (c *MockCloud) ProviderID() kops.CloudProviderID {

--- a/upup/pkg/fi/cloudup/baremetal/cloud.go
+++ b/upup/pkg/fi/cloudup/baremetal/cloud.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
+
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"

--- a/upup/pkg/fi/cloudup/baremetal/cloud.go
+++ b/upup/pkg/fi/cloudup/baremetal/cloud.go
@@ -18,6 +18,9 @@ package baremetal
 
 import (
 	"fmt"
+
+	"github.com/golang/glog"
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
@@ -43,4 +46,25 @@ func (c *Cloud) DNS() (dnsprovider.Interface, error) {
 
 func (c *Cloud) FindVPCInfo(id string) (*fi.VPCInfo, error) {
 	return nil, fmt.Errorf("baremetal FindVPCInfo not supported")
+}
+
+// GetCloudGroups is not implemented yet, that needs to return the instances and groups that back a kops cluster.
+// Baremetal may not support this.
+func (c *Cloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+	glog.V(8).Infof("baremetal cloud GetCloudGroups not implemented yet")
+	return nil, fmt.Errorf("baremetal provider does not support getting cloud groups at this time.")
+}
+
+// DeleteGroup is not implemented yet, is a func that needs to delete a DO instance group.
+// Baremetal may not support this.
+func (c *Cloud) DeleteGroup(name string, template string) error {
+	glog.V(8).Infof("digitalocean cloud provider DeleteGroup not implemented yet")
+	return fmt.Errorf("digital ocean cloud provider does not support deleting cloud groups at this time.")
+}
+
+//DeleteInstance is not implemented yet, is func needs to delete a DO instance.
+//Baremetal may not support this.
+func (c *Cloud) DeleteInstance(id *string) error {
+	glog.V(8).Infof("baremetal cloud provider DeleteInstance not implemented yet")
+	return fmt.Errorf("baremetal cloud provider does not support deleting cloud instances at this time.")
 }

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -46,6 +46,10 @@ type GCECloud interface {
 	// FindClusterStatus gets the status of the cluster as it exists in GCE, inferred from volumes
 	FindClusterStatus(cluster *kops.Cluster) (*kops.ClusterStatus, error)
 
+	// FindInstanceTemplates finds all instance templates that are associated with the current cluster
+	// It matches them by looking for instance metadata with key='cluster-name' and value of our cluster name
+	FindInstanceTemplates(clusterName string) ([]*compute.InstanceTemplate, error)
+
 	Zones() ([]string, error)
 }
 
@@ -238,11 +242,8 @@ func (c *gceCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instanceg
 // FindInstanceTemplates finds all instance templates that are associated with the current cluster
 // It matches them by looking for instance metadata with key='cluster-name' and value of our cluster name
 func (c *gceCloudImplementation) FindInstanceTemplates(clusterName string) ([]*compute.InstanceTemplate, error) {
-
 	findClusterName := strings.TrimSpace(clusterName)
-
 	var matches []*compute.InstanceTemplate
-
 	ctx := context.Background()
 
 	err := c.Compute().InstanceTemplates.List(c.Project()).Pages(ctx, func(page *compute.InstanceTemplateList) error {

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -18,11 +18,14 @@ package gce
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/storage/v1"
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
@@ -42,6 +45,8 @@ type GCECloud interface {
 
 	// FindClusterStatus gets the status of the cluster as it exists in GCE, inferred from volumes
 	FindClusterStatus(cluster *kops.Cluster) (*kops.ClusterStatus, error)
+
+	Zones() ([]string, error)
 }
 
 type gceCloudImplementation struct {
@@ -149,6 +154,36 @@ func (c *gceCloudImplementation) Labels() map[string]string {
 	return tags
 }
 
+// TODO refactor this out of resources
+// this is needed for delete groups and other new methods
+
+// Zones returns the zones in a region
+func (c *gceCloudImplementation) Zones() ([]string, error) {
+
+	var zones []string
+	// TODO: Only zones in api.Cluster object, if we have one?
+	gceZones, err := c.Compute().Zones.List(c.Project()).Do()
+	if err != nil {
+		return nil, fmt.Errorf("error listing zones: %v", err)
+	}
+	for _, gceZone := range gceZones.Items {
+		u, err := ParseGoogleCloudURL(gceZone.Region)
+		if err != nil {
+			return nil, err
+		}
+		if u.Name != c.Region() {
+			continue
+		}
+		zones = append(zones, gceZone.Name)
+	}
+	if len(zones) == 0 {
+		return nil, fmt.Errorf("unable to determine zones in region %q", c.Region())
+	}
+
+	glog.Infof("Scanning zones: %v", zones)
+	return zones, nil
+}
+
 func (c *gceCloudImplementation) WaitForOp(op *compute.Operation) error {
 	return WaitForOp(c.compute, op)
 }
@@ -180,4 +215,61 @@ func (c *gceCloudImplementation) GetApiIngressStatus(cluster *kops.Cluster) ([]k
 	}
 
 	return ingresses, nil
+}
+
+// DeleteGroup deletes a cloud of instances controlled by an Instance Group Manager
+func (c *gceCloudImplementation) DeleteGroup(name string, template string) error {
+	glog.V(8).Infof("gce cloud provider DeleteGroup not implemented yet")
+	return fmt.Errorf("gce cloud provider does not support deleting cloud groups at this time.")
+}
+
+// DeleteInstance deletes a GCE instance
+func (c *gceCloudImplementation) DeleteInstance(id *string) error {
+	glog.V(8).Infof("gce cloud provider DeleteInstance not implemented yet")
+	return fmt.Errorf("gce cloud provider does not support deleting cloud instances at this time.")
+}
+
+// GetCloudGroups returns a map of CloudGroup that backs a list of instance groups
+func (c *gceCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+	glog.V(8).Infof("gce cloud provider GetCloudGroups not implemented yet")
+	return nil, fmt.Errorf("gce cloud provider does not support getting cloud groups at this time.")
+}
+
+// FindInstanceTemplates finds all instance templates that are associated with the current cluster
+// It matches them by looking for instance metadata with key='cluster-name' and value of our cluster name
+func (c *gceCloudImplementation) FindInstanceTemplates(clusterName string) ([]*compute.InstanceTemplate, error) {
+
+	findClusterName := strings.TrimSpace(clusterName)
+
+	var matches []*compute.InstanceTemplate
+
+	ctx := context.Background()
+
+	err := c.Compute().InstanceTemplates.List(c.Project()).Pages(ctx, func(page *compute.InstanceTemplateList) error {
+		for _, t := range page.Items {
+			match := false
+			for _, item := range t.Properties.Metadata.Items {
+				if item.Key == "cluster-name" {
+					if strings.TrimSpace(item.Value) == findClusterName {
+						match = true
+					} else {
+						match = false
+						break
+					}
+				}
+			}
+
+			if !match {
+				continue
+			}
+
+			matches = append(matches, t)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error listing instance groups: %v", err)
+	}
+
+	return matches, nil
 }

--- a/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
@@ -18,6 +18,7 @@ package gce
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	compute "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/storage/v1"
@@ -50,22 +51,29 @@ func buildMockGCECloud(region string, project string) *mockGCECloud {
 	return i
 }
 
+// FindInstanceTemplates finds all instance templates that are associated with the current cluster
+// It matches them by looking for instance metadata with key='cluster-name' and value of our cluster name
+func (c *mockGCECloud) FindInstanceTemplates(clusterName string) ([]*compute.InstanceTemplate, error) {
+	glog.V(8).Infof("mockGCECloud cloud provider FindInstanceTemplates not implemented yet")
+	return nil, fmt.Errorf("mockGCECloud cloud provider does not support finding instance templates at this time")
+}
+
 // GetCloudGroups is not implemented yet
 func (c *mockGCECloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
 	glog.V(8).Infof("mockGCECloud cloud provider GetCloudGroups not implemented yet")
-	return nil, fmt.Errorf("mockGCECloud cloud provider does not support getting cloud groups at this time.")
+	return nil, fmt.Errorf("mockGCECloud cloud provider does not support getting cloud groups at this time")
 }
 
 // DeleteGroup is not implemented yet
 func (c *mockGCECloud) DeleteGroup(name string, template string) error {
 	glog.V(8).Infof("mockGCECloud cloud provider DeleteGroup not implemented yet")
-	return fmt.Errorf("mockGCECloud cloud provider does not support deleting cloud groups at this time.")
+	return fmt.Errorf("mockGCECloud cloud provider does not support deleting cloud groups at this time")
 }
 
 // DeleteInstance is not implemented yet
 func (c *mockGCECloud) DeleteInstance(id *string) error {
 	glog.V(8).Infof("mockGCECloud cloud provider DeleteInstance not implemented yet")
-	return fmt.Errorf("mockGCECloud cloud provider does not support deleting cloud instances at this time.")
+	return fmt.Errorf("mockGCECloud cloud provider does not support deleting cloud instances at this time")
 }
 
 // Zones is not implemented yet

--- a/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/glog"
 	compute "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/storage/v1"
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
@@ -47,6 +48,29 @@ func InstallMockGCECloud(region string, project string) *mockGCECloud {
 func buildMockGCECloud(region string, project string) *mockGCECloud {
 	i := &mockGCECloud{region: region, project: project}
 	return i
+}
+
+// GetCloudGroups is not implemented yet
+func (c *mockGCECloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+	glog.V(8).Infof("mockGCECloud cloud provider GetCloudGroups not implemented yet")
+	return nil, fmt.Errorf("mockGCECloud cloud provider does not support getting cloud groups at this time.")
+}
+
+// DeleteGroup is not implemented yet
+func (c *mockGCECloud) DeleteGroup(name string, template string) error {
+	glog.V(8).Infof("mockGCECloud cloud provider DeleteGroup not implemented yet")
+	return fmt.Errorf("mockGCECloud cloud provider does not support deleting cloud groups at this time.")
+}
+
+// DeleteInstance is not implemented yet
+func (c *mockGCECloud) DeleteInstance(id *string) error {
+	glog.V(8).Infof("mockGCECloud cloud provider DeleteInstance not implemented yet")
+	return fmt.Errorf("mockGCECloud cloud provider does not support deleting cloud instances at this time.")
+}
+
+// Zones is not implemented yet
+func (c *mockGCECloud) Zones() ([]string, error) {
+	return nil, fmt.Errorf("not yet implented")
 }
 
 // mockGCECloud returns a copy of the mockGCECloud bound to the specified labels

--- a/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
+++ b/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
@@ -101,6 +102,24 @@ func NewVSphereCloud(spec *kops.ClusterSpec) (*VSphereCloud, error) {
 	spec.CloudConfig.VSpherePassword = fi.String(password)
 	glog.V(2).Infof("Created vSphere Cloud successfully: %+v", vsphereCloud)
 	return vsphereCloud, nil
+}
+
+// GetCloudGroups is not implemented yet, that needs to return the instances and groups that back a kops cluster.
+func (c *VSphereCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+	glog.V(8).Infof("vSphere cloud provider GetCloudGroups not implemented yet")
+	return nil, fmt.Errorf("vSphere cloud provider does not support getting cloud groups at this time.")
+}
+
+// DeleteGroup is not implemented yet, is a func that needs to delete a vSphere instance group.
+func (c *VSphereCloud) DeleteGroup(name string, template string) error {
+	glog.V(8).Infof("vSphere cloud provider DeleteGroup not implemented yet")
+	return fmt.Errorf("vSphere cloud provider does not support deleting cloud groups at this time.")
+}
+
+// DeleteInstance is not implemented yet, is func needs to delete a vSphereCloud instance.
+func (c *VSphereCloud) DeleteInstance(id *string) error {
+	glog.V(8).Infof("vSphere cloud provider DeleteInstance not implemented yet")
+	return fmt.Errorf("vSphere cloud provider does not support deleting cloud instances at this time.")
 }
 
 // DNS returns dnsprovider interface for this vSphere cloud.


### PR DESCRIPTION
This builds on https://github.com/kubernetes/kops/pull/3442

This in includes the implementation of 

1. GetCloudGroups - not wired in yet
2. DeleteGroup - wired in and using
3. DeleteInstance - wired in and using

Still, need a lot more refactoring of instancegroups.go to use GetCloudGroups.  Only review https://github.com/kubernetes/kops/commit/564b6bc237c7ec3fae5d9fd67c75346019a20427 please.

TODO

- [x] code comments
- [x] testing