### PR TITLE
Kops Toolbox Template Missing Variables

### DIFF
--- a/cmd/kops/toolbox_template.go
+++ b/cmd/kops/toolbox_template.go
@@ -52,11 +52,12 @@ var (
 
 // the options for the command
 type toolboxTemplateOption struct {
-	clusterName  string
-	configPath   []string
-	outputPath   string
-	snippetsPath []string
-	templatePath []string
+	clusterName   string
+	configPath    []string
+	failOnMissing bool
+	outputPath    string
+	snippetsPath  []string
+	templatePath  []string
 }
 
 // NewCmdToolboxTemplate returns a new templating command
@@ -84,6 +85,7 @@ func NewCmdToolboxTemplate(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringSliceVar(&options.templatePath, "template", options.templatePath, "Path to template file or directory of templates to render")
 	cmd.Flags().StringSliceVar(&options.snippetsPath, "snippets", options.snippetsPath, "Path to directory containing snippets used for templating")
 	cmd.Flags().StringVar(&options.outputPath, "output", options.outputPath, "Path to output file, otherwise defaults to stdout")
+	cmd.Flags().BoolVar(&options.failOnMissing, "fail-on-missing", true, "Fail on referencing unset variables in templates")
 
 	return cmd
 }
@@ -160,10 +162,11 @@ func runToolBoxTemplate(f *util.Factory, out io.Writer, options *toolboxTemplate
 			return fmt.Errorf("unable to read template: %s, error: %s", x, err)
 		}
 
-		rendered, err := r.Render(string(content), context, snippets)
+		rendered, err := r.Render(string(content), context, snippets, options.failOnMissing)
 		if err != nil {
 			return fmt.Errorf("unable to render template: %s, error: %s", x, err)
 		}
+
 		io.WriteString(writer, rendered)
 
 		// @check if we should need to add document separator

--- a/docs/cli/kops_toolbox_template.md
+++ b/docs/cli/kops_toolbox_template.md
@@ -29,6 +29,7 @@ kops toolbox template
 ### Options
 
 ```
+      --fail-on-missing        Fail on referencing unset variables in templates (default true)
       --output string          Path to output file, otherwise defaults to stdout
       --snippets stringSlice   Path to directory containing snippets used for templating
       --template stringSlice   Path to template file or directory of templates to render

--- a/pkg/util/templater/integration_tests.yml
+++ b/pkg/util/templater/integration_tests.yml
@@ -82,10 +82,3 @@
       members: [a1 b1]
     - name: events
       members: [a1 b1]
-
-
-
-
-
-
-

--- a/pkg/util/templater/templater.go
+++ b/pkg/util/templater/templater.go
@@ -39,14 +39,15 @@ func NewTemplater() *Templater {
 }
 
 // Render is responsible for actually rendering the template
-func (r *Templater) Render(content string, context map[string]interface{}, snippets map[string]string) (rendered string, err error) {
-
+func (r *Templater) Render(content string, context map[string]interface{}, snippets map[string]string, failOnMissing bool) (rendered string, err error) {
 	// @step: create the template
 	tm := template.New(templateName)
 	if _, err = tm.Funcs(r.templateFuncsMap(tm)).Parse(content); err != nil {
 		return
 	}
-	tm.Option("missingkey=error")
+	if failOnMissing {
+		tm.Option("missingkey=error")
+	}
 
 	// @step: add the snippits into the mix
 	for filename, snippet := range snippets {

--- a/pkg/util/templater/templater_test.go
+++ b/pkg/util/templater/templater_test.go
@@ -147,6 +147,18 @@ func TestRenderContext(t *testing.T) {
 	makeRenderTests(t, cases)
 }
 
+func TestAllowForMissingVars(t *testing.T) {
+	cases := []renderTest{
+		{
+			Context:        map[string]interface{}{},
+			Template:       `{{ default "is missing" .name }}`,
+			Expected:       "is missing",
+			DisableMissing: true,
+		},
+	}
+	makeRenderTests(t, cases)
+}
+
 func TestRenderIntegration(t *testing.T) {
 	var cases []renderTest
 	content, err := ioutil.ReadFile("integration_tests.yml")
@@ -161,17 +173,18 @@ func TestRenderIntegration(t *testing.T) {
 }
 
 type renderTest struct {
-	Expected string
-	Snippets map[string]string
-	Context  map[string]interface{}
-	Template string
-	NotOK    bool
+	Context        map[string]interface{}
+	DisableMissing bool
+	Expected       string
+	NotOK          bool
+	Snippets       map[string]string
+	Template       string
 }
 
 func makeRenderTests(t *testing.T, tests []renderTest) {
 	r := NewTemplater()
 	for i, x := range tests {
-		render, err := r.Render(x.Template, x.Context, x.Snippets)
+		render, err := r.Render(x.Template, x.Context, x.Snippets, !x.DisableMissing)
 		if x.NotOK {
 			if err == nil {
 				t.Errorf("case %d: should have thrown an error", i)


### PR DESCRIPTION
The current implementation fails on templates which reference unset variables, it is however useful at times to permit overriding this behavior and using sprig default() for example to handle defaults.

- added a new command line option --fail-on-missing (defaults to true, so keeps the current behaviour)
- updated the unit tests to reflect the changes