### PR TITLE
Calico v3 upgrade

### DIFF
--- a/cmd/kops/BUILD.bazel
+++ b/cmd/kops/BUILD.bazel
@@ -78,6 +78,7 @@ go_library(
         "//pkg/instancegroups:go_default_library",
         "//pkg/kopscodecs:go_default_library",
         "//pkg/kubeconfig:go_default_library",
+        "//pkg/model/components:go_default_library",
         "//pkg/pki:go_default_library",
         "//pkg/pretty:go_default_library",
         "//pkg/resources:go_default_library",

--- a/docs/calico-v3.md
+++ b/docs/calico-v3.md
@@ -1,0 +1,96 @@
+# Calico Version 3
+In early 2018 Version 3 of Calico was released, it included a reworked data
+model and with that a switch from the etcd v2 to v3 API. This document covers
+the requirements, upgrade process, and configuration to install
+Calico Version 3.
+
+## Requirements
+- The main requirement needed for Calico Version 3 is the etcd v3 API available
+  with etcd server version 3.
+- Another requirement is for the Kubernetes version to be a minimum of v1.7.0.
+
+### etcd
+Due to the etcd v3 API being a requirement of Calico Version 3
+(when using etcd as the datastore) not all Kops installations will be
+upgradable to Calico V3. Installations using etcd v2 (or earlier) will need
+to remain on Calico V2 or update to etcdv3.
+
+## Configuration of a new cluster
+To ensure a new cluster will have Calico Version 3 installed the following
+two configurations options should be set:
+- `spec.etcdClusters.etcdMembers[0].Version` (Main cluster) should be
+  set to a Version of etcd greater than 3.x or the default version
+  needs to be greater than 3.x.
+- The Networking config must have the Calico MajorVersion set to `v3` like
+  the following:
+  ```
+  spec:
+    networking:
+      calico:
+        majorVersion: v3
+  ```
+
+Both of the above two settings can be set by doing a `kops edit cluster ...`
+before bringing the cluster up for the first time.
+
+With the above two settings your Kops deployed cluster will be running with
+Calico Version 3.
+
+### Create cluster networking flag
+
+When enabling Calico with the `--networking calico` flag, etcd will be set to
+a v3 version. Feel free to change to a different v3 version of etcd.
+
+## Upgrading an existing cluster
+Assuming your cluster meets the requirements it is possible to upgrade
+your Calico Kops cluster.
+
+A few notes about the upgrade:
+- During the first portion of the migration, while the calico-kube-controllers
+  pod is running its Init, no new policies will be applied though already
+  applied policy will be active.
+- During the migration no new pods will be scheduled as adding new workloads
+  to Calico is blocked. Once the calico-complete-upgrade job has completed
+  pods will once again be schedulable.
+- The upgrade process that has been automated in kops can be found in
+  [the Upgrading Calico docs](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/upgrade).
+
+Perform the upgrade with the following steps:
+
+1. First you must ensure that you are running Calico V2.6.5+. With the
+   latest Kops (greater than 1.9) ensuring your cluster is updated can be
+   done by doing a `kops update` on the cluster.
+1. Verify your Calico data will migrate successfully by installing and
+   configuring the
+   [calico-upgrade command](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/setup)
+   and then run `calico-upgrade dry-run` and verify it reports that the
+   migration can be completed successfully.
+1. Set `majorVersion` field as below by editing
+   your cluster configuration with `kops edit cluster`.
+   ```
+   spec:
+     networking:
+       calico:
+         majorVersion: v3
+   ```
+1. Update your cluster with `kops update` like you would normally update.
+1. Monitor the progress of the migration by using
+   `kubectl get pods -n kube-system` and checking the status of the following pods:
+   - calico-node pods should restart one at a time and all becoming Running
+   - calico-kube-controllers pod will restart and after the first calico-node
+     pod starts running it will start running
+   - calico-complete-upgrade pod will be Completed after all the calico-node
+     pods start running
+   If any of the above fail by entering a crash loop you should investigate
+   by checking the logs with `kubectl -n kube-system logs <pod name>`.
+1. Once the calico-node and calico-kube-controllers are running and the
+   calico-complete-upgrade pod has completed the migration has finished
+   successfully.
+
+### Recovering from a partial migration
+
+The InitContainer of the first calico-node pod that starts will perform the
+datastore migration necessary for upgrading from Calico v2 to Calico v3, if
+this InitContainer is killed or restarted when the new datastore is being
+populated it will be necessary to manually remove the Calico data in the
+etcd v3 API before the migration will be successful.

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -34,7 +34,7 @@ has built in support for CNI networking components.
 
 Several different CNI providers are currently built into kops:
 
-* [Calico](http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/)
+* [Calico](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/calico#installing-with-the-etcd-datastore)
 * [Canal (Flannel + Calico)](https://github.com/projectcalico/canal)
 * [flannel](https://github.com/coreos/flannel) - use `--networking flannel-vxlan` (recommended) or `--networking flannel-udp` (legacy).  `--networking flannel` now selects `flannel-vxlan`.
 * [kopeio-vxlan](https://github.com/kopeio/networking)
@@ -170,7 +170,8 @@ To enable this mode in a cluster, with Calico as the CNI and Network Policy prov
 
 ```
   networking:
-    calico: {}
+    calico:
+      majorVersion: v3
 ```
 
 You will need to change that block, and add an additional field, to look like this:
@@ -178,6 +179,7 @@ You will need to change that block, and add an additional field, to look like th
 ```
   networking:
     calico:
+      majorVersion: v3
       crossSubnet: true
 ```
 
@@ -193,6 +195,8 @@ Only the masters have the IAM policy (`ec2:*`) to allow k8s-ec2-srcdst to execut
 #### More information about Calico
 
 For Calico specific documentation please visit the [Calico Docs](http://docs.projectcalico.org/latest/getting-started/kubernetes/).
+
+For details on upgrading a Calico v2 deployment see [Calico Version 3](calico-v3.md).
 
 #### Getting help with Calico
 

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -87,6 +87,8 @@ type CalicoNetworkingSpec struct {
 	PrometheusGoMetricsEnabled bool `json:"prometheusGoMetricsEnabled,omitempty"`
 	// PrometheusProcessMetricsEnabled enables Prometheus process metrics collection
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
+	// MajorVersion is the version of Calico to use
+	MajorVersion string `json:"majorVersion,omitempty"`
 }
 
 // CanalNetworkingSpec declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -87,6 +87,8 @@ type CalicoNetworkingSpec struct {
 	PrometheusGoMetricsEnabled bool `json:"prometheusGoMetricsEnabled,omitempty"`
 	// PrometheusProcessMetricsEnabled enables Prometheus process metrics collection
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
+	// MajorVersion is the version of Calico to use
+	MajorVersion string `json:"majorVersion,omitempty"`
 }
 
 // CanalNetworkingSpec declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -453,6 +453,7 @@ func autoConvert_v1alpha1_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
+	out.MajorVersion = in.MajorVersion
 	return nil
 }
 
@@ -469,6 +470,7 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha1_CalicoNetworkingSpec(in *
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
+	out.MajorVersion = in.MajorVersion
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -87,6 +87,8 @@ type CalicoNetworkingSpec struct {
 	PrometheusGoMetricsEnabled bool `json:"prometheusGoMetricsEnabled,omitempty"`
 	// PrometheusProcessMetricsEnabled enables Prometheus process metrics collection
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
+	// MajorVersion is the version of Calico to use
+	MajorVersion string `json:"majorVersion,omitempty"`
 }
 
 // CanalNetworkingSpec declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -489,6 +489,7 @@ func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
+	out.MajorVersion = in.MajorVersion
 	return nil
 }
 
@@ -505,6 +506,7 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
+	out.MajorVersion = in.MajorVersion
 	return nil
 }
 

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -291,3 +291,47 @@ func Test_Validate_AdditionalPolicies(t *testing.T) {
 		testErrors(t, g.Input, errs, g.ExpectedErrors)
 	}
 }
+
+type caliInput struct {
+	Calico *kops.CalicoNetworkingSpec
+	Etcd   *kops.EtcdClusterSpec
+}
+
+func Test_Validate_Calico(t *testing.T) {
+	grid := []struct {
+		Input          caliInput
+		ExpectedErrors []string
+	}{
+		{
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{},
+				Etcd:   &kops.EtcdClusterSpec{},
+			},
+		},
+		{
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					MajorVersion: "v3",
+				},
+				Etcd: &kops.EtcdClusterSpec{
+					Version: "3.2.18",
+				},
+			},
+		},
+		{
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					MajorVersion: "v3",
+				},
+				Etcd: &kops.EtcdClusterSpec{
+					Version: "2.2.18",
+				},
+			},
+			ExpectedErrors: []string{"Invalid value::Calico.MajorVersion"},
+		},
+	}
+	for _, g := range grid {
+		errs := validateNetworkingCalico(g.Input.Calico, g.Input.Etcd, field.NewPath("Calico"))
+		testErrors(t, g.Input, errs, g.ExpectedErrors)
+	}
+}

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.6.yaml.template
@@ -141,7 +141,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v2.6.7
+          image: quay.io/calico/node:v2.6.9
           resources:
             requests:
               cpu: 10m
