### PR TITLE
Fix flannel version

### DIFF
--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -439,7 +439,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Flannel != nil {
 		key := "networking.flannel"
-		version := "0.9.0-kops.1"
+		version := "0.9.1"
 
 		{
 			location := key + "/pre-k8s-1.6.yaml"


### PR DESCRIPTION
Breaking out from https://github.com/kubernetes/kops/pull/3952 since this is needed for Kops 1.8