### PR TITLE
1.7.1 Release notes first pass

### DIFF
--- a/docs/releases/1.7.1.md
+++ b/docs/releases/1.7.1.md
@@ -1,0 +1,12 @@
+*Please see [1.7-NOTES.md](1.7-NOTES.md) for known issues, significant changes, and required actions for 1.7.*
+
+This document describes the changes since 1.7.0.
+
+# Significant changes
+
+* kube-dns has been updated with the hotfix for CVE-2017-14491.  For more details, please see [CVE Advisory](kops/docs/advisories/cve_2017_14491.md).
+
+# Full changelist
+
+* Update images in CI tests (thanks @justinsb)
+* Update kube-dns to 1.14.5 for CVE-2017-14491 (thanks @mikesplain)


### PR DESCRIPTION
We'll need to move the current release notes in master for 1.7.1 to 1.8.0 (https://github.com/kubernetes/kops/pull/3572) since
they were not included in this release at this time and cherry-pick
these notes into master.