### PR TITLE
Update find logic for newly shared objects

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
+++ b/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
@@ -79,6 +79,7 @@ func (e *DHCPOptions) Find(c *fi.Context) (*DHCPOptions, error) {
 	actual := &DHCPOptions{
 		ID:   o.DhcpOptionsId,
 		Name: findNameTag(o.Tags),
+		Tags: intersectTags(o.Tags, e.Tags),
 	}
 
 	for _, s := range o.DhcpConfigurations {
@@ -104,6 +105,7 @@ func (e *DHCPOptions) Find(c *fi.Context) (*DHCPOptions, error) {
 
 	// Avoid spurious changes
 	actual.Lifecycle = e.Lifecycle
+	actual.Shared = e.Shared
 
 	return actual, nil
 }

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway.go
@@ -93,6 +93,7 @@ func (e *InternetGateway) Find(c *fi.Context) (*InternetGateway, error) {
 	actual := &InternetGateway{
 		ID:   igw.InternetGatewayId,
 		Name: findNameTag(igw.Tags),
+		Tags: intersectTags(igw.Tags, e.Tags),
 	}
 
 	glog.V(2).Infof("found matching InternetGateway %q", *actual.ID)

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway_test.go
@@ -89,6 +89,7 @@ func TestSharedInternetGatewayDoesNotRename(t *testing.T) {
 			VPC:    vpc1,
 			Shared: fi.Bool(true),
 			ID:     internetGateway.InternetGateway.InternetGatewayId,
+			Tags:   make(map[string]string),
 		}
 
 		return map[string]fi.Task{

--- a/upup/pkg/fi/cloudup/awstasks/routetable.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetable.go
@@ -62,12 +62,14 @@ func (e *RouteTable) Find(c *fi.Context) (*RouteTable, error) {
 		ID:   rt.RouteTableId,
 		VPC:  &VPC{ID: rt.VpcId},
 		Name: e.Name,
+		Tags: intersectTags(rt.Tags, e.Tags),
 	}
 	glog.V(2).Infof("found matching RouteTable %q", *actual.ID)
 	e.ID = actual.ID
 
 	// Prevent spurious changes
 	actual.Lifecycle = e.Lifecycle
+	actual.Shared = e.Shared
 
 	return actual, nil
 }

--- a/upup/pkg/fi/dryrun_target.go
+++ b/upup/pkg/fi/dryrun_target.go
@@ -215,12 +215,16 @@ func (t *DryRunTarget) PrintReport(taskMap map[string]Task, out io.Writer) error
 				if err != nil {
 					return err
 				}
+				taskName := getTaskName(r.changes)
+				fmt.Fprintf(b, "  %s/%s\n", taskName, idForTask(taskMap, r.e))
+
 				if len(changeList) == 0 {
+					fmt.Fprintf(b, "   internal consistency error!\n")
+					fmt.Fprintf(b, "    actual: %+v\n", r.a)
+					fmt.Fprintf(b, "    expect: %+v\n", r.e)
 					continue
 				}
 
-				taskName := getTaskName(r.changes)
-				fmt.Fprintf(b, "  %s/%s\n", taskName, idForTask(taskMap, r.e))
 				for _, change := range changeList {
 					lines := strings.Split(change.Description, "\n")
 					if len(lines) == 1 {


### PR DESCRIPTION
We need to discover the tags and assume the Shared flag, or else the
objects will always be dirty.