### PR TITLE
Tweaking verify-gendocs for bazel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ GID:=$(shell id -g)
 TESTABLE_PACKAGES:=$(shell egrep -v "k8s.io/kops/cloudmock|k8s.io/kops/vendor" hack/.packages)
 BAZEL_OPTIONS?=
 API_OPTIONS?=
+OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 
 # See http://stackoverflow.com/questions/18136918/how-to-get-current-relative-directory-of-your-makefile
 MAKEDIR:=$(strip $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))"))
@@ -326,10 +327,12 @@ gcs-publish-ci: gcs-upload
 	gsutil -h "Cache-Control:private, max-age=0, no-transform" cp ${UPLOAD}/${LATEST_FILE} ${GCS_LOCATION}
 
 .PHONY: gen-cli-docs
-gen-cli-docs: ${KOPS} # Regenerate CLI docs
-	KOPS_STATE_STORE= \
-	KOPS_FEATURE_FLAGS= \
+gen-cli-docs: ${KOPS} # Generate CLI docs
 	${KOPS} genhelpdocs --out docs/cli
+
+.PHONY: gen-cli-docs-bazel
+gen-cli-docs-bazel: # Generate CLI docs using bazel
+	bazel run //cmd/kops:kops -- genhelpdocs --out ${KOPS_ROOT}/docs/cli
 
 .PHONY: gen-api-docs
 gen-api-docs:
@@ -507,6 +510,15 @@ verify-gendocs: ${KOPS}
 	     exit 1; \
 	fi
 	@echo "cli docs up-to-date"
+
+.PHONY: verify-gendocs-bazel
+verify-gendocs-bazel: bazel-build-cli
+	@TMP_DOCS="$$(mktemp -d)"; \
+	${KOPS_ROOT}/bazel-bin/cmd/kops/${OS}_amd64_pure_stripped/kops genhelpdocs --out "$$TMP_DOCS"; \
+	\
+	if ! diff -r "$$TMP_DOCS" '${KOPS_ROOT}/docs/cli'; then \
+	     exit 1; \
+	fi
 
 .PHONY: verify-bazel
 verify-bazel:

--- a/hack/verify-gendocs.sh
+++ b/hack/verify-gendocs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+if make verify-gendocs-bazel; then
+	echo ""
+	echo "Success: docs are up to date"
+else
+	echo ""
+	echo "FAIL: - the hack/verify-gendocs.sh test failed, documentation is not up to date"
+	echo "FAIL: - please run the command 'make gen-cli-docs'"
+fi


### PR DESCRIPTION
Using bazel for verify-gendocs, so that we can re-use the bazel cache for a test run, and verify that the docs are up to date.