### PR TITLE
Remove world read permissions on sensitive key files.

### DIFF
--- a/nodeup/pkg/model/convenience.go
+++ b/nodeup/pkg/model/convenience.go
@@ -115,6 +115,7 @@ func buildCertificateRequest(c *fi.ModelBuilderContext, b *NodeupModelContext, n
 		Path:     location,
 		Contents: fi.NewStringResource(serialized),
 		Type:     nodetasks.FileType_File,
+		Mode:     s("0600"),
 	})
 
 	return nil
@@ -141,6 +142,7 @@ func buildPrivateKeyRequest(c *fi.ModelBuilderContext, b *NodeupModelContext, na
 		Path:     location,
 		Contents: fi.NewStringResource(serialized),
 		Type:     nodetasks.FileType_File,
+		Mode:     s("0600"),
 	})
 
 	return nil

--- a/nodeup/pkg/model/secrets.go
+++ b/nodeup/pkg/model/secrets.go
@@ -113,6 +113,7 @@ func (b *SecretBuilder) Build(c *fi.ModelBuilderContext) error {
 			Path:     filepath.Join(b.PathSrvKubernetes(), "server.key"),
 			Contents: fi.NewStringResource(serialized),
 			Type:     nodetasks.FileType_File,
+			Mode:     s("0600"),
 		}
 		c.AddTask(t)
 	}
@@ -150,6 +151,7 @@ func (b *SecretBuilder) Build(c *fi.ModelBuilderContext) error {
 			Path:     filepath.Join(b.PathSrvKubernetes(), "proxy-client.key"),
 			Contents: fi.NewStringResource(serialized),
 			Type:     nodetasks.FileType_File,
+			Mode:     s("0600"),
 		}
 		c.AddTask(t)
 	}
@@ -260,6 +262,7 @@ func (b *SecretBuilder) writePrivateKey(c *fi.ModelBuilderContext, id string) er
 		Path:     filepath.Join(b.PathSrvKubernetes(), id+".key"),
 		Contents: fi.NewStringResource(serialized),
 		Type:     nodetasks.FileType_File,
+		Mode:     s("0600"),
 	}
 	c.AddTask(t)
 


### PR DESCRIPTION
The key files pulled from S3 had world read permissions by default (644). This PR sets the permissions to 600 on `.key` and `.pem` files.