### PR TITLE
GCE: Set network tier, to avoid spurious changes

### DIFF
--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -242,7 +242,8 @@ func (e *InstanceTemplate) mapToGCE(project string) (*compute.InstanceTemplate, 
 		AccessConfigs: []*compute.AccessConfig{{
 			Kind: "compute#accessConfig",
 			//NatIP: *e.IPAddress.Address,
-			Type: "ONE_TO_ONE_NAT",
+			Type:        "ONE_TO_ONE_NAT",
+			NetworkTier: "PREMIUM",
 		}},
 		Network: e.Network.URL(project),
 	}


### PR DESCRIPTION
Otherwise we were seeing instance templates changing every time.

PREMIUM is the default, so we set it to PREMIUM for compatability.  In
future we may want to expose this option.