### PR TITLE
Unify create-create overrides and set-cluster fields

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/kops/pkg/apis/kops/registry"
 	"k8s.io/kops/pkg/apis/kops/validation"
 	"k8s.io/kops/pkg/assets"
+	"k8s.io/kops/pkg/commands"
 	"k8s.io/kops/pkg/dns"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi"
@@ -1041,7 +1042,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		cluster.Spec.SSHAccess = c.SSHAccess
 	}
 
-	if err := setOverrides(c.Overrides, cluster, instanceGroups); err != nil {
+	if err := commands.SetClusterFields(c.Overrides, cluster, instanceGroups); err != nil {
 		return err
 	}
 
@@ -1244,29 +1245,6 @@ func parseCloudLabels(s string) (map[string]string, error) {
 		m[pair[0]] = pair[1]
 	}
 	return m, nil
-}
-
-// setOverrides sets override values in the spec
-func setOverrides(overrides []string, cluster *api.Cluster, instanceGroups []*api.InstanceGroup) error {
-	for _, override := range overrides {
-		kv := strings.SplitN(override, "=", 2)
-		if len(kv) != 2 {
-			return fmt.Errorf("unhandled override: %q", override)
-		}
-
-		// For now we have hard-code the values we want to support; we'll get test coverage and then do this properly...
-		switch kv[0] {
-		case "cluster.spec.nodePortAccess":
-			cluster.Spec.NodePortAccess = append(cluster.Spec.NodePortAccess, kv[1])
-		case "cluster.spec.etcdClusters[*].version":
-			for _, etcd := range cluster.Spec.EtcdClusters {
-				etcd.Version = kv[1]
-			}
-		default:
-			return fmt.Errorf("unhandled override: %q", override)
-		}
-	}
-	return nil
 }
 
 func getZoneToSubnetProviderID(VPCID string, region string, subnetIDs []string) (map[string]string, error) {

--- a/pkg/commands/set_cluster.go
+++ b/pkg/commands/set_cluster.go
@@ -59,7 +59,7 @@ func RunSetCluster(f *util.Factory, cmd *cobra.Command, out io.Writer, options *
 		return err
 	}
 
-	if err := setClusterFields(options.Fields, cluster); err != nil {
+	if err := SetClusterFields(options.Fields, cluster, instanceGroups); err != nil {
 		return err
 	}
 
@@ -70,8 +70,8 @@ func RunSetCluster(f *util.Factory, cmd *cobra.Command, out io.Writer, options *
 	return nil
 }
 
-// setClusterFields sets field values in the cluster
-func setClusterFields(fields []string, cluster *api.Cluster) error {
+// SetClusterFields sets field values in the cluster
+func SetClusterFields(fields []string, cluster *api.Cluster, instanceGroups []*api.InstanceGroup) error {
 	for _, field := range fields {
 		kv := strings.SplitN(field, "=", 2)
 		if len(kv) != 2 {
@@ -80,8 +80,14 @@ func setClusterFields(fields []string, cluster *api.Cluster) error {
 
 		// For now we have hard-code the values we want to support; we'll get test coverage and then do this properly...
 		switch kv[0] {
+		case "cluster.spec.nodePortAccess":
+			cluster.Spec.NodePortAccess = append(cluster.Spec.NodePortAccess, kv[1])
 		case "spec.kubernetesVersion":
 			cluster.Spec.KubernetesVersion = kv[1]
+		case "cluster.spec.etcdClusters[*].version":
+			for _, c := range cluster.Spec.EtcdClusters {
+				c.Version = kv[1]
+			}
 		default:
 			return fmt.Errorf("unhandled field: %q", field)
 		}

--- a/pkg/commands/set_cluster_test.go
+++ b/pkg/commands/set_cluster_test.go
@@ -40,8 +40,10 @@ func TestSetClusterFields(t *testing.T) {
 	}
 
 	for _, g := range grid {
+		var igs []*kops.InstanceGroup
 		c := g.Input
-		err := setClusterFields(g.Fields, &c)
+
+		err := SetClusterFields(g.Fields, &c, igs)
 		if err != nil {
 			t.Errorf("unexpected error from setClusterFields %v: %v", g.Fields, err)
 			continue


### PR DESCRIPTION
Supports e2e upgrade tests