### PR TITLE
Fix ccm startup wrt dns controller (set dnsPolicy to Default and host…

### DIFF
--- a/upup/models/cloudup/resources/addons/core.addons.k8s.io/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/core.addons.k8s.io/k8s-1.7.yaml.template
@@ -128,6 +128,15 @@ spec:
         - --allocate-node-cidrs=true
         - --configure-cloud-routes=true
         - --cluster-cidr={{ .KubeControllerManager.ClusterCIDR }}
+        volumeMounts:
+        - name: ca-certificates
+          mountPath: /etc/ssl/certs
+      hostNetwork: true
+      dnsPolicy: Default
+      volumes:
+      - name: ca-certificates
+        hostPath:
+          path: /etc/ssl/certs
       tolerations:
       # this is required so CCM can bootstrap itself
       - key: node.cloudprovider.kubernetes.io/uninitialized


### PR DESCRIPTION
…Network: true)

A simple fix following 2 days of debugging.

The problem was the CCM needs DNS to start first, since it needs DNS to talk to AWS api. However, until CCM removes the `k8s.io....cloudprovider: uninitialized` taint, DNS cannot be run (kubelet taints node when started with cloudProvider: external). This deadlock was stopping the k8s cluster from starting up. This PR fixes this.

Will follow up with a docs PR tomorrow. 

@justinsb @chrislovecnm 