### PR TITLE
only enable SSE when not using custom s3 endpoint

### DIFF
--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -124,7 +124,10 @@ func (p *S3Path) WriteFile(data io.ReadSeeker, aclObj ACL) error {
 	request.Body = data
 	request.Bucket = aws.String(p.bucket)
 	request.Key = aws.String(p.key)
-	request.ServerSideEncryption = aws.String(sse)
+	// only support SSE if a custom endpoint is not provided
+	if aws.StringValue(client.Config.Endpoint) == "" {
+		request.ServerSideEncryption = aws.String(sse)
+	}
 
 	acl := os.Getenv("KOPS_STATE_S3_ACL")
 	acl = strings.TrimSpace(acl)


### PR DESCRIPTION
This was originally brought up since using SSE on a custom endpoint that is S3 compatible does not work (digitalocean spaces for example), if this is not a desired behaviour for other custom endpoints I can start work for creating a `do://` VFS instead of piggybacking off of S3 VFS.

re: https://github.com/kubernetes/kops/pull/4697#discussion_r178475607