### PR TITLE
docs: upgrade.md: drop DrainAndValidateRollingUpdate note

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -27,9 +27,6 @@ node restart), but currently you must:
 
 Upgrade uses the latest Kubernetes version considered stable by kops, defined in `https://github.com/kubernetes/kops/blob/master/channels/stable`.
 
-NOTE: rolling-update does not yet perform a real rolling update - it just shuts down machines in sequence with a delay;
- there will be downtime [Issue #37](https://github.com/kubernetes/kops/issues/37)
-We have implemented a new feature that does drain and validate nodes.  This feature is experimental, and you can use the new feature by setting `export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate"`.
 
 ### Terraform Users
 


### PR DESCRIPTION
Drop the note about rolling-update not performing a real rolling update as the feature flag has been enabled by default.

Also provides consistency with what is mentioned in kops_rolling-update_cluster.md.