### PR TITLE
Lifecycle overrides

### DIFF
--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -232,15 +232,15 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 	}
 
 	applyCmd := &cloudup.ApplyClusterCmd{
-		Clientset:       clientset,
-		Cluster:         cluster,
-		DryRun:          isDryrun,
-		InstanceGroups:  instanceGroups,
-		MaxTaskDuration: c.MaxTaskDuration,
-		Models:          strings.Split(c.Models, ","),
-		OutDir:          c.OutDir,
-		Phase:           phase,
-		TargetName:      targetName,
+		Clientset:          clientset,
+		Cluster:            cluster,
+		DryRun:             isDryrun,
+		InstanceGroups:     instanceGroups,
+		MaxTaskDuration:    c.MaxTaskDuration,
+		Models:             strings.Split(c.Models, ","),
+		OutDir:             c.OutDir,
+		Phase:              phase,
+		TargetName:         targetName,
 		LifecycleOverrides: lifecycleOverrideMap,
 	}
 

--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -26,13 +26,14 @@ kops update cluster
 ### Options
 
 ```
-      --create-kube-config      Will control automatically creating the kube config file on your local filesystem (default true)
-      --model string            Models to apply (separate multiple models with commas) (default "config,proto,cloudup")
-      --out string              Path to write any local output
-      --phase string            Subset of tasks to run: assets, cluster, network, security
-      --ssh-public-key string   SSH public key to use (deprecated: use kops create secret instead)
-      --target string           Target - direct, terraform, cloudformation (default "direct")
-  -y, --yes                     Create cloud resources, without --yes update is in dry run mode
+      --create-kube-config                Will control automatically creating the kube config file on your local filesystem (default true)
+      --lifecycle-overrides stringSlice   comma separated list of phase overrides, example: SecurityGroups=Ignore,InternetGateway=ExistsAndWarnIfChanges
+      --model string                      Models to apply (separate multiple models with commas) (default "config,proto,cloudup")
+      --out string                        Path to write any local output
+      --phase string                      Subset of tasks to run: assets, cluster, network, security
+      --ssh-public-key string             SSH public key to use (deprecated: use kops create secret instead)
+      --target string                     Target - direct, terraform, cloudformation (default "direct")
+  -y, --yes                               Create cloud resources, without --yes update is in dry run mode
 ```
 
 ### Options inherited from parent commands

--- a/upup/pkg/fi/assettasks/copydockerimage_fitask.go
+++ b/upup/pkg/fi/assettasks/copydockerimage_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &CopyDockerImage{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *CopyDockerImage) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *CopyDockerImage) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &CopyDockerImage{}

--- a/upup/pkg/fi/assettasks/copyfile_fitask.go
+++ b/upup/pkg/fi/assettasks/copyfile_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &CopyFile{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *CopyFile) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *CopyFile) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &CopyFile{}

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -123,6 +123,9 @@ type ApplyClusterCmd struct {
 
 	// Phase can be set to a Phase to run the specific subset of tasks, if we don't want to run everything
 	Phase Phase
+
+	// LifecycleOverrides is passed in to override the lifecycle for one of more tasks.
+	LifecycleOverrides map[string]fi.Lifecycle
 }
 
 func (c *ApplyClusterCmd) Run() error {
@@ -628,7 +631,7 @@ func (c *ApplyClusterCmd) Run() error {
 
 	tf.AddTo(l.TemplateFunctions)
 
-	taskMap, err := l.BuildTasks(modelStore, fileModels, assetBuilder, &stageAssetsLifecycle)
+	taskMap, err := l.BuildTasks(modelStore, fileModels, assetBuilder, &stageAssetsLifecycle, c.LifecycleOverrides)
 	if err != nil {
 		return fmt.Errorf("error building tasks: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -125,6 +125,8 @@ type ApplyClusterCmd struct {
 	Phase Phase
 
 	// LifecycleOverrides is passed in to override the lifecycle for one of more tasks.
+	// The key value is the task name such as InternetGateway and the value is the fi.Lifecycle
+	// that is re-mapped.
 	LifecycleOverrides map[string]fi.Lifecycle
 }
 

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &AutoscalingGroup{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *AutoscalingGroup) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *AutoscalingGroup) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &AutoscalingGroup{}

--- a/upup/pkg/fi/cloudup/awstasks/dhcpoptions_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/dhcpoptions_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &DHCPOptions{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *DHCPOptions) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *DHCPOptions) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &DHCPOptions{}

--- a/upup/pkg/fi/cloudup/awstasks/dnsname_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &DNSName{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *DNSName) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *DNSName) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &DNSName{}

