### PR TITLE
Typo fix in documentation.md

### DIFF
--- a/docs/development/documentation.md
+++ b/docs/development/documentation.md
@@ -17,5 +17,5 @@ This command changes the cloud specification in the registry.
 It does not update the cloud resources, to apply the changes use "kops update cluster".
 ```
 
-* `Example`: Example(s) of how to use the command. This field is formatted as a code snippet in the docs, so make sure if you have comments that are written as a bash comment (e.g. `# this is a comment`).
+* `Example`: Example(s) of how to use the command. This field is formatted as a code snippet in the docs, so make sure if you have comments that these are written as a bash comment (e.g. `# this is a comment`).
 

--- a/docs/development/documentation.md
+++ b/docs/development/documentation.md
@@ -2,7 +2,7 @@
 
 ## CLI commands
 
-`kops` uses cobra for it's CLI implementation. Each command should have the following help fields defined where possible:
+`kops` uses cobra for its CLI implementation. Each command should have the following help fields defined where possible:
 
 * `Short`: A short statement describing the command in the third person present, starting with a capital letter and ending without a period.
   * Example: "Edits a cluster"
@@ -17,5 +17,5 @@ This command changes the cloud specification in the registry.
 It does not update the cloud resources, to apply the changes use "kops update cluster".
 ```
 
-* `Example`: Example(s) of how to use the command. This field is formatted as a code snippet in the docs, so make sure if you have comments that these are written as a bash comment (e.g. `# this is a comment`).
+* `Example`: Example(s) of how to use the command. This field is formatted as a code snippet in the docs, so make sure if you have comments that are written as a bash comment (e.g. `# this is a comment`).
 


### PR DESCRIPTION
Line 5: for it's CLI implementation->for its CLI implementation
Line 20: that these are ->that are