### PR TITLE
mounting kubectl from the host instead to installing in protokube

### DIFF
--- a/images/protokube-builder/onbuild.sh
+++ b/images/protokube-builder/onbuild.sh
@@ -32,9 +32,4 @@ cp /src/.build/local/protokube /src/.build/artifacts/
 make channels
 cp /src/.build/local/channels /src/.build/artifacts/
 
-# channels uses protokube
-cd /src/.build/artifacts/
-curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.6.6/bin/linux/amd64/kubectl
-chmod +x kubectl
-
 chown -R $HOST_UID:$HOST_GID /src/.build/artifacts

--- a/images/protokube/Dockerfile
+++ b/images/protokube/Dockerfile
@@ -21,8 +21,6 @@ RUN apt-get update && apt-get install --yes \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-COPY /.build/artifacts/kubectl /usr/bin/kubectl
-
 COPY /.build/artifacts/protokube /usr/bin/protokube
 COPY /.build/artifacts/channels /usr/bin/channels
 

--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -246,3 +246,15 @@ func (c *NodeupModelContext) UseSecureKubelet() bool {
 
 	return false
 }
+
+// KubectlPath returns distro based path for kubectl
+func (c *NodeupModelContext) KubectlPath() string {
+	kubeletCommand := "/usr/local/bin"
+	if c.Distribution == distros.DistributionCoreOS {
+		kubeletCommand = "/opt/bin"
+	}
+	if c.Distribution == distros.DistributionContainerOS {
+		kubeletCommand = "/home/kubernetes/bin"
+	}
+	return kubeletCommand
+}

--- a/nodeup/pkg/model/kubectl.go
+++ b/nodeup/pkg/model/kubectl.go
@@ -52,7 +52,7 @@ func (b *KubectlBuilder) Build(c *fi.ModelBuilderContext) error {
 		}
 
 		t := &nodetasks.File{
-			Path:     b.kubectlPath(),
+			Path:     b.KubectlPath() + "/" + assetName,
 			Contents: asset,
 			Type:     nodetasks.FileType_File,
 			Mode:     s("0755"),
@@ -99,15 +99,4 @@ func (b *KubectlBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 
 	return nil
-}
-
-func (b *KubectlBuilder) kubectlPath() string {
-	kubeletCommand := "/usr/local/bin/kubectl"
-	if b.Distribution == distros.DistributionCoreOS {
-		kubeletCommand = "/opt/bin/kubectl"
-	}
-	if b.Distribution == distros.DistributionContainerOS {
-		kubeletCommand = "/home/kubernetes/bin/kubectl"
-	}
-	return kubeletCommand
 }


### PR DESCRIPTION
So this will fix our protokube kubectl versioning issue.  Kubectl is in on host, if we are on a master, and is always the right version, so let's use it!  Refactored a bit to get the distro path for kubectl.  Need to test on gossip.  Set the path on protokube and mounted kubectl in `/opt/kops/bin`.

/approve

TODO

- [ ] test gossip

Fixes https://github.com/kubernetes/kops/issues/3518