--- a/upup/pkg/fi/cloudup/awstasks/dnszone_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnszone_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &DNSZone{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *DNSZone) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *DNSZone) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &DNSZone{}

--- a/upup/pkg/fi/cloudup/awstasks/ebsvolume_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/ebsvolume_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &EBSVolume{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *EBSVolume) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *EBSVolume) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &EBSVolume{}

--- a/upup/pkg/fi/cloudup/awstasks/elasticip_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/elasticip_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &ElasticIP{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *ElasticIP) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *ElasticIP) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &ElasticIP{}

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &IAMInstanceProfile{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *IAMInstanceProfile) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *IAMInstanceProfile) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &IAMInstanceProfile{}

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &IAMInstanceProfileRole{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *IAMInstanceProfileRole) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *IAMInstanceProfileRole) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &IAMInstanceProfileRole{}

--- a/upup/pkg/fi/cloudup/awstasks/iamrole_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrole_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &IAMRole{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *IAMRole) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *IAMRole) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &IAMRole{}

--- a/upup/pkg/fi/cloudup/awstasks/iamrolepolicy_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrolepolicy_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &IAMRolePolicy{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *IAMRolePolicy) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *IAMRolePolicy) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &IAMRolePolicy{}

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &InternetGateway{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *InternetGateway) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *InternetGateway) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &InternetGateway{}

--- a/upup/pkg/fi/cloudup/awstasks/launchconfiguration_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchconfiguration_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &LaunchConfiguration{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *LaunchConfiguration) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *LaunchConfiguration) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &LaunchConfiguration{}

--- a/upup/pkg/fi/cloudup/awstasks/loadbalancer_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/loadbalancer_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &LoadBalancer{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *LoadBalancer) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *LoadBalancer) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &LoadBalancer{}

--- a/upup/pkg/fi/cloudup/awstasks/loadbalancerattachment_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/loadbalancerattachment_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &LoadBalancerAttachment{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *LoadBalancerAttachment) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *LoadBalancerAttachment) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &LoadBalancerAttachment{}

--- a/upup/pkg/fi/cloudup/awstasks/natgateway_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &NatGateway{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *NatGateway) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *NatGateway) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &NatGateway{}

--- a/upup/pkg/fi/cloudup/awstasks/route_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/route_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &Route{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Route) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *Route) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &Route{}

--- a/upup/pkg/fi/cloudup/awstasks/routetable_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetable_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &RouteTable{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *RouteTable) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *RouteTable) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &RouteTable{}

--- a/upup/pkg/fi/cloudup/awstasks/routetableassociation_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetableassociation_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &RouteTableAssociation{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *RouteTableAssociation) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *RouteTableAssociation) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &RouteTableAssociation{}

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &SecurityGroup{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *SecurityGroup) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *SecurityGroup) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &SecurityGroup{}

--- a/upup/pkg/fi/cloudup/awstasks/securitygrouprule_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygrouprule_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &SecurityGroupRule{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *SecurityGroupRule) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *SecurityGroupRule) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &SecurityGroupRule{}

--- a/upup/pkg/fi/cloudup/awstasks/sshkey_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/sshkey_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &SSHKey{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *SSHKey) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *SSHKey) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &SSHKey{}

--- a/upup/pkg/fi/cloudup/awstasks/subnet_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &Subnet{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Subnet) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *Subnet) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &Subnet{}

--- a/upup/pkg/fi/cloudup/awstasks/vpc_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &VPC{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *VPC) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *VPC) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &VPC{}

--- a/upup/pkg/fi/cloudup/awstasks/vpcdhcpoptionsassociation_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpcdhcpoptionsassociation_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &VPCDHCPOptionsAssociation{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *VPCDHCPOptionsAssociation) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *VPCDHCPOptionsAssociation) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &VPCDHCPOptionsAssociation{}

--- a/upup/pkg/fi/cloudup/dotasks/droplet_fitask.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &Droplet{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Droplet) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *Droplet) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &Droplet{}

