### PR TITLE
Bump alpha channels for CVE

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -32,13 +32,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.9.0"
-    recommendedVersion: 1.9.3
+    recommendedVersion: 1.9.4
     requiredVersion: 1.9.0
   - range: ">=1.8.0"
-    recommendedVersion: 1.8.8
+    recommendedVersion: 1.8.9
     requiredVersion: 1.8.0
   - range: ">=1.7.0"
-    recommendedVersion: 1.7.13
+    recommendedVersion: 1.7.14
     requiredVersion: 1.7.0
   - range: ">=1.6.0"
     recommendedVersion: 1.6.13
@@ -53,15 +53,15 @@ spec:
   - range: ">=1.9.0-alpha.1"
     recommendedVersion: 1.9.0-alpha.1
     #requiredVersion: 1.9.0-alpha.1
-    kubernetesVersion: 1.9.3
+    kubernetesVersion: 1.9.4
   - range: ">=1.8.0-alpha.1"
     recommendedVersion: 1.8.1
     requiredVersion: 1.7.1
-    kubernetesVersion: 1.8.8
+    kubernetesVersion: 1.8.9
   - range: ">=1.7.0-alpha.1"
     recommendedVersion: 1.8.1
     requiredVersion: 1.7.1
-    kubernetesVersion: 1.7.13
+    kubernetesVersion: 1.7.14
   - range: ">=1.6.0-alpha.1"
     recommendedVersion: 1.8.1
     requiredVersion: 1.7.1


### PR DESCRIPTION
Update alpha channels for https://github.com/kubernetes/kubernetes/issues/60814 & https://github.com/kubernetes/kubernetes/issues/60813

@chrislovecnm @justinsb should we bump stable?