### PR TITLE
Use bundles when loading keysets

### DIFF
--- a/cmd/kops/BUILD.bazel
+++ b/cmd/kops/BUILD.bazel
@@ -129,6 +129,7 @@ go_binary(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "create_cluster_integration_test.go",
         "create_cluster_test.go",

--- a/upup/pkg/fi/BUILD.bazel
+++ b/upup/pkg/fi/BUILD.bazel
@@ -44,10 +44,12 @@ go_library(
         "//dnsprovider/pkg/dnsprovider:go_default_library",
         "//pkg/acls:go_default_library",
         "//pkg/apis/kops:go_default_library",
+        "//pkg/apis/kops/v1alpha2:go_default_library",
         "//pkg/assets:go_default_library",
         "//pkg/client/clientset_generated/clientset/typed/kops/internalversion:go_default_library",
         "//pkg/cloudinstances:go_default_library",
         "//pkg/diff:go_default_library",
+        "//pkg/kopscodecs:go_default_library",
         "//pkg/pki:go_default_library",
         "//pkg/sshcredentials:go_default_library",
         "//upup/pkg/fi/utils:go_default_library",
@@ -59,12 +61,14 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "dryruntarget_test.go",
         "vfs_castore_test.go",


### PR DESCRIPTION
This avoids the need to list directories, which is problematic on GCE.

It also makes for a more consistent experience; we can move nodeup to use
the bundle always, and we can move writing to the Mirror task, so that VFS
& kops-server are more similar.

Builds on #3837