### PR TITLE
adding kops test version to avoid kops upgrade warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))
 DNS_CONTROLLER_TAG=1.7.1
 
 KOPS_RELEASE_VERSION = 1.8.0-alpha.1
+# This is the previously released version used for integration testing, so that we do not get kops
+# upgrade messages
+KOPS_RELEASE_TEST_VERSION = 1.7.0
 KOPS_CI_VERSION      = 1.8.0-alpha.2
 
 # kops local location
@@ -201,7 +204,7 @@ hooks: # Install Git hooks
 
 .PHONY: test
 test: ${BINDATA_TARGETS}  # Run tests locally
-	go test -v ${TESTABLE_PACKAGES}
+	go test -ldflags "-X k8s.io/kops/cmd/kops.TestVersion=${KOPS_RELEASE_TEST_VERSION} ${EXTRA_LDFLAGS}"  -v ${TESTABLE_PACKAGES}
 
 ${DIST}/linux/amd64/nodeup: ${BINDATA_TARGETS}
 	mkdir -p ${DIST}

--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -41,9 +41,14 @@ import (
 
 	"github.com/ghodss/yaml"
 	"golang.org/x/crypto/ssh"
+	"k8s.io/kops"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 )
+
+// TestVersion is set by the Makefile so that we do get kops upgrade warnings.
+// We cannot use the release version, because CI will fail before we have a release.
+var TestVersion = "1.7.0"
 
 // TestMinimal runs the test on a minimum configuration, similar to kops create cluster minimal.example.com --zones us-west-1a
 func TestMinimal(t *testing.T) {
@@ -237,6 +242,7 @@ func runTest(t *testing.T, h *testutils.IntegrationTestHarness, clusterName stri
 }
 
 func runTestAWS(t *testing.T, clusterName string, srcDir string, version string, private bool, zones int) {
+	kops.Version = TestVersion
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
@@ -270,6 +276,7 @@ func runTestAWS(t *testing.T, clusterName string, srcDir string, version string,
 }
 
 func runTestGCE(t *testing.T, clusterName string, srcDir string, version string, private bool, zones int) {
+	kops.Version = TestVersion
 	featureflag.ParseFlags("+AlphaAllowGCE")
 
 	h := testutils.NewIntegrationTestHarness(t)
@@ -295,6 +302,9 @@ func runTestGCE(t *testing.T, clusterName string, srcDir string, version string,
 
 func runTestCloudformation(t *testing.T, clusterName string, srcDir string, version string, private bool) {
 	var stdout bytes.Buffer
+	// TODO this is hardcoded in the cf file
+	// TODO we may want to build the file dynamically
+	kops.Version = "1.5.0"
 
 	inputYAML := "in-" + version + ".yaml"
 	expectedCfPath := "cloudformation.json"
@@ -307,7 +317,12 @@ func runTestCloudformation(t *testing.T, clusterName string, srcDir string, vers
 
 	h.SetupMockAWS()
 
+
 	factory := util.NewFactory(factoryOptions)
+
+	// TODO this is hardcoded in the cf file
+	// TODO we may want to build the file dynamically
+	kops.Version = "1.5.0"
 
 	{
 		options := &CreateOptions{}


### PR DESCRIPTION
This sets the kops version during our integration tests.  In cloud formation, the version is hardcoded.  We could dynamically pull the stable kops channel, but let's start with simple.