### PR TITLE
Fix containerRegistry for Kubernetes < 1.10

### DIFF
--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -151,7 +151,11 @@ func (a *AssetBuilder) RemapImage(image string) (string, error) {
 		normalized := image
 
 		// Remove the 'standard' kubernetes image prefix, just for sanity
-		normalized = strings.TrimPrefix(normalized, "k8s.gcr.io/")
+		if !util.IsKubernetesGTE("1.10", a.KubernetesVersion) && strings.HasPrefix(normalized, "gcr.io/google_containers/") {
+			normalized = strings.TrimPrefix(normalized, "gcr.io/google_containers/")
+		} else {
+			normalized = strings.TrimPrefix(normalized, "k8s.gcr.io/")
+		}
 
 		// We can't nest arbitrarily
 		// Some risk of collisions, but also -- and __ in the names appear to be blocked by docker hub


### PR DESCRIPTION
The containerRegistry setting is currently broken for Kubernets < 1.10 because in line 134, the registry uri path is patched over and the subsequent trim in line 154 fails to notice this.
The container path build for the containerRegistry then includes the registry part of the name as its string replaced version in the container name, which cannot be resolved.

Note that this specifically affects the 1.9 (possibly 1.8) branch of kops, I would appreciate it if this was included in a bugfix release :)