### PR TITLE
Documentation - cloudProvider required in kubelet spec with Amazon VPC backend

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -252,6 +252,23 @@ spec:
     enableCustomMetrics: true
 ```
 
+#### Setting kubelet configurations together with the Amazon VPC backend
+Setting kubelet configurations together with the networking Amazon VPC backend requires to also set the `cloudProvider: aws` setting in this block. Example:
+
+```yaml
+spec:
+  kubelet:
+    enableCustomMetrics: true
+    cloudProvider: aws
+...
+...
+  cloudProvider: aws
+...
+...
+  networking:
+    amazonvpc: {}
+```
+
 ### kubeScheduler
 
 This block contains configurations for `kube-scheduler`.  See https://kubernetes.io/docs/admin/kube-scheduler/


### PR DESCRIPTION
The code in https://github.com/kubernetes/kops/blob/80c692fa1a6b60dc09cca37b75e8e863979f2989/pkg/apis/kops/validation/legacy.go#L496-L499

shows that the `cloudProvider: aws` must be set for the kubelet block when using the Amazon VPC backend. This PR explains this .