### PR TITLE
Fixing stdout on tests - cleaning house

### DIFF
--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -163,7 +163,6 @@ F`
 		// We do need to cleanup, as otherwise we get some spurious changes on complex diffs
 		diffs = dmp.DiffCleanupSemantic(diffs)
 
-		t.Logf("diffs %v", diffs)
 	}
 
 	actual := FormatDiff(l, r)

--- a/upup/pkg/fi/vfs_castore_test.go
+++ b/upup/pkg/fi/vfs_castore_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package fi
 
 import (
-	"fmt"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -35,7 +34,6 @@ func TestBigInt_Format(t *testing.T) {
 		s1 := r.String()
 		s2 := r.Text(10)
 
-		fmt.Printf("%s\n", s1)
 		if s1 != s2 {
 			t.Fatalf("%s not the same as %s", s1, s2)
 		}


### PR DESCRIPTION
We are printing to STDOUT and logging in some tests.  Not needed.