### PR TITLE
Don't autobuild protobuf files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,9 +192,7 @@ codegen: kops-gobindata
 	PATH=${GOPATH_1ST}/bin:${PATH} go generate k8s.io/kops/upup/pkg/fi/fitasks
 
 .PHONY: protobuf
-protobuf: protokube/pkg/gossip/mesh/mesh.pb.go
-
-protokube/pkg/gossip/mesh/mesh.pb.go: protokube/pkg/gossip/mesh/mesh.proto
+protobuf:
 	cd ${GOPATH_1ST}/src; protoc --gofast_out=. k8s.io/kops/protokube/pkg/gossip/mesh/mesh.proto
 
 .PHONY: hooks


### PR DESCRIPTION
Requires us to ship protoc, exposes us to problems with timestamp skew
on checkout.  Also the mesh.proto rarely changes.

To rebuild: make protobuf