### PR TITLE
[WIP] CNI update for k8s 1.9

### DIFF
--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -181,36 +181,6 @@ func (a *AssetBuilder) RemapFileAndSHA(fileURL *url.URL) (*url.URL, *hashing.Has
 	return fileAsset.FileURL, h, nil
 }
 
-// TODO - remove this method as CNI does now have a SHA file
-
-// RemapFileAndSHAValue is used exclusively to remap the cni tarball, as the tarball does not have a sha file in object storage.
-func (a *AssetBuilder) RemapFileAndSHAValue(fileURL *url.URL, shaValue string) (*url.URL, error) {
-	if fileURL == nil {
-		return nil, fmt.Errorf("unable to remap a nil URL")
-	}
-
-	fileAsset := &FileAsset{
-		FileURL:  fileURL,
-		SHAValue: shaValue,
-	}
-
-	if a.AssetsLocation != nil && a.AssetsLocation.FileRepository != nil {
-		fileAsset.CanonicalFileURL = fileURL
-
-		normalizedFile, err := a.normalizeURL(fileURL)
-		if err != nil {
-			return nil, err
-		}
-
-		fileAsset.FileURL = normalizedFile
-		glog.V(4).Infof("adding remapped file: %q", fileAsset.FileURL.String())
-	}
-
-	a.FileAssets = append(a.FileAssets, fileAsset)
-
-	return fileAsset.FileURL, nil
-}
-
 // FindHash returns the hash value of a FileAsset.
 func (a *AssetBuilder) findHash(file *FileAsset) (*hashing.Hash, error) {
 

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1007,12 +1007,12 @@ func (c *ApplyClusterCmd) addFileAssets(assetBuilder *assets.AssetBuilder) error
 	}
 
 	if usesCNI(c.Cluster) {
-		cniAsset, cniAssetHashString, err := findCNIAssets(c.Cluster, assetBuilder)
+		cniAsset, cniAssetHashString, err := CNISource(assetBuilder, c.Cluster.Spec.KubernetesVersion)
 		if err != nil {
 			return err
 		}
 
-		c.Assets = append(c.Assets, cniAssetHashString+"@"+cniAsset.String())
+		c.Assets = append(c.Assets, cniAssetHashString.String()+"@"+cniAsset.String())
 	}
 
 	// TODO figure out if we can only do this for CoreOS only and GCE Container OS

--- a/upup/pkg/fi/cloudup/networking.go
+++ b/upup/pkg/fi/cloudup/networking.go
@@ -17,15 +17,8 @@ limitations under the License.
 package cloudup
 
 import (
-	"fmt"
-	"net/url"
-	"os"
-
-	"github.com/blang/semver"
 	"github.com/golang/glog"
 	api "k8s.io/kops/pkg/apis/kops"
-	"k8s.io/kops/pkg/apis/kops/util"
-	"k8s.io/kops/pkg/assets"
 )
 
 func usesCNI(c *api.Cluster) bool {
@@ -93,65 +86,4 @@ func usesCNI(c *api.Cluster) bool {
 	// Assume other modes also use CNI
 	glog.Warningf("Unknown networking mode configured")
 	return true
-}
-
-// TODO: we really need to sort this out:
-// https://github.com/kubernetes/kops/issues/724
-// https://github.com/kubernetes/kops/issues/626
-// https://github.com/kubernetes/kubernetes/issues/30338
-
-const (
-	// 1.5.x k8s uses release 07a8a28637e97b22eb8dfe710eeae1344f69d16e
-	defaultCNIAssetK8s1_5           = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz"
-	defaultCNIAssetHashStringK8s1_5 = "19d49f7b2b99cd2493d5ae0ace896c64e289ccbb"
-
-	// 1.6.x k8s uses release 0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff
-	defaultCNIAssetK8s1_6           = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz"
-	defaultCNIAssetHashStringK8s1_6 = "1d9788b0f5420e1a219aad2cb8681823fc515e7c"
-
-	// Environment variable for overriding CNI url
-	ENV_VAR_CNI_VERSION_URL = "CNI_VERSION_URL"
-)
-
-func findCNIAssets(c *api.Cluster, assetBuilder *assets.AssetBuilder) (*url.URL, string, error) {
-
-	if cniVersionURL := os.Getenv(ENV_VAR_CNI_VERSION_URL); cniVersionURL != "" {
-		u, err := url.Parse(cniVersionURL)
-		if err != nil {
-			return nil, "", fmt.Errorf("unable to parse %q as a URL: %v", cniVersionURL, err)
-		}
-		glog.Infof("Using CNI asset version %q, as set in %s", cniVersionURL, ENV_VAR_CNI_VERSION_URL)
-		return u, "", nil
-	}
-
-	sv, err := util.ParseKubernetesVersion(c.Spec.KubernetesVersion)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to lookup kubernetes version: %v", err)
-	}
-
-	sv.Pre = nil
-	sv.Build = nil
-
-	var cniAsset, cniAssetHash string
-	if sv.GTE(semver.Version{Major: 1, Minor: 6, Patch: 0, Pre: nil, Build: nil}) {
-		cniAsset = defaultCNIAssetK8s1_6
-		cniAssetHash = defaultCNIAssetHashStringK8s1_6
-		glog.V(2).Infof("Adding default CNI asset for k8s 1.6.x and higher: %s", defaultCNIAssetK8s1_6)
-	} else {
-		cniAsset = defaultCNIAssetK8s1_5
-		cniAssetHash = defaultCNIAssetHashStringK8s1_5
-		glog.V(2).Infof("Adding default CNI asset for k8s 1.5: %s", defaultCNIAssetK8s1_5)
-	}
-
-	u, err := url.Parse(cniAsset)
-	if err != nil {
-		return nil, "", nil
-	}
-
-	u, err = assetBuilder.RemapFileAndSHAValue(u, cniAssetHash)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return u, cniAssetHash, nil
 }

