### PR TITLE
Refactoring to use cloud method for getting cloud groups

### DIFF
--- a/cmd/kops/delete_instancegroup.go
+++ b/cmd/kops/delete_instancegroup.go
@@ -109,7 +109,11 @@ func NewCmdDeleteInstanceGroup(f *util.Factory, out io.Writer) *cobra.Command {
 	return cmd
 }
 
+// RunDeleteInstanceGroup runs the deletion of an instance group
 func RunDeleteInstanceGroup(f *util.Factory, out io.Writer, options *DeleteInstanceGroupOptions) error {
+
+	// TODO make this drain and validate the ig?
+	// TODO implement drain and validate logic
 	groupName := options.GroupName
 	if groupName == "" {
 		return fmt.Errorf("GroupName is required")

--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kops/cmd/kops/util"
 	api "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/instancegroups"
 	"k8s.io/kops/pkg/pretty"
@@ -274,32 +275,32 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 		return err
 	}
 
-	groups, err := instancegroups.FindCloudInstanceGroups(cloud, cluster, instanceGroups, warnUnmatched, nodes)
+	groups, err := cloud.GetCloudGroups(cluster, instanceGroups, warnUnmatched, nodes)
 	if err != nil {
 		return err
 	}
 
 	{
 		t := &tables.Table{}
-		t.AddColumn("NAME", func(r *instancegroups.CloudInstanceGroup) string {
+		t.AddColumn("NAME", func(r *cloudinstances.CloudInstanceGroup) string {
 			return r.InstanceGroup.ObjectMeta.Name
 		})
-		t.AddColumn("STATUS", func(r *instancegroups.CloudInstanceGroup) string {
+		t.AddColumn("STATUS", func(r *cloudinstances.CloudInstanceGroup) string {
 			return r.Status
 		})
-		t.AddColumn("NEEDUPDATE", func(r *instancegroups.CloudInstanceGroup) string {
+		t.AddColumn("NEEDUPDATE", func(r *cloudinstances.CloudInstanceGroup) string {
 			return strconv.Itoa(len(r.NeedUpdate))
 		})
-		t.AddColumn("READY", func(r *instancegroups.CloudInstanceGroup) string {
+		t.AddColumn("READY", func(r *cloudinstances.CloudInstanceGroup) string {
 			return strconv.Itoa(len(r.Ready))
 		})
-		t.AddColumn("MIN", func(r *instancegroups.CloudInstanceGroup) string {
-			return strconv.Itoa(r.MinSize())
+		t.AddColumn("MIN", func(r *cloudinstances.CloudInstanceGroup) string {
+			return strconv.Itoa(r.MinSize)
 		})
-		t.AddColumn("MAX", func(r *instancegroups.CloudInstanceGroup) string {
-			return strconv.Itoa(r.MaxSize())
+		t.AddColumn("MAX", func(r *cloudinstances.CloudInstanceGroup) string {
+			return strconv.Itoa(r.MaxSize)
 		})
-		t.AddColumn("NODES", func(r *instancegroups.CloudInstanceGroup) string {
+		t.AddColumn("NODES", func(r *cloudinstances.CloudInstanceGroup) string {
 			var nodes []*v1.Node
 			for _, i := range r.Ready {
 				if i.Node != nil {
@@ -313,7 +314,7 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 			}
 			return strconv.Itoa(len(nodes))
 		})
-		var l []*instancegroups.CloudInstanceGroup
+		var l []*cloudinstances.CloudInstanceGroup
 		for _, v := range groups {
 			l = append(l, v)
 		}

--- a/hack/.packages
+++ b/hack/.packages
@@ -56,6 +56,7 @@ k8s.io/kops/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha2
 k8s.io/kops/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha2/fake
 k8s.io/kops/pkg/client/simple
 k8s.io/kops/pkg/client/simple/vfsclientset
+k8s.io/kops/pkg/cloudinstances
 k8s.io/kops/pkg/diff
 k8s.io/kops/pkg/dns
 k8s.io/kops/pkg/edit

--- a/pkg/cloudinstances/cloud_instance_group.go
+++ b/pkg/cloudinstances/cloud_instance_group.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudinstances
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"k8s.io/client-go/pkg/api/v1"
+	api "k8s.io/kops/pkg/apis/kops"
+)
+
+// CloudInstanceGroup is the cloud backing of InstanceGroup.
+type CloudInstanceGroup struct {
+	InstanceGroup     *api.InstanceGroup
+	GroupName         string
+	GroupTemplateName string
+	Status            string
+	Ready             []*CloudInstanceMember
+	NeedUpdate        []*CloudInstanceMember
+	MinSize           int
+	MaxSize           int
+}
+
+// CloudInstanceGroupInstance describes an instances in a CloudInstanceGroup group.
+type CloudInstanceMember struct {
+	ID   *string
+	Node *v1.Node
+}
+
+// NewCloudInstanceGroup creates a CloudInstanceGroup and validates its initial values.
+func NewCloudInstanceGroup(groupName string, groupTemplateName string, ig *api.InstanceGroup, minSize int, maxSize int) (*CloudInstanceGroup, error) {
+	if groupName == "" {
+		return nil, fmt.Errorf("group name for cloud instance group must be set")
+	}
+	if groupTemplateName == "" {
+		return nil, fmt.Errorf("group template name for cloud instance group must be set")
+	}
+	if ig == nil {
+		return nil, fmt.Errorf("kops instance group for cloud instance group must be set")
+	}
+
+	if minSize < 0 {
+		return nil, fmt.Errorf("cloud instance group min size must be zero or greater")
+	}
+	if maxSize < 0 {
+		return nil, fmt.Errorf("cloud instance group max size must be zero or greater")
+	}
+
+	cg := &CloudInstanceGroup{
+		GroupName:         groupName,
+		GroupTemplateName: groupTemplateName,
+		InstanceGroup:     ig,
+		MinSize:           minSize,
+		MaxSize:           maxSize,
+	}
+
+	return cg, nil
+}
+
+// NewCloudInstanceMember creates a new CloudInstanceGroupMember
+func (c *CloudInstanceGroup) NewCloudInstanceMember(instanceId *string, newGroupName string, currentGroupName string, nodeMap map[string]*v1.Node) error {
+	if instanceId == nil {
+		return fmt.Errorf("instance id for cloud instance member cannot be nil")
+	}
+	cm := &CloudInstanceMember{
+		ID: instanceId,
+	}
+	id := *instanceId
+	node := nodeMap[id]
+	if node != nil {
+		cm.Node = node
+	} else {
+		glog.V(8).Infof("unable to find node for instance: %s", id)
+	}
+
+	if newGroupName == currentGroupName {
+		c.Ready = append(c.Ready, cm)
+	} else {
+		c.NeedUpdate = append(c.NeedUpdate, cm)
+	}
+
+	return nil
+}
+
+// MarkIsReady sets the CloudInstanceGroup status for Ready or NeedsUpdate
+func (c *CloudInstanceGroup) MarkIsReady() {
+	if len(c.NeedUpdate) == 0 {
+		c.Status = "Ready"
+	} else {
+		c.Status = "NeedsUpdate"
+	}
+}
+
+// GetNodeMap returns a list of nodes keyed by there external id
+func GetNodeMap(nodes []v1.Node) map[string]*v1.Node {
+	nodeMap := make(map[string]*v1.Node)
+	for i := range nodes {
+		node := &nodes[i]
+		nodeMap[node.Spec.ExternalID] = node
+	}
+
+	return nodeMap
+}
+
+// GetInstanceGroup filters a list of instancegroups for recognized cloud groups
+func GetInstanceGroup(name string, clusterName string, instancegroups []*api.InstanceGroup) (*api.InstanceGroup, error) {
+	var instancegroup *api.InstanceGroup
+	for _, g := range instancegroups {
+		var groupName string
+		switch g.Spec.Role {
+		case api.InstanceGroupRoleMaster:
+			groupName = g.ObjectMeta.Name + ".masters." + clusterName
+		case api.InstanceGroupRoleNode:
+			groupName = g.ObjectMeta.Name + "." + clusterName
+		case api.InstanceGroupRoleBastion:
+			groupName = g.ObjectMeta.Name + "." + clusterName
+		default:
+			glog.Warningf("Ignoring InstanceGroup of unknown role %q", g.Spec.Role)
+			continue
+		}
+
+		if name == groupName {
+			if instancegroup != nil {
+				return nil, fmt.Errorf("found multiple instance groups matching ASG %q", groupName)
+			}
+			instancegroup = g
+		}
+	}
+
+	return instancegroup, nil
+}

--- a/pkg/instancegroups/delete.go
+++ b/pkg/instancegroups/delete.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancegroups
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	api "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/client/simple"
+	"k8s.io/kops/upup/pkg/fi"
+)
+
+// DeleteInstanceGroup removes the cloud resources for an InstanceGroup
+type DeleteInstanceGroup struct {
+	Cluster   *api.Cluster
+	Cloud     fi.Cloud
+	Clientset simple.Clientset
+}
+
+func (c *DeleteInstanceGroup) DeleteInstanceGroup(group *api.InstanceGroup) error {
+	groups, err := FindCloudInstanceGroups(c.Cloud, c.Cluster, []*api.InstanceGroup{group}, false, nil)
+	if err != nil {
+		return fmt.Errorf("error finding CloudInstanceGroups: %v", err)
+	}
+	cig := groups[group.ObjectMeta.Name]
+	if cig == nil {
+		glog.Warningf("AutoScalingGroup %q not found in cloud - skipping delete", group.ObjectMeta.Name)
+	} else {
+		if len(groups) != 1 {
+			return fmt.Errorf("Multiple InstanceGroup resources found in cloud")
+		}
+
+		glog.Infof("Deleting AutoScalingGroup %q", group.ObjectMeta.Name)
+
+		err = cig.Delete(c.Cloud)
+		if err != nil {
+			return fmt.Errorf("error deleting cloud resources for InstanceGroup: %v", err)
+		}
+	}
+
+	err = c.Clientset.InstanceGroupsFor(c.Cluster).Delete(group.ObjectMeta.Name, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -94,41 +94,7 @@ func FindCloudInstanceGroups(cloud fi.Cloud, cluster *api.Cluster, instancegroup
 	return groups, nil
 }
 
-// DeleteInstanceGroup removes the cloud resources for an InstanceGroup
-type DeleteInstanceGroup struct {
-	Cluster   *api.Cluster
-	Cloud     fi.Cloud
-	Clientset simple.Clientset
-}
 
-func (c *DeleteInstanceGroup) DeleteInstanceGroup(group *api.InstanceGroup) error {
-	groups, err := FindCloudInstanceGroups(c.Cloud, c.Cluster, []*api.InstanceGroup{group}, false, nil)
-	if err != nil {
-		return fmt.Errorf("error finding CloudInstanceGroups: %v", err)
-	}
-	cig := groups[group.ObjectMeta.Name]
-	if cig == nil {
-		glog.Warningf("AutoScalingGroup %q not found in cloud - skipping delete", group.ObjectMeta.Name)
-	} else {
-		if len(groups) != 1 {
-			return fmt.Errorf("Multiple InstanceGroup resources found in cloud")
-		}
-
-		glog.Infof("Deleting AutoScalingGroup %q", group.ObjectMeta.Name)
-
-		err = cig.Delete(c.Cloud)
-		if err != nil {
-			return fmt.Errorf("error deleting cloud resources for InstanceGroup: %v", err)
-		}
-	}
-
-	err = c.Clientset.InstanceGroupsFor(c.Cluster).Delete(group.ObjectMeta.Name, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
 
 // CloudInstanceGroup is the AWS ASG backing an InstanceGroup.
 type CloudInstanceGroup struct {

--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	api "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kops/upup/pkg/fi"
 )
 
@@ -48,7 +49,7 @@ type RollingUpdateCluster struct {
 }
 
 // RollingUpdate performs a rolling update on a K8s Cluster.
-func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*CloudInstanceGroup, instanceGroups *api.InstanceGroupList) error {
+func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*cloudinstances.CloudInstanceGroup, instanceGroups *api.InstanceGroupList) error {
 	if len(groups) == 0 {
 		glog.Infof("Cloud Instance Group length is zero. Not doing a rolling-update.")
 		return nil
@@ -57,9 +58,9 @@ func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*CloudInstanceGro
 	var resultsMutex sync.Mutex
 	results := make(map[string]error)
 
-	masterGroups := make(map[string]*CloudInstanceGroup)
-	nodeGroups := make(map[string]*CloudInstanceGroup)
-	bastionGroups := make(map[string]*CloudInstanceGroup)
+	masterGroups := make(map[string]*cloudinstances.CloudInstanceGroup)
+	nodeGroups := make(map[string]*cloudinstances.CloudInstanceGroup)
+	bastionGroups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	for k, group := range groups {
 		switch group.InstanceGroup.Spec.Role {
 		case api.InstanceGroupRoleNode:
@@ -79,14 +80,17 @@ func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*CloudInstanceGro
 
 		for k, bastionGroup := range bastionGroups {
 			wg.Add(1)
-			go func(k string, group *CloudInstanceGroup) {
+			go func(k string, group *cloudinstances.CloudInstanceGroup) {
 				resultsMutex.Lock()
 				results[k] = fmt.Errorf("function panic bastions")
 				resultsMutex.Unlock()
 
 				defer wg.Done()
 
-				err := group.RollingUpdate(c, instanceGroups, true, c.BastionInterval)
+				g, err := NewRollingUpdateInstanceGroup(c.Cloud, group)
+				if err == nil {
+					err = g.RollingUpdate(c, instanceGroups, true, c.BastionInterval)
+				}
 
 				resultsMutex.Lock()
 				results[k] = err
@@ -116,7 +120,10 @@ func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*CloudInstanceGro
 			defer wg.Done()
 
 			for k, group := range masterGroups {
-				err := group.RollingUpdate(c, instanceGroups, false, c.MasterInterval)
+				g, err := NewRollingUpdateInstanceGroup(c.Cloud, group)
+				if err == nil {
+					err = g.RollingUpdate(c, instanceGroups, false, c.MasterInterval)
+				}
 
 				resultsMutex.Lock()
 				results[k] = err
@@ -151,7 +158,10 @@ func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*CloudInstanceGro
 			defer wg.Done()
 
 			for k, group := range nodeGroups {
-				err := group.RollingUpdate(c, instanceGroups, false, c.NodeInterval)
+				g, err := NewRollingUpdateInstanceGroup(c.Cloud, group)
+				if err == nil {
+					err = g.RollingUpdate(c, instanceGroups, false, c.NodeInterval)
+				}
 
 				resultsMutex.Lock()
 				results[k] = err

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/cloudmock/aws/mockautoscaling"
 	kopsapi "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 )
 
@@ -97,10 +98,10 @@ func TestRollingUpdateAllNeedUpdate(t *testing.T) {
 	setUpCloud(c)
 
 	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
-	groups := make(map[string]*CloudInstanceGroup)
-	groups["node-1"] = &CloudInstanceGroup{
-		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[0].AutoScalingGroupName),
-		asg:     asgGroups.AutoScalingGroups[0],
+	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
+	groups["node-1"] = &cloudinstances.CloudInstanceGroup{
+		GroupName:         aws.StringValue(asgGroups.AutoScalingGroups[0].AutoScalingGroupName),
+		GroupTemplateName: aws.StringValue(asgGroups.AutoScalingGroups[0].LaunchConfigurationName),
 		InstanceGroup: &kopsapi.InstanceGroup{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name: "node-1",
@@ -109,39 +110,31 @@ func TestRollingUpdateAllNeedUpdate(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleNode,
 			},
 		},
-		Ready: []*CloudInstanceGroupInstance{
+		Ready: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-1a"),
-				},
+				ID:   aws.String("node-1a"),
 				Node: &v1.Node{},
 			},
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-1b"),
-				},
+				ID:   aws.String("node-1b"),
 				Node: &v1.Node{},
 			},
 		},
-		NeedUpdate: []*CloudInstanceGroupInstance{
+		NeedUpdate: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-1a"),
-				},
+				ID:   aws.String("node-1a"),
 				Node: &v1.Node{},
 			},
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-1b"),
-				},
+				ID:   aws.String("node-1b"),
 				Node: &v1.Node{},
 			},
 		},
 	}
 
-	groups["node-2"] = &CloudInstanceGroup{
-		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[1].AutoScalingGroupName),
-		asg:     asgGroups.AutoScalingGroups[1],
+	groups["node-2"] = &cloudinstances.CloudInstanceGroup{
+		GroupName:         aws.StringValue(asgGroups.AutoScalingGroups[1].AutoScalingGroupName),
+		GroupTemplateName: aws.StringValue(asgGroups.AutoScalingGroups[1].LaunchConfigurationName),
 		InstanceGroup: &kopsapi.InstanceGroup{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name: "node-2",
@@ -150,39 +143,31 @@ func TestRollingUpdateAllNeedUpdate(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleNode,
 			},
 		},
-		Ready: []*CloudInstanceGroupInstance{
+		Ready: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-2a"),
-				},
+				ID:   aws.String("node-2a"),
 				Node: &v1.Node{},
 			},
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-2b"),
-				},
+				ID:   aws.String("node-2b"),
 				Node: &v1.Node{},
 			},
 		},
-		NeedUpdate: []*CloudInstanceGroupInstance{
+		NeedUpdate: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-2a"),
-				},
+				ID:   aws.String("node-2a"),
 				Node: &v1.Node{},
 			},
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-2b"),
-				},
+				ID:   aws.String("node-2b"),
 				Node: &v1.Node{},
 			},
 		},
 	}
 
-	groups["master-1"] = &CloudInstanceGroup{
-		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[2].AutoScalingGroupName),
-		asg:     asgGroups.AutoScalingGroups[2],
+	groups["master-1"] = &cloudinstances.CloudInstanceGroup{
+		GroupName:         aws.StringValue(asgGroups.AutoScalingGroups[2].AutoScalingGroupName),
+		GroupTemplateName: aws.StringValue(asgGroups.AutoScalingGroups[2].LaunchConfigurationName),
 		InstanceGroup: &kopsapi.InstanceGroup{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name: "master-1",
@@ -191,27 +176,23 @@ func TestRollingUpdateAllNeedUpdate(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleMaster,
 			},
 		},
-		Ready: []*CloudInstanceGroupInstance{
+		Ready: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("master-1a"),
-				},
+				ID:   aws.String("master-1a"),
 				Node: &v1.Node{},
 			},
 		},
-		NeedUpdate: []*CloudInstanceGroupInstance{
+		NeedUpdate: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("master-1a"),
-				},
+				ID:   aws.String("master-1a"),
 				Node: &v1.Node{},
 			},
 		},
 	}
 
-	groups["bastion-1"] = &CloudInstanceGroup{
-		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[3].AutoScalingGroupName),
-		asg:     asgGroups.AutoScalingGroups[3],
+	groups["bastion-1"] = &cloudinstances.CloudInstanceGroup{
+		GroupName:         aws.StringValue(asgGroups.AutoScalingGroups[3].AutoScalingGroupName),
+		GroupTemplateName: aws.StringValue(asgGroups.AutoScalingGroups[3].LaunchConfigurationName),
 		InstanceGroup: &kopsapi.InstanceGroup{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name: "bastion-1",
@@ -220,19 +201,15 @@ func TestRollingUpdateAllNeedUpdate(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleBastion,
 			},
 		},
-		Ready: []*CloudInstanceGroupInstance{
+		Ready: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("bastion-1a"),
-				},
+				ID:   aws.String("bastion-1a"),
 				Node: &v1.Node{},
 			},
 		},
-		NeedUpdate: []*CloudInstanceGroupInstance{
+		NeedUpdate: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("bastion-1a"),
-				},
+				ID:   aws.String("bastion-1a"),
 				Node: &v1.Node{},
 			},
 		},
@@ -271,10 +248,10 @@ func TestRollingUpdateNoneNeedUpdate(t *testing.T) {
 
 	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
 
-	groups := make(map[string]*CloudInstanceGroup)
-	groups["node-1"] = &CloudInstanceGroup{
-		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[0].AutoScalingGroupName),
-		asg:     asgGroups.AutoScalingGroups[0],
+	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
+	groups["node-1"] = &cloudinstances.CloudInstanceGroup{
+		GroupName:         aws.StringValue(asgGroups.AutoScalingGroups[0].AutoScalingGroupName),
+		GroupTemplateName: aws.StringValue(asgGroups.AutoScalingGroups[0].LaunchConfigurationName),
 		InstanceGroup: &kopsapi.InstanceGroup{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name: "node-1",
@@ -283,25 +260,21 @@ func TestRollingUpdateNoneNeedUpdate(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleNode,
 			},
 		},
-		Ready: []*CloudInstanceGroupInstance{
+		Ready: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-1a"),
-				},
+				ID:   aws.String("node-1a"),
 				Node: &v1.Node{},
 			},
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-1b"),
-				},
+				ID:   aws.String("node-1b"),
 				Node: &v1.Node{},
 			},
 		},
 	}
 
-	groups["node-2"] = &CloudInstanceGroup{
-		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[1].AutoScalingGroupName),
-		asg:     asgGroups.AutoScalingGroups[1],
+	groups["node-2"] = &cloudinstances.CloudInstanceGroup{
+		GroupName:         aws.StringValue(asgGroups.AutoScalingGroups[1].AutoScalingGroupName),
+		GroupTemplateName: aws.StringValue(asgGroups.AutoScalingGroups[1].LaunchConfigurationName),
 		InstanceGroup: &kopsapi.InstanceGroup{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name: "node-2",
@@ -310,25 +283,21 @@ func TestRollingUpdateNoneNeedUpdate(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleNode,
 			},
 		},
-		Ready: []*CloudInstanceGroupInstance{
+		Ready: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-2a"),
-				},
+				ID:   aws.String("node-2a"),
 				Node: &v1.Node{},
 			},
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-2b"),
-				},
+				ID:   aws.String("node-2b"),
 				Node: &v1.Node{},
 			},
 		},
 	}
 
