### PR TITLE
Fix bazel deprecation notice

### DIFF
--- a/channels/cmd/channels/BUILD.bazel
+++ b/channels/cmd/channels/BUILD.bazel
@@ -11,6 +11,5 @@ go_library(
 go_binary(
     name = "channels",
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/channels/cmd/channels",
     visibility = ["//visibility:public"],
 )

--- a/channels/pkg/channels/BUILD.bazel
+++ b/channels/pkg/channels/BUILD.bazel
@@ -28,7 +28,6 @@ go_test(
     name = "go_default_test",
     srcs = ["addons_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/channels/pkg/channels",
     deps = [
         "//channels/pkg/api:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",

--- a/cmd/kops-server/BUILD.bazel
+++ b/cmd/kops-server/BUILD.bazel
@@ -15,6 +15,5 @@ go_library(
 go_binary(
     name = "kops-server",
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/cmd/kops-server",
     visibility = ["//visibility:public"],
 )

--- a/cmd/kops/BUILD.bazel
+++ b/cmd/kops/BUILD.bazel
@@ -118,7 +118,6 @@ go_library(
 go_binary(
     name = "kops",
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/cmd/kops",
     visibility = ["//visibility:public"],
     x_defs = {
         "k8s.io/kops.Version": "{KOPS_VERSION}",  # keep
@@ -142,7 +141,6 @@ go_test(
         "//tests/integration/update_cluster:exported_testdata",  # keep
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/cmd/kops",
     deps = [
         "//cmd/kops/util:go_default_library",
         "//pkg/apis/kops:go_default_library",

--- a/cmd/nodeup/BUILD.bazel
+++ b/cmd/nodeup/BUILD.bazel
@@ -17,6 +17,5 @@ go_library(
 go_binary(
     name = "nodeup",
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/cmd/nodeup",
     visibility = ["//visibility:public"],
 )

--- a/dns-controller/cmd/dns-controller/BUILD.bazel
+++ b/dns-controller/cmd/dns-controller/BUILD.bazel
@@ -27,6 +27,5 @@ go_library(
 go_binary(
     name = "dns-controller",
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/dns-controller/cmd/dns-controller",
     visibility = ["//visibility:public"],
 )

--- a/dns-controller/pkg/dns/BUILD.bazel
+++ b/dns-controller/pkg/dns/BUILD.bazel
@@ -27,5 +27,4 @@ go_test(
         "zonespec_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/dns-controller/pkg/dns",
 )

--- a/dns-controller/pkg/util/BUILD.bazel
+++ b/dns-controller/pkg/util/BUILD.bazel
@@ -15,5 +15,4 @@ go_test(
     name = "go_default_test",
     srcs = ["equality_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/dns-controller/pkg/util",
 )

--- a/dnsprovider/pkg/dnsprovider/BUILD.bazel
+++ b/dnsprovider/pkg/dnsprovider/BUILD.bazel
@@ -19,6 +19,5 @@ go_test(
     name = "go_default_test",
     srcs = ["dns_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/dnsprovider/pkg/dnsprovider",
     deps = ["//dnsprovider/pkg/dnsprovider/rrstype:go_default_library"],
 )

--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/BUILD.bazel
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/BUILD.bazel
@@ -30,7 +30,6 @@ go_test(
     name = "go_default_test",
     srcs = ["route53_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/aws/route53",
     deps = [
         "//dnsprovider/pkg/dnsprovider:go_default_library",
         "//dnsprovider/pkg/dnsprovider/providers/aws/route53/stubs:go_default_library",

--- a/dnsprovider/pkg/dnsprovider/providers/coredns/BUILD.bazel
+++ b/dnsprovider/pkg/dnsprovider/providers/coredns/BUILD.bazel
@@ -29,7 +29,6 @@ go_test(
     name = "go_default_test",
     srcs = ["coredns_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/coredns",
     deps = [
         "//dnsprovider/pkg/dnsprovider:go_default_library",
         "//dnsprovider/pkg/dnsprovider/providers/coredns/stubs:go_default_library",

--- a/dnsprovider/pkg/dnsprovider/providers/google/clouddns/BUILD.bazel
+++ b/dnsprovider/pkg/dnsprovider/providers/google/clouddns/BUILD.bazel
@@ -34,7 +34,6 @@ go_test(
     name = "go_default_test",
     srcs = ["clouddns_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/google/clouddns",
     deps = [
         "//dnsprovider/pkg/dnsprovider:go_default_library",
         "//dnsprovider/pkg/dnsprovider/rrstype:go_default_library",

--- a/examples/kops-api-example/BUILD.bazel
+++ b/examples/kops-api-example/BUILD.bazel
@@ -22,6 +22,5 @@ go_library(
 go_binary(
     name = "kops-api-example",
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/examples/kops-api-example",
     visibility = ["//visibility:public"],
 )

--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -1,6 +1,5 @@
 package(default_visibility = ["//visibility:public"])
 
-
 # this does not work, and I am uncertain we will need it
 #sh_test(
 #    name = "verify-packages",
@@ -29,4 +28,3 @@ test_suite(
         "verify-gofmt",
     ],
 )
-

--- a/images/BUILD.bazel
+++ b/images/BUILD.bazel
@@ -43,6 +43,10 @@ container_image(
         packages["systemd-shim"],
         packages["systemd"],
     ],
+    files = [
+        "//channels/cmd/channels",
+        "//protokube/cmd/protokube",
+    ],
     # Cannot use directory with packages or they get installed with
     # directory as the root.
     # directory = "/usr/bin/",
@@ -52,20 +56,14 @@ container_image(
         "/usr/bin/channels": "/channels",
         "/usr/bin/protokube": "/protokube",
     },
-    files = [
-        "//channels/cmd/channels",
-        "//protokube/cmd/protokube",
-    ],
 )
 
 container_bundle(
-  name = "protokube",
-
-  images = {
-    "protokube:{PROTOKUBE_TAG}": "protokube-image",
-  },
-
-  stamp = True,
+    name = "protokube",
+    images = {
+        "protokube:{PROTOKUBE_TAG}": "protokube-image",
+    },
+    stamp = True,
 )
 
 container_image(

--- a/kube-discovery/cmd/kube-discovery/BUILD.bazel
+++ b/kube-discovery/cmd/kube-discovery/BUILD.bazel
@@ -16,6 +16,5 @@ go_library(
 go_binary(
     name = "kube-discovery",
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/kube-discovery/cmd/kube-discovery",
     visibility = ["//visibility:public"],
 )

--- a/nodeup/pkg/model/BUILD.bazel
+++ b/nodeup/pkg/model/BUILD.bazel
@@ -67,7 +67,6 @@ go_test(
     ],
     data = glob(["tests/**"]),  #keep
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/nodeup/pkg/model",
     deps = [
         "//nodeup/pkg/distros:go_default_library",
         "//pkg/apis/kops:go_default_library",

--- a/pkg/acls/s3/BUILD.bazel
+++ b/pkg/acls/s3/BUILD.bazel
@@ -18,7 +18,6 @@ go_test(
     name = "go_default_test",
     srcs = ["storage_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/acls/s3",
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//pkg/values:go_default_library",

--- a/pkg/apis/kops/BUILD.bazel
+++ b/pkg/apis/kops/BUILD.bazel
@@ -41,6 +41,5 @@ go_test(
         "semver_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/apis/kops",
     deps = ["//vendor/github.com/blang/semver:go_default_library"],
 )

--- a/pkg/apis/kops/install/BUILD.bazel
+++ b/pkg/apis/kops/install/BUILD.bazel
@@ -21,5 +21,4 @@ go_test(
     name = "go_default_test",
     srcs = ["roundtrip_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/apis/kops/install",
 )

--- a/pkg/apis/kops/model/BUILD.bazel
+++ b/pkg/apis/kops/model/BUILD.bazel
@@ -15,6 +15,5 @@ go_test(
     name = "go_default_test",
     srcs = ["utils_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/apis/kops/model",
     deps = ["//pkg/apis/kops:go_default_library"],
 )

--- a/pkg/apis/kops/util/BUILD.bazel
+++ b/pkg/apis/kops/util/BUILD.bazel
@@ -19,5 +19,4 @@ go_test(
     name = "go_default_test",
     srcs = ["versions_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/apis/kops/util",
 )

--- a/pkg/apis/kops/validation/BUILD.bazel
+++ b/pkg/apis/kops/validation/BUILD.bazel
@@ -36,7 +36,6 @@ go_test(
         "validation_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/apis/kops/validation",
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/apiserver/BUILD.bazel
+++ b/pkg/apiserver/BUILD.bazel
@@ -27,5 +27,4 @@ go_test(
     name = "go_default_test",
     srcs = ["scheme_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/apiserver",
 )

--- a/pkg/diff/BUILD.bazel
+++ b/pkg/diff/BUILD.bazel
@@ -15,6 +15,5 @@ go_test(
     name = "go_default_test",
     srcs = ["diff_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/diff",
     deps = ["//vendor/github.com/sergi/go-diff/diffmatchpatch:go_default_library"],
 )

--- a/pkg/featureflag/BUILD.bazel
+++ b/pkg/featureflag/BUILD.bazel
@@ -12,6 +12,5 @@ go_test(
     name = "go_default_test",
     srcs = ["featureflag_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/featureflag",
     deps = ["//vendor/github.com/golang/glog:go_default_library"],
 )

--- a/pkg/flagbuilder/BUILD.bazel
+++ b/pkg/flagbuilder/BUILD.bazel
@@ -16,7 +16,6 @@ go_test(
     name = "go_default_test",
     srcs = ["buildflags_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/flagbuilder",
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//upup/pkg/fi:go_default_library",

--- a/pkg/formatter/BUILD.bazel
+++ b/pkg/formatter/BUILD.bazel
@@ -16,6 +16,5 @@ go_test(
     name = "go_default_test",
     srcs = ["instancegroup_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/formatter",
     deps = ["//pkg/apis/kops:go_default_library"],
 )

--- a/pkg/instancegroups/BUILD.bazel
+++ b/pkg/instancegroups/BUILD.bazel
@@ -28,7 +28,6 @@ go_test(
     name = "go_default_test",
     srcs = ["rollingupdate_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/instancegroups",
     deps = [
         "//cloudmock/aws/mockautoscaling:go_default_library",
         "//pkg/apis/kops:go_default_library",

--- a/pkg/k8scodecs/BUILD.bazel
+++ b/pkg/k8scodecs/BUILD.bazel
@@ -21,7 +21,6 @@ go_test(
     name = "go_default_test",
     srcs = ["codecs_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/k8scodecs",
     deps = [
         "//pkg/diff:go_default_library",
         "//vendor/github.com/MakeNowJust/heredoc:go_default_library",

--- a/pkg/k8sversion/BUILD.bazel
+++ b/pkg/k8sversion/BUILD.bazel
@@ -15,5 +15,4 @@ go_test(
     name = "go_default_test",
     srcs = ["version_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/k8sversion",
 )

--- a/pkg/kopscodecs/BUILD.bazel
+++ b/pkg/kopscodecs/BUILD.bazel
@@ -23,7 +23,6 @@ go_test(
     name = "go_default_test",
     srcs = ["codecs_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/kopscodecs",
     deps = [
         "//pkg/apis/kops/v1alpha2:go_default_library",
         "//pkg/diff:go_default_library",

--- a/pkg/model/BUILD.bazel
+++ b/pkg/model/BUILD.bazel
@@ -59,7 +59,6 @@ go_test(
     ],
     data = glob(["tests/**"]),  #keep
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/model",
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//pkg/apis/nodeup:go_default_library",

--- a/pkg/model/awsmodel/BUILD.bazel
+++ b/pkg/model/awsmodel/BUILD.bazel
@@ -27,7 +27,6 @@ go_test(
     name = "go_default_test",
     srcs = ["autoscalinggroup_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/model/awsmodel",
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//pkg/model:go_default_library",

--- a/pkg/model/components/BUILD.bazel
+++ b/pkg/model/components/BUILD.bazel
@@ -42,7 +42,6 @@ go_test(
         "kubescheduler_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/model/components",
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//pkg/apis/kops/util:go_default_library",

--- a/pkg/model/iam/BUILD.bazel
+++ b/pkg/model/iam/BUILD.bazel
@@ -21,7 +21,6 @@ go_test(
     srcs = ["iam_builder_test.go"],
     data = glob(["tests/*"]),  #keep
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/model/iam",
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//pkg/diff:go_default_library",

--- a/pkg/pki/BUILD.bazel
+++ b/pkg/pki/BUILD.bazel
@@ -19,5 +19,4 @@ go_test(
         "privatekey_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/pki",
 )

--- a/pkg/resources/BUILD.bazel
+++ b/pkg/resources/BUILD.bazel
@@ -35,7 +35,6 @@ go_test(
     size = "small",
     srcs = ["aws_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/resources",
     deps = [
         "//cloudmock/aws/mockec2:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",

--- a/pkg/resources/digitalocean/dns/BUILD.bazel
+++ b/pkg/resources/digitalocean/dns/BUILD.bazel
@@ -20,7 +20,6 @@ go_test(
     size = "small",
     srcs = ["dns_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/resources/digitalocean/dns",
     deps = [
         "//dnsprovider/pkg/dnsprovider/rrstype:go_default_library",
         "//vendor/github.com/digitalocean/godo:go_default_library",

--- a/pkg/resources/gce/BUILD.bazel
+++ b/pkg/resources/gce/BUILD.bazel
@@ -24,5 +24,4 @@ go_test(
     size = "small",
     srcs = ["gce_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/resources/gce",
 )

--- a/pkg/systemd/BUILD.bazel
+++ b/pkg/systemd/BUILD.bazel
@@ -15,5 +15,4 @@ go_test(
     name = "go_default_test",
     srcs = ["manifest_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/systemd",
 )

--- a/pkg/util/stringorslice/BUILD.bazel
+++ b/pkg/util/stringorslice/BUILD.bazel
@@ -11,6 +11,5 @@ go_test(
     name = "go_default_test",
     srcs = ["stringorslice_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/util/stringorslice",
     deps = ["//vendor/github.com/golang/glog:go_default_library"],
 )

--- a/pkg/util/templater/BUILD.bazel
+++ b/pkg/util/templater/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
     srcs = ["templater_test.go"],
     data = glob(["integration_tests.yml"]),  #keep
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/util/templater",
     deps = [
         "//pkg/diff:go_default_library",
         "//vendor/gopkg.in/yaml.v2:go_default_library",

--- a/pkg/validation/BUILD.bazel
+++ b/pkg/validation/BUILD.bazel
@@ -27,7 +27,6 @@ go_test(
         "validate_cluster_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/pkg/validation",
     deps = [
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/protokube/cmd/protokube/BUILD.bazel
+++ b/protokube/cmd/protokube/BUILD.bazel
@@ -23,6 +23,5 @@ go_library(
 go_binary(
     name = "protokube",
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/protokube/cmd/protokube",
     visibility = ["//visibility:public"],
 )

--- a/protokube/pkg/protokube/BUILD.bazel
+++ b/protokube/pkg/protokube/BUILD.bazel
@@ -69,6 +69,5 @@ go_test(
     name = "go_default_test",
     srcs = ["volume_mounter_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/protokube/pkg/protokube",
     deps = ["//protokube/pkg/etcd:go_default_library"],
 )

--- a/protokube/tests/integration/build_etcd_manifest/BUILD.bazel
+++ b/protokube/tests/integration/build_etcd_manifest/BUILD.bazel
@@ -4,7 +4,6 @@ go_test(
     name = "go_default_test",
     srcs = ["integration_test.go"],
     data = glob(["main/*"]),  #keep
-    importpath = "k8s.io/kops/protokube/tests/integration/build_etcd_manifest",
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//pkg/diff:go_default_library",

--- a/tests/codecs/BUILD.bazel
+++ b/tests/codecs/BUILD.bazel
@@ -3,7 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     srcs = ["componentconfig_test.go"],
-    importpath = "k8s.io/kops/tests/codecs",
     deps = [
         "//pkg/apis/kops/v1alpha2:go_default_library",
         "//pkg/diff:go_default_library",

--- a/tests/integration/channel/BUILD.bazel
+++ b/tests/integration/channel/BUILD.bazel
@@ -7,7 +7,6 @@ go_test(
         "exported_testdata",  # keep
         "//channels:channeldata",  # keep
     ],
-    importpath = "k8s.io/kops/tests/integration/channel",
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",

--- a/tests/integration/conversion/BUILD.bazel
+++ b/tests/integration/conversion/BUILD.bazel
@@ -6,7 +6,6 @@ go_test(
     data = [
         "exported_testdata",  # keep
     ],
-    importpath = "k8s.io/kops/tests/integration/conversion",
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//pkg/apis/kops/v1alpha1:go_default_library",

--- a/upup/pkg/fi/BUILD.bazel
+++ b/upup/pkg/fi/BUILD.bazel
@@ -99,7 +99,6 @@ go_test(
         "vfs_castore_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/upup/pkg/fi",
     deps = [
         "//pkg/pki:go_default_library",
         "//util/pkg/vfs:go_default_library",

--- a/upup/pkg/fi/assettasks/BUILD.bazel
+++ b/upup/pkg/fi/assettasks/BUILD.bazel
@@ -28,5 +28,4 @@ go_test(
     name = "go_default_test",
     srcs = ["copyfile_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/upup/pkg/fi/assettasks",
 )

--- a/upup/pkg/fi/cloudup/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/BUILD.bazel
@@ -93,7 +93,6 @@ go_test(
         "//upup/pkg/fi/cloudup/tests:exported_testdata",  # keep
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/upup/pkg/fi/cloudup",
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//pkg/apis/kops/validation:go_default_library",

--- a/upup/pkg/fi/cloudup/awstasks/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/awstasks/BUILD.bazel
@@ -99,7 +99,6 @@ go_test(
         "vpc_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/upup/pkg/fi/cloudup/awstasks",
     deps = [
         "//cloudmock/aws/mockec2:go_default_library",
         "//pkg/apis/kops:go_default_library",

--- a/upup/pkg/fi/cloudup/awsup/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/awsup/BUILD.bazel
@@ -52,7 +52,6 @@ go_test(
         "aws_utils_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/upup/pkg/fi/cloudup/awsup",
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",

--- a/upup/pkg/fi/cloudup/dotasks/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/dotasks/BUILD.bazel
@@ -23,7 +23,6 @@ go_test(
     name = "go_default_test",
     srcs = ["volume_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/upup/pkg/fi/cloudup/dotasks",
     deps = [
         "//pkg/resources/digitalocean:go_default_library",
         "//upup/pkg/fi:go_default_library",

--- a/upup/pkg/fi/fitasks/BUILD.bazel
+++ b/upup/pkg/fi/fitasks/BUILD.bazel
@@ -33,6 +33,5 @@ go_test(
     size = "small",
     srcs = ["keypair_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/upup/pkg/fi/fitasks",
     deps = ["//upup/pkg/fi:go_default_library"],
 )

--- a/upup/pkg/fi/nodeup/nodetasks/BUILD.bazel
+++ b/upup/pkg/fi/nodeup/nodetasks/BUILD.bazel
@@ -39,6 +39,5 @@ go_test(
         "service_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/upup/pkg/fi/nodeup/nodetasks",
     deps = ["//upup/pkg/fi:go_default_library"],
 )

--- a/upup/tools/generators/fitask/BUILD.bazel
+++ b/upup/tools/generators/fitask/BUILD.bazel
@@ -14,6 +14,5 @@ go_library(
 go_binary(
     name = "fitask",
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/upup/tools/generators/fitask",
     visibility = ["//visibility:public"],
 )

--- a/util/pkg/vfs/BUILD.bazel
+++ b/util/pkg/vfs/BUILD.bazel
@@ -52,5 +52,4 @@ go_test(
         "s3fs_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/kops/util/pkg/vfs",
 )

--- a/vendor/github.com/jteeuwen/go-bindata/go-bindata/BUILD.bazel
+++ b/vendor/github.com/jteeuwen/go-bindata/go-bindata/BUILD.bazel
@@ -15,6 +15,5 @@ go_library(
 go_binary(
     name = "go-bindata",
     embed = [":go_default_library"],
-    importpath = "github.com/jteeuwen/go-bindata/go-bindata",
     visibility = ["//visibility:public"],
 )

--- a/vendor/k8s.io/code-generator/cmd/client-gen/BUILD.bazel
+++ b/vendor/k8s.io/code-generator/cmd/client-gen/BUILD.bazel
@@ -17,6 +17,5 @@ go_library(
 go_binary(
     name = "client-gen",
     embed = [":go_default_library"],
-    importpath = "k8s.io/code-generator/cmd/client-gen",
     visibility = ["//visibility:public"],
 )

--- a/vendor/k8s.io/code-generator/cmd/conversion-gen/BUILD.bazel
+++ b/vendor/k8s.io/code-generator/cmd/conversion-gen/BUILD.bazel
@@ -16,6 +16,5 @@ go_library(
 go_binary(
     name = "conversion-gen",
     embed = [":go_default_library"],
-    importpath = "k8s.io/code-generator/cmd/conversion-gen",
     visibility = ["//visibility:public"],
 )

--- a/vendor/k8s.io/code-generator/cmd/deepcopy-gen/BUILD.bazel
+++ b/vendor/k8s.io/code-generator/cmd/deepcopy-gen/BUILD.bazel
@@ -16,6 +16,5 @@ go_library(
 go_binary(
     name = "deepcopy-gen",
     embed = [":go_default_library"],
-    importpath = "k8s.io/code-generator/cmd/deepcopy-gen",
     visibility = ["//visibility:public"],
 )

--- a/vendor/k8s.io/code-generator/cmd/defaulter-gen/BUILD.bazel
+++ b/vendor/k8s.io/code-generator/cmd/defaulter-gen/BUILD.bazel
@@ -16,6 +16,5 @@ go_library(
 go_binary(
     name = "defaulter-gen",
     embed = [":go_default_library"],
-    importpath = "k8s.io/code-generator/cmd/defaulter-gen",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This should clean up all the bazel deprecation notices.

For some reason I couldn't get this to work with bazel gazelle but the golang client was able to update files as expected.