### PR TITLE
Fixed minor typo in 1.8-NOTES.md file

### DIFF
--- a/docs/releases/1.8-NOTES.md
+++ b/docs/releases/1.8-NOTES.md
@@ -62,7 +62,7 @@
 
 * Addons: added external-dns, kube-state-metrics addon.  Updates for autoscaler, dashboard, heapster, 
 
-* Networking: initial support or kube-router & romana.  Updates for weave, kopeio-networking, flannel, canal, calico.
+* Networking: initial support for kube-router & romana.  Updates for weave, kopeio-networking, flannel, canal, calico.
 
 * Docker: Docker 1.13.1 will be used with kubernetes 1.8 (overrides for 17.03.2 and 17.09 possible).
 


### PR DESCRIPTION
Change 'or' to 'for' in line ... kube-router & romana...