### PR TITLE
Disable locksmithd on CoreOS if UpdatePolicy set

### DIFF
--- a/nodeup/pkg/model/BUILD.bazel
+++ b/nodeup/pkg/model/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "protokube.go",
         "secrets.go",
         "sysctls.go",
+        "update_service.go",
     ],
     importpath = "k8s.io/kops/nodeup/pkg/model",
     visibility = ["//visibility:public"],

--- a/nodeup/pkg/model/update_service.go
+++ b/nodeup/pkg/model/update_service.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"k8s.io/kops/nodeup/pkg/distros"
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/systemd"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
+
+	"github.com/golang/glog"
+)
+
+// UpdateServiceBuilder disables the OS automatic updates
+type UpdateServiceBuilder struct {
+	*NodeupModelContext
+}
+
+// ServiceName is the name given to the service to be created
+const ServiceName = "update-service"
+
+var _ fi.ModelBuilder = &UpdateServiceBuilder{}
+
+// Build is responsible for creating the relevant systemd service based on OS
+func (b *UpdateServiceBuilder) Build(c *fi.ModelBuilderContext) error {
+	if b.Cluster.Spec.UpdatePolicy == nil || *b.Cluster.Spec.UpdatePolicy != kops.UpdatePolicyExternal {
+		glog.Infof("UpdatePolicy not set in Cluster Spec; skipping creation of %s", ServiceName)
+		return nil
+	}
+
+	for _, spec := range [][]kops.HookSpec{b.InstanceGroup.Spec.Hooks, b.Cluster.Spec.Hooks} {
+		for _, hook := range spec {
+			if hook.Name == ServiceName || hook.Name == ServiceName+".service" {
+				glog.Infof("Detected kops Hook for '%s'; skipping creation", ServiceName)
+				return nil
+			}
+		}
+	}
+
+	if b.Distribution == distros.DistributionCoreOS {
+		glog.Infof("Detected OS %s; building %s service to disable update scheduler", ServiceName, b.Distribution)
+		c.AddTask(b.buildCoreOSSystemdService())
+	}
+
+	return nil
+}
+
+func (b *UpdateServiceBuilder) buildCoreOSSystemdService() *nodetasks.Service {
+	manifest := &systemd.Manifest{}
+	manifest.Set("Unit", "Description", "Disable OS Update Scheduler")
+
+	manifest.Set("Unit", "Before", "locksmithd.service")
+	manifest.Set("Service", "Type", "oneshot")
+	manifest.Set("Service", "ExecStart", "/usr/bin/systemctl mask --now locksmithd.service")
+
+	manifestString := manifest.Render()
+	glog.V(8).Infof("Built service manifest %q\n%s", ServiceName, manifestString)
+
+	service := &nodetasks.Service{
+		Name:       ServiceName + ".service",
+		Definition: s(manifestString),
+	}
+
+	service.InitDefaults()
+
+	return service
+}

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -216,6 +216,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 
 	loader := NewLoader(c.config, c.cluster, assetStore, nodeTags)
 	loader.Builders = append(loader.Builders, &model.DirectoryBuilder{NodeupModelContext: modelContext})
+	loader.Builders = append(loader.Builders, &model.UpdateServiceBuilder{NodeupModelContext: modelContext})
 	loader.Builders = append(loader.Builders, &model.DockerBuilder{NodeupModelContext: modelContext})
 	loader.Builders = append(loader.Builders, &model.ProtokubeBuilder{NodeupModelContext: modelContext})
 	loader.Builders = append(loader.Builders, &model.CloudConfigBuilder{NodeupModelContext: modelContext})


### PR DESCRIPTION
Fixes #4458

Disable `locksmithd.service` if running CoreOS, and the following is set within your kops ClusterSpec:
```
spec:
  updatePolicy: external
```