### PR TITLE
Cluster subnet should check for Region

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -458,10 +458,8 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 
 		if subnet == nil {
 			subnet = &api.ClusterSubnetSpec{
-				Name: subnetName,
-				// region and zone are the same for DO
+				Name:   subnetName,
 				Region: region,
-				Zone:   region,
 			}
 			cluster.Spec.Subnets = append(cluster.Spec.Subnets, *subnet)
 		}
@@ -558,7 +556,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		masterAZs := sets.NewString()
 		duplicateAZs := false
 		for _, ig := range masters {
-			zones, err := model.FindZonesForInstanceGroup(cluster, ig)
+			zones, err := model.FindZonesOrRegionForInstanceGroup(cluster, ig)
 			if err != nil {
 				return err
 			}

--- a/pkg/apis/kops/model/utils.go
+++ b/pkg/apis/kops/model/utils.go
@@ -32,8 +32,9 @@ func FindSubnet(c *kops.Cluster, subnetName string) *kops.ClusterSubnetSpec {
 	return nil
 }
 
-// FindZonesForInstanceGroup computes the zones for an instance group, which are the zones directly declared in the InstanceGroup, or the subnet zones
-func FindZonesForInstanceGroup(c *kops.Cluster, ig *kops.InstanceGroup) ([]string, error) {
+// FindZonesOrRegionForInstanceGroup computes the zones or region for an instance group,
+// which are the zones/regions directly declared in the InstanceGroup, or the subnet
+func FindZonesOrRegionForInstanceGroup(c *kops.Cluster, ig *kops.InstanceGroup) ([]string, error) {
 	zones := sets.NewString(ig.Spec.Zones...)
 	for _, subnetName := range ig.Spec.Subnets {
 		subnet := FindSubnet(c, subnetName)
@@ -43,6 +44,13 @@ func FindZonesForInstanceGroup(c *kops.Cluster, ig *kops.InstanceGroup) ([]strin
 
 		if subnet.Zone != "" {
 			zones.Insert(subnet.Zone)
+			continue
+		}
+
+		// fallback to setting the Region
+		if subnet.Region != "" {
+			zones.Insert(subnet.Region)
+			continue
 		}
 	}
 	return zones.List(), nil

--- a/pkg/apis/kops/model/utils_test.go
+++ b/pkg/apis/kops/model/utils_test.go
@@ -73,9 +73,9 @@ func Test_FindSubnet(t *testing.T) {
 	}
 }
 
-// Test_FindZonesForInstanceGroup tests FindZonesForInstanceGroup
-func Test_FindZonesForInstanceGroup(t *testing.T) {
-	cluster := &kops.Cluster{
+// TestW_FindZonesOrRegionForInstanceGroup tests FindZonesOrRegionForInstanceGroup for a cluster
+func Test_FindZonesOrRegionForInstanceGroup(t *testing.T) {
+	clusterWithZones := &kops.Cluster{
 		Spec: kops.ClusterSpec{
 			Subnets: []kops.ClusterSubnetSpec{
 				{Name: "zonea", Zone: "zonea"},
@@ -84,14 +84,25 @@ func Test_FindZonesForInstanceGroup(t *testing.T) {
 		},
 	}
 
-	grid := []struct {
+	clusterWithRegion := &kops.Cluster{
+		Spec: kops.ClusterSpec{
+			Subnets: []kops.ClusterSubnetSpec{
+				{Name: "region1", Region: "region1"},
+				{Name: "region2", Region: "region2"},
+			},
+		},
+	}
+
+	testcases := []struct {
+		name        string
 		cluster     *kops.Cluster
 		ig          *kops.InstanceGroup
 		expected    []string
 		expectError bool
 	}{
 		{
-			cluster: cluster,
+			name:    "cluster with only 1 zone",
+			cluster: clusterWithZones,
 			ig: &kops.InstanceGroup{
 				Spec: kops.InstanceGroupSpec{
 					Subnets: []string{"zonea"},
@@ -100,7 +111,8 @@ func Test_FindZonesForInstanceGroup(t *testing.T) {
 			expected: []string{"zonea"},
 		},
 		{
-			cluster: cluster,
+			name:    "cluster with multiple zones",
+			cluster: clusterWithZones,
 			ig: &kops.InstanceGroup{
 				Spec: kops.InstanceGroupSpec{
 					Subnets: []string{"zonea", "zoneb"},
@@ -109,17 +121,28 @@ func Test_FindZonesForInstanceGroup(t *testing.T) {
 			expected: []string{"zonea", "zoneb"},
 		},
 		{
-			cluster: cluster,
+			name:    "cluster with 1 region",
+			cluster: clusterWithRegion,
 			ig: &kops.InstanceGroup{
 				Spec: kops.InstanceGroupSpec{
-					Subnets: []string{"zoneb", "zonea"},
+					Subnets: []string{"region1"},
 				},
 			},
-			// Order is not preserved (they are in fact sorted)
-			expected: []string{"zonea", "zoneb"},
+			expected: []string{"region1"},
 		},
 		{
-			cluster: cluster,
+			name:    "cluster with multiple regions",
+			cluster: clusterWithRegion,
+			ig: &kops.InstanceGroup{
+				Spec: kops.InstanceGroupSpec{
+					Subnets: []string{"region1", "region2"},
+				},
+			},
+			expected: []string{"region1", "region2"},
+		},
+		{
+			name:    "cluster with invalid zone",
+			cluster: clusterWithZones,
 			ig: &kops.InstanceGroup{
 				Spec: kops.InstanceGroupSpec{
 					Subnets: []string{"zoneb", "nope"},
@@ -128,7 +151,18 @@ func Test_FindZonesForInstanceGroup(t *testing.T) {
 			expectError: true,
 		},
 		{
-			cluster: cluster,
+			name:    "cluster with invalid region",
+			cluster: clusterWithRegion,
+			ig: &kops.InstanceGroup{
+				Spec: kops.InstanceGroupSpec{
+					Subnets: []string{"region1", "nope"},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:    "cluster with existing zones",
+			cluster: clusterWithZones,
 			ig: &kops.InstanceGroup{
 				Spec: kops.InstanceGroupSpec{
 					Zones: []string{"directa", "directb"},
@@ -137,7 +171,8 @@ func Test_FindZonesForInstanceGroup(t *testing.T) {
 			expected: []string{"directa", "directb"},
 		},
 		{
-			cluster: cluster,
+			name:    "cluster with new and existing zones",
+			cluster: clusterWithZones,
 			ig: &kops.InstanceGroup{
 				Spec: kops.InstanceGroupSpec{
 					Zones:   []string{"directa", "directb"},
@@ -149,22 +184,22 @@ func Test_FindZonesForInstanceGroup(t *testing.T) {
 			expected: []string{"directa", "directb", "zonea", "zoneb"},
 		},
 	}
-	for i, g := range grid {
-		actual, err := FindZonesForInstanceGroup(g.cluster, g.ig)
-		if err != nil {
-			if g.expectError {
-				continue
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := FindZonesOrRegionForInstanceGroup(tc.cluster, tc.ig)
+			if err != nil {
+				if tc.expectError {
+					return
+				}
+				t.Errorf("unexpected error: %v", err)
 			}
-			t.Errorf("unexpected error for %d: %v", i, err)
-			continue
-		}
-		if g.expectError {
-			t.Errorf("expected error for %d, result was %v", i, actual)
-			continue
-		}
-		if !reflect.DeepEqual(actual, g.expected) {
-			t.Errorf("unexpected result for %d: actual=%v, expected=%v", i, actual, g.expected)
-			continue
-		}
+			if tc.expectError {
+				t.Errorf("expected error, result was %v", actual)
+			}
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("unexpected result: actual=%v, expected=%v", actual, tc.expected)
+			}
+		})
 	}
 }

--- a/pkg/formatter/instancegroup.go
+++ b/pkg/formatter/instancegroup.go
@@ -36,7 +36,7 @@ func RenderInstanceGroupSubnets(cluster *kops.Cluster) InstanceGroupRenderFuncti
 //RenderInstanceGroupZones renders the zone names for an InstanceGroup
 func RenderInstanceGroupZones(cluster *kops.Cluster) InstanceGroupRenderFunction {
 	return func(ig *kops.InstanceGroup) string {
-		zones, err := model.FindZonesForInstanceGroup(cluster, ig)
+		zones, err := model.FindZonesOrRegionForInstanceGroup(cluster, ig)
 		if err != nil {
 			glog.Warningf("error fetch zones for instancegroup: %v", err)
 			return ""

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -138,7 +138,7 @@ func (m *KopsModelContext) FindSubnet(name string) *kops.ClusterSubnetSpec {
 
 // FindZonesForInstanceGroup finds the zones for an InstanceGroup
 func (m *KopsModelContext) FindZonesForInstanceGroup(ig *kops.InstanceGroup) ([]string, error) {
-	return model.FindZonesForInstanceGroup(m.Cluster, ig)
+	return model.FindZonesOrRegionForInstanceGroup(m.Cluster, ig)
 }
 
 // MasterInstanceGroups returns InstanceGroups with the master role

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -61,7 +61,7 @@ func (b *MasterVolumeBuilder) Build(c *fi.ModelBuilderContext) error {
 				return fmt.Errorf("InstanceGroup not found (for etcd %s/%s): %q", m.Name, etcd.Name, igName)
 			}
 
-			zones, err := model.FindZonesForInstanceGroup(b.Cluster, ig)
+			zones, err := model.FindZonesOrRegionForInstanceGroup(b.Cluster, ig)
 			if err != nil {
 				return err
 			}

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -1087,7 +1087,7 @@ func (c *awsCloudImplementation) DefaultInstanceType(cluster *kops.Cluster, ig *
 	}
 
 	// Find the AZs the InstanceGroup targets
-	igZones, err := model.FindZonesForInstanceGroup(cluster, ig)
+	igZones, err := model.FindZonesOrRegionForInstanceGroup(cluster, ig)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes bug where `FindZonesForInstanceGroup` doesn't return corresponding Subnets that had `Region` set instead of `Zones`. Also refactored tests in `pkg/apis/kops/model/utils_test.go`