### PR TITLE
add openstack cloud provider

### DIFF
--- a/hack/.packages
+++ b/hack/.packages
@@ -122,6 +122,7 @@ k8s.io/kops/upup/pkg/fi/cloudup/do
 k8s.io/kops/upup/pkg/fi/cloudup/dotasks
 k8s.io/kops/upup/pkg/fi/cloudup/gce
 k8s.io/kops/upup/pkg/fi/cloudup/gcetasks
+k8s.io/kops/upup/pkg/fi/cloudup/openstack
 k8s.io/kops/upup/pkg/fi/cloudup/terraform
 k8s.io/kops/upup/pkg/fi/cloudup/vsphere
 k8s.io/kops/upup/pkg/fi/cloudup/vspheretasks

--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -249,6 +249,7 @@ const CloudProviderBareMetal CloudProviderID = "baremetal"
 const CloudProviderGCE CloudProviderID = "gce"
 const CloudProviderDO CloudProviderID = "digitalocean"
 const CloudProviderVSphere CloudProviderID = "vsphere"
+const CloudProviderOpenstack CloudProviderID = "openstack"
 
 // FindImage returns the image for the cloudprovider, or nil if none found
 func (c *Channel) FindImage(provider CloudProviderID, kubernetesVersion semver.Version) *ChannelImageSpec {

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -101,6 +101,9 @@ func ValidateCluster(c *kops.Cluster, strict bool) *field.Error {
 		}
 	case kops.CloudProviderAWS:
 	case kops.CloudProviderVSphere:
+	case kops.CloudProviderOpenstack:
+		requiresNetworkCIDR = false
+		requiresSubnetCIDR = false
 
 	default:
 		return field.Invalid(fieldSpec.Child("CloudProvider"), c.Spec.CloudProvider, "CloudProvider not recognized")
@@ -280,6 +283,8 @@ func ValidateCluster(c *kops.Cluster, strict bool) *field.Error {
 			k8sCloudProvider = "vsphere"
 		case kops.CloudProviderBareMetal:
 			k8sCloudProvider = ""
+		case kops.CloudProviderOpenstack:
+			k8sCloudProvider = "openstack"
 		default:
 			return field.Invalid(fieldSpec.Child("CloudProvider"), c.Spec.CloudProvider, "unknown cloudprovider")
 		}

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -115,6 +115,8 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 		c.CloudProvider = "vsphere"
 	case kops.CloudProviderBareMetal:
 		// for baremetal, we don't specify a cloudprovider to apiserver
+	case kops.CloudProviderOpenstack:
+		c.CloudProvider = "openstack"
 	default:
 		return fmt.Errorf("unknown cloudprovider %q", clusterSpec.CloudProvider)
 	}

--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -113,6 +113,9 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 	case kops.CloudProviderBareMetal:
 		// No cloudprovider
 
+	case kops.CloudProviderOpenstack:
+		kcm.CloudProvider = "openstack"
+
 	default:
 		return fmt.Errorf("unknown cloudprovider %q", clusterSpec.CloudProvider)
 	}

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -172,6 +172,10 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.Kubelet.HairpinMode = "promiscuous-bridge"
 	}
 
+	if cloudProvider == kops.CloudProviderOpenstack {
+		clusterSpec.Kubelet.CloudProvider = "openstack"
+	}
+
 	if clusterSpec.ExternalCloudControllerManager != nil {
 		clusterSpec.Kubelet.CloudProvider = "external"
 	}

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/dotasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gcetasks"
+	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
 	"k8s.io/kops/upup/pkg/fi/cloudup/vsphere"
 	"k8s.io/kops/upup/pkg/fi/cloudup/vspheretasks"
@@ -437,6 +438,8 @@ func (c *ApplyClusterCmd) Run() error {
 			// No additional tasks (yet)
 		}
 
+	case kops.CloudProviderOpenstack:
+
 	default:
 		return fmt.Errorf("unknown CloudProvider %q", cluster.Spec.CloudProvider)
 	}
