### PR TITLE
deprecate kube-apiserver flag `--address` `--insecure-port`

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -184,10 +184,10 @@ type KubeAPIServerConfig struct {
 	CloudProvider string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
 	// SecurePort is the port the kube runs on
 	SecurePort int32 `json:"securePort,omitempty" flag:"secure-port"`
-	// InsecurePort is the port the insecure api runs
-	InsecurePort int32 `json:"insecurePort,omitempty" flag:"insecure-port"`
-	// Address is the binding address for the kube api
-	Address string `json:"address,omitempty" flag:"address"`
+	// Deprecated: InsecurePort is the port the insecure api runs
+	InsecurePort int32 `json:"insecurePort,omitempty" flag:"insecure-port" flag-empty:"-1"`
+	// Deprecated: Address is the binding address for the kube api
+	Address string `json:"address,omitempty" flag:"address" flag-empty:"255.255.255.255"`
 	// AdmissionControl is a list of admission controllers to user
 	AdmissionControl []string `json:"admissionControl,omitempty" flag:"admission-control"`
 	// ServiceClusterIPRange is the service address range

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -184,10 +184,10 @@ type KubeAPIServerConfig struct {
 	CloudProvider string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
 	// SecurePort is the port the kube runs on
 	SecurePort int32 `json:"securePort,omitempty" flag:"secure-port"`
-	// InsecurePort is the port the insecure api runs
-	InsecurePort int32 `json:"insecurePort,omitempty" flag:"insecure-port"`
-	// Address is the binding address for the kube api
-	Address string `json:"address,omitempty" flag:"address"`
+	// Deprecated: InsecurePort is the port the insecure api runs
+	InsecurePort int32 `json:"insecurePort,omitempty" flag:"insecure-port" flag-empty:"-1"`
+	// Deprecated: Address is the binding address for the kube api
+	Address string `json:"address,omitempty" flag:"address" flag-empty:"255.255.255.255"`
 	// AdmissionControl is a list of admission controllers to user
 	AdmissionControl []string `json:"admissionControl,omitempty" flag:"admission-control"`
 	// ServiceClusterIPRange is the service address range

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -184,10 +184,10 @@ type KubeAPIServerConfig struct {
 	CloudProvider string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
 	// SecurePort is the port the kube runs on
 	SecurePort int32 `json:"securePort,omitempty" flag:"secure-port"`
-	// InsecurePort is the port the insecure api runs
-	InsecurePort int32 `json:"insecurePort,omitempty" flag:"insecure-port"`
-	// Address is the binding address for the kube api
-	Address string `json:"address,omitempty" flag:"address"`
+	// Deprecated: InsecurePort is the port the insecure api runs
+	InsecurePort int32 `json:"insecurePort,omitempty" flag:"insecure-port" flag-empty:"-1"`
+	// Deprecated: Address is the binding address for the kube api
+	Address string `json:"address,omitempty" flag:"address" flag-empty:"255.255.255.255"`
 	// AdmissionControl is a list of admission controllers to user
 	AdmissionControl []string `json:"admissionControl,omitempty" flag:"admission-control"`
 	// ServiceClusterIPRange is the service address range

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -127,6 +127,7 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 
 	c.LogLevel = 2
 	c.SecurePort = 443
+	c.InsecurePort = 8080
 	c.Address = "127.0.0.1"
 	c.AllowPrivileged = fi.Bool(true)
 	c.ServiceClusterIPRange = clusterSpec.ServiceClusterIPRange
@@ -210,13 +211,12 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 		c.AnonymousAuth = fi.Bool(false)
 	}
 
-	// We disable the insecure port from 1.6 onwards
-	if b.IsKubernetesGTE("1.6") {
-		c.InsecurePort = 0
-		glog.V(4).Infof("Enabling apiserver insecure port, for healthchecks (issue #43784)")
-		c.InsecurePort = 8080
-	} else {
-		c.InsecurePort = 8080
+	// We disable the insecure port and address from 1.10 onwards
+	// https://github.com/kubernetes/kubernetes/issues/58951
+	if b.IsKubernetesGTE("1.10") {
+		glog.V(4).Infof("disable apiserver insecure port and address")
+		c.InsecurePort = -1
+		c.Address = "255.255.255.255"
 	}
 
 	return nil


### PR DESCRIPTION
fix #4355 

Stop supporting these flags since kubernetes 1.10.