### PR TITLE
Typo fix "DNS wil be"->"DNS will be"

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -256,7 +256,7 @@ type AlwaysAllowAuthorizationSpec struct {
 
 // AccessSpec provides configuration details related to kubeapi dns and ELB access
 type AccessSpec struct {
-	// DNS wil be used to provide config on kube-apiserver elb dns
+	// DNS will be used to provide config on kube-apiserver elb dns
 	DNS *DNSAccessSpec `json:"dns,omitempty"`
 	// LoadBalancer is the configuration for the kube-apiserver ELB
 	LoadBalancer *LoadBalancerAccessSpec `json:"loadBalancer,omitempty"`


### PR DESCRIPTION
line 259: "DNS wil be" should be replaced with "DNS will be"