@@ -226,7 +226,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v1.11.2
+          image: quay.io/calico/cni:v1.11.5
           resources:
             requests:
               cpu: 10m
@@ -379,7 +379,7 @@ spec:
         operator: Exists
       containers:
         - name: calico-kube-controllers
-          image: quay.io/calico/kube-controllers:v1.0.3
+          image: quay.io/calico/kube-controllers:v1.0.4
           resources:
             requests:
               cpu: 10m

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7-v3.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7-v3.yaml.template
@@ -32,16 +32,11 @@ data:
           "etcd_scheme": "https",
           {{- end }}
           "log_level": "info",
-          {{- if .Networking.Calico.MTU }}
-          "mtu": {{- or .Networking.Calico.MTU }},
-          {{- end }}
           "ipam": {
             "type": "calico-ipam"
           },
           "policy": {
             "type": "k8s",
-            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
           },
           "kubernetes": {
             "kubeconfig": "/etc/cni/net.d/__KUBECONFIG_FILENAME__"
@@ -60,35 +55,22 @@ data:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: calico
+  name: calico-node
   labels:
     role.kubernetes.io/networking: "1"
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - namespaces
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
 ---
 
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: calico
+  name: calico-node
   namespace: kube-system
   labels:
     role.kubernetes.io/networking: "1"
@@ -97,16 +79,68 @@ metadata:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: calico
+  name: calico-node
   labels:
     role.kubernetes.io/networking: "1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: calico
+  name: calico-node
 subjects:
 - kind: ServiceAccount
-  name: calico
+  name: calico-node
+  namespace: kube-system
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-kube-controllers
+  labels:
+    role.kubernetes.io/networking: "1"
+rules:
+  - apiGroups:
+    - ""
+    - extensions
+    resources:
+      - pods
+      - namespaces
+      - networkpolicies
+      - nodes
+    verbs:
+      - watch
+      - list
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-kube-controllers
+  labels:
+    role.kubernetes.io/networking: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-kube-controllers
+subjects:
+- kind: ServiceAccount
+  name: calico-kube-controllers
   namespace: kube-system
 
 ---
@@ -127,9 +161,9 @@ spec:
     matchLabels:
       k8s-app: calico-node
   updateStrategy:
+    type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 1
-    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -139,14 +173,16 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostNetwork: true
-      serviceAccountName: calico
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoExecute
-        operator: Exists
-      - effect: NoSchedule
-        operator: Exists
+        # Make sure calico/node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      serviceAccountName: calico-node
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
@@ -155,10 +191,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v2.6.9
-          resources:
-            requests:
-              cpu: 10m
+          image: quay.io/calico/node:v3.2.1
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -174,17 +207,12 @@ spec:
             - name: ETCD_CA_CERT_FILE
               value: /certs/ca.pem
             {{- end }}
-            # Enable BGP.  Disable to enforce policy only.
+            # Choose the backend to use.
             - name: CALICO_NETWORKING_BACKEND
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
                   key: calico_backend
-            # Configure the IP Pool from which Pod IPs will be chosen.
-            - name: CALICO_IPV4POOL_CIDR
-              value: "{{ .KubeControllerManager.ClusterCIDR }}"
-            - name: CALICO_IPV4POOL_IPIP
-              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}cross-subnet{{- else -}}always{{- end -}}"
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "kops,bgp"
@@ -196,9 +224,17 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            # Auto-detect the BGP IP address.
-            - name: IP
-              value: ""
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
+            # chosen from this range. Changing this value after installation will have
+            # no effect. This should fall within `--cluster-cidr`.
+            # Configure the IP Pool from which Pod IPs will be chosen.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "{{ .KubeControllerManager.ClusterCIDR }}"
+            - name: CALICO_IPV4POOL_IPIP
+              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}cross-subnet{{- else -}}always{{- end -}}"
             # Disable IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"
