### PR TITLE
Tolerate errors from Find for tasks with WarnIfInsufficientAccess

### DIFF
--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -469,38 +469,38 @@ func (c *ApplyClusterCmd) Run() error {
 	l.WorkDir = c.OutDir
 	l.ModelStore = modelStore
 
-	stageAssetsLifecycle := lifecyclePointer(fi.LifecycleSync)
-	securityLifecycle := lifecyclePointer(fi.LifecycleSync)
-	networkLifecycle := lifecyclePointer(fi.LifecycleSync)
-	clusterLifecycle := lifecyclePointer(fi.LifecycleSync)
+	stageAssetsLifecycle := fi.LifecycleSync
+	securityLifecycle := fi.LifecycleSync
+	networkLifecycle := fi.LifecycleSync
+	clusterLifecycle := fi.LifecycleSync
 
 	switch c.Phase {
 	case Phase(""):
 	// Everything ... the default
 	case PhaseStageAssets:
-		networkLifecycle = lifecyclePointer(fi.LifecycleIgnore)
-		securityLifecycle = lifecyclePointer(fi.LifecycleIgnore)
-		clusterLifecycle = lifecyclePointer(fi.LifecycleIgnore)
+		networkLifecycle = fi.LifecycleIgnore
+		securityLifecycle = fi.LifecycleIgnore
+		clusterLifecycle = fi.LifecycleIgnore
 
 	case PhaseNetwork:
-		stageAssetsLifecycle = lifecyclePointer(fi.LifecycleIgnore)
-		securityLifecycle = lifecyclePointer(fi.LifecycleIgnore)
-		clusterLifecycle = lifecyclePointer(fi.LifecycleIgnore)
+		stageAssetsLifecycle = fi.LifecycleIgnore
+		securityLifecycle = fi.LifecycleIgnore
+		clusterLifecycle = fi.LifecycleIgnore
 
 	case PhaseSecurity:
-		stageAssetsLifecycle = lifecyclePointer(fi.LifecycleIgnore)
-		networkLifecycle = lifecyclePointer(fi.LifecycleIgnore)
-		clusterLifecycle = lifecyclePointer(fi.LifecycleIgnore)
+		stageAssetsLifecycle = fi.LifecycleIgnore
+		networkLifecycle = fi.LifecycleIgnore
+		clusterLifecycle = fi.LifecycleIgnore
 
 	case PhaseCluster:
 		if c.TargetName == TargetDryRun {
-			stageAssetsLifecycle = lifecyclePointer(fi.LifecycleExistsAndWarnIfChanges)
-			securityLifecycle = lifecyclePointer(fi.LifecycleExistsAndWarnIfChanges)
-			networkLifecycle = lifecyclePointer(fi.LifecycleExistsAndWarnIfChanges)
+			stageAssetsLifecycle = fi.LifecycleExistsAndWarnIfChanges
+			securityLifecycle = fi.LifecycleExistsAndWarnIfChanges
+			networkLifecycle = fi.LifecycleExistsAndWarnIfChanges
 		} else {
-			stageAssetsLifecycle = lifecyclePointer(fi.LifecycleIgnore)
-			networkLifecycle = lifecyclePointer(fi.LifecycleExistsAndValidates)
-			securityLifecycle = lifecyclePointer(fi.LifecycleExistsAndValidates)
+			stageAssetsLifecycle = fi.LifecycleIgnore
+			networkLifecycle = fi.LifecycleExistsAndValidates
+			securityLifecycle = fi.LifecycleExistsAndValidates
 		}
 
 	default:
@@ -523,11 +523,11 @@ func (c *ApplyClusterCmd) Run() error {
 			l.Builders = append(l.Builders,
 				&BootstrapChannelBuilder{
 					cluster:      cluster,
-					Lifecycle:    clusterLifecycle,
+					Lifecycle:    &clusterLifecycle,
 					templates:    templates,
 					assetBuilder: assetBuilder,
 				},
-				&model.PKIModelBuilder{KopsModelContext: modelContext, Lifecycle: clusterLifecycle},
+				&model.PKIModelBuilder{KopsModelContext: modelContext, Lifecycle: &clusterLifecycle},
 			)
 
 			switch kops.CloudProviderID(cluster.Spec.CloudProvider) {
@@ -537,25 +537,25 @@ func (c *ApplyClusterCmd) Run() error {
 				}
 
 				l.Builders = append(l.Builders,
-					&model.MasterVolumeBuilder{KopsModelContext: modelContext, Lifecycle: clusterLifecycle},
-					&awsmodel.APILoadBalancerBuilder{AWSModelContext: awsModelContext, Lifecycle: clusterLifecycle, SecurityLifecycle: securityLifecycle},
-					&model.BastionModelBuilder{KopsModelContext: modelContext, Lifecycle: clusterLifecycle, SecurityLifecycle: securityLifecycle},
-					&model.DNSModelBuilder{KopsModelContext: modelContext, Lifecycle: clusterLifecycle},
-					&model.ExternalAccessModelBuilder{KopsModelContext: modelContext, Lifecycle: securityLifecycle},
-					&model.FirewallModelBuilder{KopsModelContext: modelContext, Lifecycle: securityLifecycle},
-					&model.SSHKeyModelBuilder{KopsModelContext: modelContext, Lifecycle: securityLifecycle},
+					&model.MasterVolumeBuilder{KopsModelContext: modelContext, Lifecycle: &clusterLifecycle},
+					&awsmodel.APILoadBalancerBuilder{AWSModelContext: awsModelContext, Lifecycle: &clusterLifecycle, SecurityLifecycle: &securityLifecycle},
+					&model.BastionModelBuilder{KopsModelContext: modelContext, Lifecycle: &clusterLifecycle, SecurityLifecycle: &securityLifecycle},
+					&model.DNSModelBuilder{KopsModelContext: modelContext, Lifecycle: &clusterLifecycle},
+					&model.ExternalAccessModelBuilder{KopsModelContext: modelContext, Lifecycle: &securityLifecycle},
+					&model.FirewallModelBuilder{KopsModelContext: modelContext, Lifecycle: &securityLifecycle},
+					&model.SSHKeyModelBuilder{KopsModelContext: modelContext, Lifecycle: &securityLifecycle},
 				)
 
 				l.Builders = append(l.Builders,
-					&model.NetworkModelBuilder{KopsModelContext: modelContext, Lifecycle: networkLifecycle},
+					&model.NetworkModelBuilder{KopsModelContext: modelContext, Lifecycle: &networkLifecycle},
 				)
 
 				l.Builders = append(l.Builders,
-					&model.IAMModelBuilder{KopsModelContext: modelContext, Lifecycle: securityLifecycle},
+					&model.IAMModelBuilder{KopsModelContext: modelContext, Lifecycle: &securityLifecycle},
 				)
 			case kops.CloudProviderDO:
 				l.Builders = append(l.Builders,
-					&model.MasterVolumeBuilder{KopsModelContext: modelContext, Lifecycle: clusterLifecycle},
+					&model.MasterVolumeBuilder{KopsModelContext: modelContext, Lifecycle: &clusterLifecycle},
 				)
 
 			case kops.CloudProviderGCE:
@@ -563,14 +563,20 @@ func (c *ApplyClusterCmd) Run() error {
 					KopsModelContext: modelContext,
 				}
 
-				l.Builders = append(l.Builders,
-					&model.MasterVolumeBuilder{KopsModelContext: modelContext, Lifecycle: clusterLifecycle},
+				storageAclLifecycle := securityLifecycle
+				if storageAclLifecycle != fi.LifecycleIgnore {
+					// This is a best-effort permissions fix
+					storageAclLifecycle = fi.LifecycleWarnIfInsufficientAccess
+				}
 
-					&gcemodel.APILoadBalancerBuilder{GCEModelContext: gceModelContext, Lifecycle: securityLifecycle},
-					&gcemodel.ExternalAccessModelBuilder{GCEModelContext: gceModelContext, Lifecycle: securityLifecycle},
-					&gcemodel.FirewallModelBuilder{GCEModelContext: gceModelContext, Lifecycle: securityLifecycle},
-					&gcemodel.NetworkModelBuilder{GCEModelContext: gceModelContext, Lifecycle: networkLifecycle},
-					&gcemodel.StorageAclBuilder{GCEModelContext: gceModelContext, Cloud: cloud.(gce.GCECloud), Lifecycle: securityLifecycle},
+				l.Builders = append(l.Builders,
+					&model.MasterVolumeBuilder{KopsModelContext: modelContext, Lifecycle: &clusterLifecycle},
+
+					&gcemodel.APILoadBalancerBuilder{GCEModelContext: gceModelContext, Lifecycle: &securityLifecycle},
+					&gcemodel.ExternalAccessModelBuilder{GCEModelContext: gceModelContext, Lifecycle: &securityLifecycle},
+					&gcemodel.FirewallModelBuilder{GCEModelContext: gceModelContext, Lifecycle: &securityLifecycle},
+					&gcemodel.NetworkModelBuilder{GCEModelContext: gceModelContext, Lifecycle: &networkLifecycle},
+					&gcemodel.StorageAclBuilder{GCEModelContext: gceModelContext, Cloud: cloud.(gce.GCECloud), Lifecycle: &storageAclLifecycle},
 				)
 
 			case kops.CloudProviderVSphere:
@@ -687,7 +693,7 @@ func (c *ApplyClusterCmd) Run() error {
 		l.Builders = append(l.Builders, &awsmodel.AutoscalingGroupModelBuilder{
 			AWSModelContext: awsModelContext,
 			BootstrapScript: bootstrapScriptBuilder,
-			Lifecycle:       clusterLifecycle,
+			Lifecycle:       &clusterLifecycle,
 		})
 	case kops.CloudProviderDO:
 		doModelContext := &domodel.DOModelContext{
@@ -697,7 +703,7 @@ func (c *ApplyClusterCmd) Run() error {
 		l.Builders = append(l.Builders, &domodel.DropletBuilder{
 			DOModelContext:  doModelContext,
 			BootstrapScript: bootstrapScriptBuilder,
-			Lifecycle:       clusterLifecycle,
+			Lifecycle:       &clusterLifecycle,
 		})
 	case kops.CloudProviderGCE:
 		{
@@ -708,7 +714,7 @@ func (c *ApplyClusterCmd) Run() error {
 			l.Builders = append(l.Builders, &gcemodel.AutoscalingGroupModelBuilder{
 				GCEModelContext: gceModelContext,
 				BootstrapScript: bootstrapScriptBuilder,
-				Lifecycle:       clusterLifecycle,
+				Lifecycle:       &clusterLifecycle,
 			})
 		}
 	case kops.CloudProviderVSphere:
@@ -720,7 +726,7 @@ func (c *ApplyClusterCmd) Run() error {
 			l.Builders = append(l.Builders, &vspheremodel.AutoscalingGroupModelBuilder{
 				VSphereModelContext: vsphereModelContext,
 				BootstrapScript:     bootstrapScriptBuilder,
-				Lifecycle:           clusterLifecycle,
+				Lifecycle:           &clusterLifecycle,
 			})
 		}
 
@@ -735,7 +741,7 @@ func (c *ApplyClusterCmd) Run() error {
 
 	tf.AddTo(l.TemplateFunctions)
 
-	taskMap, err := l.BuildTasks(modelStore, fileModels, assetBuilder, stageAssetsLifecycle)
+	taskMap, err := l.BuildTasks(modelStore, fileModels, assetBuilder, &stageAssetsLifecycle)
 	if err != nil {
 		return fmt.Errorf("error building tasks: %v", err)
 	}

--- a/upup/pkg/fi/context.go
+++ b/upup/pkg/fi/context.go
@@ -44,6 +44,14 @@ type Context struct {
 	CheckExisting bool
 
 	tasks map[string]Task
+
+	warnings []*Warning
+}
+
+// Warning holds the details of a warning encountered during validation/creation
+type Warning struct {
+	Task    Task
+	Message string
 }
 
 func NewContext(target Target, cluster *kops.Cluster, cloud Cloud, keystore Keystore, secretStore SecretStore, clusterConfigBase vfs.Path, checkExisting bool, tasks map[string]Task) (*Context, error) {
@@ -216,4 +224,17 @@ func (c *Context) Render(a, e, changes Task) error {
 		rvErr = rv[0].Interface().(error)
 	}
 	return rvErr
+}
+
+// AddWarning records a warning encountered during validation / creation.
+// Typically this will be an error that we choose to ignore because of Lifecycle.
+func (c *Context) AddWarning(task Task, message string) {
+	warning := &Warning{
+		Task:    task,
+		Message: message,
+	}
+	// We don't actually do anything with these warnings yet, other than log them to glog below.
+	// In future we might produce a structured warning report.
+	c.warnings = append(c.warnings, warning)
+	glog.Warningf("warning during task %s: %s", task, message)
 }

--- a/upup/pkg/fi/default_methods.go
+++ b/upup/pkg/fi/default_methods.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fi
 
 import (
+	"fmt"
 	"k8s.io/kops/upup/pkg/fi/utils"
 	"reflect"
 )
@@ -44,6 +45,12 @@ func DefaultDeltaRunMethod(e Task, c *Context) error {
 	if checkExisting {
 		a, err = invokeFind(e, c)
 		if err != nil {
+			if lifecycle != nil && *lifecycle == LifecycleWarnIfInsufficientAccess {
+				// For now we assume all errors are permissions problems
+				// TODO: bounded retry?
+				c.AddWarning(e, fmt.Sprintf("error checking if task exists; assuming it is correctly configured: %v", err))
+				return nil
+			}
 			return err
 		}
 	}

--- a/upup/pkg/fi/lifecycle.go
+++ b/upup/pkg/fi/lifecycle.go
@@ -25,6 +25,9 @@ const (
 	// LifecycleIgnore will skip the task
 	LifecycleIgnore Lifecycle = "Ignore"
 
+	// LifecycleWarnIfInsufficientAccess will warn but ignore the task if there is an error during the find
+	LifecycleWarnIfInsufficientAccess Lifecycle = "WarnIfInsufficientAccess"
+
 	// LifecycleExistsAndValidates will check that the task exists and is the same
 	LifecycleExistsAndValidates Lifecycle = "ExistsAndValidates"
 


### PR DESCRIPTION
We glog.Warning a message, and we record a structured warning for future
use, but we allow operation to continue.