### PR TITLE
Change ca key perms on master

### DIFF
--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -68,6 +68,7 @@ func (b *KubeControllerManagerBuilder) Build(c *fi.ModelBuilderContext) error {
 			Path:     filepath.Join(b.PathSrvKubernetes(), "ca.key"),
 			Contents: fi.NewStringResource(serialized),
 			Type:     nodetasks.FileType_File,
+			Mode: s("0600"),
 		})
 	}
 

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -68,7 +68,7 @@ func (b *KubeControllerManagerBuilder) Build(c *fi.ModelBuilderContext) error {
 			Path:     filepath.Join(b.PathSrvKubernetes(), "ca.key"),
 			Contents: fi.NewStringResource(serialized),
 			Type:     nodetasks.FileType_File,
-			Mode: s("0600"),
+			Mode:     s("0600"),
 		})
 	}
 


### PR DESCRIPTION
This forced download of ca.key in /srv/kubernetes with fixed permissions 600 instead of default perms.
Fix for https://github.com/kubernetes/kops/issues/5163