### PR TITLE
Add SubnetType tags to run_in_existing_vpc docs

### DIFF
--- a/docs/run_in_existing_vpc.md
+++ b/docs/run_in_existing_vpc.md
@@ -156,12 +156,14 @@ spec:
   ```
   "kubernetes.io/cluster/<cluster-name>" = "shared"
   "kubernetes.io/role/elb"               = "1"
+  "SubnetType"                           = "Utility"
   ```
 
   Private Subnets:
   ```
   "kubernetes.io/cluster/<cluster-name>" = "shared"
   "kubernetes.io/role/internal-elb"      = "1"
+  "SubnetType"                           = "Private"
   ```
 
 


### PR DESCRIPTION
Hey Ho KubeCon :)

This fixes docs for people who manage there subnets through terraform without kops and use kops 1.9. In this release the tag Key SubnetType were added with possible values "Private" and "Utility".

Greetings, Thomas