### PR TITLE
Fix CoreOS logrotate service failure.

### DIFF
--- a/nodeup/pkg/model/logrotate.go
+++ b/nodeup/pkg/model/logrotate.go
@@ -89,8 +89,7 @@ func (b *LogrotateBuilder) Build(c *fi.ModelBuilderContext) error {
 // addLogrotateService creates a logrotate systemd task to act as target for the timer, if one is needed
 func (b *LogrotateBuilder) addLogrotateService(c *fi.ModelBuilderContext) error {
 	switch b.Distribution {
-	case distros.DistributionCoreOS:
-	case distros.DistributionContainerOS:
+	case distros.DistributionCoreOS, distros.DistributionContainerOS:
 		// logrotate service already exists
 		return nil
 	}


### PR DESCRIPTION
The switch statement was incorrect, causing a bad logrotate unit file to be created for CoreOS.