### PR TITLE
Add configurable dnsmasq params to KubeDNS

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -296,6 +296,10 @@ type KubeDNSConfig struct {
 	Domain string `json:"domain,omitempty"`
 	// ServerIP is the server ip
 	ServerIP string `json:"serverIP,omitempty"`
+	// CacheMaxSize is the maximum entries to keep in dnsmaq
+	CacheMaxSize int `json:"cacheMaxSize,omitempty"`
+	// CacheMaxConcurrent is the maximum number of concurrent queries for dnsmasq
+	CacheMaxConcurrent int `json:"cacheMaxConcurrent,omitempty"`
 }
 
 // ExternalDNSConfig are options of the dns-controller

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -295,6 +295,10 @@ type KubeDNSConfig struct {
 	Domain string `json:"domain,omitempty"`
 	// ServerIP is the server ip
 	ServerIP string `json:"serverIP,omitempty"`
+	// CacheMaxSize is the maximum entries to keep in dnsmaq
+	CacheMaxSize int `json:"cacheMaxSize,omitempty"`
+	// CacheMaxConcurrent is the maximum number of concurrent queries for dnsmasq
+	CacheMaxConcurrent int `json:"cacheMaxConcurrent,omitempty"`
 }
 
 // ExternalDNSConfig are options of the dns-controller

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -2093,6 +2093,8 @@ func autoConvert_v1alpha1_KubeDNSConfig_To_kops_KubeDNSConfig(in *KubeDNSConfig,
 	out.Replicas = in.Replicas
 	out.Domain = in.Domain
 	out.ServerIP = in.ServerIP
+	out.CacheMaxSize = in.CacheMaxSize
+	out.CacheMaxConcurrent = in.CacheMaxConcurrent
 	return nil
 }
 
@@ -2106,6 +2108,8 @@ func autoConvert_kops_KubeDNSConfig_To_v1alpha1_KubeDNSConfig(in *kops.KubeDNSCo
 	out.Replicas = in.Replicas
 	out.Domain = in.Domain
 	out.ServerIP = in.ServerIP
+	out.CacheMaxSize = in.CacheMaxSize
+	out.CacheMaxConcurrent = in.CacheMaxConcurrent
 	return nil
 }
 
@@ -2125,6 +2129,7 @@ func autoConvert_v1alpha1_KubeProxyConfig_To_kops_KubeProxyConfig(in *KubeProxyC
 	out.HostnameOverride = in.HostnameOverride
 	out.Master = in.Master
 	out.Enabled = in.Enabled
+	out.ProxyMode = in.ProxyMode
 	out.FeatureGates = in.FeatureGates
 	return nil
 }
@@ -2145,6 +2150,7 @@ func autoConvert_kops_KubeProxyConfig_To_v1alpha1_KubeProxyConfig(in *kops.KubeP
 	out.HostnameOverride = in.HostnameOverride
 	out.Master = in.Master
 	out.Enabled = in.Enabled
+	out.ProxyMode = in.ProxyMode
 	out.FeatureGates = in.FeatureGates
 	return nil
 }

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -293,6 +293,10 @@ type KubeDNSConfig struct {
 	Replicas int    `json:"replicas,omitempty"`
 	Domain   string `json:"domain,omitempty"`
 	ServerIP string `json:"serverIP,omitempty"`
+	// CacheMaxSize is the maximum entries to keep in dnsmaq
+	CacheMaxSize int `json:"cacheMaxSize,omitempty"`
+	// CacheMaxConcurrent is the maximum number of concurrent queries for dnsmasq
+	CacheMaxConcurrent int `json:"cacheMaxConcurrent,omitempty"`
 }
 
 // ExternalDNSConfig are options of the dns-controller

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2357,6 +2357,8 @@ func autoConvert_v1alpha2_KubeDNSConfig_To_kops_KubeDNSConfig(in *KubeDNSConfig,
 	out.Replicas = in.Replicas
 	out.Domain = in.Domain
 	out.ServerIP = in.ServerIP
+	out.CacheMaxSize = in.CacheMaxSize
+	out.CacheMaxConcurrent = in.CacheMaxConcurrent
 	return nil
 }
 
@@ -2370,6 +2372,8 @@ func autoConvert_kops_KubeDNSConfig_To_v1alpha2_KubeDNSConfig(in *kops.KubeDNSCo
 	out.Replicas = in.Replicas
 	out.Domain = in.Domain
 	out.ServerIP = in.ServerIP
+	out.CacheMaxSize = in.CacheMaxSize
+	out.CacheMaxConcurrent = in.CacheMaxConcurrent
 	return nil
 }
 
@@ -2389,6 +2393,7 @@ func autoConvert_v1alpha2_KubeProxyConfig_To_kops_KubeProxyConfig(in *KubeProxyC
 	out.HostnameOverride = in.HostnameOverride
 	out.Master = in.Master
 	out.Enabled = in.Enabled
+	out.ProxyMode = in.ProxyMode
 	out.FeatureGates = in.FeatureGates
 	return nil
 }
@@ -2409,6 +2414,7 @@ func autoConvert_kops_KubeProxyConfig_To_v1alpha2_KubeProxyConfig(in *kops.KubeP
 	out.HostnameOverride = in.HostnameOverride
 	out.Master = in.Master
 	out.Enabled = in.Enabled
+	out.ProxyMode = in.ProxyMode
 	out.FeatureGates = in.FeatureGates
 	return nil
 }

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -36,6 +36,15 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	clusterSpec.KubeDNS.Replicas = 2
+
+	if clusterSpec.KubeDNS.CacheMaxSize == 0 {
+		clusterSpec.KubeDNS.CacheMaxSize = 1000
+	}
+
+	if clusterSpec.KubeDNS.CacheMaxConcurrent == 0 {
+		clusterSpec.KubeDNS.CacheMaxConcurrent = 150
+	}
+
 	ip, err := WellKnownServiceIP(clusterSpec, 10)
 	if err != nil {
 		return err

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -165,7 +165,8 @@ spec:
         - -restartDnsmasq=true
         - --
         - -k
-        - --cache-size=1000
+        - --cache-size={{ KubeDNS.CacheMaxSize }}
+        - --dns-forward-max={{ KubeDNS.CacheMaxConcurrent }}
         - --no-negcache
         - --log-facility=-
         - --server=/{{ KubeDNS.Domain }}/127.0.0.1#10053

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
@@ -142,7 +142,8 @@ spec:
           successThreshold: 1
           failureThreshold: 5
         args:
-        - --cache-size=1000
+        - --cache-size={{ KubeDNS.CacheMaxSize }}
+        - --dns-forward-max={{ KubeDNS.CacheMaxConcurrent }}
         - --no-resolv
         - --server=127.0.0.1#10053
         - --log-facility=-


### PR DESCRIPTION
This PR lets kops manage two dnsmasq parameters that people may wish to change for tuning their kubedns setup