### PR TITLE
Update ingress versions and fix to quay registry

### DIFF
--- a/addons/ingress-nginx/v1.6.0-gce.yaml
+++ b/addons/ingress-nginx/v1.6.0-gce.yaml
@@ -272,7 +272,7 @@ spec:
       terminationGracePeriodSeconds: 60
       serviceAccountName: nginx-ingress-controller
       containers:
-      - image: k8s.gcr.io/nginx-ingress-controller:0.9.0-beta.10
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.11.0
         name: nginx-ingress-controller
         imagePullPolicy: Always
         ports:

--- a/addons/ingress-nginx/v1.6.0.yaml
+++ b/addons/ingress-nginx/v1.6.0.yaml
@@ -274,7 +274,7 @@ spec:
       terminationGracePeriodSeconds: 60
       serviceAccountName: nginx-ingress-controller
       containers:
-      - image: k8s.gcr.io/nginx-ingress-controller:0.9.0
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.11.0
         name: nginx-ingress-controller
         imagePullPolicy: Always
         ports:


### PR DESCRIPTION
k8s.gcr.io no longer hosts ingress-controller, and update to latest as suggested by @aledbf 