### PR TITLE
Require kops 1.7.1 (with the CVE fix), recommend kops 1.8.1

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -48,22 +48,22 @@ spec:
     requiredVersion: 1.4.2
   kopsVersions:
   - range: ">=1.8.0-alpha.1"
-    recommendedVersion: 1.8.0
-    #requiredVersion: 1.8.0
+    recommendedVersion: 1.8.1
+    requiredVersion: 1.7.1
     kubernetesVersion: 1.8.7
   - range: ">=1.7.0-alpha.1"
-    recommendedVersion: 1.7.1
-    #requiredVersion: 1.7.0
+    recommendedVersion: 1.8.1
+    requiredVersion: 1.7.1
     kubernetesVersion: 1.7.12
   - range: ">=1.6.0-alpha.1"
-    #recommendedVersion: 1.6.0
-    #requiredVersion: 1.6.0
+    recommendedVersion: 1.8.1
+    requiredVersion: 1.7.1
     kubernetesVersion: 1.6.13
   - range: ">=1.5.0-alpha1"
-    recommendedVersion: 1.5.1
-    #requiredVersion: 1.5.1
+    recommendedVersion: 1.8.1
+    requiredVersion: 1.7.1
     kubernetesVersion: 1.5.8
   - range: "<1.5.0"
-    recommendedVersion: 1.4.4
-    #requiredVersion: 1.4.4
+    recommendedVersion: 1.8.1
+    requiredVersion: 1.7.1
     kubernetesVersion: 1.4.12

--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -55,9 +55,13 @@ type ChannelSpec struct {
 type KopsVersionSpec struct {
 	Range string `json:"range,omitempty"`
 
+	// RecommendedVersion is the recommended version of kops to use for this Range of kops versions
 	RecommendedVersion string `json:"recommendedVersion,omitempty"`
-	RequiredVersion    string `json:"requiredVersion,omitempty"`
 
+	// RequiredVersion is the required version of kops to use for this Range of kops versions, forcing an upgrade
+	RequiredVersion string `json:"requiredVersion,omitempty"`
+
+	// KubernetesVersion is the default version of kubernetes to use with this kops version e.g. for new clusters
 	KubernetesVersion string `json:"kubernetesVersion,omitempty"`
 }
 
@@ -285,6 +289,8 @@ func (c *Channel) FindImage(provider CloudProviderID, kubernetesVersion semver.V
 	return matches[0]
 }
 
+// RecommendedKubernetesVersion returns the recommended kubernetes version for a version of kops
+// It is used by default when creating a new cluster, for example
 func RecommendedKubernetesVersion(c *Channel, kopsVersionString string) *semver.Version {
 	kopsVersion, err := semver.ParseTolerant(kopsVersionString)
 	if err != nil {


### PR DESCRIPTION
We make it recommended in the stable channel, and will test the mandatory
upgrade in the alpha channel.