--- a/upup/pkg/fi/cloudup/dotasks/volume_fitask.go
+++ b/upup/pkg/fi/cloudup/dotasks/volume_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &Volume{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Volume) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *Volume) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &Volume{}

--- a/upup/pkg/fi/cloudup/gcetasks/address_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/address_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &Address{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Address) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *Address) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &Address{}

--- a/upup/pkg/fi/cloudup/gcetasks/disk_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/disk_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &Disk{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Disk) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *Disk) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &Disk{}

--- a/upup/pkg/fi/cloudup/gcetasks/firewallrule_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/firewallrule_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &FirewallRule{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *FirewallRule) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *FirewallRule) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &FirewallRule{}

--- a/upup/pkg/fi/cloudup/gcetasks/forwardingrule_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/forwardingrule_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &ForwardingRule{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *ForwardingRule) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *ForwardingRule) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &ForwardingRule{}

--- a/upup/pkg/fi/cloudup/gcetasks/instance_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instance_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &Instance{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Instance) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *Instance) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &Instance{}

--- a/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &InstanceGroupManager{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *InstanceGroupManager) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *InstanceGroupManager) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &InstanceGroupManager{}

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &InstanceTemplate{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *InstanceTemplate) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *InstanceTemplate) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &InstanceTemplate{}

--- a/upup/pkg/fi/cloudup/gcetasks/network_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/network_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &Network{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Network) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *Network) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &Network{}

--- a/upup/pkg/fi/cloudup/gcetasks/storagebucketacl_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storagebucketacl_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &StorageBucketAcl{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *StorageBucketAcl) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *StorageBucketAcl) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &StorageBucketAcl{}

--- a/upup/pkg/fi/cloudup/gcetasks/storagebucketiam_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storagebucketiam_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &StorageBucketIam{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *StorageBucketIam) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *StorageBucketIam) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &StorageBucketIam{}

--- a/upup/pkg/fi/cloudup/gcetasks/storageobjectacl_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storageobjectacl_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &StorageObjectAcl{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *StorageObjectAcl) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *StorageObjectAcl) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &StorageObjectAcl{}

--- a/upup/pkg/fi/cloudup/gcetasks/subnet_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/subnet_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &Subnet{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Subnet) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *Subnet) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &Subnet{}

--- a/upup/pkg/fi/cloudup/gcetasks/targetpool_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/targetpool_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &TargetPool{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *TargetPool) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *TargetPool) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &TargetPool{}

--- a/upup/pkg/fi/cloudup/loader.go
+++ b/upup/pkg/fi/cloudup/loader.go
@@ -149,7 +149,7 @@ func ignoreHandler(i *loader.TreeWalkItem) error {
 	return nil
 }
 
-func (l *Loader) BuildTasks(modelStore vfs.Path, models []string, assetBuilder *assets.AssetBuilder, lifecycle *fi.Lifecycle) (map[string]fi.Task, error) {
+func (l *Loader) BuildTasks(modelStore vfs.Path, models []string, assetBuilder *assets.AssetBuilder, lifecycle *fi.Lifecycle, lifecycleOverrides map[string]fi.Lifecycle) (map[string]fi.Task, error) {
 	// Second pass: load everything else
 	tw := &loader.TreeWalker{
 		DefaultHandler: l.objectHandler,
@@ -172,7 +172,8 @@ func (l *Loader) BuildTasks(modelStore vfs.Path, models []string, assetBuilder *
 
 	for _, builder := range l.Builders {
 		context := &fi.ModelBuilderContext{
-			Tasks: l.tasks,
+			Tasks:              l.tasks,
+			LifecycleOverrides: lifecycleOverrides,
 		}
 		err := builder.Build(context)
 		if err != nil {

--- a/upup/pkg/fi/cloudup/openstacktasks/securitygroup_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/securitygroup_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &SecurityGroup{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *SecurityGroup) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *SecurityGroup) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &SecurityGroup{}

--- a/upup/pkg/fi/cloudup/openstacktasks/securitygrouprule.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/securitygrouprule.go
@@ -160,6 +160,10 @@ func (r *SecurityGroupRule) GetLifecycle() *fi.Lifecycle {
 	return r.Lifecycle
 }
 
+func (r *SecurityGroupRule) SetLifecycle(lifecycle fi.Lifecycle) {
+	r.Lifecycle = &lifecycle
+}
+
 func (r *SecurityGroupRule) String() string {
 	return fi.TaskAsString(r)
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/volume_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/volume_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &Volume{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Volume) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *Volume) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &Volume{}

--- a/upup/pkg/fi/fitasks/keypair_fitask.go
+++ b/upup/pkg/fi/fitasks/keypair_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &Keypair{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Keypair) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *Keypair) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &Keypair{}

--- a/upup/pkg/fi/fitasks/managedfile_fitask.go
+++ b/upup/pkg/fi/fitasks/managedfile_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &ManagedFile{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *ManagedFile) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *ManagedFile) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &ManagedFile{}

--- a/upup/pkg/fi/fitasks/mirrorkeystore_fitask.go
+++ b/upup/pkg/fi/fitasks/mirrorkeystore_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &MirrorKeystore{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *MirrorKeystore) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *MirrorKeystore) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &MirrorKeystore{}

--- a/upup/pkg/fi/fitasks/mirrorsecrets_fitask.go
+++ b/upup/pkg/fi/fitasks/mirrorsecrets_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &MirrorSecrets{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *MirrorSecrets) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *MirrorSecrets) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &MirrorSecrets{}

--- a/upup/pkg/fi/fitasks/secret_fitask.go
+++ b/upup/pkg/fi/fitasks/secret_fitask.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ var _ fi.HasLifecycle = &Secret{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Secret) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *Secret) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &Secret{}

