### PR TITLE
using same disk sizes for gce

### DIFF
--- a/hack/.packages
+++ b/hack/.packages
@@ -68,6 +68,7 @@ k8s.io/kops/pkg/kubemanifest
 k8s.io/kops/pkg/model
 k8s.io/kops/pkg/model/awsmodel
 k8s.io/kops/pkg/model/components
+k8s.io/kops/pkg/model/defaults
 k8s.io/kops/pkg/model/gcemodel
 k8s.io/kops/pkg/model/iam
 k8s.io/kops/pkg/model/resources

--- a/pkg/model/defaults/volumes.go
+++ b/pkg/model/defaults/volumes.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaults
+
+import (
+	"fmt"
+
+	"k8s.io/kops/pkg/apis/kops"
+)
+
+const (
+	DefaultVolumeSizeNode    = 128
+	DefaultVolumeSizeMaster  = 64
+	DefaultVolumeSizeBastion = 32
+)
+
+// FindDefaultVolumeSize returns the default volume size based on role.
+func FindDefaultVolumeSize(volumeSize int32, role kops.InstanceGroupRole) (int32, error) {
+	if volumeSize == 0 {
+		switch role {
+		case kops.InstanceGroupRoleMaster:
+			volumeSize = DefaultVolumeSizeMaster
+		case kops.InstanceGroupRoleNode:
+			volumeSize = DefaultVolumeSizeNode
+		case kops.InstanceGroupRoleBastion:
+			volumeSize = DefaultVolumeSizeBastion
+		default:
+			return -1, fmt.Errorf("this case should not get hit, kops.Role not found %s", role)
+		}
+	}
+
+	return volumeSize, nil
+}

--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -22,12 +22,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/model"
+	"k8s.io/kops/pkg/model/defaults"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gcetasks"
 )
 
 const (
-	DefaultVolumeSize = 100
 	DefaultVolumeType = "pd-standard"
 )
 
@@ -54,8 +54,9 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		var instanceTemplate *gcetasks.InstanceTemplate
 		{
 			volumeSize := fi.Int32Value(ig.Spec.RootVolumeSize)
-			if volumeSize == 0 {
-				volumeSize = DefaultVolumeSize
+			volumeSize, err := defaults.FindDefaultVolumeSize(fi.Int32Value(ig.Spec.RootVolumeSize), ig.Spec.Role)
+			if err != nil {
+				return fmt.Errorf("this case should not get hit, kops.Role not found %s", ig.Spec.Role)
 			}
 			volumeType := fi.StringValue(ig.Spec.RootVolumeType)
 			if volumeType == "" {

--- a/tests/integration/ha_gce/kubernetes.tf
+++ b/tests/integration/ha_gce/kubernetes.tf
@@ -343,7 +343,7 @@ resource "google_compute_instance_template" "master-us-test1-a-ha-gce-example-co
     source_image = "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-57-9202-64-0"
     mode         = "READ_WRITE"
     disk_type    = "pd-standard"
-    disk_size_gb = 100
+    disk_size_gb = 64
   }
 
   network_interface = {
@@ -382,7 +382,7 @@ resource "google_compute_instance_template" "master-us-test1-b-ha-gce-example-co
     source_image = "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-57-9202-64-0"
     mode         = "READ_WRITE"
     disk_type    = "pd-standard"
-    disk_size_gb = 100
+    disk_size_gb = 64
   }
 
   network_interface = {
@@ -421,7 +421,7 @@ resource "google_compute_instance_template" "master-us-test1-c-ha-gce-example-co
     source_image = "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-57-9202-64-0"
     mode         = "READ_WRITE"
     disk_type    = "pd-standard"
-    disk_size_gb = 100
+    disk_size_gb = 64
   }
 
   network_interface = {
@@ -460,7 +460,7 @@ resource "google_compute_instance_template" "nodes-ha-gce-example-com" {
     source_image = "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-57-9202-64-0"
     mode         = "READ_WRITE"
     disk_type    = "pd-standard"
-    disk_size_gb = 100
+    disk_size_gb = 128
   }
 
   network_interface = {


### PR DESCRIPTION
Using the same disk size for gce and aws.  We need to override the disk sizes in the e2e tests, but that is another PR.

Closes: https://github.com/kubernetes/kops/issues/3294