### PR TITLE
Support for OIDC 'username-prefix' and 'groups-prefix' flags

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -137,8 +137,11 @@ spec:
     oidcIssuerURL: https://your-oidc-provider.svc.cluster.local
     oidcClientID: kubernetes
     oidcUsernameClaim: sub
+    oidcUsernamePrefix: "oidc:"
     oidcGroupsClaim: user_roles
+    oidcGroupsPrefix: "oidc:"
     oidcCAFile: /etc/kubernetes/ssl/kc-ca.pem
+
 ```
 
 #### audit logging

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -225,18 +225,29 @@ type KubeAPIServerConfig struct {
 	KubeletPreferredAddressTypes []string `json:"kubeletPreferredAddressTypes,omitempty" flag:"kubelet-preferred-address-types"`
 	// StorageBackend is the backend storage
 	StorageBackend *string `json:"storageBackend,omitempty" flag:"storage-backend"`
-	// The OpenID claim to use as the user name.
-	// Note that claims other than the default ('sub') is not guaranteed to be unique and immutable.
+	// OIDCUsernameClaim is the OpenID claim to use as the user name.
+	// Note that claims other than the default ('sub') is not guaranteed to be
+	// unique and immutable.
 	OIDCUsernameClaim *string `json:"oidcUsernameClaim,omitempty" flag:"oidc-username-claim"`
-	// If provided, the name of a custom OpenID Connect claim for specifying user groups.
+	// OIDCUsernamePrefix is the prefix prepended to username claims to prevent
+	// clashes with existing names (such as 'system:' users).
+	OIDCUsernamePrefix *string `json:"oidcUsernamePrefix,omitempty" flag:"oidc-username-prefix"`
+	// OIDCGroupsClaim if provided, the name of a custom OpenID Connect claim for
+	// specifying user groups.
 	// The claim value is expected to be a string or array of strings.
 	OIDCGroupsClaim *string `json:"oidcGroupsClaim,omitempty" flag:"oidc-groups-claim"`
-	// The URL of the OpenID issuer, only HTTPS scheme will be accepted.
+	// OIDCGroupsPrefix is the prefix prepended to group claims to prevent
+	// clashes with existing names (such as 'system:' groups)
+	OIDCGroupsPrefix *string `json:"oidcGroupsPrefix,omitempty" flag:"oidc-groups-prefix"`
+	// OIDCIssuerURL is the URL of the OpenID issuer, only HTTPS scheme will
+	// be accepted.
 	// If set, it will be used to verify the OIDC JSON Web Token (JWT).
 	OIDCIssuerURL *string `json:"oidcIssuerURL,omitempty" flag:"oidc-issuer-url"`
-	// The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
+	// OIDCClientID is the client ID for the OpenID Connect client, must be set
+	// if oidc-issuer-url is set.
 	OIDCClientID *string `json:"oidcClientID,omitempty" flag:"oidc-client-id"`
-	// If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file
+	// OIDCCAFile if set, the OpenID server's certificate will be verified by one
+	// of the authorities in the oidc-ca-file
 	OIDCCAFile *string `json:"oidcCAFile,omitempty" flag:"oidc-ca-file"`
 	// The apiserver's client certificate used for outbound requests.
 	ProxyClientCertFile *string `json:"proxyClientCertFile,omitempty" flag:"proxy-client-cert-file"`

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -225,18 +225,29 @@ type KubeAPIServerConfig struct {
 	KubeletPreferredAddressTypes []string `json:"kubeletPreferredAddressTypes,omitempty" flag:"kubelet-preferred-address-types"`
 	// StorageBackend is the backend storage
 	StorageBackend *string `json:"storageBackend,omitempty" flag:"storage-backend"`
-	// The OpenID claim to use as the user name.
-	// Note that claims other than the default ('sub') is not guaranteed to be unique and immutable.
+	// OIDCUsernameClaim is the OpenID claim to use as the user name.
+	// Note that claims other than the default ('sub') is not guaranteed to be
+	// unique and immutable.
 	OIDCUsernameClaim *string `json:"oidcUsernameClaim,omitempty" flag:"oidc-username-claim"`
-	// If provided, the name of a custom OpenID Connect claim for specifying user groups.
+	// OIDCUsernamePrefix is the prefix prepended to username claims to prevent
+	// clashes with existing names (such as 'system:' users).
+	OIDCUsernamePrefix *string `json:"oidcUsernamePrefix,omitempty" flag:"oidc-username-prefix"`
+	// OIDCGroupsClaim if provided, the name of a custom OpenID Connect claim for
+	// specifying user groups.
 	// The claim value is expected to be a string or array of strings.
 	OIDCGroupsClaim *string `json:"oidcGroupsClaim,omitempty" flag:"oidc-groups-claim"`
-	// The URL of the OpenID issuer, only HTTPS scheme will be accepted.
+	// OIDCGroupsPrefix is the prefix prepended to group claims to prevent
+	// clashes with existing names (such as 'system:' groups)
+	OIDCGroupsPrefix *string `json:"oidcGroupsPrefix,omitempty" flag:"oidc-groups-prefix"`
+	// OIDCIssuerURL is the URL of the OpenID issuer, only HTTPS scheme will
+	// be accepted.
 	// If set, it will be used to verify the OIDC JSON Web Token (JWT).
 	OIDCIssuerURL *string `json:"oidcIssuerURL,omitempty" flag:"oidc-issuer-url"`
-	// The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
+	// OIDCClientID is the client ID for the OpenID Connect client, must be set
+	// if oidc-issuer-url is set.
 	OIDCClientID *string `json:"oidcClientID,omitempty" flag:"oidc-client-id"`
-	// If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file
+	// OIDCCAFile if set, the OpenID server's certificate will be verified by one
+	// of the authorities in the oidc-ca-file
 	OIDCCAFile *string `json:"oidcCAFile,omitempty" flag:"oidc-ca-file"`
 	// The apiserver's client certificate used for outbound requests.
 	ProxyClientCertFile *string `json:"proxyClientCertFile,omitempty" flag:"proxy-client-cert-file"`

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1831,7 +1831,9 @@ func autoConvert_v1alpha1_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.KubeletPreferredAddressTypes = in.KubeletPreferredAddressTypes
 	out.StorageBackend = in.StorageBackend
 	out.OIDCUsernameClaim = in.OIDCUsernameClaim
+	out.OIDCUsernamePrefix = in.OIDCUsernamePrefix
 	out.OIDCGroupsClaim = in.OIDCGroupsClaim
+	out.OIDCGroupsPrefix = in.OIDCGroupsPrefix
 	out.OIDCIssuerURL = in.OIDCIssuerURL
 	out.OIDCClientID = in.OIDCClientID
 	out.OIDCCAFile = in.OIDCCAFile
@@ -1890,7 +1892,9 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha1_KubeAPIServerConfig(in *ko
 	out.KubeletPreferredAddressTypes = in.KubeletPreferredAddressTypes
 	out.StorageBackend = in.StorageBackend
 	out.OIDCUsernameClaim = in.OIDCUsernameClaim
+	out.OIDCUsernamePrefix = in.OIDCUsernamePrefix
 	out.OIDCGroupsClaim = in.OIDCGroupsClaim
+	out.OIDCGroupsPrefix = in.OIDCGroupsPrefix
 	out.OIDCIssuerURL = in.OIDCIssuerURL
 	out.OIDCClientID = in.OIDCClientID
 	out.OIDCCAFile = in.OIDCCAFile

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -1920,8 +1920,26 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 			**out = **in
 		}
 	}
+	if in.OIDCUsernamePrefix != nil {
+		in, out := &in.OIDCUsernamePrefix, &out.OIDCUsernamePrefix
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
 	if in.OIDCGroupsClaim != nil {
 		in, out := &in.OIDCGroupsClaim, &out.OIDCGroupsClaim
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
+	if in.OIDCGroupsPrefix != nil {
+		in, out := &in.OIDCGroupsPrefix, &out.OIDCGroupsPrefix
 		if *in == nil {
 			*out = nil
 		} else {

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -225,18 +225,29 @@ type KubeAPIServerConfig struct {
 	KubeletPreferredAddressTypes []string `json:"kubeletPreferredAddressTypes,omitempty" flag:"kubelet-preferred-address-types"`
 	// StorageBackend is the backend storage
 	StorageBackend *string `json:"storageBackend,omitempty" flag:"storage-backend"`
-	// The OpenID claim to use as the user name.
-	// Note that claims other than the default ('sub') is not guaranteed to be unique and immutable.
+	// OIDCUsernameClaim is the OpenID claim to use as the user name.
+	// Note that claims other than the default ('sub') is not guaranteed to be
+	// unique and immutable.
 	OIDCUsernameClaim *string `json:"oidcUsernameClaim,omitempty" flag:"oidc-username-claim"`
-	// If provided, the name of a custom OpenID Connect claim for specifying user groups.
+	// OIDCUsernamePrefix is the prefix prepended to username claims to prevent
+	// clashes with existing names (such as 'system:' users).
+	OIDCUsernamePrefix *string `json:"oidcUsernamePrefix,omitempty" flag:"oidc-username-prefix"`
+	// OIDCGroupsClaim if provided, the name of a custom OpenID Connect claim for
+	// specifying user groups.
 	// The claim value is expected to be a string or array of strings.
 	OIDCGroupsClaim *string `json:"oidcGroupsClaim,omitempty" flag:"oidc-groups-claim"`
-	// The URL of the OpenID issuer, only HTTPS scheme will be accepted.
+	// OIDCGroupsPrefix is the prefix prepended to group claims to prevent
+	// clashes with existing names (such as 'system:' groups)
+	OIDCGroupsPrefix *string `json:"oidcGroupsPrefix,omitempty" flag:"oidc-groups-prefix"`
+	// OIDCIssuerURL is the URL of the OpenID issuer, only HTTPS scheme will
+	// be accepted.
 	// If set, it will be used to verify the OIDC JSON Web Token (JWT).
 	OIDCIssuerURL *string `json:"oidcIssuerURL,omitempty" flag:"oidc-issuer-url"`
-	// The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
+	// OIDCClientID is the client ID for the OpenID Connect client, must be set
+	// if oidc-issuer-url is set.
 	OIDCClientID *string `json:"oidcClientID,omitempty" flag:"oidc-client-id"`
-	// If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file
+	// OIDCCAFile if set, the OpenID server's certificate will be verified by one
+	// of the authorities in the oidc-ca-file
 	OIDCCAFile *string `json:"oidcCAFile,omitempty" flag:"oidc-ca-file"`
 	// The apiserver's client certificate used for outbound requests.
 	ProxyClientCertFile *string `json:"proxyClientCertFile,omitempty" flag:"proxy-client-cert-file"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2093,7 +2093,9 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.KubeletPreferredAddressTypes = in.KubeletPreferredAddressTypes
 	out.StorageBackend = in.StorageBackend
 	out.OIDCUsernameClaim = in.OIDCUsernameClaim
