### PR TITLE
Updates for x1 instance family

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/machine_types.go
+++ b/upup/pkg/fi/cloudup/awsup/machine_types.go
@@ -607,6 +607,13 @@ var MachineTypes []AWSMachineTypeInfo = []AWSMachineTypeInfo{
 
 	// x1 family
 	{
+		Name:           "x1.16xlarge",
+		MemoryGB:       976,
+		ECU:            174.5,
+		Cores:          64,
+		EphemeralDisks: []int{1920},
+	},
+	{
 		Name:           "x1.32xlarge",
 		MemoryGB:       1952,
 		ECU:            349,


### PR DESCRIPTION
This PR adds support for the "x1.16xlarge" instance type.
ref: https://aws.amazon.com/ec2/pricing/on-demand/