### PR TITLE
`kops get ...` should exit with non-zero if the resource don't exist

### DIFF
--- a/cmd/kops/get.go
+++ b/cmd/kops/get.go
@@ -125,8 +125,7 @@ func RunGet(context Factory, out io.Writer, options *GetOptions) error {
 	}
 
 	if cluster == nil {
-		fmt.Fprintf(os.Stderr, "No cluster found\n")
-		return nil
+		return fmt.Errorf("No cluster found")
 	}
 
 	clusterList := &api.ClusterList{}

--- a/cmd/kops/get_cluster.go
+++ b/cmd/kops/get_cluster.go
@@ -133,8 +133,7 @@ func RunGetClusters(context Factory, out io.Writer, options *GetClusterOptions) 
 	}
 
 	if len(clusters) == 0 {
-		fmt.Fprintf(os.Stderr, "No clusters found\n")
-		return nil
+		return fmt.Errorf("No clusters found")
 	}
 
 	if options.FullSpec {

--- a/cmd/kops/get_federation.go
+++ b/cmd/kops/get_federation.go
@@ -83,8 +83,7 @@ func RunGetFederations(context Factory, out io.Writer, options *GetFederationOpt
 		federations = append(federations, &list.Items[i])
 	}
 	if len(federations) == 0 {
-		fmt.Fprintf(out, "No federations found\n")
-		return nil
+		return fmt.Errorf("No federations found")
 	}
 	switch options.output {
 

--- a/cmd/kops/get_instancegroups.go
+++ b/cmd/kops/get_instancegroups.go
@@ -109,8 +109,7 @@ func RunGetInstanceGroups(options *GetInstanceGroupsOptions, args []string) erro
 	}
 
 	if len(instancegroups) == 0 {
-		fmt.Fprintf(os.Stderr, "No InstanceGroup objects found\n")
-		return nil
+		return fmt.Errorf("No InstanceGroup objects found")
 	}
 
 	switch options.output {

--- a/cmd/kops/get_secrets.go
+++ b/cmd/kops/get_secrets.go
@@ -167,9 +167,7 @@ func RunGetSecrets(options *GetSecretsOptions, args []string) error {
 	}
 
 	if len(items) == 0 {
-		fmt.Fprintf(os.Stderr, "No secrets found\n")
-
-		return nil
+		return fmt.Errorf("No secrets found")
 	}
 	switch options.output {
 


### PR DESCRIPTION
Without this change, `kops get --name non-existing-cluster` will exit with a status of `0`, which makes it difficult to check if a cluster (and other resources) exist in a shell script.

cc @chrislovecnm, who I think originally wrote this code.