### PR TITLE
Set the default docker for kubernetes 1.9 to 17.03.2

### DIFF
--- a/pkg/model/components/docker.go
+++ b/pkg/model/components/docker.go
@@ -51,7 +51,7 @@ func (b *DockerOptionsBuilder) BuildOptions(o interface{}) error {
 
 		dockerVersion := ""
 		if sv.Major == 1 && sv.Minor >= 8 {
-			dockerVersion = "1.13.1"
+			dockerVersion = "17.03.2"
 		} else if sv.Major == 1 && sv.Minor >= 6 {
 			dockerVersion = "1.12.6"
 		} else if sv.Major == 1 && sv.Minor >= 5 {

--- a/pkg/model/components/docker.go
+++ b/pkg/model/components/docker.go
@@ -51,7 +51,7 @@ func (b *DockerOptionsBuilder) BuildOptions(o interface{}) error {
 
 		dockerVersion := ""
 		if sv.Major == 1 && sv.Minor >= 8 {
-			dockerVersion = "17.03.2"
+			dockerVersion = "1.13.1"
 		} else if sv.Major == 1 && sv.Minor >= 6 {
 			dockerVersion = "1.12.6"
 		} else if sv.Major == 1 && sv.Minor >= 5 {

--- a/pkg/model/components/docker.go
+++ b/pkg/model/components/docker.go
@@ -50,7 +50,9 @@ func (b *DockerOptionsBuilder) BuildOptions(o interface{}) error {
 		}
 
 		dockerVersion := ""
-		if sv.Major == 1 && sv.Minor >= 8 {
+		if sv.Major == 1 && sv.Minor >= 9 {
+			dockerVersion = "17.03.2"
+		} else if sv.Major == 1 && sv.Minor >= 8 {
 			dockerVersion = "1.13.1"
 		} else if sv.Major == 1 && sv.Minor >= 6 {
 			dockerVersion = "1.12.6"


### PR DESCRIPTION
Since [17.03.2](https://docs.docker.com/release-notes/docker-ce/#17060-ce-2017-06-28) has [been validated for 1.8](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.8/release-notes-draft.md#external-dependencies) and GKE are [now using it](https://cloud.google.com/container-optimized-os/docs/release-notes#cos-stable-62-9901-59-0) in their COS images, I think it's a better default than 1.13.1.

