### PR TITLE
Tag subnets on AWS so load balancers are properly created

### DIFF
--- a/pkg/model/network.go
+++ b/pkg/model/network.go
@@ -155,6 +155,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			CIDR:             s(subnetSpec.CIDR),
 			Shared:           fi.Bool(sharedSubnet),
 			Tags:             tags,
+			Type:             subnetSpec.Type,
 		}
 
 		if subnetSpec.ProviderID != "" {


### PR DESCRIPTION
Without having these tags, internal load balancers are nondeterministically created and sometimes end up in inappropriate subnets. 

Closes #2011 