### PR TITLE
ElasticIP: Always tag

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
@@ -229,10 +229,10 @@ func (_ *ElasticIP) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *ElasticIP) e
 	} else {
 		publicIp = a.PublicIP
 		eipId = a.ID
-		err := t.AddAWSTags(*a.ID, changes.Tags)
-		if err != nil {
-			return fmt.Errorf("unable to tag ElasticIP: %v", err)
-		}
+	}
+
+	if err := t.AddAWSTags(*e.ID, e.Tags); err != nil {
+		return err
 	}
 
 	// Tag the associated subnet


### PR DESCRIPTION
Previously we weren't tagging the ElasticIP on initial creation.