### PR TITLE
Let a user set a hostnameOverride when the cloud provider is aws.

### DIFF
--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -149,7 +149,10 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		}
 
 		// Use the hostname from the AWS metadata service
-		clusterSpec.Kubelet.HostnameOverride = "@aws"
+		// if hostnameOverride is not set.
+		if clusterSpec.Kubelet.HostnameOverride == "" {
+			clusterSpec.Kubelet.HostnameOverride = "@aws"
+		}
 	}
 
 	if cloudProvider == kops.CloudProviderDO {

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -308,7 +308,7 @@ func evaluateSpec(c *api.Cluster) error {
 }
 
 func evaluateHostnameOverride(hostnameOverride string) (string, error) {
-	if hostnameOverride == "" {
+	if hostnameOverride == "" || hostnameOverride == "@hostname" {
 		return "", nil
 	}
 	k := strings.TrimSpace(hostnameOverride)


### PR DESCRIPTION
Let a user use the hostname or set a hostnameOverride when the cloud provider is aws. This would allow for a more descriptive name to be used. The name of the hosts when using @hostname can be set by using a hook or some other method.