### PR TITLE
bump channels dashboard to 1.6.3

### DIFF
--- a/addons/kubernetes-dashboard/addon.yaml
+++ b/addons/kubernetes-dashboard/addon.yaml
@@ -23,3 +23,7 @@ spec:
     selector:
       k8s-addon: kubernetes-dashboard.addons.k8s.io
     manifest: v1.6.1.yaml 
+  - version: 1.6.3
+    selector:
+      k8s-addon: kubernetes-dashboard.addons.k8s.io
+    manifest: v1.6.3.yaml


### PR DESCRIPTION
Add the latest dashboard version to the `addon.yaml` used by the `channels` tool