### PR TITLE
Typo fix: Kuberenetes->Kubernetes

### DIFF
--- a/docs/manifests_and_customizing_via_api.md
+++ b/docs/manifests_and_customizing_via_api.md
@@ -17,7 +17,7 @@ This document also applies to using the `kops` API to customize a Kubernetes clu
 
 > We like to think of it as `kubectl` for Clusters.
 
-Because of the above statement `kops` includes an API which provides a feature for users to utilize YAML or JSON manifests for managing their `kops` created Kubernetes installations. In the same way that you can use a YAML manifest to deploy a Job, you can deploy and manage a `kops` Kuberenetes instance with a manifest. All of these values are also usable via the interactive editor with `kops edit`.
+Because of the above statement `kops` includes an API which provides a feature for users to utilize YAML or JSON manifests for managing their `kops` created Kubernetes installations. In the same way that you can use a YAML manifest to deploy a Job, you can deploy and manage a `kops` Kubernetes instance with a manifest. All of these values are also usable via the interactive editor with `kops edit`.
 
 > You can see all the options that are currently supported in Kops [here](https://github.com/kubernetes/kops/blob/master/pkg/apis/kops/componentconfig.go) or [more prettily here](https://godoc.org/k8s.io/kops/pkg/apis/kops#ClusterSpec)
 

--- a/docs/node_resource_handling.md
+++ b/docs/node_resource_handling.md
@@ -1,4 +1,4 @@
-## Node Resource Handling In Kuberenetes
+## Node Resource Handling In Kubernetes
 
 An aspect of Kubernetes clusters that is often overlooked is the resources non-
 pod components require to run, such as:


### PR DESCRIPTION
In two docs, Kubernetes is written as Kuberenetes.