### PR TITLE
Add data-root and exec-root attributes to the docker config spec

### DIFF
--- a/pkg/apis/kops/dockerconfig.go
+++ b/pkg/apis/kops/dockerconfig.go
@@ -24,8 +24,12 @@ type DockerConfig struct {
 	Bridge *string `json:"bridge,omitempty" flag:"bridge"`
 	// BridgeIP is a specific IP address and netmask for the docker0 bridge, using standard CIDR notation
 	BridgeIP *string `json:"bridgeIP,omitempty" flag:"bip"`
+	// DataRoot is the root directory of persistent docker state (default "/var/lib/docker")
+	DataRoot *string `json:"dataRoot,omitempty" flag:"data-root"`
 	// DefaultUlimit is the ulimits for containers
 	DefaultUlimit []string `json:"defaultUlimit,omitempty" flag:"default-ulimit,repeat"`
+	// ExecRoot is the root directory for execution state files (default "/var/run/docker")
+	ExecRoot *string `json:"execRoot,omitempty" flag:"exec-root"`
 	// Hosts enables you to configure the endpoints the docker daemon listens on i.e tcp://0.0.0.0.2375 or unix:///var/run/docker.sock etc
 	Hosts []string `json:"hosts,omitempty" flag:"host,repeat"`
 	// IPMasq enables ip masquerading for containers

--- a/pkg/apis/kops/v1alpha1/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha1/dockerconfig.go
@@ -24,8 +24,12 @@ type DockerConfig struct {
 	Bridge *string `json:"bridge,omitempty" flag:"bridge"`
 	// BridgeIP is a specific IP address and netmask for the docker0 bridge, using standard CIDR notation
 	BridgeIP *string `json:"bridgeIP,omitempty" flag:"bip"`
+	// DataRoot is the root directory of persistent docker state (default "/var/lib/docker")
+	DataRoot *string `json:"dataRoot,omitempty" flag:"data-root"`
 	// DefaultUlimit is the ulimits for containers
 	DefaultUlimit []string `json:"defaultUlimit,omitempty" flag:"default-ulimit,repeat"`
+	// ExecRoot is the root directory for execution state files (default "/var/run/docker")
+	ExecRoot *string `json:"execRoot,omitempty" flag:"exec-root"`
 	// Hosts enables you to configure the endpoints the docker daemon listens on i.e tcp://0.0.0.0.2375 or unix:///var/run/docker.sock etc
 	Hosts []string `json:"hosts,omitempty" flag:"host,repeat"`
 	// IPMasq enables ip masquerading for containers

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1335,7 +1335,9 @@ func autoConvert_v1alpha1_DockerConfig_To_kops_DockerConfig(in *DockerConfig, ou
 	out.AuthorizationPlugins = in.AuthorizationPlugins
 	out.Bridge = in.Bridge
 	out.BridgeIP = in.BridgeIP
+	out.DataRoot = in.DataRoot
 	out.DefaultUlimit = in.DefaultUlimit
+	out.ExecRoot = in.ExecRoot
 	out.Hosts = in.Hosts
 	out.IPMasq = in.IPMasq
 	out.IPTables = in.IPTables
@@ -1364,7 +1366,9 @@ func autoConvert_kops_DockerConfig_To_v1alpha1_DockerConfig(in *kops.DockerConfi
 	out.AuthorizationPlugins = in.AuthorizationPlugins
 	out.Bridge = in.Bridge
 	out.BridgeIP = in.BridgeIP
+	out.DataRoot = in.DataRoot
 	out.DefaultUlimit = in.DefaultUlimit
+	out.ExecRoot = in.ExecRoot
 	out.Hosts = in.Hosts
 	out.IPMasq = in.IPMasq
 	out.IPTables = in.IPTables

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -1011,10 +1011,28 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 			**out = **in
 		}
 	}
+	if in.DataRoot != nil {
+		in, out := &in.DataRoot, &out.DataRoot
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
 	if in.DefaultUlimit != nil {
 		in, out := &in.DefaultUlimit, &out.DefaultUlimit
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.ExecRoot != nil {
+		in, out := &in.ExecRoot, &out.ExecRoot
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
 	}
 	if in.Hosts != nil {
 		in, out := &in.Hosts, &out.Hosts

--- a/pkg/apis/kops/v1alpha2/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha2/dockerconfig.go
@@ -24,8 +24,12 @@ type DockerConfig struct {
 	Bridge *string `json:"bridge,omitempty" flag:"bridge"`
 	// BridgeIP is a specific IP address and netmask for the docker0 bridge, using standard CIDR notation
 	BridgeIP *string `json:"bridgeIP,omitempty" flag:"bip"`
+	// DataRoot is the root directory of persistent docker state (default "/var/lib/docker")
+	DataRoot *string `json:"dataRoot,omitempty" flag:"data-root"`
 	// DefaultUlimit is the ulimits for containers
 	DefaultUlimit []string `json:"defaultUlimit,omitempty" flag:"default-ulimit,repeat"`
+	// ExecRoot is the root directory for execution state files (default "/var/run/docker")
+	ExecRoot *string `json:"execRoot,omitempty" flag:"exec-root"`
 	// Hosts enables you to configure the endpoints the docker daemon listens on i.e tcp://0.0.0.0.2375 or unix:///var/run/docker.sock etc
 	Hosts []string `json:"hosts,omitempty" flag:"host,repeat"`
 	// IPMasq enables ip masquerading for containers

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1436,7 +1436,9 @@ func autoConvert_v1alpha2_DockerConfig_To_kops_DockerConfig(in *DockerConfig, ou
 	out.AuthorizationPlugins = in.AuthorizationPlugins
 	out.Bridge = in.Bridge
 	out.BridgeIP = in.BridgeIP
+	out.DataRoot = in.DataRoot
 	out.DefaultUlimit = in.DefaultUlimit
+	out.ExecRoot = in.ExecRoot
 	out.Hosts = in.Hosts
 	out.IPMasq = in.IPMasq
 	out.IPTables = in.IPTables
@@ -1465,7 +1467,9 @@ func autoConvert_kops_DockerConfig_To_v1alpha2_DockerConfig(in *kops.DockerConfi
 	out.AuthorizationPlugins = in.AuthorizationPlugins
 	out.Bridge = in.Bridge
 	out.BridgeIP = in.BridgeIP
+	out.DataRoot = in.DataRoot
 	out.DefaultUlimit = in.DefaultUlimit
+	out.ExecRoot = in.ExecRoot
 	out.Hosts = in.Hosts
 	out.IPMasq = in.IPMasq
 	out.IPTables = in.IPTables

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -978,10 +978,28 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 			**out = **in
 		}
 	}
+	if in.DataRoot != nil {
+		in, out := &in.DataRoot, &out.DataRoot
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
 	if in.DefaultUlimit != nil {
 		in, out := &in.DefaultUlimit, &out.DefaultUlimit
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.ExecRoot != nil {
+		in, out := &in.ExecRoot, &out.ExecRoot
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
 	}
 	if in.Hosts != nil {
 		in, out := &in.Hosts, &out.Hosts

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -1106,10 +1106,28 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 			**out = **in
 		}
 	}
+	if in.DataRoot != nil {
+		in, out := &in.DataRoot, &out.DataRoot
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
 	if in.DefaultUlimit != nil {
 		in, out := &in.DefaultUlimit, &out.DefaultUlimit
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.ExecRoot != nil {
+		in, out := &in.ExecRoot, &out.ExecRoot
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
 	}
 	if in.Hosts != nil {
 		in, out := &in.Hosts, &out.Hosts


### PR DESCRIPTION
This PR exposes the docker flags `--data-root` and `--exec-root` to the cluster spec. These flags are used to place the docker roots—by default `/var/lib/docker` and `/var/run/docker` for the data and exec roots respectively—in a different location, mostly useful for custom images.