### PR TITLE
Adding additional tags and shared to various AWS components

### DIFF
--- a/pkg/model/network.go
+++ b/pkg/model/network.go
@@ -39,10 +39,10 @@ var _ fi.ModelBuilder = &NetworkModelBuilder{}
 func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	sharedVPC := b.Cluster.SharedVPC()
 	vpcName := b.ClusterName()
+	tags := b.CloudTags(vpcName, sharedVPC)
 
 	// VPC that holds everything for the cluster
 	{
-		tags := b.CloudTags(vpcName, sharedVPC)
 
 		t := &awstasks.VPC{
 			Name:             s(vpcName),
@@ -78,6 +78,9 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Name:              s(b.ClusterName()),
 			Lifecycle:         b.Lifecycle,
 			DomainNameServers: s("AmazonProvidedDNS"),
+
+			Tags:   tags,
+			Shared: fi.Bool(sharedVPC),
 		}
 		if b.Region == "us-east-1" {
 			dhcp.DomainName = s("ec2.internal")
@@ -114,6 +117,8 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Lifecycle: b.Lifecycle,
 			VPC:       b.LinkToVPC(),
 			Shared:    fi.Bool(sharedVPC),
+
+			Tags: tags,
 		}
 		c.AddTask(igw)
 
@@ -123,6 +128,9 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 				Lifecycle: b.Lifecycle,
 
 				VPC: b.LinkToVPC(),
+
+				Tags:   tags,
+				Shared: fi.Bool(sharedVPC),
 			}
 			c.AddTask(publicRouteTable)
 
@@ -268,6 +276,24 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			c.AddTask(ngw)
 		}
 
+		// kops needs to have the correct shared or owned tag on private route tables,
+		// but the 'Name' tag  for the private route table does not match the standard
+		// 'Name' tag value.
+		// Making a copy of the map to use for private route tables, and maintaining the 'Name'
+		// tag with a value like "private-us-test-1a.privatedns1.example.com" instead of using
+		// the usual value like "privatedns1.example.com".
+		privateTags := make(map[string]string)
+		for k, v := range tags {
+			privateTags[k] = v
+		}
+		// We do not set the Name on shared resources remove it if it exists
+		// otherwise set it.
+		if sharedVPC {
+			delete(privateTags, "Name")
+		} else {
+			privateTags["Name"] = b.NamePrivateRouteTableInZone(zone)
+		}
+
 		// Private Route Table
 		//
 		// The private route table that will route to the NAT Gateway
@@ -275,6 +301,9 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Name:      s(b.NamePrivateRouteTableInZone(zone)),
 			VPC:       b.LinkToVPC(),
 			Lifecycle: b.Lifecycle,
+
+			Shared: fi.Bool(sharedVPC),
+			Tags:   privateTags,
 		}
 		c.AddTask(rt)
 

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json
@@ -169,6 +169,10 @@
           {
             "Key": "Name",
             "Value": "additionaluserdata.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/additionaluserdata.example.com",
+            "Value": "owned"
           }
         ]
       }
@@ -184,6 +188,10 @@
           {
             "Key": "Name",
             "Value": "additionaluserdata.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/additionaluserdata.example.com",
+            "Value": "owned"
           }
         ]
       }
@@ -214,6 +222,10 @@
           {
             "Key": "Name",
             "Value": "additionaluserdata.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/additionaluserdata.example.com",
+            "Value": "owned"
           }
         ]
       }

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -226,8 +226,9 @@ resource "aws_internet_gateway" "complex-example-com" {
   vpc_id = "${aws_vpc.complex-example-com.id}"
 
   tags = {
-    KubernetesCluster = "complex.example.com"
-    Name              = "complex.example.com"
+    KubernetesCluster                           = "complex.example.com"
+    Name                                        = "complex.example.com"
+    "kubernetes.io/cluster/complex.example.com" = "owned"
   }
 }
 
@@ -306,8 +307,9 @@ resource "aws_route_table" "complex-example-com" {
   vpc_id = "${aws_vpc.complex-example-com.id}"
 
   tags = {
-    KubernetesCluster = "complex.example.com"
-    Name              = "complex.example.com"
+    KubernetesCluster                           = "complex.example.com"
+    Name                                        = "complex.example.com"
+    "kubernetes.io/cluster/complex.example.com" = "owned"
   }
 }
 
