### PR TITLE
Update route-related IAM permissions for Romana

### DIFF
--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -19,7 +19,6 @@
       "Sid": "kopsK8sEC2MasterPermsAllResources",
       "Effect": "Allow",
       "Action": [
-        "ec2:CreateRoute",
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
         "ec2:CreateVolume",
@@ -35,6 +34,7 @@
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateRoute",
         "ec2:DeleteRoute",
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -19,7 +19,6 @@
       "Sid": "kopsK8sEC2MasterPermsAllResources",
       "Effect": "Allow",
       "Action": [
-        "ec2:CreateRoute",
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
         "ec2:CreateVolume",
@@ -35,6 +34,7 @@
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateRoute",
         "ec2:DeleteRoute",
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",


### PR DESCRIPTION
This is a fix for issue #4183 to ensure the IAM master role contains all required permissions for Romana. The missing permission was `ReplaceRoute`.

Instead of deleting the existing `CreateRoute` and `DeleteRoute` permissions in other sections, they have been kept intact, because removing them is likely to affect other CNI providers.
But for clarity and in case they are removed in the future, all 3 permissions are added in the romana-specific SID.
I did move the existing CreateRoute item to the same section as DeleteRoute for consistency.