--- a/upup/pkg/fi/cloudup/urls.go
+++ b/upup/pkg/fi/cloudup/urls.go
@@ -66,7 +66,7 @@ const (
 	defaultCNIAssetK8s1_6 = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz"
 
 	// defaultCNIAssetK8s1_9 is the CNI tarball for for 1.9.x k8s.
-	defaultCNIAssetK8s1_9 = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-201d934018af9097d6719d70688dabd578ee2b2e.tar.gz"
+	defaultCNIAssetK8s1_9 = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz"
 )
 
 // BaseUrl returns the base url for the distribution of kops - in particular for nodeup & docker images
@@ -207,12 +207,12 @@ func CNISource(assetsBuilder *assets.AssetBuilder, kubernetesVersion string) (*u
 		sv.Build = nil
 
 		var cniAsset string
-		if sv.GTE(semver.Version{Major: 1, Minor: 6, Patch: 0, Pre: nil, Build: nil}) {
-			cniAsset = defaultCNIAssetK8s1_6
-			glog.V(2).Infof("Adding default CNI asset for k8s 1.6.x and higher: %s", defaultCNIAssetK8s1_6)
-		} else if sv.GTE(semver.Version{Major: 1, Minor: 9, Patch: 0, Pre: nil, Build: nil}) {
+		if sv.GTE(semver.Version{Major: 1, Minor: 9, Patch: 0, Pre: nil, Build: nil}) {
 			cniAsset = defaultCNIAssetK8s1_9
 			glog.V(2).Infof("Adding default CNI asset for k8s 1.9.x and higher: %s", defaultCNIAssetK8s1_9)
+		} else if sv.GTE(semver.Version{Major: 1, Minor: 6, Patch: 0, Pre: nil, Build: nil}) {
+			cniAsset = defaultCNIAssetK8s1_6
+			glog.V(2).Infof("Adding default CNI asset for k8s 1.6.x and higher: %s", defaultCNIAssetK8s1_6)
 		} else {
 			cniAsset = defaultCNIAssetK8s1_5
 			glog.V(2).Infof("Adding default CNI asset for k8s 1.5: %s", defaultCNIAssetK8s1_5)

--- a/upup/pkg/fi/cloudup/urls.go
+++ b/upup/pkg/fi/cloudup/urls.go
@@ -190,7 +190,7 @@ func ProtokubeImageSource(assetsBuilder *assets.AssetBuilder) (*url.URL, *hashin
 	return protokubeLocation, protokubeHash, nil
 }
 
-// CNISource returns the source for the cni tarball.
+// CNISource returns the URL and hash for the cni tarball.
 func CNISource(assetsBuilder *assets.AssetBuilder, kubernetesVersion string) (*url.URL, *hashing.Hash, error) {
 	// Avoid repeated logging
 	if cniLocation != nil && cniHash != nil {
@@ -218,7 +218,11 @@ func CNISource(assetsBuilder *assets.AssetBuilder, kubernetesVersion string) (*u
 			glog.V(2).Infof("Adding default CNI asset for k8s 1.5: %s", defaultCNIAssetK8s1_5)
 		}
 
-		cniLocation, cniHash, err = KopsFileUrl(cniAsset, assetsBuilder)
+		u, err := url.Parse(cniAsset)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to parse CNI asset URL: %q", cniAsset)
+		}
+		cniLocation, cniHash, err = assetsBuilder.RemapFileAndSHA(u)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -226,7 +230,7 @@ func CNISource(assetsBuilder *assets.AssetBuilder, kubernetesVersion string) (*u
 	} else {
 		cniLocation, err := url.Parse(env)
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to parse env var PROTOKUBE_IMAGE %q as an url: %v", env, err)
+			return nil, nil, fmt.Errorf("unable to parse env var CNI_VERSION_URL %q as an url: %v", env, err)
 		}
 
 		cniLocation, cniHash, err = assetsBuilder.RemapFileAndSHA(cniLocation)

--- a/upup/pkg/fi/cloudup/urls_test.go
+++ b/upup/pkg/fi/cloudup/urls_test.go
@@ -17,35 +17,10 @@ limitations under the License.
 package cloudup
 
 import (
-	"os"
 	"testing"
 
 	"k8s.io/kops/pkg/assets"
 )
-
-func Test_FindCNIAssetFromEnvironmentVariable(t *testing.T) {
-
-	desiredCNIVersion := "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-TEST-VERSION.tar.gz"
-	os.Setenv("CNI_VERSION_URL", desiredCNIVersion)
-	defer func() {
-		os.Unsetenv("CNI_VERSION_URL")
-	}()
-
-	assetBuilder := assets.NewAssetBuilder(nil, "")
-	cniAsset, cniAssetHashString, err := CNISource(assetBuilder, "")
-
-	if err != nil {
-		t.Errorf("Unable to parse k8s version %s", err)
-	}
-
-	if cniAsset.String() != desiredCNIVersion {
-		t.Errorf("Expected CNI version from Environment variable %q, but got %q instead", desiredCNIVersion, cniAsset)
-	}
-
-	if cniAssetHashString.String() != "" {
-		t.Errorf("Expected Empty CNI Version Hash String, but got %q instead", cniAssetHashString)
-	}
-}
 
 func Test_FindCNIAssetDefaultValue1_6(t *testing.T) {
 
@@ -54,6 +29,10 @@ func Test_FindCNIAssetDefaultValue1_6(t *testing.T) {
 
 	if err != nil {
 		t.Errorf("Unable to parse k8s version %s", err)
+	}
+
+	if cniAsset == nil {
+		t.Errorf("unable to find cni asset")
 	}
 
 	if cniAsset.String() != defaultCNIAssetK8s1_6 {
@@ -69,6 +48,9 @@ func Test_FindCNIAssetDefaultValue1_9(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unable to parse k8s version %s", err)
 	}
+	if cniAsset == nil {
+		t.Errorf("unable to find cni asset")
+	}
 
 	if cniAsset.String() != defaultCNIAssetK8s1_9 {
 		t.Errorf("Expected default CNI version %q and got %q", defaultCNIAssetK8s1_9, cniAsset)
@@ -83,6 +65,10 @@ func Test_FindCNIAssetDefaultValue1_5(t *testing.T) {
 
 	if err != nil {
 		t.Errorf("Unable to parse k8s version %s", err)
+	}
+
+	if cniAsset == nil {
+		t.Errorf("unable to find cni asset")
 	}
 
 	if cniAsset.String() != defaultCNIAssetK8s1_5 {


### PR DESCRIPTION
This PR refactors cni to use remote SHA1 files, and add CNI 0.6.0 for k8s 1.9.

This PR is dependent on the proper staging of the previous CNI tarballs and SHA1 files see https://github.com/kubernetes/kubernetes/pull/51250 since they are not updated properly yet.

Most of these commits should drop out after a couple of merges.