### PR TITLE
Fix resources for etcd-events

### DIFF
--- a/docs/development/instancesizes.md
+++ b/docs/development/instancesizes.md
@@ -4,7 +4,7 @@ Note these are only _requests_, not limits.
 
 ```
 50m  dns-controller
-150m etcd main
+200m etcd main
 100m etcd events
 150m kube-apiserver
 100m kube-controller-manager
@@ -13,7 +13,10 @@ Note these are only _requests_, not limits.
 
 ====
 
-750m total
-
-(leaving 250m for misc services e.g. CNI controller, log infrastructure etc)
+800m total
 ```
+
+* One a 1 core master, this leaves 200m for misc services e.g. CNI controller, log infrastructure etc.  That will be
+less if we start reserving capacity on the master.
+
+* kube-dns is relatively CPU hungry, and runs on the nodes.

--- a/protokube/pkg/protokube/etcd_cluster.go
+++ b/protokube/pkg/protokube/etcd_cluster.go
@@ -103,7 +103,7 @@ func newEtcdController(kubeBoot *KubeBoot, v *Volume, spec *etcd.EtcdClusterSpec
 		// @TODO we need to deprecate this port and use 2379, but that would be a breaking change
 		ClientPort:        4001,
 		ClusterName:       "etcd-" + spec.ClusterKey,
-		CPURequest:        resource.MustParse("200m"),
+		CPURequest:        resource.MustParse("100m"),
 		DataDirName:       "data-" + spec.ClusterKey,
 		ImageSource:       kubeBoot.EtcdImageSource,
 		TLSCA:             kubeBoot.TLSCA,


### PR DESCRIPTION
etcd-events only requests 100m, otherwise we run out of cpu on a 1
core master.