### PR TITLE
Add route53 max changeset batch size flag

### DIFF
--- a/dns-controller/cmd/dns-controller/main.go
+++ b/dns-controller/cmd/dns-controller/main.go
@@ -65,7 +65,7 @@ func main() {
 	flags.StringVar(&gossipListen, "gossip-listen", "0.0.0.0:3998", "The address on which to listen if gossip is enabled")
 	flags.StringVar(&gossipSecret, "gossip-secret", gossipSecret, "Secret to use to secure gossip")
 	flags.StringVar(&watchNamespace, "watch-namespace", "", "Limits the functionality for pods, services and ingress to specific namespace, by default all")
-	flag.IntVar(&route53.MaxBatchSize, "route53-batch-size", 900, "Maximum number of operations performed per changeset batch")
+	flag.IntVar(&route53.MaxBatchSize, "route53-batch-size", route53.MaxBatchSize, "Maximum number of operations performed per changeset batch")
 
 	// Trick to avoid 'logging before flag.Parse' warning
 	flag.CommandLine.Parse([]string{})

--- a/dns-controller/cmd/dns-controller/main.go
+++ b/dns-controller/cmd/dns-controller/main.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/kops/dns-controller/pkg/dns"
 	"k8s.io/kops/dns-controller/pkg/watchers"
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider"
-	_ "k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/aws/route53"
+	"k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/aws/route53"
 	k8scoredns "k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/coredns"
 	_ "k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/google/clouddns"
 	_ "k8s.io/kops/pkg/resources/digitalocean/dns"
@@ -65,6 +65,8 @@ func main() {
 	flags.StringVar(&gossipListen, "gossip-listen", "0.0.0.0:3998", "The address on which to listen if gossip is enabled")
 	flags.StringVar(&gossipSecret, "gossip-secret", gossipSecret, "Secret to use to secure gossip")
 	flags.StringVar(&watchNamespace, "watch-namespace", "", "Limits the functionality for pods, services and ingress to specific namespace, by default all")
+	flag.IntVar(&route53.MaxBatchSize, "route53-batch-size", 900, "Maximum number of operations performed per changeset batch")
+
 	// Trick to avoid 'logging before flag.Parse' warning
 	flag.CommandLine.Parse([]string{})
 

--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53.go
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53.go
@@ -32,6 +32,10 @@ const (
 	ProviderName = "aws-route53"
 )
 
+var (
+	MaxBatchSize int
+)
+
 func init() {
 	dnsprovider.RegisterDnsProvider(ProviderName, func(config io.Reader) (dnsprovider.Interface, error) {
 		return newRoute53(config)

--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53.go
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53.go
@@ -32,9 +32,8 @@ const (
 	ProviderName = "aws-route53"
 )
 
-var (
-	MaxBatchSize int
-)
+// MaxBatchSize is used to limit the max size of resource record changesets
+var MaxBatchSize = 900
 
 func init() {
 	dnsprovider.RegisterDnsProvider(ProviderName, func(config io.Reader) (dnsprovider.Interface, error) {

--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/rrchangeset.go
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/rrchangeset.go
@@ -105,9 +105,6 @@ func (c *ResourceRecordChangeset) Apply() error {
 	}
 
 	for {
-		// Limit batch size
-		maxBatchSize := 900
-
 		var batch []*route53.Change
 		// We group the changes so that changes with the same key are in the same batch
 		for k := range keys {
@@ -115,7 +112,7 @@ func (c *ResourceRecordChangeset) Apply() error {
 				continue
 			}
 
-			if len(batch)+3 >= maxBatchSize {
+			if len(batch)+3 >= MaxBatchSize {
 				break
 			}
 
@@ -142,6 +139,7 @@ func (c *ResourceRecordChangeset) Apply() error {
 				sb.WriteString(fmt.Sprintf("\t%s %s %s\n", aws.StringValue(change.Action), aws.StringValue(change.ResourceRecordSet.Type), aws.StringValue(change.ResourceRecordSet.Name)))
 			}
 
+			glog.V(8).Infof("Route53 MaxBatchSize: %v\n", MaxBatchSize)
 			glog.V(8).Infof("Route53 Changeset:\n%s", sb.String())
 		}
 


### PR DESCRIPTION
This PR is to address issue #4495 

Simply adds a flag to configure the batch size of route53 changesets.