### PR TITLE
Git Ignore - Merge Conflict Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# git mergetool
+*.orig
+
 # Go embed files?
 *.go-e
 


### PR DESCRIPTION
- adding the *.orig to the .gitignore to ensure the mergetool files are not accidently committed