### PR TITLE
Fix spelling

### DIFF
--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -219,7 +219,7 @@ func RunCreate(f *util.Factory, out io.Writer, c *CreateOptions) error {
 				if err != nil {
 					return err
 				} else {
-					fmt.Fprintf(&sb, "Added ssh creadential\n")
+					fmt.Fprintf(&sb, "Added ssh credential\n")
 				}
 
 			default:


### PR DESCRIPTION
Fix spelling of credential in the `kops create` command.