### PR TITLE
add support for changing the weave peer connection limit

### DIFF
--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -57,7 +57,8 @@ type KopeioNetworkingSpec struct {
 
 // WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU *int32 `json:"mtu,omitempty"`
+	MTU       *int32 `json:"mtu,omitempty"`
+	ConnLimit *int32 `json:"connLimit,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -57,7 +57,8 @@ type KopeioNetworkingSpec struct {
 
 // WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU *int32 `json:"mtu,omitempty"`
+	MTU       *int32 `json:"mtu,omitempty"`
+	ConnLimit *int32 `json:"connLimit,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -2704,6 +2704,7 @@ func Convert_kops_UserData_To_v1alpha1_UserData(in *kops.UserData, out *UserData
 
 func autoConvert_v1alpha1_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveNetworkingSpec, out *kops.WeaveNetworkingSpec, s conversion.Scope) error {
 	out.MTU = in.MTU
+	out.ConnLimit = in.ConnLimit
 	return nil
 }
 
@@ -2714,6 +2715,7 @@ func Convert_v1alpha1_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveN
 
 func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha1_WeaveNetworkingSpec(in *kops.WeaveNetworkingSpec, out *WeaveNetworkingSpec, s conversion.Scope) error {
 	out.MTU = in.MTU
+	out.ConnLimit = in.ConnLimit
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2730,6 +2730,15 @@ func (in *WeaveNetworkingSpec) DeepCopyInto(out *WeaveNetworkingSpec) {
 			**out = **in
 		}
 	}
+	if in.ConnLimit != nil {
+		in, out := &in.ConnLimit, &out.ConnLimit
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int32)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -57,7 +57,8 @@ type KopeioNetworkingSpec struct {
 
 // WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU *int32 `json:"mtu,omitempty"`
+	MTU       *int32 `json:"mtu,omitempty"`
+	ConnLimit *int32 `json:"connLimit,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3024,6 +3024,7 @@ func Convert_kops_UserData_To_v1alpha2_UserData(in *kops.UserData, out *UserData
 
 func autoConvert_v1alpha2_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveNetworkingSpec, out *kops.WeaveNetworkingSpec, s conversion.Scope) error {
 	out.MTU = in.MTU
+	out.ConnLimit = in.ConnLimit
 	return nil
 }
 
@@ -3034,6 +3035,7 @@ func Convert_v1alpha2_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveN
 
 func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha2_WeaveNetworkingSpec(in *kops.WeaveNetworkingSpec, out *WeaveNetworkingSpec, s conversion.Scope) error {
 	out.MTU = in.MTU
+	out.ConnLimit = in.ConnLimit
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2840,6 +2840,15 @@ func (in *WeaveNetworkingSpec) DeepCopyInto(out *WeaveNetworkingSpec) {
 			**out = **in
 		}
 	}
+	if in.ConnLimit != nil {
+		in, out := &in.ConnLimit, &out.ConnLimit
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int32)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3051,6 +3051,15 @@ func (in *WeaveNetworkingSpec) DeepCopyInto(out *WeaveNetworkingSpec) {
 			**out = **in
 		}
 	}
+	if in.ConnLimit != nil {
+		in, out := &in.ConnLimit, &out.ConnLimit
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int32)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
@@ -123,6 +123,10 @@ spec:
             - name: WEAVE_MTU
               value: "{{ .Networking.Weave.MTU }}"
             {{- end }}
+            {{- if .Networking.Weave.ConnLimit }}
+            - name: CONN_LIMIT
+              value: "{{ .Networking.Weave.ConnLimit }}"
+            {{- end }}
           image: 'weaveworks/weave-kube:2.1.3'
           livenessProbe:
             httpGet:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -131,6 +131,10 @@ spec:
             - name: WEAVE_MTU
               value: "{{ .Networking.Weave.MTU }}"
             {{- end }}
+            {{- if .Networking.Weave.ConnLimit }}
+            - name: CONN_LIMIT
+              value: "{{ .Networking.Weave.ConnLimit }}"
+            {{- end }}
           image: 'weaveworks/weave-kube:2.1.3'
           livenessProbe:
             httpGet:

--- a/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
@@ -42,6 +42,10 @@ spec:
             - name: WEAVE_MTU
               value: "{{ .Networking.Weave.MTU }}"
             {{- end }}
+            {{- if .Networking.Weave.ConnLimit }}
+            - name: CONN_LIMIT
+              value: "{{ .Networking.Weave.ConnLimit }}"
+            {{- end }}
           image: 'weaveworks/weave-kube:2.1.3'
           livenessProbe:
             httpGet:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -388,8 +388,8 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Weave != nil {
 		key := "networking.weave"
-		// 2.1.3-kops.1 = 2.1.3, kops packaging version 1.
-		version := "2.1.3-kops.1"
+		// 2.1.3-kops.2 = 2.1.3, kops packaging version 2.
+		version := "2.1.3-kops.2"
 
 		{
 			location := key + "/pre-k8s-1.6.yaml"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -69,18 +69,18 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.1.3-kops.1
+    version: 2.1.3-kops.2
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.7.0'
     manifest: networking.weave/k8s-1.6.yaml
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.1.3-kops.1
+    version: 2.1.3-kops.2
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0'
     manifest: networking.weave/k8s-1.7.yaml
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.1.3-kops.1
+    version: 2.1.3-kops.2


### PR DESCRIPTION
Weave limits the number of connections between peers and the default is 30.
As described here: https://github.com/weaveworks/weave/blob/ce9c5162bd94018ad5caca2c914cb5780727147c/site/kubernetes/kube-addon.md
Setting the CONN_LIMIT environment variable controls this setting. Adding a field in the
WeaveNetworkingSpec and adding the env var to the associated templates lets users
have clusters larger than 30 nodes and still use weave's peer discovery

The weave authors have indicated that 100 is not an unreasonable setting.
weaveworks/weave#1621 (comment)