### PR TITLE
Bump image in alpha channel: ENA in jessie

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -4,22 +4,26 @@ spec:
     - name: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
       providerID: aws
       kubernetesVersion: ">=1.4.0 <1.5.0"
-    - name: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-07-28
+    - name: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
       providerID: aws
       kubernetesVersion: ">=1.5.0 <1.6.0"
-    - name: kope.io/k8s-1.6-debian-jessie-amd64-hvm-ebs-2017-12-01
+    - name: kope.io/k8s-1.6-debian-jessie-amd64-hvm-ebs-2017-12-02
       providerID: aws
       kubernetesVersion: ">=1.6.0 <1.7.0"
-    - name: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2017-12-01
+    - name: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2017-12-02
       providerID: aws
       kubernetesVersion: ">=1.7.0 <1.8.0"
-    - name: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2017-12-01
+    - name: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2017-12-02
       providerID: aws
       kubernetesVersion: ">=1.8.0 <1.9.0"
     # Moving to stretch in 1.9 (if goes well)
-    - name: kope.io/k8s-1.8-debian-stretch-amd64-hvm-ebs-2017-12-01
+    - name: kope.io/k8s-1.8-debian-stretch-amd64-hvm-ebs-2017-12-02
       providerID: aws
-      kubernetesVersion: ">=1.9.0"
+      kubernetesVersion: ">=1.9.0 <1.10.0"
+    # Need stretch as default in 1.10 (for nvme)
+    - name: kope.io/k8s-1.8-debian-stretch-amd64-hvm-ebs-2017-12-02
+      providerID: aws
+      kubernetesVersion: ">=1.10.0"
     - providerID: gce
       name: "cos-cloud/cos-stable-60-9592-90-0"
   cluster:


### PR DESCRIPTION
NVME detection only works on stretch though