### PR TITLE
NAT gateway deletion: honor shared tag

### DIFF
--- a/pkg/resources/aws/BUILD.bazel
+++ b/pkg/resources/aws/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "aws.go",
         "errors.go",
         "filters.go",
+        "natgateway.go",
         "routetable.go",
         "securitygroup.go",
         "tags.go",

--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -760,22 +760,9 @@ func ListSubnets(cloud fi.Cloud, clusterName string) ([]*resources.Resource, err
 				continue
 			}
 
-			resourceTracker := &resources.Resource{
-				Name:    id,
-				ID:      id,
-				Type:    TypeNatGateway,
-				Deleter: DeleteNatGateway,
-				Shared:  sharedNgwIds.Has(id) || !ownedNatGatewayIds.Has(id),
-			}
-
-			// The NAT gateway blocks deletion of any associated Elastic IPs
-			for _, address := range ngw.NatGatewayAddresses {
-				if address.AllocationId != nil {
-					resourceTracker.Blocks = append(resourceTracker.Blocks, TypeElasticIp+":"+aws.StringValue(address.AllocationId))
-				}
-			}
-
-			resourceTrackers = append(resourceTrackers, resourceTracker)
+			forceShared := sharedNgwIds.Has(id) || !ownedNatGatewayIds.Has(id)
+			r := buildNatGatewayResource(ngw, forceShared, clusterName)
+			resourceTrackers = append(resourceTrackers, r)
 		}
 	}
 
@@ -1197,19 +1184,14 @@ func FindNatGateways(cloud fi.Cloud, routeTables map[string]*resources.Resource,
 			return nil, fmt.Errorf("NextToken set from DescribeNatGateways, but pagination not implemented")
 		}
 
-		for _, t := range response.NatGateways {
-			natGatewayId := aws.StringValue(t.NatGatewayId)
-			ngwTracker := &resources.Resource{
-				Name:    natGatewayId,
-				ID:      natGatewayId,
-				Type:    TypeNatGateway,
-				Deleter: DeleteNatGateway,
-				Shared:  !ownedNatGatewayIds.Has(natGatewayId),
-			}
-			resourceTrackers = append(resourceTrackers, ngwTracker)
+		for _, ngw := range response.NatGateways {
+			natGatewayId := aws.StringValue(ngw.NatGatewayId)
+
+			forceShared := !ownedNatGatewayIds.Has(natGatewayId)
+			resourceTrackers = append(resourceTrackers, buildNatGatewayResource(ngw, forceShared, clusterName))
 
 			// If we're deleting the NatGateway, we should delete the ElasticIP also
-			for _, address := range t.NatGatewayAddresses {
+			for _, address := range ngw.NatGatewayAddresses {
 				if address.AllocationId != nil {
 					name := aws.StringValue(address.PublicIp)
 					if name == "" {
@@ -1235,7 +1217,6 @@ func FindNatGateways(cloud fi.Cloud, routeTables map[string]*resources.Resource,
 							Shared:  HasSharedTag(TypeElasticIp+":"+*eip.AllocationId, eip.Tags, clusterName) || !ownedNatGatewayIds.Has(natGatewayId),
 						}
 						resourceTrackers = append(resourceTrackers, eipTracker)
-						ngwTracker.Blocks = append(ngwTracker.Blocks, eipTracker.Type+":"+eipTracker.ID)
 					}
 				}
 			}

--- a/pkg/resources/aws/natgateway.go
+++ b/pkg/resources/aws/natgateway.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+
+	"k8s.io/kops/pkg/resources"
+)
+
+func buildNatGatewayResource(ngw *ec2.NatGateway, forceShared bool, clusterName string) *resources.Resource {
+	id := aws.StringValue(ngw.NatGatewayId)
+
+	r := &resources.Resource{
+		Name:    id,
+		ID:      id,
+		Type:    TypeNatGateway,
+		Deleter: DeleteNatGateway,
+		Shared:  forceShared,
+	}
+
+	if HasSharedTag(r.Type+":"+r.Name, ngw.Tags, clusterName) {
+		r.Shared = true
+	}
+
+	// The NAT gateway blocks deletion of any associated Elastic IPs
+	for _, address := range ngw.NatGatewayAddresses {
+		if address.AllocationId != nil {
+			r.Blocks = append(r.Blocks, TypeElasticIp+":"+aws.StringValue(address.AllocationId))
+		}
+	}
+
+	return r
+}


### PR DESCRIPTION
We previously weren't tagging NAT gateways (it wasn't supported).  Now
we are, so if a NAT gateway is tagged as shared, we will honor that tag.