### PR TITLE
deprecated API values that are no longer used with kube-dns

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -266,8 +266,10 @@ type LoadBalancerAccessSpec struct {
 // KubeDNSConfig defines the kube dns configuration
 type KubeDNSConfig struct {
 	// Image is the name of the docker image to run
+	// Deprecated as this is now in the addon
 	Image string `json:"image,omitempty"`
 	// Replicas is the number of pod replicas
+	// Deprecated as this is now in the addon, and controlled by autoscaler
 	Replicas int `json:"replicas,omitempty"`
 	// Domain is the dns domain
 	Domain string `json:"domain,omitempty"`

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -265,8 +265,10 @@ type LoadBalancerAccessSpec struct {
 // KubeDNSConfig defines the kube dns configuration
 type KubeDNSConfig struct {
 	// Image is the name of the docker image to run
+	// Deprecated as this is now in the addon
 	Image string `json:"image,omitempty"`
 	// Replicas is the number of pod replicas
+	// Deprecated as this is now in the addon, and controlled by autoscaler
 	Replicas int `json:"replicas,omitempty"`
 	// Domain is the dns domain
 	Domain string `json:"domain,omitempty"`

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -265,8 +265,10 @@ type LoadBalancerAccessSpec struct {
 
 type KubeDNSConfig struct {
 	// Image is the name of the docker image to run
+	// Deprecated as this is now in the addon
 	Image string `json:"image,omitempty"`
 
+	// Deprecated as this is now in the addon, and controlled by autoscaler
 	Replicas int    `json:"replicas,omitempty"`
 	Domain   string `json:"domain,omitempty"`
 	ServerIP string `json:"serverIP,omitempty"`

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -42,9 +42,6 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 	clusterSpec.KubeDNS.ServerIP = ip.String()
 	clusterSpec.KubeDNS.Domain = clusterSpec.ClusterDNSDomain
-	// TODO: Once we start shipping more images, start using them
-	// TODO we need to pull this as this is no longer used
-	clusterSpec.KubeDNS.Image = "gcr.io/google_containers/kubedns-amd64:1.3"
 
 	return nil
 }


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kops/issues/2909

`Image` and `Replicas` are not used.