### PR TITLE
Destinctive names for ClusterRoleBindings in prometheus-operator addon

### DIFF
--- a/addons/prometheus-operator/v0.19.0.yaml
+++ b/addons/prometheus-operator/v0.19.0.yaml
@@ -1,7 +1,8 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-operator
+  name: prometheus-operator-default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -5380,7 +5381,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-operator
+  name: prometheus-operator-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
`ClusterRoleBindings`, to my knowledge, are "global" entities, i.e. if they are specified by the same name they'll get overwritten if provisioned from the same `yaml` source.

In this case the binding `prometheus-operator` was created twice, resulting in the `prometheus-operator` in the `default` namespace unable to access the API.

I've renamed the relevant bindings to avoid naming conflicts.

Fixes #5252 