### PR TITLE
Kuberenets 1.11 has deprecated ExternalID this replaces it with Provi…

### DIFF
--- a/pkg/cloudinstances/BUILD.bazel
+++ b/pkg/cloudinstances/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/kops:go_default_library",
+        "//pkg/apis/kops/util:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
     ],

--- a/pkg/cloudinstances/cloud_instance_group.go
+++ b/pkg/cloudinstances/cloud_instance_group.go
@@ -18,13 +18,13 @@ package cloudinstances
 
 import (
 	"fmt"
-        "strings"
+	"strings"
 
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
-        "k8s.io/kops/pkg/apis/kops"
-        "k8s.io/kops/pkg/apis/kops/util"
+	"k8s.io/kops/pkg/apis/kops"
 	api "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/util"
 )
 
 // CloudInstanceGroup is the cloud backing of InstanceGroup.
@@ -87,20 +87,20 @@ func (c *CloudInstanceGroup) Status() string {
 
 // GetNodeMap returns a list of nodes keyed by their external id
 func GetNodeMap(nodes []v1.Node, cluster *kops.Cluster) map[string]*v1.Node {
-        sv, _ := util.ParseKubernetesVersion(cluster.Spec.KubernetesVersion)
+	sv, _ := util.ParseKubernetesVersion(cluster.Spec.KubernetesVersion)
 
 	nodeMap := make(map[string]*v1.Node)
 	for i := range nodes {
 		node := &nodes[i]
-                //ExternalID is deprecated in kubernetes 1.11 https://github.com/kubernetes/kubernetes/pull/61877
-                //Mappings from ExternalID https://github.com/kubernetes/kubernetes/issues/61966#issuecomment-377659476
-                if sv.Major == 1 && sv.Minor < 10 {
-                       nodeMap[node.Spec.ExternalID] = node
-                } else {
-                        providerIDs := strings.Split(node.Spec.ProviderID,"/")
-                        instanceID := providerIDs[len(providerIDs)-1]
-                        nodeMap[instanceID] = node
-                }
+		//ExternalID is deprecated in kubernetes 1.11 https://github.com/kubernetes/kubernetes/pull/61877
+		//Mappings from ExternalID https://github.com/kubernetes/kubernetes/issues/61966#issuecomment-377659476
+		if sv.Major == 1 && sv.Minor < 10 {
+			nodeMap[node.Spec.ExternalID] = node
+		} else {
+			providerIDs := strings.Split(node.Spec.ProviderID, "/")
+			instanceID := providerIDs[len(providerIDs)-1]
+			nodeMap[instanceID] = node
+		}
 	}
 
 	return nodeMap

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -383,7 +383,7 @@ func (c *awsCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instanceg
 }
 
 func getCloudGroups(c AWSCloud, cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
-	nodeMap := cloudinstances.GetNodeMap(nodes)
+       nodeMap := cloudinstances.GetNodeMap(nodes, cluster)
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	asgs, err := FindAutoscalingGroups(c, c.Tags())

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -383,7 +383,7 @@ func (c *awsCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instanceg
 }
 
 func getCloudGroups(c AWSCloud, cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
-       nodeMap := cloudinstances.GetNodeMap(nodes, cluster)
+	nodeMap := cloudinstances.GetNodeMap(nodes, cluster)
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	asgs, err := FindAutoscalingGroups(c, c.Tags())

--- a/upup/pkg/fi/cloudup/gce/instancegroups.go
+++ b/upup/pkg/fi/cloudup/gce/instancegroups.go
@@ -100,7 +100,7 @@ func getCloudGroups(c GCECloud, cluster *kops.Cluster, instancegroups []*kops.In
 
 	project := c.Project()
 	ctx := context.Background()
-	nodesByExternalID := cloudinstances.GetNodeMap(nodes)
+       nodesByProviderID := cloudinstances.GetNodeMap(nodes, cluster)
 
 	// There is some code duplication with resources/gce.go here, but more in the structure than a straight copy-paste
 
@@ -171,7 +171,7 @@ func getCloudGroups(c GCECloud, cluster *kops.Cluster, instancegroups []*kops.In
 						CloudInstanceGroup: g,
 					}
 
-					node := nodesByExternalID[strconv.FormatUint(i.Id, 10)]
+                                       node := nodesByProviderID[strconv.FormatUint(i.Id, 10)]
 					if node != nil {
 						cm.Node = node
 					} else {

--- a/upup/pkg/fi/cloudup/gce/instancegroups.go
+++ b/upup/pkg/fi/cloudup/gce/instancegroups.go
@@ -100,7 +100,7 @@ func getCloudGroups(c GCECloud, cluster *kops.Cluster, instancegroups []*kops.In
 
 	project := c.Project()
 	ctx := context.Background()
-       nodesByProviderID := cloudinstances.GetNodeMap(nodes, cluster)
+	nodesByProviderID := cloudinstances.GetNodeMap(nodes, cluster)
 
 	// There is some code duplication with resources/gce.go here, but more in the structure than a straight copy-paste
 
@@ -171,7 +171,7 @@ func getCloudGroups(c GCECloud, cluster *kops.Cluster, instancegroups []*kops.In
 						CloudInstanceGroup: g,
 					}
 
-                                       node := nodesByProviderID[strconv.FormatUint(i.Id, 10)]
+					node := nodesByProviderID[strconv.FormatUint(i.Id, 10)]
 					if node != nil {
 						cm.Node = node
 					} else {


### PR DESCRIPTION
…derID

Per https://github.com/kubernetes/kubernetes/pull/61877 ExternalID
is now removed from k8s.