### PR TITLE
Version and validation updates for romana networking.

### DIFF
--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -469,9 +469,9 @@ func ValidateCluster(c *kops.Cluster, strict bool) *field.Error {
 		}
 	}
 
-	if kubernetesRelease.LT(semver.MustParse("1.6.0")) {
+	if kubernetesRelease.LT(semver.MustParse("1.7.0")) {
 		if c.Spec.Networking != nil && c.Spec.Networking.Romana != nil {
-			return field.Invalid(fieldSpec.Child("Networking"), "romana", "romana networking is not supported with kubernetes versions 1.5 or lower")
+			return field.Invalid(fieldSpec.Child("Networking"), "romana", "romana networking is not supported with kubernetes versions 1.6 or lower")
 		}
 	}
 

--- a/upup/models/cloudup/resources/addons/networking.romana/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.romana/k8s-1.7.yaml.template
@@ -137,7 +137,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: romana-daemon
-        image: quay.io/romana/daemon:v2.0-preview.2
+        image: quay.io/romana/daemon:v2.0.0
         imagePullPolicy: Always
         resources:
           requests:
@@ -170,7 +170,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: romana-listener
-        image: quay.io/romana/listener:v2.0-preview.2
+        image: quay.io/romana/listener:v2.0.0
         imagePullPolicy: Always
         resources:
           requests:
@@ -185,6 +185,8 @@ metadata:
   name: romana-agent
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -200,7 +202,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: romana-agent
-        image: quay.io/romana/agent:v2.0-preview.2
+        image: quay.io/romana/agent:v2.0.0
         imagePullPolicy: Always
         resources:
           requests:
@@ -213,6 +215,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         args:
         - --service-cluster-ip-range={{ .ServiceClusterIPRange }}
         securityContext:
@@ -299,7 +305,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: romana-aws
-        image: quay.io/romana/aws:v2.0-preview.2
+        image: quay.io/romana/aws:v2.0.0
         imagePullPolicy: Always
         resources:
           requests:
@@ -328,7 +334,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: romana-vpcrouter
-        image: quay.io/romana/vpcrouter-romana-plugin
+        image: quay.io/romana/vpcrouter-romana-plugin:1.1.12
         imagePullPolicy: Always
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -598,18 +598,18 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Romana != nil {
 		key := "networking.romana"
-		version := "v2.0-preview.3"
+		version := "v2.0.0"
 
 		{
-			location := key + "/k8s-1.6.yaml"
-			id := "k8s-1.6"
+			location := key + "/k8s-1.7.yaml"
+			id := "k8s-1.7"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
 				Version:           fi.String(version),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.6.0",
+				KubernetesVersion: ">=1.7.0",
 				Id:                id,
 			})
 			manifests[key+"-"+id] = "addons/" + location


### PR DESCRIPTION
This is a small update for Romana to update the version being installed, and make sure the version validation is correct - it now requires v1.7.x or higher.

It has been tested on AWS only, with a variety of versions:
- 1.6.0 - error attempting to create cluster, because version is unsupported
- 1.7.10 - no errors
- 1.8.3 - no errors

Hoping this can be squeezed into the upcoming 1.8 release.