### PR TITLE
Update elasticsearch logging to 5.6.4

### DIFF
--- a/addons/logging-elasticsearch/addon.yaml
+++ b/addons/logging-elasticsearch/addon.yaml
@@ -13,3 +13,8 @@ spec:
       k8s-addon: logging-elasticsearch.addons.k8s.io
     manifest: v1.6.0.yaml
     kubernetesVersion: ">=1.6.0" # RBAC v1beta1 is introduced as of v1.6.0
+  - version: 1.7.0
+    selector:
+      k8s-addon: logging-elasticsearch.addons.k8s.io
+    manifest: v1.7.0.yaml
+    kubernetesVersion: ">=1.6.0"

--- a/addons/logging-elasticsearch/v1.7.0.yaml
+++ b/addons/logging-elasticsearch/v1.7.0.yaml
@@ -1,0 +1,280 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: elasticsearch-logging
+  namespace: kube-system
+  labels:
+    k8s-app: elasticsearch-logging
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: elasticsearch-logging
+  labels:
+    k8s-app: elasticsearch-logging
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "services"
+  - "namespaces"
+  - "endpoints"
+  verbs:
+  - "get"
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: kube-system
+  name: elasticsearch-logging
+  labels:
+    k8s-app: elasticsearch-logging
+subjects:
+- kind: ServiceAccount
+  name: elasticsearch-logging
+  namespace: kube-system
+  apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: elasticsearch-logging
+  apiGroup: ""
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd-es
+  namespace: kube-system
+  labels:
+    k8s-app: fluentd-es
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: fluentd-es
+  labels:
+    k8s-app: fluentd-es
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "namespaces"
+  - "pods"
+  verbs:
+  - "get"
+  - "watch"
+  - "list"
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: fluentd-es
+  labels:
+    k8s-app: fluentd-es
+subjects:
+- kind: ServiceAccount
+  name: fluentd-es
+  namespace: kube-system
+  apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: fluentd-es
+  apiGroup: ""
+
+---
+
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fluentd-es
+  namespace: kube-system
+  labels:
+    k8s-addon: logging-elasticsearch.addons.k8s.io
+    k8s-app: fluentd-es
+    kubernetes.io/cluster-service: "true"
+    version: v1.22
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd-es
+        kubernetes.io/cluster-service: "true"
+        version: v1.22
+    spec:
+      serviceAccountName: fluentd-es
+      containers:
+      - name: fluentd-es
+        image: k8s.gcr.io/fluentd-elasticsearch:1.22
+        command:
+          - '/bin/sh'
+          - '-c'
+          - '/usr/sbin/td-agent 2>&1 >> /var/log/fluentd.log'
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+      #nodeSelector:
+      #  alpha.kubernetes.io/fluentd-ds-ready: "true"
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-logging
+  namespace: kube-system
+  labels:
+    k8s-addon: logging-elasticsearch.addons.k8s.io
+    k8s-app: elasticsearch-logging
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "Elasticsearch"
+spec:
+  ports:
+  - port: 9200
+    protocol: TCP
+    targetPort: db
+  selector:
+    k8s-app: elasticsearch-logging
+
+---
+
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: elasticsearch-logging
+  namespace: kube-system
+  labels:
+    k8s-addon: logging-elasticsearch.addons.k8s.io
+    k8s-app: elasticsearch-logging
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  serviceName: elasticsearch-logging
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        k8s-app: elasticsearch-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      serviceAccountName: elasticsearch-logging
+      containers:
+      - image: k8s.gcr.io/elasticsearch:v2.4.1-2
+        name: elasticsearch-logging
+        resources:
+          # need more cpu upon initialization, therefore burstable class
+          limits:
+            cpu: 1000m
+          requests:
+            cpu: 100m
+        ports:
+        - containerPort: 9200
+          name: db
+          protocol: TCP
+        - containerPort: 9300
+          name: transport
+          protocol: TCP
+        volumeMounts:
+        - name: es-persistent-storage
+          mountPath: /data
+        env:
+        - name: "NAMESPACE"
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+  volumeClaimTemplates:
+  - metadata:
+      name: es-persistent-storage
+      annotations:
+        volume.beta.kubernetes.io/storage-class: "default"
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 20Gi
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kibana-logging
+  namespace: kube-system
+  labels:
+    k8s-addon: logging-elasticsearch.addons.k8s.io
+    k8s-app: kibana-logging
+    kubernetes.io/cluster-service: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: kibana-logging
+  template:
+    metadata:
+      labels:
+        k8s-app: kibana-logging
+    spec:
+      containers:
+      - name: kibana-logging
+        image: k8s.gcr.io/kibana:v4.6.1-1
+        resources:
+          # keep request = limit to keep this container in guaranteed class
+          limits:
+            cpu: 100m
+          requests:
+            cpu: 100m
+        env:
+          - name: "ELASTICSEARCH_URL"
+            value: "http://elasticsearch-logging:9200"
+          - name: "KIBANA_BASE_URL"
+            value: "/api/v1/proxy/namespaces/kube-system/services/kibana-logging"
+        ports:
+        - containerPort: 5601
+          name: ui
+          protocol: TCP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: kibana-logging
+  namespace: kube-system
+  labels:
+    k8s-addon: logging-elasticsearch.addons.k8s.io
+    k8s-app: kibana-logging
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "Kibana"
+spec:
+  ports:
+  - port: 5601
+    protocol: TCP
+    targetPort: ui
+  selector:
+    k8s-app: kibana-logging

--- a/addons/logging-elasticsearch/v1.7.0.yaml
+++ b/addons/logging-elasticsearch/v1.7.0.yaml
@@ -101,14 +101,14 @@ metadata:
     k8s-addon: logging-elasticsearch.addons.k8s.io
     k8s-app: fluentd-es
     kubernetes.io/cluster-service: "true"
-    version: v1.22
+    version: v2.0.4
 spec:
   template:
     metadata:
       labels:
         k8s-app: fluentd-es
         kubernetes.io/cluster-service: "true"
-        version: v1.22
+        version: v2.0.4
     spec:
       serviceAccountName: fluentd-es
       containers:
@@ -185,7 +185,7 @@ spec:
     spec:
       serviceAccountName: elasticsearch-logging
       containers:
-      - image: k8s.gcr.io/elasticsearch:v2.4.1-2
+      - image: k8s.gcr.io/elasticsearch:v5.6.4
         name: elasticsearch-logging
         resources:
           # need more cpu upon initialization, therefore burstable class
@@ -242,7 +242,7 @@ spec:
     spec:
       containers:
       - name: kibana-logging
-        image: k8s.gcr.io/kibana:v4.6.1-1
+        image: docker.elastic.co/kibana/kibana:5.6.4
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:
@@ -252,8 +252,12 @@ spec:
         env:
           - name: "ELASTICSEARCH_URL"
             value: "http://elasticsearch-logging:9200"
-          - name: "KIBANA_BASE_URL"
+          - name: "SERVER_BASEPATH"
             value: "/api/v1/proxy/namespaces/kube-system/services/kibana-logging"
+          - name: "XPACK_MONITORING_ENABLED"
+            value: "false"
+          - name: "XPACK_SECURITY_ENABLED"
+            value: "false"
         ports:
         - containerPort: 5601
           name: ui


### PR DESCRIPTION
I've picked the versions of everything used by the kubernetes
fluentd-elasticsearch plugin at https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/fluentd-elasticsearch/kibana-deployment.yaml

I'm not sure exactly how versioning for addons is supposed to work. These changes don't depend on any particular version of kubernetes which is what the addon versions seem to be named after.

I've kept it in 1.6.0 for ease of diff/review for now