### PR TITLE
Enable IAM Container Registry permissions by default when creating a cluster (#3760).

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -919,8 +919,10 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		}
 	}
 
+	// Use Strict IAM policy and allow AWS ECR by default when creating a new cluster
 	cluster.Spec.IAM = &api.IAMSpec{
-		Legacy: false,
+		AllowContainerRegistry: true,
+		Legacy:                 false,
 	}
 
 	sshPublicKeys := make(map[string][]byte)

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -21,6 +21,7 @@ spec:
       name: a
     name: events
   iam:
+    allowContainerRegistry: true
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0

--- a/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
@@ -31,6 +31,7 @@ spec:
       zone: us-test-1c
     name: events
   iam:
+    allowContainerRegistry: true
     legacy: false
   kubernetesVersion: v1.6.0-alpha.3
   masterPublicName: api.ha.example.com

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -29,6 +29,7 @@ spec:
       name: c
     name: events
   iam:
+    allowContainerRegistry: true
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha1.yaml
@@ -37,6 +37,7 @@ spec:
       zone: us-test-1c
     name: events
   iam:
+    allowContainerRegistry: true
     legacy: false
   kubernetesVersion: v1.6.0-alpha.3
   masterPublicName: api.ha.example.com

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -35,6 +35,7 @@ spec:
       name: c
     name: events
   iam:
+    allowContainerRegistry: true
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -29,6 +29,7 @@ spec:
       name: c
     name: events
   iam:
+    allowContainerRegistry: true
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -37,6 +37,7 @@ spec:
       name: a-3
     name: events
   iam:
+    allowContainerRegistry: true
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0

--- a/tests/integration/create_cluster/minimal/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha1.yaml
@@ -23,6 +23,7 @@ spec:
       zone: us-test-1a
     name: events
   iam:
+    allowContainerRegistry: true
     legacy: false
   kubernetesVersion: v1.4.8
   masterPublicName: api.minimal.example.com

--- a/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
@@ -21,6 +21,7 @@ spec:
       name: a
     name: events
   iam:
+    allowContainerRegistry: true
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha1.yaml
@@ -24,6 +24,7 @@ spec:
       zone: us-test-1a
     name: events
   iam:
+    allowContainerRegistry: true
     legacy: false
   kubernetesVersion: v1.4.8
   masterPublicName: api.private.example.com

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -22,6 +22,7 @@ spec:
       name: a
     name: events
   iam:
+    allowContainerRegistry: true
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -21,6 +21,7 @@ spec:
       name: a
     name: events
   iam:
+    allowContainerRegistry: true
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0

--- a/tests/integration/create_cluster/private/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha1.yaml
@@ -28,6 +28,7 @@ spec:
       zone: us-test-1a
     name: events
   iam:
+    allowContainerRegistry: true
     legacy: false
   kubernetesVersion: v1.4.8
   masterPublicName: api.private.example.com

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -26,6 +26,7 @@ spec:
       name: a
     name: events
   iam:
+    allowContainerRegistry: true
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0


### PR DESCRIPTION
Fixes #3760 .