### PR TITLE
Add minRequestTimeout flag in kube-APIServer

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -329,7 +329,7 @@ type KubeAPIServerConfig struct {
 	RequestheaderGroupHeaders []string `json:"requestheaderGroupHeaders,omitempty" flag:"requestheader-group-headers"`
 	// List of request header prefixes to inspect. X-Remote-Extra- is suggested.
 	RequestheaderExtraHeaderPrefixes []string `json:"requestheaderExtraHeaderPrefixes,omitempty" flag:"requestheader-extra-headers-prefix"`
-	//Root certificate bundle to use to verify client certificates on incoming requests before trusting usernames in headers specified by --requestheader-username-headers
+	// Root certificate bundle to use to verify client certificates on incoming requests before trusting usernames in headers specified by --requestheader-username-headers
 	RequestheaderClientCAFile string `json:"requestheaderClientCAFile,omitempty" flag:"requestheader-client-ca-file"`
 	// List of client certificate common names to allow to provide usernames in headers specified by --requestheader-username-headers. If empty, any client certificate validated by the authorities in --requestheader-client-ca-file is allowed.
 	RequestheaderAllowedNames []string `json:"requestheaderAllowedNames,omitempty" flag:"requestheader-allowed-names"`
@@ -340,6 +340,10 @@ type KubeAPIServerConfig struct {
 
 	// EtcdQuorumRead configures the etcd-quorum-read flag, which forces consistent reads from etcd
 	EtcdQuorumRead *bool `json:"etcdQuorumRead,omitempty" flag:"etcd-quorum-read"`
+
+	// MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out.
+	// Currently only honored by the watch request handler
+	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -340,6 +340,10 @@ type KubeAPIServerConfig struct {
 
 	// EtcdQuorumRead configures the etcd-quorum-read flag, which forces consistent reads from etcd
 	EtcdQuorumRead *bool `json:"etcdQuorumRead,omitempty" flag:"etcd-quorum-read"`
+
+	// MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out.
+	// Currently only honored by the watch request handler
+	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -2163,6 +2163,7 @@ func autoConvert_v1alpha1_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.FeatureGates = in.FeatureGates
 	out.MaxRequestsInflight = in.MaxRequestsInflight
 	out.EtcdQuorumRead = in.EtcdQuorumRead
+	out.MinRequestTimeout = in.MinRequestTimeout
 	return nil
 }
 
@@ -2234,6 +2235,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha1_KubeAPIServerConfig(in *ko
 	out.FeatureGates = in.FeatureGates
 	out.MaxRequestsInflight = in.MaxRequestsInflight
 	out.EtcdQuorumRead = in.EtcdQuorumRead
+	out.MinRequestTimeout = in.MinRequestTimeout
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2102,6 +2102,15 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 			**out = **in
 		}
 	}
+	if in.MinRequestTimeout != nil {
+		in, out := &in.MinRequestTimeout, &out.MinRequestTimeout
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int32)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -340,6 +340,10 @@ type KubeAPIServerConfig struct {
 
 	// EtcdQuorumRead configures the etcd-quorum-read flag, which forces consistent reads from etcd
 	EtcdQuorumRead *bool `json:"etcdQuorumRead,omitempty" flag:"etcd-quorum-read"`
+
+	// MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out.
+	// Currently only honored by the watch request handler
+	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2427,6 +2427,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.FeatureGates = in.FeatureGates
 	out.MaxRequestsInflight = in.MaxRequestsInflight
 	out.EtcdQuorumRead = in.EtcdQuorumRead
+	out.MinRequestTimeout = in.MinRequestTimeout
 	return nil
 }
 
@@ -2498,6 +2499,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.FeatureGates = in.FeatureGates
 	out.MaxRequestsInflight = in.MaxRequestsInflight
 	out.EtcdQuorumRead = in.EtcdQuorumRead
+	out.MinRequestTimeout = in.MinRequestTimeout
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2183,6 +2183,15 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 			**out = **in
 		}
 	}
+	if in.MinRequestTimeout != nil {
+		in, out := &in.MinRequestTimeout, &out.MinRequestTimeout
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int32)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2362,6 +2362,15 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 			**out = **in
 		}
 	}
+	if in.MinRequestTimeout != nil {
+		in, out := &in.MinRequestTimeout, &out.MinRequestTimeout
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int32)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -32,6 +32,7 @@ import (
 	gossipdns "k8s.io/kops/protokube/pkg/gossip/dns"
 	"k8s.io/kops/protokube/pkg/gossip/mesh"
 	"k8s.io/kops/protokube/pkg/protokube"
+
 	// Load DNS plugins
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"


### PR DESCRIPTION
This pull requests adds the minRequestTimeout in kube-apiserver.

The reason to add this flag is to mitigate the issues happening in the watch logic using the python-kubernetes library: https://github.com/kubernetes-client/python-base/issues/57

The reason of the previous issue is that the watch connections timeout and a bug in kubernetes-python code makes any watch throw exception. A temporal solution is to extend the minRequestTimeout flag in kube-apiserver, and thus I'm needing this flag in Kops until the real solution is implemented. (I tested this flag in a local kubeadm installation and works well, but I need now to deploy it in production)

I used the guidelines in the developers documentation to create the PR code. Also, waasn't sure where in the `KubeAPIServerConfig` structe should I put the new lines to keep it organized, but as it doesn't fit with etcd or auth configuration I just added it separately in the end. If needed, tell me and I move it to a more fitting place in the list.

BTW, it's my first collaboration in the project, so, if there is anything I should change, to which branch I should merge or anything, do not hesitate to tell me about it :)

Anyways, thanks for this great framework! 👍 

EDIT: One question: 
I've tested it in a local environment and it works.
However, how can I trigger an update in my cluster without having to update to k8s 1.10? Kops 1.10 is in alpha and I'd like to keep it in 1.9.1 until 1.10 is fully stable