### PR TITLE
Rename Heptio Authenticator to AWS IAM Authenticator.

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -32,9 +32,9 @@ spec:
     rbac: {}
 ```
 
-## Heptio Authenticator for AWS
+## AWS IAM Authenticator for Kubernetes
 
-If you want to turn on Heptio Authenticator for AWS, you can add this block 
+If you want to turn on AWS IAM Authenticator for Kubernetes (formerly Heptio Authenticator for AWS), you can add this block
 to your cluster:
 
 ```
@@ -56,9 +56,8 @@ spec:
     rbac: {}
 ```
 
-Once the cluster is up you will need to create the heptio authenticator
-config as a config map. (This can also be done when boostrapping a cluster using addons)
-For more details on heptio authenticator please visit (heptio/authenticator)[https://github.com/heptio/authenticator]
+Once the cluster is up you will need to create the `aws-iam-authenticator` config as a config map. (This can also be done when boostrapping a cluster using addons)
+For more details on AWS IAM Authenticator for Kubernetes please visit (kubernetes-sigs/aws-iam-authenticator)[https://github.com/kubernetes-sigs/aws-iam-authenticator]
 Example config:
 
 ```
@@ -67,9 +66,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: kube-system
-  name: heptio-authenticator-aws
+  name: aws-iam-authenticator
   labels:
