### PR TITLE
kube-dns: turn off negcache

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -166,6 +166,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
+        - --no-negcache
         - --log-facility=-
         - --server=/{{ KubeDNS.Domain }}/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053


### PR DESCRIPTION
The equivalent of https://github.com/kubernetes/kubernetes/pull/53604

Not backporting to 1.5 at this point.