### PR TITLE
Typo fix kubernetes->Kubernetes

### DIFF
--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -8,7 +8,7 @@ Create a Kubernetes cluster.
 ### Synopsis
 
 
-Create a kubernetes cluster using command line flags. This command creates cloud based resources such as networks and virtual machines. Once the infrastructure is in place Kubernetes is installed on the virtual machines. 
+Create a Kubernetes cluster using command line flags. This command creates cloud based resources such as networks and virtual machines. Once the infrastructure is in place Kubernetes is installed on the virtual machines. 
 
 These operations are done in parallel and rely on eventual consistency.
 


### PR DESCRIPTION
In the main text of this doc, "Kubernetes" and "kubernetes" should be kept consistency.