### PR TITLE
kops set cluster: honor --name flag

### DIFF
--- a/cmd/kops/set_cluster.go
+++ b/cmd/kops/set_cluster.go
@@ -67,7 +67,7 @@ func NewCmdSetCluster(f *util.Factory, out io.Writer) *cobra.Command {
 			}
 
 			if options.ClusterName == "" {
-				options.ClusterName = ClusterNameFromKubecfg()
+				options.ClusterName = rootCommand.ClusterName()
 			}
 
 			if err := commands.RunSetCluster(f, cmd, out, options); err != nil {


### PR DESCRIPTION
We were not using the regular method to get the cluster name, and this
meant that the `--name` flag was being ignored.