### PR TITLE
dns-controller: support digitalocean

### DIFF
--- a/dns-controller/cmd/dns-controller/BUILD.bazel
+++ b/dns-controller/cmd/dns-controller/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//dnsprovider/pkg/dnsprovider/providers/aws/route53:go_default_library",
         "//dnsprovider/pkg/dnsprovider/providers/coredns:go_default_library",
         "//dnsprovider/pkg/dnsprovider/providers/google/clouddns:go_default_library",
+        "//pkg/resources/digitalocean/dns:go_default_library",
         "//protokube/pkg/gossip:go_default_library",
         "//protokube/pkg/gossip/dns:go_default_library",
         "//protokube/pkg/gossip/dns/provider:go_default_library",

--- a/dns-controller/cmd/dns-controller/main.go
+++ b/dns-controller/cmd/dns-controller/main.go
@@ -26,14 +26,17 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
 	"k8s.io/kops/dns-controller/pkg/dns"
 	"k8s.io/kops/dns-controller/pkg/watchers"
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider"
 	_ "k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/aws/route53"
 	k8scoredns "k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/coredns"
 	_ "k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/google/clouddns"
+	_ "k8s.io/kops/pkg/resources/digitalocean/dns"
 	"k8s.io/kops/protokube/pkg/gossip"
 	gossipdns "k8s.io/kops/protokube/pkg/gossip/dns"
 	gossipdnsprovider "k8s.io/kops/protokube/pkg/gossip/dns/provider"
@@ -58,7 +61,7 @@ func main() {
 	flags.BoolVar(&watchIngress, "watch-ingress", true, "Configure hostnames found in ingress resources")
 	flags.StringSliceVar(&gossipSeeds, "gossip-seed", gossipSeeds, "If set, will enable gossip zones and seed using the provided addresses")
 	flags.StringSliceVarP(&zones, "zone", "z", []string{}, "Configure permitted zones and their mappings")
-	flags.StringVar(&dnsProviderID, "dns", "aws-route53", "DNS provider we should use (aws-route53, google-clouddns, coredns, gossip)")
+	flags.StringVar(&dnsProviderID, "dns", "aws-route53", "DNS provider we should use (aws-route53, google-clouddns, digitalocean, coredns, gossip)")
 	flags.StringVar(&gossipListen, "gossip-listen", "0.0.0.0:3998", "The address on which to listen if gossip is enabled")
 	flags.StringVar(&gossipSecret, "gossip-secret", gossipSecret, "Secret to use to secure gossip")
 	flags.StringVar(&watchNamespace, "watch-namespace", "", "Limits the functionality for pods, services and ingress to specific namespace, by default all")

--- a/pkg/resources/digitalocean/cloud.go
+++ b/pkg/resources/digitalocean/cloud.go
@@ -18,13 +18,12 @@ package digitalocean
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/digitalocean/godo"
 	"github.com/golang/glog"
 	"golang.org/x/oauth2"
-
-	"fmt"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider"

--- a/pkg/resources/digitalocean/dns/BUILD.bazel
+++ b/pkg/resources/digitalocean/dns/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//vendor/github.com/digitalocean/godo:go_default_library",
         "//vendor/github.com/digitalocean/godo/context:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/golang.org/x/oauth2:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Registers digitalocean DNS provider so it can be used with dnscontroller 

https://github.com/kubernetes/kops/issues/2150