### PR TITLE
Add missing nodes/stats resource to the system:metrics-server Cluster…

### DIFF
--- a/addons/metrics-server/v1.8.x.yaml
+++ b/addons/metrics-server/v1.8.x.yaml
@@ -42,6 +42,7 @@ rules:
     resources:
       - pods
       - nodes
+      - nodes/stats
       - namespaces
     verbs:
       - get


### PR DESCRIPTION
From upstream https://github.com/kubernetes-incubator/metrics-server/pull/59/files

