### PR TITLE
Interactive cli opt

### DIFF
--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -129,6 +129,9 @@ type RollingUpdateOptions struct {
 	// BastionInterval is the minimum time to wait after stopping a bastion.  This does not include drain and validate time.
 	BastionInterval time.Duration
 
+	// Interactive rolling-update prompts user to continue after each instances is updated.
+	Interactive bool
+
 	ClusterName string
 
 	// InstanceGroups is the list of instance groups to rolling-update;
@@ -146,6 +149,7 @@ func (o *RollingUpdateOptions) InitDefaults() {
 	o.MasterInterval = 5 * time.Minute
 	o.NodeInterval = 4 * time.Minute
 	o.BastionInterval = 5 * time.Minute
+	o.Interactive = false
 
 	o.PostDrainDelay = 90 * time.Second
 	o.ValidationTimeout = 5 * time.Minute
@@ -171,6 +175,7 @@ func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().DurationVar(&options.MasterInterval, "master-interval", options.MasterInterval, "Time to wait between restarting masters")
 	cmd.Flags().DurationVar(&options.NodeInterval, "node-interval", options.NodeInterval, "Time to wait between restarting nodes")
 	cmd.Flags().DurationVar(&options.BastionInterval, "bastion-interval", options.BastionInterval, "Time to wait between restarting bastions")
+	cmd.Flags().BoolVarP(&options.Interactive, "interactive", "i", options.Interactive, "Prompt to continue after each instance is updated")
 	cmd.Flags().StringSliceVar(&options.InstanceGroups, "instance-group", options.InstanceGroups, "List of instance groups to update (defaults to all if not specified)")
 
 	if featureflag.DrainAndValidateRollingUpdate.Enabled() {
@@ -363,6 +368,7 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 		MasterInterval:    options.MasterInterval,
 		NodeInterval:      options.NodeInterval,
 		BastionInterval:   options.BastionInterval,
+		Interactive:       options.Interactive,
 		Force:             options.Force,
 		Cloud:             cloud,
 		K8sClient:         k8sClient,

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -74,6 +74,7 @@ kops rolling-update cluster
       --fail-on-validate-error       The rolling-update will fail if the cluster fails to validate. (default true)
       --force                        Force rolling update, even if no changes
       --instance-group stringSlice   List of instance groups to update (defaults to all if not specified)
+  -i, --interactive                  Prompt to continue after each instance is updated
       --master-interval duration     Time to wait between restarting masters (default 5m0s)
       --node-interval duration       Time to wait between restarting nodes (default 4m0s)
   -y, --yes                          Perform rolling update immediately, without --yes rolling-update executes a dry-run

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -255,7 +255,6 @@ func (r *RollingUpdateInstanceGroup) DeleteInstance(u *cloudinstances.CloudInsta
 		}
 	}
 
-			nodeName = u.Node.Name
 	return nil
 
 }

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -65,6 +65,11 @@ func NewRollingUpdateInstanceGroup(cloud fi.Cloud, cloudGroup *cloudinstances.Cl
 	}, nil
 }
 
+func PromptInteractive(upgradedHost string) {
+  glog.Infof("Pausing after finished %q", upgradedHost)
+  return
+}
+
 // TODO: Temporarily increase size of ASG?
 // TODO: Remove from ASG first so status is immediately updated?
 // TODO: Batch termination, like a rolling-update
@@ -169,6 +174,9 @@ func (r *RollingUpdateInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpd
 
 				glog.Warningf("Cluster validation failed after removing instance, proceeding since fail-on-validate is set to false: %v", err)
 			}
+      if rollingUpdateData.Interactive {
+        PromptInteractive(nodeName)
+      }
 		}
 	}
 
@@ -247,6 +255,7 @@ func (r *RollingUpdateInstanceGroup) DeleteInstance(u *cloudinstances.CloudInsta
 		}
 	}
 
+			nodeName = u.Node.Name
 	return nil
 
 }

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -17,11 +17,11 @@ limitations under the License.
 package instancegroups
 
 import (
+	"bufio"
 	"fmt"
 	"os"
-	"time"
-	"bufio"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -74,15 +74,15 @@ func PromptInteractive(upgradedHost string) (stop_prompting bool) {
 	glog.Infof("Pausing after finished %q", upgradedHost)
 	fmt.Printf("Continue? (Y)es, (N)o, (A)lwaysYes: [Y] ")
 	val := ""
-	var err error;
+	var err error
 	if val, err = reader.ReadString('\n'); err != nil {
 		glog.Fatalf("unable to interpret input: %v", err)
 	}
 	val = strings.TrimSpace(val)
 	val = strings.ToLower(val)
 	switch val {
-	case "y","","\n":
-		glog.V(4).Infof("Continuing with next host (response %q)\n",val)
+	case "y", "", "\n":
+		glog.V(4).Infof("Continuing with next host (response %q)\n", val)
 	case "n":
 		glog.Infof("User signaled to stop")
 		os.Exit(3)

--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -39,6 +39,8 @@ type RollingUpdateCluster struct {
 	NodeInterval time.Duration
 	// BastionInterval is the amount of time to wait after stopping a bastion instance
 	BastionInterval time.Duration
+	// Interactive prompts user to continue after each instance is updated
+	Interactive bool
 
 	Force bool
 


### PR DESCRIPTION
Sometimes when doing a kops rolling-update, I might want to ssh to a new master or new node to check that some component is configured properly, has started, or just in general look around to make sure it's behaving properly before it updates every instance in the cluster.  Especially if I know a breaking change is being deployed, I'd like to have kops wait after performing the update on each host, not on a timer, but wait until I specifically allow it to continue.

This PR adds a kops cli option, `--interactive`, that pauses after each instance gets updated. It prints out a prompt:
```
Continue? (Y)es, (N)o, (A)lwaysYes: [Y]
```
...and waits for admin approval before continuing on to the next instance. Pressing "y" or "Y" will continue. The default is "Y"es, so pressing Enter will also continue. Pressing "n" or "N" could maybe be enhanced to print out some useful information (summary, where you stopped, etc) but for now it merely exits kops immediately with exitcode 3 so that it does not deploy any more rolling updates.  Pressing "a" or "A" clears the Interactive flag and it will no longer prompt after updating each instance going forward.