### PR TITLE
Initial Ubuntu Bionic Support

### DIFF
--- a/nodeup/pkg/distros/distribution.go
+++ b/nodeup/pkg/distros/distribution.go
@@ -27,6 +27,7 @@ var (
 	DistributionJessie      Distribution = "jessie"
 	DistributionDebian9     Distribution = "debian9"
 	DistributionXenial      Distribution = "xenial"
+	DistributionBionic      Distribution = "bionic"
 	DistributionRhel7       Distribution = "rhel7"
 	DistributionCentos7     Distribution = "centos7"
 	DistributionCoreOS      Distribution = "coreos"
@@ -43,6 +44,8 @@ func (d Distribution) BuildTags() []string {
 		t = []string{} // trying to move away from tags
 	case DistributionXenial:
 		t = []string{"_xenial"}
+	case DistributionBionic:
+		t = []string{"_bionic"}
 	case DistributionCentos7:
 		t = []string{"_centos7"}
 	case DistributionRhel7:
@@ -71,7 +74,7 @@ func (d Distribution) BuildTags() []string {
 
 func (d Distribution) IsDebianFamily() bool {
 	switch d {
-	case DistributionJessie, DistributionXenial, DistributionDebian9:
+	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9:
 		return true
 	case DistributionCentos7, DistributionRhel7:
 		return false
@@ -87,7 +90,7 @@ func (d Distribution) IsRHELFamily() bool {
 	switch d {
 	case DistributionCentos7, DistributionRhel7:
 		return true
-	case DistributionJessie, DistributionXenial, DistributionDebian9:
+	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9:
 		return false
 	case DistributionCoreOS, DistributionContainerOS:
 		return false
@@ -99,7 +102,7 @@ func (d Distribution) IsRHELFamily() bool {
 
 func (d Distribution) IsSystemd() bool {
 	switch d {
-	case DistributionJessie, DistributionXenial, DistributionDebian9:
+	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9:
 		return true
 	case DistributionCentos7, DistributionRhel7:
 		return true

--- a/nodeup/pkg/distros/identify.go
+++ b/nodeup/pkg/distros/identify.go
@@ -36,6 +36,10 @@ func FindDistribution(rootfs string) (Distribution, error) {
 			line = strings.TrimSpace(line)
 			if line == "DISTRIB_CODENAME=xenial" {
 				return DistributionXenial, nil
+			} else if line == "DISTRIB_CODENAME=bionic" {
+				glog.Warningf("bionic is not fully supported nor tested for Kops and Kubernetes")
+				glog.Warningf("this should only be used for testing purposes.")
+				return DistributionBionic, nil
 			}
 		}
 	} else if !os.IsNotExist(err) {

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -498,6 +498,20 @@ var dockerVersions = []dockerVersion{
 		Hash:          "b4ce72e80ff02926de943082821bbbe73958f87a",
 		Dependencies:  []string{"libtool-ltdl", "libseccomp", "libcgroup"},
 	},
+
+	// 18.03.1 - Bionic
+	{
+		DockerVersion: "18.03.1",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionBionic},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "18.03.1~ce~3-0~ubuntu",
+		Source:        "https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce_18.03.1~ce~3-0~ubuntu_amd64.deb",
+		Hash:          "b55b32bd0e9176dd32b1e6128ad9fda10a65cc8b",
+		Dependencies:  []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		//Depends: iptables, init-system-helpers, lsb-base, libapparmor1, libc6, libdevmapper1.02.1, libltdl7, libeseccomp2, libsystemd0
+		//Recommends: aufs-tools, ca-certificates, cgroupfs-mount | cgroup-lite, git, xz-utils, apparmor
+	},
 }
 
 func (d *dockerVersion) matches(arch Architecture, dockerVersion string, distro distros.Distribution) bool {


### PR DESCRIPTION
Kubernetes [doesn't officially support bionic](https://github.com/kubernetes/release/blob/28d575166a663192f161d5e2959b663b6838cca5/debian/build.go#L72).
Docker has only [stable released](https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64) 18.03.1 for Bionic.
Kubernetes also [doesn't officially support 18.03.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md)
(Do not ) use, at your own risk.

I used this for some testing but this will likely be a long term PR or closed just to keep record. Docker version must be specified in cluster config for this to work as is.