### PR TITLE
Fix flannel error on starting

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.6.yaml.template
@@ -130,7 +130,8 @@ spec:
           limits:
             memory: 100Mi
           requests:
-            cpu: 100Mi
+            cpu: 100m
+            memory: 100Mi
         volumeMounts:
         - name: run
           mountPath: /run

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -439,7 +439,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Flannel != nil {
 		key := "networking.flannel"
-		version := "0.9.1"
+		version := "0.9.1-kops.1"
 
 		{
 			location := key + "/pre-k8s-1.6.yaml"


### PR DESCRIPTION
Fixes an issue where flannel does not startup due to limited resources:
```
kube-system   21m        21m         4         kube-flannel-ds                                       DaemonSet                                               Warning   FailedPlacement           daemonset-controller                      failed to place pod on "ip-10-25-40-53.ec2.internal": Node didn't have enough resource: cpu, requested: 104857600000, used: 0, capacity: 2000
```