### PR TITLE
Deletion: check if VPC is shared

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -199,7 +199,7 @@ func addUntaggedRouteTables(cloud awsup.AWSCloud, clusterName string, resources 
 			continue
 		}
 
-		if resources["vpc:"+vpcID] == nil {
+		if resources["vpc:"+vpcID] == nil || resources["vpc:"+vpcID].Shared {
 			// Not deleting this VPC; ignore
 			continue
 		}


### PR DESCRIPTION
We have logic that checks if a VPC is being deleted, but it did not
consider the fact that VPCs can be shared.

Issue #4767