@@ -217,20 +253,40 @@ spec:
             # Enable Prometheus process metrics collection
             - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
               value: "{{- or .Networking.Calico.PrometheusProcessMetricsEnabled "true" }}"
+            # Auto-detect the BGP IP address.
+            - name: IP
+              value: "autodetect"
             - name: FELIX_HEALTHENABLED
               value: "true"
-            {{- if .Networking.Calico.MTU }}
-            - name: FELIX_IPINIPMTU
-              value: "{{- or .Networking.Calico.MTU }}"
-            {{- end}}
           securityContext:
             privileged: true
+          resources:
+            requests:
+              cpu: 10m
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 9099
+              host: localhost
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+              - /bin/calico-node
+              - -bird-ready
+              - -felix-ready
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
             - mountPath: /var/run/calico
               name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
               readOnly: false
             # Necessary for gossip based DNS
             - mountPath: /etc/hosts
@@ -244,16 +300,12 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v1.11.5
-          resources:
-            requests:
-              cpu: 10m
-          imagePullPolicy: Always
+          image: quay.io/calico/cni:v3.2.1
           command: ["/install-cni.sh"]
           env:
-            # The name of calico config file
+            # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
-              value: 10-calico.conflist
+              value: "10-calico.conflist"
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
               valueFrom:
