### PR TITLE
Bump weave version in bootstrapchannelbuilder

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
@@ -123,7 +123,7 @@ spec:
             - name: WEAVE_MTU
               value: "{{ .Networking.Weave.MTU }}"
             {{- end }}
-          image: 'weaveworks/weave-kube:2.1.2'
+          image: 'weaveworks/weave-kube:2.1.3'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -158,7 +158,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.1.2'
+          image: 'weaveworks/weave-npc:2.1.3'
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
@@ -50,6 +50,46 @@ subjects:
     name: weave-net
     namespace: kube-system
 ---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: weave-net
+  namespace: kube-system
+  labels:
+    name: weave-net
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    resourceNames:
+      - weave-net
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: weave-net
+  namespace: kube-system
+  labels:
+    name: weave-net
+roleRef:
+  kind: Role
+  name: weave-net
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: weave-net
+    namespace: kube-system
+---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -83,7 +123,7 @@ spec:
             - name: WEAVE_MTU
               value: "{{ .Networking.Weave.MTU }}"
             {{- end }}
-          image: 'weaveworks/weave-kube:2.0.5'
+          image: 'weaveworks/weave-kube:2.1.2'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -118,7 +158,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.0.5'
+          image: 'weaveworks/weave-npc:2.1.2'
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -131,7 +131,7 @@ spec:
             - name: WEAVE_MTU
               value: "{{ .Networking.Weave.MTU }}"
             {{- end }}
-          image: 'weaveworks/weave-kube:2.1.2'
+          image: 'weaveworks/weave-kube:2.1.3'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -168,7 +168,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.1.2'
+          image: 'weaveworks/weave-npc:2.1.3'
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -24,6 +24,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - 'networking.k8s.io'
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -43,6 +51,46 @@ metadata:
     role.kubernetes.io/networking: "1"
 roleRef:
   kind: ClusterRole
+  name: weave-net
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: weave-net
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: weave-net
+  namespace: kube-system
+  labels:
+    name: weave-net
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    resourceNames:
+      - weave-net
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: weave-net
+  namespace: kube-system
+  labels:
+    name: weave-net
+roleRef:
+  kind: Role
   name: weave-net
   apiGroup: rbac.authorization.k8s.io
 subjects:
@@ -83,7 +131,7 @@ spec:
             - name: WEAVE_MTU
               value: "{{ .Networking.Weave.MTU }}"
             {{- end }}
-          image: 'weaveworks/weave-kube:2.0.5'
+          image: 'weaveworks/weave-kube:2.1.2'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -120,7 +168,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.0.5'
+          image: 'weaveworks/weave-npc:2.1.2'
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
@@ -42,7 +42,7 @@ spec:
             - name: WEAVE_MTU
               value: "{{ .Networking.Weave.MTU }}"
             {{- end }}
-          image: 'weaveworks/weave-kube:2.0.5'
+          image: 'weaveworks/weave-kube:2.1.2'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -77,7 +77,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.0.5'
+          image: 'weaveworks/weave-npc:2.1.2'
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
@@ -42,7 +42,7 @@ spec:
             - name: WEAVE_MTU
               value: "{{ .Networking.Weave.MTU }}"
             {{- end }}
-          image: 'weaveworks/weave-kube:2.1.2'
+          image: 'weaveworks/weave-kube:2.1.3'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -77,7 +77,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.1.2'
+          image: 'weaveworks/weave-npc:2.1.3'
           resources:
             requests:
               cpu: 50m

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -388,8 +388,8 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Weave != nil {
 		key := "networking.weave"
-		// 2.0.6-kops.1 = 2.0.5 with kops manifest tweaks.  This should go away with the next version bump.
-		version := "2.0.6-kops.1"
+		// 2.1.3-kops.1 = 2.1.3, kops packaging version 1.
+		version := "2.1.3-kops.1"
 
 		{
 			location := key + "/pre-k8s-1.6.yaml"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -69,18 +69,18 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.0.6-kops.1
+    version: 2.1.3-kops.1
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.7.0'
     manifest: networking.weave/k8s-1.6.yaml
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.0.6-kops.1
+    version: 2.1.3-kops.1
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0'
     manifest: networking.weave/k8s-1.7.yaml
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.0.6-kops.1
+    version: 2.1.3-kops.1


### PR DESCRIPTION
2.1.3 upstream becomes 2.1.3-kops.1, so if we need to make our own
"packaging" changes, we can do 2.1.3-kops.2 etc.