### PR TITLE
Avoid changing IAM policy for users

### DIFF
--- a/pkg/model/iam/tests/iam_builder_node_strict.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict.json
@@ -33,16 +33,10 @@
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/instancegroup/*",
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/issued/*",
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kube-proxy/*",
+        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kubelet/*",
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/ssh/*",
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/secrets/dockerconfig"
       ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:Get*"
-      ],
-      "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kubelet/*"
     }
   ]
 }

--- a/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
@@ -33,16 +33,10 @@
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/instancegroup/*",
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/issued/*",
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kube-proxy/*",
+        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kubelet/*",
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/ssh/*",
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/secrets/dockerconfig"
       ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:Get*"
-      ],
-      "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kubelet/*"
     },
     {
       "Effect": "Allow",


### PR DESCRIPTION
Follow on to #5253, making it so that users that don't adopt bootstrap
kubelet config don't have their IAM policies change.