### PR TITLE
Fix for validating kubeconfig's hosts

### DIFF
--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -72,7 +72,7 @@ func hasPlaceHolderIP(clusterName string) (bool, error) {
 		return true, fmt.Errorf("unable to parse Kubernetes cluster API URL: %v", err)
 	}
 
-	hostAddrs, err := net.LookupHost(apiAddr.Host)
+	hostAddrs, err := net.LookupHost(apiAddr.Hostname())
 	if err != nil {
 		return true, fmt.Errorf("unable to resolve Kubernetes cluster API URL dns: %v", err)
 	}


### PR DESCRIPTION
URL's Host field is "host" or "host:port". (see https://golang.org/pkg/net/url/#URL )
"host:port" can't be used as net.LookupHost's parameter.
I recommend using URL.Hostname() instead of URL.Host.