### PR TITLE
Add SubnetType Tag to Subnets

### DIFF
--- a/pkg/model/network.go
+++ b/pkg/model/network.go
@@ -157,6 +157,8 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			glog.V(2).Infof("unable to properly tag subnet %q because it has unknown type %q. Load balancers may be created in incorrect subnets", subnetSpec.Name, subnetSpec.Type)
 		}
 
+		tags["SubnetType"] = string(subnetSpec.Type)
+
 		subnet := &awstasks.Subnet{
 			Name:             s(subnetName),
 			Lifecycle:        b.Lifecycle,

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json
@@ -413,6 +413,10 @@
             "Value": "us-test-1a.additionaluserdata.example.com"
           },
           {
+            "Key": "SubnetType",
+            "Value": "Public"
+          },
+          {
             "Key": "kubernetes.io/cluster/additionaluserdata.example.com",
             "Value": "owned"
           },

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -513,6 +513,7 @@ resource "aws_subnet" "us-test-1a-complex-example-com" {
   tags = {
     KubernetesCluster                           = "complex.example.com"
     Name                                        = "us-test-1a.complex.example.com"
+    SubnetType                                  = "Public"
     "kubernetes.io/cluster/complex.example.com" = "owned"
     "kubernetes.io/role/elb"                    = "1"
   }

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -543,6 +543,7 @@ resource "aws_subnet" "us-test-1a-ha-example-com" {
   tags = {
     KubernetesCluster                      = "ha.example.com"
     Name                                   = "us-test-1a.ha.example.com"
+    SubnetType                             = "Public"
     "kubernetes.io/cluster/ha.example.com" = "owned"
     "kubernetes.io/role/elb"               = "1"
   }
@@ -556,6 +557,7 @@ resource "aws_subnet" "us-test-1b-ha-example-com" {
   tags = {
     KubernetesCluster                      = "ha.example.com"
     Name                                   = "us-test-1b.ha.example.com"
+    SubnetType                             = "Public"
     "kubernetes.io/cluster/ha.example.com" = "owned"
     "kubernetes.io/role/elb"               = "1"
   }
@@ -569,6 +571,7 @@ resource "aws_subnet" "us-test-1c-ha-example-com" {
   tags = {
     KubernetesCluster                      = "ha.example.com"
     Name                                   = "us-test-1c.ha.example.com"
+    SubnetType                             = "Public"
     "kubernetes.io/cluster/ha.example.com" = "owned"
     "kubernetes.io/role/elb"               = "1"
   }

--- a/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
+++ b/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
@@ -80,6 +80,7 @@ resource "aws_subnet" "us-test-1a-privateweave-example-com" {
   tags = {
     KubernetesCluster                                = "privateweave.example.com"
     Name                                             = "us-test-1a.privateweave.example.com"
+    SubnetType                                       = "Private"
     "kubernetes.io/cluster/privateweave.example.com" = "owned"
     "kubernetes.io/role/internal-elb"                = "1"
   }
@@ -93,6 +94,7 @@ resource "aws_subnet" "utility-us-test-1a-privateweave-example-com" {
   tags = {
     KubernetesCluster                                = "privateweave.example.com"
     Name                                             = "utility-us-test-1a.privateweave.example.com"
+    SubnetType                                       = "Utility"
     "kubernetes.io/cluster/privateweave.example.com" = "owned"
     "kubernetes.io/role/elb"                         = "1"
   }

--- a/tests/integration/update_cluster/minimal-141/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-141/kubernetes.tf
@@ -373,6 +373,7 @@ resource "aws_subnet" "us-test-1a-minimal-141-example-com" {
   tags = {
     KubernetesCluster                               = "minimal-141.example.com"
     Name                                            = "us-test-1a.minimal-141.example.com"
+    SubnetType                                      = "Public"
     "kubernetes.io/cluster/minimal-141.example.com" = "owned"
     "kubernetes.io/role/elb"                        = "1"
   }

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
@@ -413,6 +413,10 @@
             "Value": "us-test-1a.minimal.example.com"
           },
           {
+            "Key": "SubnetType",
+            "Value": "Public"
+          },
+          {
             "Key": "kubernetes.io/cluster/minimal.example.com",
             "Value": "owned"
           },

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -373,6 +373,7 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
   tags = {
     KubernetesCluster                           = "minimal.example.com"
     Name                                        = "us-test-1a.minimal.example.com"
+    SubnetType                                  = "Public"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
     "kubernetes.io/role/elb"                    = "1"
   }

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -653,6 +653,7 @@ resource "aws_subnet" "us-test-1a-privatecalico-example-com" {
   tags = {
     KubernetesCluster                                 = "privatecalico.example.com"
     Name                                              = "us-test-1a.privatecalico.example.com"
+    SubnetType                                        = "Private"
     "kubernetes.io/cluster/privatecalico.example.com" = "owned"
     "kubernetes.io/role/internal-elb"                 = "1"
   }
@@ -666,6 +667,7 @@ resource "aws_subnet" "utility-us-test-1a-privatecalico-example-com" {
   tags = {
     KubernetesCluster                                 = "privatecalico.example.com"
     Name                                              = "utility-us-test-1a.privatecalico.example.com"
+    SubnetType                                        = "Utility"
     "kubernetes.io/cluster/privatecalico.example.com" = "owned"
     "kubernetes.io/role/elb"                          = "1"
   }

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -644,6 +644,7 @@ resource "aws_subnet" "us-test-1a-privatecanal-example-com" {
   tags = {
     KubernetesCluster                                = "privatecanal.example.com"
     Name                                             = "us-test-1a.privatecanal.example.com"
+    SubnetType                                       = "Private"
     "kubernetes.io/cluster/privatecanal.example.com" = "owned"
     "kubernetes.io/role/internal-elb"                = "1"
   }
@@ -657,6 +658,7 @@ resource "aws_subnet" "utility-us-test-1a-privatecanal-example-com" {
   tags = {
     KubernetesCluster                                = "privatecanal.example.com"
     Name                                             = "utility-us-test-1a.privatecanal.example.com"
+    SubnetType                                       = "Utility"
     "kubernetes.io/cluster/privatecanal.example.com" = "owned"
     "kubernetes.io/role/elb"                         = "1"
   }

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -649,6 +649,7 @@ resource "aws_subnet" "us-test-1a-privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "us-test-1a.privatedns1.example.com"
+    SubnetType                                      = "Private"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
     "kubernetes.io/role/internal-elb"               = "1"
   }
@@ -662,6 +663,7 @@ resource "aws_subnet" "utility-us-test-1a-privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "utility-us-test-1a.privatedns1.example.com"
+    SubnetType                                      = "Utility"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
     "kubernetes.io/role/elb"                        = "1"
   }

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -635,6 +635,7 @@ resource "aws_subnet" "us-test-1a-privatedns2-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns2.example.com"
     Name                                            = "us-test-1a.privatedns2.example.com"
+    SubnetType                                      = "Private"
     "kubernetes.io/cluster/privatedns2.example.com" = "owned"
     "kubernetes.io/role/internal-elb"               = "1"
   }
@@ -648,6 +649,7 @@ resource "aws_subnet" "utility-us-test-1a-privatedns2-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns2.example.com"
     Name                                            = "utility-us-test-1a.privatedns2.example.com"
+    SubnetType                                      = "Utility"
     "kubernetes.io/cluster/privatedns2.example.com" = "owned"
     "kubernetes.io/role/elb"                        = "1"
   }

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -644,6 +644,7 @@ resource "aws_subnet" "us-test-1a-privateflannel-example-com" {
   tags = {
     KubernetesCluster                                  = "privateflannel.example.com"
     Name                                               = "us-test-1a.privateflannel.example.com"
+    SubnetType                                         = "Private"
     "kubernetes.io/cluster/privateflannel.example.com" = "owned"
     "kubernetes.io/role/internal-elb"                  = "1"
   }
@@ -657,6 +658,7 @@ resource "aws_subnet" "utility-us-test-1a-privateflannel-example-com" {
   tags = {
     KubernetesCluster                                  = "privateflannel.example.com"
     Name                                               = "utility-us-test-1a.privateflannel.example.com"
+    SubnetType                                         = "Utility"
     "kubernetes.io/cluster/privateflannel.example.com" = "owned"
     "kubernetes.io/role/elb"                           = "1"
   }

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -635,6 +635,7 @@ resource "aws_subnet" "us-test-1a-privatekopeio-example-com" {
   tags = {
     KubernetesCluster                                 = "privatekopeio.example.com"
     Name                                              = "us-test-1a.privatekopeio.example.com"
+    SubnetType                                        = "Private"
     "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
     "kubernetes.io/role/internal-elb"                 = "1"
   }
@@ -648,6 +649,7 @@ resource "aws_subnet" "utility-us-test-1a-privatekopeio-example-com" {
   tags = {
     KubernetesCluster                                 = "privatekopeio.example.com"
     Name                                              = "utility-us-test-1a.privatekopeio.example.com"
+    SubnetType                                        = "Utility"
     "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
     "kubernetes.io/role/elb"                          = "1"
   }

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -644,6 +644,7 @@ resource "aws_subnet" "us-test-1a-privateweave-example-com" {
   tags = {
     KubernetesCluster                                = "privateweave.example.com"
     Name                                             = "us-test-1a.privateweave.example.com"
+    SubnetType                                       = "Private"
     "kubernetes.io/cluster/privateweave.example.com" = "owned"
     "kubernetes.io/role/internal-elb"                = "1"
   }
@@ -657,6 +658,7 @@ resource "aws_subnet" "utility-us-test-1a-privateweave-example-com" {
   tags = {
     KubernetesCluster                                = "privateweave.example.com"
     Name                                             = "utility-us-test-1a.privateweave.example.com"
+    SubnetType                                       = "Utility"
     "kubernetes.io/cluster/privateweave.example.com" = "owned"
     "kubernetes.io/role/elb"                         = "1"
   }

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -364,6 +364,7 @@ resource "aws_subnet" "us-test-1a-sharedvpc-example-com" {
   tags = {
     KubernetesCluster                             = "sharedvpc.example.com"
     Name                                          = "us-test-1a.sharedvpc.example.com"
+    SubnetType                                    = "Public"
     "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
     "kubernetes.io/role/elb"                      = "1"
   }


### PR DESCRIPTION
Makes it easier to programatically search for Subnets with a given type in AWS, for example in Terraform (where exact Tag matching is required):

```
# Get a list of the Public subnets
data "aws_subnet_ids" "selected" {
  vpc_id = "${var.vpc_id}"
  tags   = {
    SubnetType = "Public"
  }
}
```

The `kubernetes.io/role/elb` Tag can't be used in all cases like above, as both Utility & Public Type Subnets have this Tag set.
  
  