### PR TITLE
Add stdin support for create -f and replace -f

### DIFF
--- a/docs/cli/kops_create.md
+++ b/docs/cli/kops_create.md
@@ -13,7 +13,7 @@ Create a resource:
   * instancegroup  
   * secret  
 
-Create a cluster, instancegroup or secret using command line parameters or YAML configuration specification files. (Note: secrets cannot be created from YAML config files yet).
+Create a cluster, instancegroup or secret using command line parameters, YAML configuration specification files, or stdin. (Note: secrets cannot be created from YAML config files yet).
 
 ```
 kops create -f FILENAME [flags]
@@ -27,6 +27,9 @@ kops create -f FILENAME [flags]
   
   # Create secret from secret spec file
   kops create -f secret.yaml
+  
+  # Create an instancegroup based on the YAML passed into stdin.
+  cat instancegroup.yaml | kops create -f -
   
   # Create a cluster in AWS
   kops create cluster --name=kubernetes-cluster.example.com \

--- a/docs/cli/kops_replace.md
+++ b/docs/cli/kops_replace.md
@@ -19,6 +19,9 @@ kops replace -f FILENAME [flags]
   # Replace a cluster desired configuration using a YAML file
   kops replace -f my-cluster.yaml
   
+  # Replace an instancegroup using YAML passed into stdin.
+  cat instancegroup.yaml | kops replace -f -
+  
   # Note, if the resource does not exist the command will error, use --force to provision resource
   kops replace -f my-cluster.yaml --force
 ```


### PR DESCRIPTION
This allows clusters to be created using STDIN, using `kops create -f -` and `kops replace -f -`, similar to the behavior of kubectl