### PR TITLE
Refactor: clean up SecretStore to not use KeystoreItem

### DIFF
--- a/cmd/kops/delete_secret.go
+++ b/cmd/kops/delete_secret.go
@@ -139,7 +139,7 @@ func RunDeleteSecret(f *util.Factory, out io.Writer, options *DeleteSecretOption
 
 	switch secrets[0].Type {
 	case kops.SecretTypeSecret:
-		err = secretStore.DeleteSecret(secrets[0])
+		err = secretStore.DeleteSecret(secrets[0].Name)
 	case SecretTypeSSHPublicKey:
 		sshCredential := &kops.SSHCredential{}
 		sshCredential.Name = secrets[0].Name

--- a/cmd/kops/get_secrets.go
+++ b/cmd/kops/get_secrets.go
@@ -113,14 +113,14 @@ func listSecrets(keyStore fi.CAStore, secretStore fi.SecretStore, sshCredentialS
 	}
 
 	if findType == "" || findType == strings.ToLower(string(kops.SecretTypeSecret)) {
-		l, err := secretStore.ListSecrets()
+		names, err := secretStore.ListSecrets()
 		if err != nil {
 			return nil, fmt.Errorf("error listing secrets %v", err)
 		}
 
-		for _, id := range l {
+		for _, name := range names {
 			i := &fi.KeystoreItem{
-				Name: id,
+				Name: name,
 				Type: kops.SecretTypeSecret,
 			}
 			if findType != "" && findType != strings.ToLower(string(i.Type)) {

--- a/upup/pkg/fi/secrets.go
+++ b/upup/pkg/fi/secrets.go
@@ -29,7 +29,7 @@ type SecretStore interface {
 	// Secret returns a secret.  Returns an error if not found
 	Secret(id string) (*Secret, error)
 	// DeleteSecret deletes the specified secret
-	DeleteSecret(item *KeystoreItem) error
+	DeleteSecret(id string) error
 	// FindSecret finds a secret, if exists.  Returns nil,nil if not found
 	FindSecret(id string) (*Secret, error)
 	// GetOrCreateSecret creates a secret

--- a/upup/pkg/fi/secrets/clientset_secretstore.go
+++ b/upup/pkg/fi/secrets/clientset_secretstore.go
@@ -140,9 +140,27 @@ func (c *ClientsetSecretStore) Secret(name string) (*fi.Secret, error) {
 }
 
 // DeleteSecret implements fi.SecretStore::DeleteSecret
-func (c *ClientsetSecretStore) DeleteSecret(item *fi.KeystoreItem) error {
+func (c *ClientsetSecretStore) DeleteSecret(name string) error {
 	client := c.clientset.Keysets(c.namespace)
-	return fi.DeleteKeysetItem(client, item.Name, kops.SecretTypeKeypair, item.Id)
+
+	keyset, err := client.Get(name, v1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		} else {
+			return fmt.Errorf("error reading Keyset %q: %v", name, err)
+		}
+	}
+
+	if keyset.Spec.Type != kops.SecretTypeSecret {
+		return fmt.Errorf("mismatch on Keyset type on %q", name)
+	}
+
+	if err := client.Delete(name, &v1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("error deleting Keyset %q: %v", name, err)
+	}
+
+	return nil
 }
 
 // GetOrCreateSecret implements fi.SecretStore::GetOrCreateSecret

--- a/upup/pkg/fi/secrets/vfs_secretstore.go
+++ b/upup/pkg/fi/secrets/vfs_secretstore.go
@@ -74,15 +74,9 @@ func (c *VFSSecretStore) FindSecret(id string) (*fi.Secret, error) {
 }
 
 // DeleteSecret implements fi.SecretStore DeleteSecret
-func (c *VFSSecretStore) DeleteSecret(item *fi.KeystoreItem) error {
-	switch item.Type {
-	case kops.SecretTypeSecret:
-		p := c.buildSecretPath(item.Name)
-		return p.Remove()
-
-	default:
-		return fmt.Errorf("deletion of secretstore items of type %v not (yet) supported", item.Type)
-	}
+func (c *VFSSecretStore) DeleteSecret(name string) error {
+	p := c.buildSecretPath(name)
+	return p.Remove()
 }
 
 func (c *VFSSecretStore) ListSecrets() ([]string, error) {


### PR DESCRIPTION
More moving to use API objects, except in this case we eventually want to
deprecate SecretStore entirely.

Builds on #3833