### PR TITLE
Update bazelbuild/rules_go to 0.9.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,12 +3,14 @@
 
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.8.1/rules_go-0.8.1.tar.gz",
-    sha256 = "90bb270d0a92ed5c83558b2797346917c46547f6f7103e648941ecdb6b9d0e72",
+    sha256 = "4d8d6244320dd751590f9100cf39fd7a4b75cd901e1f3ffdfd6f048328883695",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.9.0/rules_go-0.9.0.tar.gz",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+
 go_rules_dependencies()
+
 go_register_toolchains()
 
 #=============================================================================
@@ -29,10 +31,10 @@ load(
 container_repositories()
 
 container_pull(
-  name = "debian_hyperkube_base_amd64",
-  registry = "gcr.io",
-  repository = "google_containers/debian-hyperkube-base-amd64",
-  # 'tag' is also supported, but digest is encouraged for reproducibility.
-  digest = "sha256:fc1b461367730660ac5a40c1eb2d1b23221829acf8a892981c12361383b3742b",
-  tag = "0.8",
+    name = "debian_hyperkube_base_amd64",
+    # 'tag' is also supported, but digest is encouraged for reproducibility.
+    digest = "sha256:fc1b461367730660ac5a40c1eb2d1b23221829acf8a892981c12361383b3742b",
+    registry = "gcr.io",
+    repository = "google_containers/debian-hyperkube-base-amd64",
+    tag = "0.8",
 )

--- a/upup/pkg/fi/cloudup/awstasks/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/awstasks/BUILD.bazel
@@ -71,6 +71,7 @@ go_library(
         "//upup/pkg/fi/cloudup/cloudformation:go_default_library",
         "//upup/pkg/fi/cloudup/terraform:go_default_library",
         "//upup/pkg/fi/utils:go_default_library",
+        "//util/pkg/slice:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/awserr:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/autoscaling:go_default_library",

--- a/vendor/github.com/coreos/etcd/BUILD.bazel
+++ b/vendor/github.com/coreos/etcd/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
 
 go_binary(
     name = "etcd",
+    embed = [":go_default_library"],
     importpath = "github.com/coreos/etcd",
-    library = ":go_default_library",
     visibility = ["//visibility:public"],
 )

--- a/vendor/github.com/coreos/etcd/contrib/systemd/etcd2-backup-coreos/BUILD.bazel
+++ b/vendor/github.com/coreos/etcd/contrib/systemd/etcd2-backup-coreos/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
 
 go_binary(
     name = "etcd2-backup-coreos",
+    embed = [":go_default_library"],
     importpath = "github.com/coreos/etcd/contrib/systemd/etcd2-backup-coreos",
-    library = ":go_default_library",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
There's a bug in `bazelbuild/rules_go` before 0.9.0 which causes builds to fail with Bazel 0.10.0+.

I'm proactively updating the dependency so things don't break when Bazel 0.10.0 is released. This should be backwards compatible with older versions of Bazel (0.8.0+).