### PR TITLE
Update rules go to support go 1.10.2 and 1.9.6

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,8 +3,8 @@
 
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.11.0/rules_go-0.11.0.tar.gz",
-    sha256 = "f70c35a8c779bb92f7521ecb5a1c6604e9c3edd431e50b6376d7497abc8ad3c1",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.11.1/rules_go-0.11.1.tar.gz",
+    sha256 = "1868ff68d6079e31b2f09b828b58d62e57ca8e9636edff699247c9108518570b",
 )
 
 http_archive(


### PR DESCRIPTION
To keep us up to date!