### PR TITLE
Add support for C5 instance family

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/machine_types.go
+++ b/upup/pkg/fi/cloudup/awsup/machine_types.go
@@ -279,7 +279,51 @@ var MachineTypes []AWSMachineTypeInfo = []AWSMachineTypeInfo{
 		Cores:          32,
 		EphemeralDisks: nil,
 	},
-
+	
+	// c5 family
+	{
+		Name:           "c5.large",
+		MemoryGB:       4,
+		ECU:            8,
+		Cores:          2,
+		EphemeralDisks: nil,
+	},
+	{
+		Name:           "c5.xlarge",
+		MemoryGB:       8,
+		ECU:            16,
+		Cores:          4,
+		EphemeralDisks: nil,
+	},
+	{
+		Name:           "c5.2xlarge",
+		MemoryGB:       16,
+		ECU:            31,
+		Cores:          8,
+		EphemeralDisks: nil,
+	},
+	{
+		Name:           "c5.4xlarge",
+		MemoryGB:       32,
+		ECU:            62,
+		Cores:          16,
+		EphemeralDisks: nil,
+	},
+	{
+		Name:           "c5.9xlarge",
+		MemoryGB:       72,
+		ECU:            139,
+		Cores:          36,
+		EphemeralDisks: nil,
+	},	
+	{
+		Name:           "c5.18xlarge",
+		MemoryGB:       144,
+		ECU:            278,
+		Cores:          72,
+		EphemeralDisks: nil,
+	},	
+	
 	// cc2 family
 	{
 		Name:           "cc2.8xlarge",

--- a/upup/pkg/fi/cloudup/awsup/machine_types.go
+++ b/upup/pkg/fi/cloudup/awsup/machine_types.go
@@ -279,7 +279,7 @@ var MachineTypes []AWSMachineTypeInfo = []AWSMachineTypeInfo{
 		Cores:          32,
 		EphemeralDisks: nil,
 	},
-	
+
 	// c5 family
 	{
 		Name:           "c5.large",
@@ -315,15 +315,15 @@ var MachineTypes []AWSMachineTypeInfo = []AWSMachineTypeInfo{
 		ECU:            139,
 		Cores:          36,
 		EphemeralDisks: nil,
-	},	
+	},
 	{
 		Name:           "c5.18xlarge",
 		MemoryGB:       144,
 		ECU:            278,
 		Cores:          72,
 		EphemeralDisks: nil,
-	},	
-	
+	},
+
 	// cc2 family
 	{
 		Name:           "cc2.8xlarge",


### PR DESCRIPTION
AWS [released](https://aws.amazon.com/blogs/aws/now-available-compute-intensive-c5-instances-for-amazon-ec2) 5th generation of Compute oriented EC2 series. This PR adds support for them.