### PR TITLE
Moved paragraph relating to runtimeConfig

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -174,6 +174,8 @@ spec:
       apps/v1alpha1: "true"
 ```
 
+Will result in the flag `--runtime-config=batch/v2alpha1=true,apps/v1alpha1=true`. Note that `kube-apiserver` accepts `true` as a value for switch-like flags.
+
 #### serviceNodePortRange
 
 This value is passed as `--service-node-port-range` for `kube-apiserver`.
@@ -183,8 +185,6 @@ spec:
   kubeAPIServer:
     serviceNodePortRange: 30000-33000
 ```
-
-Will result in the flag `--runtime-config=batch/v2alpha1=true,apps/v1alpha1=true`. Note that `kube-apiserver` accepts `true` as a value for switch-like flags.
 
 ### externalDns
 


### PR DESCRIPTION
This paragraph makes more sense under the runtimeConfig section than under the serviceNodePortRange section