### PR TITLE
Map horizontal-pod-autoscaler-use-rest-clients flag

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -323,6 +323,9 @@ type KubeControllerManagerConfig struct {
 	// long the autoscaler has to wait before another upscale operation can
 	// be performed after the current one has completed.
 	HorizontalPodAutoscalerUpscaleDelay *metav1.Duration `json:"horizontalPodAutoscalerUpscaleDelay,omitempty" flag:"horizontal-pod-autoscaler-upscale-delay"`
+	// HorizontalPodAutoscalerUseRestClients determines if the new-style clients
+	// should be used if support for custom metrics is enabled.
+	HorizontalPodAutoscalerUseRestClients *bool `json:"horizontalPodAutoscalerUseRestClients,omitempty" flag:"horizontal-pod-autoscaler-use-rest-clients"`
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
 }

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -323,6 +323,9 @@ type KubeControllerManagerConfig struct {
 	// long the autoscaler has to wait before another upscale operation can
 	// be performed after the current one has completed.
 	HorizontalPodAutoscalerUpscaleDelay *metav1.Duration `json:"horizontalPodAutoscalerUpscaleDelay,omitempty" flag:"horizontal-pod-autoscaler-upscale-delay"`
+	// HorizontalPodAutoscalerUseRestClients determines if the new-style clients
+	// should be used if support for custom metrics is enabled.
+	HorizontalPodAutoscalerUseRestClients *bool `json:"horizontalPodAutoscalerUseRestClients,omitempty" flag:"horizontal-pod-autoscaler-use-rest-clients"`
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
 }

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1944,6 +1944,7 @@ func autoConvert_v1alpha1_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.HorizontalPodAutoscalerSyncPeriod = in.HorizontalPodAutoscalerSyncPeriod
 	out.HorizontalPodAutoscalerDownscaleDelay = in.HorizontalPodAutoscalerDownscaleDelay
 	out.HorizontalPodAutoscalerUpscaleDelay = in.HorizontalPodAutoscalerUpscaleDelay
+	out.HorizontalPodAutoscalerUseRestClients = in.HorizontalPodAutoscalerUseRestClients
 	out.FeatureGates = in.FeatureGates
 	return nil
 }
@@ -1979,6 +1980,7 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha1_KubeControllerMana
 	out.HorizontalPodAutoscalerSyncPeriod = in.HorizontalPodAutoscalerSyncPeriod
 	out.HorizontalPodAutoscalerDownscaleDelay = in.HorizontalPodAutoscalerDownscaleDelay
 	out.HorizontalPodAutoscalerUpscaleDelay = in.HorizontalPodAutoscalerUpscaleDelay
+	out.HorizontalPodAutoscalerUseRestClients = in.HorizontalPodAutoscalerUseRestClients
 	out.FeatureGates = in.FeatureGates
 	return nil
 }

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2173,6 +2173,15 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 			**out = **in
 		}
 	}
+	if in.HorizontalPodAutoscalerUseRestClients != nil {
+		in, out := &in.HorizontalPodAutoscalerUseRestClients, &out.HorizontalPodAutoscalerUseRestClients
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	if in.FeatureGates != nil {
 		in, out := &in.FeatureGates, &out.FeatureGates
 		*out = make(map[string]string, len(*in))

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -323,6 +323,9 @@ type KubeControllerManagerConfig struct {
 	// long the autoscaler has to wait before another upscale operation can
 	// be performed after the current one has completed.
 	HorizontalPodAutoscalerUpscaleDelay *metav1.Duration `json:"horizontalPodAutoscalerUpscaleDelay,omitempty" flag:"horizontal-pod-autoscaler-upscale-delay"`
+	// HorizontalPodAutoscalerUseRestClients determines if the new-style clients
+	// should be used if support for custom metrics is enabled.
+	HorizontalPodAutoscalerUseRestClients *bool `json:"horizontalPodAutoscalerUseRestClients,omitempty" flag:"horizontal-pod-autoscaler-use-rest-clients"`
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2206,6 +2206,7 @@ func autoConvert_v1alpha2_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.HorizontalPodAutoscalerSyncPeriod = in.HorizontalPodAutoscalerSyncPeriod
 	out.HorizontalPodAutoscalerDownscaleDelay = in.HorizontalPodAutoscalerDownscaleDelay
 	out.HorizontalPodAutoscalerUpscaleDelay = in.HorizontalPodAutoscalerUpscaleDelay
+	out.HorizontalPodAutoscalerUseRestClients = in.HorizontalPodAutoscalerUseRestClients
 	out.FeatureGates = in.FeatureGates
 	return nil
 }
@@ -2241,6 +2242,7 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha2_KubeControllerMana
 	out.HorizontalPodAutoscalerSyncPeriod = in.HorizontalPodAutoscalerSyncPeriod
 	out.HorizontalPodAutoscalerDownscaleDelay = in.HorizontalPodAutoscalerDownscaleDelay
 	out.HorizontalPodAutoscalerUpscaleDelay = in.HorizontalPodAutoscalerUpscaleDelay
+	out.HorizontalPodAutoscalerUseRestClients = in.HorizontalPodAutoscalerUseRestClients
 	out.FeatureGates = in.FeatureGates
 	return nil
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2299,6 +2299,15 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 			**out = **in
 		}
 	}
