### PR TITLE
Modified OS detection logic when updating http proxy settings.

### DIFF
--- a/nodeup/pkg/bootstrap/install.go
+++ b/nodeup/pkg/bootstrap/install.go
@@ -19,6 +19,10 @@ package bootstrap
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kops/nodeup/pkg/distros"
@@ -27,9 +31,6 @@ import (
 	"k8s.io/kops/upup/pkg/fi/nodeup/local"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 	"k8s.io/kops/util/pkg/vfs"
-	"os"
-	"strings"
-	"time"
 )
 
 type Installation struct {
@@ -138,6 +139,7 @@ func (i *Installation) buildSystemdJob() *nodetasks.Service {
 		manifest.Set("Service", "Environment", buffer.String())
 	}
 
+	manifest.Set("Service", "EnvironmentFile", "/etc/environment")
 	manifest.Set("Service", "ExecStart", command)
 	manifest.Set("Service", "Type", "oneshot")
 

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -564,6 +564,7 @@ func (b *DockerBuilder) buildSystemdService(dockerVersionMajor int64, dockerVers
 
 	manifest.Set("Service", "Type", "notify")
 	manifest.Set("Service", "EnvironmentFile", "/etc/sysconfig/docker")
+	manifest.Set("Service", "EnvironmentFile", "/etc/environment")
 
 	if usesDockerSocket {
 		manifest.Set("Service", "ExecStart", dockerdCommand+" -H fd:// \"$DOCKER_OPTS\"")
@@ -632,6 +633,7 @@ func (b *DockerBuilder) buildContainerOSConfigurationDropIn(c *fi.ModelBuilderCo
 	lines := []string{
 		"[Service]",
 		"EnvironmentFile=/etc/sysconfig/docker",
+		"EnvironmentFile=/etc/environment",
 	}
 	contents := strings.Join(lines, "\n")
 

--- a/nodeup/pkg/model/tests/dockerbuilder/docker_1.12.1/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/docker_1.12.1/tasks.yaml
@@ -236,6 +236,7 @@ definition: |
   [Service]
   Type=notify
   EnvironmentFile=/etc/sysconfig/docker
+  EnvironmentFile=/etc/environment
   ExecStart=/usr/bin/dockerd -H fd:// "$DOCKER_OPTS"
   ExecReload=/bin/kill -s HUP $MAINPID
   KillMode=process

--- a/nodeup/pkg/model/tests/dockerbuilder/logflags/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/logflags/tasks.yaml
@@ -236,6 +236,7 @@ definition: |
   [Service]
   Type=notify
   EnvironmentFile=/etc/sysconfig/docker
+  EnvironmentFile=/etc/environment
   ExecStart=/usr/bin/dockerd -H fd:// "$DOCKER_OPTS"
   ExecReload=/bin/kill -s HUP $MAINPID
   KillMode=process

--- a/nodeup/pkg/model/tests/dockerbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/simple/tasks.yaml
@@ -236,6 +236,7 @@ definition: |
   [Service]
   Type=notify
   EnvironmentFile=/etc/sysconfig/docker
+  EnvironmentFile=/etc/environment
   ExecStart=/usr/bin/dockerd -H fd:// "$DOCKER_OPTS"
   ExecReload=/bin/kill -s HUP $MAINPID
   KillMode=process

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -282,47 +282,34 @@ func (b *BootstrapScript) createProxyEnv(ps *kops.EgressProxySpec) string {
 			httpProxyURL += ps.HTTPProxy.Host
 		}
 
-		// Set base env variables
-		buffer.WriteString("export http_proxy=" + httpProxyURL + "\n")
-		buffer.WriteString("export https_proxy=${http_proxy}\n")
-		buffer.WriteString("export no_proxy=" + ps.ProxyExcludes + "\n")
-		buffer.WriteString("export NO_PROXY=${no_proxy}\n")
-
-		// TODO move the rest of this configuration work to nodeup
-
-		// Set env variables for docker
-		buffer.WriteString("echo \"export http_proxy=${http_proxy}\" >> /etc/default/docker\n")
-		buffer.WriteString("echo \"export https_proxy=${http_proxy}\" >> /etc/default/docker\n")
-		buffer.WriteString("echo \"export no_proxy=${no_proxy}\" >> /etc/default/docker\n")
-		buffer.WriteString("echo \"export NO_PROXY=${no_proxy}\" >> /etc/default/docker\n")
-
 		// Set env variables for base environment
-		buffer.WriteString("echo \"export http_proxy=${http_proxy}\" >> /etc/environment\n")
-		buffer.WriteString("echo \"export https_proxy=${http_proxy}\" >> /etc/environment\n")
-		buffer.WriteString("echo \"export no_proxy=${no_proxy}\" >> /etc/environment\n")
-		buffer.WriteString("echo \"export NO_PROXY=${no_proxy}\" >> /etc/environment\n")
+		buffer.WriteString(`echo "http_proxy=` + httpProxyURL + `" >> /etc/environment` + "\n")
+		buffer.WriteString(`echo "https_proxy=` + httpProxyURL + `" >> /etc/environment` + "\n")
+		buffer.WriteString(`echo "no_proxy=` + ps.ProxyExcludes + `" >> /etc/environment` + "\n")
+		buffer.WriteString(`echo "NO_PROXY=` + ps.ProxyExcludes + `" >> /etc/environment` + "\n")
 
-		// Set env variables to systemd
-		buffer.WriteString("echo DefaultEnvironment=\\\"http_proxy=${http_proxy}\\\" \\\"https_proxy=${http_proxy}\\\"")
-		buffer.WriteString("echo DefaultEnvironment=\\\"http_proxy=${http_proxy}\\\" \\\"https_proxy=${http_proxy}\\\"")
-		buffer.WriteString(" \\\"NO_PROXY=${no_proxy}\\\" \\\"no_proxy=${no_proxy}\\\"")
+		// Load the proxy environment variables
+		buffer.WriteString("while read in; do export $in; done < /etc/environment\n")
+
+		// Set env variables for package manager depending on OS Distribution (N/A for CoreOS)
+		// Note: Nodeup will source the `/etc/environment` file within docker config in the correct location
+		buffer.WriteString("case `cat /proc/version` in\n")
+		buffer.WriteString("*[Dd]ebian*)\n")
+		buffer.WriteString(`  echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;` + "\n")
+		buffer.WriteString("*[Uu]buntu*)\n")
+		buffer.WriteString(`  echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;` + "\n")
+		buffer.WriteString("*[Rr]ed[Hh]at*)\n")
+		buffer.WriteString(`  echo "http_proxy=${http_proxy}" >> /etc/yum.conf ;;` + "\n")
+		buffer.WriteString("esac\n")
+
+		// Set env variables for systemd
+		buffer.WriteString(`echo "DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\"`)
+		buffer.WriteString(` \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\""`)
 		buffer.WriteString(" >> /etc/systemd/system.conf\n")
-
-		// source in the environment this step ensures that environment file is correct
-		buffer.WriteString("source /etc/environment\n")
 
 		// Restart stuff
 		buffer.WriteString("systemctl daemon-reload\n")
 		buffer.WriteString("systemctl daemon-reexec\n")
-
-		// TODO do we need no_proxy in these as well??
-		// TODO handle CoreOS
-		// Depending on OS set package manager proxy settings
-		buffer.WriteString("if [ -f /etc/lsb-release ] || [ -f /etc/debian_version ]; then\n")
-		buffer.WriteString("    echo \"Acquire::http::Proxy \\\"${http_proxy}\\\";\" > /etc/apt/apt.conf.d/30proxy\n")
-		buffer.WriteString("elif [ -f /etc/redhat-release ]; then\n")
-		buffer.WriteString("  echo \"http_proxy=${http_proxy}\" >> /etc/yum.conf\n")
-		buffer.WriteString("fi\n")
 	}
 	return buffer.String()
 }

--- a/pkg/model/bootstrapscript_test.go
+++ b/pkg/model/bootstrapscript_test.go
@@ -41,14 +41,14 @@ func Test_ProxyFunc(t *testing.T) {
 		t.Fatalf("script cannot be empty")
 	}
 
-	if !strings.HasPrefix(script, "export http_proxy=http://example.com:80") {
+	if !strings.HasPrefix(script, "echo \"http_proxy=http://example.com:80\" >> /etc/environment") {
 		t.Fatalf("script not setting http_proxy properly")
 	}
 
 	ps.ProxyExcludes = "www.google.com,www.kubernetes.io"
 
 	script = b.createProxyEnv(ps)
-	if !strings.Contains(script, "export no_proxy="+ps.ProxyExcludes) {
+	if !strings.Contains(script, "no_proxy="+ps.ProxyExcludes) {
 		t.Fatalf("script not setting no_proxy properly")
 	}
 }

--- a/pkg/model/tests/data/bootstrapscript_0.txt
+++ b/pkg/model/tests/data/bootstrapscript_0.txt
@@ -23,27 +23,22 @@ NODEUP_HASH=NUSHash
 
 
 
-export http_proxy=http://example.com:80
-export https_proxy=${http_proxy}
-export no_proxy=
-export NO_PROXY=${no_proxy}
-echo "export http_proxy=${http_proxy}" >> /etc/default/docker
-echo "export https_proxy=${http_proxy}" >> /etc/default/docker
-echo "export no_proxy=${no_proxy}" >> /etc/default/docker
-echo "export NO_PROXY=${no_proxy}" >> /etc/default/docker
-echo "export http_proxy=${http_proxy}" >> /etc/environment
-echo "export https_proxy=${http_proxy}" >> /etc/environment
-echo "export no_proxy=${no_proxy}" >> /etc/environment
-echo "export NO_PROXY=${no_proxy}" >> /etc/environment
-echo DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\"echo DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\" >> /etc/systemd/system.conf
-source /etc/environment
+echo "http_proxy=http://example.com:80" >> /etc/environment
+echo "https_proxy=http://example.com:80" >> /etc/environment
+echo "no_proxy=" >> /etc/environment
+echo "NO_PROXY=" >> /etc/environment
+while read in; do export $in; done < /etc/environment
+case `cat /proc/version` in
+*[Dd]ebian*)
+  echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
+*[Uu]buntu*)
+  echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
+*[Rr]ed[Hh]at*)
+  echo "http_proxy=${http_proxy}" >> /etc/yum.conf ;;
+esac
+echo "DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\"" >> /etc/systemd/system.conf
 systemctl daemon-reload
 systemctl daemon-reexec
