### PR TITLE
Add prometheus scrape to kube-dns

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -105,6 +105,8 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         # For 1.6, we keep the old tolerations in case of a downgrade to 1.5
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '10055'
     spec:
       dnsPolicy: Default  # Don't use cluster DNS.
       serviceAccountName: kube-dns


### PR DESCRIPTION
While debugging some dns issues (https://github.com/kubernetes/kubernetes/issues/45976), I discovered we do not enable prometheus scrape by default on kube-dns.  We enable it for enough other components by default that I figured it wouldn't be a big deal.

Thoughts welcome!