### PR TITLE
Docs updates to clarify and fix typos in rolling-update cmd.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))
 # Keep in sync with upup/models/cloudup/resources/addons/dns-controller/
 DNS_CONTROLLER_TAG=1.7.1
 
-KOPS_RELEASE_VERSION = 1.7.1-beta.2
-KOPS_CI_VERSION      = 1.7.1-beta.3
+KOPS_RELEASE_VERSION = 1.8.0-alpha.1
+KOPS_CI_VERSION      = 1.8.0-alpha.2
 
 # kops local location
 KOPS                 = ${LOCAL}/kops

--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -43,42 +43,41 @@ import (
 
 var (
 	rollingupdate_long = pretty.LongDesc(i18n.T(`
-	This command updates a kubernetes cluster to match the cloud, and kops specifications.
+	This command updates a kubernetes cluster to match the cloud and kops specifications.
 
-	To perform rolling update, you need to update the cloud resources first with the command
+	To perform a rolling update, you need to update the cloud resources first with the command
 	` + pretty.Bash("kops update cluster") + `.
 
-	If rolling-update does not report that the cluster needs to be rolled you can force the cluster to be
+	If rolling-update does not report that the cluster needs to be rolled, you can force the cluster to be
 	rolled with the force flag.  Rolling update drains and validates the cluster by default.  A cluster is
-	deemed validated when all required nodes are running, and all pods in the kube-system namespace are operational.
-	When a node is deleted rolling-update sleeps the interval for the node type, and the tries for the same period
-	of time for the cluster to be validated.  For instance setting --master-interval=3m causes rolling-update
-	to wait for 3m after a master is rolled, and another 3m for the cluster to stabilize and pass
+	deemed validated when all required nodes are running and all pods in the kube-system namespace are operational.
+	When a node is deleted, rolling-update sleeps the interval for the node type, and then tries for the same period
+	of time for the cluster to be validated.  For instance, setting --master-interval=3m causes rolling-update
+	to wait for 3 minutes after a master is rolled, and another 3 minutes for the cluster to stabilize and pass
 	validation.
 
-	Note: terraform users will need run the following commands all from the same directory
-	` + pretty.Bash("kops update cluster --target=terraform") + `then
-	` + pretty.Bash("terraform plan") + ` then ` + pretty.Bash("terraform apply") +
-		`prior to running` + pretty.Bash("kops rolling-update cluster") + `.`))
+	Note: terraform users will need to run all of the following commands from the same directory
+	` + pretty.Bash("kops update cluster --target=terraform") + ` then ` + pretty.Bash("terraform plan") + ` then
+	` + pretty.Bash("terraform apply") + ` prior to running ` + pretty.Bash("kops rolling-update cluster") + `.`))
 
 	rollingupdate_example = templates.Examples(i18n.T(`
-		# Preview a rolling-update
+		# Preview a rolling-update.
 		kops rolling-update cluster
 
 		# Roll the currently selected kops cluster with defaults.
-	    # Nodes will be drained and the cluster will be validated between node replacement
+		# Nodes will be drained and the cluster will be validated between node replacement.
 		kops rolling-update cluster --yes
 
-		# Roll the k8s-cluster.example.com kops cluster
-		# do not fail if the cluster does not validate
-		# wait 8 min to create new node, and at least 8 min
-	    # to validate the cluster.
+		# Roll the k8s-cluster.example.com kops cluster,
+		# do not fail if the cluster does not validate,
+		# wait 8 min to create new node, and wait at least
+		# 8 min to validate the cluster.
 		kops rolling-update cluster k8s-cluster.example.com --yes \
 		  --fail-on-validate-error="false" \
 		  --master-interval=8m \
 		  --node-interval=8m
 
-		# Roll the k8s-cluster.example.com kops cluster
+		# Roll the k8s-cluster.example.com kops cluster,
 		# do not validate the cluster because of the cloudonly flag.
 	    # Force the entire cluster to roll, even if rolling update
 	    # reports that the cluster does not need to be rolled.
@@ -86,9 +85,9 @@ var (
 	      --cloudonly \
 		  --force
 
-		# Roll the k8s-cluster.example.com kops cluster
-		# only roll the node instancegroup
-		# use the new drain an validate functionality
+		# Roll the k8s-cluster.example.com kops cluster,
+		# only roll the node instancegroup,
+		# use the new drain an validate functionality.
 		kops rolling-update cluster k8s-cluster.example.com --yes \
 		  --fail-on-validate-error="false" \
 		  --node-interval 8m \
@@ -123,7 +122,7 @@ type RollingUpdateOptions struct {
 	ClusterName string
 
 	// InstanceGroups is the list of instance groups to rolling-update;
-	// if not specified all instance groups will be updated
+	// if not specified, all instance groups will be updated
 	InstanceGroups []string
 }
 

--- a/docs/cli/kops_rolling-update.md
+++ b/docs/cli/kops_rolling-update.md
@@ -8,43 +8,43 @@ Rolling update a cluster.
 ### Synopsis
 
 
-This command updates a kubernetes cluster to match the cloud, and kops specifications.
+This command updates a kubernetes cluster to match the cloud and kops specifications.
 
-To perform rolling update, you need to update the cloud resources first with the command
+To perform a rolling update, you need to update the cloud resources first with the command
 `kops update cluster`.
 
-If rolling-update does not report that the cluster needs to be rolled you can force the cluster to be
+If rolling-update does not report that the cluster needs to be rolled, you can force the cluster to be
 rolled with the force flag.  Rolling update drains and validates the cluster by default.  A cluster is
-deemed validated when all required nodes are running, and all pods in the kube-system namespace are operational.
-When a node is deleted rolling-update sleeps the interval for the node type, and the tries for the same period
-of time for the cluster to be validated.  For instance setting --master-interval=3m causes rolling-update
-to wait for 3m after a master is rolled, and another 3m for the cluster to stabilize and pass
+deemed validated when all required nodes are running and all pods in the kube-system namespace are operational.
+When a node is deleted, rolling-update sleeps the interval for the node type, and then tries for the same period
+of time for the cluster to be validated.  For instance, setting --master-interval=3m causes rolling-update
+to wait for 3 minutes after a master is rolled, and another 3 minutes for the cluster to stabilize and pass
 validation.
 
-Note: terraform users will need run the following commands all from the same directory
-`kops update cluster --target=terraform`then
-`terraform plan` then `terraform apply`prior to running`kops rolling-update cluster`.
+Note: terraform users will need to run all of the following commands from the same directory
+`kops update cluster --target=terraform` then `terraform plan` then
+`terraform apply` prior to running `kops rolling-update cluster`.
 
 ### Examples
 
 ```
-  # Preview a rolling-update
+  # Preview a rolling-update.
   kops rolling-update cluster
   
   # Roll the currently selected kops cluster with defaults.
-  # Nodes will be drained and the cluster will be validated between node replacement
+  # Nodes will be drained and the cluster will be validated between node replacement.
   kops rolling-update cluster --yes
   
-  # Roll the k8s-cluster.example.com kops cluster
-  # do not fail if the cluster does not validate
-  # wait 8 min to create new node, and at least 8 min
-  # to validate the cluster.
+  # Roll the k8s-cluster.example.com kops cluster,
+  # do not fail if the cluster does not validate,
+  # wait 8 min to create new node, and wait at least
+  # 8 min to validate the cluster.
   kops rolling-update cluster k8s-cluster.example.com --yes \
   --fail-on-validate-error="false" \
   --master-interval=8m \
   --node-interval=8m
   
-  # Roll the k8s-cluster.example.com kops cluster
+  # Roll the k8s-cluster.example.com kops cluster,
   # do not validate the cluster because of the cloudonly flag.
   # Force the entire cluster to roll, even if rolling update
   # reports that the cluster does not need to be rolled.
@@ -52,9 +52,9 @@ Note: terraform users will need run the following commands all from the same dir
   --cloudonly \
   --force
   
-  # Roll the k8s-cluster.example.com kops cluster
-  # only roll the node instancegroup
-  # use the new drain an validate functionality
+  # Roll the k8s-cluster.example.com kops cluster,
+  # only roll the node instancegroup,
+  # use the new drain an validate functionality.
   kops rolling-update cluster k8s-cluster.example.com --yes \
   --fail-on-validate-error="false" \
   --node-interval 8m \

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -8,22 +8,22 @@ Rolling update a cluster.
 ### Synopsis
 
 
-This command updates a kubernetes cluster to match the cloud, and kops specifications.
+This command updates a kubernetes cluster to match the cloud and kops specifications.
 
-To perform rolling update, you need to update the cloud resources first with the command
+To perform a rolling update, you need to update the cloud resources first with the command
 `kops update cluster`.
 
-If rolling-update does not report that the cluster needs to be rolled you can force the cluster to be
+If rolling-update does not report that the cluster needs to be rolled, you can force the cluster to be
 rolled with the force flag.  Rolling update drains and validates the cluster by default.  A cluster is
-deemed validated when all required nodes are running, and all pods in the kube-system namespace are operational.
-When a node is deleted rolling-update sleeps the interval for the node type, and the tries for the same period
-of time for the cluster to be validated.  For instance setting --master-interval=3m causes rolling-update
-to wait for 3m after a master is rolled, and another 3m for the cluster to stabilize and pass
+deemed validated when all required nodes are running and all pods in the kube-system namespace are operational.
+When a node is deleted, rolling-update sleeps the interval for the node type, and then tries for the same period
+of time for the cluster to be validated.  For instance, setting --master-interval=3m causes rolling-update
+to wait for 3 minutes after a master is rolled, and another 3 minutes for the cluster to stabilize and pass
 validation.
 
-Note: terraform users will need run the following commands all from the same directory
-`kops update cluster --target=terraform`then
-`terraform plan` then `terraform apply`prior to running`kops rolling-update cluster`.
+Note: terraform users will need to run all of the following commands from the same directory
+`kops update cluster --target=terraform` then `terraform plan` then
+`terraform apply` prior to running `kops rolling-update cluster`.
 
 ```
 kops rolling-update cluster
@@ -32,23 +32,23 @@ kops rolling-update cluster
 ### Examples
 
 ```
-  # Preview a rolling-update
+  # Preview a rolling-update.
   kops rolling-update cluster
   
   # Roll the currently selected kops cluster with defaults.
-  # Nodes will be drained and the cluster will be validated between node replacement
+  # Nodes will be drained and the cluster will be validated between node replacement.
   kops rolling-update cluster --yes
   
-  # Roll the k8s-cluster.example.com kops cluster
-  # do not fail if the cluster does not validate
-  # wait 8 min to create new node, and at least 8 min
-  # to validate the cluster.
+  # Roll the k8s-cluster.example.com kops cluster,
+  # do not fail if the cluster does not validate,
+  # wait 8 min to create new node, and wait at least
+  # 8 min to validate the cluster.
   kops rolling-update cluster k8s-cluster.example.com --yes \
   --fail-on-validate-error="false" \
   --master-interval=8m \
   --node-interval=8m
   
-  # Roll the k8s-cluster.example.com kops cluster
+  # Roll the k8s-cluster.example.com kops cluster,
   # do not validate the cluster because of the cloudonly flag.
   # Force the entire cluster to roll, even if rolling update
   # reports that the cluster does not need to be rolled.
@@ -56,9 +56,9 @@ kops rolling-update cluster
   --cloudonly \
   --force
   
-  # Roll the k8s-cluster.example.com kops cluster
-  # only roll the node instancegroup
-  # use the new drain an validate functionality
+  # Roll the k8s-cluster.example.com kops cluster,
+  # only roll the node instancegroup,
+  # use the new drain an validate functionality.
   kops rolling-update cluster k8s-cluster.example.com --yes \
   --fail-on-validate-error="false" \
   --node-interval 8m \

--- a/protokube/tests/integration/build_etcd_manifest/main/non_tls.yaml
+++ b/protokube/tests/integration/build_etcd_manifest/main/non_tls.yaml
@@ -78,6 +78,9 @@ spec:
       name: varetcdata
     - mountPath: /var/log/etcd.log
       name: varlogetcd
+    - mountPath: /etc/hosts
+      name: hosts
+      readOnly: true
   hostNetwork: true
   volumes:
   - hostPath:
@@ -86,4 +89,7 @@ spec:
   - hostPath:
       path: /var/log/etcd.log
     name: varlogetcd
+  - hostPath:
+      path: /etc/hosts
+    name: hosts
 status: {}

--- a/protokube/tests/integration/build_etcd_manifest/main/tls.yaml
+++ b/protokube/tests/integration/build_etcd_manifest/main/tls.yaml
@@ -94,6 +94,9 @@ spec:
       name: varetcdata
     - mountPath: /var/log/etcd.log
       name: varlogetcd
+    - mountPath: /etc/hosts
+      name: hosts
+      readOnly: true
     - mountPath: /srv/kubernetes
       name: srvkubernetes
       readOnly: true
@@ -105,6 +108,9 @@ spec:
   - hostPath:
       path: /var/log/etcd.log
     name: varlogetcd
+  - hostPath:
+      path: /etc/hosts
+    name: hosts
   - hostPath:
       path: /srv/kubernetes
     name: srvkubernetes


### PR DESCRIPTION
Helps with https://github.com/kubernetes/kops/issues/3441; tried to keep the same voicing, but feel free to revert/update as desired of course.