### PR TITLE
Fix the issue described in #5412 where the authenticator is no longer…

### DIFF
--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -212,6 +212,15 @@ func (b *KubeAPIServerBuilder) writeAuthenticationConfig(c *fi.ModelBuilderConte
 		}
 
 		{
+			c.AddTask(&nodetasks.UserTask{
+				Name:  "aws-iam-authenticator",
+				UID:   10000,
+				Shell: "/sbin/nologin",
+				Home:  "/srv/kubernetes/aws-iam-authenticator",
+			})
+		}
+
+		{
 			certificate, err := b.NodeupModelContext.KeyStore.FindCert(id)
 			if err != nil {
 				return fmt.Errorf("error fetching %q certificate from keystore: %v", id, err)
@@ -230,6 +239,8 @@ func (b *KubeAPIServerBuilder) writeAuthenticationConfig(c *fi.ModelBuilderConte
 				Contents: fi.NewBytesResource(certificateData),
 				Type:     nodetasks.FileType_File,
 				Mode:     fi.String("600"),
+				Owner:    fi.String("aws-iam-authenticator"),
+				Group:    fi.String("aws-iam-authenticator"),
 			})
 		}
 
@@ -252,6 +263,8 @@ func (b *KubeAPIServerBuilder) writeAuthenticationConfig(c *fi.ModelBuilderConte
 				Contents: fi.NewBytesResource(keyData),
 				Type:     nodetasks.FileType_File,
 				Mode:     fi.String("600"),
+				Owner:    fi.String("aws-iam-authenticator"),
+				Group:    fi.String("aws-iam-authenticator"),
 			})
 		}
 

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -211,6 +211,9 @@ func (b *KubeAPIServerBuilder) writeAuthenticationConfig(c *fi.ModelBuilderConte
 			})
 		}
 
+		// We create user aws-iam-authenticator and hardcode its UID to 10000 as
+		// that is the ID used inside the aws-iam-authenticator container.
+		// The owner/group for the keypair to aws-iam-authenticator
 		{
 			c.AddTask(&nodetasks.UserTask{
 				Name:  "aws-iam-authenticator",

--- a/upup/pkg/fi/nodeup/nodetasks/user.go
+++ b/upup/pkg/fi/nodeup/nodetasks/user.go
@@ -19,6 +19,7 @@ package nodetasks
 import (
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/golang/glog"
@@ -32,6 +33,7 @@ import (
 type UserTask struct {
 	Name string
 
+	UID   int    `json:"uid"`
 	Shell string `json:"shell"`
 	Home  string `json:"home"`
 }
@@ -74,6 +76,7 @@ func (e *UserTask) Find(c *fi.Context) (*UserTask, error) {
 
 	actual := &UserTask{
 		Name:  e.Name,
+		UID:   info.Uid,
 		Shell: info.Shell,
 		Home:  info.Home,
 	}
@@ -91,6 +94,9 @@ func (_ *UserTask) CheckChanges(a, e, changes *UserTask) error {
 
 func buildUseraddArgs(e *UserTask) []string {
 	var args []string
+	if e.UID != 0 {
+		args = append(args, "-u", strconv.Itoa(e.UID))
+	}
 	if e.Shell != "" {
 		args = append(args, "-s", e.Shell)
 	}
@@ -114,6 +120,9 @@ func (_ *UserTask) RenderLocal(t *local.LocalTarget, a, e, changes *UserTask) er
 	} else {
 		var args []string
 
+		if changes.UID != 0 {
+			args = append(args, "-u", strconv.Itoa(e.UID))
+		}
 		if changes.Shell != "" {
 			args = append(args, "-s", e.Shell)
 		}


### PR DESCRIPTION
Fix the issue described in #5412 where the authenticator is no longer able to read the authentication key pair it requires.

The issue here lies with https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/master/Dockerfile.scratch the user set to run inside the container that is built is `aws-iam-authenticator` which will not match the UID for what the Certs on the host.

We create user `aws-iam-authenticator` and hardcode its UID to 10000 as that is the ID used inside the aws-iam-authenticator container. The owner/group for the keypair to aws-iam-authenticator

This relies on #5424 being merged first as it uses the `aws-iam-authenticator` name and path.