### PR TITLE
Update Additional user-data per #3853

### DIFF
--- a/docs/instance_groups.md
+++ b/docs/instance_groups.md
@@ -219,12 +219,12 @@ spec:
 Kops utilizes cloud-init to initialize and setup a host at boot time. However in certain cases you may already be leaveraging certain features of cloud-init in your infrastructure and would like to continue doing so. More information on cloud-init can be found [here](http://cloudinit.readthedocs.io/en/latest/)
 
 
-Aditional user-user data can be passed to the host provisioning by setting the `ExtraUserData` field. A list of valid user-data content-types can be found [here](http://cloudinit.readthedocs.io/en/latest/topics/format.html#mime-multi-part-archive) 
+Aditional user-user data can be passed to the host provisioning by setting the `AdditionalUserData` field. A list of valid user-data content-types can be found [here](http://cloudinit.readthedocs.io/en/latest/topics/format.html#mime-multi-part-archive) 
 
 Example:
 ```
 spec:
-  extraUserData:
+  additionalUserData:
   - name: myscript.sh
     type: text/x-shellscript
     content: |


### PR DESCRIPTION
Looking at https://godoc.org/k8s.io/kops/pkg/apis/kops#InstanceGroupSpec and https://github.com/kubernetes/kops/pull/3633, the field is `AdditionalUserData` not `ExtraUserData`

This addresses https://github.com/kubernetes/kops/issues/3853