### PR TITLE
Fix documentation of shared resource tags in kops > 1.8

### DIFF
--- a/docs/run_in_existing_vpc.md
+++ b/docs/run_in_existing_vpc.md
@@ -148,15 +148,21 @@ After you upgraded to kops 1.8 remove KubernetesCluster Tag from Subnets as it i
 These are currently needed Tags on shared resources:
 
 Public Subnets:
+```
 - "kubernetes.io/cluster/<cluster-name>" = "shared"
 - "kubernetes.io/role/elb" = "1"
+```
 
 Private Subnets:
+```
 - "kubernetes.io/cluster/<cluster-name>" = "shared"
 - "kubernetes.io/role/internal-elb"         = "1"
+```
 
 VPC:
+```
 - "kubernetes.io/cluster/<cluster-name>" = "shared"
+```
 
 
 ### Shared NAT Gateways

--- a/docs/run_in_existing_vpc.md
+++ b/docs/run_in_existing_vpc.md
@@ -140,7 +140,24 @@ Once you're happy, you can create the cluster using:
 kops update cluster ${CLUSTER_NAME} --yes
 ```
 
-If you run in AWS private topology with shared subnets, and you would like Kubernetes to provision resources in these shared subnets, you must create tags on them with Key=value `KubernetesCluster=<clustername>`. This is important, for example, if your `utility` subnets are shared, you will not be able to launch any services that create Elastic Load Balancers (ELBs).
+If you run in AWS private topology with shared subnets, and you would like Kubernetes to provision resources in these shared subnets, you must create tags on them.
+This is important, for example, if your `utility` subnets are shared, you will not be able to launch any services that create Elastic Load Balancers (ELBs).
+Prior to kops 1.8 KubernetesCluster tag was used for this. This lead to several problems if there were more than one Kubernetes Cluster in a subnet.
+After you upgraded to kops 1.8 remove KubernetesCluster Tag from Subnets as it is prioritized against "kubernetes.io/cluster/<clustername>"
+
+These are currently needed Tags on shared resources:
+
+Public Subnets:
+- "kubernetes.io/cluster/<cluster-name>" = "shared"
+- "kubernetes.io/role/elb" = "1"
+
+Private Subnets:
+- "kubernetes.io/cluster/<cluster-name>" = "shared"
+- "kubernetes.io/role/internal-elb"         = "1"
+
+VPC:
+- "kubernetes.io/cluster/<cluster-name>" = "shared"
+
 
 ### Shared NAT Gateways
 

--- a/docs/run_in_existing_vpc.md
+++ b/docs/run_in_existing_vpc.md
@@ -57,11 +57,14 @@ Once you're happy, you can create the cluster using:
 kops update cluster ${CLUSTER_NAME} --yes
 ```
 
+This will add an additional Tag to your aws vpc resource. This tag
+will be removed automatically if you delete your kops cluster.
+```
+- "kubernetes.io/cluster/<cluster-name>" = "shared"
+```
 
-Finally, if your shared VPC has a KubernetesCluster tag (because it was created with kops), you should
-probably remove that tag to indicate that the resources are not owned by that cluster, and so
-deleting the cluster won't try to delete the VPC.  (Deleting the VPC won't succeed anyway, because it's in use,
-but it's better to avoid the later confusion!)
+Prior to kops 1.8 this Tag Key was KubernetesCluster which is obsolete and should
+not be used anymore as it only supports one cluster.
 
 
 ### VPC with multiple CIDRs
@@ -157,11 +160,6 @@ Private Subnets:
 ```
 - "kubernetes.io/cluster/<cluster-name>" = "shared"
 - "kubernetes.io/role/internal-elb"         = "1"
-```
-
-VPC:
-```
-- "kubernetes.io/cluster/<cluster-name>" = "shared"
 ```
 
 

--- a/docs/run_in_existing_vpc.md
+++ b/docs/run_in_existing_vpc.md
@@ -146,20 +146,20 @@ kops update cluster ${CLUSTER_NAME} --yes
 If you run in AWS private topology with shared subnets, and you would like Kubernetes to provision resources in these shared subnets, you must create tags on them.
 This is important, for example, if your `utility` subnets are shared, you will not be able to launch any services that create Elastic Load Balancers (ELBs).
 Prior to kops 1.8 `KubernetesCluster` tag was used for this. This lead to several problems if there were more than one Kubernetes Cluster in a subnet.
