### PR TITLE
add proxy mode flag to kube-proxy

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -180,6 +180,8 @@ type KubeProxyConfig struct {
 	Master string `json:"master,omitempty" flag:"master"`
 	// Enabled allows enabling or disabling kube-proxy
 	Enabled *bool `json:"enabled,omitempty"`
+	// Which proxy mode to use: (userspace, iptables(default), ipvs)
+	ProxyMode string `json:"proxyMode,omitempty" flag:"proxy-mode"`
 	// FeatureGates is a series of key pairs used to switch on features for the proxy
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
 }

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -180,6 +180,8 @@ type KubeProxyConfig struct {
 	Master string `json:"master,omitempty" flag:"master"`
 	// Enabled allows enabling or disabling kube-proxy
 	Enabled *bool `json:"enabled,omitempty"`
+	// Which proxy mode to use: (userspace, iptables(default), ipvs)
+	ProxyMode string `json:"proxyMode,omitempty" flag:"proxy-mode"`
 	// FeatureGates is a series of key pairs used to switch on features for the proxy
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
 }

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -180,6 +180,8 @@ type KubeProxyConfig struct {
 	Master string `json:"master,omitempty" flag:"master"`
 	// Enabled allows enabling or disabling kube-proxy
 	Enabled *bool `json:"enabled,omitempty"`
+	// Which proxy mode to use: (userspace, iptables, ipvs)
+	ProxyMode string `json:"proxyMode,omitempty" flag:"proxy-mode"`
 	// FeatureGates is a series of key pairs used to switch on features for the proxy
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
 }


### PR DESCRIPTION
add support proxy-mode flag for kube-proxy.
It's need for IPVS setup. 
```
- --feature-gates=SupportIPVSProxyMode=true
- --proxy-mode=ipvs
```