### PR TITLE
Tweak kops create ig flag to edit, not editor

### DIFF
--- a/cmd/kops/create_ig.go
+++ b/cmd/kops/create_ig.go
@@ -43,15 +43,18 @@ type CreateInstanceGroupOptions struct {
 	DryRun bool
 	// Output type during a DryRun
 	Output string
-	// Launch editor when creating an instance group
-	Editor bool
+	// Edit will launch an editor when creating an instance group
+	Edit bool
 }
 
 var (
 	create_ig_long = templates.LongDesc(i18n.T(`
-		Create an instancegroup configuration.  kops has the concept of "instance groups",
-		which are a group of similar virtual machines. On AWS, they map to an
-		AutoScalingGroup. An ig work either as a Kubernetes master or a node.`))
+		Create an InstanceGroup configuration.
+
+	    An InstanceGroup is a group of similar virtual machines.
+		On AWS, an InstanceGroup maps to an AutoScalingGroup.
+
+		The Role of an InstanceGroup defines whether machines will act as a Kubernetes master or node.`))
 
 	create_ig_example = templates.Examples(i18n.T(`
 
@@ -70,8 +73,8 @@ var (
 // NewCmdCreateInstanceGroup create a new cobra command object for creating a instancegroup.
 func NewCmdCreateInstanceGroup(f *util.Factory, out io.Writer) *cobra.Command {
 	options := &CreateInstanceGroupOptions{
-		Role:   string(api.InstanceGroupRoleNode),
-		Editor: true,
+		Role: string(api.InstanceGroupRoleNode),
+		Edit: true,
 	}
 
 	cmd := &cobra.Command{
@@ -99,7 +102,7 @@ func NewCmdCreateInstanceGroup(f *util.Factory, out io.Writer) *cobra.Command {
 	// DryRun mode that will print YAML or JSON
 	cmd.Flags().BoolVar(&options.DryRun, "dry-run", options.DryRun, "If true, only print the object that would be sent, without sending it. This flag can be used to create a cluster YAML or JSON manifest.")
 	cmd.Flags().StringVarP(&options.Output, "output", "o", options.Output, "Ouput format. One of json|yaml")
-	cmd.Flags().BoolVar(&options.Editor, "editor", options.Editor, "Default true. If true, an editor will be opened to edit default values.")
+	cmd.Flags().BoolVar(&options.Edit, "edit", options.Edit, "If true, an editor will be opened to edit default values.")
 
 	return cmd
 }
@@ -186,7 +189,7 @@ func RunCreateInstanceGroup(f *util.Factory, cmd *cobra.Command, args []string, 
 		}
 	}
 
-	if options.Editor {
+	if options.Edit {
 		var (
 			edit = editor.NewDefaultEditor(editorEnvs)
 		)

--- a/docs/cli/kops_create_instancegroup.md
+++ b/docs/cli/kops_create_instancegroup.md
@@ -8,7 +8,11 @@ Create an instancegroup.
 ### Synopsis
 
 
-Create an instancegroup configuration.  kops has the concept of "instance groups", which are a group of similar virtual machines. On AWS, they map to an AutoScalingGroup. An ig work either as a Kubernetes master or a node.
+Create an InstanceGroup configuration. 
+
+An InstanceGroup is a group of similar virtual machines. On AWS, an InstanceGroup maps to an AutoScalingGroup. 
+
+The Role of an InstanceGroup defines whether machines will act as a Kubernetes master or node.
 
 ```
 kops create instancegroup
@@ -30,7 +34,7 @@ kops create instancegroup
 
 ```
       --dry-run              If true, only print the object that would be sent, without sending it. This flag can be used to create a cluster YAML or JSON manifest.
-      --editor               Default true. If true, an editor will be opened to edit default values. (default true)
+      --edit                 If true, an editor will be opened to edit default values. (default true)
   -o, --output string        Ouput format. One of json|yaml
       --role string          Type of instance group to create (Node,Master,Bastion) (default "Node")
       --subnet stringSlice   Subnets in which to create instance group


### PR DESCRIPTION
As EDITOR is the env var used to configure the editor, which will be confusing.
