### PR TITLE
Fix distroless error

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,13 +42,13 @@ container_pull(
 )
 
 git_repository(
-    name = "distroless_rules",
+    name = "distroless",
     remote = "https://github.com/googlecloudplatform/distroless.git",
     commit = "886114394dfed219001ec3b068b139a3456e49d4"
 )
 
 load(
-    "@distroless_rules//package_manager:package_manager.bzl",
+    "@distroless//package_manager:package_manager.bzl",
     "package_manager_repositories",
     "dpkg_src",
     "dpkg_list",


### PR DESCRIPTION
This should fix an error like:

```
WARNING: /private/var/tmp/_bazel_mikesplain/0b08596454ccfeb191e11d822b5dc7c9/external/distroless_rules/WORKSPACE:1: Workspace name in /private/var/tmp/_bazel_mikesplain/0b08596454ccfeb191e11d822b5dc7c9/external/distroless_rules/WORKSPACE (@distroless) does not match the name given in the repository's definition (@distroless_rules); this will cause a build error in future versions
```
