### PR TITLE
added i3.metal AWS instance type

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/machine_types.go
+++ b/upup/pkg/fi/cloudup/awsup/machine_types.go
@@ -567,6 +567,13 @@ var MachineTypes []AWSMachineTypeInfo = []AWSMachineTypeInfo{
 		Cores:          64,
 		EphemeralDisks: []int{1900, 1900, 1900, 1900, 1900, 1900, 1900, 1900},
 	},
+	{
+		Name:           "i3.metal",
+		MemoryGB:       512,
+		ECU:            208,
+		Cores:          72,
+		EphemeralDisks: []int{1900, 1900, 1900, 1900, 1900, 1900, 1900, 1900},
+	},
 
 	// r3 family
 	{


### PR DESCRIPTION
fixes #5188 
Adds the i3.metal AWS instance type to KOPS.  ECUs , local storage etc validated from [here](https://aws.amazon.com/ec2/pricing/on-demand/)