### PR TITLE
Add  to aws-china.md to prevent Etag not match the HASH of file.

### DIFF
--- a/docs/aws-china.md
+++ b/docs/aws-china.md
@@ -254,10 +254,25 @@ done
 
 ## Upload assets
 
+## Get default S3 multipart_threshold
+
+AWS_S3_DEFAULT_MULTIPART_THRESHOLD=$(aws configure get default.s3.multipart_threshold)
+
+if [ ! -n "$AWS_S3_DEFAULT_MULTIPART_THRESHOLD" ]; then
+  AWS_S3_DEFAULT_MULTIPART_THRESHOLD=8MB
+fi
+
+## Set multipart_threshold to 1024MB to prevent Etag not returns MD5 when upload multipart
+
+aws configure set default.s3.multipart_threshold 1024MB
+
 aws s3api create-bucket --bucket $ASSET_BUCKET --create-bucket-configuration LocationConstraint=$AWS_REGION
 for dir in "kubernetes" "kops"; do
   aws s3 sync --acl public-read "$dir" "s3://$ASSET_BUCKET/$ASSET_PREFIX$dir"
 done
+
+aws configure set default.s3.multipart_threshold $AWS_S3_DEFAULT_MULTIPART_THRESHOLD
+
 ```
 
 When create the cluster, add these parameters to the command line.

--- a/upup/pkg/fi/cloudup/networking.go
+++ b/upup/pkg/fi/cloudup/networking.go
@@ -114,7 +114,8 @@ const (
 	defaultCNIAssetHashStringK8s1_9 = "d595d3ded6499a64e8dac02466e2f5f2ce257c9f"
 
 	// Environment variable for overriding CNI url
-	ENV_VAR_CNI_VERSION_URL = "CNI_VERSION_URL"
+	ENV_VAR_CNI_VERSION_URL       = "CNI_VERSION_URL"
+	ENV_VAR_CNI_ASSET_HASH_STRING = "CNI_ASSET_HASH_STRING"
 )
 
 func findCNIAssets(c *api.Cluster, assetBuilder *assets.AssetBuilder) (*url.URL, string, error) {
@@ -124,8 +125,17 @@ func findCNIAssets(c *api.Cluster, assetBuilder *assets.AssetBuilder) (*url.URL,
 		if err != nil {
 			return nil, "", fmt.Errorf("unable to parse %q as a URL: %v", cniVersionURL, err)
 		}
+
 		glog.Infof("Using CNI asset version %q, as set in %s", cniVersionURL, ENV_VAR_CNI_VERSION_URL)
-		return u, "", nil
+
+		if cniAssetHashString := os.Getenv(ENV_VAR_CNI_ASSET_HASH_STRING); cniAssetHashString != "" {
+
+			glog.Infof("Using CNI asset hash %q, as set in %s", cniAssetHashString, ENV_VAR_CNI_ASSET_HASH_STRING)
+
+			return u, cniAssetHashString, nil
+		} else {
+			return u, "", nil
+		}
 	}
 
 	sv, err := util.ParseKubernetesVersion(c.Spec.KubernetesVersion)


### PR DESCRIPTION
I follow the docs [https://github.com/leeeboo/kops/blob/master/docs/aws-china.md#offline-mode](url) to build cluster offline in cn-north-1.
I find a bug in the docs. When sync files to s3, aws cli will upload multipart (8MB per one part). It will let the Etag which s3 returns not match the md5 of the file. So the cluster can not startup.