### PR TITLE
DNS Controller Optional

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -240,8 +240,11 @@ type RBACAuthorizationSpec struct {
 type AlwaysAllowAuthorizationSpec struct {
 }
 
+// AccessSpec provides configuration details related to kubeapi dns and ELB access
 type AccessSpec struct {
-	DNS          *DNSAccessSpec          `json:"dns,omitempty"`
+	// DNS wil be used to provide config on kube-apiserver elb dns
+	DNS *DNSAccessSpec `json:"dns,omitempty"`
+	// LoadBalancer is the configuration for the kube-apiserver ELB
 	LoadBalancer *LoadBalancerAccessSpec `json:"loadBalancer,omitempty"`
 }
 
@@ -281,6 +284,8 @@ type KubeDNSConfig struct {
 
 // ExternalDNSConfig are options of the dns-controller
 type ExternalDNSConfig struct {
+	// Disable indicates we do not wish to run the dns-controller addon
+	Disable bool `json:"disable,omitempty"`
 	// WatchIngress indicates you want the dns-controller to watch and create dns entries for ingress resources
 	WatchIngress *bool `json:"watchIngress,omitempty"`
 	// WatchNamespace is namespace to watch, detaults to all (use to control whom can creates dns entries)

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -239,8 +239,11 @@ type RBACAuthorizationSpec struct {
 type AlwaysAllowAuthorizationSpec struct {
 }
 
+// AccessSpec provides configuration details related to kubeapi dns and ELB access
 type AccessSpec struct {
-	DNS          *DNSAccessSpec          `json:"dns,omitempty"`
+	// DNS wil be used to provide config on kube-apiserver elb dns
+	DNS *DNSAccessSpec `json:"dns,omitempty"`
+	// LoadBalancer is the configuration for the kube-apiserver ELB
 	LoadBalancer *LoadBalancerAccessSpec `json:"loadBalancer,omitempty"`
 }
 
@@ -280,6 +283,8 @@ type KubeDNSConfig struct {
 
 // ExternalDNSConfig are options of the dns-controller
 type ExternalDNSConfig struct {
+	// Disable indicates we do not wish to run the dns-controller addon
+	Disable bool `json:"disable,omitempty"`
 	// WatchIngress indicates you want the dns-controller to watch and create dns entries for ingress resources
 	WatchIngress *bool `json:"watchIngress,omitempty"`
 	// WatchNamespace is namespace to watch, detaults to all (use to control whom can creates dns entries)

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1264,6 +1264,7 @@ func Convert_kops_ExecContainerAction_To_v1alpha1_ExecContainerAction(in *kops.E
 }
 
 func autoConvert_v1alpha1_ExternalDNSConfig_To_kops_ExternalDNSConfig(in *ExternalDNSConfig, out *kops.ExternalDNSConfig, s conversion.Scope) error {
+	out.Disable = in.Disable
 	out.WatchIngress = in.WatchIngress
 	out.WatchNamespace = in.WatchNamespace
 	return nil
@@ -1275,6 +1276,7 @@ func Convert_v1alpha1_ExternalDNSConfig_To_kops_ExternalDNSConfig(in *ExternalDN
 }
 
 func autoConvert_kops_ExternalDNSConfig_To_v1alpha1_ExternalDNSConfig(in *kops.ExternalDNSConfig, out *ExternalDNSConfig, s conversion.Scope) error {
+	out.Disable = in.Disable
 	out.WatchIngress = in.WatchIngress
 	out.WatchNamespace = in.WatchNamespace
 	return nil

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -21,11 +21,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	reflect "reflect"
-
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	reflect "reflect"
 )
 
 func init() {

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -240,8 +240,11 @@ type RBACAuthorizationSpec struct {
 type AlwaysAllowAuthorizationSpec struct {
 }
 
+// AccessSpec provides configuration details related to kubeapi dns and ELB access
 type AccessSpec struct {
-	DNS          *DNSAccessSpec          `json:"dns,omitempty"`
+	// DNS wil be used to provide config on kube-apiserver elb dns
+	DNS *DNSAccessSpec `json:"dns,omitempty"`
+	// LoadBalancer is the configuration for the kube-apiserver ELB
 	LoadBalancer *LoadBalancerAccessSpec `json:"loadBalancer,omitempty"`
 }
 
@@ -278,6 +281,8 @@ type KubeDNSConfig struct {
 
 // ExternalDNSConfig are options of the dns-controller
 type ExternalDNSConfig struct {
+	// Disable indicates we do not wish to run the dns-controller addon
+	Disable bool `json:"disable,omitempty"`
 	// WatchIngress indicates you want the dns-controller to watch and create dns entries for ingress resources
 	WatchIngress *bool `json:"watchIngress,omitempty"`
 	// WatchNamespace is namespace to watch, detaults to all (use to control whom can creates dns entries)

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1373,6 +1373,7 @@ func Convert_kops_ExecContainerAction_To_v1alpha2_ExecContainerAction(in *kops.E
 }
 
 func autoConvert_v1alpha2_ExternalDNSConfig_To_kops_ExternalDNSConfig(in *ExternalDNSConfig, out *kops.ExternalDNSConfig, s conversion.Scope) error {
+	out.Disable = in.Disable
 	out.WatchIngress = in.WatchIngress
 	out.WatchNamespace = in.WatchNamespace
 	return nil
@@ -1384,6 +1385,7 @@ func Convert_v1alpha2_ExternalDNSConfig_To_kops_ExternalDNSConfig(in *ExternalDN
 }
 
 func autoConvert_kops_ExternalDNSConfig_To_v1alpha2_ExternalDNSConfig(in *kops.ExternalDNSConfig, out *ExternalDNSConfig, s conversion.Scope) error {
+	out.Disable = in.Disable
 	out.WatchIngress = in.WatchIngress
 	out.WatchNamespace = in.WatchNamespace
 	return nil
@@ -2202,6 +2204,8 @@ func autoConvert_v1alpha2_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.TerminatedPodGCThreshold = in.TerminatedPodGCThreshold
 	out.UseServiceAccountCredentials = in.UseServiceAccountCredentials
 	out.HorizontalPodAutoscalerSyncPeriod = in.HorizontalPodAutoscalerSyncPeriod
+	out.HorizontalPodAutoscalerDownscaleDelay = in.HorizontalPodAutoscalerDownscaleDelay
+	out.HorizontalPodAutoscalerUpscaleDelay = in.HorizontalPodAutoscalerUpscaleDelay
 	out.FeatureGates = in.FeatureGates
 	return nil
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -21,11 +21,10 @@ limitations under the License.
 package v1alpha2
 
 import (
-	reflect "reflect"
-
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	reflect "reflect"
 )
 
 func init() {
@@ -2275,6 +2274,24 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 	}
 	if in.HorizontalPodAutoscalerSyncPeriod != nil {
 		in, out := &in.HorizontalPodAutoscalerSyncPeriod, &out.HorizontalPodAutoscalerSyncPeriod
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
+	if in.HorizontalPodAutoscalerDownscaleDelay != nil {
+		in, out := &in.HorizontalPodAutoscalerDownscaleDelay, &out.HorizontalPodAutoscalerDownscaleDelay
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
+	if in.HorizontalPodAutoscalerUpscaleDelay != nil {
+		in, out := &in.HorizontalPodAutoscalerUpscaleDelay, &out.HorizontalPodAutoscalerUpscaleDelay
 		if *in == nil {
 			*out = nil
 		} else {

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -21,11 +21,10 @@ limitations under the License.
 package kops
 
 import (
-	reflect "reflect"
-
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	reflect "reflect"
 )
 
 func init() {

--- a/pkg/client/clientset_generated/clientset/scheme/register.go
+++ b/pkg/client/clientset_generated/clientset/scheme/register.go
@@ -17,8 +17,6 @@ limitations under the License.
 package scheme
 
 import (
-	os "os"
-
 	announced "k8s.io/apimachinery/pkg/apimachinery/announced"
 	registered "k8s.io/apimachinery/pkg/apimachinery/registered"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +24,7 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	kops "k8s.io/kops/pkg/apis/kops/install"
+	os "os"
 )
 
 var Scheme = runtime.NewScheme()

--- a/pkg/client/clientset_generated/internalclientset/scheme/register.go
+++ b/pkg/client/clientset_generated/internalclientset/scheme/register.go
@@ -17,8 +17,6 @@ limitations under the License.
 package scheme
 
 import (
-	os "os"
-
 	announced "k8s.io/apimachinery/pkg/apimachinery/announced"
 	registered "k8s.io/apimachinery/pkg/apimachinery/registered"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +24,7 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	kops "k8s.io/kops/pkg/apis/kops/install"
+	os "os"
 )
 
 var Scheme = runtime.NewScheme()


### PR DESCRIPTION
The current implementation enforces a dns-controller is running; given the user can switch the make the kube-apiserver server Internal and then reuse the dns for the masterInternalName; this effectlively removes the need to run the service (assuming your not using it for pods, node and service dns)

- adding a disableDnsController to the ExternalDNS spec provides a toggle on the addon (name is definitely up for debate)
- the default behaviour remains, the dns-controller is always pushed as an addon