### PR TITLE
Update kubelet to be secureKubelet by default

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -48,7 +48,7 @@ By default AnonymousAuth on the kubelet is 'on' and so communication between kub
 # In the cluster spec
 spec:
   kubelet:
-    AnonymousAuth: false
+    anonymousAuth: false
 ```
 
 **Note** on a existing cluster with 'anonymousAuth' unset you would need to first roll out the masters and then update the node instance groups.

--- a/docs/security.md
+++ b/docs/security.md
@@ -48,7 +48,7 @@ By default AnonymousAuth on the kubelet is 'on' and so communication between kub
 # In the cluster spec
 spec:
   kubelet:
-    anonymousAuth: false
+    AnonymousAuth: false
 ```
 
 **Note** on a existing cluster with 'anonymousAuth' unset you would need to first roll out the masters and then update the node instance groups.

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -60,6 +60,7 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 	clusterSpec.Kubelet.ClusterDNS = ip.String()
 	clusterSpec.Kubelet.ClusterDomain = clusterSpec.ClusterDNSDomain
 	clusterSpec.Kubelet.NonMasqueradeCIDR = clusterSpec.NonMasqueradeCIDR
+	clusterSpec.Kubelet.anonymousAuth = fi.Bool(false)
 
 	if b.Context.IsKubernetesLT("1.7") {
 		// babysit-daemons removed in 1.7

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -60,7 +60,11 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 	clusterSpec.Kubelet.ClusterDNS = ip.String()
 	clusterSpec.Kubelet.ClusterDomain = clusterSpec.ClusterDNSDomain
 	clusterSpec.Kubelet.NonMasqueradeCIDR = clusterSpec.NonMasqueradeCIDR
-	clusterSpec.Kubelet.anonymousAuth = fi.Bool(false)
+
+	// Set secure kubelet on by default when the user has not set this flag
+	if clusterSpec.Kubelet.AnonymousAuth == nil {
+		clusterSpec.Kubelet.AnonymousAuth = fi.Bool(false)
+	}
 
 	if b.Context.IsKubernetesLT("1.7") {
 		// babysit-daemons removed in 1.7

--- a/tests/integration/create_cluster/minimal/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha1.yaml
@@ -26,6 +26,8 @@ spec:
     allowContainerRegistry: true
     legacy: false
   kubernetesVersion: v1.4.8
+  kubelet:
+    anonymousAuth: false
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
@@ -25,6 +25,8 @@ spec:
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.4.8
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -207,6 +207,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
     master: http://127.0.0.1:8080
   kubelet:
     allowPrivileged: true
+    anonymousAuth: false
     apiServers: https://api.internal.additionaluserdata.example.com
     babysitDaemons: true
     cgroupRoot: docker
@@ -225,6 +226,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
     reconcileCIDR: true
   masterKubelet:
     allowPrivileged: true
+    anonymousAuth: false
     apiServers: http://127.0.0.1:8080
     babysitDaemons: true
     cgroupRoot: docker

--- a/tests/integration/update_cluster/additional_user-data/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/additional_user-data/in-v1alpha2.yaml
@@ -19,6 +19,8 @@ spec:
       name: us-test-1a
     name: events
   kubernetesVersion: v1.4.12
+  kubelet:
+    anonymousAuth: false
   masterInternalName: api.internal.additionaluserdata.example.com
   masterPublicName: api.additionaluserdata.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -198,6 +198,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     master: http://127.0.0.1:8080
   kubelet:
     allowPrivileged: true
+    anonymousAuth: false
     apiServers: https://api.internal.minimal.example.com
     babysitDaemons: true
     cgroupRoot: docker
@@ -216,6 +217,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     reconcileCIDR: true
   masterKubelet:
     allowPrivileged: true
+    anonymousAuth: false
     apiServers: http://127.0.0.1:8080
     babysitDaemons: true
     cgroupRoot: docker

--- a/tests/integration/update_cluster/minimal-cloudformation/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/in-v1alpha2.yaml
@@ -19,6 +19,8 @@ spec:
       name: us-test-1a
     name: events
   kubernetesVersion: v1.4.12
+  kubelet:
+    anonymousAuth: false
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/minimal/in-v1alpha0.yaml
+++ b/tests/integration/update_cluster/minimal/in-v1alpha0.yaml
@@ -18,6 +18,8 @@ spec:
       zone: us-test-1a
     name: events
   kubernetesVersion: v1.4.12
+  kubelet:
+    anonymousAuth: false
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/minimal/in-v1alpha1.yaml
+++ b/tests/integration/update_cluster/minimal/in-v1alpha1.yaml
@@ -19,6 +19,8 @@ spec:
       zone: us-test-1a
     name: events
   kubernetesVersion: v1.4.12
+  kubelet:
+    anonymousAuth: false
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/minimal/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal/in-v1alpha2.yaml
@@ -19,6 +19,8 @@ spec:
       name: us-test-1a
     name: events
   kubernetesVersion: v1.8.0
+  kubelet:
+    anonymousAuth: false
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16


### PR DESCRIPTION
Turns on secureKubelet by default based on @gambol99 's work on #3125 
Towards an effort to complete issue #3998 