### PR TITLE
Kube Proxy IPVS Kernel Module

### DIFF
--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -204,6 +204,8 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 	{
 		addHostPathMapping(pod, container, "kubeconfig", "/var/lib/kube-proxy/kubeconfig")
 		addHostPathMapping(pod, container, "logfile", "/var/log/kube-proxy.log").ReadOnly = false
+		// @note: mapping the host modules directory to fix the missing ipvs kernel module
+		addHostPathMapping(pod, container, "modules", "/lib/modules")
 
 		// Map SSL certs from host: /usr/share/ca-certificates -> /etc/ssl/certs
 		sslCertsHost := addHostPathMapping(pod, container, "ssl-certs-hosts", "/usr/share/ca-certificates")


### PR DESCRIPTION
- fixing the the 'Could not get ipvs family information from the kernel. It is possible that ipvs is not enabled in your kernel. Native loadbalancing will not work until this is fixed.' error
- for reference, it mirrors the fix from https://github.com/kubernetes-incubator/bootkube/pull/742

before
```shell
[ep-acp-jest@acp] (master) $ kubectl -n kube-system logs kube-proxy-ip-10-250-100-55.eu-west-2.compute.internal
Flag --resource-container has been deprecated, This feature will be removed in a later release.
W0301 21:18:44.695034       1 server.go:191] WARNING: all flags other than --config, --write-config-to, and --cleanup are deprecated. Please begin using a config file ASAP.
I0301 21:18:44.697585       1 iptables.go:192] Could not connect to D-Bus system bus: dial unix /var/run/dbus/system_bus_socket: connect: no such file or directory
time="2018-03-01T21:18:44Z" level=warning msg="Running modprobe ip_vs failed with message: `modprobe: ERROR: ../libkmod/libkmod.c:557 kmod_search_moddep() could not open moddep file '/lib/modules/4.14.16-coreos/modules.dep.bin'`, error: exit status 1"
time="2018-03-01T21:18:44Z" level=error msg="Could not get ipvs family information from the kernel. It is possible that ipvs is not enabled in your kernel. Native loadbalancing will not work until this is fixed."
W0301 21:18:44.702918       1 server_others.go:268] Flag proxy-mode="" unknown, assuming iptables proxy
```

after

```shell
core@ip-10-250-31-251 /etc/kubernetes/manifests $ docker logs 473e93f69cac
Flag --resource-container has been deprecated, This feature will be removed in a later release.
W0301 21:43:18.106609       1 server.go:191] WARNING: all flags other than --config, --write-config-to, and --cleanup are deprecated. Please begin using a config file ASAP.
I0301 21:43:18.109131       1 iptables.go:192] Could not connect to D-Bus system bus: dial unix /var/run/dbus/system_bus_socket: connect: no such file or directory
W0301 21:43:18.277882       1 server_others.go:268] Flag proxy-mode="" unknown, assuming iptables proxy
I0301 21:43:18.279494       1 server_others.go:122] Using iptables Proxier.
```