### PR TITLE
Docs tweak - specify flag, not kube-up env var

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -195,14 +195,15 @@ NOTE: Where the corresponding configuration value can be empty, fields can be se
 Will result in the flag `--resolv-conf=` being built.
 
 #### Enable Custom metrics support
-To use custom metrics in kubernetes as per [custom metrics doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics) we have to set flag  `ENABLE_CUSTOM_METRICS` to `true` on all the kubelets.
-we can specify that in the `kubelet` spec in our cluster.yml.
+To use custom metrics in kubernetes as per [custom metrics doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics)
+we have to set the flag `--enable-custom-metrics` to `true` on all the kubelets. We can specify that in the `kubelet` spec in our cluster.yml.
 
 ```
 spec:
   kubelet:
     enableCustomMetrics: true
 ```
+
 ### kubeScheduler
 
 This block contains configurations for `kube-scheduler`.  See https://kubernetes.io/docs/admin/kube-scheduler/


### PR DESCRIPTION
ENABLE_CUSTOM_METRICS is a kube-up artifact; the flags are the truth.