### PR TITLE
Adding support for S3 Default Bucket Encryption

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -271,6 +271,12 @@ to revert or recover a previous state store.
 aws s3api put-bucket-versioning --bucket prefix-example-com-state-store  --versioning-configuration Status=Enabled
 ```
 
+### Using S3 default bucket encryption
+
+kops supports [default bucket encryption](https://aws.amazon.com/de/blogs/aws/new-amazon-s3-encryption-security-features/) to encrypt the kops state in an S3 bucket. In this way, whatever default server side encryption is set for your bucket, it will be used for the kops state, too. You may want to use this AWS feature e.g. for easily encrypting every written object by default or when for compliance reasons you need to use specific encryption keys (KMS, CMK).
+
+If your S3 bucket has a default encryption set up, kops will use it. If the default encryption is not set or it cannot be checked, kops will resort to using client side AES256 encryption.
+ 
 ### Sharing an S3 bucket across multiple accounts
 
 It is possible to use a single S3 bucket for storing kops state for clusters

--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -40,16 +40,21 @@ var (
 	s3UrlRegexp = regexp.MustCompile(`s3([-.](?P<region>\w{2}-\w+-\d{1})|[-.](?P<bucket>[\w.\-\_]+)|)?.amazonaws.com(.cn)?(?P<path>.*)?`)
 )
 
+type S3BucketDetails struct {
+	region            string
+	defaultEncryption bool
+}
+
 type S3Context struct {
-	mutex           sync.Mutex
-	clients         map[string]*s3.S3
-	bucketLocations map[string]string
+	mutex         sync.Mutex
+	clients       map[string]*s3.S3
+	bucketDetails map[string]*S3BucketDetails
 }
 
 func NewS3Context() *S3Context {
 	return &S3Context{
-		clients:         make(map[string]*s3.S3),
-		bucketLocations: make(map[string]string),
+		clients:       make(map[string]*s3.S3),
+		bucketDetails: make(map[string]*S3BucketDetails),
 	}
 }
 
@@ -106,26 +111,29 @@ func getCustomS3Config(endpoint string, region string) (*aws.Config, error) {
 	return s3Config, nil
 }
 
-func (s *S3Context) getRegionForBucket(bucket string) (string, error) {
-	region := func() string {
+func (s *S3Context) getDetailsForBucket(bucket string) (*S3BucketDetails, error) {
+	bucketDetails := func() *S3BucketDetails {
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
-		return s.bucketLocations[bucket]
+		return s.bucketDetails[bucket]
 	}()
 
-	if region != "" {
-		return region, nil
+	if bucketDetails != nil && bucketDetails.region != "" {
+		return bucketDetails, nil
 	}
+
+	bucketDetails = &S3BucketDetails{region: "", defaultEncryption: false}
 
 	// Probe to find correct region for bucket
 	endpoint := os.Getenv("S3_ENDPOINT")
 	if endpoint != "" {
 		// If customized S3 storage is set, return user-defined region
-		region = os.Getenv("S3_REGION")
-		if region == "" {
-			region = "us-east-1"
+		bucketDetails.region = os.Getenv("S3_REGION")
+		if bucketDetails.region == "" {
+			bucketDetails.region = "us-east-1"
+			bucketDetails.defaultEncryption = s.checkDefaultEncryption(bucketDetails.region, bucket)
 		}
-		return region, nil
+		return bucketDetails, nil
 	}
 
 	awsRegion := os.Getenv("AWS_REGION")
@@ -134,7 +142,7 @@ func (s *S3Context) getRegionForBucket(bucket string) (string, error) {
 	}
 
 	if err := validateRegion(awsRegion); err != nil {
-		return "", err
+		return bucketDetails, err
 	}
 
 	request := &s3.GetBucketLocationInput{
@@ -144,7 +152,7 @@ func (s *S3Context) getRegionForBucket(bucket string) (string, error) {
 
 	s3Client, err := s.getClient(awsRegion)
 	if err != nil {
-		return "", fmt.Errorf("error connecting to S3: %s", err)
+		return bucketDetails, fmt.Errorf("error connecting to S3: %s", err)
 	}
 	// Attempt one GetBucketLocation call the "normal" way (i.e. as the bucket owner)
 	response, err = s3Client.GetBucketLocation(request)
@@ -156,26 +164,61 @@ func (s *S3Context) getRegionForBucket(bucket string) (string, error) {
 	}
 
 	if err != nil {
-		return "", err
+		return bucketDetails, err
 	}
 
 	if response.LocationConstraint == nil {
 		// US Classic does not return a region
-		region = "us-east-1"
+		bucketDetails.region = "us-east-1"
+		bucketDetails.defaultEncryption = s.checkDefaultEncryption(bucketDetails.region, bucket)
 	} else {
-		region = *response.LocationConstraint
+		bucketDetails.region = *response.LocationConstraint
 		// Another special case: "EU" can mean eu-west-1
-		if region == "EU" {
-			region = "eu-west-1"
+		if bucketDetails.region == "EU" {
+			bucketDetails.region = "eu-west-1"
 		}
+		bucketDetails.defaultEncryption = s.checkDefaultEncryption(bucketDetails.region, bucket)
 	}
-	glog.V(2).Infof("Found bucket %q in region %q", bucket, region)
+	glog.V(2).Infof("Found bucket %q in region %q with default encryption set to %t", bucket, bucketDetails.region, bucketDetails.defaultEncryption)
 
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	s.bucketLocations[bucket] = region
+	s.bucketDetails[bucket] = bucketDetails
 
-	return region, nil
+	return bucketDetails, nil
+}
+
+func (s *S3Context) checkDefaultEncryption(region string, bucket string) bool {
+	client, err := s.getClient(region)
+	if err != nil {
+		glog.Warningf("Unable to read bucket encryption policy in region %q: will encrypt using AES256", region)
+		return false
+	}
+
+	glog.V(4).Infof("Checking default bucket encryption %q", bucket)
+
+	request := &s3.GetBucketEncryptionInput{}
+	request.Bucket = aws.String(bucket)
+
+	glog.V(8).Infof("Calling S3 GetBucketEncryption Bucket=%q", bucket)
+
+	result, err := client.GetBucketEncryption(request)
+	if err != nil {
+		// the following cases might lead to the operation failing:
+		// 1. A deny policy on s3:GetEncryptionConfiguration
+		// 2. No default encryption policy set
+		glog.Warningf("Unable to read bucket encryption policy: will encrypt using AES256")
+		return false
+	}
+
+	// currently, only one element is in the rules array, iterating nonetheless for future compatibility
+	for _, element := range result.ServerSideEncryptionConfiguration.Rules {
+		if element.ApplyServerSideEncryptionByDefault != nil {
+			return true
+		}
+	}
+
+	return false
 }
 
 /*


### PR DESCRIPTION
End of last year AWS introduced [bucket level encryption](https://aws.amazon.com/de/blogs/aws/new-amazon-s3-encryption-security-features/). This enables the use of KMS and CMK for S3 as default on a bucket.

Currently, [kops sets](https://github.com/kubernetes/kops/blob/dd49d693995d7e54ee738e677de21ad4f6d70c5d/util/pkg/vfs/s3fs.go#L120) the encryption to AES256 when writing to S3. This client-side option overrides the default encryption that might be set on the bucket.

This PR checks for the environment variable `KOPS_STATE_S3_DEFAULT_ENC` is set to `TRUE`. If that is the case, the encryption option is omitted when writing to S3.

Guideline for the PR: We don't want to break existing users, so we should keep it that if you do nothing you are still encrypted.

An alternative implementation that omits the ugly `KOPS_STATE_S3_DEFAULT_ENC`: check if the bucket has ApplyServerSideEncryptionByDefault=true, if so then don't set ServerSideEncryption on the object, so we get the bucket policy.  If it isn't set, set ServerSideEncryption on the object as today.