-	groups["master-1"] = &CloudInstanceGroup{
-		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[2].AutoScalingGroupName),
-		asg:     asgGroups.AutoScalingGroups[2],
+	groups["master-1"] = &cloudinstances.CloudInstanceGroup{
+		GroupName:         aws.StringValue(asgGroups.AutoScalingGroups[2].AutoScalingGroupName),
+		GroupTemplateName: aws.StringValue(asgGroups.AutoScalingGroups[2].LaunchConfigurationName),
 		InstanceGroup: &kopsapi.InstanceGroup{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name: "master-1",
@@ -337,19 +306,17 @@ func TestRollingUpdateNoneNeedUpdate(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleMaster,
 			},
 		},
-		Ready: []*CloudInstanceGroupInstance{
+		Ready: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("master-1a"),
-				},
+				ID:   aws.String("master-1a"),
 				Node: &v1.Node{},
 			},
 		},
 	}
 
-	groups["bastion-1"] = &CloudInstanceGroup{
-		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[3].AutoScalingGroupName),
-		asg:     asgGroups.AutoScalingGroups[3],
+	groups["bastion-1"] = &cloudinstances.CloudInstanceGroup{
+		GroupName:         aws.StringValue(asgGroups.AutoScalingGroups[3].AutoScalingGroupName),
+		GroupTemplateName: aws.StringValue(asgGroups.AutoScalingGroups[3].LaunchConfigurationName),
 		InstanceGroup: &kopsapi.InstanceGroup{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name: "bastion-1",
@@ -358,11 +325,9 @@ func TestRollingUpdateNoneNeedUpdate(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleBastion,
 			},
 		},
-		Ready: []*CloudInstanceGroupInstance{
+		Ready: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("bastion-1a"),
-				},
+				ID:   aws.String("bastion-1a"),
 				Node: &v1.Node{},
 			},
 		},