@@ -275,6 +327,50 @@ spec:
             - mountPath: /etc/hosts
               name: etc-hosts
               readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+      initContainers:
+        - name: migrate
+          image: calico/upgrade:v1.0.5
+          command: ['/bin/sh', '-c', '/node-init-container.sh']
+          env:
+            - name: CALICO_ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            - name: CALICO_APIV1_DATASTORE_TYPE
+              value: "etcdv2"
+            - name: CALICO_APIV1_ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+          {{- if eq $etcd_scheme "https" }}
+            - name: CALICO_ETCD_CERT_FILE
+              value: /certs/calico-client.pem
+            - name: CALICO_ETCD_KEY_FILE
+              value: /certs/calico-client-key.pem
+            - name: CALICO_ETCD_CA_CERT_FILE
+              value: /certs/ca.pem
+            - name: CALICO_APIV1_ETCD_CERT_FILE
+              value: /certs/calico-client.pem
+            - name: CALICO_APIV1_ETCD_KEY_FILE
+              value: /certs/calico-client-key.pem
+            - name: CALICO_APIV1_ETCD_CA_CERT_FILE
+              value: /certs/ca.pem
+          {{- end }}
+          volumeMounts:
+            # Necessary for gossip based DNS
+            - mountPath: /etc/hosts
+              name: etc-hosts
+              readOnly: true
+          {{- if eq $etcd_scheme "https" }}
+            - mountPath: /certs
+              name: calico
+              readOnly: true
+          {{- end }}
       volumes:
         # Used by calico/node.
         - name: lib-modules
