### PR TITLE
Convert pod.beta.kubernetes.io/init-containers annotation to initContainter spec

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
@@ -34,30 +34,16 @@ spec:
         tier: node
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        pod.beta.kubernetes.io/init-containers: '[
-            {
-                "name": "install-cni",
-                "image": "busybox",
-                "command": [ "/bin/sh", "-c", "set -e -x; if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then TMP=/etc/cni/net.d/.tmp-kuberouter-cfg; cp /etc/kube-router/cni-conf.json ${TMP}; mv ${TMP} /etc/cni/net.d/10-kuberouter.conf; fi" ],
-                "volumeMounts": [
-                    {
-                        "name": "cni",
-                        "mountPath": "/etc/cni/net.d"
-                    },
-                    {
-                        "name": "kube-router-cfg",
-                        "mountPath": "/etc/kube-router"
-                    }
-                ],
-                "volumes": {
-                     "name": "cni",
-                     "hostPath": {
-                          "path": "/etc/cni/net.d"
-                     }
-                }
-            }
-        ]'
     spec:
+      initContainers:
+      - name: install-cni
+        image: busybox
+        command: [ "/bin/sh", "-c", "set -e -x; if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then TMP=/etc/cni/net.d/.tmp-kuberouter-cfg; cp /etc/kube-router/cni-conf.json ${TMP}; mv ${TMP} /etc/cni/net.d/10-kuberouter.conf; fi" ]
+        volumeMounts:
+        - mountPath: /etc/cni/net.d
+          name: cni
+        - mountPath: /etc/kube-router
+          name: kube-router-cfg
       containers:
       - name: kube-router
         image: cloudnativelabs/kube-router
@@ -112,7 +98,7 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kube-router 
+  name: kube-router
   namespace: kube-system
 ---
 # Kube-router roles


### PR DESCRIPTION
Fixes #3821

### Background

Kubernetes 1.8 removed the `pod.beta.kubernetes.io/init-containers` annotation in favor of the `initContainers` spec that was added in kubernetes 1.6. 

The effect on kube-router daemonset is that the config file is not dropped in /etc/cni/net.d, kubelet fails to init the network and node is never marked as ready. The solution is pretty simple, just move the annotation to the new initContainers spec.
