### PR TITLE
Creating the keyset.yaml file if it does not exist

### DIFF
--- a/hack/.packages
+++ b/hack/.packages
@@ -123,6 +123,7 @@ k8s.io/kops/protokube/pkg/gossip/gce
 k8s.io/kops/protokube/pkg/gossip/mesh
 k8s.io/kops/protokube/pkg/protokube
 k8s.io/kops/protokube/tests/integration/build_etcd_manifest
+k8s.io/kops/tests
 k8s.io/kops/tests/codecs
 k8s.io/kops/tests/integration/channel
 k8s.io/kops/tests/integration/conversion

--- a/pkg/kubeconfig/create_kubecfg.go
+++ b/pkg/kubeconfig/create_kubecfg.go
@@ -69,7 +69,7 @@ func BuildKubecfg(cluster *kops.Cluster, keyStore fi.Keystore, secretStore fi.Se
 	b.Context = clusterName
 
 	{
-		cert, _, err := keyStore.FindKeypair(fi.CertificateId_CA)
+		cert, _, _, err := keyStore.FindKeypair(fi.CertificateId_CA)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching CA keypair: %v", err)
 		}
@@ -84,7 +84,7 @@ func BuildKubecfg(cluster *kops.Cluster, keyStore fi.Keystore, secretStore fi.Se
 	}
 
 	{
-		cert, key, err := keyStore.FindKeypair("kubecfg")
+		cert, key, _, err := keyStore.FindKeypair("kubecfg")
 		if err != nil {
 			return nil, fmt.Errorf("error fetching kubecfg keypair: %v", err)
 		}

--- a/pkg/model/pki.go
+++ b/pkg/model/pki.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/tokens"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/fitasks"
@@ -34,8 +35,12 @@ type PKIModelBuilder struct {
 
 var _ fi.ModelBuilder = &PKIModelBuilder{}
 
-// Build is responsible for generating the various pki assets
+// Build is responsible for generating the various pki assets.
 func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
+
+	// Note: the fitasks.Keypair structs are created with a Format that == 	fitasks.KeypairType
+	// to denote that these tasks are using the newer Keypar API Type.  This value is used
+	// to upgrade a legacy Keypair to the newer Keypair API object.
 
 	// TODO: Only create the CA via this task
 	defaultCA := &fitasks.Keypair{
@@ -43,6 +48,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		Lifecycle: b.Lifecycle,
 		Subject:   "cn=kubernetes",
 		Type:      "ca",
+
+		Format: string(kops.SecretTypeKeypair),
 	}
 	c.AddTask(defaultCA)
 
@@ -55,6 +62,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Subject: "o=" + user.NodesGroup + ",cn=kubelet",
 			Type:    "client",
 			Signer:  defaultCA,
+
+			Format: string(kops.SecretTypeKeypair),
 		}
 		c.AddTask(t)
 	}
@@ -68,6 +77,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Subject:   "cn=kubelet-api",
 			Type:      "client",
 			Signer:    defaultCA,
+
+			Format: string(kops.SecretTypeKeypair),
 		})
 	}
 	{
@@ -77,6 +88,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Subject:   "cn=" + user.KubeScheduler,
 			Type:      "client",
 			Signer:    defaultCA,
+
+			Format: string(kops.SecretTypeKeypair),
 		}
 		c.AddTask(t)
 	}
@@ -88,6 +101,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Subject:   "cn=" + user.KubeProxy,
 			Type:      "client",
 			Signer:    defaultCA,
+
+			Format: string(kops.SecretTypeKeypair),
 		}
 		c.AddTask(t)
 	}
@@ -99,6 +114,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Subject:   "cn=" + user.KubeControllerManager,
 			Type:      "client",
 			Signer:    defaultCA,
+
+			Format: string(kops.SecretTypeKeypair),
 		}
 		c.AddTask(t)
 	}
