### PR TITLE
Use /bin/bash in kubelet manifest ExecStartPre

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -244,7 +244,7 @@ func (b *KubeletBuilder) buildSystemdService() *nodetasks.Service {
 	// @check if we are using bootstrap tokens and file checker
 	if !b.IsMaster && b.UseBootstrapTokens() {
 		manifest.Set("Service", "ExecStartPre",
-			fmt.Sprintf("/usr/bin/bash -c 'while [ ! -f %s ]; do sleep 5; done;'", b.KubeletBootstrapKubeconfig()))
+			fmt.Sprintf("/bin/bash -c 'while [ ! -f %s ]; do sleep 5; done;'", b.KubeletBootstrapKubeconfig()))
 	}
 
 	manifest.Set("Service", "ExecStart", kubeletCommand+" \"$DAEMON_ARGS\"")


### PR DESCRIPTION
Closes #5381 

I originally thought we might need to try to address platform-dependent `bash` paths, but it looks like there are other places we've hard-coded `/bin/bash` (e.g. https://github.com/kubernetes/kops/blob/8fad9da430e831cd0a92a61830c8b4834551f592/nodeup/pkg/model/firewall.go#L71)  so perhaps it is easiest to put that idea off the future.