### PR TITLE
Etcd TLS Peer & CLient Auth

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -222,6 +222,17 @@ func (c *NodeupModelContext) UseEtcdTLS() bool {
 	return false
 }
 
+// UseTLSAuth checks the peer-auth is set in both cluster
+// @NOTE: in retrospect i think we should have consolidated the common config in the wrapper struct; it
+// feels wierd we set things like version, tls etc per cluster since they both have to be the same.
+func (c *NodeupModelContext) UseTLSAuth() bool {
+	if len(c.Cluster.Spec.EtcdClusters) != 2 {
+		return false
+	}
+
+	return c.Cluster.Spec.EtcdClusters[0].EnableTLSAuth && c.Cluster.Spec.EtcdClusters[1].EnableTLSAuth
+}
+
 // UsesCNI checks if the cluster has CNI configured
 func (c *NodeupModelContext) UsesCNI() bool {
 	networking := c.Cluster.Spec.Networking

--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -226,11 +226,17 @@ func (c *NodeupModelContext) UseEtcdTLS() bool {
 // @NOTE: in retrospect i think we should have consolidated the common config in the wrapper struct; it
 // feels wierd we set things like version, tls etc per cluster since they both have to be the same.
 func (c *NodeupModelContext) UseTLSAuth() bool {
-	if len(c.Cluster.Spec.EtcdClusters) != 2 {
+	if !c.UseEtcdTLS() {
 		return false
 	}
 
-	return c.Cluster.Spec.EtcdClusters[0].EnableTLSAuth && c.Cluster.Spec.EtcdClusters[1].EnableTLSAuth
+	for _, x := range c.Cluster.Spec.EtcdClusters {
+		if x.EnableTLSAuth {
+			return true
+		}
+	}
+
+	return false
 }
 
 // UsesCNI checks if the cluster has CNI configured

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -212,6 +212,7 @@ type ProtokubeFlags struct {
 	PeerTLSCaFile             *string  `json:"peer-ca,omitempty" flag:"peer-ca"`
 	PeerTLSCertFile           *string  `json:"peer-cert,omitempty" flag:"peer-cert"`
 	PeerTLSKeyFile            *string  `json:"peer-key,omitempty" flag:"peer-key"`
+	TLSAuth                   *bool    `json:"tls-auth,omitempty" flag:"tls-auth"`
 	TLSCAFile                 *string  `json:"tls-ca,omitempty" flag:"tls-ca"`
 	TLSCertFile               *string  `json:"tls-cert,omitempty" flag:"tls-cert"`
 	TLSKeyFile                *string  `json:"tls-key,omitempty" flag:"tls-key"`
@@ -285,6 +286,11 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) (*Protokube
 		f.TLSCAFile = s(filepath.Join(t.PathSrvKubernetes(), "ca.crt"))
 		f.TLSCertFile = s(filepath.Join(t.PathSrvKubernetes(), "etcd.pem"))
 		f.TLSKeyFile = s(filepath.Join(t.PathSrvKubernetes(), "etcd-key.pem"))
+
+		enableAuth := true
+		if t.UseTLSAuth() {
+			f.TLSAuth = b(enableAuth)
+		}
 	}
 
 	zone := t.Cluster.Spec.DNSZone

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -286,11 +286,10 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) (*Protokube
 		f.TLSCAFile = s(filepath.Join(t.PathSrvKubernetes(), "ca.crt"))
 		f.TLSCertFile = s(filepath.Join(t.PathSrvKubernetes(), "etcd.pem"))
 		f.TLSKeyFile = s(filepath.Join(t.PathSrvKubernetes(), "etcd-key.pem"))
-
+	}
+	if t.UseTLSAuth() {
 		enableAuth := true
-		if t.UseTLSAuth() {
-			f.TLSAuth = b(enableAuth)
-		}
+		f.TLSAuth = b(enableAuth)
 	}
 
 	zone := t.Cluster.Spec.DNSZone

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -308,6 +308,8 @@ type EtcdClusterSpec struct {
 	Members []*EtcdMemberSpec `json:"etcdMembers,omitempty"`
 	// EnableEtcdTLS indicates the etcd service should use TLS between peers and clients
 	EnableEtcdTLS bool `json:"enableEtcdTLS,omitempty"`
+	// EnableTLSAuth indicates client and peer TLS auth should be enforced
+	EnableTLSAuth bool `json:"enableTLSAuth,omitempty"`
 	// Version is the version of etcd to run i.e. 2.1.2, 3.0.17 etcd
 	Version string `json:"version,omitempty"`
 	// LeaderElectionTimeout is the time (in milliseconds) for an etcd leader election timeout

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -305,6 +305,8 @@ type EtcdClusterSpec struct {
 	Name string `json:"name,omitempty"`
 	// Members stores the configurations for each member of the cluster (including the data volume)
 	Members []*EtcdMemberSpec `json:"etcdMembers,omitempty"`
+	// EnableTLSAuth indicats client and peer TLS auth should be enforced
+	EnableTLSAuth bool `json:"enableTLSAuth,omitempty"`
 	// EnableEtcdTLS indicates the etcd service should use TLS between peers and clients
 	EnableEtcdTLS bool `json:"enableEtcdTLS,omitempty"`
 	// Version is the version of etcd to run i.e. 2.1.2, 3.0.17 etcd

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1245,6 +1245,7 @@ func autoConvert_v1alpha1_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdCluste
 	} else {
 		out.Members = nil
 	}
+	out.EnableTLSAuth = in.EnableTLSAuth
 	out.EnableEtcdTLS = in.EnableEtcdTLS
 	out.Version = in.Version
 	out.LeaderElectionTimeout = in.LeaderElectionTimeout
@@ -1282,6 +1283,7 @@ func autoConvert_kops_EtcdClusterSpec_To_v1alpha1_EtcdClusterSpec(in *kops.EtcdC
 		out.Members = nil
 	}
 	out.EnableEtcdTLS = in.EnableEtcdTLS
+	out.EnableTLSAuth = in.EnableTLSAuth
 	out.Version = in.Version
 	out.LeaderElectionTimeout = in.LeaderElectionTimeout
 	out.HeartbeatInterval = in.HeartbeatInterval

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -305,6 +305,8 @@ type EtcdClusterSpec struct {
 	Members []*EtcdMemberSpec `json:"etcdMembers,omitempty"`
 	// EnableEtcdTLS indicates the etcd service should use TLS between peers and clients
 	EnableEtcdTLS bool `json:"enableEtcdTLS,omitempty"`
+	// EnableTLSAuth indicates client and peer TLS auth should be enforced
+	EnableTLSAuth bool `json:"enableTLSAuth,omitempty"`
 	// Version is the version of etcd to run i.e. 2.1.2, 3.0.17 etcd
 	Version string `json:"version,omitempty"`
 	// LeaderElectionTimeout is the time (in milliseconds) for an etcd leader election timeout

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1345,6 +1345,7 @@ func autoConvert_v1alpha2_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdCluste
 		out.Members = nil
 	}
 	out.EnableEtcdTLS = in.EnableEtcdTLS
+	out.EnableTLSAuth = in.EnableTLSAuth
 	out.Version = in.Version
 	out.LeaderElectionTimeout = in.LeaderElectionTimeout
 	out.HeartbeatInterval = in.HeartbeatInterval
@@ -1381,6 +1382,7 @@ func autoConvert_kops_EtcdClusterSpec_To_v1alpha2_EtcdClusterSpec(in *kops.EtcdC
 		out.Members = nil
 	}
 	out.EnableEtcdTLS = in.EnableEtcdTLS
+	out.EnableTLSAuth = in.EnableTLSAuth
 	out.Version = in.Version
 	out.LeaderElectionTimeout = in.LeaderElectionTimeout
 	out.HeartbeatInterval = in.HeartbeatInterval

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -106,6 +106,11 @@ func (b *BootstrapScript) ResourceNodeUp(ig *kops.InstanceGroup, cs *kops.Cluste
 			spec["kubeProxy"] = cs.KubeProxy
 
 			if ig.IsMaster() {
+				etcdSum, err := b.computeFingerprintOnStruct(cs.EtcdClusters)
+				if err != nil {
+					return "", err
+				}
+				spec["etcdFingerprint"] = etcdSum
 				spec["encryptionConfig"] = cs.EncryptionConfig
 				spec["kubeAPIServer"] = cs.KubeAPIServer
 				spec["kubeControllerManager"] = cs.KubeControllerManager
@@ -271,6 +276,16 @@ func (b *BootstrapScript) getRelevantFileAssets(allFileAssets []kops.FileAssetSp
 	}
 
 	return fileAssets, nil
+}
+
+// computeFingerprintOnStruct is computed on the struct pointer
+func (b *BootstrapScript) computeFingerprintOnStruct(v interface{}) (string, error) {
+	content, err := yaml.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+
+	return b.computeFingerprint(string(content))
 }
 
 // computeFingerprint takes a string and returns a base64 encoded fingerprint

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -106,11 +106,6 @@ func (b *BootstrapScript) ResourceNodeUp(ig *kops.InstanceGroup, cs *kops.Cluste
 			spec["kubeProxy"] = cs.KubeProxy
 
 			if ig.IsMaster() {
-				etcdSum, err := b.computeFingerprintOnStruct(cs.EtcdClusters)
-				if err != nil {
-					return "", err
-				}
-				spec["etcdFingerprint"] = etcdSum
 				spec["encryptionConfig"] = cs.EncryptionConfig
 				spec["kubeAPIServer"] = cs.KubeAPIServer
 				spec["kubeControllerManager"] = cs.KubeControllerManager
@@ -276,16 +271,6 @@ func (b *BootstrapScript) getRelevantFileAssets(allFileAssets []kops.FileAssetSp
 	}
 
 	return fileAssets, nil
-}
-
-// computeFingerprintOnStruct is computed on the struct pointer
-func (b *BootstrapScript) computeFingerprintOnStruct(v interface{}) (string, error) {
-	content, err := yaml.Marshal(v)
-	if err != nil {
-		return "", err
-	}
-
-	return b.computeFingerprint(string(content))
 }
 
 // computeFingerprint takes a string and returns a base64 encoded fingerprint

--- a/pkg/model/pki.go
+++ b/pkg/model/pki.go
@@ -116,7 +116,7 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Lifecycle:      b.Lifecycle,
 			Name:           fi.String("etcd"),
 			Subject:        "cn=etcd",
-			Type:           "server",
+			Type:           "clientServer",
 			Signer:         defaultCA,
 		})
 		c.AddTask(&fitasks.Keypair{

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -77,7 +77,7 @@ func run() error {
 	flag.StringVar(&peerCA, "peer-ca", peerCA, "Path to a file containing the peer ca in PEM format")
 	flag.StringVar(&peerCert, "peer-cert", peerCert, "Path to a file containing the peer certificate")
 	flag.StringVar(&peerKey, "peer-key", peerKey, "Path to a file containing the private key for the peers")
-	flag.BoolVar(&tlsAuth, "tls-auth", peerAuth, "Indicates the peers and client should enforce authentication via CA")
+	flag.BoolVar(&tlsAuth, "tls-auth", tlsAuth, "Indicates the peers and client should enforce authentication via CA")
 	flag.StringVar(&tlsCA, "tls-ca", tlsCA, "Path to a file containing the ca for client certificates")
 	flag.StringVar(&tlsCert, "tls-cert", tlsCert, "Path to a file containing the certificate for etcd server")
 	flag.StringVar(&tlsKey, "tls-key", tlsKey, "Path to a file containing the private key for etcd server")

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -59,7 +59,7 @@ func main() {
 // run is responsible for running the protokube service controller
 func run() error {
 	var zones []string
-	var applyTaints, initializeRBAC, containerized, master bool
+	var applyTaints, initializeRBAC, containerized, master, tlsAuth bool
 	var cloud, clusterID, dnsServer, dnsProviderID, dnsInternalSuffix, gossipSecret, gossipListen string
 	var flagChannels, tlsCert, tlsKey, tlsCA, peerCert, peerKey, peerCA string
 	var etcdBackupImage, etcdBackupStore, etcdImageSource, etcdElectionTimeout, etcdHeartbeatInterval string
@@ -77,6 +77,7 @@ func run() error {
 	flag.StringVar(&peerCA, "peer-ca", peerCA, "Path to a file containing the peer ca in PEM format")
 	flag.StringVar(&peerCert, "peer-cert", peerCert, "Path to a file containing the peer certificate")
 	flag.StringVar(&peerKey, "peer-key", peerKey, "Path to a file containing the private key for the peers")
+	flag.BoolVar(&tlsAuth, "tls-auth", peerAuth, "Indicates the peers and client should enforce authentication via CA")
 	flag.StringVar(&tlsCA, "tls-ca", tlsCA, "Path to a file containing the ca for client certificates")
 	flag.StringVar(&tlsCert, "tls-cert", tlsCert, "Path to a file containing the certificate for etcd server")
 	flag.StringVar(&tlsKey, "tls-key", tlsKey, "Path to a file containing the private key for etcd server")
@@ -311,6 +312,7 @@ func run() error {
 		PeerCA:                peerCA,
 		PeerCert:              peerCert,
 		PeerKey:               peerKey,
+		TLSAuth:               tlsAuth,
 		TLSCA:                 tlsCA,
 		TLSCert:               tlsCert,
 		TLSKey:                tlsKey,

--- a/protokube/pkg/protokube/etcd_cluster.go
+++ b/protokube/pkg/protokube/etcd_cluster.go
@@ -61,6 +61,8 @@ type EtcdCluster struct {
 	Spec *etcd.EtcdClusterSpec
 	// VolumeMountPath is the mount path
 	VolumeMountPath string
+	// TLSAuth indicates we should enforce peer and client verification
+	TLSAuth bool
 	// TLSCA is the path to a client ca for etcd clients
 	TLSCA string
 	// TLSCert is the path to a client certificate for etcd
@@ -104,24 +106,24 @@ func newEtcdController(kubeBoot *KubeBoot, v *Volume, spec *etcd.EtcdClusterSpec
 	}
 
 	cluster := &EtcdCluster{
-		// @TODO we need to deprecate this port and use 2379, but that would be a breaking change
+		CPURequest:        resource.MustParse("100m"),
 		ClientPort:        4001,
 		ClusterName:       "etcd-" + spec.ClusterKey,
-		CPURequest:        resource.MustParse("100m"),
 		DataDirName:       "data-" + spec.ClusterKey,
+		ElectionTimeout:   kubeBoot.EtcdElectionTimeout,
+		HeartbeatInterval: kubeBoot.EtcdHeartbeatInterval,
 		ImageSource:       kubeBoot.EtcdImageSource,
-		TLSCA:             kubeBoot.TLSCA,
-		TLSCert:           kubeBoot.TLSCert,
-		TLSKey:            kubeBoot.TLSKey,
 		PeerCA:            kubeBoot.PeerCA,
 		PeerCert:          kubeBoot.PeerCert,
 		PeerKey:           kubeBoot.PeerKey,
 		PeerPort:          2380,
 		PodName:           "etcd-server-" + spec.ClusterKey,
 		Spec:              spec,
+		TLSAuth:           kubeBoot.TLSAuth,
+		TLSCA:             kubeBoot.TLSCA,
+		TLSCert:           kubeBoot.TLSCert,
+		TLSKey:            kubeBoot.TLSKey,
 		VolumeMountPath:   v.Mountpoint,
-		ElectionTimeout:   kubeBoot.EtcdElectionTimeout,
-		HeartbeatInterval: kubeBoot.EtcdHeartbeatInterval,
 	}
 
 	// We used to build this through text files ... it turns out to just be more complicated than code!

--- a/protokube/pkg/protokube/etcd_manifest.go
+++ b/protokube/pkg/protokube/etcd_manifest.go
@@ -202,6 +202,12 @@ func buildEtcdEnvironmentOptions(c *EtcdCluster) []v1.EnvVar {
 	if notEmpty(c.TLSKey) {
 		options = append(options, v1.EnvVar{Name: "ETCD_KEY_FILE", Value: c.TLSKey})
 	}
+	if c.isTLS() {
+		if c.TLSAuth {
+			options = append(options, v1.EnvVar{Name: "ETCD_CLIENT_CERT_AUTH", Value: "true"})
+			options = append(options, v1.EnvVar{Name: "ETCD_PEER_CLIENT_CERT_AUTH", Value: "true"})
+		}
+	}
 
 	// @step: generate the initial cluster
 	var hosts []string

--- a/protokube/pkg/protokube/kube_boot.go
+++ b/protokube/pkg/protokube/kube_boot.go
@@ -58,6 +58,8 @@ type KubeBoot struct {
 	EtcdElectionTimeout string
 	// EtcdHeartbeatInterval is the heartbeat interval
 	EtcdHeartbeatInterval string
+	// TLSAuth indicates we should enforce peer and client verification
+	TLSAuth bool
 	// TLSCA is the path to a client ca for etcd
 	TLSCA string
 	// TLSCert is the path to a tls certificate for etcd
@@ -73,7 +75,8 @@ type KubeBoot struct {
 	// Kubernetes is the context methods for kubernetes
 	Kubernetes *KubernetesContext
 	// Master indicates we are a master node
-	Master          bool
+	Master bool
+
 	volumeMounter   *VolumeMountController
 	etcdControllers map[string]*EtcdController
 }


### PR DESCRIPTION
Some TLS settings for etcd were left out in the last PR. Namely the ETCD_PEER_CLIENT_CERT_AUTH and ETCD_PEER_CERT_AUTH which effectively tell etcd to enforce verification of the client certificate. This fix for this is very easy, the rollout on a cluster which TLS already enabled it somewhat trickier. The fix is 

* recreate the certificate for the peers to have both server and client keyusage
* switch on the environment variables to true

On a rollout this is somewhat annoying as all etcd peers must have the updated certificate before the you can enable the feature. 

At first glance this should pose an issue for rollout as on the first master node we update TLS auth, the other etcd nodes will be blocked from connecting as their certificate hasn't been updated yet. This I figured would break the cluster validation code and ergo rollout. But after some testing, the [cluster validation](https://github.com/gambol99/kops/blob/etcd_options/pkg/validation/validate_cluster.go#L88-L133) doesn't actually check the node status, it checks for pod failures but etcd would continue without pod failures, instead throwing TLS errors when peers attempt to connect without the updated certificate. To take an example on a 3 node cluster, first one breaks (i.e. other two cannot continue) but rollout continues, second is updated and forms with first node, third is broken but fixed on the final update. Note, I'm still a little concerned that timing and load could cause issues here, my testing we done a test ephemeral cluster.Hence I've kept a toggle flag in the PR for now so we can discuss.
