### PR TITLE
Downgrade Flannel in Canal deployment to v0.9.0

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.6.yaml.template
@@ -171,7 +171,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.9.1
+          image: quay.io/coreos/flannel:v0.9.0
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.8.yaml.template
@@ -3,7 +3,7 @@
 # This manifest includes the following component versions:
 #   calico/node:v2.6.2
 #   calico/cni:v1.11.0
-#   coreos/flannel:v0.9.1
+#   coreos/flannel:v0.9.0 (bug with v0.9.1: https://github.com/kubernetes/kops/issues/4037)
 
 # This ConfigMap can be used to configure a self-hosted Canal installation.
 kind: ConfigMap
@@ -194,7 +194,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.9.1
+          image: quay.io/coreos/flannel:v0.9.0
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true


### PR DESCRIPTION
Flannel v0.9.1 introduces a single change to add 2 iptables rules to the `FORWARD` chain, permitting traffic in/out of the pod network (introduced to improve compatibility with newer versions of Docker). This change is unnecessary for Canal deployments for the following reasons:
- Calico's `DefaultEndpointToHostAction` is set to `ACCEPT` in the manifest deployed by kops, allowing traffic by default once all other Calico rules are processed.
- If Calico's `ChainInsertMode` is set to `APPEND`, the flannel rules will be processed before the Calico rules, accepting traffic by default, and so Kubernetes network policies will not take effect

This change is temporary until a more permanent resolution is available with Flannel, such as providing a configurable option to disable the addition of these rules when deployed with Calico.

Related to #4037