### PR TITLE
Add a default NodeLabel with the InstanceGroup name

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -999,6 +999,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		if err != nil {
 			return err
 		}
+		fullGroup.AddInstanceGroupNodeLabel()
 		fullInstanceGroups = append(fullInstanceGroups, fullGroup)
 	}
 

--- a/cmd/kops/create_ig.go
+++ b/cmd/kops/create_ig.go
@@ -149,6 +149,9 @@ func RunCreateInstanceGroup(f *util.Factory, cmd *cobra.Command, args []string, 
 	ig.Spec.Subnets = options.Subnets
 
 	ig, err = cloudup.PopulateInstanceGroupSpec(cluster, ig, channel)
+
+	ig.AddInstanceGroupNodeLabel()
+
 	if err != nil {
 		return err
 	}

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -25,6 +25,9 @@ import (
 
 const LabelClusterName = "kops.k8s.io/cluster"
 
+// NodeLabelInstanceGroup is a node label set to the name of the instance group
+const NodeLabelInstanceGroup = "kops.k8s.io/instancegroup"
+
 // Deprecated - use the new labels & taints node-role.kubernetes.io/master and node-role.kubernetes.io/node
 const TaintNoScheduleMaster15 = "dedicated=master:NoSchedule"
 
@@ -150,5 +153,15 @@ func (g *InstanceGroup) IsMaster() bool {
 	default:
 		glog.Fatalf("Role not set in group %v", g)
 		return false
+	}
+}
+
+func (g *InstanceGroup) AddInstanceGroupNodeLabel() {
+	if g.Spec.NodeLabels == nil {
+		nodeLabels := make(map[string]string)
+		nodeLabels[NodeLabelInstanceGroup] = g.Name
+		g.Spec.NodeLabels = nodeLabels
+	} else {
+		g.Spec.NodeLabels[NodeLabelInstanceGroup] = g.Name
 	}
 }

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -58,6 +58,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -76,6 +78,8 @@ spec:
   machineType: t2.medium
   maxSize: 2
   minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
@@ -66,6 +66,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   zones:
   - us-test-1a
@@ -84,6 +86,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1b
   role: Master
   zones:
   - us-test-1b
@@ -102,6 +106,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1c
   role: Master
   zones:
   - us-test-1c
@@ -120,6 +126,8 @@ spec:
   machineType: t2.medium
   maxSize: 2
   minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
   role: Node
   zones:
   - us-test-1a

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -74,6 +74,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -92,6 +94,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1b
   role: Master
   subnets:
   - us-test-1b
@@ -110,6 +114,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1c
   role: Master
   subnets:
   - us-test-1c
@@ -128,6 +134,8 @@ spec:
   machineType: t2.medium
   maxSize: 2
   minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha1.yaml
@@ -72,6 +72,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   zones:
   - us-test-1a
@@ -90,6 +92,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1b
   role: Master
   zones:
   - us-test-1b
@@ -108,6 +112,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1c
   role: Master
   zones:
   - us-test-1c
@@ -126,6 +132,8 @@ spec:
   machineType: t2.medium
   maxSize: 2
   minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
   role: Node
   zones:
   - us-test-1a

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -80,6 +80,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -98,6 +100,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1b
   role: Master
   subnets:
   - us-test-1b
@@ -116,6 +120,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1c
   role: Master
   subnets:
   - us-test-1c
@@ -134,6 +140,8 @@ spec:
   machineType: t2.medium
   maxSize: 2
   minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -65,6 +65,8 @@ spec:
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test1-a
   role: Master
   subnets:
   - us-test1
@@ -85,6 +87,8 @@ spec:
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test1-b
   role: Master
   subnets:
   - us-test1
@@ -105,6 +109,8 @@ spec:
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test1-c
   role: Master
   subnets:
   - us-test1
@@ -125,6 +131,8 @@ spec:
   machineType: n1-standard-2
   maxSize: 2
   minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -78,6 +78,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a-1
   role: Master
   subnets:
   - us-test-1a
@@ -96,6 +98,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a-2
   role: Master
   subnets:
   - us-test-1a
@@ -114,6 +118,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a-3
   role: Master
   subnets:
   - us-test-1a
@@ -132,6 +138,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1b-1
   role: Master
   subnets:
   - us-test-1b
@@ -150,6 +158,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1b-2
   role: Master
   subnets:
   - us-test-1b
@@ -168,6 +178,8 @@ spec:
   machineType: t2.medium
   maxSize: 2
   minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha1.yaml
@@ -54,6 +54,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   zones:
   - us-test-1a
@@ -72,6 +74,8 @@ spec:
   machineType: t2.medium
   maxSize: 2
   minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
   role: Node
   zones:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
@@ -58,6 +58,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -76,6 +78,8 @@ spec:
   machineType: t2.medium
   maxSize: 2
   minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha1.yaml
@@ -60,6 +60,8 @@ spec:
   machineType: t2.micro
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: bastions
   role: Bastion
   zones:
   - utility-us-test-1a
@@ -78,6 +80,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   zones:
   - us-test-1a
@@ -96,6 +100,8 @@ spec:
   machineType: t2.medium
   maxSize: 2
   minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
   role: Node
   zones:
   - us-test-1a

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -66,6 +66,8 @@ spec:
   machineType: t2.micro
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
   - utility-us-test-1a
@@ -84,6 +86,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -102,6 +106,8 @@ spec:
   machineType: t2.medium
   maxSize: 2
   minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -61,6 +61,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -79,6 +81,8 @@ spec:
   machineType: t2.medium
   maxSize: 2
   minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/private/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha1.yaml
@@ -63,6 +63,8 @@ spec:
   machineType: t2.micro
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: bastions
   role: Bastion
   zones:
   - utility-us-test-1a
@@ -84,6 +86,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   zones:
   - us-test-1a
@@ -105,6 +109,8 @@ spec:
   machineType: t2.medium
   maxSize: 2
   minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
   role: Node
   zones:
   - us-test-1a

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -69,6 +69,8 @@ spec:
   machineType: t2.micro
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
   - utility-us-test-1a
@@ -90,6 +92,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -111,6 +115,8 @@ spec:
   machineType: t2.medium
   maxSize: 2
   minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -31,8 +31,6 @@ import (
 
 // Default Machine types for various types of instance group machine
 const (
-	defaultNodeLabel = "kops.k8s.io/instancegroup"
-
 	defaultNodeMachineTypeGCE     = "n1-standard-2"
 	defaultNodeMachineTypeVSphere = "vsphere_node"
 	defaultNodeMachineTypeDO      = "2gb"
@@ -150,14 +148,6 @@ func PopulateInstanceGroupSpec(cluster *kops.Cluster, input *kops.InstanceGroup,
 
 	if len(ig.Spec.Subnets) == 0 {
 		return nil, fmt.Errorf("unable to infer any Subnets for InstanceGroup %s ", ig.ObjectMeta.Name)
-	}
-
-	if ig.Spec.NodeLabels == nil {
-		nodeLabels := make(map[string]string)
-		nodeLabels[defaultNodeLabel] = ig.Name
-		ig.Spec.NodeLabels = nodeLabels
-	} else {
-		ig.Spec.NodeLabels[defaultNodeLabel] = ig.Name
 	}
 
 	return ig, nil

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -31,6 +31,8 @@ import (
 
 // Default Machine types for various types of instance group machine
 const (
+	defaultNodeLabel = "kops.k8s.io/instancegroup"
+
 	defaultNodeMachineTypeGCE     = "n1-standard-2"
 	defaultNodeMachineTypeVSphere = "vsphere_node"
 	defaultNodeMachineTypeDO      = "2gb"
@@ -148,6 +150,14 @@ func PopulateInstanceGroupSpec(cluster *kops.Cluster, input *kops.InstanceGroup,
 
 	if len(ig.Spec.Subnets) == 0 {
 		return nil, fmt.Errorf("unable to infer any Subnets for InstanceGroup %s ", ig.ObjectMeta.Name)
+	}
+
+	if ig.Spec.NodeLabels == nil {
+		nodeLabels := make(map[string]string)
+		nodeLabels[defaultNodeLabel] = ig.Name
+		ig.Spec.NodeLabels = nodeLabels
+	} else {
+		ig.Spec.NodeLabels[defaultNodeLabel] = ig.Name
 	}
 
 	return ig, nil


### PR DESCRIPTION
As requested in https://github.com/kubernetes/kops/issues/2999, this change just auto-populates new InstanceGroup specs with a default node label containing the name of the instance group. It would be really useful for those of us managing environments with multiple instance groups.

It allows an admin to easily view the instance groups using kubectl:
```
kubectl get nodes --label-columns kops.k8s.io/instancegroup
NAME                                           STATUS         AGE       VERSION   INSTANCEGROUP
ip-172-20-108-120.eu-west-1.compute.internal   Ready,node     3m        v1.7.4    xtra-large
ip-172-20-117-133.eu-west-1.compute.internal   Ready,master   14m       v1.7.4    master-eu-west-1c
ip-172-20-32-139.eu-west-1.compute.internal    Ready,master   14m       v1.7.4    master-eu-west-1a
ip-172-20-32-92.eu-west-1.compute.internal     Ready,node     12m       v1.7.4    nodes
ip-172-20-67-184.eu-west-1.compute.internal    Ready,master   13m       v1.7.4    master-eu-west-1b
```