### PR TITLE
Updating comment so we do not have gofmt issues with go 1.9 and go 1.10

### DIFF
--- a/pkg/resources/aws.go
+++ b/pkg/resources/aws.go
@@ -700,10 +700,10 @@ func ListKeypairs(cloud fi.Cloud, clusterName string) ([]*Resource, error) {
 	keypairName := "kubernetes." + clusterName
 
 	glog.V(2).Infof("Listing EC2 Keypairs")
-	request := &ec2.DescribeKeyPairsInput{
-	// We need to match both the name and a prefix
-	//Filters: []*ec2.Filter{awsup.NewEC2Filter("key-name", keypairName)},
-	}
+
+	// TODO: We need to match both the name and a prefix
+	// TODO: usee 'Filters: []*ec2.Filter{awsup.NewEC2Filter("key-name", keypairName)},'
+	request := &ec2.DescribeKeyPairsInput{}
 	response, err := c.EC2().DescribeKeyPairs(request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing KeyPairs: %v", err)


### PR DESCRIPTION
There is a change in gofmt between go 1.10 and go 1.9.  The aws.go file
needs formating with go 1.10, while it is passing 1.9.  This commit moves
a comment above the parens so that both go 1.9 and 1.10 formats the file
in the same manner.