### PR TITLE
Explicitly set go version in bazel build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,7 +11,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_too
 
 go_rules_dependencies()
 
-go_register_toolchains()
+go_register_toolchains(
+    go_version = "1.9.3",
+)
 
 #=============================================================================
 # Docker rules


### PR DESCRIPTION
So it doesn't float with rules_go updates