### PR TITLE
Template Fixes

### DIFF
--- a/pkg/util/templater/templater.go
+++ b/pkg/util/templater/templater.go
@@ -19,7 +19,6 @@ package templater
 import (
 	"bytes"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -51,11 +50,10 @@ func (r *Templater) Render(content string, context map[string]interface{}, snipp
 
 	// @step: add the snippits into the mix
 	for filename, snippet := range snippets {
-		name := filepath.Base(filename)
-		if name == templateName {
-			return "", fmt.Errorf("snippet cannot have the same name as the template: %s", name)
+		if filename == templateName {
+			return "", fmt.Errorf("snippet cannot have the same name as the template: %s", filename)
 		}
-		if _, err = tm.New(name).Parse(snippet); err != nil {
+		if _, err = tm.New(filename).Parse(snippet); err != nil {
 			return rendered, fmt.Errorf("unable to parse snippet: %s, error: %s", filename, err)
 		}
 	}


### PR DESCRIPTION
- fixing an issue in the way it handled inline yaml documents
- cleaning it up somewhat, the prior version was a little cryptic to read; it's easier to just split into docs, format if required and rejoin at the end.

Apologizes @justinsb ... the prior PR didn't handle YAML separators correctly; I've find it somewhat simpler by a split and join rather than using indexes and such