### PR TITLE
1.8 release notes correctly note `replace --force`

### DIFF
--- a/docs/releases/1.8-NOTES.md
+++ b/docs/releases/1.8-NOTES.md
@@ -44,7 +44,7 @@
 
 * Add `kops create secret dockerconfig`
 
-* `kops replace --create` will now replace-or-create, which is useful for CI / automated workflows
+* `kops replace --force` will now replace-or-create, which is useful for CI / automated workflows
 
 * `--watch-ingress` flag on dns-controller can now be configured through `cluster.spec.externalDns.watchIngress: true`
 


### PR DESCRIPTION
`kops replace --create` was replaced with `kops replace --force`, but
the release notes were not updated to match this.

When merging, https://github.com/kubernetes/kops/releases/tag/1.8.0 should be
manually updated to match this change.

fixes #4012