### PR TITLE
kops validate cluster can output YAML or JSON

### DIFF
--- a/docs/cli/kops_validate_cluster.md
+++ b/docs/cli/kops_validate_cluster.md
@@ -28,6 +28,12 @@ kops validate cluster
   kops validate cluster
 ```
 
+### Options
+
+```
+  -o, --output string   Ouput format. One of json|yaml|table. (default "table")
+```
+
 ### Options inherited from parent commands
 
 ```

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/kops/pkg/apis/kops/util"
 )
 
-// A cluster to validate
+// ValidationCluster a cluster to validate.
 type ValidationCluster struct {
 	MastersReady         bool              `json:"mastersReady,omitempty"`
 	MastersReadyArray    []*ValidationNode `json:"mastersReadyArray,omitempty"`
@@ -45,11 +45,15 @@ type ValidationCluster struct {
 
 	NodeList *v1.NodeList `json:"nodeList,omitempty"`
 
-	ComponentFailures []string `json:"componentFailures,omitempty"`
-	PodFailures       []string `json:"podFailures,omitempty"`
+	ComponentFailures []string              `json:"componentFailures,omitempty"`
+	PodFailures       []string              `json:"podFailures,omitempty"`
+	ErrorMessage      string                `json:"errorMessage,omitempty"`
+	Status            string                `json:"status"`
+	ClusterName       string                `json:"clusterName"`
+	InstanceGroups    []*kops.InstanceGroup `json:"instanceGroups,omitempty"`
 }
 
-// A K8s node to be validated
+// ValidationNode is A K8s node to be validated.
 type ValidationNode struct {
 	Zone     string             `json:"zone,omitempty"`
 	Role     string             `json:"role,omitempty"`
@@ -57,7 +61,12 @@ type ValidationNode struct {
 	Status   v1.ConditionStatus `json:"status,omitempty"`
 }
 
-// HasPlaceHolderIP checks if the API DNS has been updated
+const (
+	ClusterValidationFailed = "FAILED"
+	ClusterValidationPassed = "PASSED"
+)
+
+// HasPlaceHolderIP checks if the API DNS has been updated.
 func HasPlaceHolderIP(clusterName string) (bool, error) {
 
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
@@ -86,7 +95,6 @@ func HasPlaceHolderIP(clusterName string) (bool, error) {
 // ValidateCluster validate a k8s cluster with a provided instance group list
 func ValidateCluster(clusterName string, instanceGroupList *kops.InstanceGroupList, clusterKubernetesClient kubernetes.Interface) (*ValidationCluster, error) {
 	var instanceGroups []*kops.InstanceGroup
-	validationCluster := &ValidationCluster{}
 
 	for i := range instanceGroupList.Items {
 		ig := &instanceGroupList.Items[i]
@@ -94,7 +102,7 @@ func ValidateCluster(clusterName string, instanceGroupList *kops.InstanceGroupLi
 	}
 
 	if len(instanceGroups) == 0 {
-		return validationCluster, fmt.Errorf("no InstanceGroup objects found")
+		return nil, fmt.Errorf("no InstanceGroup objects found")
 	}
 
 	timeout, err := time.ParseDuration("10s")
@@ -105,6 +113,12 @@ func ValidateCluster(clusterName string, instanceGroupList *kops.InstanceGroupLi
 	nodeAA, err := NewNodeAPIAdapter(clusterKubernetesClient, timeout)
 	if err != nil {
 		return nil, fmt.Errorf("error building node adapter for %q: %v", clusterName, err)
+	}
+
+	validationCluster := &ValidationCluster{
+		ClusterName:    clusterName,
+		ErrorMessage:   ClusterValidationPassed,
+		InstanceGroups: instanceGroups,
 	}
 
 	validationCluster.NodeList, err = nodeAA.GetAllNodes()
@@ -161,7 +175,7 @@ func validateTheNodes(clusterName string, validationCluster *ValidationCluster) 
 	nodes := validationCluster.NodeList
 
 	if nodes == nil || len(nodes.Items) == 0 {
-		return validationCluster, fmt.Errorf("No nodes found in validationCluster")
+		return nil, fmt.Errorf("No nodes found in validationCluster")
 	}
 	// Needed for when NodesCount and MastersCounts are predefined, i.e tests
 	presetNodeCount := validationCluster.NodesCount == 0
@@ -217,19 +231,27 @@ func validateTheNodes(clusterName string, validationCluster *ValidationCluster) 
 	}
 
 	if !validationCluster.MastersReady {
-		return validationCluster, fmt.Errorf("your masters are NOT ready %s", clusterName)
+		validationCluster.Status = ClusterValidationFailed
+		validationCluster.ErrorMessage = fmt.Sprintf("your masters are NOT ready %s", clusterName)
+		return validationCluster, fmt.Errorf(validationCluster.ErrorMessage)
 	}
 
 	if !validationCluster.NodesReady {
-		return validationCluster, fmt.Errorf("your nodes are NOT ready %s", clusterName)
+		validationCluster.Status = ClusterValidationFailed
+		validationCluster.ErrorMessage = fmt.Sprintf("your nodes are NOT ready %s", clusterName)
+		return validationCluster, fmt.Errorf(validationCluster.ErrorMessage)
 	}
 
 	if len(validationCluster.ComponentFailures) != 0 {
-		return validationCluster, fmt.Errorf("your components are NOT healthy %s", clusterName)
+		validationCluster.Status = ClusterValidationFailed
+		validationCluster.ErrorMessage = fmt.Sprintf("your components are NOT healthy %s", clusterName)
+		return validationCluster, fmt.Errorf(validationCluster.ErrorMessage)
 	}
 
 	if len(validationCluster.PodFailures) != 0 {
-		return validationCluster, fmt.Errorf("your kube-system pods are NOT healthy %s", clusterName)
+		validationCluster.Status = ClusterValidationFailed
+		validationCluster.ErrorMessage = fmt.Sprintf("your kube-system pods are NOT healthy %s", clusterName)
+		return validationCluster, fmt.Errorf(validationCluster.ErrorMessage)
 	}
 
 	return validationCluster, nil


### PR DESCRIPTION
Adding the capability for kops validate cluster command to output YAML or JSON.
The validate.ValidationCluster struct is used as body of the JSON or
YAML document.

Outputting the list of the node API objects is a bunch of data, but we already have it, and I think
it is useful.  It is the same data as `kubectl get no -oyaml`.  That is the only question I have on this PR if we output that data.

Closes https://github.com/kubernetes/kops/issues/3539

### TODO

- [x] more testing
- [x] code comments
- [x] update cobra docs #

/assign @robinpercy @robertojrojas 

If I can get a PR review that would be awesome.