### PR TITLE
Refactor: separate out SSHCredentials from Keyset stores

### DIFF
--- a/cmd/kops/BUILD.bazel
+++ b/cmd/kops/BUILD.bazel
@@ -78,6 +78,7 @@ go_library(
         "//pkg/pretty:go_default_library",
         "//pkg/resources:go_default_library",
         "//pkg/resources/ops:go_default_library",
+        "//pkg/sshcredentials:go_default_library",
         "//pkg/util/templater:go_default_library",
         "//pkg/validation:go_default_library",
         "//upup/pkg/fi:go_default_library",

--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -209,13 +209,13 @@ func RunCreate(f *util.Factory, out io.Writer, c *CreateOptions) error {
 					return err
 				}
 
-				keyStore, err := clientset.KeyStore(cluster)
+				sshCredentialStore, err := clientset.SSHCredentialStore(cluster)
 				if err != nil {
 					return err
 				}
 
 				sshKeyArr := []byte(v.Spec.PublicKey)
-				err = keyStore.AddSSHPublicKey("admin", sshKeyArr)
+				err = sshCredentialStore.AddSSHPublicKey("admin", sshKeyArr)
 				if err != nil {
 					return err
 				} else {

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -1060,13 +1060,13 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 	}
 
 	if len(sshPublicKeys) != 0 {
-		keyStore, err := clientset.KeyStore(cluster)
+		sshCredentialStore, err := clientset.SSHCredentialStore(cluster)
 		if err != nil {
 			return err
 		}
 
 		for k, data := range sshPublicKeys {
-			err = keyStore.AddSSHPublicKey(k, data)
+			err = sshCredentialStore.AddSSHPublicKey(k, data)
 			if err != nil {
 				return fmt.Errorf("error adding SSH public key: %v", err)
 			}

--- a/cmd/kops/create_secret_sshpublickey.go
+++ b/cmd/kops/create_secret_sshpublickey.go
@@ -103,7 +103,7 @@ func RunCreateSecretPublicKey(f *util.Factory, out io.Writer, options *CreateSec
 		return err
 	}
 
-	keyStore, err := clientset.KeyStore(cluster)
+	sshCredentialStore, err := clientset.SSHCredentialStore(cluster)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func RunCreateSecretPublicKey(f *util.Factory, out io.Writer, options *CreateSec
 		return fmt.Errorf("error reading SSH public key %v: %v", options.PublicKeyPath, err)
 	}
 
-	err = keyStore.AddSSHPublicKey(options.Name, data)
+	err = sshCredentialStore.AddSSHPublicKey(options.Name, data)
 	if err != nil {
 		return fmt.Errorf("error adding SSH public key: %v", err)
 	}

--- a/cmd/kops/describe_secrets.go
+++ b/cmd/kops/describe_secrets.go
@@ -90,7 +90,12 @@ func (c *DescribeSecretsCommand) Run(args []string) error {
 		return err
 	}
 
-	items, err := listSecrets(keyStore, secretStore, c.Type, args)
+	sshCredentialStore, err := clientset.SSHCredentialStore(cluster)
+	if err != nil {
+		return err
+	}
+
+	items, err := listSecrets(keyStore, secretStore, sshCredentialStore, c.Type, args)
 	if err != nil {
 		return err
 	}
@@ -119,7 +124,7 @@ func (c *DescribeSecretsCommand) Run(args []string) error {
 				return err
 			}
 
-		case fi.SecretTypeSSHPublicKey:
+		case SecretTypeSSHPublicKey:
 			err = describeSSHPublicKey(i, &b)
 			if err != nil {
 				return err

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -153,6 +153,11 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 		return err
 	}
 
+	sshCredentialStore, err := clientset.SSHCredentialStore(cluster)
+	if err != nil {
+		return err
+	}
+
 	secretStore, err := clientset.SecretStore(cluster)
 	if err != nil {
 		return err
@@ -166,7 +171,7 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 		if err != nil {
 			return fmt.Errorf("error reading SSH key file %q: %v", c.SSHPublicKey, err)
 		}
-		err = keyStore.AddSSHPublicKey(fi.SecretNameSSHPrimary, authorized)
+		err = sshCredentialStore.AddSSHPublicKey(fi.SecretNameSSHPrimary, authorized)
 		if err != nil {
 			return fmt.Errorf("error adding SSH public key: %v", err)
 		}

--- a/examples/kops-api-example/up.go
+++ b/examples/kops-api-example/up.go
@@ -101,7 +101,7 @@ func up() error {
 		}
 	}
 
-	keyStore, err := clientset.KeyStore(cluster)
+	sshCredentialStore, err := clientset.SSHCredentialStore(cluster)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func up() error {
 		if err != nil {
 			return fmt.Errorf("error reading SSH key file %q: %v", f, err)
 		}
-		err = keyStore.AddSSHPublicKey(fi.SecretNameSSHPrimary, pubKey)
+		err = sshCredentialStore.AddSSHPublicKey(fi.SecretNameSSHPrimary, pubKey)
 		if err != nil {
 			return fmt.Errorf("error adding SSH public key: %v", err)
 		}

--- a/hack/.packages
+++ b/hack/.packages
@@ -91,6 +91,7 @@ k8s.io/kops/pkg/resources/digitalocean
 k8s.io/kops/pkg/resources/digitalocean/dns
 k8s.io/kops/pkg/resources/gce
 k8s.io/kops/pkg/resources/ops
+k8s.io/kops/pkg/sshcredentials
 k8s.io/kops/pkg/systemd
 k8s.io/kops/pkg/templates
 k8s.io/kops/pkg/testutils

--- a/pkg/client/simple/api/clientset.go
+++ b/pkg/client/simple/api/clientset.go
@@ -117,6 +117,11 @@ func (c *RESTClientset) KeyStore(cluster *kops.Cluster) (fi.CAStore, error) {
 	return fi.NewClientsetCAStore(cluster, c.KopsClient, namespace), nil
 }
 
+func (c *RESTClientset) SSHCredentialStore(cluster *kops.Cluster) (fi.SSHCredentialStore, error) {
+	namespace := restNamespaceForClusterName(cluster.Name)
+	return fi.NewClientsetSSHCredentialStore(cluster, c.KopsClient, namespace), nil
+}
+
 func (c *RESTClientset) DeleteCluster(cluster *kops.Cluster) error {
 	configBase, err := registry.ConfigBase(cluster)
 	if err != nil {

--- a/pkg/client/simple/clientset.go
+++ b/pkg/client/simple/clientset.go
@@ -58,6 +58,9 @@ type Clientset interface {
 	// KeyStore builds the key store for the specified cluster
 	KeyStore(cluster *kops.Cluster) (fi.CAStore, error)
 
+	// SSHCredentialStore builds the SSHCredential store for the specified cluster
+	SSHCredentialStore(cluster *kops.Cluster) (fi.SSHCredentialStore, error)
+
 	// DeleteCluster deletes all the state for the specified cluster
 	DeleteCluster(cluster *kops.Cluster) error
 }

--- a/pkg/client/simple/vfsclientset/clientset.go
+++ b/pkg/client/simple/vfsclientset/clientset.go
@@ -110,6 +110,15 @@ func (c *VFSClientset) KeyStore(cluster *kops.Cluster) (fi.CAStore, error) {
 	return fi.NewVFSCAStore(cluster, basedir), nil
 }
 
+func (c *VFSClientset) SSHCredentialStore(cluster *kops.Cluster) (fi.SSHCredentialStore, error) {
+	configBase, err := registry.ConfigBase(cluster)
+	if err != nil {
+		return nil, err
+	}
+	basedir := configBase.Join("pki")
+	return fi.NewVFSSSHCredentialStore(cluster, basedir), nil
+}
+
 func DeleteAllClusterState(basePath vfs.Path) error {
 	paths, err := basePath.ReadTree()
 	if err != nil {

--- a/pkg/sshcredentials/BUILD.bazel
+++ b/pkg/sshcredentials/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["fingerprint.go"],
+    importpath = "k8s.io/kops/pkg/sshcredentials",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/golang.org/x/crypto/ssh:go_default_library",
+    ],
+)

--- a/pkg/sshcredentials/fingerprint.go
+++ b/pkg/sshcredentials/fingerprint.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sshcredentials
+
+import (
+	"bytes"
+	"crypto/md5"
+	"fmt"
+	"github.com/golang/glog"
+	"golang.org/x/crypto/ssh"
+)
+
+func Fingerprint(pubkey string) (string, error) {
+	sshPublicKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(pubkey))
+	if err != nil {
+		return "", fmt.Errorf("error parsing SSH public key: %v", err)
+	}
+
+	// compute fingerprint to serve as id
+	h := md5.New()
+	_, err = h.Write(sshPublicKey.Marshal())
+	if err != nil {
+		return "", fmt.Errorf("error fingerprinting SSH public key: %v", err)
+	}
+	id := formatFingerprint(h.Sum(nil))
+	return id, nil
+}
+
+func formatFingerprint(data []byte) string {
+	var buf bytes.Buffer
+
+	for i, b := range data {
+		s := fmt.Sprintf("%0.2x", b)
+		if i != 0 {
+			buf.WriteString(":")
+		}
+		buf.WriteString(s)
+	}
+	return buf.String()
+}
+
+func insertFingerprintColons(id string) string {
+	remaining := id
+
+	var buf bytes.Buffer
+	for {
+		if remaining == "" {
+			break
+		}
+		if buf.Len() != 0 {
+			buf.WriteString(":")
+		}
+		if len(remaining) < 2 {
+			glog.Warningf("unexpected format for SSH public key id: %q", id)
+			buf.WriteString(remaining)
+			break
+		} else {
+			buf.WriteString(remaining[0:2])
+			remaining = remaining[2:]
+		}
+	}
+	return buf.String()
+}

--- a/upup/pkg/fi/BUILD.bazel
+++ b/upup/pkg/fi/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//pkg/cloudinstances:go_default_library",
         "//pkg/diff:go_default_library",
         "//pkg/pki:go_default_library",
+        "//pkg/sshcredentials:go_default_library",
         "//upup/pkg/fi/utils:go_default_library",
         "//util/pkg/hashing:go_default_library",
         "//util/pkg/vfs:go_default_library",

--- a/upup/pkg/fi/ca.go
+++ b/upup/pkg/fi/ca.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"fmt"
 
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/pki"
 	"k8s.io/kops/util/pkg/vfs"
 )
@@ -28,9 +29,8 @@ import (
 const CertificateId_CA = "ca"
 
 const (
-	SecretTypeSSHPublicKey = "SSHPublicKey"
-	SecretTypeKeypair      = "Keypair"
-	SecretTypeSecret       = "Secret"
+	SecretTypeKeypair = "Keypair"
+	SecretTypeSecret  = "Secret"
 
 	// Name for the primary SSH key
 	SecretNameSSHPrimary = "admin"
@@ -77,20 +77,30 @@ type CAStore interface {
 	FindCert(name string) (*pki.Certificate, error)
 	FindPrivateKey(name string) (*pki.PrivateKey, error)
 
-	// List will list all the items, but will not fetch the data
-	List() ([]*KeystoreItem, error)
+	// ListKeysets will return all the KeySets
+	// The key material is not guaranteed to be populated - metadata like the name will be.
+	ListKeysets() ([]*KeystoreItem, error)
 
 	// AddCert adds an alternative certificate to the pool (primarily useful for CAs)
 	AddCert(name string, cert *pki.Certificate) error
+
+	// DeleteKeyset will delete the specified Keyset
+	DeleteKeyset(item *KeystoreItem) error
+}
+
+// SSHCredentialStore holds SSHCredential objects
+type SSHCredentialStore interface {
+	// DeleteSSHCredential deletes the specified SSH credential
+	DeleteSSHCredential(item *kops.SSHCredential) error
+
+	// ListSSHCredentials will list all the SSH credentials
+	ListSSHCredentials() ([]*kops.SSHCredential, error)
 
 	// AddSSHPublicKey adds an SSH public key
 	AddSSHPublicKey(name string, data []byte) error
 
 	// FindSSHPublicKeys retrieves the SSH public keys with the specific name
-	FindSSHPublicKeys(name string) ([]*KeystoreItem, error)
-
-	// DeleteSecret will delete the specified item
-	DeleteSecret(item *KeystoreItem) error
+	FindSSHPublicKeys(name string) ([]*kops.SSHCredential, error)
 }
 
 type CertificatePool struct {

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -197,6 +197,11 @@ func (c *ApplyClusterCmd) Run() error {
 		return err
 	}
 
+	sshCredentialStore, err := c.Clientset.SSHCredentialStore(cluster)
+	if err != nil {
+		return err
+	}
+
 	secretStore, err := c.Clientset.SecretStore(cluster)
 	if err != nil {
 		return err
@@ -309,13 +314,13 @@ func (c *ApplyClusterCmd) Run() error {
 
 	var sshPublicKeys [][]byte
 	{
-		keys, err := keyStore.FindSSHPublicKeys(fi.SecretNameSSHPrimary)
+		keys, err := sshCredentialStore.FindSSHPublicKeys(fi.SecretNameSSHPrimary)
 		if err != nil {
 			return fmt.Errorf("error retrieving SSH public key %q: %v", fi.SecretNameSSHPrimary, err)
 		}
 
 		for _, k := range keys {
-			sshPublicKeys = append(sshPublicKeys, k.Data)
+			sshPublicKeys = append(sshPublicKeys, []byte(k.Spec.PublicKey))
 		}
 	}
 


### PR DESCRIPTION
We've done this in the API already, but we had a single CAStore
interface that did Keysets and SSHCredentials.  Separate out
SSHCredentials into SSHCredentialStore, and start using API objects as
our primary representation.