@@ -118,6 +135,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Subject:        "cn=etcd",
 			Type:           "clientServer",
 			Signer:         defaultCA,
+
+			Format: string(kops.SecretTypeKeypair),
 		})
 		c.AddTask(&fitasks.Keypair{
 			Name:      fi.String("etcd-client"),
@@ -125,6 +144,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Subject:   "cn=etcd-client",
 			Type:      "client",
 			Signer:    defaultCA,
+
+			Format: string(kops.SecretTypeKeypair),
 		})
 
 		// @check if calico is enabled as the CNI provider
@@ -135,6 +156,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 				Subject:   "cn=calico-client",
 				Type:      "client",
 				Signer:    defaultCA,
+
+				Format: string(kops.SecretTypeKeypair),
 			})
 		}
 	}
@@ -145,6 +168,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Subject: "cn=" + "system:kube-router",
 			Type:    "client",
 			Signer:  defaultCA,
+
+			Format: string(kops.SecretTypeKeypair),
 		}
 		c.AddTask(t)
 	}
@@ -156,6 +181,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Subject:   "o=" + user.SystemPrivilegedGroup + ",cn=kubecfg",
 			Type:      "client",
 			Signer:    defaultCA,
+
+			Format: string(kops.SecretTypeKeypair),
 		}
 		c.AddTask(t)
 	}
@@ -167,6 +194,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Subject:   "cn=apiserver-proxy-client",
 			Type:      "client",
 			Signer:    defaultCA,
+
+			Format: string(kops.SecretTypeKeypair),
 		}
 		c.AddTask(t)
 	}
@@ -177,6 +206,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Lifecycle: b.Lifecycle,
 			Subject:   "cn=apiserver-aggregator-ca",
 			Type:      "ca",
+
+			Format: string(kops.SecretTypeKeypair),
 		}
 		c.AddTask(aggregatorCA)
 
@@ -187,6 +218,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Subject: "cn=aggregator",
 			Type:    "client",
 			Signer:  aggregatorCA,
+
+			Format: string(kops.SecretTypeKeypair),
 		}
 		c.AddTask(aggregator)
 	}
@@ -199,6 +232,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Subject:   "o=" + user.SystemPrivilegedGroup + ",cn=kops",
 			Type:      "client",
 			Signer:    defaultCA,
+
+			Format: string(kops.SecretTypeKeypair),
 		}
 		c.AddTask(t)
 	}
@@ -236,6 +271,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Type:           "server",
 			AlternateNames: alternateNames,
 			Signer:         defaultCA,
+
+			Format: string(kops.SecretTypeKeypair),
 		}
 		c.AddTask(t)
 	}

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["keypair_test.go"],
+    deps = [
+        "//pkg/apis/kops:go_default_library",
+        "//upup/pkg/fi:go_default_library",
+        "//upup/pkg/fi/fitasks:go_default_library",
+        "//util/pkg/vfs:go_default_library",
+    ],
+)

