### PR TITLE
digitalocean: use new droplet sizes providing the same resources at cheaper prices

### DIFF
--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -33,14 +33,14 @@ import (
 const (
 	defaultNodeMachineTypeGCE     = "n1-standard-2"
 	defaultNodeMachineTypeVSphere = "vsphere_node"
-	defaultNodeMachineTypeDO      = "2gb"
+	defaultNodeMachineTypeDO      = "s-2vcpu-4gb"
 
 	defaultBastionMachineTypeGCE     = "f1-micro"
 	defaultBastionMachineTypeVSphere = "vsphere_bastion"
 
 	defaultMasterMachineTypeGCE     = "n1-standard-1"
 	defaultMasterMachineTypeVSphere = "vsphere_master"
-	defaultMasterMachineTypeDO      = "2gb"
+	defaultMasterMachineTypeDO      = "s-2vcpu-2gb"
 
 	defaultVSphereNodeImage = "kops_ubuntu_16_04.ova"
 	defaultDONodeImage      = "coreos-stable"


### PR DESCRIPTION
fixes https://github.com/kubernetes/kops/issues/4996

DigitalOcean earlier this year kicked off new droplet plans https://blog.digitalocean.com/new-droplet-plans/, this PR updates the master to use the same droplet size but cheaper (2 vCPU and 2 GB for $15/month instead of $20) and the nodes to use the new plan at the same price point ($20 for 2 vCPU and 4 GB  vs 2vCPU and 2GB). 

ref: https://github.com/kubernetes/kops/issues/2150