### PR TITLE
Tweak signature in #3478

### DIFF
--- a/pkg/model/defaults/volumes.go
+++ b/pkg/model/defaults/volumes.go
@@ -28,20 +28,16 @@ const (
 	DefaultVolumeSizeBastion = 32
 )
 
-// FindDefaultVolumeSize returns the default volume size based on role.
-func FindDefaultVolumeSize(volumeSize int32, role kops.InstanceGroupRole) (int32, error) {
-	if volumeSize == 0 {
-		switch role {
-		case kops.InstanceGroupRoleMaster:
-			volumeSize = DefaultVolumeSizeMaster
-		case kops.InstanceGroupRoleNode:
-			volumeSize = DefaultVolumeSizeNode
-		case kops.InstanceGroupRoleBastion:
-			volumeSize = DefaultVolumeSizeBastion
-		default:
-			return -1, fmt.Errorf("this case should not get hit, kops.Role not found %s", role)
-		}
+// DefaultInstanceGroupVolumeSize returns the default volume size for nodes in an InstanceGroup with the specified role
+func DefaultInstanceGroupVolumeSize(role kops.InstanceGroupRole) (int32, error) {
+	switch role {
+	case kops.InstanceGroupRoleMaster:
+		return DefaultVolumeSizeMaster, nil
+	case kops.InstanceGroupRoleNode:
+		return DefaultVolumeSizeNode, nil
+	case kops.InstanceGroupRoleBastion:
+		return DefaultVolumeSizeBastion, nil
+	default:
+		return -1, fmt.Errorf("unknown InstanceGroup Role %s", role)
 	}
-
-	return volumeSize, nil
 }

--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -51,9 +51,11 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		var instanceTemplate *gcetasks.InstanceTemplate
 		{
 			volumeSize := fi.Int32Value(ig.Spec.RootVolumeSize)
-			volumeSize, err := defaults.FindDefaultVolumeSize(fi.Int32Value(ig.Spec.RootVolumeSize), ig.Spec.Role)
-			if err != nil {
-				return err
+			if volumeSize == 0 {
+				volumeSize, err = defaults.DefaultInstanceGroupVolumeSize(ig.Spec.Role)
+				if err != nil {
+					return err
+				}
 			}
 			volumeType := fi.StringValue(ig.Spec.RootVolumeType)
 			if volumeType == "" {


### PR DESCRIPTION
Follow-on to #3478

Because the default doesn't depend on the user-specified value, it's
misleading to pass it in.