### PR TITLE
Tag ElasticIP when owned

### DIFF
--- a/cloudmock/aws/mockec2/address.go
+++ b/cloudmock/aws/mockec2/address.go
@@ -71,7 +71,7 @@ func (m *MockEC2) AllocateAddressWithId(request *ec2.AllocateAddressInput, id st
 
 func (m *MockEC2) AllocateAddress(request *ec2.AllocateAddressInput) (*ec2.AllocateAddressOutput, error) {
 	glog.Infof("AllocateAddress: %v", request)
-	id := m.allocateId("eip")
+	id := m.allocateId("eipalloc")
 	return m.AllocateAddressWithId(request, id)
 }
 

--- a/cloudmock/aws/mockec2/tags.go
+++ b/cloudmock/aws/mockec2/tags.go
@@ -29,6 +29,7 @@ import (
 
 // Not (yet?) in aws-sdk-go
 const ResourceTypeNatGateway = "nat-gateway"
+const ResourceTypeAddress = "elastic-ip"
 
 func (m *MockEC2) CreateTagsRequest(*ec2.CreateTagsInput) (*request.Request, *ec2.CreateTagsOutput) {
 	panic("Not implemented")
@@ -74,6 +75,8 @@ func (m *MockEC2) addTag(resourceId string, tag *ec2.Tag) {
 		resourceType = ec2.ResourceTypeDhcpOptions
 	} else if strings.HasPrefix(resourceId, "rtb-") {
 		resourceType = ec2.ResourceTypeRouteTable
+	} else if strings.HasPrefix(resourceId, "eipalloc-") {
+		resourceType = ResourceTypeAddress
 	} else {
 		glog.Fatalf("Unknown resource-type in create tags: %v", resourceId)
 	}

--- a/pkg/model/network.go
+++ b/pkg/model/network.go
@@ -267,8 +267,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			// Every NGW needs a public (Elastic) IP address, every private
 			// subnet needs a NGW, lets create it. We tie it to a subnet
 			// so we can track it in AWS
-			var eip = &awstasks.ElasticIP{}
-			eip = &awstasks.ElasticIP{
+			eip := &awstasks.ElasticIP{
 				Name:                           s(zone + "." + b.ClusterName()),
 				Lifecycle:                      b.Lifecycle,
 				AssociatedNatGatewayRouteTable: b.LinkToPrivateRouteTableInZone(zone),
@@ -277,6 +276,8 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			if b.Cluster.Spec.Subnets[i].PublicIP != "" {
 				eip.PublicIP = s(b.Cluster.Spec.Subnets[i].PublicIP)
 				eip.Tags = b.CloudTags(*eip.Name, true)
+			} else {
+				eip.Tags = b.CloudTags(*eip.Name, false)
 			}
 
 			c.AddTask(eip)

--- a/pkg/testutils/integrationtestharness.go
+++ b/pkg/testutils/integrationtestharness.go
@@ -172,11 +172,11 @@ func (h *IntegrationTestHarness) SetupMockAWS() *awsup.MockAWSCloud {
 
 	mockEC2.AllocateAddressWithId(&ec2.AllocateAddressInput{
 		Address: aws.String("123.45.67.8"),
-	}, "eip-12345678")
+	}, "eipalloc-12345678")
 
 	mockEC2.CreateNatGatewayWithId(&ec2.CreateNatGatewayInput{
 		SubnetId:     aws.String("subnet-12345678"),
-		AllocationId: aws.String("eip-12345678"),
+		AllocationId: aws.String("eipalloc-12345678"),
 	}, "nat-12345678")
 
 	return cloud


### PR DESCRIPTION
Currently we were only tagging it if shared, but tagging for owned
objects has fewer downsides.