### PR TITLE
fix issue #5372, elasticsearch cannot be started because vm.max_map_count is too low

### DIFF
--- a/addons/logging-elasticsearch/v1.7.0.yaml
+++ b/addons/logging-elasticsearch/v1.7.0.yaml
@@ -208,6 +208,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+      initContainers:
+      - image: alpine:3.6
+        command: ["/sbin/sysctl", "-w", "vm.max_map_count=262144"]
+        name: elasticsearch-logging-init
+        securityContext:
+          privileged: true
   volumeClaimTemplates:
   - metadata:
       name: es-persistent-storage


### PR DESCRIPTION
This pull request is for fixing issue #5372 https://github.com/kubernetes/kops/issues/5372
elasticsearch cannot be started because vm.max_map_count is too low

Add initContainers to increase vm.max_map_count firstly.
The solution is refer to:
https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml

I already test and pass for this changement.
