### PR TITLE
Include encryptionConfig setting within userdata for masters.

### DIFF
--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -101,6 +101,7 @@ func (b *BootstrapScript) ResourceNodeUp(ig *kops.InstanceGroup, cs *kops.Cluste
 			spec["kubeProxy"] = cs.KubeProxy
 
 			if ig.IsMaster() {
+				spec["encryptionConfig"] = cs.EncryptionConfig
 				spec["kubeAPIServer"] = cs.KubeAPIServer
 				spec["kubeControllerManager"] = cs.KubeControllerManager
 				spec["kubeScheduler"] = cs.KubeScheduler

--- a/pkg/model/tests/data/bootstrapscript_0.txt
+++ b/pkg/model/tests/data/bootstrapscript_0.txt
@@ -158,6 +158,7 @@ cloudConfig:
   nodeTags: something
 docker:
   logLevel: INFO
+encryptionConfig: null
 kubeAPIServer:
   image: CoreOS
 kubeControllerManager:

--- a/pkg/model/tests/data/bootstrapscript_1.txt
+++ b/pkg/model/tests/data/bootstrapscript_1.txt
@@ -158,6 +158,7 @@ cloudConfig:
   nodeTags: something
 docker:
   logLevel: INFO
+encryptionConfig: null
 fileAssets:
 - content: E1oeAbrnQsSldrIP1BpoP2SDykM= (fingerprint)
   name: iptables-restore

--- a/pkg/model/tests/data/bootstrapscript_2.txt
+++ b/pkg/model/tests/data/bootstrapscript_2.txt
@@ -158,6 +158,7 @@ cloudConfig:
   nodeTags: something
 docker:
   logLevel: INFO
+encryptionConfig: null
 fileAssets:
 - content: E1oeAbrnQsSldrIP1BpoP2SDykM= (fingerprint)
   name: iptables-restore

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -156,6 +156,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
     logLevel: warn
     storage: overlay,aufs
     version: 1.11.2
+  encryptionConfig: null
   kubeAPIServer:
     address: 127.0.0.1
     admissionControl:

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -147,6 +147,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     logLevel: warn
     storage: overlay,aufs
     version: 1.11.2
+  encryptionConfig: null
   kubeAPIServer:
     address: 127.0.0.1
     admissionControl:


### PR DESCRIPTION
When updating the kops `ClusterSpec.EncryptionConfig` setting, a `kops update cluster / kops rolling-update cluster` mentions no changes required, and so a forced rolling-update is required for the setting to be picked up.

Including this in bootstrapscript will add the setting to the user-data for the master nodes only (because it applies to the KubeAPIServer), marking them as requiring a rolling-update.