### PR TITLE
Update binary installation commands for macOS to use curl alone

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -13,7 +13,7 @@ Developers can also easily install [development releases](development/homebrew.m
 From Github:
 
 ```bash
-wget -O kops https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-darwin-amd64
+curl -Lo kops https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-darwin-amd64
 chmod +x ./kops
 sudo mv ./kops /usr/local/bin/
 ```


### PR DESCRIPTION
I recently got a new mac and tried to use the binary installation commands listed in the documentation to get `kops` on my machine, and macOS does not include `wget` by default. This PR changes the instructions to use `curl` to accomplish the same thing. Curl has shipped with macOS/OSX since Jaguar, as a [quick google search revealed](https://curl.haxx.se/mail/lib-2012-11/0013.html). This should make it a little quicker for users to get the binary on their machine.