### PR TITLE
add kubeconfig flag; fix for issue#2378

### DIFF
--- a/cmd/kops/delete_cluster.go
+++ b/cmd/kops/delete_cluster.go
@@ -202,7 +202,7 @@ func RunDeleteCluster(f *util.Factory, out io.Writer, options *DeleteClusterOpti
 		}
 	}
 
-	b := kubeconfig.NewKubeconfigBuilder()
+	b := kubeconfig.NewKubeconfigBuilder(rootCommand.PathOptions())
 	b.Context = clusterName
 	err = b.DeleteKubeConfig()
 	if err != nil {

--- a/cmd/kops/export_kubecfg.go
+++ b/cmd/kops/export_kubecfg.go
@@ -93,7 +93,7 @@ func RunExportKubecfg(f *util.Factory, out io.Writer, options *ExportKubecfgOpti
 		return err
 	}
 
-	conf, err := kubeconfig.BuildKubecfg(cluster, keyStore, secretStore, &commands.CloudDiscoveryStatusStore{})
+	conf, err := kubeconfig.BuildKubecfg(rootCommand.PathOptions(), cluster, keyStore, secretStore, &commands.CloudDiscoveryStatusStore{})
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/root.go
+++ b/cmd/kops/root.go
@@ -75,6 +75,8 @@ type RootCmd struct {
 
 	clusterName string
 
+	pathOptions *clientcmd.PathOptions
+
 	cobraCommand *cobra.Command
 }
 
@@ -101,6 +103,8 @@ func init() {
 
 	factory := util.NewFactory(&rootCommand.FactoryOptions)
 	rootCommand.factory = factory
+
+	rootCommand.pathOptions = clientcmd.NewDefaultPathOptions()
 
 	NewCmdRoot(factory, os.Stdout)
 }
@@ -130,6 +134,9 @@ func NewCmdRoot(f *util.Factory, out io.Writer) *cobra.Command {
 
 	defaultClusterName := os.Getenv("KOPS_CLUSTER_NAME")
 	cmd.PersistentFlags().StringVarP(&rootCommand.clusterName, "name", "", defaultClusterName, "Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable")
+
+	// file paths are common to all sub commands
+	cmd.PersistentFlags().StringVar(&rootCommand.pathOptions.LoadingRules.ExplicitPath, rootCommand.pathOptions.ExplicitFileFlag, rootCommand.pathOptions.LoadingRules.ExplicitPath, "use a particular kubeconfig file")
 
 	// create subcommands
 	cmd.AddCommand(NewCmdCompletion(f, out))
@@ -214,9 +221,13 @@ func (c *RootCmd) ClusterName() string {
 	return c.clusterName
 }
 
+func (c *RootCmd) PathOptions() *clientcmd.PathOptions {
+	return c.pathOptions
+}
+
 func ClusterNameFromKubecfg() string {
 	// Read from kubeconfig
-	pathOptions := clientcmd.NewDefaultPathOptions()
+	pathOptions := rootCommand.PathOptions()
 
 	clusterName := ""
 

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -289,7 +289,7 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 		}
 		if kubecfgCert != nil {
 			glog.Infof("Exporting kubecfg for cluster")
-			conf, err := kubeconfig.BuildKubecfg(cluster, keyStore, secretStore, &commands.CloudDiscoveryStatusStore{})
+			conf, err := kubeconfig.BuildKubecfg(rootCommand.PathOptions(), cluster, keyStore, secretStore, &commands.CloudDiscoveryStatusStore{})
 			if err != nil {
 				return nil, err
 			}

--- a/docs/cli/kops.md
+++ b/docs/cli/kops.md
@@ -19,6 +19,7 @@ kops helps you create, destroy, upgrade and maintain production-grade, highly av
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_completion.md
+++ b/docs/cli/kops_completion.md
@@ -51,6 +51,7 @@ kops completion
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_create.md
+++ b/docs/cli/kops_create.md
@@ -55,6 +55,7 @@ kops create -f FILENAME
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -113,6 +113,7 @@ kops create cluster
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_create_instancegroup.md
+++ b/docs/cli/kops_create_instancegroup.md
@@ -45,6 +45,7 @@ kops create instancegroup
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_create_secret.md
+++ b/docs/cli/kops_create_secret.md
@@ -29,6 +29,7 @@ Create a secret
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_create_secret_dockerconfig.md
+++ b/docs/cli/kops_create_secret_dockerconfig.md
@@ -37,6 +37,7 @@ kops create secret dockerconfig
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_create_secret_encryptionconfig.md
+++ b/docs/cli/kops_create_secret_encryptionconfig.md
@@ -37,6 +37,7 @@ kops create secret encryptionconfig
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_create_secret_keypair.md
+++ b/docs/cli/kops_create_secret_keypair.md
@@ -24,6 +24,7 @@ Create a secret keypair
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_create_secret_keypair_ca.md
+++ b/docs/cli/kops_create_secret_keypair_ca.md
@@ -35,6 +35,7 @@ kops create secret keypair ca
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_create_secret_sshpublickey.md
+++ b/docs/cli/kops_create_secret_sshpublickey.md
@@ -33,6 +33,7 @@ kops create secret sshpublickey
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_delete.md
+++ b/docs/cli/kops_delete.md
@@ -40,6 +40,7 @@ kops delete -f FILENAME [--yes]
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_delete_cluster.md
+++ b/docs/cli/kops_delete_cluster.md
@@ -36,6 +36,7 @@ kops delete cluster CLUSTERNAME [--yes]
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_delete_instancegroup.md
+++ b/docs/cli/kops_delete_instancegroup.md
@@ -34,6 +34,7 @@ kops delete instancegroup
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_delete_secret.md
+++ b/docs/cli/kops_delete_secret.md
@@ -25,6 +25,7 @@ kops delete secret
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_describe.md
+++ b/docs/cli/kops_describe.md
@@ -21,6 +21,7 @@ Get additional information about cloud and cluster resources.
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_describe_secrets.md
+++ b/docs/cli/kops_describe_secrets.md
@@ -31,6 +31,7 @@ kops describe secrets
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_edit.md
+++ b/docs/cli/kops_edit.md
@@ -31,6 +31,7 @@ Edit a resource configuration. This command changes the desired configuration in
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_edit_cluster.md
+++ b/docs/cli/kops_edit_cluster.md
@@ -33,6 +33,7 @@ kops edit cluster
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_edit_instancegroup.md
+++ b/docs/cli/kops_edit_instancegroup.md
@@ -33,6 +33,7 @@ kops edit instancegroup
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_export.md
+++ b/docs/cli/kops_export.md
@@ -22,6 +22,7 @@ Export configurations from a cluster.
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_export_kubecfg.md
+++ b/docs/cli/kops_export_kubecfg.md
@@ -26,6 +26,7 @@ kops export kubecfg CLUSTERNAME
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_get.md
+++ b/docs/cli/kops_get.md
@@ -51,6 +51,7 @@ kops get
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_get_clusters.md
+++ b/docs/cli/kops_get_clusters.md
@@ -41,6 +41,7 @@ kops get clusters
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_get_instancegroups.md
+++ b/docs/cli/kops_get_instancegroups.md
@@ -32,6 +32,7 @@ kops get instancegroups
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_get_secrets.md
+++ b/docs/cli/kops_get_secrets.md
@@ -35,6 +35,7 @@ kops get secrets
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_import.md
+++ b/docs/cli/kops_import.md
@@ -23,6 +23,7 @@ Imports a kubernetes cluster created by kube-up.sh into a state store.  This com
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_import_cluster.md
+++ b/docs/cli/kops_import_cluster.md
@@ -33,6 +33,7 @@ kops import cluster
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_replace.md
+++ b/docs/cli/kops_replace.md
@@ -36,6 +36,7 @@ kops replace -f FILENAME
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_rolling-update.md
+++ b/docs/cli/kops_rolling-update.md
@@ -66,6 +66,7 @@ Note: terraform users will need to run all of the following commands from the sa
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -85,6 +85,7 @@ kops rolling-update cluster
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_set.md
+++ b/docs/cli/kops_set.md
@@ -24,6 +24,7 @@ kops set does not update the cloud resources, to apply the changes use "kops upd
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_set_cluster.md
+++ b/docs/cli/kops_set_cluster.md
@@ -30,6 +30,7 @@ kops set cluster
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_toolbox.md
+++ b/docs/cli/kops_toolbox.md
@@ -22,6 +22,7 @@ Misc infrequently used commands.
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_toolbox_bundle.md
+++ b/docs/cli/kops_toolbox_bundle.md
@@ -32,6 +32,7 @@ kops toolbox bundle
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_toolbox_convert-imported.md
+++ b/docs/cli/kops_toolbox_convert-imported.md
@@ -37,6 +37,7 @@ kops toolbox convert-imported
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_toolbox_dump.md
+++ b/docs/cli/kops_toolbox_dump.md
@@ -32,6 +32,7 @@ kops toolbox dump
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_toolbox_template.md
+++ b/docs/cli/kops_toolbox_template.md
@@ -43,6 +43,7 @@ kops toolbox template
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_update.md
+++ b/docs/cli/kops_update.md
@@ -22,6 +22,7 @@ Creates or updates cloud resources to match cluster desired configuration.
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -41,6 +41,7 @@ kops update cluster
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_upgrade.md
+++ b/docs/cli/kops_upgrade.md
@@ -22,6 +22,7 @@ Automates checking for and applying Kubernetes updates. This upgrades a cluster 
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_upgrade_cluster.md
+++ b/docs/cli/kops_upgrade_cluster.md
@@ -33,6 +33,7 @@ kops upgrade cluster
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_validate.md
+++ b/docs/cli/kops_validate.md
@@ -29,6 +29,7 @@ This commands validates the following components:
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_validate_cluster.md
+++ b/docs/cli/kops_validate_cluster.md
@@ -39,6 +39,7 @@ kops validate cluster
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/docs/cli/kops_version.md
+++ b/docs/cli/kops_version.md
@@ -25,6 +25,7 @@ kops version
 ```
       --alsologtostderr                  log to standard error as well as files
       --config string                    config file (default is $HOME/.kops.yaml)
+      --kubeconfig string                use a particular kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
       --logtostderr                      log to standard error instead of files (default false)

--- a/pkg/kubeconfig/create_kubecfg.go
+++ b/pkg/kubeconfig/create_kubecfg.go
@@ -21,12 +21,13 @@ import (
 	"sort"
 
 	"github.com/golang/glog"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/dns"
 	"k8s.io/kops/upup/pkg/fi"
 )
 
-func BuildKubecfg(cluster *kops.Cluster, keyStore fi.Keystore, secretStore fi.SecretStore, status kops.StatusStore) (*KubeconfigBuilder, error) {
+func BuildKubecfg(pathOptions *clientcmd.PathOptions, cluster *kops.Cluster, keyStore fi.Keystore, secretStore fi.SecretStore, status kops.StatusStore) (*KubeconfigBuilder, error) {
 	clusterName := cluster.ObjectMeta.Name
 
 	master := cluster.Spec.MasterPublicName
@@ -64,7 +65,7 @@ func BuildKubecfg(cluster *kops.Cluster, keyStore fi.Keystore, secretStore fi.Se
 		}
 	}
 
-	b := NewKubeconfigBuilder()
+	b := NewKubeconfigBuilder(pathOptions)
 
 	b.Context = clusterName
 

--- a/pkg/kubeconfig/kubecfg_builder.go
+++ b/pkg/kubeconfig/kubecfg_builder.go
@@ -45,9 +45,9 @@ type KubeconfigBuilder struct {
 }
 
 // Create new KubeconfigBuilder
-func NewKubeconfigBuilder() *KubeconfigBuilder {
+func NewKubeconfigBuilder(pathOptions *clientcmd.PathOptions) *KubeconfigBuilder {
 	c := &KubeconfigBuilder{}
-	c.configAccess = clientcmd.NewDefaultPathOptions()
+	c.configAccess = pathOptions
 	return c
 }
 


### PR DESCRIPTION
 fix for issue #2378

Note that the kubeconfig will not be overridden if the config is borrowed from kubectl env (though that code is disabled right now).

Signed-off-by: Rajat Chopra <rchopra@redhat.com>