### PR TITLE
protokube - bumping kubectl version

### DIFF
--- a/images/protokube-builder/onbuild.sh
+++ b/images/protokube-builder/onbuild.sh
@@ -34,7 +34,7 @@ cp /src/.build/local/channels /src/.build/artifacts/
 
 # channels uses protokube
 cd /src/.build/artifacts/
-curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.6.6/bin/linux/amd64/kubectl
+curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.7.7/bin/linux/amd64/kubectl
 chmod +x kubectl
 
 chown -R $HOST_UID:$HOST_GID /src/.build/artifacts


### PR DESCRIPTION
Since we are testing with 1.9.x and will be running 1.8.x soon, I would like to have 1.7.x running.  We may want to consider having multiple kubectls depending on k8s versions soon.