### PR TITLE
GCE: log the service account & scopes in use

### DIFF
--- a/upup/pkg/fi/cloudup/gce/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/gce/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
         "//vendor/google.golang.org/api/googleapi:go_default_library",
         "//vendor/google.golang.org/api/iam/v1:go_default_library",
+        "//vendor/google.golang.org/api/oauth2/v2:go_default_library",
         "//vendor/google.golang.org/api/storage/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -18,6 +18,7 @@ package gce
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/golang/glog"
@@ -25,6 +26,7 @@ import (
 	"golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/iam/v1"
+	oauth2 "google.golang.org/api/oauth2/v2"
 	"google.golang.org/api/storage/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
@@ -85,7 +87,8 @@ func NewGCECloud(region string, project string, labels map[string]string) (GCECl
 
 	ctx := context.Background()
 
-	client, err := google.DefaultClient(ctx, compute.ComputeScope)
+	// TODO: should we create different clients with per-service scopes?
+	client, err := google.DefaultClient(ctx, compute.ComputeReadonlyScope)
 	if err != nil {
 		return nil, fmt.Errorf("error building google API client: %v", err)
 	}
@@ -108,6 +111,17 @@ func NewGCECloud(region string, project string, labels map[string]string) (GCECl
 	c.iam = iamService
 
 	gceCloudInstances[region+"::"+project] = c
+
+	{
+		// Attempt to log the current GCE service account in user, for diagnostic purposes
+		// At least until we get e2e running, we're doing this always
+		tokenInfo, err := c.getTokenInfo(client)
+		if err != nil {
+			glog.Infof("unable to get token info: %v", err)
+		} else {
+			glog.Infof("running with GCE credentials: email=%s, scope=%s", tokenInfo.Email, tokenInfo.Scope)
+		}
+	}
 
 	return c.WithLabels(labels), nil
 }
@@ -290,4 +304,31 @@ func FindInstanceTemplates(c GCECloud, clusterName string) ([]*compute.InstanceT
 	}
 
 	return matches, nil
+}
+
+// logTokenInfo returns information about the active credential
+func (c *gceCloudImplementation) getTokenInfo(client *http.Client) (*oauth2.Tokeninfo, error) {
+	tokenSource, err := google.DefaultTokenSource(context.TODO(), compute.CloudPlatformScope)
+	if err != nil {
+		return nil, fmt.Errorf("error building token source: %v", err)
+	}
+
+	token, err := tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("error getting token: %v", err)
+	}
+
+	// Note: do not log token or any portion of it
+
+	service, err := oauth2.New(client)
+	if err != nil {
+		return nil, fmt.Errorf("error creating oauth2 service client: %v", err)
+	}
+
+	tokenInfo, err := service.Tokeninfo().AccessToken(token.AccessToken).Do()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching oauth2 token info: %v", err)
+	}
+
+	return tokenInfo, nil
 }


### PR DESCRIPTION
Once we figure out why e2e is failing we can likely make this optional
(e.g. only with v=2 or above)