### PR TITLE
Add simple sanity check for 4758

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/vpc_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc_test.go
@@ -103,3 +103,28 @@ func buildTags(tags map[string]string) []*ec2.Tag {
 	}
 	return t
 }
+
+// Test4758 is a sanity check for https://github.com/kubernetes/kops/issues/4758
+func Test4758(t *testing.T) {
+	a := &VPC{
+		Name: s("cluster2.example.com"),
+		Tags: map[string]string{},
+	}
+
+	e := &VPC{
+		Name: s("cluster2.example.com"),
+		Tags: map[string]string{},
+	}
+
+	changes := &VPC{}
+	changed := fi.BuildChanges(a, e, changes)
+
+	if changed {
+		t.Errorf("expected changed=false")
+	}
+
+	expectedChanges := &VPC{}
+	if !reflect.DeepEqual(changes, expectedChanges) {
+		t.Errorf("unexpected changes: +%v", changes)
+	}
+}


### PR DESCRIPTION
The tag logic should be fixed now, but we add a quick unit test anyway.