### PR TITLE
Use system:kube-router User for clusterrole binding

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
@@ -125,10 +125,17 @@ rules:
   - apiGroups: [""]
     resources:
       - namespaces
-      - pod
-      - service
-      - node
+      - pods
+      - services
+      - nodes
       - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
     verbs:
       - get
       - list
@@ -153,3 +160,5 @@ subjects:
 - kind: ServiceAccount
   name: kube-router
   namespace: kube-system
+- kind: User
+  name: system:kube-router


### PR DESCRIPTION
Kube-router as it provides service proxy as well, it has a chicken-egg problem (can not
access api server till it can setup service proxy), so service account are not usable. certificate generated for kube-router has CN `system:kube-router`, so user  `system:kube-router` need to be given necessary RBAC permissions

Fixes #3463