### PR TITLE
docker: Adds hosts configuration option

### DIFF
--- a/pkg/apis/kops/dockerconfig.go
+++ b/pkg/apis/kops/dockerconfig.go
@@ -26,6 +26,8 @@ type DockerConfig struct {
 	BridgeIP *string `json:"bridgeIP,omitempty" flag:"bip"`
 	// DefaultUlimit is the ulimits for containers
 	DefaultUlimit []string `json:"defaultUlimit,omitempty" flag:"default-ulimit,repeat"`
+	// Hosts enables you to configure the endpoints the docker daemon listens on i.e tcp://0.0.0.0.2375 or unix:///var/run/docker.sock etc
+	Hosts []string `json:"hosts,omitempty" flag:"host,repeat"`
 	// IPMasq enables ip masquerading for containers
 	IPMasq *bool `json:"ipMasq,omitempty" flag:"ip-masq"`
 	// IPtables enables addition of iptables rules

--- a/pkg/apis/kops/v1alpha1/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha1/dockerconfig.go
@@ -26,6 +26,8 @@ type DockerConfig struct {
 	BridgeIP *string `json:"bridgeIP,omitempty" flag:"bip"`
 	// DefaultUlimit is the ulimits for containers
 	DefaultUlimit []string `json:"defaultUlimit,omitempty" flag:"default-ulimit,repeat"`
+	// Hosts enables you to configure the endpoints the docker daemon listens on i.e tcp://0.0.0.0.2375 or unix:///var/run/docker.sock etc
+	Hosts []string `json:"hosts,omitempty" flag:"host,repeat"`
 	// IPMasq enables ip masquerading for containers
 	IPMasq *bool `json:"ipMasq,omitempty" flag:"ip-masq"`
 	// IPtables enables addition of iptables rules

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1134,6 +1134,7 @@ func autoConvert_v1alpha1_DockerConfig_To_kops_DockerConfig(in *DockerConfig, ou
 	out.Bridge = in.Bridge
 	out.BridgeIP = in.BridgeIP
 	out.DefaultUlimit = in.DefaultUlimit
+	out.Hosts = in.Hosts
 	out.IPMasq = in.IPMasq
 	out.IPTables = in.IPTables
 	out.InsecureRegistry = in.InsecureRegistry
@@ -1161,6 +1162,7 @@ func autoConvert_kops_DockerConfig_To_v1alpha1_DockerConfig(in *kops.DockerConfi
 	out.Bridge = in.Bridge
 	out.BridgeIP = in.BridgeIP
 	out.DefaultUlimit = in.DefaultUlimit
+	out.Hosts = in.Hosts
 	out.IPMasq = in.IPMasq
 	out.IPTables = in.IPTables
 	out.InsecureRegistry = in.InsecureRegistry

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -895,6 +895,11 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Hosts != nil {
+		in, out := &in.Hosts, &out.Hosts
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.IPMasq != nil {
 		in, out := &in.IPMasq, &out.IPMasq
 		if *in == nil {

--- a/pkg/apis/kops/v1alpha2/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha2/dockerconfig.go
@@ -26,6 +26,8 @@ type DockerConfig struct {
 	BridgeIP *string `json:"bridgeIP,omitempty" flag:"bip"`
 	// DefaultUlimit is the ulimits for containers
 	DefaultUlimit []string `json:"defaultUlimit,omitempty" flag:"default-ulimit,repeat"`
+	// Hosts enables you to configure the endpoints the docker daemon listens on i.e tcp://0.0.0.0.2375 or unix:///var/run/docker.sock etc
+	Hosts []string `json:"hosts,omitempty" flag:"host,repeat"`
 	// IPMasq enables ip masquerading for containers
 	IPMasq *bool `json:"ipMasq,omitempty" flag:"ip-masq"`
 	// IPtables enables addition of iptables rules

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1233,6 +1233,7 @@ func autoConvert_v1alpha2_DockerConfig_To_kops_DockerConfig(in *DockerConfig, ou
 	out.Bridge = in.Bridge
 	out.BridgeIP = in.BridgeIP
 	out.DefaultUlimit = in.DefaultUlimit
+	out.Hosts = in.Hosts
 	out.IPMasq = in.IPMasq
 	out.IPTables = in.IPTables
 	out.InsecureRegistry = in.InsecureRegistry
@@ -1260,6 +1261,7 @@ func autoConvert_kops_DockerConfig_To_v1alpha2_DockerConfig(in *kops.DockerConfi
 	out.Bridge = in.Bridge
 	out.BridgeIP = in.BridgeIP
 	out.DefaultUlimit = in.DefaultUlimit
+	out.Hosts = in.Hosts
 	out.IPMasq = in.IPMasq
 	out.IPTables = in.IPTables
 	out.InsecureRegistry = in.InsecureRegistry

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -889,6 +889,11 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Hosts != nil {
+		in, out := &in.Hosts, &out.Hosts
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.IPMasq != nil {
 		in, out := &in.IPMasq, &out.IPMasq
 		if *in == nil {

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -1017,6 +1017,11 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Hosts != nil {
+		in, out := &in.Hosts, &out.Hosts
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.IPMasq != nil {
 		in, out := &in.IPMasq, &out.IPMasq
 		if *in == nil {


### PR DESCRIPTION
Enables dockerd to run on a TCP port along with the
default unix/systemd socket.

Fixes https://github.com/kubernetes/kops/issues/2383

Signed-off-by: Jaipradeesh <jaipradeesh@gmail.com>