### PR TITLE
digitalocean: external cloud controller manager avoid circular dependencies

### DIFF
--- a/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
@@ -52,12 +52,16 @@ spec:
         command:
           - "/bin/digitalocean-cloud-controller-manager"
           - "--cloud-provider=digitalocean"
-          - "--leader-elect=false"
+          - "--leader-elect=true"
         resources:
           requests:
             cpu: 100m
             memory: 50Mi
         env:
+          - name: KUBERNETES_SERVICE_HOST
+            value: "127.0.0.1"
+          - name: KUBERNETES_SERVICE_PORT
+            value: "443"
           - name: DO_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
Some network plugins (like kube-router) depend on some of the fields in node.Spec in order to work properly. Some of those fields are set by the cloud controller manager which causes circular dependencies since the CCM needs the kubernetes service IP to work to initalize nodes. In the future it might make more sense to build a dedicated PKI for this service but this seems to be a reasonable work around for now. 

https://github.com/kubernetes/kops/issues/2150 