@@ -283,6 +379,9 @@ spec:
         - name: var-run-calico
           hostPath:
             path: /var/run/calico
+        - name: var-lib-calico
+          hostPath:
+            path: /var/lib/calico
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
@@ -290,6 +389,7 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
+        # Necessary for gossip based DNS
         - name: etc-hosts
           hostPath:
             path: /etc/hosts
@@ -311,6 +411,8 @@ metadata:
   labels:
     k8s-app: calico-kube-controllers
     role.kubernetes.io/networking: "1"
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
 spec:
   # The controllers can only have a single active instance.
   replicas: 1
@@ -323,38 +425,33 @@ spec:
       labels:
         k8s-app: calico-kube-controllers
         role.kubernetes.io/networking: "1"
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       # The controllers must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.
       hostNetwork: true
-      serviceAccountName: calico
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-      - key: CriticalAddonsOnly
-        operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      serviceAccountName: calico-kube-controllers
       containers:
         - name: calico-kube-controllers
-          image: quay.io/calico/kube-controllers:v1.0.4
+          image: quay.io/calico/kube-controllers:v3.2.1
           resources:
             requests:
               cpu: 10m
           env:
-            # By default only policy, profile, workloadendpoint are turned
-            # on, node controller will decommission nodes that do not exist anymore
-            # this and CALICO_K8S_NODE_REF in calico-node fixes #3224, but invalid nodes that are
-            # already registered in calico needs to be deleted manually, see
-            # https://docs.projectcalico.org/v2.6/usage/decommissioning-a-node
-            - name: ENABLED_CONTROLLERS
-              value: policy,profile,workloadendpoint,node
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_endpoints
+            # Choose which controllers to run.
+            - name: ENABLED_CONTROLLERS
+              value: policy,profile,workloadendpoint,node
             {{- if eq $etcd_scheme "https" }}
             - name: ETCD_CERT_FILE
               value: /certs/calico-client.pem
@@ -362,18 +459,59 @@ spec:
               value: /certs/calico-client-key.pem
             - name: ETCD_CA_CERT_FILE
               value: /certs/ca.pem
+          volumeMounts:
+            - mountPath: /certs
+              name: calico
+              readOnly: true
             {{- end }}
+          readinessProbe:
+            exec:
+              command:
+              - /usr/bin/check-status
+              - -r
+      initContainers:
+        - name: migrate
+          image: calico/upgrade:v1.0.5
+          command: ['/bin/sh', '-c', '/controller-init.sh']
+          env:
+            - name: CALICO_ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            - name: CALICO_APIV1_DATASTORE_TYPE
+              value: "etcdv2"
+            - name: CALICO_APIV1_ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+          {{- if eq $etcd_scheme "https" }}
+            - name: CALICO_ETCD_CERT_FILE
+              value: /certs/calico-client.pem
+            - name: CALICO_ETCD_KEY_FILE
+              value: /certs/calico-client-key.pem
+            - name: CALICO_ETCD_CA_CERT_FILE
+              value: /certs/ca.pem
+            - name: CALICO_APIV1_ETCD_CERT_FILE
+              value: /certs/calico-client.pem
+            - name: CALICO_APIV1_ETCD_KEY_FILE
+              value: /certs/calico-client-key.pem
+            - name: CALICO_APIV1_ETCD_CA_CERT_FILE
+              value: /certs/ca.pem
+          {{- end }}
           volumeMounts:
             # Necessary for gossip based DNS
             - mountPath: /etc/hosts
               name: etc-hosts
               readOnly: true
-            {{- if eq $etcd_scheme "https" }}
+          {{- if eq $etcd_scheme "https" }}
             - mountPath: /certs
               name: calico
               readOnly: true
