### PR TITLE
Added comment for 404 on healthcheck for non-standard vpc-cidr

### DIFF
--- a/addons/kube-ingress-aws-controller/README.md
+++ b/addons/kube-ingress-aws-controller/README.md
@@ -242,6 +242,11 @@ sed -i "s/<HOSTNAME2>/demo-green-blue.example.org/" v1.0.0.yaml
 kubectl create -f v1.0.0.yaml
 ```
 
+If your VPC-CIDR is different from 10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12, 127.0.0.1/8,fd00::/8 or ::1/128 you may
+get a "Readiness probe failed: HTTP probe failed with statuscode: 404" from the skipper pods with the *latest* or
+*v0.10.7* tag of skipper.
+To prevent this, uncomment the "-whitelisted-healthcheck-cidr=<CIDR_BLOCK>" in v1.0.0.yaml and add your VPC-CIDR.
+
 Check, if the installation was successful:
 
 ```

--- a/addons/kube-ingress-aws-controller/v1.0.0.yaml
+++ b/addons/kube-ingress-aws-controller/v1.0.0.yaml
@@ -65,6 +65,7 @@ spec:
           - "-experimental-upgrade"
           - "-metrics-exp-decay-sample"
           - "-kubernetes-https-redirect=true"
+#          - "-whitelisted-healthcheck-cidr=<CIDR_BLOCK>"
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
Today I had the issue, that skipper reported 404 on the health-checks and thus all instances were marked unhealthy in the ALB. Apparently skipper introduced a CIDR-whitelisting on the health-checks and adding the "-whitelisted-healthcheck-cidr=<CIDR_BLOCK>" fixed it for me. Thought it would make sense to write it down for this approach.

[skipper Issue 644](https://github.com/zalando/skipper/issues/644)