-if [ -f /etc/lsb-release ] || [ -f /etc/debian_version ]; then
-    echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy
-elif [ -f /etc/redhat-release ]; then
-  echo "http_proxy=${http_proxy}" >> /etc/yum.conf
-fi
 
 
 function ensure-install-dir() {

--- a/pkg/model/tests/data/bootstrapscript_1.txt
+++ b/pkg/model/tests/data/bootstrapscript_1.txt
@@ -23,27 +23,22 @@ NODEUP_HASH=NUSHash
 
 
 
-export http_proxy=http://example.com:80
-export https_proxy=${http_proxy}
-export no_proxy=
-export NO_PROXY=${no_proxy}
-echo "export http_proxy=${http_proxy}" >> /etc/default/docker
-echo "export https_proxy=${http_proxy}" >> /etc/default/docker
-echo "export no_proxy=${no_proxy}" >> /etc/default/docker
-echo "export NO_PROXY=${no_proxy}" >> /etc/default/docker
-echo "export http_proxy=${http_proxy}" >> /etc/environment
-echo "export https_proxy=${http_proxy}" >> /etc/environment
-echo "export no_proxy=${no_proxy}" >> /etc/environment
-echo "export NO_PROXY=${no_proxy}" >> /etc/environment
-echo DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\"echo DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\" >> /etc/systemd/system.conf
-source /etc/environment
+echo "http_proxy=http://example.com:80" >> /etc/environment
+echo "https_proxy=http://example.com:80" >> /etc/environment
+echo "no_proxy=" >> /etc/environment
+echo "NO_PROXY=" >> /etc/environment
+while read in; do export $in; done < /etc/environment
+case `cat /proc/version` in
+*[Dd]ebian*)
+  echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
+*[Uu]buntu*)
+  echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
+*[Rr]ed[Hh]at*)
+  echo "http_proxy=${http_proxy}" >> /etc/yum.conf ;;
+esac
+echo "DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\"" >> /etc/systemd/system.conf
 systemctl daemon-reload
 systemctl daemon-reexec
