### PR TITLE
Fix rootVolumeType accepts all volume types

### DIFF
--- a/docs/instance_groups.md
+++ b/docs/instance_groups.md
@@ -66,6 +66,7 @@ The default volume size for Masters is 64 GB, while the default volume size for 
 The procedure to resize the root volume works the same way:
 
 * Edit the instance group, set `rootVolumeSize` and/or `rootVolumeType` to the desired values: `kops edit ig nodes`
+* `rootVolumeType` must be one of [supported volume types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html), e.g. `gp2` (default), `io1` (high performance) or `standard` (for testing).
 * If `rootVolumeType` is set to `io1` then you can define the number of Iops by specifing `rootVolumeIops` (defaults to 100 if not defined)
 * Preview changes: `kops update cluster <clustername>`
 * Apply changes: `kops update cluster <clustername> --yes`

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -60,16 +60,15 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 					return err
 				}
 			}
-			volumeType := fi.StringValue(ig.Spec.RootVolumeType)
-			volumeIops := fi.Int32Value(ig.Spec.RootVolumeIops)
 
-			switch volumeType {
-			case "io1":
-				if volumeIops == 0 {
-					volumeIops = DefaultVolumeIops
-				}
-			default:
+			volumeType := fi.StringValue(ig.Spec.RootVolumeType)
+			if volumeType == "" {
 				volumeType = DefaultVolumeType
+			}
+
+			volumeIops := fi.Int32Value(ig.Spec.RootVolumeIops)
+			if volumeIops == 0 {
+				volumeIops = DefaultVolumeIops
 			}
 
 			t := &awstasks.LaunchConfiguration{


### PR DESCRIPTION
This allows `rootVolumeType` of the instance group spec accepts all volume types supported by AWS. `standard` is cheaper and good for testing. Fixes #4256.