### PR TITLE
Correct deployment yaml of CoreDNS

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
@@ -79,10 +79,10 @@ metadata:
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 2
-    strategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxUnavailable: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       k8s-app: kube-dns


### PR DESCRIPTION
This corrects the deployment yaml of CoreDNS and fixes #5314 
