### PR TITLE
Fix: Update heptio authenticator to 0.3.0 #5276

### DIFF
--- a/upup/models/cloudup/resources/addons/authentication.hept.io/k8s-1.10.yaml
+++ b/upup/models/cloudup/resources/addons/authentication.hept.io/k8s-1.10.yaml
@@ -39,6 +39,7 @@ spec:
         - server
         - --config=/etc/heptio-authenticator-aws/config.yaml
         - --state-dir=/var/heptio-authenticator-aws
+        - --kubeconfig-pregenerated=true
 
         resources:
           requests:


### PR DESCRIPTION
Heptio authenticator now auto generates the configs. we do not want this to happen so we have to set the `--kubeconfig-pregenerated` flag.