### PR TITLE
Update heptio authenticator to 0.3.0

### DIFF
--- a/upup/models/cloudup/resources/addons/authentication.hept.io/k8s-1.10.yaml
+++ b/upup/models/cloudup/resources/addons/authentication.hept.io/k8s-1.10.yaml
@@ -34,7 +34,7 @@ spec:
       # - output (output kubeconfig to plug into your apiserver configuration, mounted from the host)
       containers:
       - name: heptio-authenticator-aws
-        image: gcr.io/heptio-images/authenticator:v0.1.0
+        image: gcr.io/heptio-images/authenticator:v0.3.0
         args:
         - server
         - --config=/etc/heptio-authenticator-aws/config.yaml

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -761,7 +761,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		}
 		if b.cluster.Spec.Authentication.Heptio != nil {
 			key := "authentication.hept.io"
-			version := "0.1.0"
+			version := "0.3.0"
 
 			{
 				location := key + "/k8s-1.10.yaml"


### PR DESCRIPTION
Heptio just release 0.3.0 version of authenticator with quite a few fixes, we should update this before the release of kops 1.10