### PR TITLE
Update addon.go

### DIFF
--- a/channels/pkg/channels/addon.go
+++ b/channels/pkg/channels/addon.go
@@ -137,7 +137,7 @@ func (a *Addon) EnsureUpdated(k8sClient kubernetes.Interface) (*AddonUpdate, err
 	channel := a.buildChannel()
 	err = channel.SetInstalledVersion(k8sClient, a.ChannelVersion())
 	if err != nil {
-		return nil, fmt.Errorf("error applying annotation to to record addon installation: %v", err)
+		return nil, fmt.Errorf("error applying annotation to record addon installation: %v", err)
 	}
 
 	return required, nil


### PR DESCRIPTION
line 140: return nil, fmt.Errorf("error applying annotation to to record addon installation: %v", err)
I guess the word "to to" is duplicated here, isn't it?