### PR TITLE
Support for auth plugins in channels

### DIFF
--- a/channels/pkg/cmd/BUILD.bazel
+++ b/channels/pkg/cmd/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/plugin/pkg/client/auth:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
     ],
 )

--- a/channels/pkg/cmd/factory.go
+++ b/channels/pkg/cmd/factory.go
@@ -21,6 +21,8 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 type Factory interface {


### PR DESCRIPTION
* Otherwise I get:
  `Error: cannot build kube client: No Auth Provider found for name "oidc"`