--- a/tests/keypair_test.go
+++ b/tests/keypair_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package tests
+
+import (
+	"bytes"
+	"math/big"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/fitasks"
+	"k8s.io/kops/util/pkg/vfs"
+)
+
+type MockTarget struct {
+}
+
+func (t *MockTarget) Finish(taskMap map[string]fi.Task) error {
+	return nil
+}
+
+func (t *MockTarget) ProcessDeletions() bool {
+	return false
+}
+
+var _ fi.Target = &MockTarget{}
+
+// Verifies that we regenerate keyset.yaml if they are deleted, which covers the upgrade scenario from kops 1.8 -> kops 1.9
+func TestKeypairUpgrade(t *testing.T) {
+	lifecycle := fi.LifecycleSync
+
+	defaultDeadline := 2 * time.Second
+
+	target := &MockTarget{}
+
+	cluster := &kops.Cluster{}
+	vfs.Context.ResetMemfsContext(true)
+
+	basedir, err := vfs.Context.BuildVfsPath("memfs://keystore")
+	if err != nil {
+		t.Fatalf("error building vfs path: %v", err)
+	}
+
+	keystore := fi.NewVFSCAStore(cluster, basedir, true)
+
+	// Generate predictable sequence numbers for testing
+	var n int64
+	keystore.SerialGenerator = func() *big.Int {
+		n++
+		return big.NewInt(n)
+	}
+
+	// We define a function so we can rebuild the tasks, because we modify in-place when running
+	buildTasks := func() map[string]fi.Task {
+		ca := &fitasks.Keypair{
+			Name:      fi.String(fi.CertificateId_CA),
+			Lifecycle: &lifecycle,
+			Subject:   "cn=kubernetes",
+			Type:      "ca",
+
+			Format: string(kops.SecretTypeKeypair),
+		}
+
+		kubelet := &fitasks.Keypair{
+			Name:      fi.String("kubelet"),
+			Lifecycle: &lifecycle,
+
+			Subject: "o=nodes,cn=kubelet",
+			Type:    "client",
+			Signer:  ca,
+
+			Format: string(kops.SecretTypeKeypair),
+		}
+
+		tasks := make(map[string]fi.Task)
+		tasks["ca"] = ca
+		tasks["kubelet"] = kubelet
+		return tasks
+	}
+
+	t.Logf("Building some keypairs")
+	{
+		allTasks := buildTasks()
+
+		context, err := fi.NewContext(target, nil, nil, keystore, nil, nil, true, allTasks)
+		if err != nil {
+			t.Fatalf("error building context: %v", err)
+		}
+
+		if err := context.RunTasks(defaultDeadline); err != nil {
+			t.Fatalf("unexpected error during Run: %v", err)
+		}
+	}
+
+	// Check that the expected files were generated
+	expected := []string{
+		"memfs://keystore/issued/ca/1.crt",
+		"memfs://keystore/issued/ca/keyset.yaml",
+		"memfs://keystore/issued/kubelet/2.crt",
+		"memfs://keystore/issued/kubelet/keyset.yaml",
+		"memfs://keystore/private/ca/1.key",
+		"memfs://keystore/private/ca/keyset.yaml",
+		"memfs://keystore/private/kubelet/2.key",
+		"memfs://keystore/private/kubelet/keyset.yaml",
+	}
+	checkPaths(t, basedir, expected)
+
+	// Save the contents of those files
+	contents := make(map[string][]byte)
+	for _, k := range expected {
+		p, err := vfs.Context.BuildVfsPath(k)
+		if err != nil {
+			t.Fatalf("error building vfs path: %v", err)
+		}
+		b, err := p.ReadFile()
+		if err != nil {
+			t.Fatalf("error reading vfs path: %v", err)
+		}
+		contents[k] = b
+	}
+
+	t.Logf("verifying that rerunning tasks does not change keys")
+	{
+		allTasks := buildTasks()
+
+		context, err := fi.NewContext(target, nil, nil, keystore, nil, nil, true, allTasks)
+		if err != nil {
+			t.Fatalf("error building context: %v", err)
+		}
+
+		if err := context.RunTasks(defaultDeadline); err != nil {
+			t.Fatalf("unexpected error during Run: %v", err)
+		}
+	}
+	checkContents(t, basedir, contents)
+
+	t.Logf("deleting keyset.yaml files and verifying they are recreated")
+	FailOnError(t, basedir.Join("issued/ca/keyset.yaml").Remove())
+	FailOnError(t, basedir.Join("issued/kubelet/keyset.yaml").Remove())
+	FailOnError(t, basedir.Join("private/ca/keyset.yaml").Remove())
+	FailOnError(t, basedir.Join("private/kubelet/keyset.yaml").Remove())
+
+	{
+		allTasks := buildTasks()
+
+		context, err := fi.NewContext(target, nil, nil, keystore, nil, nil, true, allTasks)
+		if err != nil {
+			t.Fatalf("error building context: %v", err)
+		}
+
+		if err := context.RunTasks(defaultDeadline); err != nil {
+			t.Fatalf("unexpected error during Run: %v", err)
+		}
+	}
+	checkContents(t, basedir, contents)
+}
+
+// FailOnError calls t.Fatalf if err != nil
+func FailOnError(t *testing.T, err error) {
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// checkPaths verifies that the path names in the tree rooted at basedir are exactly as expected
+// Unlike checkContents, it only verifies the names, not the contents
+func checkPaths(t *testing.T, basedir vfs.Path, expected []string) {
+	paths, err := basedir.ReadTree()
+	if err != nil {
+		t.Errorf("ReadTree failed: %v", err)
+	}
+
+	var actual []string
+	for _, p := range paths {
+		actual = append(actual, p.Path())
+	}
+	sort.Strings(actual)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("unexpected paths: %v", actual)
+	}
+}
+
+// checkPaths verifies that the files and their contents in the tree rooted at basedir are exactly as expected
+func checkContents(t *testing.T, basedir vfs.Path, expected map[string][]byte) {
+	paths, err := basedir.ReadTree()
+	if err != nil {
+		t.Errorf("ReadTree failed: %v", err)
+	}
+
+	actual := make(map[string][]byte)
+	for _, p := range paths {
+		b, err := p.ReadFile()
+		if err != nil {
+			t.Fatalf("error reading vfs path: %v", err)
+		}
+		actual[p.Path()] = b
+	}
+
+	var actualKeys []string
+	for k := range actual {
+		actualKeys = append(actualKeys, k)
+	}
+	sort.Strings(actualKeys)
+	var expectedKeys []string
+	for k := range expected {
+		expectedKeys = append(expectedKeys, k)
+	}
+	sort.Strings(expectedKeys)
+
+	if !reflect.DeepEqual(actualKeys, expectedKeys) {
+		t.Fatalf("unexpected paths: %v", actualKeys)
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		for k := range actual {
+			if !bytes.Equal(actual[k], expected[k]) {
+				t.Logf("mismatch on key %q", k)
+			}
+		}
+		t.Fatalf("unexpected path contents: %v", actual)
+	}
+}