@@ -429,10 +394,10 @@ func TestRollingUpdateNoneNeedUpdateWithForce(t *testing.T) {
 
 	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
 
-	groups := make(map[string]*CloudInstanceGroup)
-	groups["node-1"] = &CloudInstanceGroup{
-		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[0].AutoScalingGroupName),
-		asg:     asgGroups.AutoScalingGroups[0],
+	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
+	groups["node-1"] = &cloudinstances.CloudInstanceGroup{
+		GroupName:         aws.StringValue(asgGroups.AutoScalingGroups[0].AutoScalingGroupName),
+		GroupTemplateName: aws.StringValue(asgGroups.AutoScalingGroups[0].LaunchConfigurationName),
 		InstanceGroup: &kopsapi.InstanceGroup{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name: "node-1",
@@ -441,25 +406,21 @@ func TestRollingUpdateNoneNeedUpdateWithForce(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleNode,
 			},
 		},
-		Ready: []*CloudInstanceGroupInstance{
+		Ready: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-1a"),
-				},
+				ID:   aws.String("node-1a"),
 				Node: &v1.Node{},
 			},
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-1b"),
-				},
+				ID:   aws.String("node-1b"),
 				Node: &v1.Node{},
 			},
 		},
 	}
 
-	groups["node-2"] = &CloudInstanceGroup{
-		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[1].AutoScalingGroupName),
-		asg:     asgGroups.AutoScalingGroups[1],
+	groups["node-2"] = &cloudinstances.CloudInstanceGroup{
+		GroupName:         aws.StringValue(asgGroups.AutoScalingGroups[1].AutoScalingGroupName),
+		GroupTemplateName: aws.StringValue(asgGroups.AutoScalingGroups[1].LaunchConfigurationName),
 		InstanceGroup: &kopsapi.InstanceGroup{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name: "node-2",
@@ -468,25 +429,21 @@ func TestRollingUpdateNoneNeedUpdateWithForce(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleNode,
 			},
 		},
-		Ready: []*CloudInstanceGroupInstance{
+		Ready: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-2a"),
-				},
+				ID:   aws.String("node-2a"),
 				Node: &v1.Node{},
 			},
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-2b"),
-				},
+				ID:   aws.String("node-2b"),
 				Node: &v1.Node{},
 			},
 		},
 	}
 
