### PR TITLE
Bump channels version of dashboard to 1.7.1

### DIFF
--- a/addons/kubernetes-dashboard/addon.yaml
+++ b/addons/kubernetes-dashboard/addon.yaml
@@ -26,4 +26,8 @@ spec:
   - version: 1.6.3
     selector:
       k8s-addon: kubernetes-dashboard.addons.k8s.io
-    manifest: v1.6.3.yaml
+    manifest: v1.6.3.yaml 
+  - version: 1.7.1
+    selector:
+      k8s-addon: kubernetes-dashboard.addons.k8s.io
+    manifest: v1.7.1.yaml


### PR DESCRIPTION
Shouldn't it be a requirement to bump addons.yaml at the same time as the other files?