### PR TITLE
modify check require-kubeconfig kube version

### DIFF
--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -120,8 +120,8 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.Kubelet.KubeconfigPath = kubeconfigPath
 		clusterSpec.MasterKubelet.KubeconfigPath = kubeconfigPath
 
-		// Only pass require-kubeconfig to versions prior to 1.10; deprecated & being removed
-		if b.Context.IsKubernetesLT("1.10") {
+		// Only pass require-kubeconfig to versions prior to 1.9; deprecated & being removed
+		if b.Context.IsKubernetesLT("1.9") {
 			clusterSpec.Kubelet.RequireKubeconfig = fi.Bool(true)
 			clusterSpec.MasterKubelet.RequireKubeconfig = fi.Bool(true)
 		}


### PR DESCRIPTION
modify check require-kubeconfig kube version
Kubernetes version 1.9 does not need require-kubeconfig any more.