@@ -542,8 +544,9 @@ resource "aws_vpc_dhcp_options" "complex-example-com" {
   domain_name_servers = ["AmazonProvidedDNS"]
 
   tags = {
-    KubernetesCluster = "complex.example.com"
-    Name              = "complex.example.com"
+    KubernetesCluster                           = "complex.example.com"
+    Name                                        = "complex.example.com"
+    "kubernetes.io/cluster/complex.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -278,8 +278,9 @@ resource "aws_internet_gateway" "ha-example-com" {
   vpc_id = "${aws_vpc.ha-example-com.id}"
 
   tags = {
-    KubernetesCluster = "ha.example.com"
-    Name              = "ha.example.com"
+    KubernetesCluster                      = "ha.example.com"
+    Name                                   = "ha.example.com"
+    "kubernetes.io/cluster/ha.example.com" = "owned"
   }
 }
 
@@ -397,8 +398,9 @@ resource "aws_route_table" "ha-example-com" {
   vpc_id = "${aws_vpc.ha-example-com.id}"
 
   tags = {
-    KubernetesCluster = "ha.example.com"
-    Name              = "ha.example.com"
+    KubernetesCluster                      = "ha.example.com"
+    Name                                   = "ha.example.com"
+    "kubernetes.io/cluster/ha.example.com" = "owned"
   }
 }
 
@@ -606,8 +608,9 @@ resource "aws_vpc_dhcp_options" "ha-example-com" {
   domain_name_servers = ["AmazonProvidedDNS"]
 
   tags = {
-    KubernetesCluster = "ha.example.com"
-    Name              = "ha.example.com"
+    KubernetesCluster                      = "ha.example.com"
+    Name                                   = "ha.example.com"
+    "kubernetes.io/cluster/ha.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
+++ b/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
@@ -22,8 +22,9 @@ resource "aws_internet_gateway" "privateweave-example-com" {
   vpc_id = "${aws_vpc.privateweave-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privateweave.example.com"
-    Name              = "privateweave.example.com"
+    KubernetesCluster                                = "privateweave.example.com"
+    Name                                             = "privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
   }
 }
 
@@ -48,8 +49,9 @@ resource "aws_route_table" "private-us-test-1a-privateweave-example-com" {
   vpc_id = "${aws_vpc.privateweave-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privateweave.example.com"
-    Name              = "private-us-test-1a.privateweave.example.com"
+    KubernetesCluster                                = "privateweave.example.com"
+    Name                                             = "private-us-test-1a.privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
   }
 }
 
@@ -57,8 +59,9 @@ resource "aws_route_table" "privateweave-example-com" {
   vpc_id = "${aws_vpc.privateweave-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privateweave.example.com"
-    Name              = "privateweave.example.com"
+    KubernetesCluster                                = "privateweave.example.com"
+    Name                                             = "privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
   }
 }
 
@@ -117,8 +120,9 @@ resource "aws_vpc_dhcp_options" "privateweave-example-com" {
   domain_name_servers = ["AmazonProvidedDNS"]
 
   tags = {
-    KubernetesCluster = "privateweave.example.com"
-    Name              = "privateweave.example.com"
+    KubernetesCluster                                = "privateweave.example.com"
+    Name                                             = "privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/minimal-141/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-141/kubernetes.tf
@@ -164,8 +164,9 @@ resource "aws_internet_gateway" "minimal-141-example-com" {
   vpc_id = "${aws_vpc.minimal-141-example-com.id}"
 
   tags = {
-    KubernetesCluster = "minimal-141.example.com"
-    Name              = "minimal-141.example.com"
+    KubernetesCluster                               = "minimal-141.example.com"
+    Name                                            = "minimal-141.example.com"
+    "kubernetes.io/cluster/minimal-141.example.com" = "owned"
   }
 }
 
@@ -231,8 +232,9 @@ resource "aws_route_table" "minimal-141-example-com" {
   vpc_id = "${aws_vpc.minimal-141-example-com.id}"
 
   tags = {
-    KubernetesCluster = "minimal-141.example.com"
-    Name              = "minimal-141.example.com"
+    KubernetesCluster                               = "minimal-141.example.com"
+    Name                                            = "minimal-141.example.com"
+    "kubernetes.io/cluster/minimal-141.example.com" = "owned"
   }
 }
 
@@ -402,8 +404,9 @@ resource "aws_vpc_dhcp_options" "minimal-141-example-com" {
   domain_name_servers = ["AmazonProvidedDNS"]
 
   tags = {
-    KubernetesCluster = "minimal-141.example.com"
-    Name              = "minimal-141.example.com"
+    KubernetesCluster                               = "minimal-141.example.com"
+    Name                                            = "minimal-141.example.com"
+    "kubernetes.io/cluster/minimal-141.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
@@ -169,6 +169,10 @@
           {
             "Key": "Name",
             "Value": "minimal.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/minimal.example.com",
+            "Value": "owned"
           }
         ]
       }
@@ -184,6 +188,10 @@
           {
             "Key": "Name",
             "Value": "minimal.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/minimal.example.com",
+            "Value": "owned"
           }
         ]
       }
