### PR TITLE
Add public ssh keys for GCE

### DIFF
--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -417,6 +417,7 @@ func runTestGCE(t *testing.T, clusterName string, srcDir string, version string,
 	expectedFilenames := []string{
 		"google_compute_instance_template_nodes-" + gce.SafeClusterName(clusterName) + "_metadata_cluster-name",
 		"google_compute_instance_template_nodes-" + gce.SafeClusterName(clusterName) + "_metadata_startup-script",
+		"google_compute_instance_template_nodes-" + gce.SafeClusterName(clusterName) + "_metadata_ssh-keys",
 	}
 
 	for i := 0; i < zones; i++ {
@@ -425,6 +426,7 @@ func runTestGCE(t *testing.T, clusterName string, srcDir string, version string,
 
 		expectedFilenames = append(expectedFilenames, prefix+"cluster-name")
 		expectedFilenames = append(expectedFilenames, prefix+"startup-script")
+		expectedFilenames = append(expectedFilenames, prefix+"ssh-keys")
 	}
 
 	runTest(t, h, clusterName, srcDir, version, private, zones, expectedFilenames, "", nil)

--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -17,6 +17,9 @@ limitations under the License.
 package gcemodel
 
 import (
+	"fmt"
+	"strings"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/model"
 	"k8s.io/kops/pkg/model/defaults"
@@ -92,6 +95,15 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 					//"config": resources/config.yaml $nodeset.Name
 					"cluster-name": fi.WrapResource(fi.NewStringResource(b.ClusterName())),
 				},
+			}
+
+			if len(b.SSHPublicKeys) > 0 {
+				var gFmtKeys []string
+				for _, key := range b.SSHPublicKeys {
+					gFmtKeys = append(gFmtKeys, fmt.Sprintf("%s: %s", fi.SecretNameSSHPrimary, key))
+				}
+
+				t.Metadata["ssh-keys"] = fi.WrapResource(fi.NewStringResource(strings.Join(gFmtKeys, "\n")))
 			}
 
 			switch ig.Spec.Role {

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -353,6 +353,7 @@ resource "google_compute_instance_template" "master-us-test1-a-ha-gce-example-co
 
   metadata = {
     cluster-name   = "${file("${path.module}/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_cluster-name")}"
+    ssh-keys       = "${file("${path.module}/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_ssh-keys")}"
     startup-script = "${file("${path.module}/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_startup-script")}"
   }
 
@@ -392,6 +393,7 @@ resource "google_compute_instance_template" "master-us-test1-b-ha-gce-example-co
 
   metadata = {
     cluster-name   = "${file("${path.module}/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_cluster-name")}"
+    ssh-keys       = "${file("${path.module}/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_ssh-keys")}"
     startup-script = "${file("${path.module}/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_startup-script")}"
   }
 
@@ -431,6 +433,7 @@ resource "google_compute_instance_template" "master-us-test1-c-ha-gce-example-co
 
   metadata = {
     cluster-name   = "${file("${path.module}/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_cluster-name")}"
+    ssh-keys       = "${file("${path.module}/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_ssh-keys")}"
     startup-script = "${file("${path.module}/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_startup-script")}"
   }
 
@@ -470,6 +473,7 @@ resource "google_compute_instance_template" "nodes-ha-gce-example-com" {
 
   metadata = {
     cluster-name   = "${file("${path.module}/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_cluster-name")}"
+    ssh-keys       = "${file("${path.module}/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_ssh-keys")}"
     startup-script = "${file("${path.module}/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_startup-script")}"
   }
 

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -332,6 +332,8 @@ func (c *ApplyClusterCmd) Run() error {
 				return fmt.Errorf("GCE support is currently alpha, and is feature-gated.  export KOPS_FEATURE_FLAGS=AlphaAllowGCE")
 			}
 
+			modelContext.SSHPublicKeys = sshPublicKeys
+
 			l.AddTypes(map[string]interface{}{
 				"Disk":                 &gcetasks.Disk{},
 				"Instance":             &gcetasks.Instance{},


### PR DESCRIPTION
Adds ssh public keys in google cloud instance template metadata.

More info about gcloud ssh format in instance metadata:
https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys#instance-only
https://cloud.google.com/compute/docs/storing-retrieving-metadata
