### PR TITLE
kube-router: remove beta annotation versions (deprectated in 1.8) of init container

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
@@ -34,29 +34,6 @@ spec:
         tier: node
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        pod.beta.kubernetes.io/init-containers: '[
-            {
-                "name": "install-cni",
-                "image": "busybox",
-                "command": [ "/bin/sh", "-c", "set -e -x; if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then TMP=/etc/cni/net.d/.tmp-kuberouter-cfg; cp /etc/kube-router/cni-conf.json ${TMP}; mv ${TMP} /etc/cni/net.d/10-kuberouter.conf; fi" ],
-                "volumeMounts": [
-                    {
-                        "name": "cni",
-                        "mountPath": "/etc/cni/net.d"
-                    },
-                    {
-                        "name": "kube-router-cfg",
-                        "mountPath": "/etc/kube-router"
-                    }
-                ],
-                "volumes": {
-                     "name": "cni",
-                     "hostPath": {
-                          "path": "/etc/cni/net.d"
-                     }
-                }
-            }
-        ]'
     spec:
       containers:
       - name: kube-router
@@ -82,11 +59,29 @@ spec:
         - name: lib-modules
           mountPath: /lib/modules
           readOnly: true
-        - name: cni
+        - name: cni-conf-dir
           mountPath: /etc/cni/net.d
         - name: kubeconfig
           mountPath: /var/lib/kube-router/kubeconfig
           readOnly: true
+      initContainers:
+      - name: install-cni
+        image: busybox
+        imagePullPolicy: Always
+        command:
+        - /bin/sh
+        - -c
+        - set -e -x;
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+            TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
+            cp /etc/kube-router/cni-conf.json ${TMP};
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+          fi
+        volumeMounts:
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kube-router-cfg
+          mountPath: /etc/kube-router
       hostNetwork: true
       serviceAccountName: kube-router
       tolerations:
@@ -101,7 +96,7 @@ spec:
         name: lib-modules
       - hostPath:
           path: /etc/cni/net.d
-        name: cni
+        name: cni-conf-dir
       - name: kubeconfig
         hostPath:
           path: /var/lib/kube-router/kubeconfig


### PR DESCRIPTION
kube-router: remove beta annotation versions (deprectated in 1.8) of init container and move init container to spec section