### PR TITLE
Typo fix "etcd manager"->"etcd-manager"

### DIFF
--- a/docs/etcd/roadmap.md
+++ b/docs/etcd/roadmap.md
@@ -25,7 +25,7 @@ it matures.
 
 To make adoption easier, the etcd-manager has added a standalone backup tool, that can backup etcd into the
 [expected structure](https://github.com/kopeio/etcd-manager/blob/master/docs/backupstructure.md), even if you are not running the etcd-manager.  It should be possible to then use
-the etcd manager from that backup.
+the etcd-manager from that backup.
 
 ## Roadmap
 


### PR DESCRIPTION
In this doc,  "etcd-manager" is written as "“etcd-manager", while in line 28 "etcd manager"