### PR TITLE
DNS Controller Watch Command line

### DIFF
--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -156,7 +156,7 @@ func (tf *TemplateFunctions) DnsControllerArgv() ([]string, error) {
 		}
 		argv = append(argv, fmt.Sprintf("--watch-ingress=%t", watchIngress))
 		if tf.cluster.Spec.ExternalDNS.WatchNamespace != "" {
-			argv = append(argv, fmt.Sprintf("--watch-namespace=%q", tf.cluster.Spec.ExternalDNS.WatchNamespace))
+			argv = append(argv, fmt.Sprintf("--watch-namespace=%s", tf.cluster.Spec.ExternalDNS.WatchNamespace))
 		}
 	}
 


### PR DESCRIPTION
- adding a fix to the building of the argument, as the double quote cause an yaml parsing error
```shell
  error building tasks: error remapping manifest addons/dns-controller.addons.k8s.io/pre-k8s-1.6.yaml: error parsing yaml: error converting YAML to JSON: yaml: line 37: did not find expected key
```