### PR TITLE
link to cve Advisory release doc fixed

### DIFF
--- a/docs/releases/1.7.1.md
+++ b/docs/releases/1.7.1.md
@@ -4,9 +4,10 @@ This document describes the changes since 1.7.0.
 
 # Significant changes
 
-* kube-dns has been updated with the hotfix for CVE-2017-14491.  For more details, please see [CVE Advisory](kops/docs/advisories/cve_2017_14491.md).
+* kube-dns has been updated with the hotfix for CVE-2017-14491.  For more details, please see [CVE Advisory](../advisories/cve_2017_14491.md).
 
 # Full changelist
 
 * Update images in CI tests (thanks @justinsb)
 * Update kube-dns to 1.14.5 for CVE-2017-14491 (thanks @mikesplain)
+


### PR DESCRIPTION
This is a quick fix for the link to CVE Advisory doc 