@@ -214,6 +222,10 @@
           {
             "Key": "Name",
             "Value": "minimal.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/minimal.example.com",
+            "Value": "owned"
           }
         ]
       }

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -164,8 +164,9 @@ resource "aws_internet_gateway" "minimal-example-com" {
   vpc_id = "${aws_vpc.minimal-example-com.id}"
 
   tags = {
-    KubernetesCluster = "minimal.example.com"
-    Name              = "minimal.example.com"
+    KubernetesCluster                           = "minimal.example.com"
+    Name                                        = "minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
 }
 
@@ -231,8 +232,9 @@ resource "aws_route_table" "minimal-example-com" {
   vpc_id = "${aws_vpc.minimal-example-com.id}"
 
   tags = {
-    KubernetesCluster = "minimal.example.com"
-    Name              = "minimal.example.com"
+    KubernetesCluster                           = "minimal.example.com"
+    Name                                        = "minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
 }
 
@@ -402,8 +404,9 @@ resource "aws_vpc_dhcp_options" "minimal-example-com" {
   domain_name_servers = ["AmazonProvidedDNS"]
 
   tags = {
-    KubernetesCluster = "minimal.example.com"
-    Name              = "minimal.example.com"
+    KubernetesCluster                           = "minimal.example.com"
+    Name                                        = "minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -293,8 +293,9 @@ resource "aws_internet_gateway" "privatecalico-example-com" {
   vpc_id = "${aws_vpc.privatecalico-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privatecalico.example.com"
-    Name              = "privatecalico.example.com"
+    KubernetesCluster                                 = "privatecalico.example.com"
+    Name                                              = "privatecalico.example.com"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
   }
 }
 
@@ -404,8 +405,9 @@ resource "aws_route_table" "private-us-test-1a-privatecalico-example-com" {
   vpc_id = "${aws_vpc.privatecalico-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privatecalico.example.com"
-    Name              = "private-us-test-1a.privatecalico.example.com"
+    KubernetesCluster                                 = "privatecalico.example.com"
+    Name                                              = "private-us-test-1a.privatecalico.example.com"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
   }
 }
 
@@ -413,8 +415,9 @@ resource "aws_route_table" "privatecalico-example-com" {
   vpc_id = "${aws_vpc.privatecalico-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privatecalico.example.com"
-    Name              = "privatecalico.example.com"
+    KubernetesCluster                                 = "privatecalico.example.com"
+    Name                                              = "privatecalico.example.com"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
   }
 }
 
@@ -699,8 +702,9 @@ resource "aws_vpc_dhcp_options" "privatecalico-example-com" {
   domain_name_servers = ["AmazonProvidedDNS"]
 
   tags = {
-    KubernetesCluster = "privatecalico.example.com"
-    Name              = "privatecalico.example.com"
+    KubernetesCluster                                 = "privatecalico.example.com"
+    Name                                              = "privatecalico.example.com"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -293,8 +293,9 @@ resource "aws_internet_gateway" "privatecanal-example-com" {
   vpc_id = "${aws_vpc.privatecanal-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privatecanal.example.com"
-    Name              = "privatecanal.example.com"
+    KubernetesCluster                                = "privatecanal.example.com"
+    Name                                             = "privatecanal.example.com"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
   }
 }
 
@@ -404,8 +405,9 @@ resource "aws_route_table" "private-us-test-1a-privatecanal-example-com" {
   vpc_id = "${aws_vpc.privatecanal-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privatecanal.example.com"
-    Name              = "private-us-test-1a.privatecanal.example.com"
+    KubernetesCluster                                = "privatecanal.example.com"
+    Name                                             = "private-us-test-1a.privatecanal.example.com"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
   }
 }
 
