### PR TITLE
Fix error accompanying note in node_api_adapter.go

### DIFF
--- a/pkg/validation/node_api_adapter.go
+++ b/pkg/validation/node_api_adapter.go
@@ -71,7 +71,7 @@ func (nodeAA *NodeAPIAdapter) GetAllNodes() (nodes *v1.NodeList, err error) {
 	return nodes, nil
 }
 
-// GetReadySchedulableNodesOrDie addresses the common use case of getting nodes you can do work on.
+// GetReadySchedulableNodes addresses the common use case of getting nodes you can do work on.
 // 1) Needs to be schedulable.
 // 2) Needs to be ready.
 // If EITHER 1 or 2 is not true, most tests will want to ignore the node entirely.


### PR DESCRIPTION
line 74: "GetReadySchedulableNodesOrDie" should be replaced with “GetReadySchedulableNodes”.
"GetReadySchedulableNodesOrDie" is not defined in this file.