### PR TITLE
Updating verify scripts so that output is highlighted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -497,7 +497,8 @@ verify-gendocs: ${KOPS}
 	'${KOPS}' genhelpdocs --out "$$TMP_DOCS"; \
 	\
 	if ! diff -r "$$TMP_DOCS" '${KOPS_ROOT}/docs/cli'; then \
-	     echo "Please run make gen-cli-docs." 1>&2; \
+	     echo "FAIL: make verify-gendocs failed, as the generated markdown docs are out of date." 1>&2; \
+	     echo "FAIL: Please run the following command: make gen-cli-docs." 1>&2; \
 	     exit 1; \
 	fi
 	@echo "cli docs up-to-date"

--- a/hack/verify-apimachinery.sh
+++ b/hack/verify-apimachinery.sh
@@ -23,5 +23,6 @@ export API_OPTIONS="--verify-only"
 if make apimachinery-codegen; then
 	echo "apimachinery is up to date"
 else
-	echo "\n TEST FAILED - apimachinery is not up to date please run 'make apimachinery'"
+	echo "\n FAIL: - the verify-apimachinery.sh test failed, apimachinery is not up to date"
+	echo "\n FAIL: - please run the command 'make apimachinery'"
 fi

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -36,7 +36,8 @@ gazelle_diff=$("${TMP_GOPATH}/bin/gazelle" fix \
 if [[ -n "${gazelle_diff}" ]]; then
   echo "${gazelle_diff}" >&2
   echo >&2
-  echo "Run ./hack/update-bazel.sh" >&2
+  echo "FAIL: ./hack/verify-bazel.sh failed, as the bazel files are not up to date" >&2
+  echo "FAIL: Please execute the following command: ./hack/update-bazel.sh" >&2
   exit 1
 fi
 
@@ -48,6 +49,7 @@ if [[ -n "${old_build_files}" ]]; then
   echo "One or more BUILD files found in the tree:" >&2
   echo "${old_build_files}" >&2
   echo >&2
-  echo "Only BUILD.bazel is allowed." >&2
+  echo "FAIL: Only bazel files anmed BUILD.bazel are allowed." >&2
+  echo "FAIL: Please move incorrectly named files to BUILD.bazel" >&2
   exit 1
 fi

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -42,8 +42,8 @@ done
 
 if [[ ${#TEMP_ARRAY[@]} -gt 0 ]]; then
   for file in "${TEMP_ARRAY[@]}"; do
-    echo "Boilerplate header is wrong for: ${file}"
+    echo "FAIL: Boilerplate header is wrong for: ${file}"
   done
-  echo "Execute hack/update-header.sh to update headers"
+  echo "FAIL: Please execute ./hack/update-header.sh to update headers"
   exit 1
 fi

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -20,8 +20,8 @@ GOFMT="gofmt -s -w"
 
 bad_files=$(git ls-files "*.go" | grep -v vendor | xargs -I {} $GOFMT -l {})
 if [[ -n "${bad_files}" ]]; then
-  echo "!!! '$GOFMT' needs to be run on the following files: "
+  echo "FAIL: '$GOFMT' needs to be run on the following files: "
   echo "${bad_files}"
-  echo "!!! Please run: make gofmt"
+  echo "FAIL: please execute make gofmt"
   exit 1
 fi

--- a/hack/verify-goimports
+++ b/hack/verify-goimports
@@ -40,7 +40,7 @@ process = subprocess.Popen(['goimports', '-l'] + paths, stdout=subprocess.PIPE, 
 stdout, stderr = process.communicate()
 
 if stdout != "":
-  print("!!! 'goimports -w' needs to be run on the following files: ")
+  print("FAIL: 'goimports -w' needs to be run on the following files: ")
   print(stdout)
-  print('!!! Please run: make goimports')
+  print('FAIL: Please run the following command: make goimports')
   sys.exit(1)

--- a/hack/verify-packages.sh
+++ b/hack/verify-packages.sh
@@ -21,9 +21,9 @@ packages_file="${KUBE_ROOT}/hack/.packages"
 if ! diff -u "${packages_file}" <(go list k8s.io/kops/... | grep -v vendor); then
 	{
 		echo
-		echo "hack/.packages is not in up to date. Please run:"
+		echo "FAIL: ./hack/verify-packages.sh failed as the ./hack/.packages file is not in up to date."
 		echo
-		echo "  go list k8s.io/kops/... | grep -v vendor > hack/.packages"
+		echo "FAIL: please execute the following command:  'go list k8s.io/kops/... | grep -v vendor > hack/.packages'"
 		echo
 	} >&2
 	false


### PR DESCRIPTION
When a verify script fails we now output the word 'FAIL' at the start of the message
so that it is highlighted in the build logs.