### PR TITLE
Add AfterFiles dependencies to File tasks

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -718,9 +718,10 @@ func (b *DockerBuilder) buildContainerOSConfigurationDropIn(c *fi.ModelBuilderCo
 	contents := strings.Join(lines, "\n")
 
 	c.AddTask(&nodetasks.File{
-		Path:     "/etc/systemd/system/docker.service.d/10-kops.conf",
-		Contents: fi.NewStringResource(contents),
-		Type:     nodetasks.FileType_File,
+		AfterFiles: []string{"/etc/sysconfig/docker"},
+		Path:       "/etc/systemd/system/docker.service.d/10-kops.conf",
+		Contents:   fi.NewStringResource(contents),
+		Type:       nodetasks.FileType_File,
 		OnChangeExecute: [][]string{
 			{"systemctl", "daemon-reload"},
 			{"systemctl", "restart", "docker.service"},

--- a/upup/pkg/fi/nodeup/nodetasks/BUILD.bazel
+++ b/upup/pkg/fi/nodeup/nodetasks/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     srcs = [
         "archive_test.go",
         "bindmount_test.go",
+        "file_test.go",
         "loadimage_test.go",
         "service_test.go",
     ],

--- a/upup/pkg/fi/nodeup/nodetasks/file.go
+++ b/upup/pkg/fi/nodeup/nodetasks/file.go
@@ -38,6 +38,7 @@ const FileType_Directory = "directory"
 const FileType_File = "file"
 
 type File struct {
+	AfterFiles      []string    `json:"afterfiles,omitempty"`
 	Contents        fi.Resource `json:"contents,omitempty"`
 	Group           *string     `json:"group,omitempty"`
 	IfNotExists     bool        `json:"ifNotExists,omitempty"`
@@ -101,6 +102,17 @@ func (e *File) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 	// Requires parent directories to be created
 	for _, v := range findCreatesDirParents(e.Path, tasks) {
 		deps = append(deps, v)
+	}
+
+	// Requires other files to be created first
+	for _, f := range e.AfterFiles {
+		for _, v := range tasks {
+			if file, ok := v.(*File); ok {
+				if file.Path == f {
+					deps = append(deps, v)
+				}
+			}
+		}
 	}
 
 	return deps

--- a/upup/pkg/fi/nodeup/nodetasks/file_test.go
+++ b/upup/pkg/fi/nodeup/nodetasks/file_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodetasks
+
+import (
+	"testing"
+
+	"k8s.io/kops/upup/pkg/fi"
+)
+
+func TestFileDependencies(t *testing.T) {
+	parentFileName := "/dependedon"
+	childFileName := "/dependant"
+
+	grid := []struct {
+		parent fi.Task
+		child  fi.Task
+	}{
+		{
+			parent: &File{
+				Path:     parentFileName,
+				Contents: fi.NewStringResource("I am depended on by " + childFileName),
+				Type:     FileType_File,
+			},
+			child: &File{
+				AfterFiles: []string{parentFileName},
+				Path:       childFileName,
+				Contents:   fi.NewStringResource("I depend on " + parentFileName),
+				Type:       FileType_File,
+			},
+		},
+	}
+
+	for _, g := range grid {
+		allTasks := make(map[string]fi.Task)
+		allTasks["parent"] = g.parent
+		allTasks["child"] = g.child
+
+		deps := g.parent.(fi.HasDependencies).GetDependencies(allTasks)
+		if len(deps) != 0 {
+			t.Errorf("found unexpected dependencies for parent: %v %v", g.parent, deps)
+		}
+
+		childDeps := g.child.(fi.HasDependencies).GetDependencies(allTasks)
+		if len(childDeps) != 1 {
+			t.Errorf("found unexpected dependencies for child: %v %v", g.child, childDeps)
+		}
+	}
+}


### PR DESCRIPTION
This adds a new "AfterFiles" field to the File task.
It allows File tasks to depend on the creation of another file first. 
The typical use case would be for a service which depends on multiple files and must not be restarted before they are all written to disk, such as Docker. 

Fixes #4747 

(I am sure this can be improved. I am putting it out there as a WIP and a basis for discussion of #4747).
Feel free to squash the commits. 