### PR TITLE
Fix CVE for kube-dns pre k8s 1.6

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
@@ -131,7 +131,7 @@ spec:
           name: metrics
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-{{Arch}}:1.4
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-{{Arch}}:1.14.5
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq


### PR DESCRIPTION
Additional fix for https://github.com/kubernetes/kops/issues/3512.

Testing now