### PR TITLE
Add kubernetes-dashboard addon version constraint

### DIFF
--- a/addons/kubernetes-dashboard/addon.yaml
+++ b/addons/kubernetes-dashboard/addon.yaml
@@ -32,6 +32,7 @@ spec:
       k8s-addon: kubernetes-dashboard.addons.k8s.io
     manifest: v1.7.1.yaml
   - version: 1.8.0
+    kubernetesVersion: ">=1.8.0" 
     selector:
       k8s-addon: kubernetes-dashboard.addons.k8s.io
     manifest: v1.8.0.yaml


### PR DESCRIPTION
This PR is to fix kubernetes-dashboard addon for kubernetes 1.7 clusters.

Before Patch, running `channels apply channel kubernetes-dashboard` for a k8s 1.7 cluster results in:

```bash
error validating data: unknown object type schema.GroupVersionKind{Group:"rbac.authorization.k8s.io", Version:"v1", Kind:"Role"}
``` 

After patch:
```
NAME                    CURRENT UPDATE
kubernetes-dashboard    -       1.7.1
I1129 06:41:10.314821   20137 addon.go:129] Applying update from "/home/training/kops/addons/kubernetes-dashboard/v1.7.1.yaml"
Updated "kubernetes-dashboard" to 1.7.1
```