### PR TITLE
Adds c5d instance types

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/machine_types.go
+++ b/upup/pkg/fi/cloudup/awsup/machine_types.go
@@ -368,6 +368,50 @@ var MachineTypes []AWSMachineTypeInfo = []AWSMachineTypeInfo{
 		EphemeralDisks: nil,
 	},
 
+	// c5d family
+	{
+		Name:           "c5d.large",
+		MemoryGB:       4,
+		ECU:            8,
+		Cores:          2,
+		EphemeralDisks: []int{50},
+	},
+	{
+		Name:           "c5d.xlarge",
+		MemoryGB:       8,
+		ECU:            16,
+		Cores:          4,
+		EphemeralDisks: []int{100},
+	},
+	{
+		Name:           "c5d.2xlarge",
+		MemoryGB:       16,
+		ECU:            31,
+		Cores:          8,
+		EphemeralDisks: []int{200},
+	},
+	{
+		Name:           "c5d.4xlarge",
+		MemoryGB:       32,
+		ECU:            62,
+		Cores:          16,
+		EphemeralDisks: []int{400},
+	},
+	{
+		Name:           "c5d.9xlarge",
+		MemoryGB:       72,
+		ECU:            139,
+		Cores:          36,
+		EphemeralDisks: []int{900},
+	},
+	{
+		Name:           "c5d.18xlarge",
+		MemoryGB:       144,
+		ECU:            278,
+		Cores:          72,
+		EphemeralDisks: []int{900, 900},
+	},
+
 	// cc2 family
 	{
 		Name:           "cc2.8xlarge",


### PR DESCRIPTION
Adds c5d AWS instance types to KOPS. Machine configuration is validated against existing c5 instance types and [here](https://aws.amazon.com/ec2/pricing/on-demand/) - in particular the local storage values.