### PR TITLE
Update CoreDNS manifest

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
@@ -65,6 +65,7 @@ data:
         prometheus :9153
         proxy . /etc/resolv.conf
         cache 30
+        reload
     }
 ---
 apiVersion: extensions/v1beta1
@@ -98,7 +99,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: coredns/coredns:1.0.6
+        image: coredns/coredns:1.1.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -116,6 +117,9 @@ spec:
           protocol: UDP
         - containerPort: 53
           name: dns-tcp
+          protocol: TCP
+        - containerPort: 9153
+          name: metrics
           protocol: TCP
         livenessProbe:
           httpGet:
@@ -140,6 +144,8 @@ kind: Service
 metadata:
   name: kube-dns
   namespace: kube-system
+  annotations:
+    prometheus.io/scrape: "true"
   labels:
     k8s-addon: coredns.addons.k8s.io
     k8s-app: kube-dns

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -173,7 +173,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 	if kubeDNS.Provider == "CoreDNS" {
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.0.6"
+			version := "1.1.3"
 
 			{
 				location := key + "/k8s-1.6.yaml"


### PR DESCRIPTION
Bumps CoreDNS to 1.1.3 and updates to the latest manifest.