### PR TITLE
Makefile: fix order of directory creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,6 +352,7 @@ protokube-builder-image:
 
 .PHONY: protokube-build-in-docker
 protokube-build-in-docker: protokube-builder-image
+	mkdir -p ${IMAGES} # We have to create the directory first, so docker doesn't mess up the ownership of the dir
 	docker run -t -e VERSION=${VERSION} -e HOST_UID=${UID} -e HOST_GID=${GID} -v `pwd`:/src protokube-builder /onbuild.sh
 
 .PHONY: protokube-image
@@ -360,7 +361,6 @@ protokube-image: protokube-build-in-docker
 
 .PHONY: protokube-export
 protokube-export: protokube-image
-	mkdir -p ${IMAGES}
 	docker save protokube:${PROTOKUBE_TAG} > ${IMAGES}/protokube.tar
 	gzip --force --best ${IMAGES}/protokube.tar
 	(${SHASUMCMD} ${IMAGES}/protokube.tar.gz | cut -d' ' -f1) > ${IMAGES}/protokube.tar.gz.sha1


### PR DESCRIPTION
Without this, if we let docker create the .build/dist directory it will
be owned by root, and we won't be able to mkdir .build/dist/images
outside of docker.