### PR TITLE
cloudmock: fix prefix for RouteTableAssociation

### DIFF
--- a/cloudmock/aws/mockec2/subnets.go
+++ b/cloudmock/aws/mockec2/subnets.go
@@ -180,7 +180,7 @@ func (m *MockEC2) AssociateRouteTable(request *ec2.AssociateRouteTableInput) (*e
 		return nil, fmt.Errorf("RouteTable not found")
 	}
 
-	associationID := m.allocateId("rta-")
+	associationID := m.allocateId("rta")
 
 	rt.Associations = append(rt.Associations, &ec2.RouteTableAssociation{
 		RouteTableId:            rt.RouteTableId,


### PR DESCRIPTION
We were generating ids with two hyphens (rta--1)