### PR TITLE
Update Weave Net to version 2.0.5

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
@@ -81,7 +81,7 @@ spec:
             - name: WEAVE_MTU
               value: "{{ .Networking.Weave.MTU }}"
             {{- end }}
-          image: 'weaveworks/weave-kube:2.0.1'
+          image: 'weaveworks/weave-kube:2.0.5'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -117,7 +117,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.0.1'
+          image: 'weaveworks/weave-npc:2.0.5'
           resources:
             requests:
               cpu: 100m

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -1,3 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: weave-net
+  labels:
+    name: weave-net
+    role.kubernetes.io/networking: "1"
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - namespaces
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,6 +33,22 @@ metadata:
     name: weave-net
     role.kubernetes.io/networking: "1"
   namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: weave-net
+  labels:
+    name: weave-net
+    role.kubernetes.io/networking: "1"
+roleRef:
+  kind: ClusterRole
+  name: weave-net
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: weave-net
+    namespace: kube-system
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -18,9 +61,6 @@ metadata:
 spec:
   template:
     metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
       labels:
         name: weave-net
         role.kubernetes.io/networking: "1"
@@ -70,6 +110,8 @@ spec:
               mountPath: /host/var/lib/dbus
             - name: lib-modules
               mountPath: /lib/modules
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
         - name: weave-npc
           env:
             - name: HOSTNAME
@@ -87,12 +129,18 @@ spec:
               memory: 200Mi
           securityContext:
             privileged: true
+          volumeMounts:
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
       hostNetwork: true
       hostPID: true
       restartPolicy: Always
       securityContext:
         seLinuxOptions: {}
       serviceAccountName: weave-net
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       volumes:
         - name: weavedb
           hostPath:
@@ -112,3 +160,8 @@ spec:
         - name: lib-modules
           hostPath:
             path: /lib/modules
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+  updateStrategy:
+    type: RollingUpdate

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -306,7 +306,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 	if b.cluster.Spec.Networking.Weave != nil {
 		key := "networking.weave"
 
-		version := "2.0.1"
+		version := "2.0.5"
 
 		{
 			location := key + "/pre-k8s-1.6.yaml"
@@ -332,7 +332,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 				Version:           fi.String(version),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.6.0",
+				KubernetesVersion: ">=1.6.0 <1.7.0",
+				Id:                id,
+			})
+			manifests[key+"-"+id] = "addons/" + location
+		}
+
+		{
+			location := key + "/k8s-1.7.yaml"
+			id := "k8s-1.7"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(version),
+				Selector:          networkingSelector,
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.7.0",
 				Id:                id,
 			})
 			manifests[key+"-"+id] = "addons/" + location

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -53,11 +53,18 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.0.1
+    version: 2.0.5
   - id: k8s-1.6
-    kubernetesVersion: '>=1.6.0'
+    kubernetesVersion: '>=1.6.0 <1.7.0'
     manifest: networking.weave/k8s-1.6.yaml
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.0.1
+    version: 2.0.5
+  - id: k8s-1.7
+    kubernetesVersion: '>=1.7.0'
+    manifest: networking.weave/k8s-1.7.yaml
+    name: networking.weave
+    selector:
+      role.kubernetes.io/networking: "1"
+    version: 2.0.5


### PR DESCRIPTION
This PR also adds a manifest with a volume-mount for the iptables lock file, which avoids collisions between Weave components and kube-proxy that can sometimes result in a half-configured Weave network.

Only do this for Kubernetes 1.7 and above because it requires the change in kubernetes/kubernetes#47212

I don't really know what I'm doing in `bootstrapchannelbuilder.go`; I just followed the pattern I saw.

Other relevant updates in Weave Net since version 2.0.1 ([more details](https://github.com/weaveworks/weave/releases)):

* Fix race condition in NetworkPolicy Controller which would intermittently block all traffic for a namespace
* Add comments to each NetworkPolicy iptables rule and ipset, to help when troubleshooting
* Fix netfilter rules to block containers from accessing the Weave Net control endpoint
* Remove code that checked for an outdated fallback address for Kubernetes api-server

