### PR TITLE
Allow image override for etcd

### DIFF
--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -218,9 +218,9 @@ type ProtokubeFlags struct {
 
 // ProtokubeFlags is responsible for building the command line flags for protokube
 func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) (*ProtokubeFlags, error) {
-	// @todo: i think we should allow the user to override the source of the image, but for now
-	// lets keep that for another PR and allow the version change
 	imageVersion := t.Cluster.Spec.EtcdClusters[0].Version
+	// overrides imageVersion if set
+	etcdContainerImage := t.Cluster.Spec.EtcdClusters[0].Image
 
 	var leaderElectionTimeout string
 	var heartbeatInterval string
@@ -244,6 +244,10 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) (*Protokube
 
 	// TODO this is dupicate code with etcd model
 	image := fmt.Sprintf("gcr.io/google_containers/etcd:%s", imageVersion)
+	// override image if set as API value
+	if etcdContainerImage != "" {
+		image = etcdContainerImage
+	}
 	assets := assets.NewAssetBuilder(t.Cluster.Spec.Assets, "")
 	remapped, err := assets.RemapImage(image)
 	if err != nil {

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -312,6 +312,8 @@ type EtcdClusterSpec struct {
 	LeaderElectionTimeout *metav1.Duration `json:"leaderElectionTimeout,omitempty"`
 	// HeartbeatInterval is the time (in milliseconds) for an etcd heartbeat interval
 	HeartbeatInterval *metav1.Duration `json:"heartbeatInterval,omitempty"`
+	// Image is the etcd docker image to use. Setting this will ignore the Version specified.
+	Image string `json:"image,omitempty"`
 }
 
 // EtcdMemberSpec is a specification for a etcd member

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -311,6 +311,8 @@ type EtcdClusterSpec struct {
 	LeaderElectionTimeout *metav1.Duration `json:"leaderElectionTimeout,omitempty"`
 	// HeartbeatInterval is the time (in milliseconds) for an etcd heartbeat interval
 	HeartbeatInterval *metav1.Duration `json:"heartbeatInterval,omitempty"`
+	// Image is the etcd docker image to use. Setting this will ignore the Version specified.
+	Image string `json:"image,omitempty"`
 }
 
 // EtcdMemberSpec is a specification for a etcd member

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1207,6 +1207,7 @@ func autoConvert_v1alpha1_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdCluste
 	out.Version = in.Version
 	out.LeaderElectionTimeout = in.LeaderElectionTimeout
 	out.HeartbeatInterval = in.HeartbeatInterval
+	out.Image = in.Image
 	return nil
 }
 
@@ -1233,6 +1234,7 @@ func autoConvert_kops_EtcdClusterSpec_To_v1alpha1_EtcdClusterSpec(in *kops.EtcdC
 	out.Version = in.Version
 	out.LeaderElectionTimeout = in.LeaderElectionTimeout
 	out.HeartbeatInterval = in.HeartbeatInterval
+	out.Image = in.Image
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -309,6 +309,8 @@ type EtcdClusterSpec struct {
 	LeaderElectionTimeout *metav1.Duration `json:"leaderElectionTimeout,omitempty"`
 	// HeartbeatInterval is the time (in milliseconds) for an etcd heartbeat interval
 	HeartbeatInterval *metav1.Duration `json:"heartbeatInterval,omitempty"`
+	// Image is the etcd docker image to use. Setting this will ignore the Version specified.
+	Image string `json:"image,omitempty"`
 }
 
 // EtcdMemberSpec is a specification for a etcd member

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1306,6 +1306,7 @@ func autoConvert_v1alpha2_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdCluste
 	out.Version = in.Version
 	out.LeaderElectionTimeout = in.LeaderElectionTimeout
 	out.HeartbeatInterval = in.HeartbeatInterval
+	out.Image = in.Image
 	return nil
 }
 
@@ -1332,6 +1333,7 @@ func autoConvert_kops_EtcdClusterSpec_To_v1alpha2_EtcdClusterSpec(in *kops.EtcdC
 	out.Version = in.Version
 	out.LeaderElectionTimeout = in.LeaderElectionTimeout
 	out.HeartbeatInterval = in.HeartbeatInterval
+	out.Image = in.Image
 	return nil
 }
 

--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -43,8 +43,13 @@ func (b *EtcdOptionsBuilder) BuildOptions(o interface{}) error {
 		}
 	}
 
-	// TODO put this into API values.  Do that in another PR?
+	// default to gcr.io
 	image := fmt.Sprintf("gcr.io/google_containers/etcd:%s", spec.EtcdClusters[0].Version)
+
+	// override image if set as API value
+	if spec.EtcdClusters[0].Image != "" {
+		image = spec.EtcdClusters[0].Image
+	}
 	image, err := b.Context.AssetBuilder.RemapImage(image)
 	if err != nil {
 		return fmt.Errorf("unable to remap container %q: %v", image, err)


### PR DESCRIPTION
This allows a container image to be set that overrides the base etcd image`gcr.io/google_containers/etcd`,  since the assets remap functionality only remaps the containerRegistry and not the image name.

This is useful for AWS china deployments where there is no gcr.io availablity, but there is an equivalent mirrored image in docker hub under a different image name.