### PR TITLE
Improve S3 url parsing for vfsPath to support more naming conventions

### DIFF
--- a/pkg/acls/s3/storage.go
+++ b/pkg/acls/s3/storage.go
@@ -56,9 +56,9 @@ func (s *s3PublicAclStrategy) GetACL(p vfs.Path, cluster *kops.Cluster) (vfs.ACL
 		return "", fmt.Errorf("unable to parse: %q", fileRepository)
 	}
 
-	// We are checking that the file is in s3.amazonaws.com meaning that it is in s3
-	// This will miss edge cases when the region url is used.
-	if u.Host != "s3.amazonaws.com" {
+	// We are checking that the file repository url is in S3
+	_, err = vfs.VFSPath(fileRepository)
+	if err != nil {
 		glog.V(8).Infof("path %q is not inside of a s3 bucket", u.String)
 		return nil, nil
 	}

--- a/upup/pkg/fi/assettasks/copyfile_test.go
+++ b/upup/pkg/fi/assettasks/copyfile_test.go
@@ -33,6 +33,26 @@ func Test_BuildVFSPath(t *testing.T) {
 			true,
 		},
 		{
+			"https://s3.cn-north-1.amazonaws.com/k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
+			"s3://k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
+			true,
+		},
+		{
+			"https://s3-cn-north-1.amazonaws.com/k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
+			"s3://k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
+			true,
+		},
+		{
+			"https://s3.k8s-for-greeks-kops.amazonaws.com/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
+			"s3://k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
+			true,
+		},
+		{
+			"https://s3-k8s-for-greeks-kops.amazonaws.com/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
+			"s3://k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
+			true,
+		},
+		{
 			"https://foo/k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
 			"",
 			false,

--- a/util/pkg/vfs/s3context_test.go
+++ b/util/pkg/vfs/s3context_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vfs
+
+import "testing"
+
+func Test_VFSPath(t *testing.T) {
+	grid := []struct {
+		Input          string
+		ExpectedResult string
+		ExpectError    bool
+	}{
+		{
+			Input:          "s3.amazonaws.com/bucket",
+			ExpectedResult: "s3://bucket",
+			ExpectError:    false,
+		},
+		{
+			Input:          "s3-bucket.amazonaws.com",
+			ExpectedResult: "s3://bucket",
+			ExpectError:    false,
+		},
+		{
+			Input:          "s3-bucket.amazonaws.com/path",
+			ExpectedResult: "s3://bucket/path",
+			ExpectError:    false,
+		},
+		{
+			Input:          "s3.bucket.amazonaws.com",
+			ExpectedResult: "s3://bucket",
+			ExpectError:    false,
+		},
+		{
+			Input:          "s3.bucket_foo-bar.abc.amazonaws.com/path",
+			ExpectedResult: "s3://bucket_foo-bar.abc/path",
+			ExpectError:    false,
+		},
+		{
+			Input:          "s3-us-west-2.amazonaws.com/bucket/path",
+			ExpectedResult: "s3://bucket/path",
+			ExpectError:    false,
+		},
+		{
+			Input:          "s3-us-west-2.amazonaws.com/bucket/path",
+			ExpectedResult: "s3://bucket/path",
+			ExpectError:    false,
+		},
+		{
+			Input:          "s3.cn-north-1.amazonaws.com.cn/bucket",
+			ExpectedResult: "s3://bucket",
+			ExpectError:    false,
+		},
+		{
+			Input:          "s3.cn-north-1.amazonaws.com.cn/bucket/path",
+			ExpectedResult: "s3://bucket/path",
+			ExpectError:    false,
+		},
+		{
+			Input:          "https://s3.amazonaws.com/bucket",
+			ExpectedResult: "s3://bucket",
+			ExpectError:    false,
+		},
+		{
+			Input:          "http://s3.amazonaws.com/bucket",
+			ExpectedResult: "s3://bucket",
+			ExpectError:    false,
+		},
+		{
+			Input:          "example.com/bucket",
+			ExpectedResult: "",
+			ExpectError:    true,
+		},
+		{
+			Input:          "https://example.com/bucket",
+			ExpectedResult: "",
+			ExpectError:    true,
+		},
+		{
+			Input:          "storage.googleapis.com",
+			ExpectedResult: "",
+			ExpectError:    true,
+		},
+		{
+			Input:          "storage.googleapis.com/foo/bar",
+			ExpectedResult: "",
+			ExpectError:    true,
+		},
+		{
+			Input:          "https://storage.googleapis.com",
+			ExpectedResult: "",
+			ExpectError:    true,
+		},
+		{
+			Input:          "https://storage.googleapis.com/foo/bar",
+			ExpectedResult: "",
+			ExpectError:    true,
+		},
+	}
+	for _, g := range grid {
+		vfsPath, err := VFSPath(g.Input)
+		if !g.ExpectError {
+			if err != nil {
+				t.Fatalf("unexpected error parsing vfs path: %v", err)
+			}
+			if vfsPath != g.ExpectedResult {
+				t.Fatalf("s3 url does not match expected result (%v): %v", g.ExpectedResult, g.Input)
+			}
+		} else {
+			if err == nil {
+				t.Fatalf("unexpected error parsing %q", g.Input)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This commit should add more support for S3 URL naming conventions. This allows AWS China deployments to make use of the assets builder since S3 URL's can only be of one kind, ie. s3.\<region\>.amazonaws.com.cn.

Naming conventions for reference:
https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region

  