-if [ -f /etc/lsb-release ] || [ -f /etc/debian_version ]; then
-    echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy
-elif [ -f /etc/redhat-release ]; then
-  echo "http_proxy=${http_proxy}" >> /etc/yum.conf
-fi
 
 
 function ensure-install-dir() {

--- a/pkg/model/tests/data/bootstrapscript_2.txt
+++ b/pkg/model/tests/data/bootstrapscript_2.txt
@@ -23,27 +23,22 @@ NODEUP_HASH=NUSHash
 
 
 
-export http_proxy=http://example.com:80
-export https_proxy=${http_proxy}
-export no_proxy=
-export NO_PROXY=${no_proxy}
-echo "export http_proxy=${http_proxy}" >> /etc/default/docker
-echo "export https_proxy=${http_proxy}" >> /etc/default/docker
-echo "export no_proxy=${no_proxy}" >> /etc/default/docker
-echo "export NO_PROXY=${no_proxy}" >> /etc/default/docker
-echo "export http_proxy=${http_proxy}" >> /etc/environment
-echo "export https_proxy=${http_proxy}" >> /etc/environment
-echo "export no_proxy=${no_proxy}" >> /etc/environment
-echo "export NO_PROXY=${no_proxy}" >> /etc/environment
-echo DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\"echo DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\" >> /etc/systemd/system.conf
-source /etc/environment
+echo "http_proxy=http://example.com:80" >> /etc/environment
+echo "https_proxy=http://example.com:80" >> /etc/environment
+echo "no_proxy=" >> /etc/environment
+echo "NO_PROXY=" >> /etc/environment
+while read in; do export $in; done < /etc/environment
+case `cat /proc/version` in
+*[Dd]ebian*)
+  echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
+*[Uu]buntu*)
+  echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
+*[Rr]ed[Hh]at*)
+  echo "http_proxy=${http_proxy}" >> /etc/yum.conf ;;
+esac
+echo "DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\"" >> /etc/systemd/system.conf
 systemctl daemon-reload
 systemctl daemon-reexec
