### PR TITLE
Support replacing kops secrets via force flag

### DIFF
--- a/docs/cli/kops_create_secret_dockerconfig.md
+++ b/docs/cli/kops_create_secret_dockerconfig.md
@@ -20,12 +20,16 @@ kops create secret dockerconfig
   # Create an new docker config.
   kops create secret dockerconfig -f /path/to/docker/config.json \
   --name k8s-cluster.example.com --state s3://example.com
+  # Replace an existing docker config secret.
+  kops create secret dockerconfig -f /path/to/docker/config.json --force \
+  --name k8s-cluster.example.com --state s3://example.com
 ```
 
 ### Options
 
 ```
   -f, -- string   Path to docker config JSON file
+      --force     Force replace the kops secret if it already exists
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/kops_create_secret_encryptionconfig.md
+++ b/docs/cli/kops_create_secret_encryptionconfig.md
@@ -20,12 +20,16 @@ kops create secret encryptionconfig
   # Create a new encryption config.
   kops create secret encryptionconfig -f config.yaml \
   --name k8s-cluster.example.com --state s3://example.com
+  # Replace an existing encryption config secret.
+  kops create secret encryptionconfig -f config.yaml --force \
+  --name k8s-cluster.example.com --state s3://example.com
 ```
 
 ### Options
 
 ```
   -f, -- string   Path to encryption config yaml file
+      --force     Force replace the kops secret if it already exists
 ```
 
 ### Options inherited from parent commands

--- a/upup/pkg/fi/secrets.go
+++ b/upup/pkg/fi/secrets.go
@@ -32,8 +32,10 @@ type SecretStore interface {
 	DeleteSecret(item *KeystoreItem) error
 	// FindSecret finds a secret, if exists.  Returns nil,nil if not found
 	FindSecret(id string) (*Secret, error)
-	// GetOrCreateSecret creates or replace a secret
+	// GetOrCreateSecret creates a secret
 	GetOrCreateSecret(id string, secret *Secret) (current *Secret, created bool, err error)
+	// ReplaceSecret will forcefully update an existing secret if it exists
+	ReplaceSecret(id string, secret *Secret) (current *Secret, err error)
 	// ListSecrets lists the ids of all known secrets
 	ListSecrets() ([]string, error)
 


### PR DESCRIPTION
- Return an error when attempting to create a secret if it already exists (previously it would silently return with a successful exit code, which is misleading).
- Allow passing a `--force` flag when creating `encryptionconfig` or `dockerconfig` secrets, so they can be replaced if they already exist.
- Fixes #3895 
