### PR TITLE
Add --subnets and --utility-subnets to kops create cluster

### DIFF
--- a/cloudmock/aws/mockec2/subnets.go
+++ b/cloudmock/aws/mockec2/subnets.go
@@ -60,9 +60,10 @@ func (m *MockEC2) CreateSubnet(request *ec2.CreateSubnetInput) (*ec2.CreateSubne
 	n := m.subnetNumber
 
 	subnet := &ec2.Subnet{
-		SubnetId:  s(fmt.Sprintf("subnet-%d", n)),
-		VpcId:     request.VpcId,
-		CidrBlock: request.CidrBlock,
+		SubnetId:         s(fmt.Sprintf("subnet-%d", n)),
+		VpcId:            request.VpcId,
+		CidrBlock:        request.CidrBlock,
+		AvailabilityZone: request.AvailabilityZone,
 	}
 
 	if m.subnets == nil {
@@ -93,7 +94,10 @@ func (m *MockEC2) DescribeSubnets(request *ec2.DescribeSubnetsInput) (*ec2.Descr
 		for _, filter := range request.Filters {
 			match := false
 			switch *filter.Name {
-
+			case "vpc-id":
+				if *subnet.main.VpcId == *filter.Values[0] {
+					match = true
+				}
 			default:
 				if strings.HasPrefix(*filter.Name, "tag:") {
 					match = m.hasTag(ec2.ResourceTypeSubnet, *subnet.main.SubnetId, filter)

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -503,7 +503,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		zoneToSubnetMap[region] = subnet
 	} else {
 		var zoneToSubnetProviderID map[string]string
-		if len(c.Zones) > 0 && len(c.SubnetIDs) > 0 {
+		if len(c.Zones) > 0 && len(c.SubnetIDs) > 0 && api.CloudProviderID(cluster.Spec.CloudProvider) == api.CloudProviderAWS {
 			zoneToSubnetProviderID, err = getZoneToSubnetProviderID(c.VPCID, c.Zones[0][:len(c.Zones[0])-1], c.SubnetIDs)
 			if err != nil {
 				return err
@@ -877,7 +877,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		var utilitySubnets []api.ClusterSubnetSpec
 
 		var zoneToSubnetProviderID map[string]string
-		if len(c.Zones) > 0 && len(c.UtilitySubnetIDs) > 0 {
+		if len(c.Zones) > 0 && len(c.UtilitySubnetIDs) > 0 && api.CloudProviderID(cluster.Spec.CloudProvider) == api.CloudProviderAWS {
 			zoneToSubnetProviderID, err = getZoneToSubnetProviderID(c.VPCID, c.Zones[0][:len(c.Zones[0])-1], c.UtilitySubnetIDs)
 			if err != nil {
 				return err

--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -100,6 +100,12 @@ func TestCreateClusterSharedSubnets(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/shared_subnets", "v1alpha2")
 }
 
+// TestCreateClusterSharedSubnetsVpcLookup runs kops create cluster subnet.example.com --zones us-test-1a --master-zones us-test-1a --vpc --subnets subnet-1
+func TestCreateClusterSharedSubnetsVpcLookup(t *testing.T) {
+	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/shared_subnets_vpc_lookup", "v1alpha1")
+	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/shared_subnets_vpc_lookup", "v1alpha2")
+}
+
 // TestCreateClusterPrivateSharedSubnets runs kops create cluster private-subnet.example.com --zones us-test-1a --master-zones us-test-1a --vpc vpc-12345678 --subnets subnet-1 --utility-subnets subnet-2
 func TestCreateClusterPrivateSharedSubnets(t *testing.T) {
 	// Cannot be expressed in v1alpha1 API: runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/private_shared_subnets", "v1alpha1")

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -99,8 +99,10 @@ kops create cluster
       --project string                       Project to use (must be set on GCE)
       --ssh-access stringSlice               Restrict SSH access to this CIDR.  If not set, access will not be restricted by IP. (default [0.0.0.0/0])
       --ssh-public-key string                SSH public key to use (default "~/.ssh/id_rsa.pub")
+      --subnets stringSlice                  Set to use shared subnets
       --target string                        Valid targets: direct, terraform, direct. Set this flag to terraform if you want kops to generate terraform (default "direct")
   -t, --topology string                      Controls network topology for the cluster. public|private. Default is 'public'. (default "public")
+      --utility-subnets stringSlice          Set to use shared utility subnets
       --vpc string                           Set to use a shared VPC
   -y, --yes                                  Specify --yes to immediately create the cluster
       --zones stringSlice                    Zones in which to run the cluster

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -1,0 +1,93 @@
+apiVersion: kops/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  name: private-subnets.example.com
+spec:
+  api:
+    loadBalancer:
+      type: Public
+  authorization:
+    alwaysAllow: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://tests/private-subnets.example.com
+  etcdClusters:
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: a
+    name: main
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: a
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  kubernetesVersion: v1.4.8
+  masterPublicName: api.private-subnets.example.com
+  networkCIDR: 10.0.0.0/12
+  networkID: vpc-12345678
+  networking:
+    kopeio: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  subnets:
+  - cidr: 10.10.0.0/24
+    id: subnet-1
+    name: us-test-1a
+    type: Private
+    zone: us-test-1a
+  - cidr: 10.11.0.0/24
+    id: subnet-2
+    name: utility-us-test-1a
+    type: Utility
+    zone: us-test-1a
+  topology:
+    dns:
+      type: Public
+    masters: private
+    nodes: private
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: private-subnets.example.com
+  name: master-us-test-1a
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
+  role: Master
+  subnets:
+  - us-test-1a
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: private-subnets.example.com
+  name: nodes
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  machineType: t2.medium
+  maxSize: 2
+  minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
+  role: Node
+  subnets:
+  - us-test-1a

--- a/tests/integration/create_cluster/private_shared_subnets/options.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/options.yaml
@@ -1,0 +1,12 @@
+ClusterName: private-subnets.example.com
+Zones:
+- us-test-1a
+Cloud: aws
+Topology: private
+Networking: kopeio-vxlan
+VPCID: vpc-12345678
+SubnetIDs:
+- subnet-1
+UtilitySubnetIDs:
+- subnet-2
+KubernetesVersion: v1.4.8

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha1.yaml
@@ -1,0 +1,83 @@
+apiVersion: kops/v1alpha1
+kind: Cluster
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  name: subnet.example.com
+spec:
+  adminAccess:
+  - 0.0.0.0/0
+  api:
+    dns: {}
+  authorization:
+    alwaysAllow: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://tests/subnet.example.com
+  etcdClusters:
+  - etcdMembers:
+    - name: a
+      zone: us-test-1a
+    name: main
+  - etcdMembers:
+    - name: a
+      zone: us-test-1a
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubernetesVersion: v1.4.8
+  masterPublicName: api.subnet.example.com
+  networkCIDR: 10.0.0.0/12
+  networkID: vpc-12345678
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  topology:
+    dns:
+      type: Public
+    masters: public
+    nodes: public
+  zones:
+  - cidr: 10.10.0.0/24
+    id: subnet-1
+    name: us-test-1a
+
+---
+
+apiVersion: kops/v1alpha1
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: subnet.example.com
+  name: master-us-test-1a
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
+  role: Master
+  zones:
+  - us-test-1a
+
+---
+
+apiVersion: kops/v1alpha1
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: subnet.example.com
+  name: nodes
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  machineType: t2.medium
+  maxSize: 2
+  minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
+  role: Node
+  zones:
+  - us-test-1a

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
@@ -1,0 +1,87 @@
+apiVersion: kops/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  name: subnet.example.com
+spec:
+  api:
+    dns: {}
+  authorization:
+    alwaysAllow: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://tests/subnet.example.com
+  etcdClusters:
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: a
+    name: main
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: a
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  kubernetesVersion: v1.4.8
+  masterPublicName: api.subnet.example.com
+  networkCIDR: 10.0.0.0/12
+  networkID: vpc-12345678
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  subnets:
+  - cidr: 10.10.0.0/24
+    id: subnet-1
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a
+  topology:
+    dns:
+      type: Public
+    masters: public
+    nodes: public
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: subnet.example.com
+  name: master-us-test-1a
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
+  role: Master
+  subnets:
+  - us-test-1a
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: subnet.example.com
+  name: nodes
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  machineType: t2.medium
+  maxSize: 2
+  minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
+  role: Node
+  subnets:
+  - us-test-1a

--- a/tests/integration/create_cluster/shared_subnets/options.yaml
+++ b/tests/integration/create_cluster/shared_subnets/options.yaml
@@ -1,0 +1,8 @@
+ClusterName: subnet.example.com
+Zones:
+- us-test-1a
+Cloud: aws
+VPCID: vpc-12345678
+SubnetIDs:
+- subnet-1
+KubernetesVersion: v1.4.8

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha1.yaml
@@ -1,0 +1,83 @@
+apiVersion: kops/v1alpha1
+kind: Cluster
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  name: subnet.example.com
+spec:
+  adminAccess:
+  - 0.0.0.0/0
+  api:
+    dns: {}
+  authorization:
+    alwaysAllow: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://tests/subnet.example.com
+  etcdClusters:
+  - etcdMembers:
+    - name: a
+      zone: us-test-1a
+    name: main
+  - etcdMembers:
+    - name: a
+      zone: us-test-1a
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubernetesVersion: v1.4.8
+  masterPublicName: api.subnet.example.com
+  networkCIDR: 10.0.0.0/12
+  networkID: vpc-12345678
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  topology:
+    dns:
+      type: Public
+    masters: public
+    nodes: public
+  zones:
+  - cidr: 10.10.0.0/24
+    id: subnet-1
+    name: us-test-1a
+
+---
+
+apiVersion: kops/v1alpha1
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: subnet.example.com
+  name: master-us-test-1a
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
+  role: Master
+  zones:
+  - us-test-1a
+
+---
+
+apiVersion: kops/v1alpha1
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: subnet.example.com
+  name: nodes
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  machineType: t2.medium
+  maxSize: 2
+  minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
+  role: Node
+  zones:
+  - us-test-1a

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
@@ -1,0 +1,87 @@
+apiVersion: kops/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  name: subnet.example.com
+spec:
+  api:
+    dns: {}
+  authorization:
+    alwaysAllow: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://tests/subnet.example.com
+  etcdClusters:
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: a
+    name: main
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: a
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  kubernetesVersion: v1.4.8
+  masterPublicName: api.subnet.example.com
+  networkCIDR: 10.0.0.0/12
+  networkID: vpc-12345678
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  subnets:
+  - cidr: 10.10.0.0/24
+    id: subnet-1
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a
+  topology:
+    dns:
+      type: Public
+    masters: public
+    nodes: public
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: subnet.example.com
+  name: master-us-test-1a
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
+  role: Master
+  subnets:
+  - us-test-1a
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: subnet.example.com
+  name: nodes
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  machineType: t2.medium
+  maxSize: 2
+  minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
+  role: Node
+  subnets:
+  - us-test-1a

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/options.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/options.yaml
@@ -1,0 +1,7 @@
+ClusterName: subnet.example.com
+Zones:
+- us-test-1a
+Cloud: aws
+SubnetIDs:
+- subnet-1
+KubernetesVersion: v1.4.8

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha1.yaml
@@ -1,0 +1,82 @@
+apiVersion: kops/v1alpha1
+kind: Cluster
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  name: vpc.example.com
+spec:
+  adminAccess:
+  - 0.0.0.0/0
+  api:
+    dns: {}
+  authorization:
+    alwaysAllow: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://tests/vpc.example.com
+  etcdClusters:
+  - etcdMembers:
+    - name: a
+      zone: us-test-1a
+    name: main
+  - etcdMembers:
+    - name: a
+      zone: us-test-1a
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubernetesVersion: v1.4.8
+  masterPublicName: api.vpc.example.com
+  networkCIDR: 10.0.0.0/12
+  networkID: vpc-12345678
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  topology:
+    dns:
+      type: Public
+    masters: public
+    nodes: public
+  zones:
+  - cidr: 10.2.0.0/15
+    name: us-test-1a
+
+---
+
+apiVersion: kops/v1alpha1
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: vpc.example.com
+  name: master-us-test-1a
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
+  role: Master
+  zones:
+  - us-test-1a
+
+---
+
+apiVersion: kops/v1alpha1
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: vpc.example.com
+  name: nodes
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  machineType: t2.medium
+  maxSize: 2
+  minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
+  role: Node
+  zones:
+  - us-test-1a

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -1,0 +1,86 @@
+apiVersion: kops/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  name: vpc.example.com
+spec:
+  api:
+    dns: {}
+  authorization:
+    alwaysAllow: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://tests/vpc.example.com
+  etcdClusters:
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: a
+    name: main
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: a
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  kubernetesVersion: v1.4.8
+  masterPublicName: api.vpc.example.com
+  networkCIDR: 10.0.0.0/12
+  networkID: vpc-12345678
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  subnets:
+  - cidr: 10.2.0.0/15
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a
+  topology:
+    dns:
+      type: Public
+    masters: public
+    nodes: public
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: vpc.example.com
+  name: master-us-test-1a
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
+  role: Master
+  subnets:
+  - us-test-1a
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: 2017-01-01T00:00:00Z
+  labels:
+    kops.k8s.io/cluster: vpc.example.com
+  name: nodes
+spec:
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  machineType: t2.medium
+  maxSize: 2
+  minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
+  role: Node
+  subnets:
+  - us-test-1a

--- a/tests/integration/create_cluster/shared_vpc/options.yaml
+++ b/tests/integration/create_cluster/shared_vpc/options.yaml
@@ -1,0 +1,6 @@
+ClusterName: vpc.example.com
+Zones:
+- us-test-1a
+Cloud: aws
+VPCID: vpc-12345678
+KubernetesVersion: v1.4.8

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -872,6 +872,10 @@ func (c *awsCloudImplementation) DescribeInstance(instanceID string) (*ec2.Insta
 
 // DescribeVPC is a helper that queries for the specified vpc by id
 func (c *awsCloudImplementation) DescribeVPC(vpcID string) (*ec2.Vpc, error) {
+	return describeVPC(c, vpcID)
+}
+
+func describeVPC(c AWSCloud, vpcID string) (*ec2.Vpc, error) {
 	glog.V(2).Infof("Calling DescribeVPC for VPC %q", vpcID)
 	request := &ec2.DescribeVpcsInput{
 		VpcIds: []*string{&vpcID},
@@ -1034,6 +1038,10 @@ func (c *awsCloudImplementation) Route53() route53iface.Route53API {
 }
 
 func (c *awsCloudImplementation) FindVPCInfo(vpcID string) (*fi.VPCInfo, error) {
+	return findVPCInfo(c, vpcID)
+}
+
+func findVPCInfo(c AWSCloud, vpcID string) (*fi.VPCInfo, error) {
 	vpc, err := c.DescribeVPC(vpcID)
 	if err != nil {
 		return nil, err
@@ -1053,7 +1061,7 @@ func (c *awsCloudImplementation) FindVPCInfo(vpcID string) (*fi.VPCInfo, error) 
 			Filters: []*ec2.Filter{NewEC2Filter("vpc-id", vpcID)},
 		}
 
-		response, err := c.ec2.DescribeSubnets(request)
+		response, err := c.EC2().DescribeSubnets(request)
 		if err != nil {
 			return nil, fmt.Errorf("error listing subnets in VPC %q: %v", vpcID, err)
 		}

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -161,7 +161,7 @@ func (c *MockAWSCloud) DescribeInstance(instanceID string) (*ec2.Instance, error
 }
 
 func (c *MockAWSCloud) DescribeVPC(vpcID string) (*ec2.Vpc, error) {
-	return nil, fmt.Errorf("MockAWSCloud DescribeVPC not implemented")
+	return describeVPC(c, vpcID)
 }
 
 func (c *MockAWSCloud) ResolveImage(name string) (*ec2.Image, error) {
@@ -214,7 +214,7 @@ func (c *MockAWSCloud) Route53() route53iface.Route53API {
 }
 
 func (c *MockAWSCloud) FindVPCInfo(id string) (*fi.VPCInfo, error) {
-	return nil, fmt.Errorf("MockAWSCloud FindVPCInfo not implemented")
+	return findVPCInfo(c, id)
 }
 
 // DefaultInstanceType determines an instance type for the specified cluster & instance group


### PR DESCRIPTION
This change adds two new options to `kops create cluster`

When specifying `--vpc`, `--subnets` can be specified as an unordered array of subnet ids. Kops will then look up the zones of the subnets to find which zone to add the subnet id to.

If `--topology private` is also specified, `--utility-subnets` can similarly be specified.

~If a zone was specified but a subnet wasn't given that matches the zone, then the subnet will be allocated a CIDR with the current behaviour.~ This case fails validation here https://github.com/kubernetes/kops/blob/7bd0a6a703e4f38c62f9c69bcf8a73f1daaa751e/pkg/apis/kops/validation/validation.go#L151

I can add unit tests and docs changes if required, but I am keen to get feedback before I proceed much further.

I have only added support for AWS.

I have tested this by running a command similar to this:

```bash
kops create cluster \
  --zones=us-east-1a,us-east-1b,us-east-1c \
  --topology private \
  --master-zones=us-east-1a,us-east-1b,us-east-1c  \
  --vpc $vpc_id \
  --subnets subnet-111111,subnet-222222,subnet-333333 \
  --utility-subnets subnet-444444,subnet-555555,subnet-666666 \
  $cluster_hosted_zone_name
```

And the cluster spec was as expected.