### PR TITLE
Kops Template YAML Formatting

### DIFF
--- a/docs/cli/kops_toolbox_template.md
+++ b/docs/cli/kops_toolbox_template.md
@@ -29,7 +29,9 @@ kops toolbox template
 ### Options
 
 ```
+      --config-value string    Show the value of a specific configuration value
       --fail-on-missing        Fail on referencing unset variables in templates (default true)
+      --format-yaml            Attempt to format the generated yaml content before output
       --output string          Path to output file, otherwise defaults to stdout
       --snippets stringSlice   Path to directory containing snippets used for templating
       --template stringSlice   Path to template file or directory of templates to render


### PR DESCRIPTION
Adding an extra option to the toolbox templating to format the YAML before writing out; which is usefull to cleanup formating issues and as detecting errors in the template

- added a formating options --format-yaml to the toolbox template
- updated the cli documentation
- the option is off by default to retain behavior 