-	groups["master-1"] = &CloudInstanceGroup{
-		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[2].AutoScalingGroupName),
-		asg:     asgGroups.AutoScalingGroups[2],
+	groups["master-1"] = &cloudinstances.CloudInstanceGroup{
+		GroupName:         aws.StringValue(asgGroups.AutoScalingGroups[2].AutoScalingGroupName),
+		GroupTemplateName: aws.StringValue(asgGroups.AutoScalingGroups[2].LaunchConfigurationName),
 		InstanceGroup: &kopsapi.InstanceGroup{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name: "master-1",
@@ -495,19 +452,17 @@ func TestRollingUpdateNoneNeedUpdateWithForce(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleMaster,
 			},
 		},
-		Ready: []*CloudInstanceGroupInstance{
+		Ready: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("master-1a"),
-				},
+				ID:   aws.String("master-1a"),
 				Node: &v1.Node{},
 			},
 		},
 	}
 
-	groups["bastion-1"] = &CloudInstanceGroup{
-		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[3].AutoScalingGroupName),
-		asg:     asgGroups.AutoScalingGroups[3],
+	groups["bastion-1"] = &cloudinstances.CloudInstanceGroup{
+		GroupName:         aws.StringValue(asgGroups.AutoScalingGroups[3].AutoScalingGroupName),
+		GroupTemplateName: aws.StringValue(asgGroups.AutoScalingGroups[3].LaunchConfigurationName),
 		InstanceGroup: &kopsapi.InstanceGroup{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name: "bastion-1",
@@ -516,11 +471,9 @@ func TestRollingUpdateNoneNeedUpdateWithForce(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleBastion,
 			},
 		},
-		Ready: []*CloudInstanceGroupInstance{
+		Ready: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("bastion-1a"),
-				},
+				ID:   aws.String("bastion-1a"),
 				Node: &v1.Node{},
 			},
 		},
@@ -557,7 +510,7 @@ func TestRollingUpdateEmptyGroup(t *testing.T) {
 	setUpCloud(c)
 
 	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
-	groups := make(map[string]*CloudInstanceGroup)
+	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 
 	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
 	if err != nil {
@@ -620,10 +573,10 @@ func TestRollingUpdateUnknownRole(t *testing.T) {
 
 	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
 
-	groups := make(map[string]*CloudInstanceGroup)
-	groups["node-1"] = &CloudInstanceGroup{
-		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[0].AutoScalingGroupName),
-		asg:     asgGroups.AutoScalingGroups[0],
+	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
+	groups["node-1"] = &cloudinstances.CloudInstanceGroup{
+		GroupName:         aws.StringValue(asgGroups.AutoScalingGroups[0].AutoScalingGroupName),
+		GroupTemplateName: aws.StringValue(asgGroups.AutoScalingGroups[0].LaunchConfigurationName),
 		InstanceGroup: &kopsapi.InstanceGroup{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name: "node-1",
@@ -632,25 +585,21 @@ func TestRollingUpdateUnknownRole(t *testing.T) {
 				Role: "Unknown",
 			},
 		},
-		Ready: []*CloudInstanceGroupInstance{
+		Ready: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-1a"),
-				},
+				ID:   aws.String("node-1a"),
 				Node: &v1.Node{},
 			},
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-1b"),
-				},
+				ID:   aws.String("node-1b"),
 				Node: &v1.Node{},
 			},
 		},
 	}
 
