### PR TITLE
GCE: Don't set bucket-level permissions

### DIFF
--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -61,6 +61,11 @@ var EnableSeparateConfigBase = New("EnableSeparateConfigBase", Bool(false))
 // SpecOverrideFlag allows setting spec values on create
 var SpecOverrideFlag = New("SpecOverrideFlag", Bool(false))
 
+// GoogleCloudBucketAcl means the ACL will be set on a bucket when using GCS
+// In particular, this is the only (?) way to grant the bucket.list permission
+// However we should no longer need it, with the keyset.yaml fix
+var GoogleCloudBucketAcl = New("GoogleCloudBucketAcl", Bool(false))
+
 var flags = make(map[string]*FeatureFlag)
 var flagsMutex sync.Mutex
 

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -528,8 +528,13 @@ func (c *ApplyClusterCmd) Run() error {
 					&gcemodel.ExternalAccessModelBuilder{GCEModelContext: gceModelContext, Lifecycle: &securityLifecycle},
 					&gcemodel.FirewallModelBuilder{GCEModelContext: gceModelContext, Lifecycle: &securityLifecycle},
 					&gcemodel.NetworkModelBuilder{GCEModelContext: gceModelContext, Lifecycle: &networkLifecycle},
-					&gcemodel.StorageAclBuilder{GCEModelContext: gceModelContext, Cloud: cloud.(gce.GCECloud), Lifecycle: &storageAclLifecycle},
 				)
+
+				if featureflag.GoogleCloudBucketAcl.Enabled() {
+					l.Builders = append(l.Builders,
+						&gcemodel.StorageAclBuilder{GCEModelContext: gceModelContext, Cloud: cloud.(gce.GCECloud), Lifecycle: &storageAclLifecycle},
+					)
+				}
 
 			case kops.CloudProviderVSphere:
 				// No special settings (yet!)


### PR DESCRIPTION
We previously needed them to allow list operations; however we now use a
keyset.yaml file instead of listing keys.  That should be the sole use,
so we should no longer need this permission.

If not, we can re-enable the code easily.