-if [ -f /etc/lsb-release ] || [ -f /etc/debian_version ]; then
-    echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy
-elif [ -f /etc/redhat-release ]; then
-  echo "http_proxy=${http_proxy}" >> /etc/yum.conf
-fi
 
 
 function ensure-install-dir() {

--- a/pkg/model/tests/data/bootstrapscript_3.txt
+++ b/pkg/model/tests/data/bootstrapscript_3.txt
@@ -23,27 +23,22 @@ NODEUP_HASH=NUSHash
 
 
 
-export http_proxy=http://example.com:80
-export https_proxy=${http_proxy}
-export no_proxy=
-export NO_PROXY=${no_proxy}
-echo "export http_proxy=${http_proxy}" >> /etc/default/docker
-echo "export https_proxy=${http_proxy}" >> /etc/default/docker
-echo "export no_proxy=${no_proxy}" >> /etc/default/docker
-echo "export NO_PROXY=${no_proxy}" >> /etc/default/docker
-echo "export http_proxy=${http_proxy}" >> /etc/environment
-echo "export https_proxy=${http_proxy}" >> /etc/environment
-echo "export no_proxy=${no_proxy}" >> /etc/environment
-echo "export NO_PROXY=${no_proxy}" >> /etc/environment
-echo DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\"echo DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\" >> /etc/systemd/system.conf
-source /etc/environment
+echo "http_proxy=http://example.com:80" >> /etc/environment
+echo "https_proxy=http://example.com:80" >> /etc/environment
+echo "no_proxy=" >> /etc/environment
+echo "NO_PROXY=" >> /etc/environment
+while read in; do export $in; done < /etc/environment
+case `cat /proc/version` in
+*[Dd]ebian*)
+  echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
+*[Uu]buntu*)
+  echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
+*[Rr]ed[Hh]at*)
+  echo "http_proxy=${http_proxy}" >> /etc/yum.conf ;;
+esac
+echo "DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\"" >> /etc/systemd/system.conf
 systemctl daemon-reload
 systemctl daemon-reexec
