### PR TITLE
Add missing "-nanny" in image name.

### DIFF
--- a/docs/advisories/cve_2017_14491.md
+++ b/docs/advisories/cve_2017_14491.md
@@ -83,7 +83,7 @@ Apply the update to the container:
 
 ```bash
 kubectl set image deployment/kube-dns -n kube-system \
- dnsmasq=gcr.io/google_containers/k8s-dns-dnsmasq-amd64:1.14.5
+ dnsmasq=gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5
 ```
 
 Validate the change was applied to the deployment:


### PR DESCRIPTION
The instructions for hot-fixing the recent dnsmasq vulnerability use a different image name than what is in use by the dnsmasq container. When the command in question is run it causes the container to fail on startup. Using the "nanny" image works, though.