### PR TITLE
digitalocean: don't set --cloud-provider=external on control plane starting v1.10

### DIFF
--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -294,7 +294,8 @@ func ValidateCluster(c *kops.Cluster, strict bool) *field.Error {
 		case kops.CloudProviderGCE:
 			k8sCloudProvider = "gce"
 		case kops.CloudProviderDO:
-			k8sCloudProvider = "external"
+			// cloud provider should be blank since digitalocean uses external cloud controller
+			k8sCloudProvider = ""
 		case kops.CloudProviderVSphere:
 			k8sCloudProvider = "vsphere"
 		case kops.CloudProviderBareMetal:

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -145,7 +145,7 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 	case kops.CloudProviderGCE:
 		c.CloudProvider = "gce"
 	case kops.CloudProviderDO:
-		c.CloudProvider = "external"
+		// not required for digitalocean since it is managed by digitalocean-cloud-controller-manager
 	case kops.CloudProviderVSphere:
 		c.CloudProvider = "vsphere"
 	case kops.CloudProviderBareMetal:

--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -105,7 +105,7 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 		kcm.ClusterName = gce.SafeClusterName(b.Context.ClusterName)
 
 	case kops.CloudProviderDO:
-		kcm.CloudProvider = "external"
+		// cloud provider is specified by digitalocean-cloud-controller-manager
 
 	case kops.CloudProviderVSphere:
 		kcm.CloudProvider = "vsphere"


### PR DESCRIPTION
Starting in v1.10 there's a subtle difference when setting `--cloud-provider=""` vs `--cloud-provider=external` on the kube-apiserver and the kube-controller-manager. The main difference here is that the `nodeipam` controller is disabled if `--cloud-provider=external` but still enabled when `--cloud-provider=""`. This was required to accommodate for the fact that GCE does IPAM allocations via API calls so we needed a mechanism to disable it on the KCM during the transition. kubelet's should still have still set `--cloud-provider=external`. 

ref: https://github.com/kubernetes/kops/issues/2150