### PR TITLE
Fix kubeScheduler.usePolicyConfigMap - missing namespace flag

### DIFF
--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -102,7 +102,7 @@ func (b *KubeSchedulerBuilder) buildPod() (*v1.Pod, error) {
 	flags = append(flags, "--kubeconfig="+"/var/lib/kube-scheduler/kubeconfig")
 
 	if c.UsePolicyConfigMap != nil {
-		flags = append(flags, "--policy-configmap=scheduler-policy")
+		flags = append(flags, "--policy-configmap=scheduler-policy --policy-configmap-namespace=kube-system")
 	}
 
 	pod := &v1.Pod{


### PR DESCRIPTION
This PR fixes the following issue: https://github.com/kubernetes/kops/issues/4725
