### PR TITLE
Update Canal to use Calico v2.6.2.

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.8.yaml.template
@@ -1,3 +1,10 @@
+# Canal w/ Calico Version v2.6.2
+# https://docs.projectcalico.org/v2.6/releases#v2.6.2
+# This manifest includes the following component versions:
+#   calico/node:v2.6.2
+#   calico/cni:v1.11.0
+#   coreos/flannel:v0.9.0
+
 # This ConfigMap can be used to configure a self-hosted Canal installation.
 kind: ConfigMap
 apiVersion: v1
@@ -84,7 +91,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v2.5.1
+          image: quay.io/calico/node:v2.6.2
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -166,7 +173,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v1.10.0
+          image: quay.io/calico/cni:v1.11.0
           command: ["/install-cni.sh"]
           env:
             # The CNI network config to install on each node.
@@ -187,7 +194,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.8.0
+          image: quay.io/coreos/flannel:v0.9.0
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -506,7 +506,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		versions := map[string]string{
 			"pre-k8s-1.6": "2.4.1",
 			"k8s-1.6":     "2.4.1",
-			"k8s-1.8":     "2.5.1",
+			"k8s-1.8":     "2.6.2",
 		}
 
 		{


### PR DESCRIPTION
Calico v2.6 adds support for egress Network Policies with Kubernetes v1.8.

The dnsmasq packages have also been updated in v2.6.2, which resolves a number of CVEs detected on the older versions (https://github.com/projectcalico/calico/issues/1169).