### PR TITLE
Fix etcd Keypair change showing on every kops update when TLS enabled

### DIFF
--- a/upup/pkg/fi/fitasks/keypair.go
+++ b/upup/pkg/fi/fitasks/keypair.go
@@ -31,7 +31,7 @@ import (
 var wellKnownCertificateTypes = map[string]string{
 	"ca":           "CA,KeyUsageCRLSign,KeyUsageCertSign",
 	"client":       "ExtKeyUsageClientAuth,KeyUsageDigitalSignature",
-	"clientServer": "ExtKeyUsageServerAuth,KeyUsageDigitalSignature,ExtKeyUsageClientAuth,KeyUsageKeyEncipherment",
+	"clientServer": "ExtKeyUsageClientAuth,ExtKeyUsageServerAuth,KeyUsageDigitalSignature,KeyUsageKeyEncipherment",
 	"server":       "ExtKeyUsageServerAuth,KeyUsageDigitalSignature,KeyUsageKeyEncipherment",
 }
 


### PR DESCRIPTION
When `EnableEtcdTLS` is configured in kops ClusterSpec, fixes the following change always showing up when performing a kops update cluster:

```
Will modify resources:
  Keypair/etcd
  	Type                	 ExtKeyUsageClientAuth,ExtKeyUsageServerAuth,KeyUsageDigitalSignature,KeyUsageKeyEncipherment -> clientServer
```