### PR TITLE
Fixes issue when setting docker version

### DIFF
--- a/nodeup/pkg/model/docker_test.go
+++ b/nodeup/pkg/model/docker_test.go
@@ -38,6 +38,7 @@ func TestDockerBuilder_LogFlags(t *testing.T) {
 }
 
 func TestDockerBuilder_BuildFlags(t *testing.T) {
+	logDriver := "json-file"
 	grid := []struct {
 		config   kops.DockerConfig
 		expected string
@@ -48,20 +49,20 @@ func TestDockerBuilder_BuildFlags(t *testing.T) {
 		},
 		{
 			kops.DockerConfig{
-				LogDriver: "json-file",
+				LogDriver: &logDriver,
 			},
 			"--log-driver=json-file",
 		},
 		{
 			kops.DockerConfig{
-				LogDriver: "json-file",
+				LogDriver: &logDriver,
 				LogOpt:    []string{"max-size=10m"},
 			},
 			"--log-driver=json-file --log-opt=max-size=10m",
 		},
 		{
 			kops.DockerConfig{
-				LogDriver: "json-file",
+				LogDriver: &logDriver,
 				LogOpt:    []string{"max-size=10m", "max-file=5"},
 			},
 			"--log-driver=json-file --log-opt=max-file=5 --log-opt=max-size=10m",

--- a/pkg/apis/kops/dockerconfig.go
+++ b/pkg/apis/kops/dockerconfig.go
@@ -37,7 +37,7 @@ type DockerConfig struct {
 	// LiveRestore enables live restore of docker when containers are still running
 	LiveRestore *bool `json:"liveRestore,omitempty" flag:"live-restore"`
 	// LogDriver is the default driver for container logs (default "json-file")
-	LogDriver string `json:"logDriver,omitempty" flag:"log-driver"`
+	LogDriver *string `json:"logDriver,omitempty" flag:"log-driver"`
 	// LogLevel is the logging level ("debug", "info", "warn", "error", "fatal") (default "info")
 	LogLevel *string `json:"logLevel,omitempty" flag:"log-level"`
 	// Logopt is a series of options given to the log driver options for containers

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -21,7 +21,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	kops "k8s.io/kops/pkg/apis/kops"
@@ -1341,9 +1340,7 @@ func autoConvert_v1alpha1_DockerConfig_To_kops_DockerConfig(in *DockerConfig, ou
 	out.IPTables = in.IPTables
 	out.InsecureRegistry = in.InsecureRegistry
 	out.LiveRestore = in.LiveRestore
-	if err := v1.Convert_Pointer_string_To_string(&in.LogDriver, &out.LogDriver, s); err != nil {
-		return err
-	}
+	out.LogDriver = in.LogDriver
 	out.LogLevel = in.LogLevel
 	out.LogOpt = in.LogOpt
 	out.MTU = in.MTU
@@ -1370,9 +1367,7 @@ func autoConvert_kops_DockerConfig_To_v1alpha1_DockerConfig(in *kops.DockerConfi
 	out.IPTables = in.IPTables
 	out.InsecureRegistry = in.InsecureRegistry
 	out.LiveRestore = in.LiveRestore
-	if err := v1.Convert_string_To_Pointer_string(&in.LogDriver, &out.LogDriver, s); err != nil {
-		return err
-	}
+	out.LogDriver = in.LogDriver
 	out.LogLevel = in.LogLevel
 	out.LogOpt = in.LogOpt
 	out.MTU = in.MTU

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -21,7 +21,6 @@ limitations under the License.
 package v1alpha2
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	kops "k8s.io/kops/pkg/apis/kops"
@@ -1442,9 +1441,7 @@ func autoConvert_v1alpha2_DockerConfig_To_kops_DockerConfig(in *DockerConfig, ou
 	out.IPTables = in.IPTables
 	out.InsecureRegistry = in.InsecureRegistry
 	out.LiveRestore = in.LiveRestore
-	if err := v1.Convert_Pointer_string_To_string(&in.LogDriver, &out.LogDriver, s); err != nil {
-		return err
-	}
+	out.LogDriver = in.LogDriver
 	out.LogLevel = in.LogLevel
 	out.LogOpt = in.LogOpt
 	out.MTU = in.MTU
@@ -1471,9 +1468,7 @@ func autoConvert_kops_DockerConfig_To_v1alpha2_DockerConfig(in *kops.DockerConfi
 	out.IPTables = in.IPTables
 	out.InsecureRegistry = in.InsecureRegistry
 	out.LiveRestore = in.LiveRestore
-	if err := v1.Convert_string_To_Pointer_string(&in.LogDriver, &out.LogDriver, s); err != nil {
-		return err
-	}
+	out.LogDriver = in.LogDriver
 	out.LogLevel = in.LogLevel
 	out.LogOpt = in.LogOpt
 	out.MTU = in.MTU

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -1152,6 +1152,15 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 			**out = **in
 		}
 	}
+	if in.LogDriver != nil {
+		in, out := &in.LogDriver, &out.LogDriver
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
 	if in.LogLevel != nil {
 		in, out := &in.LogLevel, &out.LogLevel
 		if *in == nil {

--- a/pkg/model/components/docker.go
+++ b/pkg/model/components/docker.go
@@ -73,9 +73,10 @@ func (b *DockerOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if sv.Major == 1 && sv.Minor >= 6 {
-		if len(clusterSpec.Docker.LogOpt) == 0 && clusterSpec.Docker.LogDriver == "" {
+		if len(clusterSpec.Docker.LogOpt) == 0 && clusterSpec.Docker.LogDriver == nil {
 			// Use built-in docker logging, if not configured otherwise (by the user)
-			clusterSpec.Docker.LogDriver = "json-file"
+			logDriver := "json-file"
+			clusterSpec.Docker.LogDriver = &logDriver
 			clusterSpec.Docker.LogOpt = append(clusterSpec.Docker.LogOpt, "max-size=10m")
 			clusterSpec.Docker.LogOpt = append(clusterSpec.Docker.LogOpt, "max-file=5")
 		}


### PR DESCRIPTION
Previously when setting docker version, logdriver was automatically
added to cluster config. Switching it to a pointer fixes this issue.

Fixes #5384