--- a/upup/pkg/fi/ca.go
+++ b/upup/pkg/fi/ca.go
@@ -43,8 +43,11 @@ type KeystoreItem struct {
 // Keystore contains just the functions we need to issue keypairs, not to list / manage them
 type Keystore interface {
 	// FindKeypair finds a cert & private key, returning nil where either is not found
-	// (if the certificate is found but not keypair, that is not an error: only the cert will be returned)
-	FindKeypair(name string) (*pki.Certificate, *pki.PrivateKey, error)
+	// (if the certificate is found but not keypair, that is not an error: only the cert will be returned).
+	// This func returns a cert, private key and a string.  The string value is the Format of the keystore which is either
+	// an empty string, which denotes a Legacy Keypair, or a value of "Keypair".  This string is used by a keypair
+	// task convert a Legacy Keypair to the new Keypair API format.
+	FindKeypair(name string) (*pki.Certificate, *pki.PrivateKey, string, error)
 
 	CreateKeypair(signer string, name string, template *x509.Certificate, privateKey *pki.PrivateKey) (*pki.Certificate, error)
 

--- a/upup/pkg/fi/vfs_castore.go
+++ b/upup/pkg/fi/vfs_castore.go
@@ -47,6 +47,10 @@ type VFSCAStore struct {
 
 	mutex     sync.Mutex
 	cachedCAs map[string]*cachedEntry
+
+	// SerialGenerator is the function for generating certificate serial numbers
+	// It can be replaced for testing purposes.
+	SerialGenerator func() *big.Int
 }
 
 type cachedEntry struct {
@@ -57,12 +61,17 @@ type cachedEntry struct {
 var _ CAStore = &VFSCAStore{}
 var _ SSHCredentialStore = &VFSCAStore{}
 
-func NewVFSCAStore(cluster *kops.Cluster, basedir vfs.Path, allowList bool) CAStore {
+func NewVFSCAStore(cluster *kops.Cluster, basedir vfs.Path, allowList bool) *VFSCAStore {
 	c := &VFSCAStore{
 		basedir:   basedir,
 		cluster:   cluster,
 		cachedCAs: make(map[string]*cachedEntry),
 		allowList: allowList,
+	}
+
+	c.SerialGenerator = func() *big.Int {
+		t := time.Now().UnixNano()
+		return pki.BuildPKISerial(t)
 	}
 
 	return c
@@ -157,8 +166,7 @@ func (c *VFSCAStore) generateCACertificate(name string) (*keyset, *keyset, error
 		return nil, nil, err
 	}
 
-	t := time.Now().UnixNano()
-	serial := pki.BuildPKISerial(t).String()
+	serial := c.SerialGenerator().String()
 
 	err = c.storePrivateKey(name, &keysetItem{id: serial, privateKey: caPrivateKey})
 	if err != nil {
@@ -924,7 +932,7 @@ func (c *VFSCAStore) FindPrivateKeyset(name string) (*kops.Keyset, error) {
 }
 
 func (c *VFSCAStore) CreateKeypair(signer string, id string, template *x509.Certificate, privateKey *pki.PrivateKey) (*pki.Certificate, error) {
-	serial := c.buildSerial()
+	serial := c.SerialGenerator()
 
 	cert, err := c.IssueCert(signer, id, serial, privateKey, template)
 	if err != nil {
@@ -1075,11 +1083,6 @@ func (c *VFSCAStore) deleteCertificate(name string, id string) (bool, error) {
 		}
 		return true, nil
 	}
-}
-
-func (c *VFSCAStore) buildSerial() *big.Int {
-	t := time.Now().UnixNano()
-	return pki.BuildPKISerial(t)
 }
 
 // AddSSHPublicKey stores an SSH public key

--- a/upup/pkg/fi/vfs_castore.go
+++ b/upup/pkg/fi/vfs_castore.go
@@ -94,7 +94,7 @@ func (s *VFSCAStore) readCAKeypairs(id string) (*keyset, *keyset, error) {
 		return cached.certificates, cached.privateKeys, nil
 	}
 
-	caCertificates, err := s.loadCertificates(s.buildCertificatePoolPath(id), true)
+	caCertificates, _, err := s.loadCertificates(s.buildCertificatePoolPath(id), true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -180,7 +180,7 @@ func (c *VFSCAStore) generateCACertificate(name string) (*keyset, *keyset, error
 	}
 
 	// Make double-sure it round-trips
-	certificates, err := c.loadCertificates(c.buildCertificatePoolPath(name), true)
+	certificates, _, err := c.loadCertificates(c.buildCertificatePoolPath(name), true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -233,27 +233,27 @@ func (c *VFSCAStore) parseKeysetYaml(data []byte) (*kops.Keyset, error) {
 // loadCertificatesBundle loads a keyset from the path
 // Returns (nil, nil) if the file is not found
 // Bundles avoid the need for a list-files permission, which can be tricky on e.g. GCE
-func (c *VFSCAStore) loadKeysetBundle(p vfs.Path) (*keyset, error) {
+func (c *VFSCAStore) loadKeysetBundle(p vfs.Path) (*keyset, string, error) {
 	data, err := p.ReadFile()
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, "", nil
 		} else {
-			return nil, fmt.Errorf("unable to read bundle %q: %v", p, err)
+			return nil, "", fmt.Errorf("unable to read bundle %q: %v", p, err)
 		}
 	}
 
 	o, err := c.parseKeysetYaml(data)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing bundle %q: %v", p, err)
+		return nil, "", fmt.Errorf("error parsing bundle %q: %v", p, err)
 	}
 
-	keyset, err := parseKeyset(o)
+	keyset, version, err := parseKeyset(o)
 	if err != nil {
-		return nil, fmt.Errorf("error mapping bundle %q: %v", p, err)
+		return nil, "", fmt.Errorf("error mapping bundle %q: %v", p, err)
 	}
 
-	return keyset, nil
+	return keyset, version, nil
 }
 
 func (k *keyset) ToAPIObject(name string, includePrivateKeyMaterial bool) (*kops.Keyset, error) {
@@ -354,14 +354,14 @@ func SerializeKeyset(o *kops.Keyset) ([]byte, error) {
 	return objectData.Bytes(), nil
 }
 
-func (c *VFSCAStore) loadCertificates(p vfs.Path, useBundle bool) (*keyset, error) {
+func (c *VFSCAStore) loadCertificates(p vfs.Path, useBundle bool) (*keyset, string, error) {
 	// Attempt to load prebuilt bundle, which avoids having to list files, which is a permission that can be hard to
 	// give on GCE / other clouds
 	if useBundle {
 		bundlePath := p.Join("keyset.yaml")
-		bundle, err := c.loadKeysetBundle(bundlePath)
+		bundle, version, err := c.loadKeysetBundle(bundlePath)
 		if !c.allowList {
-			return bundle, err
+			return bundle, version, err
 		}
 
 		if err != nil {
@@ -369,7 +369,7 @@ func (c *VFSCAStore) loadCertificates(p vfs.Path, useBundle bool) (*keyset, erro
 		} else if bundle == nil {
 			glog.V(2).Infof("no certificate bundle %q, falling back to directory-list method", bundlePath)
 		} else {
-			return bundle, nil
+			return bundle, version, nil
 		}
 	}
 
@@ -380,9 +380,9 @@ func (c *VFSCAStore) loadCertificates(p vfs.Path, useBundle bool) (*keyset, erro
 	files, err := p.ReadDir()
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, "", nil
 		}
-		return nil, err
+		return nil, "", err
 	}
 
 	for _, f := range files {
@@ -395,7 +395,7 @@ func (c *VFSCAStore) loadCertificates(p vfs.Path, useBundle bool) (*keyset, erro
 
 		cert, err := c.loadOneCertificate(f)
 		if err != nil {
-			return nil, fmt.Errorf("error loading certificate %q: %v", f, err)
+			return nil, "", fmt.Errorf("error loading certificate %q: %v", f, err)
 		}
 
 		keyset.items[id] = &keysetItem{
@@ -405,12 +405,12 @@ func (c *VFSCAStore) loadCertificates(p vfs.Path, useBundle bool) (*keyset, erro
 	}
 
 	if len(keyset.items) == 0 {
-		return nil, nil
+		return nil, "", nil
 	}
 
 	keyset.primary = keyset.findPrimary()
 
-	return keyset, nil
+	return keyset, "", nil
 }
 
 func (c *VFSCAStore) loadOneCertificate(p vfs.Path) (*pki.Certificate, error) {
@@ -444,28 +444,25 @@ func (c *VFSCAStore) CertificatePool(id string, createIfMissing bool) (*Certific
 
 }
 
-func (c *VFSCAStore) FindKeypair(id string) (*pki.Certificate, *pki.PrivateKey, error) {
-	cert, err := c.FindCert(id)
+func (c *VFSCAStore) FindKeypair(id string) (*pki.Certificate, *pki.PrivateKey, string, error) {
+	cert, keypairType, err := c.findCert(id)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 
 	key, err := c.FindPrivateKey(id)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 
-	return cert, key, nil
+	return cert, key, keypairType, nil
 }
 
-func (c *VFSCAStore) FindCert(name string) (*pki.Certificate, error) {
-	var certs *keyset
-
-	var err error
+func (c *VFSCAStore) findCert(name string) (*pki.Certificate, string, error) {
 	p := c.buildCertificatePoolPath(name)
-	certs, err = c.loadCertificates(p, true)
+	certs, keypairType, err := c.loadCertificates(p, true)
 	if err != nil {
-		return nil, fmt.Errorf("error in 'FindCert' attempting to load cert %q: %v", name, err)
+		return nil, "", fmt.Errorf("error in 'FindCert' attempting to load cert %q: %v", name, err)
 	}
 
 	var cert *pki.Certificate
@@ -473,7 +470,12 @@ func (c *VFSCAStore) FindCert(name string) (*pki.Certificate, error) {
 		cert = certs.primary.certificate
 	}
 
-	return cert, nil
+	return cert, keypairType, nil
+}
+
+func (c *VFSCAStore) FindCert(name string) (*pki.Certificate, error) {
+	cert, _, err := c.findCert(name)
+	return cert, err
 }
 
 func (c *VFSCAStore) FindCertificatePool(name string) (*CertificatePool, error) {
@@ -481,7 +483,7 @@ func (c *VFSCAStore) FindCertificatePool(name string) (*CertificatePool, error) 
 
 	var err error
 	p := c.buildCertificatePoolPath(name)
-	certs, err = c.loadCertificates(p, true)
+	certs, _, err = c.loadCertificates(p, true)
 	if err != nil {
 		return nil, fmt.Errorf("error in 'FindCertificatePool' attempting to load cert %q: %v", name, err)
 	}
@@ -508,7 +510,7 @@ func (c *VFSCAStore) FindCertificatePool(name string) (*CertificatePool, error) 
 
 func (c *VFSCAStore) FindCertificateKeyset(name string) (*kops.Keyset, error) {
 	p := c.buildCertificatePoolPath(name)
-	certs, err := c.loadCertificates(p, true)
+	certs, _, err := c.loadCertificates(p, true)
 	if err != nil {
 		return nil, fmt.Errorf("error in 'FindCertificatePool' attempting to load cert %q: %v", name, err)
 	}
@@ -805,7 +807,7 @@ func (c *VFSCAStore) loadPrivateKeys(p vfs.Path, useBundle bool) (*keyset, error
 	// give on GCE / other clouds
 	if useBundle {
 		bundlePath := p.Join("keyset.yaml")
-		bundle, err := c.loadKeysetBundle(bundlePath)
+		bundle, _, err := c.loadKeysetBundle(bundlePath)
 
 		if !c.allowList {
 			return bundle, err
@@ -982,7 +984,7 @@ func (c *VFSCAStore) storeCertificate(name string, ki *keysetItem) error {
 	// Write the bundle
 	{
 		p := c.buildCertificatePoolPath(name)
-		ks, err := c.loadCertificates(p, false)
+		ks, _, err := c.loadCertificates(p, false)
 		if err != nil {
 			return err
 		}
@@ -1050,7 +1052,7 @@ func (c *VFSCAStore) deleteCertificate(name string, id string) (bool, error) {
 	// Update the bundle
 	{
 		p := c.buildPrivateKeyPoolPath(name)
-		ks, err := c.loadCertificates(p, false)
+		ks, _, err := c.loadCertificates(p, false)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
If the Keypair is not found kops creates a new keyset file.  We are
setting the Format to v1, which denotes that we do not have a keyset
file.

This commit enables upgrading from kops 1.8 -> 1.9 while upgrading an
existing cluster.  Clusters built with kops 1.8 do not have the keyset
file, and these code changes allow the creation of the keyset file.

Fixes: https://github.com/kubernetes/kops/issues/4546

~~The only thing I do not like about this fix is that we are generating a new private key.  Not a horrible thing, but not sure how stuff like etcd will behave.~~

Edit: with changes I am not generating a new private key.