### PR TITLE
digitalocean: add kubelet hostname override

### DIFF
--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -162,6 +162,7 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 
 	if cloudProvider == kops.CloudProviderDO {
 		clusterSpec.Kubelet.CloudProvider = "external"
+		clusterSpec.Kubelet.HostnameOverride = "@digitalocean"
 	}
 
 	if cloudProvider == kops.CloudProviderGCE {

--- a/util/pkg/vfs/context.go
+++ b/util/pkg/vfs/context.go
@@ -79,6 +79,9 @@ func (c *VFSContext) ReadFile(location string) ([]byte, error) {
 			case "aws":
 				httpURL := "http://169.254.169.254/latest/" + u.Path
 				return c.readHttpLocation(httpURL, nil)
+			case "digitalocean":
+				httpURL := "http://169.254.169.254/metadata/v1" + u.Path
+				return c.readHttpLocation(httpURL, nil)
 
 			default:
 				return nil, fmt.Errorf("unknown metadata type: %q in %q", u.Host, location)


### PR DESCRIPTION
Uses the nodes private IPv4 address (fetched from metadata service) for hostname override. This is so we can use node's hostname to reach the node and we know private IPs will unique.

https://github.com/kubernetes/kops/issues/2150