### PR TITLE
Mock kops version in tests

### DIFF
--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -243,6 +243,7 @@ func runTestAWS(t *testing.T, clusterName string, srcDir string, version string,
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
+	h.MockKopsVersion("1.7.0")
 	h.SetupMockAWS()
 
 	expectedFilenames := []string{
@@ -278,6 +279,7 @@ func runTestGCE(t *testing.T, clusterName string, srcDir string, version string,
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
+	h.MockKopsVersion("1.7.0")
 	h.SetupMockGCE()
 
 	expectedFilenames := []string{
@@ -309,6 +311,7 @@ func runTestCloudformation(t *testing.T, clusterName string, srcDir string, vers
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
+	h.MockKopsVersion("1.7.0")
 	h.SetupMockAWS()
 
 	factory := util.NewFactory(factoryOptions)

--- a/pkg/model/components/BUILD.bazel
+++ b/pkg/model/components/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//pkg/apis/kops:go_default_library",
+        "//pkg/apis/kops/util:go_default_library",
         "//pkg/assets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],

--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["integrationtestharness.go"],
     visibility = ["//visibility:public"],
     deps = [
+        "//:go_default_library",
         "//cloudmock/aws/mockec2:go_default_library",
         "//cloudmock/aws/mockroute53:go_default_library",
         "//pkg/apis/kops:go_default_library",

--- a/pkg/testutils/integrationtestharness.go
+++ b/pkg/testutils/integrationtestharness.go
@@ -17,21 +17,23 @@ limitations under the License.
 package testutils
 
 import (
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/golang/glog"
-	"io/ioutil"
+	kopsroot "k8s.io/kops"
 	"k8s.io/kops/cloudmock/aws/mockec2"
 	"k8s.io/kops/cloudmock/aws/mockroute53"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/util/pkg/vfs"
-	"os"
-	"path"
-	"path/filepath"
-	"testing"
 )
 
 type IntegrationTestHarness struct {
@@ -40,6 +42,9 @@ type IntegrationTestHarness struct {
 
 	// The original kops DefaultChannelBase value, restored on Close
 	originalDefaultChannelBase string
+
+	// originalKopsVersion is the original kops.Version value, restored on Close
+	originalKopsVersion string
 }
 
 func NewIntegrationTestHarness(t *testing.T) *IntegrationTestHarness {
@@ -76,6 +81,10 @@ func (h *IntegrationTestHarness) Close() {
 				h.T.Fatalf("failed to remove temp dir %q: %v", h.TempDir, err)
 			}
 		}
+	}
+
+	if h.originalKopsVersion != "" {
+		kopsroot.Version = h.originalKopsVersion
 	}
 
 	if h.originalDefaultChannelBase != "" {
@@ -134,4 +143,14 @@ func (h *IntegrationTestHarness) SetupMockAWS() {
 // SetupMockGCE configures a mock GCE cloud provider
 func (h *IntegrationTestHarness) SetupMockGCE() {
 	gce.InstallMockGCECloud("us-test1", "testproject")
+}
+
+// MockKopsVersion will set the kops version to the specified value, until Close is called
+func (h *IntegrationTestHarness) MockKopsVersion(version string) {
+	if h.originalKopsVersion != "" {
+		h.T.Fatalf("MockKopsVersion called twice (%s and %s)", version, h.originalKopsVersion)
+	}
+
+	h.originalKopsVersion = kopsroot.Version
+	kopsroot.Version = version
 }


### PR DESCRIPTION
This avoids having to update the tests every time our version changes.