### PR TITLE
Updating kops version when using bazel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))
 DNS_CONTROLLER_TAG=1.8.0
 
 # Keep in sync with logic in get_workspace_status
+# Update variables in tools/get_workplace_status.sh for the bazel build
 KOPS_RELEASE_VERSION = 1.8.1
 KOPS_CI_VERSION      = 1.8.2-alpha.1
 

--- a/tools/get_workspace_status.sh
+++ b/tools/get_workspace_status.sh
@@ -45,8 +45,10 @@ echo "BUILD_SCM_STATUS ${tree_status}"
 # Compute KOPS_VERSION.  Keep in sync with logic in Makefile
 GITSHA=$(git describe --always)
 
-KOPS_RELEASE_VERSION=1.8.0
-KOPS_CI_VERSION=1.8.1-beta.1
+# These variables need to match the values in our Makefile
+# When we cut a new release we need to increment these accordingly
+KOPS_RELEASE_VERSION=1.8.1
+KOPS_CI_VERSION=1.8.2-alpha.1
 
 if [[ -z "${VERSION}" ]]; then
   if [[ -z "${CI}" ]]; then


### PR DESCRIPTION
We bumped the version in the Makefile, but I did not understand that we
have to bump the version in the workplace status script.  I added a note
in the Makefile, and bumped the version in the script.

/assign @mikesplain 