### PR TITLE
Revert "digitalocean: don't set --cloud-provider=external on control plane starting v1.10"

### DIFF
--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -301,8 +301,7 @@ func ValidateCluster(c *kops.Cluster, strict bool) *field.Error {
 		case kops.CloudProviderGCE:
 			k8sCloudProvider = "gce"
 		case kops.CloudProviderDO:
-			// cloud provider should be blank since digitalocean uses external cloud controller
-			k8sCloudProvider = ""
+			k8sCloudProvider = "external"
 		case kops.CloudProviderVSphere:
 			k8sCloudProvider = "vsphere"
 		case kops.CloudProviderBareMetal:

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -144,7 +144,7 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 	case kops.CloudProviderGCE:
 		c.CloudProvider = "gce"
 	case kops.CloudProviderDO:
-		// not required for digitalocean since it is managed by digitalocean-cloud-controller-manager
+		c.CloudProvider = "external"
 	case kops.CloudProviderVSphere:
 		c.CloudProvider = "vsphere"
 	case kops.CloudProviderBareMetal:

--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -105,7 +105,7 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 		kcm.ClusterName = gce.SafeClusterName(b.Context.ClusterName)
 
 	case kops.CloudProviderDO:
-		// cloud provider is specified by digitalocean-cloud-controller-manager
+		kcm.CloudProvider = "external"
 
 	case kops.CloudProviderVSphere:
 		kcm.CloudProvider = "vsphere"


### PR DESCRIPTION
Reverts kubernetes/kops#4990

This is not needed starting Kubernetes v1.10.3 (https://github.com/kubernetes/kubernetes/pull/63725). This can be reverted assuming kops 1.10 will run Kubernetes 1.10.3 