### PR TITLE
bazel: expose version as in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))
 # Keep in sync with upup/models/cloudup/resources/addons/dns-controller/
 DNS_CONTROLLER_TAG=1.8.0
 
+# Keep in sync with logic in get_workspace_status
 KOPS_RELEASE_VERSION = 1.8.0
 KOPS_CI_VERSION      = 1.8.1-beta.1
 
@@ -56,6 +57,7 @@ KOPS_ROOT           ?= $(patsubst %/,%,$(abspath $(dir $(firstword $(MAKEFILE_LI
 
 GITSHA := $(shell cd ${GOPATH_1ST}/src/k8s.io/kops; git describe --always)
 
+# Keep in sync with logic in get_workspace_status
 ifndef VERSION
   # To keep both CI and end-users building from source happy,
   # we expect that CI sets CI=1.

--- a/cmd/kops/BUILD.bazel
+++ b/cmd/kops/BUILD.bazel
@@ -125,7 +125,7 @@ go_binary(
     importpath = "k8s.io/kops/cmd/kops",
     visibility = ["//visibility:public"],
     x_defs = {
-        "k8s.io/kops.Version": "1.8.0",  # keep
+        "k8s.io/kops.Version": "{KOPS_VERSION}",  # keep
         "k8s.io/kops.GitVersion": "{BUILD_SCM_REVISION}",  # keep
     },
 )

--- a/tools/get_workspace_status
+++ b/tools/get_workspace_status
@@ -28,3 +28,18 @@ else
 fi
 echo "BUILD_SCM_STATUS ${tree_status}"
 
+# Compute KOPS_VERSION.  Keep in sync with logic in Makefile
+GITSHA=$(git describe --always)
+
+KOPS_RELEASE_VERSION=1.8.0
+KOPS_CI_VERSION=1.8.1-beta.1
+
+if [[ -z "${VERSION}" ]]; then
+  if [[ -z "${CI}" ]]; then
+    VERSION=${KOPS_RELEASE_VERSION}
+  else
+    VERSION="${KOPS_CI_VERSION}+${GITSHA}"
+  fi
+fi
+
+echo "KOPS_VERSION ${VERSION}"


### PR DESCRIPTION
This means that bazel build should stamp kops with the same version as
the Makefile does, given the same env vars.