### PR TITLE
Fix suspicious space in struct tag value

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -358,7 +358,7 @@ type terraformAutoscalingGroup struct {
 	Tags                    []*terraformASGTag   `json:"tag,omitempty"`
 	MetricsGranularity      *string              `json:"metrics_granularity,omitempty"`
 	EnabledMetrics          []*string            `json:"enabled_metrics,omitempty"`
-	SuspendedProcesses      []*string            `json:"suspended_processes, omitempty"`
+	SuspendedProcesses      []*string            `json:"suspended_processes,omitempty"`
 }
 
 func (_ *AutoscalingGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *AutoscalingGroup) error {


### PR DESCRIPTION
```upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go:361: struct field tag `json:"suspended_processes, omitempty"` not compatible with reflect.StructTag.Get: suspicious space in struct tag value```
https://travis-ci.org/kubernetes/kops/jobs/346356096