### PR TITLE
Support for hostPort when using canal

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.8.yaml.template
@@ -25,24 +25,34 @@ data:
   cni_network_config: |-
     {
         "name": "k8s-pod-network",
-        "cniVersion": "0.1.0",
-        "type": "calico",
-        "log_level": "info",
-        "datastore_type": "kubernetes",
-        "nodename": "__KUBERNETES_NODE_NAME__",
-        "ipam": {
-            "type": "host-local",
-            "subnet": "usePodCidr"
-        },
-        "policy": {
-            "type": "k8s",
-            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-        },
-        "kubernetes": {
-            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-            "kubeconfig": "__KUBECONFIG_FILEPATH__"
-        }
+        "cniVersion": "0.3.0",
+        "plugins": [
+            {
+                "type": "calico",
+                "log_level": "info",
+                "datastore_type": "kubernetes",
+                "nodename": "__KUBERNETES_NODE_NAME__",
+                "ipam": {
+                    "type": "host-local",
+                    "subnet": "usePodCidr"
+                },
+                "policy": {
+                    "type": "k8s",
+                    "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+                },
+                "kubernetes": {
+                    "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+                    "kubeconfig": "__KUBECONFIG_FILEPATH__"
+                }
+            },
+            {
+                "type": "portmap",
+                "capabilities": {"portMappings": true},
+                "snat": true
+            }
+        ]
     }
+
 
   # Flannel network configuration. Mounted into the flannel container.
   net-conf.json: |
@@ -176,6 +186,8 @@ spec:
           image: quay.io/calico/cni:v1.11.0
           command: ["/install-cni.sh"]
           env:
+            - name: CNI_CONF_NAME
+              value: "10-calico.conflist"
             # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG
               valueFrom:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -532,7 +532,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		versions := map[string]string{
 			"pre-k8s-1.6": "2.4.2-kops.1",
 			"k8s-1.6":     "2.4.2-kops.1",
-			"k8s-1.8":     "2.6.3-kops.1",
+			"k8s-1.8":     "2.6.3-kops.2",
 		}
 
 		{


### PR DESCRIPTION
Similar to: https://github.com/kubernetes/kops/pull/3206

Without this, we are unable to get `hostPort` working with `canal`. The same is true for `flannel`, but this does add support for plain flannel.