### PR TITLE
Add -nanny to new image name in hotfix for 1.4x-1.5x

### DIFF
--- a/docs/advisories/cve_2017_14491.md
+++ b/docs/advisories/cve_2017_14491.md
@@ -136,7 +136,7 @@ Upgrade the kube-dns container to the new version.
 
 ```bash
 kubectl set image deployment/kube-dns -n kube-system \
- dnsmasq=gcr.io/google_containers/k8s-dns-dnsmasq-amd64:1.14.5
+ dnsmasq=gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5
 ```
 
 Validate the change was applied to the deployment:


### PR DESCRIPTION
This uses the dnsmasq image with `-nanny` suffix also in the section for kubernetes versions 1.4.x-1.5.x hotfix. Using the image without `-nanny` suffix results in dnsmasq completing and the pod never becoming ready.