### PR TITLE
Typo delete duplicated "is ", "utilty"->"utility"

### DIFF
--- a/docs/advisories/cve_2017_14491.md
+++ b/docs/advisories/cve_2017_14491.md
@@ -31,7 +31,7 @@ kubectl get deployment -n kube-system kube-dns \
 -o jsonpath='{.spec.template.spec.containers[?(@.name == "dnsmasq")].image}'
 ```
 
-The upgrade is will occur once the channels utilty picks up the change within a
+The upgrade will occur once the channels utility picks up the change within a
 few minutes.
 
 ## Tested Kubernetes Versions


### PR DESCRIPTION
In "The upgrade is will occur once the channels utilty picks up the change within a
few minutes.", “is” is superfluous.
"utilty" is wrong word, should be utility here.