### PR TITLE
Ensure iptables forwarding is enabled

### DIFF
--- a/nodeup/pkg/model/firewall.go
+++ b/nodeup/pkg/model/firewall.go
@@ -17,12 +17,10 @@ limitations under the License.
 package model
 
 import (
-	"k8s.io/kops/nodeup/pkg/distros"
+	"github.com/golang/glog"
 	"k8s.io/kops/pkg/systemd"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
-
-	"github.com/golang/glog"
 )
 
 // FirewallBuilder configures the firewall (iptables)
@@ -34,10 +32,9 @@ var _ fi.ModelBuilder = &FirewallBuilder{}
 
 // Build is responsible for generating any node firewall rules
 func (b *FirewallBuilder) Build(c *fi.ModelBuilderContext) error {
-	if b.Distribution == distros.DistributionContainerOS {
-		c.AddTask(b.buildFirewallScript())
-		c.AddTask(b.buildSystemdService())
-	}
+	// We need forwarding enabled (https://github.com/kubernetes/kubernetes/issues/40182)
+	c.AddTask(b.buildFirewallScript())
+	c.AddTask(b.buildSystemdService())
 
 	return nil
 }

--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -115,13 +115,10 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"")
 	}
 
-	if b.Cluster.Spec.CloudProvider == string(kops.CloudProviderGCE) {
-		sysctls = append(sysctls,
-			"# GCE settings",
-			"",
-			"net.ipv4.ip_forward=1",
-			"")
-	}
+	sysctls = append(sysctls,
+		"# Prevent docker from changing iptables: https://github.com/kubernetes/kubernetes/issues/40182",
+		"net.ipv4.ip_forward=1",
+		"")
 
 	t := &nodetasks.File{
 		Path:            "/etc/sysctl.d/99-k8s-general.conf",


### PR DESCRIPTION
Docker 1.13 changed how it set up iptables in a way that broke
forwarding.

We previously got away with it because we set the ip_forward sysctl,
which meant that docker wouldn't change the rule.  But if we're using an
image that preinstalled docker, docker might have already reconfigured
iptables before we run, and we didn't set it back.

We now set it back.

https://github.com/kubernetes/kubernetes/issues/40182