### PR TITLE
Upgrade to flannel v0.10.0 and explicitly specify amd64 arch

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.6.yaml.template
@@ -99,7 +99,7 @@ spec:
       - operator: Exists
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.9.1-amd64
+        image: quay.io/coreos/flannel:v0.10.0-amd64
         command:
         - cp
         args:
@@ -113,7 +113,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.9.1-amd64
+        image: quay.io/coreos/flannel:v0.10.0-amd64
         command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
         securityContext:
           privileged: true

--- a/upup/models/cloudup/resources/addons/networking.flannel/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/pre-k8s-1.6.yaml.template
@@ -54,7 +54,7 @@ spec:
       serviceAccountName: flannel
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.9.1
+        image: quay.io/coreos/flannel:v0.10.0-amd64
         command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
         securityContext:
           privileged: true
@@ -79,7 +79,7 @@ spec:
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.9.1
+        image: quay.io/coreos/flannel:v0.10.0-amd64
         command: [ "/bin/sh", "-c", "set -e -x; cp -f /etc/kube-flannel/cni-conf.json /etc/cni/net.d/10-flannel.conf; while true; do sleep 3600; done" ]
         resources:
           limits:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -473,7 +473,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Flannel != nil {
 		key := "networking.flannel"
-		version := "0.9.1-kops.2"
+		version := "0.10.0-kops.1"
 
 		{
 			location := key + "/pre-k8s-1.6.yaml"


### PR DESCRIPTION
Upgraded flannel similar as performed in https://github.com/coreos/flannel/commit/11f29d9e0bf0ed411cda3dcd5fcc941434d94cf1

Test cluster successfully spins up on Kubernetes 1.9.6.