### PR TITLE
WIP - ProtokubeIsFile - possible new API value

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -176,6 +176,11 @@ type Assets struct {
 	ContainerRegistry *string `json:"containerRegistry,omitempty"`
 	// FileRepository is the url for a private file serving repository
 	FileRepository *string `json:"fileRepository,omitempty"`
+	// ProtokubeIsFile allow a user to treat protokube as a file or container
+	// Default "true" protokube is a tar ball that is downloaded and imported.
+	// Setting this "false" sets protokube to a container, which is staged
+	// in a registry.
+	ProtokubeIsFile bool `json:"protokubeIsFile"`
 }
 
 // IAMSpec adds control over the IAM security policies applied to resources


### PR DESCRIPTION
ProtokubeIsFile allows a user to treat protokube as a file or a container.
Default "true" protokube is a tarball that is downloaded and imported.
Setting this "false" sets protokube to a container, which is staged in a registry.  The other option is that protokube is always staged in a registry. The reason users need protokube in a registry is for security screening.

AssetsBuilder needs to know where to put protokube this flag allows that.

/assign @justinsb 

PTLA