### PR TITLE
Force nodeup to use the bundle

### DIFF
--- a/cmd/kops/util/factory.go
+++ b/cmd/kops/util/factory.go
@@ -108,7 +108,10 @@ func (f *Factory) Clientset() (simple.Clientset, error) {
 				return nil, field.Invalid(field.NewPath("State Store"), registryPath, INVALID_STATE_ERROR)
 			}
 
-			f.clientset = vfsclientset.NewVFSClientset(basePath)
+			// For kops CLI / controller, we do allow vfs list (unlike nodeup!)
+			allowVFSList := true
+
+			f.clientset = vfsclientset.NewVFSClientset(basePath, allowVFSList)
 		}
 	}
 

--- a/examples/kops-api-example/apply.go
+++ b/examples/kops-api-example/apply.go
@@ -22,7 +22,8 @@ import (
 )
 
 func apply() error {
-	clientset := vfsclientset.NewVFSClientset(registryBase)
+	allowList := true
+	clientset := vfsclientset.NewVFSClientset(registryBase, allowList)
 
 	cluster, err := clientset.GetCluster(clusterName)
 	if err != nil {

--- a/examples/kops-api-example/up.go
+++ b/examples/kops-api-example/up.go
@@ -28,7 +28,8 @@ import (
 )
 
 func up() error {
-	clientset := vfsclientset.NewVFSClientset(registryBase)
+	allowList := true
+	clientset := vfsclientset.NewVFSClientset(registryBase, allowList)
 
 	cluster := &api.Cluster{}
 	cluster.ObjectMeta.Name = clusterName

--- a/pkg/client/simple/vfsclientset/clientset.go
+++ b/pkg/client/simple/vfsclientset/clientset.go
@@ -31,7 +31,8 @@ import (
 )
 
 type VFSClientset struct {
-	basePath vfs.Path
+	basePath  vfs.Path
+	allowList bool
 }
 
 var _ simple.Clientset = &VFSClientset{}
@@ -107,7 +108,7 @@ func (c *VFSClientset) KeyStore(cluster *kops.Cluster) (fi.CAStore, error) {
 		return nil, err
 	}
 	basedir := configBase.Join("pki")
-	return fi.NewVFSCAStore(cluster, basedir), nil
+	return fi.NewVFSCAStore(cluster, basedir, c.allowList), nil
 }
 
 func (c *VFSClientset) SSHCredentialStore(cluster *kops.Cluster) (fi.SSHCredentialStore, error) {
@@ -168,9 +169,10 @@ func (c *VFSClientset) DeleteCluster(cluster *kops.Cluster) error {
 	return DeleteAllClusterState(configBase)
 }
 
-func NewVFSClientset(basePath vfs.Path) simple.Clientset {
+func NewVFSClientset(basePath vfs.Path, allowList bool) simple.Clientset {
 	vfsClientset := &VFSClientset{
-		basePath: basePath,
+		basePath:  basePath,
+		allowList: allowList,
 	}
 	return vfsClientset
 }

--- a/upup/pkg/fi/cloudup/populatecluster_test.go
+++ b/upup/pkg/fi/cloudup/populatecluster_test.go
@@ -109,7 +109,7 @@ func mockedPopulateClusterSpec(c *api.Cluster) (*api.Cluster, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error building vfspath: %v", err)
 	}
-	clientset := vfsclientset.NewVFSClientset(basePath)
+	clientset := vfsclientset.NewVFSClientset(basePath, true)
 	return PopulateClusterSpec(clientset, c, assetBuilder)
 }
 

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -203,7 +203,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 			return fmt.Errorf("error building key store path: %v", err)
 		}
 
-		modelContext.KeyStore = fi.NewVFSCAStore(c.cluster, p)
+		modelContext.KeyStore = fi.NewVFSCAStore(c.cluster, p, false)
 	} else {
 		return fmt.Errorf("KeyStore not set")
 	}


### PR DESCRIPTION
We disable fallback entirely for nodeup, so we can still share code, but
won't accidentally be using the wrong code path.

Builds on #3839