### PR TITLE
Amazon VPC CNI: Upgrade to v1.0 and Allow Custom Images

### DIFF
--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -124,6 +124,9 @@ type RomanaNetworkingSpec struct {
 
 // AmazonVPCNetworkingSpec declares that we want Amazon VPC CNI networking
 type AmazonVPCNetworkingSpec struct {
+	// The container image name to use, which by default is:
+	// 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:0.1.1
+	ImageName string `json:"imageName,omitempty"`
 }
 
 // CiliumNetworkingSpec declares that we want Cilium networking

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -125,7 +125,7 @@ type RomanaNetworkingSpec struct {
 // AmazonVPCNetworkingSpec declares that we want Amazon VPC CNI networking
 type AmazonVPCNetworkingSpec struct {
 	// The container image name to use, which by default is:
-	// 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:0.1.1
+	// 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.0.0
 	ImageName string `json:"imageName,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -123,7 +123,11 @@ type RomanaNetworkingSpec struct {
 }
 
 // AmazonVPCNetworkingSpec declares that we want Amazon VPC CNI networking
-type AmazonVPCNetworkingSpec struct{}
+type AmazonVPCNetworkingSpec struct {
+	// The container image name to use, which by default is:
+	// 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:0.1.1
+	ImageName string `json:"imageName,omitempty"`
+}
 
 // CiliumNetworkingSpec declares that we want Cilium networking
 type CiliumNetworkingSpec struct {

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -125,7 +125,7 @@ type RomanaNetworkingSpec struct {
 // AmazonVPCNetworkingSpec declares that we want Amazon VPC CNI networking
 type AmazonVPCNetworkingSpec struct {
 	// The container image name to use, which by default is:
-	// 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:0.1.1
+	// 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.0.0
 	ImageName string `json:"imageName,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -249,6 +249,7 @@ func Convert_kops_AlwaysAllowAuthorizationSpec_To_v1alpha1_AlwaysAllowAuthorizat
 }
 
 func autoConvert_v1alpha1_AmazonVPCNetworkingSpec_To_kops_AmazonVPCNetworkingSpec(in *AmazonVPCNetworkingSpec, out *kops.AmazonVPCNetworkingSpec, s conversion.Scope) error {
+	out.ImageName = in.ImageName
 	return nil
 }
 
@@ -258,6 +259,7 @@ func Convert_v1alpha1_AmazonVPCNetworkingSpec_To_kops_AmazonVPCNetworkingSpec(in
 }
 
 func autoConvert_kops_AmazonVPCNetworkingSpec_To_v1alpha1_AmazonVPCNetworkingSpec(in *kops.AmazonVPCNetworkingSpec, out *AmazonVPCNetworkingSpec, s conversion.Scope) error {
+	out.ImageName = in.ImageName
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -123,7 +123,11 @@ type RomanaNetworkingSpec struct {
 }
 
 // AmazonVPCNetworkingSpec declares that we want Amazon VPC CNI networking
-type AmazonVPCNetworkingSpec struct{}
+type AmazonVPCNetworkingSpec struct {
+	// The container image name to use, which by default is:
+	// 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:0.1.1
+	ImageName string `json:"imageName,omitempty"`
+}
 
 // CiliumNetworkingSpec declares that we want Cilium networking
 type CiliumNetworkingSpec struct {

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -125,7 +125,7 @@ type RomanaNetworkingSpec struct {
 // AmazonVPCNetworkingSpec declares that we want Amazon VPC CNI networking
 type AmazonVPCNetworkingSpec struct {
 	// The container image name to use, which by default is:
-	// 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:0.1.1
+	// 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.0.0
 	ImageName string `json:"imageName,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -263,6 +263,7 @@ func Convert_kops_AlwaysAllowAuthorizationSpec_To_v1alpha2_AlwaysAllowAuthorizat
 }
 
 func autoConvert_v1alpha2_AmazonVPCNetworkingSpec_To_kops_AmazonVPCNetworkingSpec(in *AmazonVPCNetworkingSpec, out *kops.AmazonVPCNetworkingSpec, s conversion.Scope) error {
+	out.ImageName = in.ImageName
 	return nil
 }
 
@@ -272,6 +273,7 @@ func Convert_v1alpha2_AmazonVPCNetworkingSpec_To_kops_AmazonVPCNetworkingSpec(in
 }
 
 func autoConvert_kops_AmazonVPCNetworkingSpec_To_v1alpha2_AmazonVPCNetworkingSpec(in *kops.AmazonVPCNetworkingSpec, out *AmazonVPCNetworkingSpec, s conversion.Scope) error {
+	out.ImageName = in.ImageName
 	return nil
 }
 

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/0.1.1-kops.1.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/0.1.1-kops.1.yaml.template
@@ -23,7 +23,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       containers:
-      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:0.1.1
+      - image: {{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:0.1.1" }}
         name: aws-node
         env:
           - name: ECS_CNI_LOGLEVEL

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.7.yaml.template
@@ -1,3 +1,44 @@
+# Vendored from https://github.com/aws/amazon-vpc-cni-k8s/blob/release-1.0/config/v1.0/aws-k8s-cni.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: aws-node
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  - namespaces
+  verbs: ["list", "watch", "get"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  verbs: ["list", "watch"]
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-node
+  namespace: kube-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: aws-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+- kind: ServiceAccount
+  name: aws-node
+  namespace: kube-system
+
+---
+
 kind: DaemonSet
 apiVersion: extensions/v1beta1
 metadata:
@@ -6,6 +47,8 @@ metadata:
   labels:
     k8s-app: aws-node
 spec:
+  updateStrategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       k8s-app: aws-node
@@ -16,6 +59,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      serviceAccountName: aws-node
       hostNetwork: true
       tolerations:
       - key: node-role.kubernetes.io/master
@@ -23,11 +67,15 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       containers:
-      - image: {{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.0.0" }}
+      - image: "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.0.0" }}"
         name: aws-node
         env:
-          - name: ECS_CNI_LOGLEVEL
+          - name: AWS_VPC_K8S_CNI_LOGLEVEL
             value: DEBUG
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         resources:
           requests:
             cpu: 10m
@@ -40,6 +88,8 @@ spec:
           name: cni-net-dir
         - mountPath: /host/var/log
           name: log-dir
+        - mountPath: /var/run/docker.sock
+          name: dockersock
       volumes:
       - name: cni-bin-dir
         hostPath:
@@ -50,6 +100,9 @@ spec:
       - name: log-dir
         hostPath:
           path: /var/log
+      - name: dockersock
+        hostPath:
+          path: /var/run/docker.sock
 
 ---
 

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.7.yaml.template
@@ -23,7 +23,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       containers:
-      - image: {{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:0.1.1" }}
+      - image: {{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.0.0" }}
         name: aws-node
         env:
           - name: ECS_CNI_LOGLEVEL

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -699,11 +699,11 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.AmazonVPC != nil {
 		key := "networking.amazon-vpc-routed-eni"
-		version := "0.1.1-kops.1"
+		version := "1.0.0-kops.1"
 
 		{
-			location := fmt.Sprintf("%v/%v.yaml", key, version)
 			id := "k8s-1.7"
+			location := key + "/" + id + ".yaml"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),


### PR DESCRIPTION
We use the Amazon's VPC CNI plugin (`amazonvpc` in the cluster spec), which is currently bundled at version 0.1.1. The intent for this PR are:

1. To allow the docker image to be overridden in the cluster spec, which would allow easier testing to network upgrades or custom image builds. The spec snippet looks like:

```yaml
spec:
  networking:
    amazonvpc:
      imageName: repo.example.com/amazon-k8s-cni:0.1.1
```

2. To upgrade the default image version from 0.1.1 to 0.1.4.

I'm not intimately familiar with the kops way, so let me know if there's a better approach I should use or I've missed updating any generated files.