### PR TITLE
heptio-authenticator-aws unable to read generated certificate due to too restrictive file permissions.

### DIFF
--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -229,7 +229,7 @@ func (b *KubeAPIServerBuilder) writeAuthenticationConfig(c *fi.ModelBuilderConte
 				Path:     "/srv/kubernetes/heptio-authenticator-aws/cert.pem",
 				Contents: fi.NewBytesResource(certificateData),
 				Type:     nodetasks.FileType_File,
-				Mode:     fi.String("600"),
+				Mode:     fi.String("644"),
 			})
 		}
 
@@ -251,7 +251,7 @@ func (b *KubeAPIServerBuilder) writeAuthenticationConfig(c *fi.ModelBuilderConte
 				Path:     "/srv/kubernetes/heptio-authenticator-aws/key.pem",
 				Contents: fi.NewBytesResource(keyData),
 				Type:     nodetasks.FileType_File,
-				Mode:     fi.String("600"),
+				Mode:     fi.String("644"),
 			})
 		}
 


### PR DESCRIPTION
```
$ kops version
Version 1.10.0-alpha.1

kubectl version
Client Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.3", GitCommit:"d2835416544f298c919e2ead3be3d0864b52323b", GitTreeState:"clean", BuildDate:"2018-02-09T21:50:44Z", GoVersion:"go1.9.4", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.3", GitCommit:"2bba0127d85d5a46ab4b778548be28623b32d0b0", GitTreeState:"clean", BuildDate:"2018-05-21T09:05:37Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
```

Having previously set up `heptio-authenticator-aws` manually, I am delighted to have support baked into KOPS 1.10.

However, after creating a cluster and deployed a `ConfigMap` I expected the `heptio-authenticator-aws` Pod to transition to a `Running` STATUS. However, checking the logs revealed that the container was unable to read the pre generated certificate.

```
$ kubectl get po -n kube-system
NAME                                                  READY     STATUS             RESTARTS   AGE
heptio-authenticator-aws-2gs24                        0/1       CrashLoopBackOff   22         1d

$ kubectl logs heptio-authenticator-aws-2gs24  -n kube-system
time="2018-07-05T18:40:34Z" level=info msg="mapping IAM user" groups="[system:masters]" user="arn:aws:iam::REDACTED:user/alice" username=alice
time="2018-07-05T18:40:34Z" level=fatal msg="could not load/generate a certificate" error="open /var/heptio-authenticator-aws/cert.pem: permission denied"
```

Turns out the container runs as user `aws-iam-authenticator`, so does not have permission to read the certificate, which is owned by `root` and has permissions of `600`.

Changing the permissions to `644` resolved the issue.

```
NAME                                                  READY     STATUS    RESTARTS   AGE
heptio-authenticator-aws-8jg6h                        1/1       Running   0          10m

$ kubectl logs heptio-authenticator-aws-8jg6h -n kube-system
time="2018-07-05T18:46:18Z" level=info msg="mapping IAM user" groups="[system:masters]" user="arn:aws:iam::REDACTED:user/alice" username=alice
time="2018-07-05T18:46:18Z" level=info msg="loaded existing keypair" certPath=/var/heptio-authenticator-aws/cert.pem keyPath=/var/heptio-authenticator-aws/key.pem
time="2018-07-05T18:46:19Z" level=info msg="listening on https://127.0.0.1:21362/authenticate"
time="2018-07-05T18:46:19Z" level=info msg="reconfigure your apiserver with `--authentication-token-webhook-config-file=/etc/kubernetes/heptio-authenticator-aws/kubeconfig.yaml` to enable (assuming default hostPath mounts)"
```
