### PR TITLE
Typo fix: seet->set

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/tags.go
+++ b/upup/pkg/fi/cloudup/awstasks/tags.go
@@ -42,7 +42,7 @@ func findNameTag(tags []*ec2.Tag) *string {
 }
 
 // intersectTags returns the tags of interest from a specified list of AWS tags;
-// because we only add tags, this set of tags of interest is the tags that occur in the desired seet.
+// because we only add tags, this set of tags of interest is the tags that occur in the desired set.
 func intersectTags(tags []*ec2.Tag, desired map[string]string) map[string]string {
 	if tags == nil {
 		return nil


### PR DESCRIPTION
I guess here should be "set", not "seet".