### PR TITLE
Enable override bind address for kube-proxy.

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -186,6 +186,8 @@ type KubeProxyConfig struct {
 	ClusterCIDR string `json:"clusterCIDR,omitempty" flag:"cluster-cidr"`
 	// HostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
 	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
+	// BindAddress is IP address for the proxy server to serve on
+	BindAddress string `json:"bindAddress,omitempty" flag:"bind-address"`
 	// Master is the address of the Kubernetes API server (overrides any value in kubeconfig)
 	Master string `json:"master,omitempty" flag:"master"`
 	// Enabled allows enabling or disabling kube-proxy

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -186,6 +186,8 @@ type KubeProxyConfig struct {
 	ClusterCIDR string `json:"clusterCIDR,omitempty" flag:"cluster-cidr"`
 	// HostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
 	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
+	// BindAddress is IP address for the proxy server to serve on
+	BindAddress string `json:"bindAddress,omitempty" flag:"bind-address"`
 	// Master is the address of the Kubernetes API server (overrides any value in kubeconfig)
 	Master string `json:"master,omitempty" flag:"master"`
 	// Enabled allows enabling or disabling kube-proxy

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -2221,6 +2221,7 @@ func autoConvert_v1alpha1_KubeProxyConfig_To_kops_KubeProxyConfig(in *KubeProxyC
 	out.LogLevel = in.LogLevel
 	out.ClusterCIDR = in.ClusterCIDR
 	out.HostnameOverride = in.HostnameOverride
+	out.BindAddress = in.BindAddress
 	out.Master = in.Master
 	out.Enabled = in.Enabled
 	out.ProxyMode = in.ProxyMode
@@ -2242,6 +2243,7 @@ func autoConvert_kops_KubeProxyConfig_To_v1alpha1_KubeProxyConfig(in *kops.KubeP
 	out.LogLevel = in.LogLevel
 	out.ClusterCIDR = in.ClusterCIDR
 	out.HostnameOverride = in.HostnameOverride
+	out.BindAddress = in.BindAddress
 	out.Master = in.Master
 	out.Enabled = in.Enabled
 	out.ProxyMode = in.ProxyMode

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -186,6 +186,8 @@ type KubeProxyConfig struct {
 	ClusterCIDR string `json:"clusterCIDR,omitempty" flag:"cluster-cidr"`
 	// HostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
 	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
+	// BindAddress is IP address for the proxy server to serve on
+	BindAddress string `json:"bindAddress,omitempty" flag:"bind-address"`
 	// Master is the address of the Kubernetes API server (overrides any value in kubeconfig)
 	Master string `json:"master,omitempty" flag:"master"`
 	// Enabled allows enabling or disabling kube-proxy

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2485,6 +2485,7 @@ func autoConvert_v1alpha2_KubeProxyConfig_To_kops_KubeProxyConfig(in *KubeProxyC
 	out.LogLevel = in.LogLevel
 	out.ClusterCIDR = in.ClusterCIDR
 	out.HostnameOverride = in.HostnameOverride
+	out.BindAddress = in.BindAddress
 	out.Master = in.Master
 	out.Enabled = in.Enabled
 	out.ProxyMode = in.ProxyMode
@@ -2506,6 +2507,7 @@ func autoConvert_kops_KubeProxyConfig_To_v1alpha2_KubeProxyConfig(in *kops.KubeP
 	out.LogLevel = in.LogLevel
 	out.ClusterCIDR = in.ClusterCIDR
 	out.HostnameOverride = in.HostnameOverride
+	out.BindAddress = in.BindAddress
 	out.Master = in.Master
 	out.Enabled = in.Enabled
 	out.ProxyMode = in.ProxyMode

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -321,6 +322,10 @@ func evaluateSpec(c *api.Cluster) error {
 		if err != nil {
 			return err
 		}
+		c.Spec.KubeProxy.BindAddress, err = evaluateBindAddress(c.Spec.KubeProxy.BindAddress)
+		if err != nil {
+			return err
+		}
 	}
 
 	if c.Spec.Docker != nil {
@@ -378,6 +383,36 @@ func evaluateHostnameOverride(hostnameOverride string) (string, error) {
 	}
 
 	return hostnameOverride, nil
+}
+
+func evaluateBindAddress(bindAddress string) (string, error) {
+	if bindAddress == "" {
+		return "", nil
+	}
+	if bindAddress == "@aws" {
+		vBytes, err := vfs.Context.ReadFile("metadata://aws/meta-data/local-ipv4")
+		if err != nil {
+			return "", fmt.Errorf("error reading local IP from AWS metadata: %v", err)
+		}
+
+		// The local-ipv4 gets it's IP from the AWS.
+		// For now just choose the first one.
+		ips := strings.Fields(string(vBytes))
+		if len(ips) == 0 {
+			glog.Warningf("Local IP from AWS metadata service was empty")
+			return "", nil
+		} else {
+			ip := ips[0]
+			glog.Infof("Using IP from AWS metadata service: %s", ip)
+
+			return ip, nil
+		}
+	}
+
+	if net.ParseIP(bindAddress) == nil {
+		return "", fmt.Errorf("bindAddress is not valid IP address")
+	}
+	return bindAddress, nil
 }
 
 // evaluateDockerSpec selects the first supported storage mode, if it is a list


### PR DESCRIPTION
When using kube-proxy in userspace mode, you have to bind to primary ip address of underlying machine.