### PR TITLE
Adds permissions for ELB and NLB req'd by 1.9

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -599,6 +599,7 @@ func addMasterELBPolicies(p *Policy, resource stringorslice.StringOrSlice, legac
 			Sid:    "kopsK8sELBMasterPermsRestrictive",
 			Effect: StatementEffectAllow,
 			Action: stringorslice.Of(
+				"elasticloadbalancing:AddTags",                                 // aws_loadbalancer.go
 				"elasticloadbalancing:AttachLoadBalancerToSubnets",             // aws_loadbalancer.go
 				"elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",       // aws_loadbalancer.go
 				"elasticloadbalancing:CreateLoadBalancer",                      // aws_loadbalancer.go
@@ -622,15 +623,20 @@ func addMasterELBPolicies(p *Policy, resource stringorslice.StringOrSlice, legac
 			Sid:    "kopsK8sNLBMasterPermsRestrictive",
 			Effect: StatementEffectAllow,
 			Action: stringorslice.Of(
-				"elasticloadbalancing:CreateListener",       // aws_loadbalancer.go
-				"elasticloadbalancing:DescribeListeners",    // aws_loadbalancer.go
-				"elasticloadbalancing:CreateTargetGroup",    // aws_loadbalancer.go
-				"elasticloadbalancing:DescribeTargetGroups", // aws_loadbalancer.go
-				"elasticloadbalancing:RegisterTargets",      // aws_loadbalancer.go
-				"elasticloadbalancing:DescribeTargetHealth", // aws_loadbalancer.go
-				"elasticloadbalancing:AddTags",              // aws_loadbalancer.go
-				"elasticloadbalancing:ModifyTargetGroup",    // aws_loadbalancer.go
-				"ec2:DescribeVpcs",                          // aws_loadbalancer.go
+				"ec2:DescribeVpcs",                                       // aws_loadbalancer.go
+				"elasticloadbalancing:AddTags",                           // aws_loadbalancer.go
+				"elasticloadbalancing:CreateListener",                    // aws_loadbalancer.go
+				"elasticloadbalancing:CreateTargetGroup",                 // aws_loadbalancer.go
+				"elasticloadbalancing:DeleteListener",                    // aws_loadbalancer.go
+				"elasticloadbalancing:DeleteTargetGroup",                 // aws_loadbalancer.go
+				"elasticloadbalancing:DescribeListeners",                 // aws_loadbalancer.go
+				"elasticloadbalancing:DescribeLoadBalancerPolicies",      // aws_loadbalancer.go
+				"elasticloadbalancing:DescribeTargetGroups",              // aws_loadbalancer.go
+				"elasticloadbalancing:DescribeTargetHealth",              // aws_loadbalancer.go
+				"elasticloadbalancing:ModifyListener",                    // aws_loadbalancer.go
+				"elasticloadbalancing:ModifyTargetGroup",                 // aws_loadbalancer.go
+				"elasticloadbalancing:RegisterTargets",                   // aws_loadbalancer.go
+				"elasticloadbalancing:SetLoadBalancerPoliciesOfListener", // aws_loadbalancer.go
 			),
 			Resource: resource,
 		})

--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -84,6 +84,7 @@
       "Sid": "kopsK8sELBMasterPermsRestrictive",
       "Effect": "Allow",
       "Action": [
+        "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
         "elasticloadbalancing:CreateLoadBalancer",
@@ -108,15 +109,20 @@
       "Sid": "kopsK8sNLBMasterPermsRestrictive",
       "Effect": "Allow",
       "Action": [
-        "elasticloadbalancing:CreateListener",
-        "elasticloadbalancing:DescribeListeners",
-        "elasticloadbalancing:CreateTargetGroup",
-        "elasticloadbalancing:DescribeTargetGroups",
-        "elasticloadbalancing:RegisterTargets",
-        "elasticloadbalancing:DescribeTargetHealth",
+        "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:CreateTargetGroup",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:DeleteTargetGroup",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeLoadBalancerPolicies",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:ModifyListener",
         "elasticloadbalancing:ModifyTargetGroup",
-        "ec2:DescribeVpcs"
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
       "Resource": [
         "*"

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -1,4 +1,4 @@
-{
+  {
   "Version": "2012-10-17",
   "Statement": [
     {
@@ -84,6 +84,7 @@
       "Sid": "kopsK8sELBMasterPermsRestrictive",
       "Effect": "Allow",
       "Action": [
+        "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
         "elasticloadbalancing:CreateLoadBalancer",
@@ -108,15 +109,20 @@
       "Sid": "kopsK8sNLBMasterPermsRestrictive",
       "Effect": "Allow",
       "Action": [
-        "elasticloadbalancing:CreateListener",
-        "elasticloadbalancing:DescribeListeners",
-        "elasticloadbalancing:CreateTargetGroup",
-        "elasticloadbalancing:DescribeTargetGroups",
-        "elasticloadbalancing:RegisterTargets",
-        "elasticloadbalancing:DescribeTargetHealth",
+        "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:CreateTargetGroup",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:DeleteTargetGroup",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeLoadBalancerPolicies",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:ModifyListener",
         "elasticloadbalancing:ModifyTargetGroup",
-        "ec2:DescribeVpcs"
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
       "Resource": [
         "*"


### PR DESCRIPTION
Adds appropriate IAM permissions to Masters (in restrictive mode) for ELB and NLB.

Closes https://github.com/kubernetes/kops/issues/3883
