### PR TITLE
Adding iam phase back

### DIFF
--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -181,17 +181,9 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 
 	var phase cloudup.Phase
 	if c.Phase != "" {
-		switch strings.ToLower(c.Phase) {
-		case string(cloudup.PhaseStageAssets):
-			phase = cloudup.PhaseStageAssets
-		case string(cloudup.PhaseNetwork):
-			phase = cloudup.PhaseNetwork
-		case string(cloudup.PhaseSecurity), "iam": // keeping IAM for backwards compatibility
-			phase = cloudup.PhaseSecurity
-		case string(cloudup.PhaseCluster):
-			phase = cloudup.PhaseCluster
-		default:
-			return fmt.Errorf("unknown phase %q, available phases: %s", c.Phase, strings.Join(cloudup.Phases.List(), ","))
+		phase, err = parsePhase(c.Phase)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -334,6 +326,14 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 	}
 
 	return nil
+}
+
+func parsePhase(phase string) (cloudup.Phase, error) {
+	if v, ok := cloudup.PhasesNameMap[phase]; ok {
+		return v, nil
+	}
+
+	return "", fmt.Errorf("unknown phase %q, available phases: %s", phase, strings.Join(cloudup.Phases.List(), ","))
 }
 
 func usesBastion(instanceGroups []*kops.InstanceGroup) bool {

--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -29,7 +29,7 @@ kops update cluster
       --create-kube-config      Will control automatically creating the kube config file on your local filesystem (default true)
       --model string            Models to apply (separate multiple models with commas) (default "config,proto,cloudup")
       --out string              Path to write any local output
-      --phase string            Subset of tasks to run: assets, cluster, network, security
+      --phase string            Subset of tasks to run: assets, cluster, iam, network, security
       --ssh-public-key string   SSH public key to use (deprecated: use kops create secret instead)
       --target string           Target - direct, terraform, cloudformation (default "direct")
   -y, --yes                     Create cloud resources, without --yes update is in dry run mode

--- a/upup/pkg/fi/cloudup/phase.go
+++ b/upup/pkg/fi/cloudup/phase.go
@@ -22,13 +22,15 @@ import "k8s.io/apimachinery/pkg/util/sets"
 type Phase string
 
 const (
-	// PhaseStageAssets uploads various assets such as containers in a private registry
+	// PhaseStageAssets uploads various assets such as containers in a private registry.
 	PhaseStageAssets Phase = "assets"
 	// PhaseNetwork creates network infrastructure.
 	PhaseNetwork Phase = "network"
-	// PhaseSecurity creates IAM profiles and roles, security groups and firewalls
+	// PhaseIAM creates IAM profiles and roles.
+	PhaseIAM Phase = "iam"
+	// PhaseSecurity security groups and firewalls.
 	PhaseSecurity Phase = "security"
-	// PhaseCluster creates the servers, and load-alancers
+	// PhaseCluster creates the servers, and load-balancers.
 	PhaseCluster Phase = "cluster"
 )
 
@@ -38,4 +40,14 @@ var Phases = sets.NewString(
 	string(PhaseSecurity),
 	string(PhaseNetwork),
 	string(PhaseCluster),
+	string(PhaseIAM),
 )
+
+// PhasesNameMap map of phases to phase types that is used to parse ux phase flag.
+var PhasesNameMap = map[string]Phase{
+	"assets":   PhaseStageAssets,
+	"network":  PhaseNetwork,
+	"security": PhaseSecurity,
+	"cluster":  PhaseCluster,
+	"iam":      PhaseIAM,
+}


### PR DESCRIPTION
To support self-managed IAM Profiles and Security Groups we
need to separate the security phase into security and iam phases.  Without this PR a
user would not be forced to provide both IAM Profiles and Security
Groups, and not use those features separately.

I included `parsePhase` func from another PR https://github.com/kubernetes/kops/pull/4153, so I would limit merge hell.