@@ -413,8 +415,9 @@ resource "aws_route_table" "privatecanal-example-com" {
   vpc_id = "${aws_vpc.privatecanal-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privatecanal.example.com"
-    Name              = "privatecanal.example.com"
+    KubernetesCluster                                = "privatecanal.example.com"
+    Name                                             = "privatecanal.example.com"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
   }
 }
 
@@ -690,8 +693,9 @@ resource "aws_vpc_dhcp_options" "privatecanal-example-com" {
   domain_name_servers = ["AmazonProvidedDNS"]
 
   tags = {
-    KubernetesCluster = "privatecanal.example.com"
-    Name              = "privatecanal.example.com"
+    KubernetesCluster                                = "privatecanal.example.com"
+    Name                                             = "privatecanal.example.com"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -293,8 +293,9 @@ resource "aws_internet_gateway" "privatedns1-example-com" {
   vpc_id = "${aws_vpc.privatedns1-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privatedns1.example.com"
-    Name              = "privatedns1.example.com"
+    KubernetesCluster                               = "privatedns1.example.com"
+    Name                                            = "privatedns1.example.com"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
 
@@ -409,8 +410,9 @@ resource "aws_route_table" "private-us-test-1a-privatedns1-example-com" {
   vpc_id = "${aws_vpc.privatedns1-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privatedns1.example.com"
-    Name              = "private-us-test-1a.privatedns1.example.com"
+    KubernetesCluster                               = "privatedns1.example.com"
+    Name                                            = "private-us-test-1a.privatedns1.example.com"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
 
@@ -418,8 +420,9 @@ resource "aws_route_table" "privatedns1-example-com" {
   vpc_id = "${aws_vpc.privatedns1-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privatedns1.example.com"
-    Name              = "privatedns1.example.com"
+    KubernetesCluster                               = "privatedns1.example.com"
+    Name                                            = "privatedns1.example.com"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
 
@@ -695,8 +698,9 @@ resource "aws_vpc_dhcp_options" "privatedns1-example-com" {
   domain_name_servers = ["AmazonProvidedDNS"]
 
   tags = {
-    KubernetesCluster = "privatedns1.example.com"
-    Name              = "privatedns1.example.com"
+    KubernetesCluster                               = "privatedns1.example.com"
+    Name                                            = "privatedns1.example.com"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -395,8 +395,8 @@ resource "aws_route_table" "private-us-test-1a-privatedns2-example-com" {
   vpc_id = "vpc-12345678"
 
   tags = {
-    KubernetesCluster = "privatedns2.example.com"
-    Name              = "private-us-test-1a.privatedns2.example.com"
+    KubernetesCluster                               = "privatedns2.example.com"
+    "kubernetes.io/cluster/privatedns2.example.com" = "shared"
   }
 }
 
@@ -404,8 +404,8 @@ resource "aws_route_table" "privatedns2-example-com" {
   vpc_id = "vpc-12345678"
 
   tags = {
-    KubernetesCluster = "privatedns2.example.com"
-    Name              = "privatedns2.example.com"
+    KubernetesCluster                               = "privatedns2.example.com"
+    "kubernetes.io/cluster/privatedns2.example.com" = "shared"
   }
 }
 

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -293,8 +293,9 @@ resource "aws_internet_gateway" "privateflannel-example-com" {
   vpc_id = "${aws_vpc.privateflannel-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privateflannel.example.com"
-    Name              = "privateflannel.example.com"
+    KubernetesCluster                                  = "privateflannel.example.com"
+    Name                                               = "privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
   }
 }
 
@@ -404,8 +405,9 @@ resource "aws_route_table" "private-us-test-1a-privateflannel-example-com" {
   vpc_id = "${aws_vpc.privateflannel-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privateflannel.example.com"
-    Name              = "private-us-test-1a.privateflannel.example.com"
+    KubernetesCluster                                  = "privateflannel.example.com"
+    Name                                               = "private-us-test-1a.privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
   }
 }
 
@@ -413,8 +415,9 @@ resource "aws_route_table" "privateflannel-example-com" {
   vpc_id = "${aws_vpc.privateflannel-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privateflannel.example.com"
-    Name              = "privateflannel.example.com"
+    KubernetesCluster                                  = "privateflannel.example.com"
+    Name                                               = "privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
   }
 }
 
@@ -690,8 +693,9 @@ resource "aws_vpc_dhcp_options" "privateflannel-example-com" {
   domain_name_servers = ["AmazonProvidedDNS"]
 
   tags = {
-    KubernetesCluster = "privateflannel.example.com"
-    Name              = "privateflannel.example.com"
+    KubernetesCluster                                  = "privateflannel.example.com"
+    Name                                               = "privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -289,8 +289,9 @@ resource "aws_internet_gateway" "privatekopeio-example-com" {
   vpc_id = "${aws_vpc.privatekopeio-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privatekopeio.example.com"
-    Name              = "privatekopeio.example.com"
+    KubernetesCluster                                 = "privatekopeio.example.com"
+    Name                                              = "privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
   }
 }
 
@@ -395,8 +396,9 @@ resource "aws_route_table" "private-us-test-1a-privatekopeio-example-com" {
   vpc_id = "${aws_vpc.privatekopeio-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privatekopeio.example.com"
-    Name              = "private-us-test-1a.privatekopeio.example.com"
+    KubernetesCluster                                 = "privatekopeio.example.com"
+    Name                                              = "private-us-test-1a.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
   }
 }
 
@@ -404,8 +406,9 @@ resource "aws_route_table" "privatekopeio-example-com" {
   vpc_id = "${aws_vpc.privatekopeio-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privatekopeio.example.com"
-    Name              = "privatekopeio.example.com"
+    KubernetesCluster                                 = "privatekopeio.example.com"
+    Name                                              = "privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
   }
 }
 
@@ -681,8 +684,9 @@ resource "aws_vpc_dhcp_options" "privatekopeio-example-com" {
   domain_name_servers = ["AmazonProvidedDNS"]
 
   tags = {
-    KubernetesCluster = "privatekopeio.example.com"
-    Name              = "privatekopeio.example.com"
+    KubernetesCluster                                 = "privatekopeio.example.com"
+    Name                                              = "privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -293,8 +293,9 @@ resource "aws_internet_gateway" "privateweave-example-com" {
   vpc_id = "${aws_vpc.privateweave-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privateweave.example.com"
-    Name              = "privateweave.example.com"
+    KubernetesCluster                                = "privateweave.example.com"
+    Name                                             = "privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
   }
 }
 
@@ -404,8 +405,9 @@ resource "aws_route_table" "private-us-test-1a-privateweave-example-com" {
   vpc_id = "${aws_vpc.privateweave-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privateweave.example.com"
-    Name              = "private-us-test-1a.privateweave.example.com"
+    KubernetesCluster                                = "privateweave.example.com"
+    Name                                             = "private-us-test-1a.privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
   }
 }
 
@@ -413,8 +415,9 @@ resource "aws_route_table" "privateweave-example-com" {
   vpc_id = "${aws_vpc.privateweave-example-com.id}"
 
   tags = {
-    KubernetesCluster = "privateweave.example.com"
-    Name              = "privateweave.example.com"
+    KubernetesCluster                                = "privateweave.example.com"
+    Name                                             = "privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
   }
 }
 
@@ -690,8 +693,9 @@ resource "aws_vpc_dhcp_options" "privateweave-example-com" {
   domain_name_servers = ["AmazonProvidedDNS"]
 
   tags = {
-    KubernetesCluster = "privateweave.example.com"
-    Name              = "privateweave.example.com"
+    KubernetesCluster                                = "privateweave.example.com"
+    Name                                             = "privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -222,8 +222,8 @@ resource "aws_route_table" "sharedvpc-example-com" {
   vpc_id = "vpc-12345678"
 
   tags = {
-    KubernetesCluster = "sharedvpc.example.com"
-    Name              = "sharedvpc.example.com"
+    KubernetesCluster                             = "sharedvpc.example.com"
+    "kubernetes.io/cluster/sharedvpc.example.com" = "shared"
   }
 }
 

--- a/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
+++ b/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
@@ -38,6 +38,12 @@ type DHCPOptions struct {
 	ID                *string
 	DomainName        *string
 	DomainNameServers *string
+
+	// Shared is set if this is a shared DHCPOptions
+	Shared *bool
+
+	// Tags is a map of aws tags that are added to the InternetGateway
+	Tags map[string]string
 }
 
 var _ fi.CompareWithID = &DHCPOptions{}
@@ -157,7 +163,7 @@ func (_ *DHCPOptions) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *DHCPOption
 		e.ID = response.DhcpOptions.DhcpOptionsId
 	}
 
-	return t.AddAWSTags(*e.ID, t.Cloud.BuildTags(e.Name))
+	return t.AddAWSTags(*e.ID, e.Tags)
 }
 
 type terraformDHCPOptions struct {
@@ -167,11 +173,9 @@ type terraformDHCPOptions struct {
 }
 
 func (_ *DHCPOptions) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *DHCPOptions) error {
-	cloud := t.Cloud.(awsup.AWSCloud)
-
 	tf := &terraformDHCPOptions{
 		DomainName: e.DomainName,
-		Tags:       cloud.BuildTags(e.Name),
+		Tags:       e.Tags,
 	}
 
 	if e.DomainNameServers != nil {
@@ -192,11 +196,9 @@ type cloudformationDHCPOptions struct {
 }
 
 func (_ *DHCPOptions) RenderCloudformation(t *cloudformation.CloudformationTarget, a, e, changes *DHCPOptions) error {
-	cloud := t.Cloud.(awsup.AWSCloud)
-
 	cf := &cloudformationDHCPOptions{
 		DomainName: e.DomainName,
-		Tags:       buildCloudformationTags(cloud.BuildTags(e.Name)),
+		Tags:       buildCloudformationTags(e.Tags),
 	}
 
 	if e.DomainNameServers != nil {

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway.go
@@ -32,9 +32,13 @@ type InternetGateway struct {
 	Name      *string
 	Lifecycle *fi.Lifecycle
 
-	ID     *string
-	VPC    *VPC
+	ID  *string
+	VPC *VPC
+	// Shared is set if this is a shared InternetGateway
 	Shared *bool
+
+	// Tags is a map of aws tags that are added to the InternetGateway
+	Tags map[string]string
 }
 
 var _ fi.CompareWithID = &InternetGateway{}
@@ -163,12 +167,7 @@ func (_ *InternetGateway) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Intern
 		}
 	}
 
-	tags := t.Cloud.BuildTags(e.Name)
-	if shared {
-		// Don't tag shared resources
-		tags = nil
-	}
-	return t.AddAWSTags(*e.ID, tags)
+	return t.AddAWSTags(*e.ID, e.Tags)
 }
 
 type terraformInternetGateway struct {
@@ -203,11 +202,9 @@ func (_ *InternetGateway) RenderTerraform(t *terraform.TerraformTarget, a, e, ch
 		return nil
 	}
 
-	cloud := t.Cloud.(awsup.AWSCloud)
-
 	tf := &terraformInternetGateway{
 		VPCID: e.VPC.TerraformLink(),
-		Tags:  cloud.BuildTags(e.Name),
+		Tags:  e.Tags,
 	}
 
 	return t.RenderResource("aws_internet_gateway", *e.Name, tf)
@@ -263,11 +260,9 @@ func (_ *InternetGateway) RenderCloudformation(t *cloudformation.CloudformationT
 		return nil
 	}
 
-	cloud := t.Cloud.(awsup.AWSCloud)
-
 	{
 		cf := &cloudformationInternetGateway{
-			Tags: buildCloudformationTags(cloud.BuildTags(e.Name)),
+			Tags: buildCloudformationTags(e.Tags),
 		}
 
 		err := t.RenderResource("AWS::EC2::InternetGateway", *e.Name, cf)


### PR DESCRIPTION
This PR adds the base tags to DHCP Options, IGW, and Route Tables.
These components are not tagged correctly, and this can cause issues
with deletion. Name tags are not added to shared resources, as we allow
shared resources to have maintained names.  An owned/shared tags with the
syntax  "kubernetes.io/cluster/$CLUSTERNAME" = "owned" is added to the
resources as well.  We are maintaining the Name tag value for private
route tables, as these resources do not use the standard value.

We may want to add these tags to NAT GW and Elastic IPs as well....