### PR TITLE
refactoring bastion builders so that we can do sg lifecycle

### DIFF
--- a/pkg/model/BUILD.bazel
+++ b/pkg/model/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "bastion.go",
+        "bastion_loadbalancer.go",
         "bootstrapscript.go",
         "context.go",
         "convenience.go",

--- a/pkg/model/bastion_loadbalancer.go
+++ b/pkg/model/bastion_loadbalancer.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
+)
+
+const BastionELBDefaultIdleTimeout = 5 * time.Minute
+
+// BastionLoadBalancerModelBuilder adds model objects to support bastion load balancers
+type BastionLoadBalancerModelBuilder struct {
+	*KopsModelContext
+	Lifecycle *fi.Lifecycle
+}
+
+var _ fi.ModelBuilder = &BastionLoadBalancerModelBuilder{}
+
+// Build creates the tasks for a bastion load balancer
+func (b *BastionLoadBalancerModelBuilder) Build(c *fi.ModelBuilderContext) error {
+	var bastionGroups []*kops.InstanceGroup
+	for _, ig := range b.InstanceGroups {
+		if ig.Spec.Role == kops.InstanceGroupRoleBastion {
+			bastionGroups = append(bastionGroups, ig)
+		}
+	}
+
+	if len(bastionGroups) == 0 {
+		return nil
+	}
+
+	var elbSubnets []*awstasks.Subnet
+	{
+		zones := sets.NewString()
+		for _, ig := range bastionGroups {
+			subnets, err := b.GatherSubnets(ig)
+			if err != nil {
+				return err
+			}
+			for _, s := range subnets {
+				zones.Insert(s.Zone)
+			}
+		}
+
+		for zoneName := range zones {
+			utilitySubnet, err := b.LinkToUtilitySubnetInZone(zoneName)
+			if err != nil {
+				return err
+			}
+			elbSubnets = append(elbSubnets, utilitySubnet)
+		}
+	}
+
+	// Create ELB itself
+	var elb *awstasks.LoadBalancer
+	{
+		loadBalancerName := b.GetELBName32("bastion")
+
+		idleTimeout := BastionELBDefaultIdleTimeout
+		if b.Cluster.Spec.Topology != nil && b.Cluster.Spec.Topology.Bastion != nil && b.Cluster.Spec.Topology.Bastion.IdleTimeoutSeconds != nil {
+			idleTimeout = time.Second * time.Duration(*b.Cluster.Spec.Topology.Bastion.IdleTimeoutSeconds)
+		}
+
+		elb = &awstasks.LoadBalancer{
+			Name:      s("bastion." + b.ClusterName()),
+			Lifecycle: b.Lifecycle,
+
+			LoadBalancerName: s(loadBalancerName),
+			SecurityGroups: []*awstasks.SecurityGroup{
+				b.LinkToELBSecurityGroup(BastionELBSecurityGroupPrefix),
+			},
+			Subnets: elbSubnets,
+			Listeners: map[string]*awstasks.LoadBalancerListener{
+				"22": {InstancePort: 22},
+			},
+
+			HealthCheck: &awstasks.LoadBalancerHealthCheck{
+				Target:             s("TCP:22"),
+				Timeout:            i64(5),
+				Interval:           i64(10),
+				HealthyThreshold:   i64(2),
+				UnhealthyThreshold: i64(2),
+			},
+
+			ConnectionSettings: &awstasks.LoadBalancerConnectionSettings{
+				IdleTimeout: i64(int64(idleTimeout.Seconds())),
+			},
+		}
+
+		c.AddTask(elb)
+	}
+
+	for _, ig := range bastionGroups {
+		// We build the ASG when we iterate over the instance groups
+
+		// Attach the ELB to the ASG
+		t := &awstasks.LoadBalancerAttachment{
+			Name:      s("bastion-elb-attachment"),
+			Lifecycle: b.Lifecycle,
+
+			LoadBalancer:     elb,
+			AutoscalingGroup: b.LinkToAutoscalingGroup(ig),
+		}
+		c.AddTask(t)
+	}
+
+	bastionPublicName := ""
+	if b.Cluster.Spec.Topology != nil && b.Cluster.Spec.Topology.Bastion != nil {
+		bastionPublicName = b.Cluster.Spec.Topology.Bastion.BastionPublicName
+	}
+	if bastionPublicName != "" {
+		// Here we implement the bastion CNAME logic
+		// By default bastions will create a CNAME that follows the `bastion-$clustername` formula
+		t := &awstasks.DNSName{
+			Name:      s(bastionPublicName),
+			Lifecycle: b.Lifecycle,
+
+			Zone:               b.LinkToDNSZone(),
+			ResourceType:       s("A"),
+			TargetLoadBalancer: elb,
+		}
+		c.AddTask(t)
+
+	}
+	return nil
+}

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -537,6 +537,7 @@ func (c *ApplyClusterCmd) Run() error {
 					&model.MasterVolumeBuilder{KopsModelContext: modelContext, Lifecycle: clusterLifecycle},
 					&awsmodel.APILoadBalancerBuilder{AWSModelContext: awsModelContext, Lifecycle: networkLifecycle},
 					&model.BastionModelBuilder{KopsModelContext: modelContext, Lifecycle: networkLifecycle},
+					&model.BastionLoadBalancerModelBuilder{KopsModelContext: modelContext, Lifecycle: networkLifecycle},
 					&model.DNSModelBuilder{KopsModelContext: modelContext, Lifecycle: networkLifecycle},
 					&model.ExternalAccessModelBuilder{KopsModelContext: modelContext, Lifecycle: clusterLifecycle},
 					&model.FirewallModelBuilder{KopsModelContext: modelContext, Lifecycle: clusterLifecycle},


### PR DESCRIPTION
Did not want to do it here, but we probably should move the builders under the awsmodel.  Creating another builder so that security groups and ELB can run on there own.