### PR TITLE
Add notes for 1.8.1 release

### DIFF
--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -37,6 +37,7 @@ See [1.5.0-alpha4 commit](https://github.com/kubernetes/kops/commit/a60d7982e04c
 * Edit makefile
 * If updating dns-controller: bump version in Makefile, code, manifests, and tests
 
+`git commit -m "Release 1.X.Y`
 
 ## Check builds OK
 
@@ -73,7 +74,9 @@ git push --tags
 For the time being, we are also maintaining a release branch.  We push released
 versions to that.
 
-`git push origin release-1.7:release`
+`git push origin release-1.8:release`
+
+## Pull request to master branch (for release commit)
 
 ## Upload to github
 

--- a/docs/releases/1.8.1.md
+++ b/docs/releases/1.8.1.md
@@ -1,0 +1,6 @@
+Release 1.8.1 is a small patch release, which updates network plugins, but also tolerates a new schema
+file that will be added in kops 1.9.0.  This will provide a downgrade option from kops 1.9.0.
+
+* Ignore keyset.yaml files; provides a downgrade option from (upcoming) kops 1.9.0
+* Update flannel, weave, romana, kopeio-networking, calico, canal
+* Stop passing deprecated require-kubeconfig flag for kubernetes >= 1.9


### PR DESCRIPTION
Version will not be updated on master branch, as it is already on the
1.9 train.