### PR TITLE
Add Node IAM permissions to access kube-router key in S3.

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -348,6 +348,17 @@ func (b *PolicyBuilder) AddS3Permissions(p *Policy) (*Policy, error) {
 							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/secrets/dockerconfig"}, ""),
 						),
 					})
+
+					if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.Kuberouter != nil {
+						p.Statement = append(p.Statement, &Statement{
+							Sid:    "kopsK8sS3NodeBucketGetKuberouter",
+							Effect: StatementEffectAllow,
+							Action: stringorslice.Slice([]string{"s3:Get*"}),
+							Resource: stringorslice.Of(
+								strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/pki/private/kube-router/*"}, ""),
+							),
+						})
+					}
 				}
 			}
 		} else if _, ok := vfsPath.(*vfs.MemFSPath); ok {


### PR DESCRIPTION
Fixes #3792 

An additional S3 IAM permission is added to the nodes policy when `Networking.Kuberouter` is specified.