### PR TITLE
Add kubernetes 1.9.3 into alpha & stable channels

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -31,6 +31,9 @@ spec:
     networking:
       kubenet: {}
   kubernetesVersions:
+  - range: ">=1.9.0"
+    recommendedVersion: 1.9.3
+    requiredVersion: 1.9.0
   - range: ">=1.8.0"
     recommendedVersion: 1.8.7
     requiredVersion: 1.8.0
@@ -47,6 +50,10 @@ spec:
     recommendedVersion: 1.4.12
     requiredVersion: 1.4.2
   kopsVersions:
+  - range: ">=1.9.0-alpha.1"
+    recommendedVersion: 1.9.0-alpha.1
+    #requiredVersion: 1.9.0-alpha.1
+    kubernetesVersion: 1.9.3
   - range: ">=1.8.0-alpha.1"
     recommendedVersion: 1.8.1
     requiredVersion: 1.7.1

--- a/channels/stable
+++ b/channels/stable
@@ -31,6 +31,9 @@ spec:
     networking:
       kubenet: {}
   kubernetesVersions:
+  - range: ">=1.9.0"
+    recommendedVersion: 1.9.3
+    requiredVersion: 1.9.0
   - range: ">=1.8.0"
     recommendedVersion: 1.8.6
     requiredVersion: 1.8.0
@@ -47,6 +50,10 @@ spec:
     recommendedVersion: 1.4.12
     requiredVersion: 1.4.2
   kopsVersions:
+  - range: ">=1.9.0-alpha.1"
+    recommendedVersion: 1.9.0-alpha.1
+    #requiredVersion: 1.9.0-alpha.1
+    kubernetesVersion: 1.9.3
   - range: ">=1.8.0-alpha.1"
     recommendedVersion: 1.8.0
     #requiredVersion: 1.8.0


### PR DESCRIPTION
For users of kops 1.9 we will initially recommend the current version of
kubernetes, 1.9.3.