### PR TITLE
Typo fix in dockerconfig.go

### DIFF
--- a/pkg/apis/kops/v1alpha1/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha1/dockerconfig.go
@@ -36,7 +36,7 @@ type DockerConfig struct {
 	InsecureRegistry *string `json:"insecureRegistry,omitempty" flag:"insecure-registry"`
 	// LiveRestore enables live restore of docker when containers are still running
 	LiveRestore *bool `json:"liveRestore,omitempty" flag:"live-restore"`
-	// LogDriver is the defailt driver for container logs (default "json-file")
+	// LogDriver is the default driver for container logs (default "json-file")
 	LogDriver *string `json:"logDriver,omitempty" flag:"log-driver"`
 	// LogLevel is the logging level ("debug", "info", "warn", "error", "fatal") (default "info")
 	LogLevel *string `json:"logLevel,omitempty" flag:"log-level"`

--- a/pkg/apis/kops/v1alpha2/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha2/dockerconfig.go
@@ -36,7 +36,7 @@ type DockerConfig struct {
 	InsecureRegistry *string `json:"insecureRegistry,omitempty" flag:"insecure-registry"`
 	// LiveRestore enables live restore of docker when containers are still running
 	LiveRestore *bool `json:"liveRestore,omitempty" flag:"live-restore"`
-	// LogDriver is the defailt driver for container logs (default "json-file")
+	// LogDriver is the default driver for container logs (default "json-file")
 	LogDriver *string `json:"logDriver,omitempty" flag:"log-driver"`
 	// LogLevel is the logging level ("debug", "info", "warn", "error", "fatal") (default "info")
 	LogLevel *string `json:"logLevel,omitempty" flag:"log-level"`


### PR DESCRIPTION
Typo fix: defailt->default.
This typo "defailt" exists in 3 dockerconfig.go files, two are here, another one is in #4800.
I am not sure these alpha folders need or not to be fixed.  If not, please tell me to close this PR. 
Thanks.