### PR TITLE
Fix default region from aws config as well as env

### DIFF
--- a/pkg/model/BUILD.bazel
+++ b/pkg/model/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//upup/pkg/fi/cloudup/openstacktasks:go_default_library",
         "//upup/pkg/fi/fitasks:go_default_library",
         "//util/pkg/vfs:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/ghodss/yaml"
 
 	"k8s.io/kops/pkg/apis/kops"
@@ -94,6 +96,13 @@ func (b *BootstrapScript) ResourceNodeUp(ig *kops.InstanceGroup, cs *kops.Cluste
 			if os.Getenv("AWS_REGION") != "" {
 				return fmt.Sprintf("export AWS_REGION=%s\n",
 					os.Getenv("AWS_REGION"))
+			} else {
+				sess := session.Must(session.NewSession(aws.NewConfig().
+					WithMaxRetries(3),
+				))
+				if *sess.Config.Region != "" {
+					return fmt.Sprintf("export AWS_REGION=%s\n", *sess.Config.Region)
+				}
 			}
 			return ""
 		},


### PR DESCRIPTION
Fixes #4451

If you have region set in your aws config then if you do not have AWS_REGION set in your env, kops will attempt a session setup to determine the correct region to default to, and if that fails, doesn't set the env for nodeup.  This is a much better fallback than not doing anything.