### PR TITLE
[addons] Add PodDisruptionBudget for kube-dns pods

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -213,6 +213,21 @@ spec:
 
 ---
 
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+
+---
+
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Context
---
When scaling in a node pool, the cluster autoscaler can
potentially remove all nodes on which kube-dns pods at once.

It happened on our cluster (kops, atop AWS) this morning and resulted
in a 1-2 minutes downtime.

The fix
---
Since Kubernetes 1.6, the cluster autoscaler is supposed to support
PodDisruptionBudgets when scaling down. Therefore, adding such a PDB
for kube-dns might be relevant, and prevent kube-dns downtime during
scale-in or node rolling upgrades.