### PR TITLE
When kops searches for AMI by name, if > 1 are returned, uses the latest.

### DIFF
--- a/pkg/testutils/integrationtestharness.go
+++ b/pkg/testutils/integrationtestharness.go
@@ -129,6 +129,7 @@ func (h *IntegrationTestHarness) SetupMockAWS() {
 	}})
 
 	mockEC2.Images = append(mockEC2.Images, &ec2.Image{
+		CreationDate:   aws.String("2016-10-21T20:07:19.000Z"),
 		ImageId:        aws.String("ami-12345678"),
 		Name:           aws.String("k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21"),
 		OwnerId:        aws.String(awsup.WellKnownAccountKopeio),
@@ -136,6 +137,7 @@ func (h *IntegrationTestHarness) SetupMockAWS() {
 	})
 
 	mockEC2.Images = append(mockEC2.Images, &ec2.Image{
+		CreationDate:   aws.String("2017-01-09T17:08:27.000Z"),
 		ImageId:        aws.String("ami-15000000"),
 		Name:           aws.String("k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09"),
 		OwnerId:        aws.String(awsup.WellKnownAccountKopeio),

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -948,11 +948,16 @@ func resolveImage(ec2Client ec2iface.EC2API, name string) (*ec2.Image, error) {
 	if response == nil || len(response.Images) == 0 {
 		return nil, fmt.Errorf("could not find Image for %q", name)
 	}
-	if len(response.Images) != 1 {
-		return nil, fmt.Errorf("found multiple Images for %q", name)
-	}
 
 	image := response.Images[0]
+	for _, v := range response.Images {
+		itime, _ := time.Parse(time.RFC3339, *image.CreationDate)
+		vtime, _ := time.Parse(time.RFC3339, *v.CreationDate)
+		if vtime.After(itime) {
+			image = v
+		}
+	}
+
 	glog.V(4).Infof("Resolved image %q", aws.StringValue(image.ImageId))
 	return image, nil
 }


### PR DESCRIPTION
Use case: we build our own k8s images and would like to be able to use a search pattern to find the latest image during updates and not have to modify every run.

A positive side-effect is it also allows using wildcards in name.

For example, let's say you have images named: 
- `k8s-1.8-2017-11-13`
- `k8s-1.8-2017-12-15`,
- `k8s-1.8-2018-01-02`
- `k8s-1.8-2018-01-14` 

You can specify `account_id/k8s-1.8-*` and kops will use the ami for `k8s-1.8-2018-01-14`.

`account_id/k8s-1.8-2017-*` returns `k8s-1.8-2017-12-15`
`account_id/k8s-1.8-2017-11-13` returns that image since no wildcard is used.  If you had multiple images with the same name, then the latest would still be returned.