### PR TITLE
Updating variables to use Camel Case

### DIFF
--- a/cmd/kops/completion.go
+++ b/cmd/kops/completion.go
@@ -45,7 +45,7 @@ const boilerPlate = `
 `
 
 var (
-	completion_shells = map[string]func(out io.Writer, cmd *cobra.Command) error{
+	completionShells = map[string]func(out io.Writer, cmd *cobra.Command) error{
 		"bash": runCompletionBash,
 		"zsh":  runCompletionZsh,
 	}
@@ -125,7 +125,7 @@ func RunCompletion(f *util.Factory, cmd *cobra.Command, args []string, out io.Wr
 		return fmt.Errorf("shell is required")
 	}
 
-	run, found := completion_shells[c.Shell]
+	run, found := completionShells[c.Shell]
 	if !found {
 		return fmt.Errorf("Unsupported shell type %q.", args[0])
 	}

--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -42,7 +42,7 @@ type CreateOptions struct {
 }
 
 var (
-	create_long = templates.LongDesc(i18n.T(`
+	createLong = templates.LongDesc(i18n.T(`
 		Create a resource:` + validResources +
 		`
 	Create a cluster, instancegroup or secret using command line parameters
@@ -50,7 +50,7 @@ var (
 	(Note: secrets cannot be created from YAML config files yet).
 	`))
 
-	create_example = templates.Examples(i18n.T(`
+	createExample = templates.Examples(i18n.T(`
 
 	# Create a cluster from the configuration specification in a YAML file
 	kops create -f my-cluster.yaml
@@ -72,7 +72,7 @@ var (
 	kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \
 		--name k8s-cluster.example.com --state s3://example.com
 	`))
-	create_short = i18n.T("Create a resource by command line, filename or stdin.")
+	createShort = i18n.T("Create a resource by command line, filename or stdin.")
 )
 
 func NewCmdCreate(f *util.Factory, out io.Writer) *cobra.Command {
@@ -80,9 +80,9 @@ func NewCmdCreate(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "create -f FILENAME",
-		Short:   create_short,
-		Long:    create_long,
-		Example: create_example,
+		Short:   createShort,
+		Long:    createLong,
+		Example: createExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if cmdutil.IsFilenameSliceEmpty(options.Filenames) {
 				cmd.Help()

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -160,7 +160,7 @@ func (o *CreateClusterOptions) InitDefaults() {
 }
 
 var (
-	create_cluster_long = templates.LongDesc(i18n.T(`
+	createClusterLong = templates.LongDesc(i18n.T(`
 	Create a kubernetes cluster using command line flags.
 	This command creates cloud based resources such as networks and virtual machines. Once
 	the infrastructure is in place Kubernetes is installed on the virtual machines.
@@ -168,7 +168,7 @@ var (
 	These operations are done in parallel and rely on eventual consistency.
 	`))
 
-	create_cluster_example = templates.Examples(i18n.T(`
+	createClusterExample = templates.Examples(i18n.T(`
 	# Create a cluster in AWS
 	kops create cluster --name=kubernetes-cluster.example.com \
 	--state=s3://kops-state-1234 --zones=eu-west-1a \
@@ -213,7 +213,7 @@ var (
 
 	`))
 
-	create_cluster_short = i18n.T("Create a Kubernetes cluster.")
+	createClusterShort = i18n.T("Create a Kubernetes cluster.")
 )
 
 func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
@@ -225,9 +225,9 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "cluster",
-		Short:   create_cluster_short,
-		Long:    create_cluster_long,
-		Example: create_cluster_example,
+		Short:   createClusterShort,
+		Long:    createClusterLong,
+		Example: createClusterExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if cmd.Flag("associate-public-ip").Changed {
 				options.AssociatePublicIP = &associatePublicIP

--- a/cmd/kops/create_ig.go
+++ b/cmd/kops/create_ig.go
@@ -49,7 +49,7 @@ type CreateInstanceGroupOptions struct {
 }
 
 var (
-	create_ig_long = templates.LongDesc(i18n.T(`
+	createIgLong = templates.LongDesc(i18n.T(`
 		Create an InstanceGroup configuration.
 
 	    An InstanceGroup is a group of similar virtual machines.
@@ -57,7 +57,7 @@ var (
 
 		The Role of an InstanceGroup defines whether machines will act as a Kubernetes master or node.`))
 
-	create_ig_example = templates.Examples(i18n.T(`
+	createIgExample = templates.Examples(i18n.T(`
 
 		# Create an instancegroup for the k8s-cluster.example.com cluster.
 		kops create ig --name=k8s-cluster.example.com node-example \
@@ -68,7 +68,7 @@ var (
 		  --role node --subnet my-subnet-name --dry-run -oyaml
 		`))
 
-	create_ig_short = i18n.T(`Create an instancegroup.`)
+	createIgShort = i18n.T(`Create an instancegroup.`)
 )
 
 // NewCmdCreateInstanceGroup create a new cobra command object for creating a instancegroup.
@@ -81,9 +81,9 @@ func NewCmdCreateInstanceGroup(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "instancegroup",
 		Aliases: []string{"instancegroups", "ig"},
-		Short:   create_ig_short,
-		Long:    create_ig_long,
-		Example: create_ig_example,
+		Short:   createIgShort,
+		Long:    createIgLong,
+		Example: createIgExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunCreateInstanceGroup(f, cmd, args, os.Stdout, options)
 			if err != nil {

--- a/cmd/kops/create_secret.go
+++ b/cmd/kops/create_secret.go
@@ -26,10 +26,10 @@ import (
 )
 
 var (
-	create_secret_long = templates.LongDesc(i18n.T(`
+	createSecretLong = templates.LongDesc(i18n.T(`
 	Create a secret`))
 
-	create_secret_example = templates.Examples(i18n.T(`
+	createSecretExample = templates.Examples(i18n.T(`
 	# Create an new ssh public key called admin.
 	kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \
 		--name k8s-cluster.example.com --state s3://example.com
@@ -41,15 +41,15 @@ var (
 		--name k8s-cluster.example.com --state s3://example.com
 	`))
 
-	create_secret_short = i18n.T(`Create a secret.`)
+	createSecretShort = i18n.T(`Create a secret.`)
 )
 
 func NewCmdCreateSecret(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "secret",
-		Short:   create_secret_short,
-		Long:    create_secret_long,
-		Example: create_secret_example,
+		Short:   createSecretShort,
+		Long:    createSecretLong,
+		Example: createSecretExample,
 	}
 
 	// create subcommands

--- a/cmd/kops/create_secret_dockerconfig.go
+++ b/cmd/kops/create_secret_dockerconfig.go
@@ -31,12 +31,12 @@ import (
 )
 
 var (
-	create_secret_dockerconfig_long = templates.LongDesc(i18n.T(`
+	createSecretDockerconfigLong = templates.LongDesc(i18n.T(`
 	Create a new docker config, and store it in the state store.
 	Used to configure docker on each master or node (ie. for auth)
 	Use update to modify it, this command will only create a new entry.`))
 
-	create_secret_dockerconfig_example = templates.Examples(i18n.T(`
+	createSecretDockerconfigExample = templates.Examples(i18n.T(`
 	# Create an new docker config.
 	kops create secret dockerconfig -f /path/to/docker/config.json \
 		--name k8s-cluster.example.com --state s3://example.com
@@ -45,7 +45,7 @@ var (
 		--name k8s-cluster.example.com --state s3://example.com
 	`))
 
-	create_secret_dockerconfig_short = i18n.T(`Create a docker config.`)
+	createSecretDockerconfigShort = i18n.T(`Create a docker config.`)
 )
 
 type CreateSecretDockerConfigOptions struct {
@@ -59,9 +59,9 @@ func NewCmdCreateSecretDockerConfig(f *util.Factory, out io.Writer) *cobra.Comma
 
 	cmd := &cobra.Command{
 		Use:     "dockerconfig",
-		Short:   create_secret_dockerconfig_short,
-		Long:    create_secret_dockerconfig_long,
-		Example: create_secret_dockerconfig_example,
+		Short:   createSecretDockerconfigShort,
+		Long:    createSecretDockerconfigLong,
+		Example: createSecretDockerconfigExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 0 {
 				exitWithError(fmt.Errorf("syntax: -f <DockerConfigPath>"))

--- a/cmd/kops/create_secret_encryptionconfig.go
+++ b/cmd/kops/create_secret_encryptionconfig.go
@@ -31,12 +31,12 @@ import (
 )
 
 var (
-	create_secret_encryptionconfig_long = templates.LongDesc(i18n.T(`
+	createSecretEncryptionconfigLong = templates.LongDesc(i18n.T(`
 	Create a new encryption config, and store it in the state store.
 	Used to configure encryption-at-rest by the kube-apiserver process
 	on each of the master nodes. The config is not updated by this command.`))
 
-	create_secret_encryptionconfig_example = templates.Examples(i18n.T(`
+	createSecretEncryptionconfigExample = templates.Examples(i18n.T(`
 	# Create a new encryption config.
 	kops create secret encryptionconfig -f config.yaml \
 		--name k8s-cluster.example.com --state s3://example.com
@@ -45,7 +45,7 @@ var (
 		--name k8s-cluster.example.com --state s3://example.com
 	`))
 
-	create_secret_encryptionconfig_short = i18n.T(`Create an encryption config.`)
+	createSecretEncryptionconfigShort = i18n.T(`Create an encryption config.`)
 )
 
 type CreateSecretEncryptionConfigOptions struct {
@@ -59,9 +59,9 @@ func NewCmdCreateSecretEncryptionConfig(f *util.Factory, out io.Writer) *cobra.C
 
 	cmd := &cobra.Command{
 		Use:     "encryptionconfig",
-		Short:   create_secret_encryptionconfig_short,
-		Long:    create_secret_encryptionconfig_long,
-		Example: create_secret_encryptionconfig_example,
+		Short:   createSecretEncryptionconfigShort,
+		Long:    createSecretEncryptionconfigLong,
+		Example: createSecretEncryptionconfigExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 0 {
 				exitWithError(fmt.Errorf("syntax: -f <EncryptionConfigPath>"))

--- a/cmd/kops/create_secret_sshpublickey.go
+++ b/cmd/kops/create_secret_sshpublickey.go
@@ -29,17 +29,17 @@ import (
 )
 
 var (
-	create_secret_sshpublickey_long = templates.LongDesc(i18n.T(`
+	createSecretSSHPublicKeyLong = templates.LongDesc(i18n.T(`
 	Create a new ssh public key, and store the key in the state store.  The
 	key is not updated by this command.`))
 
-	create_secret_sshpublickey_example = templates.Examples(i18n.T(`
+	createSecretSSHPublicKeyExample = templates.Examples(i18n.T(`
 	# Create an new ssh public key called admin.
 	kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \
 		--name k8s-cluster.example.com --state s3://example.com
 	`))
 
-	create_secret_sshpublickey_short = i18n.T(`Create a ssh public key.`)
+	createSecretSSHPublicKeyShort = i18n.T(`Create a ssh public key.`)
 )
 
 type CreateSecretPublickeyOptions struct {
@@ -53,9 +53,9 @@ func NewCmdCreateSecretPublicKey(f *util.Factory, out io.Writer) *cobra.Command 
 
 	cmd := &cobra.Command{
 		Use:     "sshpublickey",
-		Short:   create_secret_sshpublickey_short,
-		Long:    create_secret_sshpublickey_long,
-		Example: create_secret_sshpublickey_example,
+		Short:   createSecretSSHPublicKeyShort,
+		Long:    createSecretSSHPublicKeyLong,
+		Example: createSecretSSHPublicKeyExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
 				exitWithError(fmt.Errorf("syntax: NAME -i <PublicKeyPath>"))

--- a/cmd/kops/delete.go
+++ b/cmd/kops/delete.go
@@ -43,11 +43,11 @@ type DeleteOptions struct {
 }
 
 var (
-	delete_long = templates.LongDesc(i18n.T(`
+	deleteLong = templates.LongDesc(i18n.T(`
 	Delete Kubernetes clusters, instancegroups, and secrets, or a combination of the before mentioned.
 	`))
 
-	delete_example = templates.Examples(i18n.T(`
+	deleteExample = templates.Examples(i18n.T(`
 		# Delete a cluster using a manifest file
 		kops delete -f my-cluster.yaml
 
@@ -59,7 +59,7 @@ var (
 		kops delete ig --name=k8s-cluster.example.com node-example --yes
 	`))
 
-	delete_short = i18n.T("Delete clusters,instancegroups, or secrets.")
+	deleteShort = i18n.T("Delete clusters,instancegroups, or secrets.")
 )
 
 func NewCmdDelete(f *util.Factory, out io.Writer) *cobra.Command {
@@ -67,9 +67,9 @@ func NewCmdDelete(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:        "delete -f FILENAME [--yes]",
-		Short:      delete_short,
-		Long:       delete_long,
-		Example:    delete_example,
+		Short:      deleteShort,
+		Long:       deleteLong,
+		Example:    deleteExample,
 		SuggestFor: []string{"rm"},
 		Run: func(cmd *cobra.Command, args []string) {
 			if cmdutil.IsFilenameSliceEmpty(options.Filenames) {

--- a/cmd/kops/delete_cluster.go
+++ b/cmd/kops/delete_cluster.go
@@ -44,19 +44,19 @@ type DeleteClusterOptions struct {
 }
 
 var (
-	delete_cluster_long = templates.LongDesc(i18n.T(`
+	deleteClusterLong = templates.LongDesc(i18n.T(`
 	Deletes a Kubernetes cluster and all associated resources.  Resources include instancegroups,
 	secrets and the state store.  There is no "UNDO" for this command.
 	`))
 
-	delete_cluster_example = templates.Examples(i18n.T(`
+	deleteClusterExample = templates.Examples(i18n.T(`
 	# Delete a cluster.
 	# The --yes option runs the command immediately.
 	kops delete cluster --name=k8s.cluster.site --yes
 
 	`))
 
-	delete_cluster_short = i18n.T("Delete a cluster.")
+	deleteClusterShort = i18n.T("Delete a cluster.")
 )
 
 func NewCmdDeleteCluster(f *util.Factory, out io.Writer) *cobra.Command {
@@ -64,9 +64,9 @@ func NewCmdDeleteCluster(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "cluster CLUSTERNAME [--yes]",
-		Short:   delete_cluster_short,
-		Long:    delete_cluster_long,
-		Example: delete_cluster_example,
+		Short:   deleteClusterShort,
+		Long:    deleteClusterLong,
+		Example: deleteClusterExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := rootCommand.ProcessArgs(args)
 			if err != nil {

--- a/cmd/kops/delete_instancegroup.go
+++ b/cmd/kops/delete_instancegroup.go
@@ -33,12 +33,12 @@ import (
 )
 
 var (
-	delete_ig_long = templates.LongDesc(i18n.T(`
+	deleteIgLong = templates.LongDesc(i18n.T(`
 		Delete an instancegroup configuration.  kops has the concept of "instance groups",
 		which are a group of similar virtual machines. On AWS, they map to an
 		AutoScalingGroup. An ig work either as a Kubernetes master or a node.`))
 
-	delete_ig_example = templates.Examples(i18n.T(`
+	deleteIgExample = templates.Examples(i18n.T(`
 
 		# Delete an instancegroup for the k8s-cluster.example.com cluster.
 		# The --yes option runs the command immediately.
@@ -46,7 +46,7 @@ var (
 		kops delete ig --name=k8s-cluster.example.com node-example --yes
 		`))
 
-	delete_ig_short = i18n.T(`Delete instancegroup`)
+	deleteIgShort = i18n.T(`Delete instancegroup`)
 )
 
 type DeleteInstanceGroupOptions struct {
@@ -61,9 +61,9 @@ func NewCmdDeleteInstanceGroup(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "instancegroup",
 		Aliases: []string{"instancegroups", "ig"},
-		Short:   delete_ig_short,
-		Long:    delete_ig_long,
-		Example: delete_ig_example,
+		Short:   deleteIgShort,
+		Long:    deleteIgLong,
+		Example: deleteIgExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
 				exitWithError(fmt.Errorf("Specify name of instance group to delete"))

--- a/cmd/kops/delete_secret.go
+++ b/cmd/kops/delete_secret.go
@@ -29,14 +29,14 @@ import (
 )
 
 var (
-	delete_secret_long = templates.LongDesc(i18n.T(`
+	deleteSecretLong = templates.LongDesc(i18n.T(`
 		Delete a secret.`))
 
-	delete_secret_example = templates.Examples(i18n.T(`
+	deleteSecretExample = templates.Examples(i18n.T(`
 
 		`))
 
-	delete_secret_short = i18n.T(`Delete a secret`)
+	deleteSecretShort = i18n.T(`Delete a secret`)
 )
 
 type DeleteSecretOptions struct {
@@ -51,9 +51,9 @@ func NewCmdDeleteSecret(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "secret",
-		Short:   delete_secret_short,
-		Long:    delete_secret_long,
-		Example: delete_secret_example,
+		Short:   deleteSecretShort,
+		Long:    deleteSecretLong,
+		Example: deleteSecretExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 2 && len(args) != 3 {
 				exitWithError(fmt.Errorf("Syntax: <type> <name> [<id>]"))

--- a/cmd/kops/describe.go
+++ b/cmd/kops/describe.go
@@ -23,13 +23,13 @@ import (
 )
 
 var (
-	describe_long = templates.LongDesc(i18n.T(`
+	describeLong = templates.LongDesc(i18n.T(`
 	Get additional information about cloud and cluster resources.
 	`))
 
-	describe_example = templates.Examples(i18n.T(`
+	describeExample = templates.Examples(i18n.T(`
 	`))
-	describe_short = i18n.T(`Describe a resource.`)
+	describeShort = i18n.T(`Describe a resource.`)
 )
 
 // DescribeCmd represents the describe command
@@ -40,9 +40,9 @@ type DescribeCmd struct {
 var describeCmd = DescribeCmd{
 	cobraCommand: &cobra.Command{
 		Use:     "describe",
-		Short:   describe_short,
-		Long:    describe_long,
-		Example: describe_example,
+		Short:   describeShort,
+		Long:    describeLong,
+		Example: describeExample,
 	},
 }
 

--- a/cmd/kops/describe_secrets.go
+++ b/cmd/kops/describe_secrets.go
@@ -33,15 +33,15 @@ import (
 )
 
 var (
-	describe_secret_long = templates.LongDesc(i18n.T(`
+	describeSecretLong = templates.LongDesc(i18n.T(`
 	Get additional information about cluster secrets.
 	`))
 
 	// TODO: what is an example??
-	describe_secret_example = templates.Examples(i18n.T(`
+	describeSecretExample = templates.Examples(i18n.T(`
 	
 	`))
-	describe_secret_short = i18n.T(`Describe a cluster secret`)
+	describeSecretShort = i18n.T(`Describe a cluster secret`)
 )
 
 type DescribeSecretsCommand struct {
@@ -54,9 +54,9 @@ func init() {
 	cmd := &cobra.Command{
 		Use:     "secrets",
 		Aliases: []string{"secret"},
-		Short:   describe_secret_short,
-		Long:    describe_secret_long,
-		Example: describe_secret_example,
+		Short:   describeSecretShort,
+		Long:    describeSecretLong,
+		Example: describeSecretExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := describeSecretsCommand.Run(args)
 			if err != nil {

--- a/cmd/kops/edit.go
+++ b/cmd/kops/edit.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	edit_long = templates.LongDesc(i18n.T(`Edit a resource configuration.
+	editLong = templates.LongDesc(i18n.T(`Edit a resource configuration.
 	This command changes the desired configuration in the registry.
 
     	To set your preferred editor, you can define the EDITOR environment variable.
@@ -35,7 +35,7 @@ var (
     	kops edit does not update the cloud resources, to apply the changes use "kops update cluster".
     	`))
 
-	edit_example = templates.Examples(i18n.T(`
+	editExample = templates.Examples(i18n.T(`
 	# Edit a cluster configuration.
 	kops edit cluster k8s-cluster.example.com --state=s3://kops-state-1234
 
@@ -49,8 +49,8 @@ func NewCmdEdit(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "edit",
 		Short:   i18n.T("Edit clusters and other resources."),
-		Long:    edit_long,
-		Example: edit_example,
+		Long:    editLong,
+		Example: editExample,
 	}
 
 	// create subcommands

--- a/cmd/kops/edit_cluster.go
+++ b/cmd/kops/edit_cluster.go
@@ -44,7 +44,7 @@ type EditClusterOptions struct {
 }
 
 var (
-	edit_cluster_long = templates.LongDesc(i18n.T(`Edit a cluster configuration.
+	editClusterLong = templates.LongDesc(i18n.T(`Edit a cluster configuration.
 
 	This command changes the desired cluster configuration in the registry.
 
@@ -53,7 +53,7 @@ var (
 
 	kops edit does not update the cloud resources, to apply the changes use "kops update cluster".`))
 
-	edit_cluster_example = templates.Examples(i18n.T(`
+	editClusterExample = templates.Examples(i18n.T(`
 		# Edit a cluster configuration in AWS.
 		kops edit cluster k8s.cluster.site --state=s3://kops-state-1234
 	`))
@@ -65,8 +65,8 @@ func NewCmdEditCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "cluster",
 		Short:   i18n.T("Edit cluster."),
-		Long:    edit_cluster_long,
-		Example: edit_cluster_example,
+		Long:    editClusterLong,
+		Example: editClusterExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunEditCluster(f, cmd, args, out, options)
 			if err != nil {

--- a/cmd/kops/edit_instancegroup.go
+++ b/cmd/kops/edit_instancegroup.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	edit_instancegroup_long = templates.LongDesc(i18n.T(`Edit a cluster configuration.
+	editInstancegroupLong = templates.LongDesc(i18n.T(`Edit a cluster configuration.
 
 	This command changes the instancegroup desired configuration in the registry.
 
@@ -46,12 +46,12 @@ var (
 
 	kops edit does not update the cloud resources, to apply the changes use "kops update cluster".`))
 
-	edit_instancegroup_example = templates.Examples(i18n.T(`
+	editInstancegroupExample = templates.Examples(i18n.T(`
 	# Edit an instancegroup desired configuration.
 	kops edit ig --name k8s-cluster.example.com node --state=s3://kops-state-1234
 	`))
 
-	edit_instancegroup_short = i18n.T(`Edit instancegroup.`)
+	editInstancegroupShort = i18n.T(`Edit instancegroup.`)
 )
 
 type EditInstanceGroupOptions struct {
@@ -63,9 +63,9 @@ func NewCmdEditInstanceGroup(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "instancegroup",
 		Aliases: []string{"instancegroups", "ig"},
-		Short:   edit_instancegroup_short,
-		Long:    edit_instancegroup_long,
-		Example: edit_instancegroup_example,
+		Short:   editInstancegroupShort,
+		Long:    editInstancegroupLong,
+		Example: editInstancegroupExample,
 		Run: func(cmd *cobra.Command, args []string) {
 
 			err := RunEditInstanceGroup(f, cmd, args, os.Stdout, options)

--- a/cmd/kops/export.go
+++ b/cmd/kops/export.go
@@ -26,15 +26,15 @@ import (
 )
 
 var (
-	export_long = templates.LongDesc(i18n.T(`
+	exportLong = templates.LongDesc(i18n.T(`
 	Export configurations from a cluster.`))
 
-	export_example = templates.Examples(i18n.T(`
+	exportExample = templates.Examples(i18n.T(`
 	# export a kubecfg file
 	kops export kubecfg kubernetes-cluster.example.com
 		`))
 
-	export_short = i18n.T(`Export configuration.`)
+	exportShort = i18n.T(`Export configuration.`)
 )
 
 type ExportOptions struct {
@@ -44,9 +44,9 @@ func NewCmdExport(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "export",
-		Short:   export_short,
-		Long:    export_long,
-		Example: export_example,
+		Short:   exportShort,
+		Long:    exportLong,
+		Example: exportExample,
 	}
 
 	// create subcommands

--- a/cmd/kops/export_kubecfg.go
+++ b/cmd/kops/export_kubecfg.go
@@ -28,18 +28,18 @@ import (
 )
 
 var (
-	export_kubecfg_long = templates.LongDesc(i18n.T(`
+	exportKubecfgLong = templates.LongDesc(i18n.T(`
 	Export a kubecfg file for a cluster from the state store. The configuration
 	will be saved into a users $HOME/.kube/config file.
 	To export the kubectl configuration to a specific file set the KUBECONFIG
 	environment variable.`))
 
-	export_kubecfg_example = templates.Examples(i18n.T(`
+	exportKubecfgExample = templates.Examples(i18n.T(`
 	# export a kubecfg file
 	kops export kubecfg kubernetes-cluster.example.com
 		`))
 
-	export_kubecfg_short = i18n.T(`Export kubecfg.`)
+	exportKubecfgShort = i18n.T(`Export kubecfg.`)
 )
 
 type ExportKubecfgOptions struct {
@@ -52,9 +52,9 @@ func NewCmdExportKubecfg(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "kubecfg CLUSTERNAME",
-		Short:   export_kubecfg_short,
-		Long:    export_kubecfg_long,
-		Example: export_kubecfg_example,
+		Short:   exportKubecfgShort,
+		Long:    exportKubecfgLong,
+		Example: exportKubecfgExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunExportKubecfg(f, out, options, args)
 			if err != nil {

--- a/cmd/kops/get.go
+++ b/cmd/kops/get.go
@@ -33,10 +33,10 @@ import (
 )
 
 var (
-	get_long = templates.LongDesc(i18n.T(`
+	getLong = templates.LongDesc(i18n.T(`
 	Display one or many resources.` + validResources))
 
-	get_example = templates.Examples(i18n.T(`
+	getExample = templates.Examples(i18n.T(`
 	# Get all clusters in a state store
 	kops get clusters
 
@@ -55,7 +55,7 @@ var (
 	# Get the admin password for a cluster
 	kops get secrets admin -oplaintext`))
 
-	get_short = i18n.T(`Get one or many resources.`)
+	getShort = i18n.T(`Get one or many resources.`)
 )
 
 type GetOptions struct {
@@ -77,9 +77,9 @@ func NewCmdGet(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:        "get",
 		SuggestFor: []string{"list"},
-		Short:      get_short,
-		Long:       get_long,
-		Example:    get_example,
+		Short:      getShort,
+		Long:       getLong,
+		Example:    getExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 0 {
 				options.clusterName = args[0]

--- a/cmd/kops/get_cluster.go
+++ b/cmd/kops/get_cluster.go
@@ -35,10 +35,10 @@ import (
 )
 
 var (
-	get_cluster_long = templates.LongDesc(i18n.T(`
+	getClusterLong = templates.LongDesc(i18n.T(`
 	Display one or many cluster resources.`))
 
-	get_cluster_example = templates.Examples(i18n.T(`
+	getClusterExample = templates.Examples(i18n.T(`
 	# Get all clusters in a state store
 	kops get clusters
 
@@ -52,7 +52,7 @@ var (
 	kops get cluster k8s-cluster.example.com -o yaml > cluster-desired-config.yaml
 	`))
 
-	get_cluster_short = i18n.T(`Get one or many clusters.`)
+	getClusterShort = i18n.T(`Get one or many clusters.`)
 
 	// Warning for --full.  Since we are not using the template from kubectl
 	// we have to have zero white space before the comment characters otherwise
@@ -88,9 +88,9 @@ func NewCmdGetCluster(f *util.Factory, out io.Writer, getOptions *GetOptions) *c
 	cmd := &cobra.Command{
 		Use:     "clusters",
 		Aliases: []string{"cluster"},
-		Short:   get_cluster_short,
-		Long:    get_cluster_long,
-		Example: get_cluster_example,
+		Short:   getClusterShort,
+		Long:    getClusterLong,
+		Example: getClusterExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 0 {
 				options.ClusterNames = append(options.ClusterNames, args...)

--- a/cmd/kops/get_instancegroups.go
+++ b/cmd/kops/get_instancegroups.go
@@ -34,10 +34,10 @@ import (
 )
 
 var (
-	get_instancegroups_long = templates.LongDesc(i18n.T(`
+	getInstancegroupsLong = templates.LongDesc(i18n.T(`
 	Display one or many instancegroup resources.`))
 
-	get_instancegroups_example = templates.Examples(i18n.T(`
+	getInstancegroupsExample = templates.Examples(i18n.T(`
 	# Get all instancegroups in a state store
 	kops get ig
 
@@ -48,7 +48,7 @@ var (
 	kops get ig --name k8s-cluster.example.com -o yaml > instancegroups-desired-config.yaml
 	`))
 
-	get_instancegroups_short = i18n.T(`Get one or many instancegroups`)
+	getInstancegroupsShort = i18n.T(`Get one or many instancegroups`)
 )
 
 type GetInstanceGroupsOptions struct {
@@ -63,9 +63,9 @@ func NewCmdGetInstanceGroups(f *util.Factory, out io.Writer, getOptions *GetOpti
 	cmd := &cobra.Command{
 		Use:     "instancegroups",
 		Aliases: []string{"instancegroup", "ig"},
-		Short:   get_instancegroups_short,
-		Long:    get_instancegroups_long,
-		Example: get_instancegroups_example,
+		Short:   getInstancegroupsShort,
+		Long:    getInstancegroupsLong,
+		Example: getInstancegroupsExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunGetInstanceGroups(&options, args)
 			if err != nil {

--- a/cmd/kops/get_secrets.go
+++ b/cmd/kops/get_secrets.go
@@ -38,17 +38,17 @@ import (
 const SecretTypeSSHPublicKey = kops.KeysetType("SSHPublicKey")
 
 var (
-	get_secret_long = templates.LongDesc(i18n.T(`
+	getSecretLong = templates.LongDesc(i18n.T(`
 	Display one or many secrets.`))
 
-	get_secret_example = templates.Examples(i18n.T(`
+	getSecretExample = templates.Examples(i18n.T(`
 	# Get a secret
 	kops get secrets kube -oplaintext
 
 	# Get the admin password for a cluster
 	kops get secrets admin -oplaintext`))
 
-	get_secret_short = i18n.T(`Get one or many secrets.`)
+	getSecretShort = i18n.T(`Get one or many secrets.`)
 )
 
 type GetSecretsOptions struct {
@@ -63,9 +63,9 @@ func NewCmdGetSecrets(f *util.Factory, out io.Writer, getOptions *GetOptions) *c
 	cmd := &cobra.Command{
 		Use:     "secrets",
 		Aliases: []string{"secret"},
-		Short:   get_secret_short,
-		Long:    get_secret_long,
-		Example: get_secret_example,
+		Short:   getSecretShort,
+		Long:    getSecretLong,
+		Example: getSecretExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunGetSecrets(&options, args)
 			if err != nil {

--- a/cmd/kops/import.go
+++ b/cmd/kops/import.go
@@ -23,24 +23,24 @@ import (
 )
 
 var (
-	import_long = templates.LongDesc(i18n.T(`
+	importLong = templates.LongDesc(i18n.T(`
 	Imports a kubernetes cluster created by kube-up.sh into a state store.  This command
 	only support AWS clusters at this time.`))
 
-	import_example = templates.Examples(i18n.T(`
+	importExample = templates.Examples(i18n.T(`
 	# Import a cluser
 	kops import cluster --name k8s-cluster.example.com --region us-east-1 \
 	  --state=s3://k8s-cluster.example.com`))
 
-	import_short = i18n.T(`Import a cluster.`)
+	importShort = i18n.T(`Import a cluster.`)
 )
 
 // importCmd represents the import command
 var importCmd = &cobra.Command{
 	Use:     "import",
-	Short:   import_short,
-	Long:    import_long,
-	Example: import_example,
+	Short:   importShort,
+	Long:    importLong,
+	Example: importExample,
 }
 
 func init() {

--- a/cmd/kops/import_cluster.go
+++ b/cmd/kops/import_cluster.go
@@ -33,9 +33,9 @@ var importCluster ImportClusterCmd
 func init() {
 	cmd := &cobra.Command{
 		Use:     "cluster",
-		Short:   import_short,
-		Long:    import_long,
-		Example: import_example,
+		Short:   importShort,
+		Long:    importLong,
+		Example: importExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := importCluster.Run()
 			if err != nil {

--- a/cmd/kops/rollingupdate.go
+++ b/cmd/kops/rollingupdate.go
@@ -26,9 +26,9 @@ import (
 func NewCmdRollingUpdate(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "rolling-update",
-		Short:   rollingupdate_short,
-		Long:    rollingupdate_long,
-		Example: rollingupdate_example,
+		Short:   rollingupdateShort,
+		Long:    rollingupdateLong,
+		Example: rollingupdateExample,
 	}
 
 	// create subcommands

--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -43,7 +43,7 @@ import (
 )
 
 var (
-	rollingupdate_long = pretty.LongDesc(i18n.T(`
+	rollingupdateLong = pretty.LongDesc(i18n.T(`
 	This command updates a kubernetes cluster to match the cloud and kops specifications.
 
 	To perform a rolling update, you need to update the cloud resources first with the command
@@ -61,7 +61,7 @@ var (
 	` + pretty.Bash("kops update cluster --target=terraform") + ` then ` + pretty.Bash("terraform plan") + ` then
 	` + pretty.Bash("terraform apply") + ` prior to running ` + pretty.Bash("kops rolling-update cluster") + `.`))
 
-	rollingupdate_example = templates.Examples(i18n.T(`
+	rollingupdateExample = templates.Examples(i18n.T(`
 		# Preview a rolling-update.
 		kops rolling-update cluster
 
@@ -95,7 +95,7 @@ var (
 		  --instance-group nodes
 		`))
 
-	rollingupdate_short = i18n.T(`Rolling update a cluster.`)
+	rollingupdateShort = i18n.T(`Rolling update a cluster.`)
 )
 
 // RollingUpdateOptions is the command Object for a Rolling Update.
@@ -163,9 +163,9 @@ func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "cluster",
-		Short:   rollingupdate_short,
-		Long:    rollingupdate_long,
-		Example: rollingupdate_example,
+		Short:   rollingupdateShort,
+		Long:    rollingupdateLong,
+		Example: rollingupdateExample,
 	}
 
 	cmd.Flags().BoolVarP(&options.Yes, "yes", "y", options.Yes, "Perform rolling update immediately, without --yes rolling-update executes a dry-run")

--- a/cmd/kops/root.go
+++ b/cmd/kops/root.go
@@ -48,7 +48,7 @@ const (
 )
 
 var (
-	root_long = templates.LongDesc(i18n.T(`
+	rootLong = templates.LongDesc(i18n.T(`
 	kops is Kubernetes ops.
 
 	kops is the easiest way to get a production grade Kubernetes cluster up and running.
@@ -59,7 +59,7 @@ var (
 	officially supported, with GCE and VMware vSphere in alpha support.
 	`))
 
-	root_short = i18n.T(`kops is Kubernetes ops.`)
+	rootShort = i18n.T(`kops is Kubernetes ops.`)
 )
 
 type Factory interface {
@@ -83,8 +83,8 @@ var _ Factory = &RootCmd{}
 var rootCommand = RootCmd{
 	cobraCommand: &cobra.Command{
 		Use:   "kops",
-		Short: root_short,
-		Long:  root_long,
+		Short: rootShort,
+		Long:  rootLong,
 	},
 }
 

--- a/cmd/kops/toolbox.go
+++ b/cmd/kops/toolbox.go
@@ -26,23 +26,23 @@ import (
 )
 
 var (
-	toolbox_long = templates.LongDesc(i18n.T(`
+	toolboxLong = templates.LongDesc(i18n.T(`
 	Misc infrequently used commands.`))
 
-	toolbox_example = templates.Examples(i18n.T(`
+	toolboxExample = templates.Examples(i18n.T(`
 	# Dump cluster information
 	kops toolbox dump --name k8s-cluster.example.com
 	`))
 
-	toolbox_short = i18n.T(`Misc infrequently used commands.`)
+	toolboxShort = i18n.T(`Misc infrequently used commands.`)
 )
 
 func NewCmdToolbox(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "toolbox",
-		Short:   toolbox_short,
-		Long:    toolbox_long,
-		Example: toolbox_example,
+		Short:   toolboxShort,
+		Long:    toolboxLong,
+		Example: toolboxExample,
 	}
 
 	cmd.AddCommand(NewCmdToolboxConvertImported(f, out))

--- a/cmd/kops/toolbox_bundle.go
+++ b/cmd/kops/toolbox_bundle.go
@@ -38,15 +38,15 @@ import (
 )
 
 var (
-	toolbox_bundle_long = templates.LongDesc(i18n.T(`
+	toolboxBundleLong = templates.LongDesc(i18n.T(`
 	Creates a bundle for enrolling a bare metal machine.`))
 
-	toolbox_bundle_example = templates.Examples(i18n.T(`
+	toolboxBundleExample = templates.Examples(i18n.T(`
 	# Bundle
 	kops toolbox bundle --name k8s-cluster.example.com
 	`))
 
-	toolbox_bundle_short = i18n.T(`Bundle cluster information`)
+	toolboxBundleShort = i18n.T(`Bundle cluster information`)
 )
 
 type ToolboxBundleOptions struct {
@@ -63,9 +63,9 @@ func NewCmdToolboxBundle(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "bundle",
-		Short:   toolbox_bundle_short,
-		Long:    toolbox_bundle_long,
-		Example: toolbox_bundle_example,
+		Short:   toolboxBundleShort,
+		Long:    toolboxBundleLong,
+		Example: toolboxBundleExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunToolboxBundle(f, out, options, args)
 			if err != nil {

--- a/cmd/kops/toolbox_convert_imported.go
+++ b/cmd/kops/toolbox_convert_imported.go
@@ -31,10 +31,10 @@ import (
 )
 
 var (
-	toolbox_convert_imported_long = templates.LongDesc(i18n.T(`
+	toolboxConvertImportedLong = templates.LongDesc(i18n.T(`
 	Convert an imported cluster into a kops cluster.`))
 
-	toolbox_convert_imported_example = templates.Examples(i18n.T(`
+	toolboxConvertImportedExample = templates.Examples(i18n.T(`
 
 	# Import and convert a cluster
 	kops import cluster --name k8s-cluster.example.com --region us-east-1 \
@@ -44,7 +44,7 @@ var (
 	  --newname k8s-cluster.example.com
 	`))
 
-	toolbox_convert_imported_short = i18n.T(`Convert an imported cluster into a kops cluster.`)
+	toolboxConvertImportedShort = i18n.T(`Convert an imported cluster into a kops cluster.`)
 )
 
 type ToolboxConvertImportedOptions struct {
@@ -66,9 +66,9 @@ func NewCmdToolboxConvertImported(f *util.Factory, out io.Writer) *cobra.Command
 
 	cmd := &cobra.Command{
 		Use:     "convert-imported",
-		Short:   toolbox_convert_imported_short,
-		Long:    toolbox_convert_imported_long,
-		Example: toolbox_convert_imported_example,
+		Short:   toolboxConvertImportedShort,
+		Long:    toolboxConvertImportedLong,
+		Example: toolboxConvertImportedExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := rootCommand.ProcessArgs(args); err != nil {
 				exitWithError(err)

--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -33,15 +33,15 @@ import (
 )
 
 var (
-	toolbox_dump_long = templates.LongDesc(i18n.T(`
+	toolboxDumpLong = templates.LongDesc(i18n.T(`
 	Displays cluster information.  Includes information about cloud and Kubernetes resources.`))
 
-	toolbox_dump_example = templates.Examples(i18n.T(`
+	toolboxDumpExample = templates.Examples(i18n.T(`
 	# Dump cluster information
 	kops toolbox dump --name k8s-cluster.example.com
 	`))
 
-	toolbox_dump_short = i18n.T(`Dump cluster information`)
+	toolboxDumpShort = i18n.T(`Dump cluster information`)
 )
 
 type ToolboxDumpOptions struct {
@@ -60,9 +60,9 @@ func NewCmdToolboxDump(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "dump",
-		Short:   toolbox_dump_short,
-		Long:    toolbox_dump_long,
-		Example: toolbox_dump_example,
+		Short:   toolboxDumpShort,
+		Long:    toolboxDumpLong,
+		Example: toolboxDumpExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := rootCommand.ProcessArgs(args); err != nil {
 				exitWithError(err)

--- a/cmd/kops/update.go
+++ b/cmd/kops/update.go
@@ -26,11 +26,11 @@ import (
 )
 
 var (
-	update_long = templates.LongDesc(i18n.T(`
+	updateLong = templates.LongDesc(i18n.T(`
 	Creates or updates cloud resources to match cluster desired configuration.
 	`))
 
-	update_example = templates.Examples(i18n.T(`
+	updateExample = templates.Examples(i18n.T(`
 		# After cluster has been created, configure it with:
 		kops update cluster k8s.cluster.site --yes --state=s3://kops-state-1234
 	`))
@@ -42,8 +42,8 @@ func NewCmdUpdate(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "update",
 		Short:   update_short,
-		Long:    update_long,
-		Example: update_example,
+		Long:    updateLong,
+		Example: updateExample,
 	}
 
 	//  subcommands

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -40,7 +40,7 @@ import (
 )
 
 var (
-	update_cluster_long = templates.LongDesc(i18n.T(`
+	updateClusterLong = templates.LongDesc(i18n.T(`
 	Create or update cloud or cluster resources to match current cluster state.  If the cluster or cloud resources already
 	exist this command may modify those resources.
 
@@ -48,12 +48,12 @@ var (
 	be required as well.
 	`))
 
-	update_cluster_example = templates.Examples(i18n.T(`
+	updateClusterExample = templates.Examples(i18n.T(`
 	# After cluster has been edited or upgraded, configure it with:
 	kops update cluster k8s-cluster.example.com --yes --state=s3://kops-state-1234 --yes
 	`))
 
-	update_cluster_short = i18n.T("Update a cluster.")
+	updateClusterShort = i18n.T("Update a cluster.")
 )
 
 type UpdateClusterOptions struct {
@@ -88,9 +88,9 @@ func NewCmdUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "cluster",
-		Short:   update_cluster_short,
-		Long:    update_cluster_long,
-		Example: update_cluster_example,
+		Short:   updateClusterShort,
+		Long:    updateClusterLong,
+		Example: updateClusterExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := rootCommand.ProcessArgs(args)
 			if err != nil {

--- a/cmd/kops/upgrade.go
+++ b/cmd/kops/upgrade.go
@@ -23,26 +23,26 @@ import (
 )
 
 var (
-	upgrade_long = templates.LongDesc(i18n.T(`
+	upgradeLong = templates.LongDesc(i18n.T(`
 	Automates checking for and applying Kubernetes updates. This upgrades a cluster to the latest recommended
 	production ready k8s version. After this command is run, use kops update cluster and kops rolling-update cluster
 	to finish a cluster upgrade.
 	`))
 
-	upgrade_example = templates.Examples(i18n.T(`
+	upgradeExample = templates.Examples(i18n.T(`
 	# Upgrade a cluster's Kubernetes version.
 	kops upgrade cluster kubernetes-cluster.example.com --yes --state=s3://kops-state-1234
 	`))
 
-	upgrade_short = i18n.T("Upgrade a kubernetes cluster.")
+	upgradeShort = i18n.T("Upgrade a kubernetes cluster.")
 )
 
 // upgradeCmd represents the upgrade command
 var upgradeCmd = &cobra.Command{
 	Use:     "upgrade",
-	Short:   upgrade_short,
-	Long:    upgrade_long,
-	Example: upgrade_example,
+	Short:   upgradeShort,
+	Long:    upgradeLong,
+	Example: upgradeExample,
 }
 
 func init() {

--- a/cmd/kops/upgrade_cluster.go
+++ b/cmd/kops/upgrade_cluster.go
@@ -46,9 +46,9 @@ var upgradeCluster UpgradeClusterCmd
 func init() {
 	cmd := &cobra.Command{
 		Use:     "cluster",
-		Short:   upgrade_short,
-		Long:    upgrade_long,
-		Example: upgrade_example,
+		Short:   upgradeShort,
+		Long:    upgradeLong,
+		Example: upgradeExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := upgradeCluster.Run(args)
 			if err != nil {

--- a/cmd/kops/validate.go
+++ b/cmd/kops/validate.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	validate_long = templates.LongDesc(i18n.T(`
+	validateLong = templates.LongDesc(i18n.T(`
 	This commands validates the following components:
 
 	1. All k8s masters are running and have "Ready" status.
@@ -35,21 +35,21 @@ var (
 	4. All pods in the kube-system namespace are running and healthy.
 	`))
 
-	validate_example = templates.Examples(i18n.T(`
+	validateExample = templates.Examples(i18n.T(`
 	# Validate a cluster.
 	# This command uses the currently selected kops cluster as
 	# set by the kubectl config.
 	kops validate cluster`))
 
-	validate_short = i18n.T(`Validate a kops cluster.`)
+	validateShort = i18n.T(`Validate a kops cluster.`)
 )
 
 func NewCmdValidate(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "validate",
-		Short:   validate_short,
-		Long:    validate_long,
-		Example: validate_example,
+		Short:   validateShort,
+		Long:    validateLong,
+		Example: validateExample,
 	}
 
 	// create subcommands

--- a/cmd/kops/validate_cluster.go
+++ b/cmd/kops/validate_cluster.go
@@ -60,9 +60,9 @@ func NewCmdValidateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "cluster",
-		Short:   validate_short,
-		Long:    validate_long,
-		Example: validate_example,
+		Short:   validateShort,
+		Long:    validateLong,
+		Example: validateExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunValidateCluster(f, cmd, args, os.Stdout, options)
 			if err != nil {

--- a/cmd/kops/version.go
+++ b/cmd/kops/version.go
@@ -26,13 +26,13 @@ import (
 )
 
 var (
-	version_long = templates.LongDesc(i18n.T(`
+	versionLong = templates.LongDesc(i18n.T(`
 	Print the kops version and git SHA.`))
 
-	version_example = templates.Examples(i18n.T(`
+	versionExample = templates.Examples(i18n.T(`
 	kops version`))
 
-	version_short = i18n.T(`Print the kops version information.`)
+	versionShort = i18n.T(`Print the kops version information.`)
 )
 
 type VersionCmd struct {
@@ -42,9 +42,9 @@ type VersionCmd struct {
 var versionCmd = VersionCmd{
 	cobraCommand: &cobra.Command{
 		Use:     "version",
-		Short:   version_short,
-		Long:    version_long,
-		Example: version_example,
+		Short:   versionShort,
+		Long:    versionLong,
+		Example: versionExample,
 	},
 }
 


### PR DESCRIPTION
I am fixing the work where I used snake case variables instead of camel
case.  Go likes camel case much better.  This commit is only a refactor
of names.

/assign @robinpercy 