+	out.OIDCUsernamePrefix = in.OIDCUsernamePrefix
 	out.OIDCGroupsClaim = in.OIDCGroupsClaim
+	out.OIDCGroupsPrefix = in.OIDCGroupsPrefix
 	out.OIDCIssuerURL = in.OIDCIssuerURL
 	out.OIDCClientID = in.OIDCClientID
 	out.OIDCCAFile = in.OIDCCAFile
@@ -2152,7 +2154,9 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.KubeletPreferredAddressTypes = in.KubeletPreferredAddressTypes
 	out.StorageBackend = in.StorageBackend
 	out.OIDCUsernameClaim = in.OIDCUsernameClaim
+	out.OIDCUsernamePrefix = in.OIDCUsernamePrefix
 	out.OIDCGroupsClaim = in.OIDCGroupsClaim
+	out.OIDCGroupsPrefix = in.OIDCGroupsPrefix
 	out.OIDCIssuerURL = in.OIDCIssuerURL
 	out.OIDCClientID = in.OIDCClientID
 	out.OIDCCAFile = in.OIDCCAFile

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2046,8 +2046,26 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 			**out = **in
 		}
 	}
+	if in.OIDCUsernamePrefix != nil {
+		in, out := &in.OIDCUsernamePrefix, &out.OIDCUsernamePrefix
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
 	if in.OIDCGroupsClaim != nil {
 		in, out := &in.OIDCGroupsClaim, &out.OIDCGroupsClaim
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
+	if in.OIDCGroupsPrefix != nil {
+		in, out := &in.OIDCGroupsPrefix, &out.OIDCGroupsPrefix
 		if *in == nil {
 			*out = nil
 		} else {

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2265,8 +2265,26 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 			**out = **in
 		}
 	}
+	if in.OIDCUsernamePrefix != nil {
+		in, out := &in.OIDCUsernamePrefix, &out.OIDCUsernamePrefix
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
 	if in.OIDCGroupsClaim != nil {
 		in, out := &in.OIDCGroupsClaim, &out.OIDCGroupsClaim
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
+	if in.OIDCGroupsPrefix != nil {
+		in, out := &in.OIDCGroupsPrefix, &out.OIDCGroupsPrefix
 		if *in == nil {
 			*out = nil
 		} else {


### PR DESCRIPTION
### What
Added support for `--oidc-username-prefix` and `--oidc-groups-prefix`.
By passing these it's possible to override the default prefixes used to map the OIDC user with the username in kubernetes.

### See
See: https://kubernetes.io/docs/admin/authentication/#configuring-the-api-server

### IMPORTANT
I'm far from a kubernetes/KOPS, this is not tested so someone needs to have a look and see if something is missing or if this can cause troubles! (don't want to accidentally cause the destruction of the universe 💥 )

It's basically the same done in this other PR: https://github.com/kubernetes/kops/pull/1438/files

I did **not** change the `zz_generated.conversion.go` files as according to comment at the top of them they're autogenerated:
```go
// This file was autogenerated by conversion-gen. Do not edit it manually!
```
(I wonder if they should be `.gitignore`d)

### Fixes
This should fix [#4007: field oidcUsernamePrefix is not recognized in cluster configuration file](https://github.com/kubernetes/kops/issues/4007)