### PR TITLE
Delete repeated kops AMI in spectre update docs

### DIFF
--- a/docs/advisories/spectre-meltdown-kernel-update.md
+++ b/docs/advisories/spectre-meltdown-kernel-update.md
@@ -50,7 +50,6 @@ For the kops-maintained AMIs, the following AMIs contain an updated kernel:
 - kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2018-01-05
 - kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-05
 - kope.io/k8s-1.8-debian-stretch-amd64-hvm-ebs-2018-01-05
-- kope.io/k8s-1.8-debian-stretch-amd64-hvm-ebs-2018-01-05
 
 These are the images that are maintained by the kubernetes/kops project; please refer to
 other vendors for the appropriate AMI version.


### PR DESCRIPTION
Hi guys!

I didn't submit an issue (that is what `CONTRIBUTING.md` says) because of the triviality of the change.

The kops debian-stretch AMI for kubernetes 1.8 is repeated when listed, this removes one of its appearances.