### PR TITLE
intersectTags: return nil if comparing against nil

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/tags.go
+++ b/upup/pkg/fi/cloudup/awstasks/tags.go
@@ -56,5 +56,9 @@ func intersectTags(tags []*ec2.Tag, desired map[string]string) map[string]string
 			actual[k] = v
 		}
 	}
+	if len(actual) == 0 && desired == nil {
+		// Avoid problems with comparison between nil & {}
+		return nil
+	}
 	return actual
 }


### PR DESCRIPTION
When we're building the tag map, if we build an empty map and are
comparing against nil, return nil.  Avoids spurious comparison issues.