### PR TITLE
Revert COS in stable/alpha channel

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -28,7 +28,7 @@ spec:
       providerID: aws
       kubernetesVersion: ">=1.11.0"
     - providerID: gce
-      name: "cos-cloud/cos-stable-65-10323-64-0"
+      name: "cos-cloud/cos-stable-60-9592-90-0"
   cluster:
     kubernetesVersion: v1.5.8
     networking:

--- a/channels/stable
+++ b/channels/stable
@@ -25,7 +25,7 @@ spec:
       providerID: aws
       kubernetesVersion: ">=1.10.0"
     - providerID: gce
-      name: "cos-cloud/cos-stable-64-10176-62-0"
+      name: "cos-cloud/cos-stable-60-9592-90-0"
   cluster:
     kubernetesVersion: v1.5.8
     networking:

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -61,7 +61,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: master-us-test1-a
 spec:
-  image: cos-cloud/cos-stable-64-10176-62-0
+  image: cos-cloud/cos-stable-60-9592-90-0
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
@@ -83,7 +83,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: master-us-test1-b
 spec:
-  image: cos-cloud/cos-stable-64-10176-62-0
+  image: cos-cloud/cos-stable-60-9592-90-0
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
@@ -105,7 +105,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: master-us-test1-c
 spec:
-  image: cos-cloud/cos-stable-64-10176-62-0
+  image: cos-cloud/cos-stable-60-9592-90-0
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
@@ -127,7 +127,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: nodes
 spec:
-  image: cos-cloud/cos-stable-64-10176-62-0
+  image: cos-cloud/cos-stable-60-9592-90-0
   machineType: n1-standard-2
   maxSize: 2
   minSize: 2


### PR DESCRIPTION
No problem with COS per-se, but these versions have the newer docker,
which includes the --storage flag.  We fixed that in master in #5258,
but older versions of kops - including the currently released version
1.9.1 - don't have the fix.

Revert to fix the problem immediately, but opened #5358 to track a
more realistic fix.