### PR TITLE
Bump Weave Net to 2.3.0

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
@@ -128,7 +128,7 @@ spec:
             - name: CONN_LIMIT
               value: "{{ .Networking.Weave.ConnLimit }}"
             {{- end }}
-          image: 'weaveworks/weave-kube:2.2.0'
+          image: 'weaveworks/weave-kube:2.3.0'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -165,7 +165,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.2.0'
+          image: 'weaveworks/weave-npc:2.3.0'
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -100,6 +100,8 @@ metadata:
     name: weave-net
     role.kubernetes.io/networking: "1"
 spec:
+  # Wait 5 seconds to let pod connect before rolling next pod
+  minReadySeconds: 5
   template:
     metadata:
       labels:
@@ -128,7 +130,7 @@ spec:
             - name: CONN_LIMIT
               value: "{{ .Networking.Weave.ConnLimit }}"
             {{- end }}
-          image: 'weaveworks/weave-kube:2.2.0'
+          image: 'weaveworks/weave-kube:2.3.0'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -166,7 +168,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.2.0'
+          image: 'weaveworks/weave-npc:2.3.0'
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
@@ -46,7 +46,7 @@ spec:
             - name: CONN_LIMIT
               value: "{{ .Networking.Weave.ConnLimit }}"
             {{- end }}
-          image: 'weaveworks/weave-kube:2.2.0'
+          image: 'weaveworks/weave-kube:2.3.0'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -83,7 +83,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.2.0'
+          image: 'weaveworks/weave-npc:2.3.0'
           resources:
             requests:
               cpu: 50m

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -401,8 +401,8 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Weave != nil {
 		key := "networking.weave"
-		// 2.2.0-kops.2 = 2.2.0, kops packaging version 1.
-		version := "2.2.0-kops.1"
+		// 2.3.0-kops.1 = 2.3.0, kops packaging version 1.
+		version := "2.3.0-kops.1"
 
 		{
 			location := key + "/pre-k8s-1.6.yaml"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -69,18 +69,18 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.2.0-kops.1
+    version: 2.3.0-kops.1
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.7.0'
     manifest: networking.weave/k8s-1.6.yaml
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.2.0-kops.1
+    version: 2.3.0-kops.1
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0'
     manifest: networking.weave/k8s-1.7.yaml
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.2.0-kops.1
+    version: 2.3.0-kops.1


### PR DESCRIPTION
Release notes since v2.2.0:

- https://github.com/weaveworks/weave/releases/tag/v2.2.1
- https://github.com/weaveworks/weave/releases/tag/v2.3.0

Notable change in the latest DaemonSet definition - `minReadySeconds: 5` (https://github.com/weaveworks/weave/pull/3235)