@@ -584,6 +587,8 @@ func (c *ApplyClusterCmd) Run() error {
 
 			case kops.CloudProviderBareMetal:
 				// No special settings (yet!)
+
+			case kops.CloudProviderOpenstack:
 
 			default:
 				return fmt.Errorf("unknown cloudprovider %q", cluster.Spec.CloudProvider)
@@ -733,6 +738,8 @@ func (c *ApplyClusterCmd) Run() error {
 	case kops.CloudProviderBareMetal:
 		// BareMetal tasks will go here
 
+	case kops.CloudProviderOpenstack:
+
 	default:
 		return fmt.Errorf("unknown cloudprovider %q", cluster.Spec.CloudProvider)
 	}
@@ -763,6 +770,8 @@ func (c *ApplyClusterCmd) Run() error {
 			target = vsphere.NewVSphereAPITarget(cloud.(*vsphere.VSphereCloud))
 		case kops.CloudProviderBareMetal:
 			target = baremetal.NewTarget(cloud.(*baremetal.Cloud))
+		case kops.CloudProviderOpenstack:
+			target = openstack.NewOpenstackAPITarget(cloud.(openstack.OpenstackCloud))
 		default:
 			return fmt.Errorf("direct configuration not supported with CloudProvider:%q", cluster.Spec.CloudProvider)
 		}

--- a/upup/pkg/fi/cloudup/openstack/apitarget.go
+++ b/upup/pkg/fi/cloudup/openstack/apitarget.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"k8s.io/kops/upup/pkg/fi"
+)
+
+type OpenstackAPITarget struct {
+	Cloud OpenstackCloud
+}
+
+var _ fi.Target = &OpenstackAPITarget{}
+
+func NewOpenstackAPITarget(cloud OpenstackCloud) *OpenstackAPITarget {
+	return &OpenstackAPITarget{
+		Cloud: cloud,
+	}
+}
+
+func (t *OpenstackAPITarget) Finish(taskMap map[string]fi.Task) error {
+	return nil
+}
+
+func (t *OpenstackAPITarget) ProcessDeletions() bool {
+	return true
+}

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -44,21 +44,21 @@ func (c *openstackCloud) ProviderID() kops.CloudProviderID {
 }
 
 func (c *openstackCloud) DNS() (dnsprovider.Interface, error) {
-	return nil, fmt.Errorf("has not implemented this method")
+	return nil, fmt.Errorf("openstackCloud::DNS not implemented")
 }
 
 func (c *openstackCloud) FindVPCInfo(id string) (*fi.VPCInfo, error) {
-	return nil, fmt.Errorf("has not implemented this method")
+	return nil, fmt.Errorf("openstackCloud::FindVPCInfo not implemented")
 }
 
 func (c *openstackCloud) DeleteInstance(i *cloudinstances.CloudInstanceGroupMember) error {
-	return fmt.Errorf("has not implemented this method")
+	return fmt.Errorf("openstackCloud::DeleteInstance not implemented")
 }
 
 func (c *openstackCloud) DeleteGroup(g *cloudinstances.CloudInstanceGroup) error {
-	return fmt.Errorf("has not implemented this method")
+	return fmt.Errorf("openstackCloud::DeleteGroup not implemented")
 }
 
 func (c *openstackCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
-	return nil, fmt.Errorf("has not implemented this method")
+	return nil, fmt.Errorf("openstackCloud::GetCloudGroups not implemented")
 }

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/cloudinstances"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+)
+
+type OpenstackCloud interface {
+	fi.Cloud
+}
+
+type openstackCloud struct {
+}
+
+var _ fi.Cloud = &openstackCloud{}
+
+func NewOpenstackCloud() (OpenstackCloud, error) {
+	return &openstackCloud{}, nil
+}
+
+func (c *openstackCloud) ProviderID() kops.CloudProviderID {
+	return kops.CloudProviderOpenstack
+}
+
+func (c *openstackCloud) DNS() (dnsprovider.Interface, error) {
+	return nil, fmt.Errorf("has not implemented this method")
+}
+
+func (c *openstackCloud) FindVPCInfo(id string) (*fi.VPCInfo, error) {
+	return nil, fmt.Errorf("has not implemented this method")
+}
+
+func (c *openstackCloud) DeleteInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return fmt.Errorf("has not implemented this method")
+}
+
+func (c *openstackCloud) DeleteGroup(g *cloudinstances.CloudInstanceGroup) error {
+	return fmt.Errorf("has not implemented this method")
+}
+
+func (c *openstackCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
+	return nil, fmt.Errorf("has not implemented this method")
+}

--- a/upup/pkg/fi/cloudup/tagbuilder.go
+++ b/upup/pkg/fi/cloudup/tagbuilder.go
@@ -79,9 +79,6 @@ func buildCloudupTags(cluster *api.Cluster) (sets.String, error) {
 		// No tags
 
 	case api.CloudProviderOpenstack:
-		{
-			tags.Insert("_openstack")
-		}
 
 	default:
 		return nil, fmt.Errorf("unknown CloudProvider %q", cluster.Spec.CloudProvider)

--- a/upup/pkg/fi/cloudup/tagbuilder.go
+++ b/upup/pkg/fi/cloudup/tagbuilder.go
@@ -78,6 +78,11 @@ func buildCloudupTags(cluster *api.Cluster) (sets.String, error) {
 	case api.CloudProviderBareMetal:
 		// No tags
 
+	case api.CloudProviderOpenstack:
+		{
+			tags.Insert("_openstack")
+		}
+
 	default:
 		return nil, fmt.Errorf("unknown CloudProvider %q", cluster.Spec.CloudProvider)
 	}

--- a/upup/pkg/fi/cloudup/utils.go
+++ b/upup/pkg/fi/cloudup/utils.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/baremetal"
 	"k8s.io/kops/upup/pkg/fi/cloudup/do"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
+	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 	"k8s.io/kops/upup/pkg/fi/cloudup/vsphere"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/aws/route53"
@@ -129,6 +130,14 @@ func BuildCloud(cluster *kops.Cluster) (fi.Cloud, error) {
 				return nil, err
 			}
 			cloud = baremetalCloud
+		}
+	case kops.CloudProviderOpenstack:
+		{
+			osc, err := openstack.NewOpenstackCloud()
+			if err != nil {
+				return nil, err
+			}
+			cloud = osc
 		}
 
 	default:


### PR DESCRIPTION
Add an Openstack cloud provider. It does not implement all the interfaces of fi.Cloud, hence, can not create a cluster, but it can pass the work flow of creating cluster for the command like "kops create cluster --cloud openstack --zones nova -v 15 --target direct --yes myoscluster4.k8s.local"
Which issue this PR fixes: #3819