### PR TITLE
Fix null pointer issues when custom PROTOKUBE_IMAGE is specified.

### DIFF
--- a/upup/pkg/fi/cloudup/urls.go
+++ b/upup/pkg/fi/cloudup/urls.go
@@ -156,11 +156,11 @@ func ProtokubeImageSource(assetsBuilder *assets.AssetBuilder) (*url.URL, *hashin
 			return nil, nil, fmt.Errorf("unable to parse env var PROTOKUBE_IMAGE %q as an url: %v", env, err)
 		}
 
-		protokubeImageSource, protokubeHash, err = assetsBuilder.RemapFileAndSHA(protokubeImageSource)
+		protokubeLocation, protokubeHash, err = assetsBuilder.RemapFileAndSHA(protokubeImageSource)
 		if err != nil {
 			return nil, nil, err
 		}
-		glog.Warningf("Using protokube location from PROTOKUBE_IMAGE env var: %q", protokubeImageSource)
+		glog.Warningf("Using protokube location from PROTOKUBE_IMAGE env var: %q", protokubeLocation)
 	}
 
 	return protokubeLocation, protokubeHash, nil


### PR DESCRIPTION
When setting a custom protokube location via the environment variable `PROTOKUBE_IMAGE`, this appeared to not be getting set properly at the time of applying Cluster updates (via `kops update cluster ${KOPS_CLUSTER_NAME} --yes`), resulting in a runtime exception.

This PR resolves the above issue, so cluster updates are correctly applied with reference to a custom protokube image location (if provided).