### PR TITLE
Increase key size in GeneratePrivateKey() to 3072

### DIFF
--- a/pkg/pki/privatekey.go
+++ b/pkg/pki/privatekey.go
@@ -29,6 +29,8 @@ import (
 	"io"
 
 	"github.com/golang/glog"
+	"os"
+	"strconv"
 )
 
 func ParsePEMPrivateKey(data []byte) (*PrivateKey, error) {
@@ -43,7 +45,17 @@ func ParsePEMPrivateKey(data []byte) (*PrivateKey, error) {
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-	rsaKey, err := rsa.GenerateKey(crypto_rand.Reader, 3072)
+	var rsaKeySize int64 = 2048
+
+	if os.Getenv("RSA_PRIVATE_KEY_SIZE") != "" {
+		var intErr error
+		rsaKeySize, intErr = strconv.ParseInt(os.Getenv("RSA_PRIVATE_KEY_SIZE"), 0, 0)
+		if intErr != nil {
+			return nil, fmt.Errorf("error getting RSA private key size: %v", intErr)
+		}
+	}
+
+	rsaKey, err := rsa.GenerateKey(crypto_rand.Reader, int(rsaKeySize))
 	if err != nil {
 		return nil, fmt.Errorf("error generating RSA private key: %v", err)
 	}

--- a/pkg/pki/privatekey.go
+++ b/pkg/pki/privatekey.go
@@ -47,9 +47,9 @@ func ParsePEMPrivateKey(data []byte) (*PrivateKey, error) {
 func GeneratePrivateKey() (*PrivateKey, error) {
 	var rsaKeySize int64 = 2048
 
-	if os.Getenv("RSA_PRIVATE_KEY_SIZE") != "" {
+	if os.Getenv("KOPS_RSA_PRIVATE_KEY_SIZE") != "" {
 		var intErr error
-		rsaKeySize, intErr = strconv.ParseInt(os.Getenv("RSA_PRIVATE_KEY_SIZE"), 0, 0)
+		rsaKeySize, intErr = strconv.ParseInt(os.Getenv("KOPS_RSA_PRIVATE_KEY_SIZE"), 0, 0)
 		if intErr != nil {
 			return nil, fmt.Errorf("error getting RSA private key size: %v", intErr)
 		}

--- a/pkg/pki/privatekey.go
+++ b/pkg/pki/privatekey.go
@@ -43,7 +43,7 @@ func ParsePEMPrivateKey(data []byte) (*PrivateKey, error) {
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-	rsaKey, err := rsa.GenerateKey(crypto_rand.Reader, 2048)
+	rsaKey, err := rsa.GenerateKey(crypto_rand.Reader, 3072)
 	if err != nil {
 		return nil, fmt.Errorf("error generating RSA private key: %v", err)
 	}


### PR DESCRIPTION
@justinsb Our SecOps group requires private keys be at 3072; others may be in the same boat. I talked to @chrislovecnm and he suggested I bump it and send a PR.