### PR TITLE
Add --enable-admission-plugins API server flag for k8s 1.10

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -210,8 +210,12 @@ type KubeAPIServerConfig struct {
 	InsecurePort int32 `json:"insecurePort,omitempty" flag:"insecure-port"`
 	// Address is the binding address for the kube api
 	Address string `json:"address,omitempty" flag:"address"`
-	// AdmissionControl is a list of admission controllers to user
+	// Deprecated: AdmissionControl is a list of admission controllers to user
 	AdmissionControl []string `json:"admissionControl,omitempty" flag:"admission-control"`
+	// EnableAdmissionPlugins is a list of enabled admission plugins
+	EnableAdmissionPlugins []string `json:"enableAdmissionPlugins,omitempty" flag:"enable-admission-plugins"`
+	// DisableAdmissionPlugins is a list of disabled admission plugins
+	DisableAdmissionPlugins []string `json:"disableAdmissionPlugins,omitempty" flag:"disable-admission-plugins"`
 	// ServiceClusterIPRange is the service address range
 	ServiceClusterIPRange string `json:"serviceClusterIPRange,omitempty" flag:"service-cluster-ip-range"`
 	// Passed as --service-node-port-range to kube-apiserver. Expects 'startPort-endPort' format. Eg. 30000-33000

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -465,5 +465,16 @@ func (c *KubeAPIServerConfig) HasAdmissionController(name string) bool {
 		}
 	}
 
+	for _, x := range c.DisableAdmissionPlugins {
+		if x == name {
+			return false
+		}
+	}
+	for _, x := range c.EnableAdmissionPlugins {
+		if x == name {
+			return true
+		}
+	}
+
 	return false
 }

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -210,8 +210,12 @@ type KubeAPIServerConfig struct {
 	InsecurePort int32 `json:"insecurePort,omitempty" flag:"insecure-port"`
 	// Address is the binding address for the kube api
 	Address string `json:"address,omitempty" flag:"address"`
-	// AdmissionControl is a list of admission controllers to user
+	// Deprecated: AdmissionControl is a list of admission controllers to user
 	AdmissionControl []string `json:"admissionControl,omitempty" flag:"admission-control"`
+	// EnableAdmissionPlugins is a list of enabled admission plugins
+	EnableAdmissionPlugins []string `json:"enableAdmissionPlugins,omitempty" flag:"enable-admission-plugins"`
+	// DisableAdmissionPlugins is a list of disabled admission plugins
+	DisableAdmissionPlugins []string `json:"disableAdmissionPlugins,omitempty" flag:"disable-admission-plugins"`
 	// ServiceClusterIPRange is the service address range
 	ServiceClusterIPRange string `json:"serviceClusterIPRange,omitempty" flag:"service-cluster-ip-range"`
 	// Passed as --service-node-port-range to kube-apiserver. Expects 'startPort-endPort' format. Eg. 30000-33000

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -465,5 +465,16 @@ func (c *KubeAPIServerConfig) HasAdmissionController(name string) bool {
 		}
 	}
 
+	for _, x := range c.DisableAdmissionPlugins {
+		if x == name {
+			return false
+		}
+	}
+	for _, x := range c.EnableAdmissionPlugins {
+		if x == name {
+			return true
+		}
+	}
+
 	return false
 }

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1932,6 +1932,8 @@ func autoConvert_v1alpha1_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.InsecurePort = in.InsecurePort
 	out.Address = in.Address
 	out.AdmissionControl = in.AdmissionControl
+	out.EnableAdmissionPlugins = in.EnableAdmissionPlugins
+	out.DisableAdmissionPlugins = in.DisableAdmissionPlugins
 	out.ServiceClusterIPRange = in.ServiceClusterIPRange
 	out.ServiceNodePortRange = in.ServiceNodePortRange
 	out.EtcdServers = in.EtcdServers
