### PR TITLE
Allow integration tests to update expected TF output

### DIFF
--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -262,6 +262,13 @@ func runTest(t *testing.T, h *testutils.IntegrationTestHarness, clusterName stri
 			diffString := diff.FormatDiff(string(testDataTF), string(actualTF))
 			t.Logf("diff:\n%s\n", diffString)
 
+			if os.Getenv("HACK_UPDATE_TF_IN_PLACE") != "" {
+				if err := ioutil.WriteFile(path.Join(srcDir, testDataTFPath), actualTF, 0644); err != nil {
+					t.Errorf("error writing terraform output: %v", err)
+				}
+				t.Errorf("terraform output differed from expected")
+				return // Avoid Fatalf as we want to keep going and update all files
+			}
 			t.Fatalf("terraform output differed from expected")
 		}
 	}


### PR DESCRIPTION
This means we don't have to manually go and fix up the terraform
expected output when it changes (but we should still be careful to
validate it!)

HACK_UPDATE_TF_IN_PLACE=1 make test