-    k8s-app: heptio-authenticator-aws
+    k8s-app: aws-iam-authenticator
 data:
   config.yaml: |
     # a unique-per-cluster identifier to prevent replay attacks

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -159,34 +159,34 @@ func (b *KubeAPIServerBuilder) writeAuthenticationConfig(c *fi.ModelBuilderConte
 	}
 
 	if b.Cluster.Spec.Authentication.Heptio != nil {
-		id := "heptio-authenticator-aws"
+		id := "aws-iam-authenticator"
 		b.Cluster.Spec.KubeAPIServer.AuthenticationTokenWebhookConfigFile = fi.String(PathAuthnConfig)
 
 		{
 			caCertificate, err := b.NodeupModelContext.KeyStore.FindCert(fi.CertificateId_CA)
 			if err != nil {
-				return fmt.Errorf("error fetching Heptio Authentication CA certificate from keystore: %v", err)
+				return fmt.Errorf("error fetching AWS IAM Authenticator CA certificate from keystore: %v", err)
 			}
 			if caCertificate == nil {
-				return fmt.Errorf("Heptio Authentication CA certificate %q not found", fi.CertificateId_CA)
+				return fmt.Errorf("AWS IAM Authenticator CA certificate %q not found", fi.CertificateId_CA)
 			}
 
 			cluster := kubeconfig.KubectlCluster{
 				Server: "https://127.0.0.1:21362/authenticate",
 			}
 			context := kubeconfig.KubectlContext{
-				Cluster: "heptio-authenticator-aws",
+				Cluster: "aws-iam-authenticator",
 				User:    "kube-apiserver",
 			}
 
 			cluster.CertificateAuthorityData, err = caCertificate.AsBytes()
 			if err != nil {
-				return fmt.Errorf("error encoding Heptio Authentication CA certificate: %v", err)
+				return fmt.Errorf("error encoding AWS IAM Authenticator CA certificate: %v", err)
 			}
 
 			config := kubeconfig.KubectlConfig{}
 			config.Clusters = append(config.Clusters, &kubeconfig.KubectlClusterWithName{
-				Name:    "heptio-authenticator-aws",
+				Name:    "aws-iam-authenticator",
 				Cluster: cluster,
 			})
 			config.Users = append(config.Users, &kubeconfig.KubectlUserWithName{
@@ -226,7 +226,7 @@ func (b *KubeAPIServerBuilder) writeAuthenticationConfig(c *fi.ModelBuilderConte
 			}
 
 			c.AddTask(&nodetasks.File{
-				Path:     "/srv/kubernetes/heptio-authenticator-aws/cert.pem",
+				Path:     "/srv/kubernetes/aws-iam-authenticator/cert.pem",
 				Contents: fi.NewBytesResource(certificateData),
 				Type:     nodetasks.FileType_File,
 				Mode:     fi.String("600"),
@@ -248,7 +248,7 @@ func (b *KubeAPIServerBuilder) writeAuthenticationConfig(c *fi.ModelBuilderConte
 			}
 
 			c.AddTask(&nodetasks.File{
-				Path:     "/srv/kubernetes/heptio-authenticator-aws/key.pem",
+				Path:     "/srv/kubernetes/aws-iam-authenticator/key.pem",
 				Contents: fi.NewBytesResource(keyData),
 				Type:     nodetasks.FileType_File,
 				Mode:     fi.String("600"),

--- a/pkg/model/pki.go
+++ b/pkg/model/pki.go
@@ -271,8 +271,8 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			}
 
 			t := &fitasks.Keypair{
-				Name:           fi.String("heptio-authenticator-aws"),
-				Subject:        "cn=heptio-authenticator-aws",
+				Name:           fi.String("aws-iam-authenticator"),
+				Subject:        "cn=aws-iam-authenticator",
 				Type:           "server",
 				AlternateNames: alternateNames,
 				Signer:         defaultCA,

--- a/upup/models/cloudup/resources/addons/authentication.hept.io/k8s-1.10.yaml
+++ b/upup/models/cloudup/resources/addons/authentication.hept.io/k8s-1.10.yaml
@@ -3,9 +3,9 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   namespace: kube-system
-  name: heptio-authenticator-aws
+  name: aws-iam-authenticator
   labels:
-    k8s-app: heptio-authenticator-aws
+    k8s-app: aws-iam-authenticator
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -14,7 +14,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
-        k8s-app: heptio-authenticator-aws
+        k8s-app: aws-iam-authenticator
     spec:
       # run on the host network (don't depend on CNI)
       hostNetwork: true
@@ -28,17 +28,17 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
 
-      # run `heptio-authenticator-aws server` with three volumes
-      # - config (mounted from the ConfigMap at /etc/heptio-authenticator-aws/config.yaml)
+      # run `aws-iam-authenticator server` with three volumes
+      # - config (mounted from the ConfigMap at /etc/aws-iam-authenticator/config.yaml)
       # - state (persisted TLS certificate and keys, mounted from the host)
       # - output (output kubeconfig to plug into your apiserver configuration, mounted from the host)
       containers:
-      - name: heptio-authenticator-aws
+      - name: aws-iam-authenticator
         image: gcr.io/heptio-images/authenticator:v0.3.0
         args:
         - server
-        - --config=/etc/heptio-authenticator-aws/config.yaml
-        - --state-dir=/var/heptio-authenticator-aws
+        - --config=/etc/aws-iam-authenticator/config.yaml
+        - --state-dir=/var/aws-iam-authenticator
         - --kubeconfig-pregenerated=true
 
         resources:
@@ -51,19 +51,19 @@ spec:
 
         volumeMounts:
         - name: config
-          mountPath: /etc/heptio-authenticator-aws/
+          mountPath: /etc/aws-iam-authenticator/
         - name: state
-          mountPath: /var/heptio-authenticator-aws/
+          mountPath: /var/aws-iam-authenticator/
         - name: output
-          mountPath: /etc/kubernetes/heptio-authenticator-aws/
+          mountPath: /etc/kubernetes/aws-iam-authenticator/
 
       volumes:
       - name: config
         configMap:
-          name: heptio-authenticator-aws
+          name: aws-iam-authenticator
       - name: output
         hostPath:
-          path: /srv/kubernetes/heptio-authenticator-aws/
+          path: /srv/kubernetes/aws-iam-authenticator/
       - name: state
         hostPath:
-          path: /srv/kubernetes/heptio-authenticator-aws/
+          path: /srv/kubernetes/aws-iam-authenticator/


### PR DESCRIPTION
In light of the recent renaming of `Heptio Authenticator` to `AWS IAM Authenticator for Kubernetes`, now might be a good time to follow suit.

References:
* [Renamed "Heptio Authenticator" to "AWS IAM Authenticator for Kubernetes"](https://github.com/kubernetes-sigs/aws-iam-authenticator/pull/104)
* [Renamed heptio-authenticator-aws -> aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator/pull/108)

This PR is an initial attempt at this. Tests pass but I have not yet created a cluster from a local build.

The changes so far are cosmetic and some questions remain:

1. Should the spec change? If so, then to what?
The `AuthenticationSpec` retains a key called `Heptio` of type `HeptioAuthenticationSpec`.

2. What about addon resources? See 1.
The `aws-iam-authenticator` manifest(s) are in a directory called `authentication.hept.io`.

3. Binary has changed but no new docker image pushed as of yet.
The docker image remains: `gcr.io/heptio-images/authenticator:v0.3.0`, so the binary will still be `heptio-authenticator-aws`. Updated images will likely be published very soon.

Original PR: https://github.com/kubernetes/kops/pull/5197