-            {{- end }}
+          {{- end }}
       volumes:
+        # Necessary for gossip based DNS
         - name: etc-hosts
           hostPath:
             path: /etc/hosts
@@ -382,60 +520,120 @@ spec:
           hostPath:
             path: /srv/kubernetes/calico
         {{- end }}
+
+# This manifest runs the Migration complete container that monitors for the
+# completion of the calico-node Daemonset rollout and when it finishes
+# successfully rolling out it will mark the migration complete and allow pods
+# to be created again.
 ---
 
-# This deployment turns off the old "policy-controller". It should remain at 0 replicas, and then
-# be removed entirely once the new kube-controllers deployment has been deployed above.
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: v1
+kind: ServiceAccount
 metadata:
-  name: calico-policy-controller
+  name: calico-upgrade-job
   namespace: kube-system
   labels:
-    k8s-app: calico-policy
+    role.kubernetes.io/networking: "1"
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-upgrade-job
+  labels:
+    role.kubernetes.io/networking: "1"
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+      - daemonsets/status
+    verbs:
+      - get
+      - list
+      - watch
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-upgrade-job
+  labels:
+    role.kubernetes.io/networking: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-upgrade-job
+subjects:
+- kind: ServiceAccount
+  name: calico-upgrade-job
+  namespace: kube-system
+---
+# If anything in this job is changed then the name of the job
+# should be changed because Jobs cannot be updated, so changing
+# the name would run a different Job if the previous version had been
+# created before and it does not hurt to rerun this job.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: calico-complete-upgrade
+  namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
-  # Turn this deployment off in favor of the kube-controllers deployment above.
-  replicas: 0
-  strategy:
-    type: Recreate
   template:
     metadata:
-      name: calico-policy-controller
-      namespace: kube-system
       labels:
-        k8s-app: calico-policy
+        role.kubernetes.io/networking: "1"
     spec:
       hostNetwork: true
-      serviceAccountName: calico
+      serviceAccountName: calico-upgrade-job
+      restartPolicy: OnFailure
       containers:
-        - name: calico-policy-controller
-          # This shouldn't get updated, since this is the last version we shipped that should be used.
-          image: quay.io/calico/kube-policy-controller:v0.7.0
+        - name: migrate-completion
+          image: calico/upgrade:v1.0.5
+          command: ['/bin/sh', '-c', '/completion-job.sh']
           env:
+            - name: EXPECTED_NODE_IMAGE
+              value: quay.io/calico/node:v3.1.1
             # The location of the Calico etcd cluster.
-            - name: ETCD_ENDPOINTS
+            - name: CALICO_ETCD_ENDPOINTS
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_endpoints
-            {{- if eq $etcd_scheme "https" }}
-            - name: ETCD_CERT_FILE
+            - name: CALICO_APIV1_DATASTORE_TYPE
+              value: "etcdv2"
+            - name: CALICO_APIV1_ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+          {{- if eq $etcd_scheme "https" }}
+            - name: CALICO_ETCD_CERT_FILE
               value: /certs/calico-client.pem
-            - name: ETCD_KEY_FILE
+            - name: CALICO_ETCD_KEY_FILE
               value: /certs/calico-client-key.pem
-            - name: ETCD_CA_CERT_FILE
+            - name: CALICO_ETCD_CA_CERT_FILE
               value: /certs/ca.pem
-            {{- end }}
+            - name: CALICO_APIV1_ETCD_CERT_FILE
+              value: /certs/calico-client.pem
+            - name: CALICO_APIV1_ETCD_KEY_FILE
+              value: /certs/calico-client-key.pem
+            - name: CALICO_APIV1_ETCD_CA_CERT_FILE
+              value: /certs/ca.pem
+          {{- end }}
           volumeMounts:
             # Necessary for gossip based DNS
             - mountPath: /etc/hosts
               name: etc-hosts
               readOnly: true
