### PR TITLE
Setting etcd3 as the default version for k8s 1.9+

### DIFF
--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -16,16 +16,18 @@ spec:
     - instanceGroup: master-us-test-1a
       name: a
     name: main
+    version: 3.1.10
   - etcdMembers:
     - instanceGroup: master-us-test-1a
       name: a
     name: events
+    version: 3.1.10
   iam:
     allowContainerRegistry: true
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.7.1
+  kubernetesVersion: v1.9.0
   masterPublicName: api.complex.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -54,7 +56,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2017-12-02
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -74,7 +76,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2017-12-02
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/complex/options.yaml
+++ b/tests/integration/create_cluster/complex/options.yaml
@@ -2,7 +2,7 @@ ClusterName: complex.example.com
 Zones:
 - us-test-1a
 Cloud: aws
-KubernetesVersion: v1.7.1
+KubernetesVersion: v1.9.0
 # We specify SSHAccess but _not_ AdminAccess
 SSHAccess:
 - 1.2.3.4/32


### PR DESCRIPTION
If the etcd version is not set, and we are using Kubernetes 1.8+ the
etcd version is set.  Currently, we have enabled etcd 3.0.17 for k8s
1.8.x, and etcd 3.1.10 for k8s 1.9.x+.