### PR TITLE
re-enable windows builds

### DIFF
--- a/.shipbot.yaml
+++ b/.shipbot.yaml
@@ -9,7 +9,7 @@ assets:
     githubName: kops-linux-amd64
   - source: .build/dist/linux/amd64/kops.sha1
     githubName: kops-linux-amd64-sha1
-#  - source: .build/dist/windows/amd64/kops.exe
-#    githubName: kops-windows-amd64
-#  - source: .build/dist/windows/amd64/kops.exe.sha1
-#    githubName: kops-windows-amd64-sha1
+  - source: .build/dist/windows/amd64/kops.exe
+    githubName: kops-windows-amd64
+  - source: .build/dist/windows/amd64/kops.exe.sha1
+    githubName: kops-windows-amd64-sha1


### PR DESCRIPTION
I've done basic smoke testing of the .exe binary.  Was able to create functional private and public clusters, validate them and delete them.