### PR TITLE
Update instancegroups.go

### DIFF
--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -337,7 +337,7 @@ func (r *RollingUpdateInstanceGroup) DrainNode(u *cloudinstances.CloudInstanceGr
 	return nil
 }
 
-// Delete and CloudInstanceGroups
+// Delete a CloudInstanceGroups
 func (r *RollingUpdateInstanceGroup) Delete() error {
 	if r.CloudGroup == nil {
 		return fmt.Errorf("group has to be set")


### PR DESCRIPTION
Line 340: “Delete and CloudInstanceGroups”
It should be “Delete a CloudInstanceGroups”, is it?