### PR TITLE
[Calico] Fix delay setting up ip routes in new nodes

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.6.yaml.template
@@ -158,6 +158,11 @@ spec:
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
+            # Set noderef for node controller.
+            - name: CALICO_K8S_NODE_REF
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             # Auto-detect the BGP IP address.
             - name: IP
               value: ""
@@ -322,6 +327,13 @@ spec:
             requests:
               cpu: 10m
           env:
+            # By default only policy, profile, workloadendpoint are turned
+            # on, node controller will decommission nodes that do not exist anymore
+            # this and CALICO_K8S_NODE_REF in calico-node fixes #3224, but invalid nodes that are
+            # already registered in calico needs to be deleted manually, see
+            # https://docs.projectcalico.org/v2.6/usage/decommissioning-a-node
+            - name: ENABLED_CONTROLLERS
+              value: policy,profile,workloadendpoint,node
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
               valueFrom:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7.yaml.template
@@ -169,6 +169,11 @@ spec:
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
+            # Set noderef for node controller.
+            - name: CALICO_K8S_NODE_REF
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             # Auto-detect the BGP IP address.
             - name: IP
               value: ""
@@ -287,6 +292,13 @@ spec:
             requests:
               cpu: 10m
           env:
+            # By default only policy, profile, workloadendpoint are turned
+            # on, node controller will decommission nodes that do not exist anymore
+            # this and CALICO_K8S_NODE_REF in calico-node fixes #3224, but invalid nodes that are
+            # already registered in calico needs to be deleted manually, see
+            # https://docs.projectcalico.org/v2.6/usage/decommissioning-a-node
+            - name: ENABLED_CONTROLLERS
+              value: policy,profile,workloadendpoint,node
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
               valueFrom:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -476,8 +476,8 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		key := "networking.projectcalico.org"
 		versions := map[string]string{
 			"pre-k8s-1.6": "2.4.1",
-			"k8s-1.6":     "2.6.2",
-			"k8s-1.7":     "2.6.2",
+			"k8s-1.6":     "2.6.6-kops.1",
+			"k8s-1.7":     "2.6.6-kops.1",
 		}
 
 		{


### PR DESCRIPTION
Activate node controller in calico-kube-controllers and add CALICO_K8S_NODE_REF in calico-node, this commit fixes #3224 and #4533 

Because this PR fixes critical issues, maybe some people would like to add this changes to running clusters, so I think we should create a new release "1.8.2" with it.

I'll open a separated PR for master.

@justinsb @chrislovecnm @caseydavenport @igorvpcleao