### PR TITLE
Switch bucket encryption policy warning to debug

### DIFF
--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -207,7 +207,7 @@ func (s *S3Context) checkDefaultEncryption(region string, bucket string) bool {
 		// the following cases might lead to the operation failing:
 		// 1. A deny policy on s3:GetEncryptionConfiguration
 		// 2. No default encryption policy set
-		glog.Warningf("Unable to read bucket encryption policy: will encrypt using AES256")
+		glog.V(8).Infof("Unable to read bucket encryption policy: will encrypt using AES256")
 		return false
 	}
 


### PR DESCRIPTION
In the 1.10.0-alpha.1, this error can show up pretty frequently:

```
Unable to read bucket encryption policy: will encrypt using AES256
```

I think it makes sense to only log this when debugging.

Fixes: https://github.com/kubernetes/kops/issues/5370
