### PR TITLE
Don't enable dns-controller prometheus metrics by default

### DIFF
--- a/dns-controller/cmd/dns-controller/main.go
+++ b/dns-controller/cmd/dns-controller/main.go
@@ -70,7 +70,7 @@ func main() {
 	flags.StringVar(&gossipSecret, "gossip-secret", gossipSecret, "Secret to use to secure gossip")
 	flags.StringVar(&watchNamespace, "watch-namespace", "", "Limits the functionality for pods, services and ingress to specific namespace, by default all")
 	flag.IntVar(&route53.MaxBatchSize, "route53-batch-size", route53.MaxBatchSize, "Maximum number of operations performed per changeset batch")
-	flag.StringVar(&metricsListen, "metrics-listen-addr", "", "The address on which to listen for Prometheus metrics.")
+	flag.StringVar(&metricsListen, "metrics-listen", "", "The address on which to listen for Prometheus metrics.")
 
 	// Trick to avoid 'logging before flag.Parse' warning
 	flag.CommandLine.Parse([]string{})

--- a/dns-controller/cmd/dns-controller/main.go
+++ b/dns-controller/cmd/dns-controller/main.go
@@ -70,7 +70,7 @@ func main() {
 	flags.StringVar(&gossipSecret, "gossip-secret", gossipSecret, "Secret to use to secure gossip")
 	flags.StringVar(&watchNamespace, "watch-namespace", "", "Limits the functionality for pods, services and ingress to specific namespace, by default all")
 	flag.IntVar(&route53.MaxBatchSize, "route53-batch-size", route53.MaxBatchSize, "Maximum number of operations performed per changeset batch")
-	flag.StringVar(&metricsListen, "metrics-listen-addr", ":3999", "The address on which to listen for Prometheus metrics.")
+	flag.StringVar(&metricsListen, "metrics-listen-addr", "", "The address on which to listen for Prometheus metrics.")
 
 	// Trick to avoid 'logging before flag.Parse' warning
 	flag.CommandLine.Parse([]string{})
@@ -79,10 +79,12 @@ func main() {
 	flags.AddGoFlagSet(flag.CommandLine)
 	flags.Parse(os.Args)
 
-	go func() {
-		http.Handle("/metrics", promhttp.Handler())
-		log.Fatal(http.ListenAndServe(metricsListen, nil))
-	}()
+	if metricsListen != "" {
+		go func() {
+			http.Handle("/metrics", promhttp.Handler())
+			log.Fatal(http.ListenAndServe(metricsListen, nil))
+		}()
+	}
 
 	zoneRules, err := dns.ParseZoneRules(zones)
 	if err != nil {

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -180,7 +180,6 @@ func (tf *TemplateFunctions) DnsControllerArgv() ([]string, error) {
 	if dns.IsGossipHostname(tf.cluster.Spec.MasterInternalName) {
 		argv = append(argv, "--dns=gossip")
 		argv = append(argv, "--gossip-seed=127.0.0.1:3999")
-		argv = append(argv, "--metrics-listen-addr=:4040")
 	} else {
 		switch kops.CloudProviderID(tf.cluster.Spec.CloudProvider) {
 		case kops.CloudProviderAWS:


### PR DESCRIPTION
We can look at enabling by default in 1.10 / 1.11; this was a late merge and I broke gossip - sorry!