@@ -1996,6 +1998,8 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha1_KubeAPIServerConfig(in *ko
 	out.InsecurePort = in.InsecurePort
 	out.Address = in.Address
 	out.AdmissionControl = in.AdmissionControl
+	out.EnableAdmissionPlugins = in.EnableAdmissionPlugins
+	out.DisableAdmissionPlugins = in.DisableAdmissionPlugins
 	out.ServiceClusterIPRange = in.ServiceClusterIPRange
 	out.ServiceNodePortRange = in.ServiceNodePortRange
 	out.EtcdServers = in.EtcdServers

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -1702,6 +1702,16 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.EnableAdmissionPlugins != nil {
+		in, out := &in.EnableAdmissionPlugins, &out.EnableAdmissionPlugins
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.DisableAdmissionPlugins != nil {
+		in, out := &in.DisableAdmissionPlugins, &out.DisableAdmissionPlugins
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.EtcdServers != nil {
 		in, out := &in.EtcdServers, &out.EtcdServers
 		*out = make([]string, len(*in))

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -210,8 +210,12 @@ type KubeAPIServerConfig struct {
 	InsecurePort int32 `json:"insecurePort,omitempty" flag:"insecure-port"`
 	// Address is the binding address for the kube api
 	Address string `json:"address,omitempty" flag:"address"`
-	// AdmissionControl is a list of admission controllers to user
+	// Deprecated: AdmissionControl is a list of admission controllers to user
 	AdmissionControl []string `json:"admissionControl,omitempty" flag:"admission-control"`
+	// EnableAdmissionPlugins is a list of enabled admission plugins
+	EnableAdmissionPlugins []string `json:"enableAdmissionPlugins,omitempty" flag:"enable-admission-plugins"`
+	// DisableAdmissionPlugins is a list of disabled admission plugins
+	DisableAdmissionPlugins []string `json:"disableAdmissionPlugins,omitempty" flag:"disable-admission-plugins"`
 	// ServiceClusterIPRange is the service address range
 	ServiceClusterIPRange string `json:"serviceClusterIPRange,omitempty" flag:"service-cluster-ip-range"`
 	// Passed as --service-node-port-range to kube-apiserver. Expects 'startPort-endPort' format. Eg. 30000-33000

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -465,5 +465,16 @@ func (c *KubeAPIServerConfig) HasAdmissionController(name string) bool {
 		}
 	}
 
+	for _, x := range c.DisableAdmissionPlugins {
+		if x == name {
+			return false
+		}
+	}
+	for _, x := range c.EnableAdmissionPlugins {
+		if x == name {
+			return true
+		}
+	}
+
 	return false
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2196,6 +2196,8 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.InsecurePort = in.InsecurePort
 	out.Address = in.Address
 	out.AdmissionControl = in.AdmissionControl
+	out.EnableAdmissionPlugins = in.EnableAdmissionPlugins
+	out.DisableAdmissionPlugins = in.DisableAdmissionPlugins
 	out.ServiceClusterIPRange = in.ServiceClusterIPRange
 	out.ServiceNodePortRange = in.ServiceNodePortRange
 	out.EtcdServers = in.EtcdServers
@@ -2260,6 +2262,8 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.InsecurePort = in.InsecurePort
 	out.Address = in.Address
 	out.AdmissionControl = in.AdmissionControl
+	out.EnableAdmissionPlugins = in.EnableAdmissionPlugins
+	out.DisableAdmissionPlugins = in.DisableAdmissionPlugins
 	out.ServiceClusterIPRange = in.ServiceClusterIPRange
 	out.ServiceNodePortRange = in.ServiceNodePortRange
 	out.EtcdServers = in.EtcdServers

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1783,6 +1783,16 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.EnableAdmissionPlugins != nil {
+		in, out := &in.EnableAdmissionPlugins, &out.EnableAdmissionPlugins
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.DisableAdmissionPlugins != nil {
+		in, out := &in.DisableAdmissionPlugins, &out.DisableAdmissionPlugins
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.EtcdServers != nil {
 		in, out := &in.EtcdServers, &out.EtcdServers
 		*out = make([]string, len(*in))

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -1962,6 +1962,16 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.EnableAdmissionPlugins != nil {
+		in, out := &in.EnableAdmissionPlugins, &out.EnableAdmissionPlugins
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.DisableAdmissionPlugins != nil {
+		in, out := &in.DisableAdmissionPlugins, &out.DisableAdmissionPlugins
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.EtcdServers != nil {
 		in, out := &in.EtcdServers, &out.EtcdServers
 		*out = make([]string, len(*in))

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -221,10 +221,25 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 			"ResourceQuota",
 		}
 	}
+	if b.IsKubernetesGTE("1.9") && b.IsKubernetesLT("1.10") {
+		c.AdmissionControl = []string{
+			"Initializers",
+			"NamespaceLifecycle",
+			"LimitRanger",
+			"ServiceAccount",
+			"PersistentVolumeLabel",
+			"DefaultStorageClass",
+			"DefaultTolerationSeconds",
+			"MutatingAdmissionWebhook",
+			"ValidatingAdmissionWebhook",
+			"NodeRestriction",
+			"ResourceQuota",
+		}
+	}
 	// Based on recommendations from:
 	// https://kubernetes.io/docs/admin/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use
-	if b.IsKubernetesGTE("1.9") {
-		c.AdmissionControl = []string{
+	if b.IsKubernetesGTE("1.10") {
+		c.EnableAdmissionPlugins = []string{
 			"Initializers",
 			"NamespaceLifecycle",
 			"LimitRanger",


### PR DESCRIPTION
According to the section on [recommended admission controllers](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use):

1. `--admission-control` has been deprecated in 1.10, replaced with a new flag.
2. The order of the list of controllers no longer matters, presumably because of [the addition of the ordered list](https://github.com/kubernetes/kubernetes/pull/58123/files#diff-57937e32f92262c443a2a79eb463e3b5R64) of all plugins, `AllOrderedPlugins`. 

As such, this PR:

1. Adds `--enable-admission-plugins` and also the additional flag, `--disable-admission-plugins`.
2. Mark `--admission-control` deprecated.
3. The list of recommended admission plugins have not changed compared to 1.9, but kops has a slightly different list of plugins, which I've carried over to the new option.
