### PR TITLE
gossip: create zone in protokube

### DIFF
--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -258,14 +258,18 @@ func run() error {
 		}()
 
 		dnsView := gossipdns.NewDNSView(gossipState)
+		zoneInfo := gossipdns.DNSZoneInfo{
+			Name: gossipdns.DefaultZoneName,
+		}
+		if _, err := dnsView.AddZone(zoneInfo); err != nil {
+			glog.Fatalf("error creating zone: %v", err)
+		}
+
 		go func() {
 			gossipdns.RunDNSUpdates(dnsTarget, dnsView)
 			glog.Fatalf("RunDNSUpdates exited unexpectedly")
 		}()
 
-		zoneInfo := gossipdns.DNSZoneInfo{
-			Name: gossipdns.DefaultZoneName,
-		}
 		dnsProvider = &protokube.GossipDnsProvider{DNSView: dnsView, Zone: zoneInfo}
 	} else {
 		var dnsScope dns.Scope

--- a/protokube/pkg/gossip/dns/dns.go
+++ b/protokube/pkg/gossip/dns/dns.go
@@ -128,9 +128,24 @@ func (v *DNSView) RemoveZone(info DNSZoneInfo) error {
 	return fmt.Errorf("zone deletion is implicit")
 }
 
-// AddZone adds the specified zone, though this is currently not supported and returns an error.
+// AddZone adds the specified zone; this creates a fake NS record just so that the zone has records
 func (v *DNSView) AddZone(info DNSZoneInfo) (*DNSZoneInfo, error) {
-	return nil, fmt.Errorf("zone creation is implicit")
+	createRecords := []*DNSRecord{
+		{
+			RrsType: "NS",
+			Name:    info.Name,
+			Rrdatas: []string{"gossip"},
+		},
+	}
+
+	err := v.ApplyChangeset(info, nil, createRecords)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DNSZoneInfo{
+		Name: info.Name,
+	}, nil
 }
 
 // ApplyChangeset applies a DNS changeset to the records.


### PR DESCRIPTION
We were doing this implicitly previously by creating the etcd records.

As etcd-manager doesn't need to create gossip records, we instead
create a zone explicilty.