### PR TITLE
Update Compatability Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ Kubernetes version.
 
 #### Compatibility Matrix
 
-| kops version | k8s 1.5.x | k8s 1.6.x | k8s 1.7.x | k8s 1.8.x |
-|--------------|-----------|-----------|-----------|-----------|
-| 1.8.x        | Y         | Y         | Y         | Y         |
-| 1.7.x        | Y         | Y         | Y         | N         |
-| 1.6.x        | Y         | Y         | N         | N         |
+| kops version | k8s 1.5.x | k8s 1.6.x | k8s 1.7.x | k8s 1.8.x | k8s 1.9.x |
+|--------------|-----------|-----------|-----------|-----------|-----------|
+| 1.9.x (unreleased)       | Y         | Y         | Y         | Y         | Y         |
+| 1.8.x        | Y         | Y         | Y         | Y         | N         |
+| 1.7.x        | Y         | Y         | Y         | N         | N         |
+| 1.6.x        | Y         | Y         | N         | N         | N         |
 
 Use the latest version of kops for all releases of Kubernetes, with the caveat
 that higher versions of Kubernetes are not _officially_ supported by kops.

--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ Kubernetes version.
 
 #### Compatibility Matrix
 
-| kops version | k8s 1.5.x | k8s 1.6.x | k8s 1.7.x | k8s 1.8.x | k8s 1.9.x |
-|--------------|-----------|-----------|-----------|-----------|-----------|
-| 1.9.x (unreleased)       | Y         | Y         | Y         | Y         | Y         |
-| 1.8.x        | Y         | Y         | Y         | Y         | N         |
-| 1.7.x        | Y         | Y         | Y         | N         | N         |
-| 1.6.x        | Y         | Y         | N         | N         | N         |
+| kops version       | k8s 1.5.x | k8s 1.6.x | k8s 1.7.x | k8s 1.8.x | k8s 1.9.x |
+|--------------------|-----------|-----------|-----------|-----------|-----------|
+| 1.9.x (unreleased) | Y         | Y         | Y         | Y         | Y         |
+| 1.8.x              | Y         | Y         | Y         | Y         | N         |
+| 1.7.x              | Y         | Y         | Y         | N         | N         |
+| 1.6.x              | Y         | Y         | N         | N         | N         |
 
 Use the latest version of kops for all releases of Kubernetes, with the caveat
 that higher versions of Kubernetes are not _officially_ supported by kops.


### PR DESCRIPTION
Since we talk about about [1.9.0 here](https://github.com/kubernetes/kops/blob/master/README.md#kubernetes-version-support), we should probably clarify that 1.9 is unreleased and add it to the matrix.

I'm not sure if we should point people to the alpha yet so I went with unreleased.

Comments welcome!