### PR TITLE
Copy alpha channel to stable

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -4,26 +4,24 @@ spec:
     - name: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
       providerID: aws
       kubernetesVersion: ">=1.4.0 <1.5.0"
-    - name: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+    - name: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
       providerID: aws
       kubernetesVersion: ">=1.5.0 <1.6.0"
-    - name: kope.io/k8s-1.6-debian-jessie-amd64-hvm-ebs-2017-12-02
+    - name: kope.io/k8s-1.6-debian-jessie-amd64-hvm-ebs-2018-01-05
       providerID: aws
       kubernetesVersion: ">=1.6.0 <1.7.0"
-    - name: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2017-12-02
+    - name: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2018-01-05
       providerID: aws
       kubernetesVersion: ">=1.7.0 <1.8.0"
-    - name: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2017-12-02
+    - name: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-05
       providerID: aws
       kubernetesVersion: ">=1.8.0 <1.9.0"
     # Moving to stretch in 1.9 (if goes well)
-    # BUT... this is causing the submit queue to block, so back to jessie temporarily: https://github.com/kubernetes/kubernetes/issues/56763
-    - name: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2017-12-02
+    - name: kope.io/k8s-1.8-debian-stretch-amd64-hvm-ebs-2018-01-05
       providerID: aws
       kubernetesVersion: ">=1.9.0 <1.10.0"
     # Need stretch as default in 1.10 (for nvme)
-    # BUT... this is causing the submit queue to block, so back to jessie temporarily: https://github.com/kubernetes/kubernetes/issues/56763
-    - name: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2017-12-02
+    - name: kope.io/k8s-1.8-debian-stretch-amd64-hvm-ebs-2018-01-05
       providerID: aws
       kubernetesVersion: ">=1.10.0"
     - providerID: gce
@@ -34,7 +32,7 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.8.0"
-    recommendedVersion: 1.8.4
+    recommendedVersion: 1.8.6
     requiredVersion: 1.8.0
   - range: ">=1.7.0"
     recommendedVersion: 1.7.11
@@ -52,7 +50,7 @@ spec:
   - range: ">=1.8.0-alpha.1"
     recommendedVersion: 1.8.0
     #requiredVersion: 1.8.0
-    kubernetesVersion: 1.8.4
+    kubernetesVersion: 1.8.6
   - range: ">=1.7.0-alpha.1"
     recommendedVersion: 1.7.1
     #requiredVersion: 1.7.0

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -54,7 +54,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -74,7 +74,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
@@ -62,7 +62,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -82,7 +82,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -102,7 +102,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1c
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -122,7 +122,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -70,7 +70,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -90,7 +90,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -110,7 +110,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1c
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -130,7 +130,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha1.yaml
@@ -68,7 +68,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -88,7 +88,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -108,7 +108,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1c
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -128,7 +128,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -76,7 +76,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -96,7 +96,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -116,7 +116,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1c
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -136,7 +136,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -57,7 +57,7 @@ metadata:
     kops.k8s.io/cluster: overrides.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -77,7 +77,7 @@ metadata:
     kops.k8s.io/cluster: overrides.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2017-12-02
+  image: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2018-01-05
   machineType: t2.medium
   maxSize: 2
   minSize: 2


### PR DESCRIPTION
Recommend k8s 1.8.6, AMI with kernel 4.4.110