### PR TITLE
Update kops_edit_instancegroup.go and kops_edit_instancegroup.md

### DIFF
--- a/cmd/kops/edit_instancegroup.go
+++ b/cmd/kops/edit_instancegroup.go
@@ -48,7 +48,7 @@ var (
 
 	editInstancegroupExample = templates.Examples(i18n.T(`
 	# Edit an instancegroup desired configuration.
-	kops edit ig --name k8s-cluster.example.com node --state=s3://kops-state-1234
+	kops edit ig --name k8s-cluster.example.com nodes --state=s3://kops-state-1234
 	`))
 
 	editInstancegroupShort = i18n.T(`Edit instancegroup.`)

--- a/docs/cli/kops_edit_instancegroup.md
+++ b/docs/cli/kops_edit_instancegroup.md
@@ -24,7 +24,7 @@ kops edit instancegroup [flags]
 
 ```
   # Edit an instancegroup desired configuration.
-  kops edit ig --name k8s-cluster.example.com node --state=s3://kops-state-1234
+  kops edit ig --name k8s-cluster.example.com nodes --state=s3://kops-state-1234
 ```
 
 ### Options


### PR DESCRIPTION
Update the Example section. Was trying to use command example and discovered that `node` gave any error. Changing it `node` to `nodes` resolve it.