### PR TITLE
Remove Romana preview notice from networking docs

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -259,8 +259,6 @@ No additional configurations are required to be done by user. Kube-router automa
 
 The following command sets up a cluster with Romana as the CNI.
 
-**NOTE** This currently deploys v2.0 Preview 2, and will be updated when the 2.0 release is completed.
-
 ```console
 $ export $ZONES=mylistofzones
 $ kops create cluster \


### PR DESCRIPTION
The Romana version was bumped from the 2.0 preview to the 2.0 GA in
pull request #3892.