### PR TITLE
Add permissions to cluster autoscaler to get statefulsets

### DIFF
--- a/addons/cluster-autoscaler/v1.6.0.yaml
+++ b/addons/cluster-autoscaler/v1.6.0.yaml
@@ -89,6 +89,7 @@ rules:
   verbs:
   - watch
   - list
+  - get
 
 ---
 


### PR DESCRIPTION
Otherwise getting error

    User system:serviceaccount:kube-system:cluster-autoscaler cannot get statefulsets.apps in the namespace xxx. (get statefulsets.apps yyy)