### PR TITLE
Adding override for setting etcd version

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -1246,6 +1246,10 @@ func setOverrides(overrides []string, cluster *api.Cluster, instanceGroups []*ap
 		switch kv[0] {
 		case "cluster.spec.nodePortAccess":
 			cluster.Spec.NodePortAccess = append(cluster.Spec.NodePortAccess, kv[1])
+		case "cluster.spec.etcdClusters[*].version":
+			for _, etcd := range cluster.Spec.EtcdClusters {
+				etcd.Version = kv[1]
+			}
 		default:
 			return fmt.Errorf("unhandled override: %q", override)
 		}


### PR DESCRIPTION
Added new override capability to set all Etcd version dynamically.  This
is needed for HA testing. For example, following flag can now be used with
```console
kops create cluster  --override \
  "cluster.spec.etcdClusters[*].version=3.0.17"
```
  