### PR TITLE
5018 - add existing vpn informations to the docs

### DIFF
--- a/addons/kube-ingress-aws-controller/README.md
+++ b/addons/kube-ingress-aws-controller/README.md
@@ -179,7 +179,7 @@ aws ec2 authorize-security-group-ingress --group-id $sgidnode --protocol all --p
 aws ec2 create-tags --resources $sgidingress --tags '[{"Key": "kubernetes.io/cluster/id", "Value": "owned"}, {"Key": "kubernetes:application", "Value": "kube-ingress-aws-controller"}]'
 ```
 
-If you have deployed the cluster into an **existing VPC** please check the [kops.md](https://github.com/zalando-incubator/kube-ingress-aws-controller/blob/master/deploy/kops.md) document in the zalando-incubator repository. 
+If you have deployed the cluster into an **existing VPC** or if kops **created a new VPC for the cluster because the default VPC was already in use** at the time when the cluster was created, please check the [kops.md](https://github.com/zalando-incubator/kube-ingress-aws-controller/blob/master/deploy/kops.md) document in the zalando-incubator repository. 
 There you will find informations regarding needed adjustments for the above AWS cli commands.
 
 ### AWS Certificate Manager (ACM)

--- a/addons/kube-ingress-aws-controller/README.md
+++ b/addons/kube-ingress-aws-controller/README.md
@@ -179,6 +179,9 @@ aws ec2 authorize-security-group-ingress --group-id $sgidnode --protocol all --p
 aws ec2 create-tags --resources $sgidingress --tags '[{"Key": "kubernetes.io/cluster/id", "Value": "owned"}, {"Key": "kubernetes:application", "Value": "kube-ingress-aws-controller"}]'
 ```
 
+If you have deployed the cluster into an **existing VPC** please check the [kops.md](https://github.com/zalando-incubator/kube-ingress-aws-controller/blob/master/deploy/kops.md) document in the zalando-incubator repository. 
+There you will find informations regarding needed adjustments for the above AWS cli commands.
+
 ### AWS Certificate Manager (ACM)
 
 To have TLS termination you can use AWS managed certificates.  If you


### PR DESCRIPTION
https://github.com/kubernetes/kops/issues/5018

have added an link to the incubator repo which is providing informations about running stuff in an existing VPC