### PR TITLE
use the primary cert from the ca cert bundle

### DIFF
--- a/nodeup/pkg/model/secrets.go
+++ b/nodeup/pkg/model/secrets.go
@@ -50,7 +50,7 @@ func (b *SecretBuilder) Build(c *fi.ModelBuilderContext) error {
 			return fmt.Errorf("certificate %q not found", fi.CertificateId_CA)
 		}
 
-		serialized, err := ca.AsString()
+		serialized, err := ca.Primary.AsString()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
If the ca cert bundle has multiple certs, some things (kube-controller-manager in particular) will fail to startup correctly

As discussed here: https://github.com/kubernetes/kops/issues/3875

I went with the simplest thing that fixes my immediate use case. Happy to discuss if there's a more appropriate long term solution.