-            {{- if eq $etcd_scheme "https" }}
+          {{- if eq $etcd_scheme "https" }}
             - mountPath: /certs
               name: calico
               readOnly: true
-            {{ end }}
+          {{- end }}
       volumes:
         - name: etc-hosts
           hostPath:
@@ -527,7 +725,7 @@ spec:
         operator: Exists
       serviceAccountName: k8s-ec2-srcdst
       containers:
-        - image: ottoyiu/k8s-ec2-srcdst:v0.2.2
+        - image: ottoyiu/k8s-ec2-srcdst:v0.2.1
           name: k8s-ec2-srcdst
           resources:
             requests:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -643,53 +643,71 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		key := "networking.projectcalico.org"
 		versions := map[string]string{
 			"pre-k8s-1.6": "2.4.2-kops.1",
-			"k8s-1.6":     "2.6.7-kops.2",
-			"k8s-1.7":     "2.6.7-kops.3",
+			"k8s-1.6":     "2.6.9-kops.1",
+			"k8s-1.7":     "2.6.9-kops.1",
+			"k8s-1.7-v3":  "3.2.1-kops.1",
 		}
 
-		{
-			id := "pre-k8s-1.6"
-			location := key + "/" + id + ".yaml"
+		if b.cluster.Spec.Networking.Calico.MajorVersion == "v3" {
+			{
+				id := "k8s-1.7-v3"
+				location := key + "/" + id + ".yaml"
 
-			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
-				Name:              fi.String(key),
-				Version:           fi.String(versions[id]),
-				Selector:          networkingSelector,
-				Manifest:          fi.String(location),
-				KubernetesVersion: "<1.6.0",
-				Id:                id,
-			})
-			manifests[key+"-"+id] = "addons/" + location
-		}
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(versions[id]),
+					Selector:          networkingSelector,
+					Manifest:          fi.String(location),
+					KubernetesVersion: ">=1.7.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
+		} else {
+			{
+				id := "pre-k8s-1.6"
+				location := key + "/" + id + ".yaml"
 
-		{
-			id := "k8s-1.6"
-			location := key + "/" + id + ".yaml"
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(versions[id]),
+					Selector:          networkingSelector,
+					Manifest:          fi.String(location),
+					KubernetesVersion: "<1.6.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
 
-			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
-				Name:              fi.String(key),
-				Version:           fi.String(versions[id]),
-				Selector:          networkingSelector,
-				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.6.0 <1.7.0",
-				Id:                id,
-			})
-			manifests[key+"-"+id] = "addons/" + location
-		}
+			{
+				id := "k8s-1.6"
+				location := key + "/" + id + ".yaml"
 
-		{
-			id := "k8s-1.7"
-			location := key + "/" + id + ".yaml"
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(versions[id]),
+					Selector:          networkingSelector,
+					Manifest:          fi.String(location),
+					KubernetesVersion: ">=1.6.0 <1.7.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
 
-			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
-				Name:              fi.String(key),
-				Version:           fi.String(versions[id]),
-				Selector:          networkingSelector,
-				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.7.0",
-				Id:                id,
-			})
-			manifests[key+"-"+id] = "addons/" + location
+			{
+				id := "k8s-1.7"
+				location := key + "/" + id + ".yaml"
+
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(versions[id]),
+					Selector:          networkingSelector,
+					Manifest:          fi.String(location),
+					KubernetesVersion: ">=1.7.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
 		}
 	}
 


### PR DESCRIPTION
Addresses #5101 

I have been able to install with Kops 1.9.0 and then using my changes here am able to upgrade to Calico v3.

Note: This PR is currently using unreleased changes from calico/upgrade that exist as https://github.com/projectcalico/calico-upgrade/pull/35, before this PR is merged I expect a release to be made based on those changes and then the images named tmjd/calico-upgrade to be replaced.

TODO:
- [x] Add docs for using the newly added field
- [x] Validation, if possible, of the cluster configuration when Calico APIVersion v3 is specified that an appropriate etcd version is being used also.