### PR TITLE
simplified AWS tutorial instruction to export AWS env variables

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -74,8 +74,8 @@ aws configure           # Use your new access and secret key here
 aws iam list-users      # you should see a list of all your IAM users here
 
 # Because "aws configure" doesn't export these vars for kops to use, we export them now
-export AWS_ACCESS_KEY_ID=<access key>
-export AWS_SECRET_ACCESS_KEY=<secret key>
+export AWS_ACCESS_KEY_ID=`aws configure get aws_access_key_id`
+export AWS_SECRET_ACCESS_KEY=`aws configure get aws_secret_access_key`
 ```
 
 ## Configure DNS


### PR DESCRIPTION
Since we already run `aws configure`, we can simply use the AWS CLI to fetch the key and secret instead of relying on the user to replace the value in the templated command.