### PR TITLE
Fixing deleting of shared IGW and DHCPOptions

### DIFF
--- a/pkg/resources/aws.go
+++ b/pkg/resources/aws.go
@@ -1045,6 +1045,7 @@ func ListDhcpOptions(cloud fi.Cloud, clusterName string) ([]*Resource, error) {
 			ID:      aws.StringValue(o.DhcpOptionsId),
 			Type:    "dhcp-options",
 			Deleter: DeleteDhcpOptions,
+			Shared:  HasSharedTag(ec2.ResourceTypeDhcpOptions+":"+aws.StringValue(o.DhcpOptionsId), o.Tags, clusterName),
 		}
 
 		var blocks []string
@@ -1150,6 +1151,7 @@ func ListInternetGateways(cloud fi.Cloud, clusterName string) ([]*Resource, erro
 			ID:      aws.StringValue(o.InternetGatewayId),
 			Type:    "internet-gateway",
 			Deleter: DeleteInternetGateway,
+			Shared:  HasSharedTag(ec2.ResourceTypeInternetGateway+":"+aws.StringValue(o.InternetGatewayId), o.Tags, clusterName),
 		}
 
 		var blocks []string


### PR DESCRIPTION
Currently shared IGW and DHCPOptions are deleted, even if the shared
tags exist.  This PR adds the HasSharedTags func to the Shared member on
both IGW and DHCPOptions resources.

We are not adding the shared or owned tags currently.  We need to follow-up with another PR to add those tags, but at least we will not delete IGW and DHCPOptions if the tag exists.