### PR TITLE
Update IAM roles documentation based on recent changes.

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// IAM Documentation: /docs/iam_roles.md
+
 // TODO: We have a couple different code paths until we do lifecycles, and
 // TODO: when we have a cluster or refactor some s3 code.  The only code that
 // TODO: is not shared by the different path is the s3 / state store stuff.


### PR DESCRIPTION
The [IAM Roles documentation](https://github.com/kubernetes/kops/blob/master/docs/iam_roles.md) has been updated to reflect recent hardening on the policies generated for Master & Compute nodes.

Fixes #3557.