### PR TITLE
coreos/containeros: restart kops-configuration service after docker drop-in is loaded

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -725,6 +725,11 @@ func (b *DockerBuilder) buildContainerOSConfigurationDropIn(c *fi.ModelBuilderCo
 		OnChangeExecute: [][]string{
 			{"systemctl", "daemon-reload"},
 			{"systemctl", "restart", "docker.service"},
+			// We need to restart kops-configuration service since nodeup needs to load images
+			// into docker with the new overlay storage. Restart is on the background because
+			// kops-configuration is of type 'one-shot' so the restart command will wait for
+			// nodeup to finish executing
+			{"systemctl", "restart", "kops-configuration.service", "&"},
 		},
 	})
 


### PR DESCRIPTION
Fixes a race condition between `DockerBuilder` and `ProtokubeBuilder` where `ProtokubeBuilder` runs `docker load` to load the protokube docker image before the new overlay is setup. The result is that protokube.service can't find the image because `docker load` loaded the image into the old docker storage.

re: https://github.com/kubernetes/kops/issues/2785 