### PR TITLE
Change FeatureGates to omitempty under KubeProxyConfig

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -171,7 +171,7 @@ type KubeProxyConfig struct {
 	// Enabled allows enabling or disabling kube-proxy
 	Enabled *bool `json:"enabled,omitempty"`
 	// FeatureGates is a series of key pairs used to switch on features for the proxy
-	FeatureGates map[string]string `json:"featureGates" flag:"feature-gates"`
+	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
 }
 
 // KubeAPIServerConfig defines the configuration for the kube api

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -171,7 +171,7 @@ type KubeProxyConfig struct {
 	// Enabled allows enabling or disabling kube-proxy
 	Enabled *bool `json:"enabled,omitempty"`
 	// FeatureGates is a series of key pairs used to switch on features for the proxy
-	FeatureGates map[string]string `json:"featureGates" flag:"feature-gates"`
+	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
 }
 
 // KubeAPIServerConfig defines the configuration for the kube api

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -171,7 +171,7 @@ type KubeProxyConfig struct {
 	// Enabled allows enabling or disabling kube-proxy
 	Enabled *bool `json:"enabled,omitempty"`
 	// FeatureGates is a series of key pairs used to switch on features for the proxy
-	FeatureGates map[string]string `json:"featureGates" flag:"feature-gates"`
+	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
 }
 
 // KubeAPIServerConfig defines the configuration for the kube api

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -202,7 +202,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
-    featureGates: null
     hostnameOverride: '@aws'
     image: k8s.gcr.io/kube-proxy:v1.4.12
     logLevel: 2
@@ -457,7 +456,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
-    featureGates: null
     hostnameOverride: '@aws'
     image: k8s.gcr.io/kube-proxy:v1.4.12
     logLevel: 2

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -193,7 +193,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
-    featureGates: null
     hostnameOverride: '@aws'
     image: k8s.gcr.io/kube-proxy:v1.4.12
     logLevel: 2
@@ -427,7 +426,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
-    featureGates: null
     hostnameOverride: '@aws'
     image: k8s.gcr.io/kube-proxy:v1.4.12
     logLevel: 2


### PR DESCRIPTION
Fixes #4499 allowing to properly edit kubeProxy in the cluster spec without explicitly adding `featureGates: null`