### PR TITLE
Add docker 17.09.0 version for Debian 9

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -457,6 +457,18 @@ var dockerVersions = []dockerVersion{
 		Dependencies:  []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 	},
 
+	// 17.09.0 - Debian9 (stretch)
+	{
+		DockerVersion: "17.09.0",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionDebian9},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "17.09.0~ce-0~debian",
+		Source:        "http://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_17.09.0~ce-0~debian_amd64.deb",
+		Hash:          "70aa5f96cf00f11374b6593ccf4ed120a65375d2",
+		Dependencies:  []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
+	},
+
 	// 17.09.0 - Xenial
 	{
 		DockerVersion: "17.09.0",


### PR DESCRIPTION
Debian 9 Stretch was missed in this commit -> https://github.com/kubernetes/kops/commit/b698c684a9ac31b32db95f109b27e0196f108f2d

We need Docker 17.09.0 for devicemapper production mode flag on Debian 9. We also would like to use multi-stage docker builds on Debian 9 k8s.

Please merge! :smile_cat: 