### PR TITLE
Respect the shared tag when deleting route tables

### DIFF
--- a/pkg/resources/aws.go
+++ b/pkg/resources/aws.go
@@ -220,7 +220,7 @@ func addUntaggedRouteTables(cloud awsup.AWSCloud, clusterName string, resources 
 			continue
 		}
 
-		t := buildTrackerForRouteTable(rt)
+		t := buildTrackerForRouteTable(rt, clusterName)
 		if resources[t.Type+":"+t.ID] == nil {
 			resources[t.Type+":"+t.ID] = t
 		}
@@ -973,19 +973,20 @@ func ListRouteTables(cloud fi.Cloud, clusterName string) ([]*Resource, error) {
 	var resourceTrackers []*Resource
 
 	for _, rt := range routeTables {
-		resourceTracker := buildTrackerForRouteTable(rt)
+		resourceTracker := buildTrackerForRouteTable(rt, clusterName)
 		resourceTrackers = append(resourceTrackers, resourceTracker)
 	}
 
 	return resourceTrackers, nil
 }
 
-func buildTrackerForRouteTable(rt *ec2.RouteTable) *Resource {
+func buildTrackerForRouteTable(rt *ec2.RouteTable, clusterName string) *Resource {
 	resourceTracker := &Resource{
 		Name:    FindName(rt.Tags),
 		ID:      aws.StringValue(rt.RouteTableId),
 		Type:    ec2.ResourceTypeRouteTable,
 		Deleter: DeleteRouteTable,
+		Shared:  HasSharedTag(ec2.ResourceTypeRouteTable+":"+*rt.RouteTableId, rt.Tags, clusterName),
 	}
 
 	var blocks []string

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -133,8 +133,11 @@ func (c *MockAWSCloud) BuildTags(name *string) map[string]string {
 }
 
 func (c *MockAWSCloud) Tags() map[string]string {
-	glog.Fatalf("MockAWSCloud Tags not implemented")
-	return nil
+	tags := make(map[string]string)
+	for k, v := range c.tags {
+		tags[k] = v
+	}
+	return tags
 }
 
 func (c *MockAWSCloud) CreateTags(resourceId string, tags map[string]string) error {


### PR DESCRIPTION
Fixes #3828.

Modifies the `buildTrackerForRouteTable` function (used by `ListRouteTables`) to set the `Shared` field of each returned route table resource, based on the presence of the `kubernetes.io/cluster/<clustername>: shared` tag. This prevents route tables with this tag from being deleted.

WIP while I add some more tests.