### PR TITLE
Check tags in lifecycle tests

### DIFF
--- a/cloudmock/aws/mockec2/api.go
+++ b/cloudmock/aws/mockec2/api.go
@@ -85,7 +85,7 @@ func (m *MockEC2) All() map[string]interface{} {
 		all[id] = o
 	}
 	for id, o := range m.KeyPairs {
-		all[id] = o
+		all["sshkey-"+id] = o
 	}
 	for id, o := range m.Vpcs {
 		all[id] = o

--- a/cloudmock/aws/mockec2/routetable.go
+++ b/cloudmock/aws/mockec2/routetable.go
@@ -106,26 +106,29 @@ func (m *MockEC2) DescribeRouteTables(request *ec2.DescribeRouteTablesInput) (*e
 }
 
 func (m *MockEC2) CreateRouteTable(request *ec2.CreateRouteTableInput) (*ec2.CreateRouteTableOutput, error) {
+	glog.Infof("CreateRouteTable: %v", request)
+
+	id := m.allocateId("rtb")
+	return m.CreateRouteTableWithId(request, id)
+}
+
+func (m *MockEC2) CreateRouteTableWithId(request *ec2.CreateRouteTableInput, id string) (*ec2.CreateRouteTableOutput, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-
-	glog.Infof("CreateRouteTable: %v", request)
 
 	if request.DryRun != nil {
 		glog.Fatalf("DryRun")
 	}
 
-	n := len(m.RouteTables) + 1
-
 	rt := &ec2.RouteTable{
-		RouteTableId: s(fmt.Sprintf("rtb-%d", n)),
+		RouteTableId: s(id),
 		VpcId:        request.VpcId,
 	}
 
 	if m.RouteTables == nil {
 		m.RouteTables = make(map[string]*ec2.RouteTable)
 	}
-	m.RouteTables[*rt.RouteTableId] = rt
+	m.RouteTables[id] = rt
 
 	copy := *rt
 	response := &ec2.CreateRouteTableOutput{

--- a/cmd/kops/lifecycle_integration_test.go
+++ b/cmd/kops/lifecycle_integration_test.go
@@ -201,6 +201,11 @@ func runLifecycleTest(h *testutils.IntegrationTestHarness, o *LifecycleTestOptio
 				resource = id[:dashIndex]
 			}
 
+			legacy := tags["KubernetesCluster"]
+			if legacy != "" && legacy != o.ClusterName {
+				t.Errorf("unexpected legacy KubernetesCluster tag: actual=%q cluster=%q", legacy, o.ClusterName)
+			}
+
 			ownership := tags["kubernetes.io/cluster/"+o.ClusterName]
 			if beforeResources[id] != nil {
 				expect := ""
@@ -221,6 +226,11 @@ func runLifecycleTest(h *testutils.IntegrationTestHarness, o *LifecycleTestOptio
 				default:
 					if ownership == "" {
 						t.Errorf("no kubernetes.io/cluster/ tag on %q", id)
+					}
+					if legacy == "" {
+						// We want to deprecate the KubernetesCluster tag, e.g. in IAM
+						// but we should probably keep it around for people that may be using it for other purposes
+						t.Errorf("no (legacy) KubernetesCluster tag on %q", id)
 					}
 				}
 			}

--- a/pkg/testutils/integrationtestharness.go
+++ b/pkg/testutils/integrationtestharness.go
@@ -159,16 +159,28 @@ func (h *IntegrationTestHarness) SetupMockAWS() *awsup.MockAWSCloud {
 		VpcId:             aws.String("vpc-12345678"),
 	})
 
+	mockEC2.CreateRouteTableWithId(&ec2.CreateRouteTableInput{
+		VpcId: aws.String("vpc-12345678"),
+	}, "rtb-12345678")
+
 	mockEC2.CreateSubnetWithId(&ec2.CreateSubnetInput{
 		VpcId:            aws.String("vpc-12345678"),
 		AvailabilityZone: aws.String("us-test-1a"),
 		CidrBlock:        aws.String("172.20.32.0/19"),
 	}, "subnet-12345678")
+	mockEC2.AssociateRouteTable(&ec2.AssociateRouteTableInput{
+		RouteTableId: aws.String("rtb-12345678"),
+		SubnetId:     aws.String("subnet-12345678"),
+	})
 	mockEC2.CreateSubnetWithId(&ec2.CreateSubnetInput{
 		VpcId:            aws.String("vpc-12345678"),
 		AvailabilityZone: aws.String("us-test-1a"),
 		CidrBlock:        aws.String("172.20.4.0/22"),
 	}, "subnet-abcdef")
+	mockEC2.AssociateRouteTable(&ec2.AssociateRouteTableInput{
+		RouteTableId: aws.String("rtb-12345678"),
+		SubnetId:     aws.String("subnet-abcdef"),
+	})
 
 	mockEC2.AllocateAddressWithId(&ec2.AllocateAddressInput{
 		Address: aws.String("123.45.67.8"),


### PR DESCRIPTION
We want to make sure that everything owned is tagged as such, and that
some shared resources (in particular subnets) are tagged as such.