### PR TITLE
Only do etcd backups on main

### DIFF
--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -246,6 +246,11 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) (*Protokube
 	}
 
 	for _, e := range t.Cluster.Spec.EtcdClusters {
+		// Because we can only specify a single EtcdBackupStore at the moment, we only backup main, not events
+		if e.Name != "main" {
+			continue
+		}
+
 		if e.Backups != nil {
 			if f.EtcdBackupImage == "" {
 				f.EtcdBackupImage = e.Backups.Image

--- a/protokube/pkg/protokube/etcd_cluster.go
+++ b/protokube/pkg/protokube/etcd_cluster.go
@@ -133,15 +133,17 @@ func newEtcdController(kubeBoot *KubeBoot, v *Volume, spec *etcd.EtcdClusterSpec
 		cluster.DataDirName = "data"
 		cluster.PodName = "etcd-server"
 		cluster.CPURequest = resource.MustParse("200m")
+
+		// Because we can only specify a single EtcdBackupStore at the moment, we only backup main, not events
+		cluster.BackupImage = kubeBoot.EtcdBackupImage
+		cluster.BackupStore = kubeBoot.EtcdBackupStore
+
 	case "events":
 		cluster.ClientPort = 4002
 		cluster.PeerPort = 2381
 	default:
 		return nil, fmt.Errorf("unknown etcd cluster key %q", spec.ClusterKey)
 	}
-
-	cluster.BackupImage = kubeBoot.EtcdBackupImage
-	cluster.BackupStore = kubeBoot.EtcdBackupStore
 
 	k.cluster = cluster
 


### PR DESCRIPTION
Because our implementation can't actually differentiate settings for
events & main, we only support backup of main for now.