-	groups["node-2"] = &CloudInstanceGroup{
-		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[1].AutoScalingGroupName),
-		asg:     asgGroups.AutoScalingGroups[1],
+	groups["node-2"] = &cloudinstances.CloudInstanceGroup{
+		GroupName:         aws.StringValue(asgGroups.AutoScalingGroups[1].AutoScalingGroupName),
+		GroupTemplateName: aws.StringValue(asgGroups.AutoScalingGroups[1].LaunchConfigurationName),
 		InstanceGroup: &kopsapi.InstanceGroup{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name: "node-2",
@@ -659,25 +608,21 @@ func TestRollingUpdateUnknownRole(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleNode,
 			},
 		},
-		Ready: []*CloudInstanceGroupInstance{
+		Ready: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-2a"),
-				},
+				ID:   aws.String("node-2a"),
 				Node: &v1.Node{},
 			},
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("node-2b"),
-				},
+				ID:   aws.String("node-2b"),
 				Node: &v1.Node{},
 			},
 		},
 	}
 
-	groups["master-1"] = &CloudInstanceGroup{
-		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[2].AutoScalingGroupName),
-		asg:     asgGroups.AutoScalingGroups[2],
+	groups["master-1"] = &cloudinstances.CloudInstanceGroup{
+		GroupName:         aws.StringValue(asgGroups.AutoScalingGroups[2].AutoScalingGroupName),
+		GroupTemplateName: aws.StringValue(asgGroups.AutoScalingGroups[2].LaunchConfigurationName),
 		InstanceGroup: &kopsapi.InstanceGroup{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name: "master-1",
@@ -686,19 +631,17 @@ func TestRollingUpdateUnknownRole(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleMaster,
 			},
 		},
-		Ready: []*CloudInstanceGroupInstance{
+		Ready: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("master-1a"),
-				},
+				ID:   aws.String("master-1a"),
 				Node: &v1.Node{},
 			},
 		},
 	}
 
