### PR TITLE
fix broken link to example policy file in the cluster_spec docs

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -177,7 +177,7 @@ spec:
 
 You could use the [fileAssets](https://github.com/kubernetes/kops/blob/master/docs/cluster_spec.md#fileassets)  feature to push an advanced audit policy file on the master nodes.
 
-Example policy file can be found [here]( https://raw.githubusercontent.com/kubernetes/website/master/docs/tasks/debug-application-cluster/audit-policy.yaml)
+Example policy file can be found [here](https://github.com/kubernetes/website/blob/master/content/en/docs/tasks/debug-application-cluster/audit-policy.yaml)
 
 #### Max Requests Inflight 
 


### PR DESCRIPTION
The link in the cluster_spec docs was broken directing to a page no longer existing. 

Corrected this to the link of the example currently displayed at: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/