### PR TITLE
hacks for tests on windows

### DIFF
--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -131,7 +131,7 @@ func RunCreate(f *util.Factory, out io.Writer, c *CreateOptions) error {
 		}
 
 		// TODO: this does not support a JSON array
-		sections := bytes.Split(contents, []byte("\n---\n"))
+		sections := bytes.Split(bytes.Replace(contents, []byte("\r\n"), []byte("\n"), -1), []byte("\n---\n"))
 		for _, section := range sections {
 			defaults := &schema.GroupVersionKind{
 				Group:   v1alpha1.SchemeGroupVersion.Group,

--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -243,7 +243,8 @@ func runCreateClusterIntegrationTest(t *testing.T, srcDir string, version string
 		t.Fatalf("unexpected error reading expected YAML: %v", err)
 	}
 
-	expectedYAML := strings.TrimSpace(string(expectedYAMLBytes))
+	//on windows, with git set to autocrlf, the reference files on disk have windows line endings
+	expectedYAML := strings.Replace(strings.TrimSpace(string(expectedYAMLBytes)), "\r\n", "\n", -1)
 
 	actualYAML := strings.Join(yamlAll, "\n\n---\n\n")
 	if actualYAML != expectedYAML {

--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -251,6 +251,7 @@ func runTest(t *testing.T, h *testutils.IntegrationTestHarness, clusterName stri
 		if err != nil {
 			t.Fatalf("unexpected error reading expected terraform output: %v", err)
 		}
+		testDataTF = bytes.Replace(testDataTF, []byte("\r\n"), []byte("\n"), -1)
 
 		if !bytes.Equal(actualTF, testDataTF) {
 			diffString := diff.FormatDiff(string(testDataTF), string(actualTF))
@@ -543,7 +544,7 @@ func runTestCloudformation(t *testing.T, clusterName string, srcDir string, vers
 		}
 		actualCF = buf.Bytes()
 
-		expectedCFTrimmed := strings.TrimSpace(string(expectedCF))
+		expectedCFTrimmed := strings.Replace(strings.TrimSpace(string(expectedCF)), "\r\n", "\n", -1)
 		actualCFTrimmed := strings.TrimSpace(string(actualCF))
 		if actualCFTrimmed != expectedCFTrimmed {
 			diffString := diff.FormatDiff(expectedCFTrimmed, actualCFTrimmed)

--- a/pkg/testutils/integrationtestharness.go
+++ b/pkg/testutils/integrationtestharness.go
@@ -68,7 +68,9 @@ func NewIntegrationTestHarness(t *testing.T) *IntegrationTestHarness {
 		}
 		channelPath += "/"
 		h.originalDefaultChannelBase = kops.DefaultChannelBase
-		kops.DefaultChannelBase = "file://" + channelPath
+
+		// Make sure any platform-specific separators that aren't /, are converted to / for use in a file: protocol URL
+		kops.DefaultChannelBase = "file://" + filepath.ToSlash(channelPath)
 	}
 
 	return h


### PR DESCRIPTION
With these changes, all tests pass for me on windows 10 running "go version go1.9.4 windows/amd64"