### PR TITLE
Update kube-dns to 1.14.5 for CVE-2017-14491

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -96,7 +96,7 @@ spec:
 
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-{{Arch}}:1.14.4
+        image: gcr.io/google_containers/k8s-dns-kube-dns-{{Arch}}:1.14.5
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -148,7 +148,7 @@ spec:
           mountPath: /kube-dns-config
 
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-{{Arch}}:1.14.4
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-{{Arch}}:1.14.5
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -187,7 +187,7 @@ spec:
           mountPath: /etc/k8s/dns/dnsmasq-nanny
 
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.4
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5
         livenessProbe:
           httpGet:
             path: /metrics

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors.
+ # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -116,7 +116,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	{
 		key := "kube-dns.addons.k8s.io"
-		version := "1.14.4"
+		version := "1.14.5"
 
 		{
 			location := key + "/pre-k8s-1.6.yaml"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
@@ -15,14 +15,14 @@ spec:
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.4
+    version: 1.14.5
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.4
+    version: 1.14.5
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
     name: limit-range.addons.k8s.io
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -15,14 +15,14 @@ spec:
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.4
+    version: 1.14.5
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.4
+    version: 1.14.5
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
     name: limit-range.addons.k8s.io
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -15,14 +15,14 @@ spec:
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.4
+    version: 1.14.5
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.4
+    version: 1.14.5
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
     name: limit-range.addons.k8s.io
     selector:


### PR DESCRIPTION
As described: https://security.googleblog.com/2017/10/behind-masq-yet-more-dns-and-dhcp.html

Not sure if it'd be possible to cut a new 1.7 release with this or something to give people a quick fix.

Current work around would be to manually update the addons in s3.  For those who may reference this, simply upgrading to 1.7.7 will not fix this in kops.

### Edit

~ @chrislovecnm

Please see https://github.com/kubernetes/kops/issues/3512 for more information on how to address these concerns with current kops releases.  We are still in the process of testing this release of kube-dns, which is a very critical component of kubernetes.