### PR TITLE
set default GracePeriodSeconds to -1 when draining nodes

### DIFF
--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -303,12 +303,13 @@ func (r *RollingUpdateInstanceGroup) DrainNode(u *cloudinstances.CloudInstanceGr
 	errOut := os.Stderr
 
 	options := &cmd.DrainOptions{
-		Factory:          f,
-		Out:              out,
-		IgnoreDaemonsets: true,
-		Force:            true,
-		DeleteLocalData:  true,
-		ErrOut:           errOut,
+		Factory:            f,
+		Out:                out,
+		IgnoreDaemonsets:   true,
+		Force:              true,
+		DeleteLocalData:    true,
+		ErrOut:             errOut,
+		GracePeriodSeconds: -1,
 	}
 
 	cmd := cmd.NewCmdDrain(f, out, errOut)


### PR DESCRIPTION
the default value for GracePeriodSeconds in kubectl drain is set to -1, therefore the drain node gives pod time to terminate gracefully, but through kops its set to use default int value 0, and therefore pods are terminated immediately.

disclaimer: I've not tested it, and plan to test it tonight by triggering a rolling update on one IG for my cluster, but theoretically this seems to be the reason why our pods are not getting any graceful termination time as reported by our users.

Please let me know if this does not make sense.