-	groups["bastion-1"] = &CloudInstanceGroup{
-		ASGName: aws.StringValue(asgGroups.AutoScalingGroups[3].AutoScalingGroupName),
-		asg:     asgGroups.AutoScalingGroups[3],
+	groups["bastion-1"] = &cloudinstances.CloudInstanceGroup{
+		GroupName:         aws.StringValue(asgGroups.AutoScalingGroups[3].AutoScalingGroupName),
+		GroupTemplateName: aws.StringValue(asgGroups.AutoScalingGroups[3].LaunchConfigurationName),
 		InstanceGroup: &kopsapi.InstanceGroup{
 			ObjectMeta: v1meta.ObjectMeta{
 				Name: "bastion-1",
@@ -707,11 +650,9 @@ func TestRollingUpdateUnknownRole(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleBastion,
 			},
 		},
-		Ready: []*CloudInstanceGroupInstance{
+		Ready: []*cloudinstances.CloudInstanceMember{
 			{
-				ASGInstance: &autoscaling.Instance{
-					InstanceId: aws.String("bastion-1a"),
-				},
+				ID:   aws.String("bastion-1a"),
 				Node: &v1.Node{},
 			},
 		},

--- a/pkg/resources/digitalocean/cloud.go
+++ b/pkg/resources/digitalocean/cloud.go
@@ -28,6 +28,7 @@ import (
 
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kops/pkg/resources/digitalocean/dns"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
@@ -81,21 +82,21 @@ func NewCloud(region string) (*Cloud, error) {
 }
 
 // GetCloudGroups is not implemented yet, that needs to return the instances and groups that back a kops cluster.
-func (c *Cloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+func (c *Cloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	glog.V(8).Infof("digitalocean cloud provider GetCloudGroups not implemented yet")
-	return nil, fmt.Errorf("digital ocean cloud provider does not support getting cloud groups at this time.")
+	return nil, fmt.Errorf("digital ocean cloud provider does not support getting cloud groups at this time")
 }
 
 // DeleteGroup is not implemented yet, is a func that needs to delete a DO instance group.
 func (c *Cloud) DeleteGroup(name string, template string) error {
 	glog.V(8).Infof("digitalocean cloud provider DeleteGroup not implemented yet")
-	return fmt.Errorf("digital ocean cloud provider does not support deleting cloud groups at this time.")
+	return fmt.Errorf("digital ocean cloud provider does not support deleting cloud groups at this time")
 }
 
 // DeleteInstance is not implemented yet, is func needs to delete a DO instance.
 func (c *Cloud) DeleteInstance(id *string) error {
 	glog.V(8).Infof("digitalocean cloud provider DeleteInstance not implemented yet")
-	return fmt.Errorf("digital ocean cloud provider does not support deleting cloud instances at this time.")
+	return fmt.Errorf("digital ocean cloud provider does not support deleting cloud instances at this time")
 }
 
 // ProviderID returns the kops api identifier for DigitalOcean cloud provider

--- a/pkg/resources/digitalocean/cloud.go
+++ b/pkg/resources/digitalocean/cloud.go
@@ -21,8 +21,12 @@ import (
 	"os"
 
 	"github.com/digitalocean/godo"
+	"github.com/golang/glog"
 	"golang.org/x/oauth2"
 
+	"fmt"
+
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/resources/digitalocean/dns"
 	"k8s.io/kops/upup/pkg/fi"
@@ -74,6 +78,24 @@ func NewCloud(region string) (*Cloud, error) {
 		dns:    dns.NewProvider(client),
 		Region: region,
 	}, nil
+}
+
+// GetCloudGroups is not implemented yet, that needs to return the instances and groups that back a kops cluster.
+func (c *Cloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+	glog.V(8).Infof("digitalocean cloud provider GetCloudGroups not implemented yet")
+	return nil, fmt.Errorf("digital ocean cloud provider does not support getting cloud groups at this time.")
+}
+
+// DeleteGroup is not implemented yet, is a func that needs to delete a DO instance group.
+func (c *Cloud) DeleteGroup(name string, template string) error {
+	glog.V(8).Infof("digitalocean cloud provider DeleteGroup not implemented yet")
+	return fmt.Errorf("digital ocean cloud provider does not support deleting cloud groups at this time.")
+}
+
+// DeleteInstance is not implemented yet, is func needs to delete a DO instance.
+func (c *Cloud) DeleteInstance(id *string) error {
+	glog.V(8).Infof("digitalocean cloud provider DeleteInstance not implemented yet")
+	return fmt.Errorf("digital ocean cloud provider does not support deleting cloud instances at this time.")
 }
 
 // ProviderID returns the kops api identifier for DigitalOcean cloud provider

--- a/pkg/resources/gce.go
+++ b/pkg/resources/gce.go
@@ -130,52 +130,18 @@ type clusterDiscoveryGCE struct {
 	zones             []string
 }
 
-// findInstanceTemplates finds all instance templates that are associated with the current cluster
-// It matches them by looking for instance metadata with key='cluster-name' and value of our cluster name
 func (d *clusterDiscoveryGCE) findInstanceTemplates() ([]*compute.InstanceTemplate, error) {
 	if d.instanceTemplates != nil {
 		return d.instanceTemplates, nil
 	}
 
-	c := d.gceCloud
-
-	//clusterTag := gce.SafeClusterName(strings.TrimSpace(d.clusterName))
-
-	findClusterName := strings.TrimSpace(d.clusterName)
-
-	var matches []*compute.InstanceTemplate
-
-	ctx := context.Background()
-
-	err := c.Compute().InstanceTemplates.List(c.Project()).Pages(ctx, func(page *compute.InstanceTemplateList) error {
-		for _, t := range page.Items {
-			match := false
-			for _, item := range t.Properties.Metadata.Items {
-				if item.Key == "cluster-name" {
-					if strings.TrimSpace(item.Value) == findClusterName {
-						match = true
-					} else {
-						match = false
-						break
-					}
-				}
-			}
-
-			if !match {
-				continue
-			}
-
-			matches = append(matches, t)
-		}
-		return nil
-	})
+	instanceTemplates, err := d.gceCloud.FindInstanceTemplates(d.clusterName)
 	if err != nil {
-		return nil, fmt.Errorf("error listing instance groups: %v", err)
+		return nil, fmt.Errorf("unable to find intance templates: %v", err)
 	}
 
-	d.instanceTemplates = matches
-
-	return matches, nil
+	d.instanceTemplates = instanceTemplates
+	return d.instanceTemplates, nil
 }
 
 func (d *clusterDiscoveryGCE) listGCEInstanceTemplates() ([]*tracker.Resource, error) {

--- a/upup/pkg/fi/cloud.go
+++ b/upup/pkg/fi/cloud.go
@@ -19,6 +19,7 @@ package fi
 import (
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 )
 
@@ -37,7 +38,7 @@ type Cloud interface {
 	DeleteGroup(name string, template string) error
 
 	// GetCloudGroups returns a map of cloud instances that back a kops cluster
-	GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*CloudGroup, error)
+	GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error)
 }
 
 type VPCInfo struct {
@@ -52,24 +53,6 @@ type SubnetInfo struct {
 	ID   string
 	Zone string
 	CIDR string
-}
-
-// CloudInstanceGroup is the cloud backing of InstanceGroup.
-type CloudGroup struct {
-	InstanceGroup     *kops.InstanceGroup
-	GroupName         string
-	GroupTemplateName string
-	Status            string
-	Ready             []*CloudGroupInstance
-	NeedUpdate        []*CloudGroupInstance
-	MinSize           int
-	MaxSize           int
-}
-
-// CloudInstanceGroupInstance describes an instance in an autoscaling group.
-type CloudGroupInstance struct {
-	ID   *string
-	Node *v1.Node
 }
 
 // zonesToCloud allows us to infer from certain well-known zones to a cloud

--- a/upup/pkg/fi/cloud.go
+++ b/upup/pkg/fi/cloud.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fi
 
 import (
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 )
@@ -28,6 +29,15 @@ type Cloud interface {
 
 	// FindVPCInfo looks up the specified VPC by id, returning info if found, otherwise (nil, nil)
 	FindVPCInfo(id string) (*VPCInfo, error)
+
+	// DeleteInstance deletes a cloud instance
+	DeleteInstance(id *string) error
+
+	// DeleteGroup delete a group of cloud instances
+	DeleteGroup(name string, template string) error
+
+	// GetCloudGroups returns a map of cloud instances that back a kops cluster
+	GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*CloudGroup, error)
 }
 
 type VPCInfo struct {
@@ -42,6 +52,24 @@ type SubnetInfo struct {
 	ID   string
 	Zone string
 	CIDR string
+}
+
+// CloudInstanceGroup is the cloud backing of InstanceGroup.
+type CloudGroup struct {
+	InstanceGroup     *kops.InstanceGroup
+	GroupName         string
+	GroupTemplateName string
+	Status            string
+	Ready             []*CloudGroupInstance
+	NeedUpdate        []*CloudGroupInstance
+	MinSize           int
+	MaxSize           int
+}
+
+// CloudInstanceGroupInstance describes an instance in an autoscaling group.
+type CloudGroupInstance struct {
+	ID   *string
+	Node *v1.Node
 }
 
 // zonesToCloud allows us to infer from certain well-known zones to a cloud

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -31,6 +31,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	dnsproviderroute53 "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/aws/route53"
@@ -116,7 +117,7 @@ func (c *MockAWSCloud) DeleteInstance(id *string) error {
 	return nil
 }
 
-func (c *MockAWSCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+func (c *MockAWSCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	return nil, fmt.Errorf("not implemented yet")
 }
 

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/golang/glog"
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
@@ -71,6 +72,20 @@ type MockCloud struct {
 	MockCloudFormation *cloudformation.CloudFormation
 	MockEC2            ec2iface.EC2API
 	MockRoute53        route53iface.Route53API
+}
+
+func (c *MockAWSCloud) DeleteGroup(name string, template string) error {
+	// TODO implement
+	return nil
+}
+
+func (c *MockAWSCloud) DeleteInstance(id *string) error {
+	// TODO implement
+	return nil
+}
+
+func (c *MockAWSCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+	return nil, fmt.Errorf("not implemented yet")
 }
 
 func (c *MockCloud) ProviderID() kops.CloudProviderID {

--- a/upup/pkg/fi/cloudup/baremetal/cloud.go
+++ b/upup/pkg/fi/cloudup/baremetal/cloud.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 )
@@ -51,21 +52,21 @@ func (c *Cloud) FindVPCInfo(id string) (*fi.VPCInfo, error) {
 
 // GetCloudGroups is not implemented yet, that needs to return the instances and groups that back a kops cluster.
 // Baremetal may not support this.
-func (c *Cloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+func (c *Cloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	glog.V(8).Infof("baremetal cloud GetCloudGroups not implemented yet")
-	return nil, fmt.Errorf("baremetal provider does not support getting cloud groups at this time.")
+	return nil, fmt.Errorf("baremetal provider does not support getting cloud groups at this time")
 }
 
 // DeleteGroup is not implemented yet, is a func that needs to delete a DO instance group.
 // Baremetal may not support this.
 func (c *Cloud) DeleteGroup(name string, template string) error {
 	glog.V(8).Infof("digitalocean cloud provider DeleteGroup not implemented yet")
-	return fmt.Errorf("digital ocean cloud provider does not support deleting cloud groups at this time.")
+	return fmt.Errorf("digital ocean cloud provider does not support deleting cloud groups at this time")
 }
 
 //DeleteInstance is not implemented yet, is func needs to delete a DO instance.
 //Baremetal may not support this.
 func (c *Cloud) DeleteInstance(id *string) error {
 	glog.V(8).Infof("baremetal cloud provider DeleteInstance not implemented yet")
-	return fmt.Errorf("baremetal cloud provider does not support deleting cloud instances at this time.")
+	return fmt.Errorf("baremetal cloud provider does not support deleting cloud instances at this time")
 }

--- a/upup/pkg/fi/cloudup/baremetal/cloud.go
+++ b/upup/pkg/fi/cloudup/baremetal/cloud.go
@@ -18,6 +18,10 @@ package baremetal
 
 import (
 	"fmt"
+
+	"github.com/golang/glog"
+
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
@@ -43,4 +47,25 @@ func (c *Cloud) DNS() (dnsprovider.Interface, error) {
 
 func (c *Cloud) FindVPCInfo(id string) (*fi.VPCInfo, error) {
 	return nil, fmt.Errorf("baremetal FindVPCInfo not supported")
+}
+
+// GetCloudGroups is not implemented yet, that needs to return the instances and groups that back a kops cluster.
+// Baremetal may not support this.
+func (c *Cloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+	glog.V(8).Infof("baremetal cloud GetCloudGroups not implemented yet")
+	return nil, fmt.Errorf("baremetal provider does not support getting cloud groups at this time.")
+}
+
+// DeleteGroup is not implemented yet, is a func that needs to delete a DO instance group.
+// Baremetal may not support this.
+func (c *Cloud) DeleteGroup(name string, template string) error {
+	glog.V(8).Infof("digitalocean cloud provider DeleteGroup not implemented yet")
+	return fmt.Errorf("digital ocean cloud provider does not support deleting cloud groups at this time.")
+}
+
+//DeleteInstance is not implemented yet, is func needs to delete a DO instance.
+//Baremetal may not support this.
+func (c *Cloud) DeleteInstance(id *string) error {
+	glog.V(8).Infof("baremetal cloud provider DeleteInstance not implemented yet")
+	return fmt.Errorf("baremetal cloud provider does not support deleting cloud instances at this time.")
 }

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -47,6 +47,10 @@ type GCECloud interface {
 	// FindClusterStatus gets the status of the cluster as it exists in GCE, inferred from volumes
 	FindClusterStatus(cluster *kops.Cluster) (*kops.ClusterStatus, error)
 
+	// FindInstanceTemplates finds all instance templates that are associated with the current cluster
+	// It matches them by looking for instance metadata with key='cluster-name' and value of our cluster name
+	FindInstanceTemplates(clusterName string) ([]*compute.InstanceTemplate, error)
+
 	Zones() ([]string, error)
 }
 
@@ -239,11 +243,8 @@ func (c *gceCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instanceg
 // FindInstanceTemplates finds all instance templates that are associated with the current cluster
 // It matches them by looking for instance metadata with key='cluster-name' and value of our cluster name
 func (c *gceCloudImplementation) FindInstanceTemplates(clusterName string) ([]*compute.InstanceTemplate, error) {
-
 	findClusterName := strings.TrimSpace(clusterName)
-
 	var matches []*compute.InstanceTemplate
-
 	ctx := context.Background()
 
 	err := c.Compute().InstanceTemplates.List(c.Project()).Pages(ctx, func(page *compute.InstanceTemplateList) error {

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/api/storage/v1"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns"
@@ -220,19 +221,19 @@ func (c *gceCloudImplementation) GetApiIngressStatus(cluster *kops.Cluster) ([]k
 // DeleteGroup deletes a cloud of instances controlled by an Instance Group Manager
 func (c *gceCloudImplementation) DeleteGroup(name string, template string) error {
 	glog.V(8).Infof("gce cloud provider DeleteGroup not implemented yet")
-	return fmt.Errorf("gce cloud provider does not support deleting cloud groups at this time.")
+	return fmt.Errorf("gce cloud provider does not support deleting cloud groups at this time")
 }
 
 // DeleteInstance deletes a GCE instance
 func (c *gceCloudImplementation) DeleteInstance(id *string) error {
 	glog.V(8).Infof("gce cloud provider DeleteInstance not implemented yet")
-	return fmt.Errorf("gce cloud provider does not support deleting cloud instances at this time.")
+	return fmt.Errorf("gce cloud provider does not support deleting cloud instances at this time")
 }
 
 // GetCloudGroups returns a map of CloudGroup that backs a list of instance groups
-func (c *gceCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+func (c *gceCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	glog.V(8).Infof("gce cloud provider GetCloudGroups not implemented yet")
-	return nil, fmt.Errorf("gce cloud provider does not support getting cloud groups at this time.")
+	return nil, fmt.Errorf("gce cloud provider does not support getting cloud groups at this time")
 }
 
 // FindInstanceTemplates finds all instance templates that are associated with the current cluster

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -18,11 +18,14 @@ package gce
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/storage/v1"
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
@@ -42,6 +45,8 @@ type GCECloud interface {
 
 	// FindClusterStatus gets the status of the cluster as it exists in GCE, inferred from volumes
 	FindClusterStatus(cluster *kops.Cluster) (*kops.ClusterStatus, error)
+
+	Zones() ([]string, error)
 }
 
 type gceCloudImplementation struct {
@@ -149,6 +154,36 @@ func (c *gceCloudImplementation) Labels() map[string]string {
 	return tags
 }
 
+// TODO refactor this out of resources
+// this is needed for delete groups and other new methods
+
+// Zones returns the zones in a region
+func (c *gceCloudImplementation) Zones() ([]string, error) {
+
+	var zones []string
+	// TODO: Only zones in api.Cluster object, if we have one?
+	gceZones, err := c.Compute().Zones.List(c.Project()).Do()
+	if err != nil {
+		return nil, fmt.Errorf("error listing zones: %v", err)
+	}
+	for _, gceZone := range gceZones.Items {
+		u, err := ParseGoogleCloudURL(gceZone.Region)
+		if err != nil {
+			return nil, err
+		}
+		if u.Name != c.Region() {
+			continue
+		}
+		zones = append(zones, gceZone.Name)
+	}
+	if len(zones) == 0 {
+		return nil, fmt.Errorf("unable to determine zones in region %q", c.Region())
+	}
+
+	glog.Infof("Scanning zones: %v", zones)
+	return zones, nil
+}
+
 func (c *gceCloudImplementation) WaitForOp(op *compute.Operation) error {
 	return WaitForOp(c.compute, op)
 }
@@ -180,4 +215,61 @@ func (c *gceCloudImplementation) GetApiIngressStatus(cluster *kops.Cluster) ([]k
 	}
 
 	return ingresses, nil
+}
+
+// DeleteGroup deletes a cloud of instances controlled by an Instance Group Manager
+func (c *gceCloudImplementation) DeleteGroup(name string, template string) error {
+	glog.V(8).Infof("gce cloud provider DeleteGroup not implemented yet")
+	return fmt.Errorf("gce cloud provider does not support deleting cloud groups at this time.")
+}
+
+// DeleteInstance deletes a GCE instance
+func (c *gceCloudImplementation) DeleteInstance(id *string) error {
+	glog.V(8).Infof("gce cloud provider DeleteInstance not implemented yet")
+	return fmt.Errorf("gce cloud provider does not support deleting cloud instances at this time.")
+}
+
+// GetCloudGroups returns a map of CloudGroup that backs a list of instance groups
+func (c *gceCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+	glog.V(8).Infof("gce cloud provider GetCloudGroups not implemented yet")
+	return nil, fmt.Errorf("gce cloud provider does not support getting cloud groups at this time.")
+}
+
+// FindInstanceTemplates finds all instance templates that are associated with the current cluster
+// It matches them by looking for instance metadata with key='cluster-name' and value of our cluster name
+func (c *gceCloudImplementation) FindInstanceTemplates(clusterName string) ([]*compute.InstanceTemplate, error) {
+
+	findClusterName := strings.TrimSpace(clusterName)
+
+	var matches []*compute.InstanceTemplate
+
+	ctx := context.Background()
+
+	err := c.Compute().InstanceTemplates.List(c.Project()).Pages(ctx, func(page *compute.InstanceTemplateList) error {
+		for _, t := range page.Items {
+			match := false
+			for _, item := range t.Properties.Metadata.Items {
+				if item.Key == "cluster-name" {
+					if strings.TrimSpace(item.Value) == findClusterName {
+						match = true
+					} else {
+						match = false
+						break
+					}
+				}
+			}
+
+			if !match {
+				continue
+			}
+
+			matches = append(matches, t)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error listing instance groups: %v", err)
+	}
+
+	return matches, nil
 }

--- a/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
@@ -58,6 +58,13 @@ func (c *mockGCECloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*k
 	return nil, fmt.Errorf("mockGCECloud cloud provider does not support getting cloud groups at this time")
 }
 
+// FindInstanceTemplates finds all instance templates that are associated with the current cluster
+// It matches them by looking for instance metadata with key='cluster-name' and value of our cluster name
+func (c *mockGCECloud) FindInstanceTemplates(clusterName string) ([]*compute.InstanceTemplate, error) {
+	glog.V(8).Infof("mockGCECloud cloud provider FindInstanceTemplates not implemented yet")
+	return nil, fmt.Errorf("mockGCECloud cloud provider does not support finding instance templates at this time")
+}
+
 // DeleteGroup is not implemented yet
 func (c *mockGCECloud) DeleteGroup(name string, template string) error {
 	glog.V(8).Infof("mockGCECloud cloud provider DeleteGroup not implemented yet")

--- a/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
@@ -18,11 +18,13 @@ package gce
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	compute "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/storage/v1"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	dnsproviderclouddns "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns"
@@ -51,21 +53,21 @@ func buildMockGCECloud(region string, project string) *mockGCECloud {
 }
 
 // GetCloudGroups is not implemented yet
-func (c *mockGCECloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+func (c *mockGCECloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	glog.V(8).Infof("mockGCECloud cloud provider GetCloudGroups not implemented yet")
-	return nil, fmt.Errorf("mockGCECloud cloud provider does not support getting cloud groups at this time.")
+	return nil, fmt.Errorf("mockGCECloud cloud provider does not support getting cloud groups at this time")
 }
 
 // DeleteGroup is not implemented yet
 func (c *mockGCECloud) DeleteGroup(name string, template string) error {
 	glog.V(8).Infof("mockGCECloud cloud provider DeleteGroup not implemented yet")
-	return fmt.Errorf("mockGCECloud cloud provider does not support deleting cloud groups at this time.")
+	return fmt.Errorf("mockGCECloud cloud provider does not support deleting cloud groups at this time")
 }
 
 // DeleteInstance is not implemented yet
 func (c *mockGCECloud) DeleteInstance(id *string) error {
 	glog.V(8).Infof("mockGCECloud cloud provider DeleteInstance not implemented yet")
-	return fmt.Errorf("mockGCECloud cloud provider does not support deleting cloud instances at this time.")
+	return fmt.Errorf("mockGCECloud cloud provider does not support deleting cloud instances at this time")
 }
 
 // Zones is not implemented yet

--- a/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/glog"
 	compute "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/storage/v1"
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
@@ -47,6 +48,29 @@ func InstallMockGCECloud(region string, project string) *mockGCECloud {
 func buildMockGCECloud(region string, project string) *mockGCECloud {
 	i := &mockGCECloud{region: region, project: project}
 	return i
+}
+
+// GetCloudGroups is not implemented yet
+func (c *mockGCECloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+	glog.V(8).Infof("mockGCECloud cloud provider GetCloudGroups not implemented yet")
+	return nil, fmt.Errorf("mockGCECloud cloud provider does not support getting cloud groups at this time.")
+}
+
+// DeleteGroup is not implemented yet
+func (c *mockGCECloud) DeleteGroup(name string, template string) error {
+	glog.V(8).Infof("mockGCECloud cloud provider DeleteGroup not implemented yet")
+	return fmt.Errorf("mockGCECloud cloud provider does not support deleting cloud groups at this time.")
+}
+
+// DeleteInstance is not implemented yet
+func (c *mockGCECloud) DeleteInstance(id *string) error {
+	glog.V(8).Infof("mockGCECloud cloud provider DeleteInstance not implemented yet")
+	return fmt.Errorf("mockGCECloud cloud provider does not support deleting cloud instances at this time.")
+}
+
+// Zones is not implemented yet
+func (c *mockGCECloud) Zones() ([]string, error) {
+	return nil, fmt.Errorf("not yet implented")
 }
 
 // mockGCECloud returns a copy of the mockGCECloud bound to the specified labels

--- a/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
+++ b/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
@@ -101,6 +102,24 @@ func NewVSphereCloud(spec *kops.ClusterSpec) (*VSphereCloud, error) {
 	spec.CloudConfig.VSpherePassword = fi.String(password)
 	glog.V(2).Infof("Created vSphere Cloud successfully: %+v", vsphereCloud)
 	return vsphereCloud, nil
+}
+
+// GetCloudGroups is not implemented yet, that needs to return the instances and groups that back a kops cluster.
+func (c *VSphereCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+	glog.V(8).Infof("vSphere cloud provider GetCloudGroups not implemented yet")
+	return nil, fmt.Errorf("vSphere cloud provider does not support getting cloud groups at this time.")
+}
+
+// DeleteGroup is not implemented yet, is a func that needs to delete a vSphere instance group.
+func (c *VSphereCloud) DeleteGroup(name string, template string) error {
+	glog.V(8).Infof("vSphere cloud provider DeleteGroup not implemented yet")
+	return fmt.Errorf("vSphere cloud provider does not support deleting cloud groups at this time.")
+}
+
+// DeleteInstance is not implemented yet, is func needs to delete a vSphereCloud instance.
+func (c *VSphereCloud) DeleteInstance(id *string) error {
+	glog.V(8).Infof("vSphere cloud provider DeleteInstance not implemented yet")
+	return fmt.Errorf("vSphere cloud provider does not support deleting cloud instances at this time.")
 }
 
 // DNS returns dnsprovider interface for this vSphere cloud.

--- a/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
+++ b/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
@@ -22,6 +22,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/vmware/govmomi"
@@ -34,12 +38,10 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	k8scoredns "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/coredns"
-	"net/url"
-	"os"
-	"strings"
 )
 
 // VSphereCloud represents a vSphere cloud instance.
@@ -105,9 +107,9 @@ func NewVSphereCloud(spec *kops.ClusterSpec) (*VSphereCloud, error) {
 }
 
 // GetCloudGroups is not implemented yet, that needs to return the instances and groups that back a kops cluster.
-func (c *VSphereCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodeMap map[string]*v1.Node) (map[string]*fi.CloudGroup, error) {
+func (c *VSphereCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	glog.V(8).Infof("vSphere cloud provider GetCloudGroups not implemented yet")
-	return nil, fmt.Errorf("vSphere cloud provider does not support getting cloud groups at this time.")
+	return nil, fmt.Errorf("vSphere cloud provider does not support getting cloud groups at this time")
 }
 
 // DeleteGroup is not implemented yet, is a func that needs to delete a vSphere instance group.


### PR DESCRIPTION
This builds on various other PRs.  The only two SHAs to review are:

1. Moving delete instancesgroups into its own file https://github.com/chrislovecnm/kops/commit/d52d767508a5abbe74ff8f802b1a3bb7c26aee55
2. Refactoring to use cloud based GetCloudGroups https://github.com/kubernetes/kops/commit/c33a078f526dd04f1a2949766bb0da4171e861cc

AWS is the only one that has GetCloudGroups implemented at this point.  GCE is next.

TODO

- [x] e2e testing rolling-update
- [x] e2e testing rolling-update with only one instance group
- [x] e2e testing force
- [x] e2e testing cloud-only

Updates

I have moved more of the code into `/pkg/cloudinstances` per guidance from @justinsb!  I am liking it more!