-After you upgraded to kops 1.8 remove `KubernetesCluster` Tag from Subnets as it is prioritized against `kubernetes.io/cluster/<clustername>`.
+After you upgraded to kops 1.8 remove `KubernetesCluster` Tag from subnets otherwise `kubernetes.io/cluster/<clustername>` won't have any effect!
 
 These are currently needed Tags on shared resources:
 
 Public Subnets:
 ```
 - "kubernetes.io/cluster/<cluster-name>" = "shared"
-- "kubernetes.io/role/elb" = "1"
+- "kubernetes.io/role/elb"               = "1"
 ```
 
 Private Subnets:
 ```
 - "kubernetes.io/cluster/<cluster-name>" = "shared"
-- "kubernetes.io/role/internal-elb"         = "1"
+- "kubernetes.io/role/internal-elb"      = "1"
 ```
 
 

--- a/docs/run_in_existing_vpc.md
+++ b/docs/run_in_existing_vpc.md
@@ -60,7 +60,7 @@ kops update cluster ${CLUSTER_NAME} --yes
 This will add an additional Tag to your aws vpc resource. This tag
 will be removed automatically if you delete your kops cluster.
 ```
-- "kubernetes.io/cluster/<cluster-name>" = "shared"
+"kubernetes.io/cluster/<cluster-name>" = "shared"
 ```
 
 Prior to kops 1.8 this Tag Key was `KubernetesCluster` which is obsolete and should
@@ -152,14 +152,14 @@ These are currently needed Tags on shared resources:
 
 Public Subnets:
 ```
-- "kubernetes.io/cluster/<cluster-name>" = "shared"
-- "kubernetes.io/role/elb"               = "1"
+"kubernetes.io/cluster/<cluster-name>" = "shared"
+"kubernetes.io/role/elb"               = "1"
 ```
 
 Private Subnets:
 ```
-- "kubernetes.io/cluster/<cluster-name>" = "shared"
-- "kubernetes.io/role/internal-elb"      = "1"
+"kubernetes.io/cluster/<cluster-name>" = "shared"
+"kubernetes.io/role/internal-elb"      = "1"
 ```
 
 

--- a/docs/run_in_existing_vpc.md
+++ b/docs/run_in_existing_vpc.md
@@ -63,7 +63,7 @@ will be removed automatically if you delete your kops cluster.
 - "kubernetes.io/cluster/<cluster-name>" = "shared"
 ```
 
-Prior to kops 1.8 this Tag Key was KubernetesCluster which is obsolete and should
+Prior to kops 1.8 this Tag Key was `KubernetesCluster` which is obsolete and should
 not be used anymore as it only supports one cluster.
 
 
@@ -145,8 +145,8 @@ kops update cluster ${CLUSTER_NAME} --yes
 
 If you run in AWS private topology with shared subnets, and you would like Kubernetes to provision resources in these shared subnets, you must create tags on them.
 This is important, for example, if your `utility` subnets are shared, you will not be able to launch any services that create Elastic Load Balancers (ELBs).
-Prior to kops 1.8 KubernetesCluster tag was used for this. This lead to several problems if there were more than one Kubernetes Cluster in a subnet.
-After you upgraded to kops 1.8 remove KubernetesCluster Tag from Subnets as it is prioritized against "kubernetes.io/cluster/<clustername>"
+Prior to kops 1.8 `KubernetesCluster` tag was used for this. This lead to several problems if there were more than one Kubernetes Cluster in a subnet.
+After you upgraded to kops 1.8 remove `KubernetesCluster` Tag from Subnets as it is prioritized against `kubernetes.io/cluster/<clustername>`.
 
 These are currently needed Tags on shared resources:
 


### PR DESCRIPTION
Hi,

this should fix the following issue:

Ref: https://github.com/kubernetes/kops/issues/4093

Greetings, Thomas