### PR TITLE
Backport: set GracePeriodSeconds to -1

### DIFF
--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -303,12 +303,13 @@ func (r *RollingUpdateInstanceGroup) DrainNode(u *cloudinstances.CloudInstanceGr
 	errOut := os.Stderr
 
 	options := &cmd.DrainOptions{
-		Factory:          f,
-		Out:              out,
-		IgnoreDaemonsets: true,
-		Force:            true,
-		DeleteLocalData:  true,
-		ErrOut:           errOut,
+		Factory:            f,
+		Out:                out,
+		IgnoreDaemonsets:   true,
+		Force:              true,
+		DeleteLocalData:    true,
+		ErrOut:             errOut,
+		GracePeriodSeconds: -1,
 	}
 
 	cmd := cmd.NewCmdDrain(f, out, errOut)


### PR DESCRIPTION
Backport https://github.com/kubernetes/kops/pull/5143 to the 1.9 release line.