### PR TITLE
FIX #4055 dns controller issue with gossip kops 1.8

### DIFF
--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -178,27 +178,26 @@ func (tf *TemplateFunctions) DnsControllerArgv() ([]string, error) {
 	}
 
 	if dns.IsGossipHostname(tf.cluster.Spec.MasterInternalName) {
-		argv = append(argv, "--dns=gossip")
 		argv = append(argv, "--gossip-seed=127.0.0.1:3999")
-	} else {
-		switch kops.CloudProviderID(tf.cluster.Spec.CloudProvider) {
-		case kops.CloudProviderAWS:
-			if strings.HasPrefix(os.Getenv("AWS_REGION"), "cn-") {
-				argv = append(argv, "--dns=gossip")
-			} else {
-				argv = append(argv, "--dns=aws-route53")
-			}
-		case kops.CloudProviderGCE:
-			argv = append(argv, "--dns=google-clouddns")
-		case kops.CloudProviderDO:
-			argv = append(argv, "--dns=digitalocean")
-		case kops.CloudProviderVSphere:
-			argv = append(argv, "--dns=coredns")
-			argv = append(argv, "--dns-server="+*tf.cluster.Spec.CloudConfig.VSphereCoreDNSServer)
+	}
 
-		default:
-			return nil, fmt.Errorf("unhandled cloudprovider %q", tf.cluster.Spec.CloudProvider)
+	switch kops.CloudProviderID(tf.cluster.Spec.CloudProvider) {
+	case kops.CloudProviderAWS:
+		if strings.HasPrefix(os.Getenv("AWS_REGION"), "cn-") {
+			argv = append(argv, "--dns=gossip")
+		} else {
+			argv = append(argv, "--dns=aws-route53")
 		}
+	case kops.CloudProviderGCE:
+		argv = append(argv, "--dns=google-clouddns")
+	case kops.CloudProviderDO:
+		argv = append(argv, "--dns=digitalocean")
+	case kops.CloudProviderVSphere:
+		argv = append(argv, "--dns=coredns")
+		argv = append(argv, "--dns-server="+*tf.cluster.Spec.CloudConfig.VSphereCoreDNSServer)
+
+	default:
+		return nil, fmt.Errorf("unhandled cloudprovider %q", tf.cluster.Spec.CloudProvider)
 	}
 
 	zone := tf.cluster.Spec.DNSZone


### PR DESCRIPTION
Revert part of commit f157ccc to fix issue #4055. The dns-controller
switch statement to set the cloud providor is enclosed in an if
statement. It will never be set to anything other than gossip if the
gossip protocol is used.  I believe this is not the intended behavior
as using the gossip protocol with any of the cloud providers in the
switch is still valid configuration.