### PR TITLE
Fix silly typo

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
@@ -1,4 +1,4 @@
- # Copyright 2016 The Kubernetes Authors.
+# Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fix silly typo that got included in 

https://github.com/kubernetes/kops/pull/3511/files#diff-d41e15155acd41a0ecf59ccd3d3309a3L1

Sorry about that!