### PR TITLE
Fix names of CloudFormation-created AutoScalingGroups

### DIFF
--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json
@@ -3,6 +3,7 @@
     "AWSAutoScalingAutoScalingGroupmasterustest1amastersadditionaluserdataexamplecom": {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
+        "AutoScalingGroupName": "master-us-test-1a.masters.additionaluserdata.example.com",
         "LaunchConfigurationName": {
           "Ref": "AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserdataexamplecom"
         },
@@ -50,6 +51,7 @@
     "AWSAutoScalingAutoScalingGroupnodesadditionaluserdataexamplecom": {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
+        "AutoScalingGroupName": "nodes.additionaluserdata.example.com",
         "LaunchConfigurationName": {
           "Ref": "AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom"
         },

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
@@ -3,6 +3,7 @@
     "AWSAutoScalingAutoScalingGroupmasterustest1amastersminimalexamplecom": {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
+        "AutoScalingGroupName": "master-us-test-1a.masters.minimal.example.com",
         "LaunchConfigurationName": {
           "Ref": "AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexamplecom"
         },
@@ -50,6 +51,7 @@
     "AWSAutoScalingAutoScalingGroupnodesminimalexamplecom": {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
+        "AutoScalingGroupName": "nodes.minimal.example.com",
         "LaunchConfigurationName": {
           "Ref": "AWSAutoScalingLaunchConfigurationnodesminimalexamplecom"
         },

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -450,7 +450,7 @@ type cloudformationASGMetricsCollection struct {
 	Metrics     []*string `json:"Metrics"`
 }
 type cloudformationAutoscalingGroup struct {
-	//Name                    *string              `json:"name,omitempty"`
+	Name                    *string                               `json:"AutoScalingGroupName,omitempty"`
 	LaunchConfigurationName *cloudformation.Literal               `json:"LaunchConfigurationName,omitempty"`
 	MaxSize                 *int64                                `json:"MaxSize,omitempty"`
 	MinSize                 *int64                                `json:"MinSize,omitempty"`
@@ -463,7 +463,7 @@ type cloudformationAutoscalingGroup struct {
 
 func (_ *AutoscalingGroup) RenderCloudformation(t *cloudformation.CloudformationTarget, a, e, changes *AutoscalingGroup) error {
 	tf := &cloudformationAutoscalingGroup{
-		//Name:                    e.Name,
+		Name:    e.Name,
 		MinSize: e.MinSize,
 		MaxSize: e.MaxSize,
 		MetricsCollection: []*cloudformationASGMetricsCollection{


### PR DESCRIPTION
With a CloudFormation-created cluster rolling updates don't work. After a bit of digging/debugging it seems to be caused by the fact that the AutoScalingGroups' names don't match the names that rolling-update expects them to have. This PR adds the expected name to the AutoScalinGroups created by kops. Interestingly the name property was already there, just commented out.