### PR TITLE
adding clean target to upload, because protokube is in a tar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ kops-dist: crossbuild-in-docker
 	(${SHASUMCMD} ${DIST}/linux/amd64/kops | cut -d' ' -f1) > ${DIST}/linux/amd64/kops.sha1
 
 .PHONY: version-dist
-version-dist: nodeup-dist kops-dist protokube-export utils-dist
+version-dist: clean nodeup-dist kops-dist protokube-export utils-dist
 	rm -rf ${UPLOAD}
 	mkdir -p ${UPLOAD}/kops/${VERSION}/linux/amd64/
 	mkdir -p ${UPLOAD}/kops/${VERSION}/darwin/amd64/


### PR DESCRIPTION
I had `S3_BUCKET=s3://my-bucket CI=1 make upload` uploaded an old version of protokube.  I think this was caused because the protokube tarball was already sitting on disk.  Adding this clean slows down the build, but protects us from stale files.

I am wondering if we should add the version number to the tarball name?

Any better ideas?

@alrs / @justinsb 