### PR TITLE
Add edit flag so create instancegroup command is usable on scripts

### DIFF
--- a/cmd/kops/create_ig.go
+++ b/cmd/kops/create_ig.go
@@ -43,8 +43,8 @@ type CreateInstanceGroupOptions struct {
 	DryRun bool
 	// Output type during a DryRun
 	Output string
-	// Do not launch editor when creating an instance group
-	NoEditor bool
+	// Launch editor when creating an instance group
+	Editor bool
 }
 
 var (
@@ -70,7 +70,8 @@ var (
 // NewCmdCreateInstanceGroup create a new cobra command object for creating a instancegroup.
 func NewCmdCreateInstanceGroup(f *util.Factory, out io.Writer) *cobra.Command {
 	options := &CreateInstanceGroupOptions{
-		Role: string(api.InstanceGroupRoleNode),
+		Role:   string(api.InstanceGroupRoleNode),
+		Editor: true,
 	}
 
 	cmd := &cobra.Command{
@@ -98,7 +99,7 @@ func NewCmdCreateInstanceGroup(f *util.Factory, out io.Writer) *cobra.Command {
 	// DryRun mode that will print YAML or JSON
 	cmd.Flags().BoolVar(&options.DryRun, "dry-run", options.DryRun, "If true, only print the object that would be sent, without sending it. This flag can be used to create a cluster YAML or JSON manifest.")
 	cmd.Flags().StringVarP(&options.Output, "output", "o", options.Output, "Ouput format. One of json|yaml")
-	cmd.Flags().BoolVar(&options.NoEditor, "no-editor", options.NoEditor, "If true, The instance group will be created by default with no option of editing it")
+	cmd.Flags().BoolVar(&options.Editor, "editor", options.Editor, "Default true. If true, an editor will be opened to edit default values.")
 
 	return cmd
 }
@@ -182,7 +183,7 @@ func RunCreateInstanceGroup(f *util.Factory, cmd *cobra.Command, args []string, 
 		}
 	}
 
-	if !options.NoEditor {
+	if options.Editor {
 		var (
 			edit = editor.NewDefaultEditor(editorEnvs)
 		)

--- a/cmd/kops/create_ig.go
+++ b/cmd/kops/create_ig.go
@@ -43,6 +43,8 @@ type CreateInstanceGroupOptions struct {
 	DryRun bool
 	// Output type during a DryRun
 	Output string
+	// Do not launch editor when creating an instance group
+	NoEditor bool
 }
 
 var (
@@ -96,6 +98,7 @@ func NewCmdCreateInstanceGroup(f *util.Factory, out io.Writer) *cobra.Command {
 	// DryRun mode that will print YAML or JSON
 	cmd.Flags().BoolVar(&options.DryRun, "dry-run", options.DryRun, "If true, only print the object that would be sent, without sending it. This flag can be used to create a cluster YAML or JSON manifest.")
 	cmd.Flags().StringVarP(&options.Output, "output", "o", options.Output, "Ouput format. One of json|yaml")
+	cmd.Flags().BoolVar(&options.NoEditor, "no-editor", options.NoEditor, "If true, The instance group will be created by default with no option of editing it")
 
 	return cmd
 }
@@ -179,42 +182,46 @@ func RunCreateInstanceGroup(f *util.Factory, cmd *cobra.Command, args []string, 
 		}
 	}
 
-	var (
-		edit = editor.NewDefaultEditor(editorEnvs)
-	)
+	if !options.NoEditor {
+		var (
+			edit = editor.NewDefaultEditor(editorEnvs)
+		)
 
-	raw, err := kopscodecs.ToVersionedYaml(ig)
-	if err != nil {
-		return err
-	}
-	ext := "yaml"
-
-	// launch the editor
-	edited, file, err := edit.LaunchTempFile(fmt.Sprintf("%s-edit-", filepath.Base(os.Args[0])), ext, bytes.NewReader(raw))
-	defer func() {
-		if file != "" {
-			os.Remove(file)
+		raw, err := kopscodecs.ToVersionedYaml(ig)
+		if err != nil {
+			return err
 		}
-	}()
-	if err != nil {
-		return fmt.Errorf("error launching editor: %v", err)
+		ext := "yaml"
+
+		// launch the editor
+		edited, file, err := edit.LaunchTempFile(fmt.Sprintf("%s-edit-", filepath.Base(os.Args[0])), ext, bytes.NewReader(raw))
+		defer func() {
+			if file != "" {
+				os.Remove(file)
+			}
+		}()
+		if err != nil {
+			return fmt.Errorf("error launching editor: %v", err)
+		}
+
+		obj, _, err := kopscodecs.ParseVersionedYaml(edited)
+		if err != nil {
+			return fmt.Errorf("error parsing yaml: %v", err)
+		}
+		group, ok := obj.(*api.InstanceGroup)
+		if !ok {
+			return fmt.Errorf("unexpected object type: %T", obj)
+		}
+
+		err = validation.ValidateInstanceGroup(group)
+		if err != nil {
+			return err
+		}
+
+		ig = group
 	}
 
-	obj, _, err := kopscodecs.ParseVersionedYaml(edited)
-	if err != nil {
-		return fmt.Errorf("error parsing yaml: %v", err)
-	}
-	group, ok := obj.(*api.InstanceGroup)
-	if !ok {
-		return fmt.Errorf("unexpected object type: %T", obj)
-	}
-
-	err = validation.ValidateInstanceGroup(group)
-	if err != nil {
-		return err
-	}
-
-	_, err = clientset.InstanceGroupsFor(cluster).Create(group)
+	_, err = clientset.InstanceGroupsFor(cluster).Create(ig)
 	if err != nil {
 		return fmt.Errorf("error storing InstanceGroup: %v", err)
 	}

--- a/docs/cli/kops_create_instancegroup.md
+++ b/docs/cli/kops_create_instancegroup.md
@@ -30,7 +30,7 @@ kops create instancegroup
 
 ```
       --dry-run              If true, only print the object that would be sent, without sending it. This flag can be used to create a cluster YAML or JSON manifest.
-      --no-editor            If true, The instance group will be created by default with no option of editing it
+      --editor               Default true. If true, an editor will be opened to edit default values. (default true)
   -o, --output string        Ouput format. One of json|yaml
       --role string          Type of instance group to create (Node,Master,Bastion) (default "Node")
       --subnet stringSlice   Subnets in which to create instance group

--- a/docs/cli/kops_create_instancegroup.md
+++ b/docs/cli/kops_create_instancegroup.md
@@ -30,6 +30,7 @@ kops create instancegroup
 
 ```
       --dry-run              If true, only print the object that would be sent, without sending it. This flag can be used to create a cluster YAML or JSON manifest.
+      --no-editor            If true, The instance group will be created by default with no option of editing it
   -o, --output string        Ouput format. One of json|yaml
       --role string          Type of instance group to create (Node,Master,Bastion) (default "Node")
       --subnet stringSlice   Subnets in which to create instance group


### PR DESCRIPTION
Until now, the opening of an interactive editor when creating a new instance group was mandatory.

This this commit, a new flag is added, so this is now optional.

This commit is backwards compatible.