### PR TITLE
Typo fix "Kubernetes 1.9"->"Kubernetes v1.9"

### DIFF
--- a/docs/releases/1.8-NOTES.md
+++ b/docs/releases/1.8-NOTES.md
@@ -13,7 +13,7 @@
 
 * New AWS instance types: P3, C5, M5, H1.  Please note that NVME volumes are not supported on the default jessie
   image, so masters will not boot on M5 and C5 instance types unless a stretch image is chosen (change stretch to jessie in the image name).
-  Also note that kubernetes will not support mounting persistent volumes on NVME instances until Kubernetes 1.9.
+  Also note that kubernetes will not support mounting persistent volumes on NVME instances until Kubernetes v1.9.
 
 * While Aggregated API Servers are supported, there are known issues in kubernetes
   such as (#55022)[https://github.com/kubernetes/kubernetes/issues/55022].  Note that this includes metrics-server and kopeio
@@ -81,7 +81,7 @@ remains the default.  We will likely change the default to stretch in kops 1.9 o
 
 * New instance types: P3, C5, M5, H1.  Please note that NVME volumes are not supported on the default jessie
 image, so masters will not boot on M5 and C5 instance types unless a stretch image is chosen (change stretch to jessie in the image name).
-Also kubernetes will not support mounting persistent volumes on NVME instances until Kubernetes 1.9.
+Also kubernetes will not support mounting persistent volumes on NVME instances until Kubernetes v1.9.
 * Support for root provisioned IOPS.
 * Properly tag public and private subnets for ELB creation in advanced network topologies
 * Use SSL in ELB API server health check


### PR DESCRIPTION
In this doc, a Kubernetes Version is written as "Kubernetes 1.x" and "Kubernetes v1.x" , for a serious doc, it needs to keep consistency.