### PR TITLE
Ignore keyset.yaml files

### DIFF
--- a/upup/pkg/fi/vfs_castore.go
+++ b/upup/pkg/fi/vfs_castore.go
@@ -220,11 +220,16 @@ func (c *VFSCAStore) loadCertificates(p vfs.Path) (*certificates, error) {
 	}
 
 	for _, f := range files {
+		name := f.Base()
+		if strings.HasSuffix(name, ".yaml") {
+			// ignore bundle
+			continue
+		}
+
 		cert, err := c.loadOneCertificate(f)
 		if err != nil {
 			return nil, fmt.Errorf("error loading certificate %q: %v", f, err)
 		}
-		name := f.Base()
 		name = strings.TrimSuffix(name, ".crt")
 		certs.certificates[name] = cert
 	}
@@ -530,11 +535,16 @@ func (c *VFSCAStore) loadPrivateKeys(p vfs.Path) (*privateKeys, error) {
 	}
 
 	for _, f := range files {
+		name := f.Base()
+		if strings.HasSuffix(name, ".yaml") {
+			// ignore bundle
+			continue
+		}
+
 		key, err := c.loadOnePrivateKey(f)
 		if err != nil {
 			return nil, fmt.Errorf("error loading private key %q: %v", f, err)
 		}
-		name := f.Base()
 		name = strings.TrimSuffix(name, ".key")
 		keys.keys[name] = key
 	}


### PR DESCRIPTION
These are written by later versions of kops (1.9), but if we try to
parse them as a certificate/key we will error out.

We're going to do a 1.8.1 release which will just ignore those files, so
that we have a downgrade path.

Issue #4156