### PR TITLE
Improving UX for placeholder IP Address

### DIFF
--- a/pkg/validation/BUILD.bazel
+++ b/pkg/validation/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Before the `kops validate cluster` attempts to connect to the K8s API
endpoint, the code now checks to see if the API DNS Entry is the kops
placeholder IP Address 203.0.113.123.  It prints a message to the user
and err's.  There is a new init func in validate cluster that disables
CGO based DNS for Darwin OS.  Darwin does two things with kops
validates; it caches the IP address, and it does not return the
placeholder IP address.  We cannot use CGO base DNS with kops validate with OSX.