### PR TITLE
update to imports that apimachinery is doing now automatically

### DIFF
--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -21,10 +21,11 @@ limitations under the License.
 package v1alpha1
 
 import (
+	reflect "reflect"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	reflect "reflect"
 )
 
 func init() {

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -21,10 +21,11 @@ limitations under the License.
 package v1alpha2
 
 import (
+	reflect "reflect"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	reflect "reflect"
 )
 
 func init() {

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -21,10 +21,11 @@ limitations under the License.
 package kops
 
 import (
+	reflect "reflect"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	reflect "reflect"
 )
 
 func init() {

--- a/pkg/client/clientset_generated/clientset/scheme/register.go
+++ b/pkg/client/clientset_generated/clientset/scheme/register.go
@@ -17,6 +17,8 @@ limitations under the License.
 package scheme
 
 import (
+	os "os"
+
 	announced "k8s.io/apimachinery/pkg/apimachinery/announced"
 	registered "k8s.io/apimachinery/pkg/apimachinery/registered"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,7 +26,6 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	kops "k8s.io/kops/pkg/apis/kops/install"
-	os "os"
 )
 
 var Scheme = runtime.NewScheme()

--- a/pkg/client/clientset_generated/internalclientset/scheme/register.go
+++ b/pkg/client/clientset_generated/internalclientset/scheme/register.go
@@ -17,6 +17,8 @@ limitations under the License.
 package scheme
 
 import (
+	os "os"
+
 	announced "k8s.io/apimachinery/pkg/apimachinery/announced"
 	registered "k8s.io/apimachinery/pkg/apimachinery/registered"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,7 +26,6 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	kops "k8s.io/kops/pkg/apis/kops/install"
-	os "os"
 )
 
 var Scheme = runtime.NewScheme()

--- a/pkg/model/bastion.go
+++ b/pkg/model/bastion.go
@@ -17,11 +17,12 @@ limitations under the License.
 package model
 
 import (
+	"time"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
-	"time"
 )
 
 const BastionELBSecurityGroupPrefix = "bastion"

--- a/pkg/pki/csr.go
+++ b/pkg/pki/csr.go
@@ -21,9 +21,10 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
-	"github.com/golang/glog"
 	"math/big"
 	"time"
+
+	"github.com/golang/glog"
 )
 
 // BuildPKISerial produces a serial number for certs that is vanishingly unlikely to collide

--- a/protokube/pkg/gossip/dns/dns.go
+++ b/protokube/pkg/gossip/dns/dns.go
@@ -18,11 +18,12 @@ package dns
 
 import (
 	"fmt"
-	"github.com/golang/glog"
-	"k8s.io/kops/protokube/pkg/gossip"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/kops/protokube/pkg/gossip"
 )
 
 // We don't really support multiple zone ids, but we could

--- a/upup/pkg/fi/cloudup/gcetasks/targetpool.go
+++ b/upup/pkg/fi/cloudup/gcetasks/targetpool.go
@@ -18,6 +18,7 @@ package gcetasks
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	compute "google.golang.org/api/compute/v0.beta"
 	"k8s.io/kops/upup/pkg/fi"

--- a/upup/pkg/fi/k8sapi/k8s_keystore.go
+++ b/upup/pkg/fi/k8sapi/k8s_keystore.go
@@ -19,6 +19,9 @@ package k8sapi
 import (
 	"crypto/x509"
 	"fmt"
+	"math/big"
+	"time"
+
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,8 +30,6 @@ import (
 	"k8s.io/kops/pkg/pki"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/util/pkg/vfs"
-	"math/big"
-	"time"
 )
 
 type KubernetesKeystore struct {


### PR DESCRIPTION
Running `make gen-api-docs` now changes imports.  General cleanup.  This is done so that we do not have more changes when generating the api docs.

/assign @andrewsykim 