### PR TITLE
Ignore shared-ownership tags on volumes

### DIFF
--- a/protokube/pkg/protokube/aws_volume.go
+++ b/protokube/pkg/protokube/aws_volume.go
@@ -226,6 +226,8 @@ func (a *AWSVolumes) findVolumes(request *ec2.DescribeVolumesInput) ([]*Volume, 
 						vol.Info.EtcdClusters = append(vol.Info.EtcdClusters, spec)
 					} else if strings.HasPrefix(k, awsup.TagNameRolePrefix) {
 						// Ignore
+					} else if strings.HasPrefix(k, awsup.TagNameClusterOwnershipPrefix) {
+						// Ignore
 					} else {
 						glog.Warningf("unknown tag on volume %q: %s=%s", volumeID, k, v)
 					}

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -77,6 +77,9 @@ const TagRoleMaster = "master"
 // TagNameKopsRole is the AWS tag used to identify the role an object plays for a cluster
 const TagNameKopsRole = "kubernetes.io/kops/role"
 
+// TagNameClusterOwnershipPrefix is the AWS tag used for ownership
+const TagNameClusterOwnershipPrefix = "kubernetes.io/cluster/"
+
 const (
 	WellKnownAccountKopeio = "383156758163"
 	WellKnownAccountRedhat = "309956199498"


### PR DESCRIPTION
We were otherwise logging a spurious warning message
`