### PR TITLE
Stick with jessie for 1.9 clusters

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -16,8 +16,7 @@ spec:
     - name: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14
       providerID: aws
       kubernetesVersion: ">=1.8.0 <1.9.0"
-    # Moving to stretch in 1.9 (if goes well)
-    - name: kope.io/k8s-1.8-debian-stretch-amd64-hvm-ebs-2018-01-14
+    - name: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14
       providerID: aws
       kubernetesVersion: ">=1.9.0 <1.10.0"
     # Need stretch as default in 1.10 (for nvme)

--- a/channels/stable
+++ b/channels/stable
@@ -16,8 +16,7 @@ spec:
     - name: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-05
       providerID: aws
       kubernetesVersion: ">=1.8.0 <1.9.0"
-    # Moving to stretch in 1.9 (if goes well)
-    - name: kope.io/k8s-1.8-debian-stretch-amd64-hvm-ebs-2018-01-05
+    - name: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-05
       providerID: aws
       kubernetesVersion: ">=1.9.0 <1.10.0"
     # Need stretch as default in 1.10 (for nvme)


### PR DESCRIPTION
We'll try to move to stretch in 1.10, which is important for nvme, but
tests are still broken on stretch.