### PR TITLE
Add prometheus scrape port to CoreDNS service

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
@@ -145,6 +145,7 @@ metadata:
   name: kube-dns
   namespace: kube-system
   annotations:
+    prometheus.io/port: "9153"
     prometheus.io/scrape: "true"
   labels:
     k8s-addon: coredns.addons.k8s.io


### PR DESCRIPTION
This addresses the issue https://github.com/kubernetes/kubeadm/issues/955