### PR TITLE
Set SleepDelay function in AWS

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -185,6 +185,14 @@ func NewAWSCloud(region string, tags map[string]string) (AWSCloud, error) {
 		config = config.WithCredentialsChainVerboseErrors(true)
 		config = request.WithRetryer(config, newLoggingRetryer(ClientMaxRetries))
 
+		// We have the updated aws sdk from 1.9, but don't have https://github.com/kubernetes/kubernetes/pull/55307
+		// Set the SleepDelay function to work around this
+		// TODO: Remove once we update to k8s >= 1.9 (or a version of the retry delayer than includes this)
+		config.SleepDelay = func(d time.Duration) {
+			glog.V(6).Infof("aws request sleeping for %v", d)
+			time.Sleep(d)
+		}
+
 		requestLogger := newRequestLogger(2)
 
 		sess, err := session.NewSession(config)


### PR DESCRIPTION
Works around nil SleepDelay problem: latest aws-sdk-go (in k8s 1.9 and
kops 1.8) has updated SleepDelay logic; fix is in
https://github.com/kubernetes/kubernetes/pull/55307 but that is only in
1.9.

Set the SleepDelay to work around the problem.