### PR TITLE
add system:masters group to admin user in static token file

### DIFF
--- a/nodeup/pkg/model/secrets.go
+++ b/nodeup/pkg/model/secrets.go
@@ -34,6 +34,11 @@ type SecretBuilder struct {
 
 var _ fi.ModelBuilder = &SecretBuilder{}
 
+const (
+	adminUser  = "admin"
+	adminGroup = "system:masters"
+)
+
 // Build is responsible for pulling down the secrets
 func (b *SecretBuilder) Build(c *fi.ModelBuilderContext) error {
 	if b.KeyStore == nil {
@@ -196,7 +201,7 @@ func (b *SecretBuilder) Build(c *fi.ModelBuilderContext) error {
 		if token == nil {
 			return fmt.Errorf("token not found: %q", key)
 		}
-		csv := string(token.Data) + ",admin,admin,system:masters"
+		csv := string(token.Data) + "," + adminUser + "," + adminUser + "," + adminGroup
 
 		t := &nodetasks.File{
 			Path:     filepath.Join(b.PathSrvKubernetes(), "basic_auth.csv"),
@@ -215,7 +220,11 @@ func (b *SecretBuilder) Build(c *fi.ModelBuilderContext) error {
 
 		var lines []string
 		for id, token := range allTokens {
-			lines = append(lines, token+","+id+","+id)
+			if id == adminUser {
+				lines = append(lines, token+","+id+","+id+","+adminGroup)
+			} else {
+				lines = append(lines, token+","+id+","+id)
+			}
 		}
 		csv := strings.Join(lines, "\n")
 


### PR DESCRIPTION
This should fix #4369

Tested using the dev version of `nodeup`:
- `admin` user in `/srv/kubernetes/known_tokens.csv` now has the `system:masters` group
    ```bash
    # grep admin /srv/kubernetes/known_tokens.csv
    0ODfxv1qwwzDwOmqTnyHTLkDZ0uwC1GZ,admin,admin,system:masters
    ```
- confirmed that using admin token to log into `kubernetes-dashboard` (created with the default `--authentication-mode=token`) now has full access