### PR TITLE
Add support for M5D instance family on AWS

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/machine_types.go
+++ b/upup/pkg/fi/cloudup/awsup/machine_types.go
@@ -250,6 +250,50 @@ var MachineTypes []AWSMachineTypeInfo = []AWSMachineTypeInfo{
 		EphemeralDisks: nil,
 	},
 
+	// m5d family
+	{
+		Name:           "m5d.large",
+		MemoryGB:       8,
+		ECU:            10,
+		Cores:          2,
+		EphemeralDisks: []int{75},
+	},
+	{
+		Name:           "m5d.xlarge",
+		MemoryGB:       16,
+		ECU:            15,
+		Cores:          4,
+		EphemeralDisks: []int{150},
+	},
+	{
+		Name:           "m5d.2xlarge",
+		MemoryGB:       32,
+		ECU:            31,
+		Cores:          8,
+		EphemeralDisks: []int{300},
+	},
+	{
+		Name:           "m5d.4xlarge",
+		MemoryGB:       64,
+		ECU:            61,
+		Cores:          16,
+		EphemeralDisks: []int{300, 300},
+	},
+	{
+		Name:           "m5d.12xlarge",
+		MemoryGB:       192,
+		ECU:            173,
+		Cores:          48,
+		EphemeralDisks: []int{900, 900},
+	},
+	{
+		Name:           "m5d.24xlarge",
+		MemoryGB:       384,
+		ECU:            345,
+		Cores:          96,
+		EphemeralDisks: []int{900, 900, 900, 900},
+	},
+
 	// c3 family
 	{
 		Name:           "c3.large",


### PR DESCRIPTION
This PR adds [the M5D instance type](https://aws.amazon.com/ec2/instance-types/m5/) that was [announced](https://aws.amazon.com/blogs/aws/ec2-instance-update-m5-instances-with-local-nvme-storage-m5d/) a few days ago.