### PR TITLE
Make LogSeveritySys configurable for Canal Networking

### DIFF
--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -87,22 +87,25 @@ type CalicoNetworkingSpec struct {
 
 // CanalNetworkingSpec declares that we want Canal networking
 type CanalNetworkingSpec struct {
-	// DefaultEndpointToHostAction allows users to configure the default behaviour
-	// for traffic between pod to host after calico rules have been processed.
-	// Default: ACCEPT (other options: DROP, RETURN)
-	DefaultEndpointToHostAction string `json:"defaultEndpointToHostAction,omitempty"`
 	// ChainInsertMode controls whether Felix inserts rules to the top of iptables chains, or
 	// appends to the bottom. Leaving the default option is safest to prevent accidentally
 	// breaking connectivity. Default: 'insert' (other options: 'append')
 	ChainInsertMode string `json:"chainInsertMode,omitempty"`
+	// DefaultEndpointToHostAction allows users to configure the default behaviour
+	// for traffic between pod to host after calico rules have been processed.
+	// Default: ACCEPT (other options: DROP, RETURN)
+	DefaultEndpointToHostAction string `json:"defaultEndpointToHostAction,omitempty"`
+	// LogSeveritySys the severity to set for logs which are sent to syslog
+	// Default: INFO (other options: DEBUG, WARNING, ERROR, CRITICAL, NONE)
+	LogSeveritySys string `json:"logSeveritySys,omitempty"`
+	// PrometheusGoMetricsEnabled enables Prometheus Go runtime metrics collection
+	PrometheusGoMetricsEnabled bool `json:"prometheusGoMetricsEnabled,omitempty"`
 	// PrometheusMetricsEnabled can be set to enable the experimental Prometheus
 	// metrics server (default: false)
 	PrometheusMetricsEnabled bool `json:"prometheusMetricsEnabled,omitempty"`
 	// PrometheusMetricsPort is the TCP port that the experimental Prometheus
 	// metrics server should bind to (default: 9091)
 	PrometheusMetricsPort int32 `json:"prometheusMetricsPort,omitempty"`
-	// PrometheusGoMetricsEnabled enables Prometheus Go runtime metrics collection
-	PrometheusGoMetricsEnabled bool `json:"prometheusGoMetricsEnabled,omitempty"`
 	// PrometheusProcessMetricsEnabled enables Prometheus process metrics collection
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -87,22 +87,25 @@ type CalicoNetworkingSpec struct {
 
 // CanalNetworkingSpec declares that we want Canal networking
 type CanalNetworkingSpec struct {
-	// DefaultEndpointToHostAction allows users to configure the default behaviour
-	// for traffic between pod to host after calico rules have been processed.
-	// Default: ACCEPT (other options: DROP, RETURN)
-	DefaultEndpointToHostAction string `json:"defaultEndpointToHostAction,omitempty"`
 	// ChainInsertMode controls whether Felix inserts rules to the top of iptables chains, or
 	// appends to the bottom. Leaving the default option is safest to prevent accidentally
 	// breaking connectivity. Default: 'insert' (other options: 'append')
 	ChainInsertMode string `json:"chainInsertMode,omitempty"`
+	// DefaultEndpointToHostAction allows users to configure the default behaviour
+	// for traffic between pod to host after calico rules have been processed.
+	// Default: ACCEPT (other options: DROP, RETURN)
+	DefaultEndpointToHostAction string `json:"defaultEndpointToHostAction,omitempty"`
+	// LogSeveritySys the severity to set for logs which are sent to syslog
+	// Default: INFO (other options: DEBUG, WARNING, ERROR, CRITICAL, NONE)
+	LogSeveritySys string `json:"logSeveritySys,omitempty"`
+	// PrometheusGoMetricsEnabled enables Prometheus Go runtime metrics collection
+	PrometheusGoMetricsEnabled bool `json:"prometheusGoMetricsEnabled,omitempty"`
 	// PrometheusMetricsEnabled can be set to enable the experimental Prometheus
 	// metrics server (default: false)
 	PrometheusMetricsEnabled bool `json:"prometheusMetricsEnabled,omitempty"`
 	// PrometheusMetricsPort is the TCP port that the experimental Prometheus
 	// metrics server should bind to (default: 9091)
 	PrometheusMetricsPort int32 `json:"prometheusMetricsPort,omitempty"`
-	// PrometheusGoMetricsEnabled enables Prometheus Go runtime metrics collection
-	PrometheusGoMetricsEnabled bool `json:"prometheusGoMetricsEnabled,omitempty"`
 	// PrometheusProcessMetricsEnabled enables Prometheus process metrics collection
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -423,11 +423,12 @@ func Convert_kops_CalicoNetworkingSpec_To_v1alpha1_CalicoNetworkingSpec(in *kops
 }
 
 func autoConvert_v1alpha1_CanalNetworkingSpec_To_kops_CanalNetworkingSpec(in *CanalNetworkingSpec, out *kops.CanalNetworkingSpec, s conversion.Scope) error {
-	out.DefaultEndpointToHostAction = in.DefaultEndpointToHostAction
 	out.ChainInsertMode = in.ChainInsertMode
+	out.DefaultEndpointToHostAction = in.DefaultEndpointToHostAction
+	out.LogSeveritySys = in.LogSeveritySys
+	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
-	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	return nil
 }
@@ -438,11 +439,12 @@ func Convert_v1alpha1_CanalNetworkingSpec_To_kops_CanalNetworkingSpec(in *CanalN
 }
 
 func autoConvert_kops_CanalNetworkingSpec_To_v1alpha1_CanalNetworkingSpec(in *kops.CanalNetworkingSpec, out *CanalNetworkingSpec, s conversion.Scope) error {
-	out.DefaultEndpointToHostAction = in.DefaultEndpointToHostAction
 	out.ChainInsertMode = in.ChainInsertMode
+	out.DefaultEndpointToHostAction = in.DefaultEndpointToHostAction
+	out.LogSeveritySys = in.LogSeveritySys
+	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
-	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	return nil
 }

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -87,22 +87,25 @@ type CalicoNetworkingSpec struct {
 
 // CanalNetworkingSpec declares that we want Canal networking
 type CanalNetworkingSpec struct {
-	// DefaultEndpointToHostAction allows users to configure the default behaviour
-	// for traffic between pod to host after calico rules have been processed.
-	// Default: ACCEPT (other options: DROP, RETURN)
-	DefaultEndpointToHostAction string `json:"defaultEndpointToHostAction,omitempty"`
 	// ChainInsertMode controls whether Felix inserts rules to the top of iptables chains, or
 	// appends to the bottom. Leaving the default option is safest to prevent accidentally
 	// breaking connectivity. Default: 'insert' (other options: 'append')
 	ChainInsertMode string `json:"chainInsertMode,omitempty"`
+	// DefaultEndpointToHostAction allows users to configure the default behaviour
+	// for traffic between pod to host after calico rules have been processed.
+	// Default: ACCEPT (other options: DROP, RETURN)
+	DefaultEndpointToHostAction string `json:"defaultEndpointToHostAction,omitempty"`
+	// LogSeveritySys the severity to set for logs which are sent to syslog
+	// Default: INFO (other options: DEBUG, WARNING, ERROR, CRITICAL, NONE)
+	LogSeveritySys string `json:"logSeveritySys,omitempty"`
+	// PrometheusGoMetricsEnabled enables Prometheus Go runtime metrics collection
+	PrometheusGoMetricsEnabled bool `json:"prometheusGoMetricsEnabled,omitempty"`
 	// PrometheusMetricsEnabled can be set to enable the experimental Prometheus
 	// metrics server (default: false)
 	PrometheusMetricsEnabled bool `json:"prometheusMetricsEnabled,omitempty"`
 	// PrometheusMetricsPort is the TCP port that the experimental Prometheus
 	// metrics server should bind to (default: 9091)
 	PrometheusMetricsPort int32 `json:"prometheusMetricsPort,omitempty"`
-	// PrometheusGoMetricsEnabled enables Prometheus Go runtime metrics collection
-	PrometheusGoMetricsEnabled bool `json:"prometheusGoMetricsEnabled,omitempty"`
 	// PrometheusProcessMetricsEnabled enables Prometheus process metrics collection
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -459,11 +459,12 @@ func Convert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *kops
 }
 
 func autoConvert_v1alpha2_CanalNetworkingSpec_To_kops_CanalNetworkingSpec(in *CanalNetworkingSpec, out *kops.CanalNetworkingSpec, s conversion.Scope) error {
-	out.DefaultEndpointToHostAction = in.DefaultEndpointToHostAction
 	out.ChainInsertMode = in.ChainInsertMode
+	out.DefaultEndpointToHostAction = in.DefaultEndpointToHostAction
+	out.LogSeveritySys = in.LogSeveritySys
+	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
-	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	return nil
 }
@@ -474,11 +475,12 @@ func Convert_v1alpha2_CanalNetworkingSpec_To_kops_CanalNetworkingSpec(in *CanalN
 }
 
 func autoConvert_kops_CanalNetworkingSpec_To_v1alpha2_CanalNetworkingSpec(in *kops.CanalNetworkingSpec, out *CanalNetworkingSpec, s conversion.Scope) error {
-	out.DefaultEndpointToHostAction = in.DefaultEndpointToHostAction
 	out.ChainInsertMode = in.ChainInsertMode
+	out.DefaultEndpointToHostAction = in.DefaultEndpointToHostAction
+	out.LogSeveritySys = in.LogSeveritySys
+	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
-	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	return nil
 }

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -233,14 +233,21 @@ func ValidateCluster(c *kops.Cluster, strict bool) *field.Error {
 		switch action {
 		case "", "ACCEPT", "DROP", "RETURN":
 		default:
-			return field.Invalid(fieldSpec.Child("Networking", "Canal", "DefaultEndpointToHostAction"), action, fmt.Sprintf("Unsupported value: %s, supports ACCEPT, DROP or RETURN", action))
+			return field.Invalid(fieldSpec.Child("Networking", "Canal", "DefaultEndpointToHostAction"), action, fmt.Sprintf("Unsupported value: %s, supports 'ACCEPT', 'DROP' or 'RETURN'", action))
 		}
 
 		chainInsertMode := c.Spec.Networking.Canal.ChainInsertMode
 		switch chainInsertMode {
 		case "", "insert", "append":
 		default:
-			return field.Invalid(fieldSpec.Child("Networking", "Canal", "ChainInsertMode"), action, fmt.Sprintf("Unsupported value: %s, supports 'insert' or 'append'", chainInsertMode))
+			return field.Invalid(fieldSpec.Child("Networking", "Canal", "ChainInsertMode"), chainInsertMode, fmt.Sprintf("Unsupported value: %s, supports 'insert' or 'append'", chainInsertMode))
+		}
+
+		logSeveritySys := c.Spec.Networking.Canal.LogSeveritySys
+		switch logSeveritySys {
+		case "", "INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL", "NONE":
+		default:
+			return field.Invalid(fieldSpec.Child("Networking", "Canal", "LogSeveritySys"), logSeveritySys, fmt.Sprintf("Unsupported value: %s, supports 'INFO', 'DEBUG', 'WARNING', 'ERROR', 'CRITICAL' or 'NONE'", logSeveritySys))
 		}
 	}
 

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.6.yaml.template
@@ -92,7 +92,7 @@ spec:
               value: "kubernetes"
             # Enable felix logging.
             - name: FELIX_LOGSEVERITYSYS
-              value: "info"
+              value: "{{- or .Networking.Canal.LogSeveritySys "INFO" }}"
             # Period, in seconds, at which felix re-applies all iptables state
             - name: FELIX_IPTABLESREFRESHINTERVAL
               value: "60"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.8.yaml.template
@@ -113,7 +113,7 @@ spec:
               value: "kubernetes"
             # Enable felix logging.
             - name: FELIX_LOGSEVERITYSYS
-              value: "info"
+              value: "{{- or .Networking.Canal.LogSeveritySys "INFO" }}"
             # Don't enable BGP.
             - name: CALICO_NETWORKING_BACKEND
               value: "none"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/pre-k8s-1.6.yaml.template
@@ -84,7 +84,7 @@ spec:
               value: "kubernetes"
             # Enable felix logging.
             - name: FELIX_LOGSEVERITYSYS
-              value: "info"
+              value: "{{- or .Networking.Canal.LogSeveritySys "INFO" }}"
             # Period, in seconds, at which felix re-applies all iptables state
             - name: FELIX_IPTABLESREFRESHINTERVAL
               value: "60"

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -564,9 +564,9 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		key := "networking.projectcalico.org.canal"
 		// 2.6.3-kops.1 = 2.6.2 with kops manifest tweaks.  This should go away with the next version bump.
 		versions := map[string]string{
-			"pre-k8s-1.6": "2.4.2-kops.1",
-			"k8s-1.6":     "2.4.2-kops.1",
-			"k8s-1.8":     "2.6.7-kops.1",
+			"pre-k8s-1.6": "2.4.2-kops.2",
+			"k8s-1.6":     "2.4.2-kops.2",
+			"k8s-1.8":     "2.6.7-kops.2",
 		}
 
 		{


### PR DESCRIPTION
When using Canal Networking, make `FELIX_LOGSEVERITYSYS` configurable (defaults to `INFO`).
```
canal:
  logSeveritySys: WARNING
```

Valid options: `INFO`, `DEBUG`, `WARNING`, `ERROR`, `CRITICAL`, `NONE`