### PR TITLE
Changing the prefix of the ResourceTag condition

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -661,7 +661,7 @@ func addMasterASPolicies(p *Policy, resource stringorslice.StringOrSlice, legacy
 				Resource: resource,
 				Condition: Condition{
 					"StringEquals": map[string]string{
-						"ec2:ResourceTag/KubernetesCluster": clusterName,
+						"autoscaling:ResourceTag/KubernetesCluster": clusterName,
 					},
 				},
 			},

--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -75,7 +75,7 @@
       ],
       "Condition": {
         "StringEquals": {
-          "ec2:ResourceTag/KubernetesCluster": "iam-builder-test.k8s.local"
+          "autoscaling:ResourceTag/KubernetesCluster": "iam-builder-test.k8s.local"
         }
       }
     },

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -75,7 +75,7 @@
       ],
       "Condition": {
         "StringEquals": {
-          "ec2:ResourceTag/KubernetesCluster": "iam-builder-test.k8s.local"
+          "autoscaling:ResourceTag/KubernetesCluster": "iam-builder-test.k8s.local"
         }
       }
     },


### PR DESCRIPTION
The prefix was `ec2` and it was not working, changing it to `autoscaling` should do the trick. This should fix #3871 