### PR TITLE
WIP: Filter images based on kops version

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -29,6 +29,9 @@ spec:
       kubernetesVersion: ">=1.11.0"
     - providerID: gce
       name: "cos-cloud/cos-stable-60-9592-90-0"
+      kopsVersion: "<1.10.0-alpha.1"
+    - providerID: gce
+      name: "cos-cloud/cos-stable-65-10323-64-0"
   cluster:
     kubernetesVersion: v1.5.8
     networking:

--- a/pkg/apis/kops/BUILD.bazel
+++ b/pkg/apis/kops/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     importpath = "k8s.io/kops/pkg/apis/kops",
     visibility = ["//visibility:public"],
     deps = [
+        "//:go_default_library",
         "//pkg/apis/kops/util:go_default_library",
         "//upup/pkg/fi/utils:go_default_library",
         "//util/pkg/vfs:go_default_library",


### PR DESCRIPTION
This lets us update the image, even when a fix is required in a newer
kops version to use it.