-if [ -f /etc/lsb-release ] || [ -f /etc/debian_version ]; then
-    echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy
-elif [ -f /etc/redhat-release ]; then
-  echo "http_proxy=${http_proxy}" >> /etc/yum.conf
-fi
 
 
 function ensure-install-dir() {

--- a/pkg/model/tests/data/bootstrapscript_4.txt
+++ b/pkg/model/tests/data/bootstrapscript_4.txt
@@ -23,27 +23,22 @@ NODEUP_HASH=NUSHash
 
 
 
-export http_proxy=http://example.com:80
-export https_proxy=${http_proxy}
-export no_proxy=
-export NO_PROXY=${no_proxy}
-echo "export http_proxy=${http_proxy}" >> /etc/default/docker
-echo "export https_proxy=${http_proxy}" >> /etc/default/docker
-echo "export no_proxy=${no_proxy}" >> /etc/default/docker
-echo "export NO_PROXY=${no_proxy}" >> /etc/default/docker
-echo "export http_proxy=${http_proxy}" >> /etc/environment
-echo "export https_proxy=${http_proxy}" >> /etc/environment
-echo "export no_proxy=${no_proxy}" >> /etc/environment
-echo "export NO_PROXY=${no_proxy}" >> /etc/environment
-echo DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\"echo DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\" >> /etc/systemd/system.conf
-source /etc/environment
+echo "http_proxy=http://example.com:80" >> /etc/environment
+echo "https_proxy=http://example.com:80" >> /etc/environment
+echo "no_proxy=" >> /etc/environment
+echo "NO_PROXY=" >> /etc/environment
+while read in; do export $in; done < /etc/environment
+case `cat /proc/version` in
+*[Dd]ebian*)
+  echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
+*[Uu]buntu*)
+  echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
+*[Rr]ed[Hh]at*)
+  echo "http_proxy=${http_proxy}" >> /etc/yum.conf ;;
+esac
+echo "DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\"" >> /etc/systemd/system.conf
 systemctl daemon-reload
 systemctl daemon-reexec
-if [ -f /etc/lsb-release ] || [ -f /etc/debian_version ]; then
-    echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy
-elif [ -f /etc/redhat-release ]; then
-  echo "http_proxy=${http_proxy}" >> /etc/yum.conf
-fi
 
 
 function ensure-install-dir() {

--- a/pkg/model/tests/data/bootstrapscript_5.txt
+++ b/pkg/model/tests/data/bootstrapscript_5.txt
@@ -23,27 +23,22 @@ NODEUP_HASH=NUSHash
 
 
 
-export http_proxy=http://example.com:80
-export https_proxy=${http_proxy}
-export no_proxy=
-export NO_PROXY=${no_proxy}
-echo "export http_proxy=${http_proxy}" >> /etc/default/docker
-echo "export https_proxy=${http_proxy}" >> /etc/default/docker
-echo "export no_proxy=${no_proxy}" >> /etc/default/docker
-echo "export NO_PROXY=${no_proxy}" >> /etc/default/docker
-echo "export http_proxy=${http_proxy}" >> /etc/environment
-echo "export https_proxy=${http_proxy}" >> /etc/environment
-echo "export no_proxy=${no_proxy}" >> /etc/environment
-echo "export NO_PROXY=${no_proxy}" >> /etc/environment
-echo DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\"echo DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\" >> /etc/systemd/system.conf
-source /etc/environment
+echo "http_proxy=http://example.com:80" >> /etc/environment
+echo "https_proxy=http://example.com:80" >> /etc/environment
+echo "no_proxy=" >> /etc/environment
+echo "NO_PROXY=" >> /etc/environment
+while read in; do export $in; done < /etc/environment
+case `cat /proc/version` in
+*[Dd]ebian*)
+  echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
+*[Uu]buntu*)
+  echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
+*[Rr]ed[Hh]at*)
+  echo "http_proxy=${http_proxy}" >> /etc/yum.conf ;;
+esac
+echo "DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\"" >> /etc/systemd/system.conf
 systemctl daemon-reload
 systemctl daemon-reexec
-if [ -f /etc/lsb-release ] || [ -f /etc/debian_version ]; then
-    echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy
-elif [ -f /etc/redhat-release ]; then
-  echo "http_proxy=${http_proxy}" >> /etc/yum.conf
-fi
 
 
 function ensure-install-dir() {


### PR DESCRIPTION
Reduce duplication in configuring http proxy settings by writing it to the system-wide `/etc/environment` file and sourcing this in accordingly for the different services (docker, package management).

I have tested and this now correctly covers CoreOS by resolving the following bugs (I don't believe any issues were raised for these):
- Docker config file was located in `/etc/sysconfig/docker` as opposed to `/etc/default/docker`
- The `/etc/lsb-release` file exists for CoreOS, so the bootstrap script was incorrectly attempting to write proxy settings into the apt proxy config file

These changes should cover CoreOS, Debian, Ubuntu, RedHat distributions including CentOS and Fedora.

**NOTE:**  A nodeup image will need to be built for these changes to work as expected, as now we rely on nodeup to update the proxy settings within the docker config (by sourcing in the env vars set within `/etc/environment`.