### PR TITLE
Bump Cilium version to released

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
@@ -26,8 +26,11 @@ data:
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
   # If you want to run cilium in debug mode change this value to true
-  debug: "true"
+  debug: "false"
   disable-ipv4: "false"
+  sidecar-http-proxy: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret
@@ -90,7 +93,7 @@ spec:
     spec:
       serviceAccountName: cilium
       containers:
-      - image: cilium/cilium:v1.0.0-rc8
+      - image: cilium/cilium:v1.0-stable
         imagePullPolicy: Always
         name: cilium-agent
         command: [ "cilium-agent" ]
@@ -263,7 +266,7 @@ rules:
 - apiGroups:
   - extensions
   resources:
-  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - networkpolicies
   - thirdpartyresources
   - ingresses
   verbs:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -703,7 +703,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Cilium != nil {
 		key := "networking.cilium.io"
-		version := "v1.0.0-rc3"
+		version := "v1.0-kops.1"
 
 		{
 			id := "k8s-1.7"


### PR DESCRIPTION
Cilium support as CNI plugin was merged with rc8 version, there is an issue for making it more configurable: #5201

In the meantime bumping version in template can work if the advanced Cilium configuration won't get into next kops release.