### PR TITLE
Remove labels.yaml

### DIFF
--- a/labels.yaml
+++ b/labels.yaml
@@ -1,5 +1,0 @@
-labels:
-  - name: approved
-    color: 0FFA16
-  - name: lgtm
-    color: 0E8A16


### PR DESCRIPTION
Instead of using the mungegithub check-labels munger, we now use a [cron job](https://git.k8s.io/test-infra/label_sync/cluster/label_sync_cron_job.yaml) that pulls from https://git.k8s.io/test-infra/label_sync/labels.yaml instead of a labels.yaml file
at repo root