### PR TITLE
[WIP] Initial implementation of ACM certificate for API server ELB

### DIFF
--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -158,6 +158,7 @@ func RunCreate(f *util.Factory, out io.Writer, c *CreateOptions) error {
 			case *kopsapi.Cluster:
 				// Adding a PerformAssignments() call here as the user might be trying to use
 				// the new `-f` feature, with an old cluster definition.
+
 				err = cloudup.PerformAssignments(v)
 				if err != nil {
 					return fmt.Errorf("error populating configuration: %v", err)

--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -158,7 +158,6 @@ func RunCreate(f *util.Factory, out io.Writer, c *CreateOptions) error {
 			case *kopsapi.Cluster:
 				// Adding a PerformAssignments() call here as the user might be trying to use
 				// the new `-f` feature, with an old cluster definition.
-
 				err = cloudup.PerformAssignments(v)
 				if err != nil {
 					return fmt.Errorf("error populating configuration: %v", err)

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -330,7 +330,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&options.NodeTenancy, "node-tenancy", options.NodeTenancy, "The tenancy of the node group on AWS. Can be either default or dedicated.")
 
 	cmd.Flags().StringVar(&options.APILoadBalancerType, "api-loadbalancer-type", options.APILoadBalancerType, "Sets the API loadbalancer type to either 'public' or 'internal'")
-	cmd.Flags().StringVar(&options.APISSLCertificate, "api-ssl-certificate", options.APISSLCertificate, "Sets the SSL Certificate to use for the API server loadbalancer. Currently only supported in AWS.")
+	cmd.Flags().StringVar(&options.APISSLCertificate, "api-ssl-certificate", options.APISSLCertificate, "Currently only supported in AWS. Sets the ARN of the SSL Certificate to use for the API server loadbalancer.")
 
 	// Allow custom public master name
 	cmd.Flags().StringVar(&options.MasterPublicName, "master-public-name", options.MasterPublicName, "Sets the public master public name")

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -123,6 +123,9 @@ type CreateClusterOptions struct {
 	// Specify API loadbalancer as public or internal
 	APILoadBalancerType string
 
+	// Specify the SSL certificate to use for the API loadbalancer. Currently only supported in AWS.
+	APISSLCertificate string
+
 	// Allow custom public master name
 	MasterPublicName string
 
@@ -327,6 +330,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&options.NodeTenancy, "node-tenancy", options.NodeTenancy, "The tenancy of the node group on AWS. Can be either default or dedicated.")
 
 	cmd.Flags().StringVar(&options.APILoadBalancerType, "api-loadbalancer-type", options.APILoadBalancerType, "Sets the API loadbalancer type to either 'public' or 'internal'")
+	cmd.Flags().StringVar(&options.APISSLCertificate, "api-ssl-certificate", options.APISSLCertificate, "Sets the SSL Certificate to use for the API server loadbalancer. Currently only supported in AWS.")
 
 	// Allow custom public master name
 	cmd.Flags().StringVar(&options.MasterPublicName, "master-public-name", options.MasterPublicName, "Sets the public master public name")
@@ -1050,6 +1054,10 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		default:
 			return fmt.Errorf("unknown api-loadbalancer-type: %q", c.APILoadBalancerType)
 		}
+	}
+
+	if c.APISSLCertificate != "" {
+		cluster.Spec.API.LoadBalancer.SSLCertificate = c.APISSLCertificate
 	}
 
 	// Use Strict IAM policy and allow AWS ECR by default when creating a new cluster

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -66,6 +66,7 @@ kops create cluster [flags]
 ```
       --admin-access strings             Restrict API access to this CIDR.  If not set, access will not be restricted by IP. (default [0.0.0.0/0])
       --api-loadbalancer-type string     Sets the API loadbalancer type to either 'public' or 'internal'
+      --api-ssl-certificate string       Currently only supported in AWS. Sets the ARN of the SSL Certificate to use for the API server loadbalancer.
       --associate-public-ip              Specify --associate-public-ip=[true|false] to enable/disable association of public IP for master ASG and nodes. Default is 'true'.
       --authorization string             Authorization mode to use: AlwaysAllow or RBAC (default "RBAC")
       --bastion                          Pass the --bastion flag to enable a bastion instance group. Only applies to private topology.

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -282,6 +282,7 @@ type LoadBalancerAccessSpec struct {
 	Type                     LoadBalancerType `json:"type,omitempty"`
 	IdleTimeoutSeconds       *int64           `json:"idleTimeoutSeconds,omitempty"`
 	AdditionalSecurityGroups []string         `json:"additionalSecurityGroups,omitempty"`
+	SSLCertificate           string           `json:"sslCertificate,omitempty"`
 }
 
 // KubeDNSConfig defines the kube dns configuration

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -281,6 +281,7 @@ type LoadBalancerAccessSpec struct {
 	Type                     LoadBalancerType `json:"type,omitempty"`
 	IdleTimeoutSeconds       *int64           `json:"idleTimeoutSeconds,omitempty"`
 	AdditionalSecurityGroups []string         `json:"additionalSecurityGroups,omitempty"`
+	SSLCertificate           string           `json:"sslCertificate,omitempty"`
 }
 
 // KubeDNSConfig defines the kube dns configuration

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -2462,6 +2462,7 @@ func autoConvert_v1alpha1_LoadBalancerAccessSpec_To_kops_LoadBalancerAccessSpec(
 	out.Type = kops.LoadBalancerType(in.Type)
 	out.IdleTimeoutSeconds = in.IdleTimeoutSeconds
 	out.AdditionalSecurityGroups = in.AdditionalSecurityGroups
+	out.SSLCertificate = in.SSLCertificate
 	return nil
 }
 
@@ -2474,6 +2475,7 @@ func autoConvert_kops_LoadBalancerAccessSpec_To_v1alpha1_LoadBalancerAccessSpec(
 	out.Type = LoadBalancerType(in.Type)
 	out.IdleTimeoutSeconds = in.IdleTimeoutSeconds
 	out.AdditionalSecurityGroups = in.AdditionalSecurityGroups
+	out.SSLCertificate = in.SSLCertificate
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -282,6 +282,7 @@ type LoadBalancerAccessSpec struct {
 	Type                     LoadBalancerType `json:"type,omitempty"`
 	IdleTimeoutSeconds       *int64           `json:"idleTimeoutSeconds,omitempty"`
 	AdditionalSecurityGroups []string         `json:"additionalSecurityGroups,omitempty"`
+	SSLCertificate           string           `json:"sslCertificate,omitempty"`
 }
 
 type KubeDNSConfig struct {

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2726,6 +2726,7 @@ func autoConvert_v1alpha2_LoadBalancerAccessSpec_To_kops_LoadBalancerAccessSpec(
 	out.Type = kops.LoadBalancerType(in.Type)
 	out.IdleTimeoutSeconds = in.IdleTimeoutSeconds
 	out.AdditionalSecurityGroups = in.AdditionalSecurityGroups
+	out.SSLCertificate = in.SSLCertificate
 	return nil
 }
 
@@ -2738,6 +2739,7 @@ func autoConvert_kops_LoadBalancerAccessSpec_To_v1alpha2_LoadBalancerAccessSpec(
 	out.Type = LoadBalancerType(in.Type)
 	out.IdleTimeoutSeconds = in.IdleTimeoutSeconds
 	out.AdditionalSecurityGroups = in.AdditionalSecurityGroups
+	out.SSLCertificate = in.SSLCertificate
 	return nil
 }
 

--- a/pkg/client/simple/vfsclientset/commonvfs.go
+++ b/pkg/client/simple/vfsclientset/commonvfs.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kops/pkg/acls"
-	kops "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/v1alpha2"
 	"k8s.io/kops/pkg/kopscodecs"
 	"k8s.io/kops/util/pkg/vfs"

--- a/pkg/kubeconfig/create_kubecfg.go
+++ b/pkg/kubeconfig/create_kubecfg.go
@@ -86,7 +86,7 @@ func BuildKubecfg(cluster *kops.Cluster, keyStore fi.Keystore, secretStore fi.Se
 	b.Context = clusterName
 
 	// add the CA Cert to the kubeconfig only if we didn't specify a SSL cert for the LB
-	if cluster.Spec.API.LoadBalancer.SSLCertificate == "" {
+	if cluster.Spec.API == nil || cluster.Spec.API.LoadBalancer == nil || cluster.Spec.API.LoadBalancer.SSLCertificate == "" {
 		cert, _, _, err := keyStore.FindKeypair(fi.CertificateId_CA)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching CA keypair: %v", err)

--- a/pkg/kubeconfig/create_kubecfg.go
+++ b/pkg/kubeconfig/create_kubecfg.go
@@ -85,7 +85,8 @@ func BuildKubecfg(cluster *kops.Cluster, keyStore fi.Keystore, secretStore fi.Se
 
 	b.Context = clusterName
 
-	{
+	// add the CA Cert to the kubeconfig only if we didn't specify a SSL cert for the LB
+	if cluster.Spec.API.LoadBalancer.SSLCertificate == "" {
 		cert, _, _, err := keyStore.FindKeypair(fi.CertificateId_CA)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching CA keypair: %v", err)

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -71,7 +71,6 @@ func hasPlaceHolderIP(clusterName string) (bool, error) {
 	if err != nil {
 		return true, fmt.Errorf("unable to parse Kubernetes cluster API URL: %v", err)
 	}
-
 	hostAddrs, err := net.LookupHost(apiAddr.Hostname())
 	if err != nil {
 		return true, fmt.Errorf("unable to resolve Kubernetes cluster API URL dns: %v", err)

--- a/upup/pkg/fi/cloudup/awstasks/load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/load_balancer.go
@@ -553,7 +553,7 @@ func (_ *LoadBalancer) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *LoadBalan
 			if elbDescription != nil {
 				// deleting the listener before recreating it
 				t.Cloud.ELB().DeleteLoadBalancerListeners(&elb.DeleteLoadBalancerListenersInput{
-					LoadBalancerName: aws.String(loadBalancerName),
+					LoadBalancerName:  aws.String(loadBalancerName),
 					LoadBalancerPorts: []*int64{aws.Int64(443)},
 				})
 			}


### PR DESCRIPTION
This is a WIP implementation fo the support for ACM certificates for the API ELB. This PR allows to specify the ARN of the SSL certificate to use for the Kubernetes API server. It makes the `certificate-authority-data`) unneeded when specifying the certificate and simplify the content of the kubeconfig file (no more need to ship the `certificate-authority-data` to the user, super handy especially in combination with the AWS authentication).

I'm not fully sure of the consequences of this PR, so I am really looking forward for feedback in this regards. I'd be happy to make changes especially in the way the ARN of the certificate needs to be passed (currently it's just a CLI flag). 

This PR fixes https://github.com/kubernetes/kops/issues/834 which I promised many weeks ago, but finally took the time to tackle. 

Also, if anyone can guide me on how to add tests for this, that'd be great! 