### PR TITLE
skipper selector changed

### DIFF
--- a/addons/kube-ingress-aws-controller/v1.0.0.yaml
+++ b/addons/kube-ingress-aws-controller/v1.0.0.yaml
@@ -37,7 +37,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      application: skipper-ingress
+      component: ingress
   updateStrategy:
     type: RollingUpdate
   template:


### PR DESCRIPTION
The selector of skipper needs to be fixed. It gives the following error:
```
The DaemonSet "skipper-ingress" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"component":"ingress"}: `selector` does not match template `labels
```
In order to be deployed the `matchLabels` has been changed.