### PR TITLE
When using private DNS add ELB name to the api certificate

### DIFF
--- a/cloudmock/aws/mockelb/api.go
+++ b/cloudmock/aws/mockelb/api.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockelb
+
+import (
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elb/elbiface"
+)
+
+type MockELB struct {
+	elbiface.ELBAPI
+}
+
+func (*MockELB) DescribeLoadBalancersPages(input *elb.DescribeLoadBalancersInput, fn func(p *elb.DescribeLoadBalancersOutput, lastPage bool) (shouldContinue bool)) error {
+	return nil
+}

--- a/hack/.packages
+++ b/hack/.packages
@@ -5,6 +5,7 @@ k8s.io/kops/channels/pkg/channels
 k8s.io/kops/channels/pkg/cmd
 k8s.io/kops/cloudmock/aws/mockautoscaling
 k8s.io/kops/cloudmock/aws/mockec2
+k8s.io/kops/cloudmock/aws/mockelb
 k8s.io/kops/cloudmock/aws/mockroute53
 k8s.io/kops/cmd/kops
 k8s.io/kops/cmd/kops/util

--- a/pkg/kubeconfig/create_kubecfg.go
+++ b/pkg/kubeconfig/create_kubecfg.go
@@ -35,7 +35,9 @@ func BuildKubecfg(cluster *kops.Cluster, keyStore fi.Keystore, secretStore fi.Se
 	}
 
 	server := "https://" + master
-	if dns.IsGossipHostname(master) {
+	topology := cluster.Spec.Topology
+
+	if dns.IsGossipHostname(master) || topology.DNS.Type == kops.DNSTypePrivate {
 		ingresses, err := status.GetApiIngressStatus(cluster)
 		if err != nil {
 			return nil, fmt.Errorf("error getting ingress status: %v", err)

--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -199,7 +199,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 		c.AddTask(t)
 	}
 
-	if dns.IsGossipHostname(b.Cluster.Name) {
+	if dns.IsGossipHostname(b.Cluster.Name) || b.UsePrivateDNS() {
 		// Ensure the ELB hostname is included in the TLS certificate,
 		// if we're not going to use an alias for it
 		// TODO: I don't love this technique for finding the task by name & modifying it

--- a/pkg/testutils/integrationtestharness.go
+++ b/pkg/testutils/integrationtestharness.go
@@ -29,6 +29,7 @@ import (
 	"github.com/golang/glog"
 	kopsroot "k8s.io/kops"
 	"k8s.io/kops/cloudmock/aws/mockec2"
+	"k8s.io/kops/cloudmock/aws/mockelb"
 	"k8s.io/kops/cloudmock/aws/mockroute53"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
@@ -98,6 +99,8 @@ func (h *IntegrationTestHarness) SetupMockAWS() {
 	cloud.MockEC2 = mockEC2
 	mockRoute53 := &mockroute53.MockRoute53{}
 	cloud.MockRoute53 = mockRoute53
+	mockELB := &mockelb.MockELB{}
+	cloud.MockELB = mockELB
 
 	mockRoute53.MockCreateZone(&route53.HostedZone{
 		Id:   aws.String("/hostedzone/Z1AFAKE1ZON3YO"),

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elb/elbiface"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
@@ -86,7 +87,7 @@ type AWSCloud interface {
 	CloudFormation() *cloudformation.CloudFormation
 	EC2() ec2iface.EC2API
 	IAM() *iam.IAM
-	ELB() *elb.ELB
+	ELB() elbiface.ELBAPI
 	Autoscaling() autoscalingiface.AutoScalingAPI
 	Route53() route53iface.Route53API
 
@@ -1021,7 +1022,7 @@ func (c *awsCloudImplementation) IAM() *iam.IAM {
 	return c.iam
 }
 
-func (c *awsCloudImplementation) ELB() *elb.ELB {
+func (c *awsCloudImplementation) ELB() elbiface.ELBAPI {
 	return c.elb
 }
 

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elb/elbiface"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/golang/glog"
@@ -74,6 +74,7 @@ type MockCloud struct {
 	MockCloudFormation *cloudformation.CloudFormation
 	MockEC2            ec2iface.EC2API
 	MockRoute53        route53iface.Route53API
+	MockELB            elbiface.ELBAPI
 }
 
 func (c *MockAWSCloud) DeleteGroup(g *cloudinstances.CloudInstanceGroup) error {
@@ -194,9 +195,11 @@ func (c *MockAWSCloud) IAM() *iam.IAM {
 	return nil
 }
 
-func (c *MockAWSCloud) ELB() *elb.ELB {
-	glog.Fatalf("MockAWSCloud ELB not implemented")
-	return nil
+func (c *MockAWSCloud) ELB() elbiface.ELBAPI {
+	if c.MockELB == nil {
+		glog.Fatalf("MockAWSCloud MockELB not set")
+	}
+	return c.MockELB
 }
 
 func (c *MockAWSCloud) Autoscaling() autoscalingiface.AutoScalingAPI {


### PR DESCRIPTION
This fixes issue #2032 by using the gossip paths with private dns as well:

* When creating the api server certificate, include the ELB hostname
* When generating kubeconfig, use the ELB hostname as the api server name