### PR TITLE
PSP Updates, new apiGroup for k8s v1.10

### DIFF
--- a/upup/models/cloudup/resources/addons/podsecuritypolicy.addons.k8s.io/k8s-1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/podsecuritypolicy.addons.k8s.io/k8s-1.10.yaml.template
@@ -30,7 +30,7 @@ metadata:
   name: kops:kube-system:psp
 rules:
 - apiGroups:
-  - extensions
+  - policy
   resources:
   - podsecuritypolicies
   resourceNames:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -113,7 +113,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 	// @check if podsecuritypolicies are enabled and if so, push the default kube-system policy
 	if b.cluster.Spec.KubeAPIServer != nil && b.cluster.Spec.KubeAPIServer.HasAdmissionController("PodSecurityPolicy") {
 		key := "podsecuritypolicy.addons.k8s.io"
-		version := "0.0.1"
+		version := "0.0.2"
 
 		{
 			location := key + "/k8s-1.9.yaml"
@@ -124,7 +124,23 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 				Version:           fi.String(version),
 				Selector:          map[string]string{"k8s-addon": key},
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.9.0",
+				KubernetesVersion: ">=1.9.0 <1.10.0",
+				Id:                id,
+			})
+			manifests[key+"-"+id] = "addons/" + location
+		}
+
+		// In k8s v1.10, the PodSecurityPolicy API has been moved to the policy/v1beta1 API group
+		{
+			location := key + "/k8s-1.10.yaml"
+			id := "k8s-1.10"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(version),
+				Selector:          map[string]string{"k8s-addon": key},
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.10.0",
 				Id:                id,
 			})
 			manifests[key+"-"+id] = "addons/" + location


### PR DESCRIPTION
Also limiting access for service-accounts in kube-system to only the kube-system namespace, as a quick-fix for https://github.com/kubernetes/kubernetes/issues/64479 (currently all deployments will be privileged if anyone is using PSPs with kops).

Ideally this should be even more specific to each service-account that requires the access, but more investigation is required to produce this full list (accounting for the SAs that each CNI provider may use, etc).