### PR TITLE
Refactor VFS CA store to reuse keyset from clientset

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -120,14 +120,24 @@ func (c *NodeupModelContext) buildPKIKubeconfig(id string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error fetching CA certificate from keystore: %v", err)
 	}
+	if caCertificate == nil {
+		return "", fmt.Errorf("CA certificate %q not found", fi.CertificateId_CA)
+	}
 
-	certificate, err := c.KeyStore.Cert(id, false)
+	certificate, err := c.KeyStore.FindCert(id)
 	if err != nil {
 		return "", fmt.Errorf("error fetching %q certificate from keystore: %v", id, err)
 	}
-	privateKey, err := c.KeyStore.PrivateKey(id, false)
+	if certificate == nil {
+		return "", fmt.Errorf("certificate %q not found", id)
+	}
+
+	privateKey, err := c.KeyStore.FindPrivateKey(id)
 	if err != nil {
 		return "", fmt.Errorf("error fetching %q private key from keystore: %v", id, err)
+	}
+	if privateKey == nil {
+		return "", fmt.Errorf("private key %q not found", id)
 	}
 
 	user := kubeconfig.KubectlUser{}

--- a/nodeup/pkg/model/convenience.go
+++ b/nodeup/pkg/model/convenience.go
@@ -96,9 +96,13 @@ func getProxyEnvVars(proxies *kops.EgressProxySpec) []v1.EnvVar {
 
 // buildCertificateRequest retrieves the certificate from a keystore
 func buildCertificateRequest(c *fi.ModelBuilderContext, b *NodeupModelContext, name, path string) error {
-	cert, err := b.KeyStore.Cert(name, false)
+	cert, err := b.KeyStore.FindCert(name)
 	if err != nil {
 		return err
+	}
+
+	if cert == nil {
+		return fmt.Errorf("certificate %q not found", name)
 	}
 
 	serialized, err := cert.AsString()
@@ -123,9 +127,13 @@ func buildCertificateRequest(c *fi.ModelBuilderContext, b *NodeupModelContext, n
 
 // buildPrivateKeyRequest retrieves a private key from the store
 func buildPrivateKeyRequest(c *fi.ModelBuilderContext, b *NodeupModelContext, name, path string) error {
-	k, err := b.KeyStore.PrivateKey(name, false)
+	k, err := b.KeyStore.FindPrivateKey(name)
 	if err != nil {
 		return err
+	}
+
+	if k == nil {
+		return fmt.Errorf("private key %q not found", name)
 	}
 
 	serialized, err := k.AsString()

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -49,9 +49,13 @@ func (b *KubeControllerManagerBuilder) Build(c *fi.ModelBuilderContext) error {
 	// If we're using the CertificateSigner, include the CA Key
 	// @TODO: use a per-machine key?  use KMS?
 	if b.useCertificateSigner() {
-		ca, err := b.KeyStore.PrivateKey(fi.CertificateId_CA, false)
+		ca, err := b.KeyStore.FindPrivateKey(fi.CertificateId_CA)
 		if err != nil {
 			return err
+		}
+
+		if ca == nil {
+			return fmt.Errorf("CA private key %q not found", fi.CertificateId_CA)
 		}
 
 		serialized, err := ca.AsString()

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -70,7 +70,7 @@ func (t *ProtokubeBuilder) Build(c *fi.ModelBuilderContext) error {
 		// retrieve the etcd peer certificates and private keys from the keystore
 		if t.UseEtcdTLS() {
 			for _, x := range []string{"etcd", "etcd-client"} {
-				if err := t.buildCeritificateTask(c, x, fmt.Sprintf("%s.pem", x)); err != nil {
+				if err := t.buildCertificateTask(c, x, fmt.Sprintf("%s.pem", x)); err != nil {
 					return err
 				}
 			}
@@ -376,10 +376,14 @@ func (t *ProtokubeBuilder) writeProxyEnvVars(buffer *bytes.Buffer) {
 }
 
 // buildCertificateTask is responsible for build a certificate request task
-func (t *ProtokubeBuilder) buildCeritificateTask(c *fi.ModelBuilderContext, name, filename string) error {
-	cert, err := t.KeyStore.Cert(name, false)
+func (t *ProtokubeBuilder) buildCertificateTask(c *fi.ModelBuilderContext, name, filename string) error {
+	cert, err := t.KeyStore.FindCert(name)
 	if err != nil {
 		return err
+	}
+
+	if cert == nil {
+		return fmt.Errorf("certificate %q not found", name)
 	}
 
 	serialized, err := cert.AsString()
@@ -399,9 +403,13 @@ func (t *ProtokubeBuilder) buildCeritificateTask(c *fi.ModelBuilderContext, name
 
 // buildPrivateKeyTask is responsible for build a certificate request task
 func (t *ProtokubeBuilder) buildPrivateTask(c *fi.ModelBuilderContext, name, filename string) error {
-	cert, err := t.KeyStore.PrivateKey(name, false)
+	cert, err := t.KeyStore.FindPrivateKey(name)
 	if err != nil {
 		return err
+	}
+
+	if cert == nil {
+		return fmt.Errorf("private key %q not found", name)
 	}
 
 	serialized, err := cert.AsString()

--- a/upup/pkg/fi/ca.go
+++ b/upup/pkg/fi/ca.go
@@ -63,16 +63,18 @@ type HasVFSPath interface {
 type CAStore interface {
 	Keystore
 
-	// Cert returns the primary specified certificate
-	// For createIfMissing=false, using FindCert is preferred
-	Cert(name string, createIfMissing bool) (*pki.Certificate, error)
 	// CertificatePool returns all active certificates with the specified id
+	// Deprecated: prefer FindCertificatePool
 	CertificatePool(name string, createIfMissing bool) (*CertificatePool, error)
-	PrivateKey(name string, createIfMissing bool) (*pki.PrivateKey, error)
+
+	// FindCertificatePool returns the named CertificatePool, or (nil,nil) if not found
+	FindCertificatePool(name string) (*CertificatePool, error)
+
+	// FindPrivateKey returns the named private key, or (nil,nil) if not found
+	FindPrivateKey(name string) (*pki.PrivateKey, error)
 
 	// FindCert returns the specified certificate, if it exists, or nil if not found
 	FindCert(name string) (*pki.Certificate, error)
-	FindPrivateKey(name string) (*pki.PrivateKey, error)
 
 	// ListKeysets will return all the KeySets
 	// The key material is not guaranteed to be populated - metadata like the name will be.

--- a/upup/pkg/fi/clientset_castore.go
+++ b/upup/pkg/fi/clientset_castore.go
@@ -194,20 +194,6 @@ func FindPrimary(keyset *kops.Keyset) *kops.KeysetItem {
 	return primary
 }
 
-// Cert implements CAStore::Cert
-func (c *ClientsetCAStore) Cert(name string, createIfMissing bool) (*pki.Certificate, error) {
-	cert, err := c.FindCert(name)
-	if err == nil && cert == nil {
-		if !createIfMissing {
-			glog.Warningf("using empty certificate, because running with DryRun")
-			return &pki.Certificate{}, err
-		}
-		return nil, fmt.Errorf("cannot find certificate %q", name)
-	}
-	return cert, err
-
-}
-
 // CertificatePool implements CAStore::CertificatePool
 func (c *ClientsetCAStore) CertificatePool(id string, createIfMissing bool) (*CertificatePool, error) {
 	cert, err := c.FindCertificatePool(id)
@@ -411,19 +397,6 @@ func (c *ClientsetCAStore) FindPrivateKey(name string) (*pki.PrivateKey, error) 
 		return keyset.primary.privateKey, nil
 	}
 	return nil, nil
-}
-
-// PrivateKey implements CAStore::PrivateKey
-func (c *ClientsetCAStore) PrivateKey(name string, createIfMissing bool) (*pki.PrivateKey, error) {
-	key, err := c.FindPrivateKey(name)
-	if err == nil && key == nil {
-		if !createIfMissing {
-			glog.Warningf("using empty certificate, because running with DryRun")
-			return &pki.PrivateKey{}, err
-		}
-		return nil, fmt.Errorf("cannot find SSL key %q", name)
-	}
-	return key, err
 }
 
 // CreateKeypair implements CAStore::CreateKeypair

--- a/upup/pkg/fi/vfs_castore.go
+++ b/upup/pkg/fi/vfs_castore.go
@@ -279,19 +279,6 @@ func (c *VFSCAStore) loadOneCertificate(p vfs.Path) (*pki.Certificate, error) {
 	return cert, nil
 }
 
-func (c *VFSCAStore) Cert(id string, createIfMissing bool) (*pki.Certificate, error) {
-	cert, err := c.FindCert(id)
-	if err == nil && cert == nil {
-		if !createIfMissing {
-			glog.Warningf("using empty certificate, because running with DryRun")
-			return &pki.Certificate{}, err
-		}
-		return nil, fmt.Errorf("cannot find certificate %q", id)
-	}
-	return cert, err
-
-}
-
 func (c *VFSCAStore) CertificatePool(id string, createIfMissing bool) (*CertificatePool, error) {
 	cert, err := c.FindCertificatePool(id)
 	if err == nil && cert == nil {
@@ -630,19 +617,6 @@ func (c *VFSCAStore) FindPrivateKey(id string) (*pki.PrivateKey, error) {
 		key = keys.keys[keys.primary]
 	}
 	return key, nil
-}
-
-func (c *VFSCAStore) PrivateKey(id string, createIfMissing bool) (*pki.PrivateKey, error) {
-	key, err := c.FindPrivateKey(id)
-	if err == nil && key == nil {
-		if !createIfMissing {
-			glog.Warningf("using empty certificate, because running with DryRun")
-			return &pki.PrivateKey{}, err
-		}
-		return nil, fmt.Errorf("cannot find SSL key %q", id)
-	}
-	return key, err
-
 }
 
 func (c *VFSCAStore) CreateKeypair(signer string, id string, template *x509.Certificate, privateKey *pki.PrivateKey) (*pki.Certificate, error) {


### PR DESCRIPTION
This ensures the two behave more similarly, but also will help us parse a
serialized keyset.

Builds on #3836