### PR TITLE
Added .service to hooks unit files

### DIFF
--- a/nodeup/pkg/model/hooks.go
+++ b/nodeup/pkg/model/hooks.go
@@ -53,12 +53,12 @@ func (h *HookBuilder) Build(c *fi.ModelBuilderContext) error {
 			var name string
 			switch hook.Name {
 			case "":
-				name = fmt.Sprintf("kops-hook-%d", j)
+				name = fmt.Sprintf("kops-hook-%d.service", j)
 				if isInstanceGroup {
-					name = fmt.Sprintf("%s-ig", name)
+					name = fmt.Sprintf("%s-ig.service", name)
 				}
 			default:
-				name = hook.Name
+				name = fmt.Sprintf("%s.service", hook.Name)
 			}
 
 			if _, found := hookNames[name]; found {


### PR DESCRIPTION
Recent versions of systemd (version 229 at least) included in Ubuntu
16.04 and Debian 9 require the systemd unit files to have a .service
extension.

Fixes #3919

Signed-off-by: Ali Rizwan <ari@hellofresh.com>