--- a/upup/pkg/fi/lifecycle.go
+++ b/upup/pkg/fi/lifecycle.go
@@ -38,4 +38,7 @@ const (
 // HasLifecycle indicates that the task has a Lifecycle
 type HasLifecycle interface {
 	GetLifecycle() *Lifecycle
+	// SetLifecycle is used to override a tasks lifecycle. If a lifecycle overide exists for a specific task name, then the
+	// lifecycle is modified.
+	SetLifecycle(lifecycle Lifecycle)
 }

--- a/upup/pkg/fi/lifecycle.go
+++ b/upup/pkg/fi/lifecycle.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package fi
 
+import "k8s.io/apimachinery/pkg/util/sets"
+
 type Lifecycle string
 
 const (
@@ -41,4 +43,24 @@ type HasLifecycle interface {
 	// SetLifecycle is used to override a tasks lifecycle. If a lifecycle overide exists for a specific task name, then the
 	// lifecycle is modified.
 	SetLifecycle(lifecycle Lifecycle)
+}
+
+// Lifecycles are used for ux validation.  When validation fails the lifecycle names are
+// printed out.
+var Lifecycles = sets.NewString(
+	string(LifecycleSync),
+	string(LifecycleIgnore),
+	string(LifecycleWarnIfInsufficientAccess),
+	string(LifecycleExistsAndValidates),
+	string(LifecycleExistsAndWarnIfChanges),
+)
+
+// LifecycleNameMap is used to validate in the UX.  When a user provides a lifecycle name
+// it then can be mapped to the actual lifecycle.
+var LifecycleNameMap = map[string]Lifecycle{
+	"Sync":                     LifecycleSync,
+	"Ignore":                   LifecycleIgnore,
+	"WarnIfInsufficientAccess": LifecycleWarnIfInsufficientAccess,
+	"ExistsAndValidates":       LifecycleExistsAndValidates,
+	"ExistsAndWarnIfChanges":   LifecycleExistsAndWarnIfChanges,
 }

--- a/upup/pkg/fi/task.go
+++ b/upup/pkg/fi/task.go
@@ -46,10 +46,12 @@ type ModelBuilder interface {
 
 // ModelBuilderContext is a context object that holds state we want to pass to ModelBuilder
 type ModelBuilderContext struct {
-	Tasks map[string]Task
+	Tasks              map[string]Task
+	LifecycleOverrides map[string]Lifecycle
 }
 
 func (c *ModelBuilderContext) AddTask(task Task) {
+	task = c.setLifecycleOverride(task)
 	key := buildTaskKey(task)
 
 	existing, found := c.Tasks[key]
@@ -64,6 +66,7 @@ func (c *ModelBuilderContext) AddTask(task Task) {
 // If it does exist, it verifies that the existing task reflect.DeepEqual the new task,
 // if they are different an error is returned.
 func (c *ModelBuilderContext) EnsureTask(task Task) error {
+	task = c.setLifecycleOverride(task)
 	key := buildTaskKey(task)
 
 	existing, found := c.Tasks[key]
@@ -81,6 +84,30 @@ func (c *ModelBuilderContext) EnsureTask(task Task) error {
 	}
 	c.Tasks[key] = task
 	return nil
+}
+
+// setLifecycleOverride determines if a lifecycle is in the LifecycleOverrides map for the current task.
+// If the lifecycle exist then the task lifecycle is set to the lifecycle provides in LifecycleOverrides.
+// This func allows for lifecycles to be passed in dynamically and have the task lifecycle set accordingly.
+func (c *ModelBuilderContext) setLifecycleOverride(task Task) Task {
+	hl, ok := task.(HasLifecycle)
+	if !ok {
+		glog.V(8).Infof("task %T does not implement HasLifecycle", task)
+		return task
+	}
+
+	typeName := TypeNameForTask(task)
+
+	glog.V(8).Infof("testing task %q", typeName)
+
+	value, ok := c.LifecycleOverrides[typeName]
+	if ok {
+		glog.V(8).Infof("overriding task %s, lifecycle %s", task, value)
+		hl.SetLifecycle(value)
+	}
+
+	return task
+
 }
 
 func buildTaskKey(task Task) string {

--- a/upup/pkg/fi/task.go
+++ b/upup/pkg/fi/task.go
@@ -86,10 +86,13 @@ func (c *ModelBuilderContext) EnsureTask(task Task) error {
 	return nil
 }
 
-// setLifecycleOverride determines if a lifecycle is in the LifecycleOverrides map for the current task.
+// setLifecycleOverride determines if a Lifecycle is in the LifecycleOverrides map for the current task.
 // If the lifecycle exist then the task lifecycle is set to the lifecycle provides in LifecycleOverrides.
 // This func allows for lifecycles to be passed in dynamically and have the task lifecycle set accordingly.
 func (c *ModelBuilderContext) setLifecycleOverride(task Task) Task {
+	// TODO(@chrislovecnm) - wonder if we should update the nodeup tasks to have lifecycle
+	// TODO - so that we can return an error here, rather than just returning.
+	// certain tasks have not implemented HasLifecycle interface
 	hl, ok := task.(HasLifecycle)
 	if !ok {
 		glog.V(8).Infof("task %T does not implement HasLifecycle", task)
@@ -97,17 +100,16 @@ func (c *ModelBuilderContext) setLifecycleOverride(task Task) Task {
 	}
 
 	typeName := TypeNameForTask(task)
-
 	glog.V(8).Infof("testing task %q", typeName)
 
+	// typeName can be values like "InternetGateway"
 	value, ok := c.LifecycleOverrides[typeName]
 	if ok {
-		glog.V(8).Infof("overriding task %s, lifecycle %s", task, value)
+		glog.Warningf("overriding task %s, lifecycle %s", task, value)
 		hl.SetLifecycle(value)
 	}
 
 	return task
-
 }
 
 func buildTaskKey(task Task) string {

--- a/upup/tools/generators/fitask/generator.go
+++ b/upup/tools/generators/fitask/generator.go
@@ -30,7 +30,7 @@ type FitaskGenerator struct {
 var _ codegen.Generator = &FitaskGenerator{}
 
 const fileHeaderDef = `/*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -84,6 +84,11 @@ var _ fi.HasLifecycle = &{{.Name}}{}
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *{{.Name}}) GetLifecycle() *fi.Lifecycle {
 	return o.Lifecycle
+}
+
+// SetLifecycle sets the Lifecycle of the object, implementing fi.SetLifecycle
+func (o *{{.Name}}) SetLifecycle(lifecycle fi.Lifecycle) {
+	o.Lifecycle = &lifecycle
 }
 
 var _ fi.HasName = &{{.Name}}{}


### PR DESCRIPTION
This PR adds the capability to override a task lifecycle dynamically.  A list of lifecycles keyed by task names is provided, and those lifecycles can override a matching task name.  

- updated the fittask generator
- updated fittasks
- https://github.com/kubernetes/kops/pull/4445/commits/7fc9b7fff1b0bf157ff57d35aa70728f02b25231 is where the magic happens

