### PR TITLE
ReadTree: clarify that returns only files

### DIFF
--- a/upup/pkg/fi/vfs_castore_test.go
+++ b/upup/pkg/fi/vfs_castore_test.go
@@ -81,9 +81,6 @@ func TestVFSCAStoreRoundTrip(t *testing.T) {
 
 	pathMap := make(map[string]vfs.Path)
 	for _, p := range paths {
-		if p.(*vfs.MemFSPath).HasChildren() {
-			continue
-		}
 		pathMap[p.Path()] = p
 	}
 

--- a/util/pkg/vfs/fs.go
+++ b/util/pkg/vfs/fs.go
@@ -152,6 +152,8 @@ func (p *FSPath) ReadTree() ([]Path, error) {
 	return paths, nil
 }
 
+// readTree recursively finds files and adds them to dest
+// It excludes directories.
 func readTree(base string, dest *[]Path) error {
 	files, err := ioutil.ReadDir(base)
 	if err != nil {
@@ -159,12 +161,13 @@ func readTree(base string, dest *[]Path) error {
 	}
 	for _, f := range files {
 		p := path.Join(base, f.Name())
-		*dest = append(*dest, NewFSPath(p))
 		if f.IsDir() {
 			err = readTree(p, dest)
 			if err != nil {
 				return err
 			}
+		} else {
+			*dest = append(*dest, NewFSPath(p))
 		}
 	}
 	return nil

--- a/util/pkg/vfs/memfs.go
+++ b/util/pkg/vfs/memfs.go
@@ -140,7 +140,9 @@ func (p *MemFSPath) ReadTree() ([]Path, error) {
 
 func (p *MemFSPath) readTree(dest *[]Path) {
 	for _, f := range p.children {
-		*dest = append(*dest, f)
+		if !f.HasChildren() {
+			*dest = append(*dest, f)
+		}
 		f.readTree(dest)
 	}
 }

--- a/util/pkg/vfs/vfs.go
+++ b/util/pkg/vfs/vfs.go
@@ -69,6 +69,7 @@ type Path interface {
 	ReadDir() ([]Path, error)
 
 	// ReadTree lists all files (recursively) in the subtree rooted at the current Path
+	/// Note: returns only files, not directories
 	ReadTree() ([]Path, error)
 }
 


### PR DESCRIPTION
Because the primary use-case is S3-style stores, we haven't really used
directories.  If we have a use-case, we can always pass a boolean
parameter or create an alternative function.