+	if in.HorizontalPodAutoscalerUseRestClients != nil {
+		in, out := &in.HorizontalPodAutoscalerUseRestClients, &out.HorizontalPodAutoscalerUseRestClients
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	if in.FeatureGates != nil {
 		in, out := &in.FeatureGates, &out.FeatureGates
 		*out = make(map[string]string, len(*in))

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2518,6 +2518,15 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 			**out = **in
 		}
 	}
+	if in.HorizontalPodAutoscalerUseRestClients != nil {
+		in, out := &in.HorizontalPodAutoscalerUseRestClients, &out.HorizontalPodAutoscalerUseRestClients
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	if in.FeatureGates != nil {
 		in, out := &in.FeatureGates, &out.FeatureGates
 		*out = make(map[string]string, len(*in))


### PR DESCRIPTION
Maps `--horizontal-pod-autoscaler-use-rest-clients` flag which is required for [Horizontal Pod Autoscaling][1]. See Kubernetes code in [kubernetes/kubernetes/blob/v1.7.11/cmd/kube-controller-manager/app/autoscaling.go#L36-L39][2].

Seems this is the missing piece for fulfilment of HPA pre-requisites, which are:

* ✅ Enable the [Aggregation Layer][4] via the following kube-apiserver flags
   * ✅ `--requestheader-client-ca-file=<path to aggregator CA cert>` (see https://github.com/kubernetes/kops/pull/3679)
   * ✅ `--requestheader-allowed-names=aggregator` (see https://github.com/kubernetes/kops/pull/3679)
   * ✅ `--requestheader-extra-headers-prefix=X-Remote-Extra-` (see https://github.com/kubernetes/kops/pull/3679)
   * ✅ `--requestheader-group-headers=X-Remote-Group` (see https://github.com/kubernetes/kops/pull/3679)
   * ✅ `--requestheader-username-headers=X-Remote-User` (see https://github.com/kubernetes/kops/pull/3679)
   * ✅ `--proxy-client-cert-file=<path to aggregator proxy cert>` (see https://github.com/kubernetes/kops/pull/3165)
   * ✅ `--proxy-client-key-file=<path to aggregator proxy key>` (see https://github.com/kubernetes/kops/pull/3165)
* ❓ [Horizontal Pod Scaling][3] ... set the appropriate flags for `kube-controller-manager`:
  * ❎  `--horizontal-pod-autoscaler-use-rest-clients` should be `true`.
  * ✅ `--kubeconfig <path-to-kubeconfig>` (already set)

**Relevant Documentation:**

* https://v1-7.docs.kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
* https://v1-7.docs.kubernetes.io/docs/tasks/access-kubernetes-api/configure-aggregation-layer/

**Relevant Issues & PRs:**

* https://github.com/kubernetes/kops/pull/3679
* https://github.com/kubernetes/kops/issues/3152
* https://github.com/kubernetes/kops/issues/2691
* https://github.com/kubernetes/kops/issues/2652
* https://github.com/kubernetes/kops/pull/3165

[1]: https://v1-7.docs.kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
[2]: https://github.com/kubernetes/kubernetes/blob/v1.7.11/cmd/kube-controller-manager/app/autoscaling.go#L36-L39
[3]: https://v1-7.docs.kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
[4]: https://v1-7.docs.kubernetes.io/docs/tasks/access-kubernetes-api/configure-aggregation-layer/