### PR TITLE
Adding override capability to set lifecycle validation for a phase

### DIFF
--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -26,13 +26,14 @@ kops update cluster
 ### Options
 
 ```
-      --create-kube-config      Will control automatically creating the kube config file on your local filesystem (default true)
-      --model string            Models to apply (separate multiple models with commas) (default "config,proto,cloudup")
-      --out string              Path to write any local output
-      --phase string            Subset of tasks to run: assets, cluster, network, security
-      --ssh-public-key string   SSH public key to use (deprecated: use kops create secret instead)
-      --target string           Target - direct, terraform, cloudformation (default "direct")
-  -y, --yes                     Create cloud resources, without --yes update is in dry run mode
+      --create-kube-config            Will control automatically creating the kube config file on your local filesystem (default true)
+      --model string                  Models to apply (separate multiple models with commas) (default "config,proto,cloudup")
+      --out string                    Path to write any local output
+      --phase string                  Subset of tasks to run: assets, cluster, network, security
+      --phase-overrides stringSlice   comma separated list of phase overrides, example: assets=ExistsAndWarnIfChanges,network=ExistsAndValidates
+      --ssh-public-key string         SSH public key to use (deprecated: use kops create secret instead)
+      --target string                 Target - direct, terraform, cloudformation (default "direct")
+  -y, --yes                           Create cloud resources, without --yes update is in dry run mode
 ```
 
 ### Options inherited from parent commands

--- a/upup/pkg/fi/BUILD.bazel
+++ b/upup/pkg/fi/BUILD.bazel
@@ -86,6 +86,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],
 )

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -124,7 +124,7 @@ type ApplyClusterCmd struct {
 	// Phase can be set to a Phase to run the specific subset of tasks, if we don't want to run everything
 	Phase Phase
 
-	// LifecycleOverrides contains a map of lifecycle values to fi.Lifecycle
+	// LifecycleOverrides is passed in to override the lifecycle for one of more phases.
 	LifecycleOverrides map[Phase]fi.Lifecycle
 }
 

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -123,6 +123,9 @@ type ApplyClusterCmd struct {
 
 	// Phase can be set to a Phase to run the specific subset of tasks, if we don't want to run everything
 	Phase Phase
+
+	// LifecycleOverrides contains a map of lifecycle values to fi.Lifecycle
+	LifecycleOverrides map[Phase]fi.Lifecycle
 }
 
 func (c *ApplyClusterCmd) Run() error {
@@ -197,6 +200,11 @@ func (c *ApplyClusterCmd) Run() error {
 	default:
 		return fmt.Errorf("unknown phase %q", c.Phase)
 	}
+
+	stageAssetsLifecycle = c.overrideLifecycle(PhaseStageAssets, stageAssetsLifecycle)
+	securityLifecycle = c.overrideLifecycle(PhaseSecurity, securityLifecycle)
+	networkLifecycle = c.overrideLifecycle(PhaseNetwork, networkLifecycle)
+	clusterLifecycle = c.overrideLifecycle(PhaseCluster, clusterLifecycle)
 
 	// This is kinda a hack.  Need to move phases out of fi.  If we use Phase here we introduce a circular
 	// go dependency.
@@ -769,6 +777,16 @@ func (c *ApplyClusterCmd) upgradeSpecs(assetBuilder *assets.AssetBuilder) error 
 	}
 
 	return nil
+}
+
+// overrideLifecycle returns the overriden lifecycle value
+func (c *ApplyClusterCmd) overrideLifecycle(key Phase, lifecycle fi.Lifecycle) fi.Lifecycle {
+	value, ok := c.LifecycleOverrides[key]
+	if ok {
+		glog.V(8).Infof("setting override %s to %s", key, value)
+		return value
+	}
+	return lifecycle
 }
 
 // validateKopsVersion ensures that kops meet the version requirements / recommendations in the channel

--- a/upup/pkg/fi/cloudup/phase.go
+++ b/upup/pkg/fi/cloudup/phase.go
@@ -40,10 +40,10 @@ var Phases = sets.NewString(
 	string(PhaseCluster),
 )
 
-// PhaseLifecycleMap map of phases to lifecycle name
-var PhaseLifecycleMap = map[Phase]string{
-	PhaseStageAssets: "stageAssetsLifecycle",
-	PhaseNetwork:     "networkLifecycle",
-	PhaseSecurity:    "securityLifecycle",
-	PhaseCluster:     "clusterLifecycle",
+// PhasesNameMap map of phases to lifecycle name
+var PhasesNameMap = map[string]Phase{
+	"assets":   PhaseStageAssets,
+	"network":  PhaseNetwork,
+	"security": PhaseSecurity,
+	"cluster":  PhaseCluster,
 }

--- a/upup/pkg/fi/cloudup/phase.go
+++ b/upup/pkg/fi/cloudup/phase.go
@@ -39,3 +39,11 @@ var Phases = sets.NewString(
 	string(PhaseNetwork),
 	string(PhaseCluster),
 )
+
+// PhaseLifecycleMap map of phases to lifecycle name
+var PhaseLifecycleMap = map[Phase]string{
+	PhaseStageAssets: "stageAssetsLifecycle",
+	PhaseNetwork:     "networkLifecycle",
+	PhaseSecurity:    "securityLifecycle",
+	PhaseCluster:     "clusterLifecycle",
+}

--- a/upup/pkg/fi/lifecycle.go
+++ b/upup/pkg/fi/lifecycle.go
@@ -50,3 +50,11 @@ var Lifecycles = sets.NewString(
 	string(LifecycleExistsAndValidates),
 	string(LifecycleExistsAndWarnIfChanges),
 )
+
+var LifecycleNameMap = map[string]Lifecycle{
+	"Sync":                     LifecycleSync,
+	"Ignore":                   LifecycleIgnore,
+	"WarnIfInsufficientAccess": LifecycleWarnIfInsufficientAccess,
+	"ExistsAndValidates":       LifecycleExistsAndValidates,
+	"ExistsAndWarnIfChanges":   LifecycleExistsAndWarnIfChanges,
+}

--- a/upup/pkg/fi/lifecycle.go
+++ b/upup/pkg/fi/lifecycle.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package fi
 
+import "k8s.io/apimachinery/pkg/util/sets"
+
 type Lifecycle string
 
 const (
@@ -39,3 +41,12 @@ const (
 type HasLifecycle interface {
 	GetLifecycle() *Lifecycle
 }
+
+// Phases are used for validation and cli help.
+var Lifecycles = sets.NewString(
+	string(LifecycleSync),
+	string(LifecycleIgnore),
+	string(LifecycleWarnIfInsufficientAccess),
+	string(LifecycleExistsAndValidates),
+	string(LifecycleExistsAndWarnIfChanges),
+)


### PR DESCRIPTION
This PR adds the --phase-overrides to kops update cluster command.  This
flag accepts a comma seperated list of phases and lifecycle.  This
feature allows for a user to have fine grain control over how kops
validates specific phases.