### PR TITLE
Adding CNI v0.6.0 which is required for Kubernetes 1.9

### DIFF
--- a/upup/pkg/fi/assetstore.go
+++ b/upup/pkg/fi/assetstore.go
@@ -203,7 +203,10 @@ func (a *AssetStore) addURL(url string, hash *hashing.Hash) error {
 	glog.V(2).Infof("added asset %q for %q", asset.Key, asset.resource)
 	a.assets = append(a.assets, asset)
 
-	if strings.HasSuffix(assetPath, ".tar.gz") {
+	// normalize filename suffix
+	file := strings.ToLower(assetPath)
+	// pickup both tar.gz and tgz files
+	if strings.HasSuffix(file, ".tar.gz") || strings.HasSuffix(file, ".tgz") {
 		err = a.addArchive(source, localFile)
 		if err != nil {
 			return err

--- a/upup/pkg/fi/cloudup/networking.go
+++ b/upup/pkg/fi/cloudup/networking.go
@@ -109,6 +109,10 @@ const (
 	defaultCNIAssetK8s1_6           = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz"
 	defaultCNIAssetHashStringK8s1_6 = "1d9788b0f5420e1a219aad2cb8681823fc515e7c"
 
+	// defaultCNIAssetK8s1_9 is the CNI tarball for for 1.9.x k8s.
+	defaultCNIAssetK8s1_9           = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz"
+	defaultCNIAssetHashStringK8s1_9 = "d595d3ded6499a64e8dac02466e2f5f2ce257c9f"
+
 	// Environment variable for overriding CNI url
 	ENV_VAR_CNI_VERSION_URL = "CNI_VERSION_URL"
 )
@@ -133,7 +137,11 @@ func findCNIAssets(c *api.Cluster, assetBuilder *assets.AssetBuilder) (*url.URL,
 	sv.Build = nil
 
 	var cniAsset, cniAssetHash string
-	if sv.GTE(semver.Version{Major: 1, Minor: 6, Patch: 0, Pre: nil, Build: nil}) {
+	if sv.GTE(semver.Version{Major: 1, Minor: 9, Patch: 0, Pre: nil, Build: nil}) {
+		cniAsset = defaultCNIAssetK8s1_9
+		cniAssetHash = defaultCNIAssetHashStringK8s1_9
+		glog.V(2).Infof("Adding default CNI asset for k8s 1.9.x and higher: %s", defaultCNIAssetK8s1_9)
+	} else if sv.GTE(semver.Version{Major: 1, Minor: 6, Patch: 0, Pre: nil, Build: nil}) {
 		cniAsset = defaultCNIAssetK8s1_6
 		cniAssetHash = defaultCNIAssetHashStringK8s1_6
 		glog.V(2).Infof("Adding default CNI asset for k8s 1.6.x and higher: %s", defaultCNIAssetK8s1_6)


### PR DESCRIPTION
I would much rather have https://github.com/kubernetes/kops/pull/4097 merged, but this is blocked by an upstream issue.  The older CNI versions do not have a SHA1 file.