### PR TITLE
Add support for M5 and H1 instance families

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/machine_types.go
+++ b/upup/pkg/fi/cloudup/awsup/machine_types.go
@@ -206,6 +206,50 @@ var MachineTypes []AWSMachineTypeInfo = []AWSMachineTypeInfo{
 		EphemeralDisks: nil,
 	},
 
+	// m5 family
+	{
+		Name:           "m5.large",
+		MemoryGB:       8,
+		ECU:            10,
+		Cores:          2,
+		EphemeralDisks: nil,
+	},
+	{
+		Name:           "m5.xlarge",
+		MemoryGB:       16,
+		ECU:            15,
+		Cores:          4,
+		EphemeralDisks: nil,
+	},
+	{
+		Name:           "m5.2xlarge",
+		MemoryGB:       32,
+		ECU:            31,
+		Cores:          8,
+		EphemeralDisks: nil,
+	},
+	{
+		Name:           "m5.4xlarge",
+		MemoryGB:       64,
+		ECU:            61,
+		Cores:          16,
+		EphemeralDisks: nil,
+	},
+	{
+		Name:           "m5.12xlarge",
+		MemoryGB:       192,
+		ECU:            173,
+		Cores:          48,
+		EphemeralDisks: nil,
+	},
+	{
+		Name:           "m5.24xlarge",
+		MemoryGB:       384,
+		ECU:            345,
+		Cores:          96,
+		EphemeralDisks: nil,
+	},
+
 	// c3 family
 	{
 		Name:           "c3.large",
@@ -387,6 +431,39 @@ var MachineTypes []AWSMachineTypeInfo = []AWSMachineTypeInfo{
 			2000, 2000, 2000, 2000, 2000, 2000,
 			2000, 2000, 2000, 2000, 2000, 2000,
 			2000, 2000, 2000, 2000, 2000, 2000,
+		},
+	},
+
+	// h1 family
+	{
+		Name:           "h1.2xlarge",
+		MemoryGB:       32,
+		ECU:            26,
+		Cores:          8,
+		EphemeralDisks: []int{2000},
+	},
+	{
+		Name:           "h1.4xlarge",
+		MemoryGB:       64,
+		ECU:            53.5,
+		Cores:          16,
+		EphemeralDisks: []int{2000, 2000},
+	},
+	{
+		Name:           "h1.8xlarge",
+		MemoryGB:       128,
+		ECU:            99,
+		Cores:          32,
+		EphemeralDisks: []int{2000, 2000, 2000, 2000},
+	},
+	{
+		Name:     "h1.16xlarge",
+		MemoryGB: 256,
+		ECU:      188,
+		Cores:    64,
+		EphemeralDisks: []int{
+			2000, 2000, 2000, 2000,
+			2000, 2000, 2000, 2000,
 		},
 	},
 


### PR DESCRIPTION
This PR adds support for the new [M5 General Purpose](https://aws.amazon.com/blogs/aws/m5-the-next-generation-of-general-purpose-ec2-instances/) and [H1 Storage-optimized](https://aws.amazon.com/blogs/aws/new-h1-instances-fast-dense-storage-for-big-data-applications/) instance types that were announced at re:Invent 2017. The blog posts note that these instance types are available immediately.

`hack/verify-gofmt.sh` exits cleanly (go1.9.2 darwin), and I've _just_ signed the CLA. Let me know if I've missed any prereqs!
