### PR TITLE
Adjust Private subnet and API ELB Logic

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -1043,7 +1043,16 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 	}
 	if cluster.Spec.API.LoadBalancer != nil && cluster.Spec.API.LoadBalancer.Type == "" {
 		switch c.APILoadBalancerType {
-		case "", "public":
+		case "":
+			if cluster.Spec.Topology.Masters == api.TopologyPrivate {
+				cluster.Spec.API.LoadBalancer.Type = api.LoadBalancerTypeInternal
+			} else {
+				cluster.Spec.API.LoadBalancer.Type = api.LoadBalancerTypePublic
+			}
+		case "public":
+			if cluster.Spec.Topology.Masters == api.TopologyPrivate {
+				return fmt.Errorf("Private topology supports --api-loadbalancer-type='internal' only")
+			}
 			cluster.Spec.API.LoadBalancer.Type = api.LoadBalancerTypePublic
 		case "internal":
 			cluster.Spec.API.LoadBalancer.Type = api.LoadBalancerTypeInternal

--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -70,11 +70,10 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 
 			switch subnet.Type {
 			case kops.SubnetTypePublic, kops.SubnetTypeUtility:
-				if lbSpec.Type != kops.LoadBalancerTypePublic {
-					continue
-				}
+			// ok
 
 			case kops.SubnetTypePrivate:
+				// Private subnets can only be added to Internal Load balancers.
 				if lbSpec.Type != kops.LoadBalancerTypeInternal {
 					continue
 				}

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha1.yaml
@@ -8,7 +8,7 @@ spec:
   - 0.0.0.0/0
   api:
     loadBalancer:
-      type: Public
+      type: Internal
   authorization:
     rbac: {}
   channel: stable

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   api:
     loadBalancer:
-      type: Public
+      type: Internal
   authorization:
     rbac: {}
   channel: stable

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha1.yaml
@@ -8,7 +8,7 @@ spec:
   - 0.0.0.0/0
   api:
     loadBalancer:
-      type: Public
+      type: Internal
   authorization:
     rbac: {}
   channel: stable

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   api:
     loadBalancer:
-      type: Public
+      type: Internal
   authorization:
     rbac: {}
   channel: stable

--- a/tests/integration/create_cluster/private/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha1.yaml
@@ -8,7 +8,7 @@ spec:
   - 0.0.0.0/0
   api:
     loadBalancer:
-      type: Public
+      type: Internal
   authorization:
     rbac: {}
   channel: stable

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   api:
     loadBalancer:
-      type: Public
+      type: Internal
   authorization:
     rbac: {}
   channel: stable

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   api:
     loadBalancer:
-      type: Public
+      type: Internal
   authorization:
     rbac: {}
   channel: stable


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kops/issues/3433

This PR allows public subnets to be added to internal load balancers and adds an error for private topology + public LB.  
