### PR TITLE
Generate locals for terraform target

### DIFF
--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -1,3 +1,24 @@
+locals = {
+  bastion_security_group_ids        = ["${aws_security_group.bastion-bastionuserdata-example-com.id}"]
+  bastions_role_arn                 = "${aws_iam_role.bastions-bastionuserdata-example-com.arn}"
+  bastions_role_name                = "${aws_iam_role.bastions-bastionuserdata-example-com.name}"
+  cluster_name                      = "bastionuserdata.example.com"
+  master_security_group_ids         = ["${aws_security_group.masters-bastionuserdata-example-com.id}"]
+  masters_role_arn                  = "${aws_iam_role.masters-bastionuserdata-example-com.arn}"
+  masters_role_name                 = "${aws_iam_role.masters-bastionuserdata-example-com.name}"
+  node_security_group_ids           = ["${aws_security_group.nodes-bastionuserdata-example-com.id}"]
+  node_subnet_ids                   = ["${aws_subnet.us-test-1a-bastionuserdata-example-com.id}"]
+  nodes_role_arn                    = "${aws_iam_role.nodes-bastionuserdata-example-com.arn}"
+  nodes_role_name                   = "${aws_iam_role.nodes-bastionuserdata-example-com.name}"
+  region                            = "us-test-1"
+  route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-bastionuserdata-example-com.id}"
+  route_table_public_id             = "${aws_route_table.bastionuserdata-example-com.id}"
+  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-bastionuserdata-example-com.id}"
+  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-bastionuserdata-example-com.id}"
+  vpc_cidr_block                    = "${aws_vpc.bastionuserdata-example-com.cidr_block}"
+  vpc_id                            = "${aws_vpc.bastionuserdata-example-com.id}"
+}
+
 output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-bastionuserdata-example-com.id}"]
 }

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -1,3 +1,19 @@
+locals = {
+  cluster_name                = "complex.example.com"
+  master_security_group_ids   = ["${aws_security_group.masters-complex-example-com.id}"]
+  masters_role_arn            = "${aws_iam_role.masters-complex-example-com.arn}"
+  masters_role_name           = "${aws_iam_role.masters-complex-example-com.name}"
+  node_security_group_ids     = ["${aws_security_group.nodes-complex-example-com.id}", "sg-exampleid3", "sg-exampleid4"]
+  node_subnet_ids             = ["${aws_subnet.us-test-1a-complex-example-com.id}"]
+  nodes_role_arn              = "${aws_iam_role.nodes-complex-example-com.arn}"
+  nodes_role_name             = "${aws_iam_role.nodes-complex-example-com.name}"
+  region                      = "us-test-1"
+  route_table_public_id       = "${aws_route_table.complex-example-com.id}"
+  subnet_us-test-1a-public_id = "${aws_subnet.us-test-1a-complex-example-com.id}"
+  vpc_cidr_block              = "${aws_vpc.complex-example-com.cidr_block}"
+  vpc_id                      = "${aws_vpc.complex-example-com.id}"
+}
+
 output "cluster_name" {
   value = "complex.example.com"
 }

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -1,3 +1,17 @@
+locals = {
+  cluster_name                = "existing-iam.example.com"
+  master_security_group_ids   = ["${aws_security_group.masters-existing-iam-example-com.id}"]
+  node_security_group_ids     = ["${aws_security_group.nodes-existing-iam-example-com.id}"]
+  node_subnet_ids             = ["${aws_subnet.us-test-1a-existing-iam-example-com.id}"]
+  region                      = "us-test-1"
+  route_table_public_id       = "${aws_route_table.existing-iam-example-com.id}"
+  subnet_us-test-1a-public_id = "${aws_subnet.us-test-1a-existing-iam-example-com.id}"
+  subnet_us-test-1b-public_id = "${aws_subnet.us-test-1b-existing-iam-example-com.id}"
+  subnet_us-test-1c-public_id = "${aws_subnet.us-test-1c-existing-iam-example-com.id}"
+  vpc_cidr_block              = "${aws_vpc.existing-iam-example-com.cidr_block}"
+  vpc_id                      = "${aws_vpc.existing-iam-example-com.id}"
+}
+
 output "cluster_name" {
   value = "existing-iam.example.com"
 }

--- a/tests/integration/update_cluster/existing_iam_cloudformation/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/kubernetes.tf
@@ -1,3 +1,16 @@
+locals = {
+  cluster_name              = "k8s-iam.us-west-2.td.priv"
+  master_security_group_ids = "${aws_security_group.masters-k8s-iam-us-west-2-td-priv.id}"
+  masters_role_arn          = "${aws_iam_role.masters-k8s-iam-us-west-2-td-priv.arn}"
+  masters_role_name         = "${aws_iam_role.masters-k8s-iam-us-west-2-td-priv.name}"
+  node_security_group_ids   = "${aws_security_group.nodes-k8s-iam-us-west-2-td-priv.id}"
+  node_subnet_ids           = ["${aws_subnet.us-west-2a-k8s-iam-us-west-2-td-priv.id}", "${aws_subnet.us-west-2b-k8s-iam-us-west-2-td-priv.id}", "${aws_subnet.us-west-2c-k8s-iam-us-west-2-td-priv.id}"]
+  nodes_role_arn            = "${aws_iam_role.nodes-k8s-iam-us-west-2-td-priv.arn}"
+  nodes_role_name           = "${aws_iam_role.nodes-k8s-iam-us-west-2-td-priv.name}"
+  region                    = "us-west-2"
+  vpc_id                    = "${aws_vpc.k8s-iam-us-west-2-td-priv.id}"
+}
+
 output "cluster_name" {
   value = "k8s-iam.us-west-2.td.priv"
 }

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -1,3 +1,21 @@
+locals = {
+  cluster_name                = "ha.example.com"
+  master_security_group_ids   = ["${aws_security_group.masters-ha-example-com.id}"]
+  masters_role_arn            = "${aws_iam_role.masters-ha-example-com.arn}"
+  masters_role_name           = "${aws_iam_role.masters-ha-example-com.name}"
+  node_security_group_ids     = ["${aws_security_group.nodes-ha-example-com.id}"]
+  node_subnet_ids             = ["${aws_subnet.us-test-1a-ha-example-com.id}", "${aws_subnet.us-test-1b-ha-example-com.id}", "${aws_subnet.us-test-1c-ha-example-com.id}"]
+  nodes_role_arn              = "${aws_iam_role.nodes-ha-example-com.arn}"
+  nodes_role_name             = "${aws_iam_role.nodes-ha-example-com.name}"
+  region                      = "us-test-1"
+  route_table_public_id       = "${aws_route_table.ha-example-com.id}"
+  subnet_us-test-1a-public_id = "${aws_subnet.us-test-1a-ha-example-com.id}"
+  subnet_us-test-1b-public_id = "${aws_subnet.us-test-1b-ha-example-com.id}"
+  subnet_us-test-1c-public_id = "${aws_subnet.us-test-1c-ha-example-com.id}"
+  vpc_cidr_block              = "${aws_vpc.ha-example-com.cidr_block}"
+  vpc_id                      = "${aws_vpc.ha-example-com.id}"
+}
+
 output "cluster_name" {
   value = "ha.example.com"
 }

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -1,3 +1,9 @@
+locals = {
+  cluster_name = "ha-gce.example.com"
+  project      = "us-test1"
+  region       = "us-test1"
+}
+
 output "cluster_name" {
   value = "ha-gce.example.com"
 }

--- a/tests/integration/update_cluster/lifecycle_phases/cluster-kubernetes.tf
+++ b/tests/integration/update_cluster/lifecycle_phases/cluster-kubernetes.tf
@@ -1,3 +1,19 @@
+locals = {
+  bastion_security_group_ids = ["${aws_security_group.bastion-lifecyclephases-example-com.id}"]
+  bastions_role_arn          = "${aws_iam_role.bastions-lifecyclephases-example-com.arn}"
+  bastions_role_name         = "${aws_iam_role.bastions-lifecyclephases-example-com.name}"
+  cluster_name               = "lifecyclephases.example.com"
+  master_security_group_ids  = ["${aws_security_group.masters-lifecyclephases-example-com.id}"]
+  masters_role_arn           = "${aws_iam_role.masters-lifecyclephases-example-com.arn}"
+  masters_role_name          = "${aws_iam_role.masters-lifecyclephases-example-com.name}"
+  node_security_group_ids    = ["${aws_security_group.nodes-lifecyclephases-example-com.id}"]
+  node_subnet_ids            = ["${aws_subnet.us-test-1a-lifecyclephases-example-com.id}"]
+  nodes_role_arn             = "${aws_iam_role.nodes-lifecyclephases-example-com.arn}"
+  nodes_role_name            = "${aws_iam_role.nodes-lifecyclephases-example-com.name}"
+  region                     = "us-test-1"
+  vpc_id                     = "${aws_vpc.lifecyclephases-example-com.id}"
+}
+
 output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-lifecyclephases-example-com.id}"]
 }

--- a/tests/integration/update_cluster/lifecycle_phases/loadbalancer-kubernetes.tf
+++ b/tests/integration/update_cluster/lifecycle_phases/loadbalancer-kubernetes.tf
@@ -1,3 +1,19 @@
+locals = {
+  bastion_security_group_ids = ["${aws_security_group.bastion-lifecyclephases-example-com.id}"]
+  bastions_role_arn          = "${aws_iam_role.bastions-lifecyclephases-example-com.arn}"
+  bastions_role_name         = "${aws_iam_role.bastions-lifecyclephases-example-com.name}"
+  cluster_name               = "lifecyclephases.example.com"
+  master_security_group_ids  = ["${aws_security_group.masters-lifecyclephases-example-com.id}"]
+  masters_role_arn           = "${aws_iam_role.masters-lifecyclephases-example-com.arn}"
+  masters_role_name          = "${aws_iam_role.masters-lifecyclephases-example-com.name}"
+  node_security_group_ids    = ["${aws_security_group.nodes-lifecyclephases-example-com.id}"]
+  node_subnet_ids            = ["${aws_subnet.us-test-1a-lifecyclephases-example-com.id}"]
+  nodes_role_arn             = "${aws_iam_role.nodes-lifecyclephases-example-com.arn}"
+  nodes_role_name            = "${aws_iam_role.nodes-lifecyclephases-example-com.name}"
+  region                     = "us-test-1"
+  vpc_id                     = "${aws_vpc.lifecyclephases-example-com.id}"
+}
+
 output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-lifecyclephases-example-com.id}"]
 }

--- a/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
+++ b/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
@@ -1,3 +1,14 @@
+locals = {
+  cluster_name                      = "lifecyclephases.example.com"
+  region                            = "us-test-1"
+  route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-lifecyclephases-example-com.id}"
+  route_table_public_id             = "${aws_route_table.lifecyclephases-example-com.id}"
+  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-lifecyclephases-example-com.id}"
+  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-lifecyclephases-example-com.id}"
+  vpc_cidr_block                    = "${aws_vpc.lifecyclephases-example-com.cidr_block}"
+  vpc_id                            = "${aws_vpc.lifecyclephases-example-com.id}"
+}
+
 output "cluster_name" {
   value = "lifecyclephases.example.com"
 }

--- a/tests/integration/update_cluster/lifecycle_phases/security-kubernetes.tf
+++ b/tests/integration/update_cluster/lifecycle_phases/security-kubernetes.tf
@@ -1,3 +1,14 @@
+locals = {
+  bastions_role_arn  = "${aws_iam_role.bastions-lifecyclephases-example-com.arn}"
+  bastions_role_name = "${aws_iam_role.bastions-lifecyclephases-example-com.name}"
+  cluster_name       = "lifecyclephases.example.com"
+  masters_role_arn   = "${aws_iam_role.masters-lifecyclephases-example-com.arn}"
+  masters_role_name  = "${aws_iam_role.masters-lifecyclephases-example-com.name}"
+  nodes_role_arn     = "${aws_iam_role.nodes-lifecyclephases-example-com.arn}"
+  nodes_role_name    = "${aws_iam_role.nodes-lifecyclephases-example-com.name}"
+  region             = "us-test-1"
+}
+
 output "bastions_role_arn" {
   value = "${aws_iam_role.bastions-lifecyclephases-example-com.arn}"
 }

--- a/tests/integration/update_cluster/minimal-141/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-141/kubernetes.tf
@@ -1,3 +1,19 @@
+locals = {
+  cluster_name                = "minimal-141.example.com"
+  master_security_group_ids   = ["${aws_security_group.masters-minimal-141-example-com.id}"]
+  masters_role_arn            = "${aws_iam_role.masters-minimal-141-example-com.arn}"
+  masters_role_name           = "${aws_iam_role.masters-minimal-141-example-com.name}"
+  node_security_group_ids     = ["${aws_security_group.nodes-minimal-141-example-com.id}"]
+  node_subnet_ids             = ["${aws_subnet.us-test-1a-minimal-141-example-com.id}"]
+  nodes_role_arn              = "${aws_iam_role.nodes-minimal-141-example-com.arn}"
+  nodes_role_name             = "${aws_iam_role.nodes-minimal-141-example-com.name}"
+  region                      = "us-test-1"
+  route_table_public_id       = "${aws_route_table.minimal-141-example-com.id}"
+  subnet_us-test-1a-public_id = "${aws_subnet.us-test-1a-minimal-141-example-com.id}"
+  vpc_cidr_block              = "${aws_vpc.minimal-141-example-com.cidr_block}"
+  vpc_id                      = "${aws_vpc.minimal-141-example-com.id}"
+}
+
 output "cluster_name" {
   value = "minimal-141.example.com"
 }

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -1,3 +1,19 @@
+locals = {
+  cluster_name                = "minimal.example.com"
+  master_security_group_ids   = ["${aws_security_group.masters-minimal-example-com.id}"]
+  masters_role_arn            = "${aws_iam_role.masters-minimal-example-com.arn}"
+  masters_role_name           = "${aws_iam_role.masters-minimal-example-com.name}"
+  node_security_group_ids     = ["${aws_security_group.nodes-minimal-example-com.id}"]
+  node_subnet_ids             = ["${aws_subnet.us-test-1a-minimal-example-com.id}"]
+  nodes_role_arn              = "${aws_iam_role.nodes-minimal-example-com.arn}"
+  nodes_role_name             = "${aws_iam_role.nodes-minimal-example-com.name}"
+  region                      = "us-test-1"
+  route_table_public_id       = "${aws_route_table.minimal-example-com.id}"
+  subnet_us-test-1a-public_id = "${aws_subnet.us-test-1a-minimal-example-com.id}"
+  vpc_cidr_block              = "${aws_vpc.minimal-example-com.cidr_block}"
+  vpc_id                      = "${aws_vpc.minimal-example-com.id}"
+}
+
 output "cluster_name" {
   value = "minimal.example.com"
 }

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -1,3 +1,22 @@
+locals = {
+  bastion_security_group_ids   = ["${aws_security_group.bastion-private-shared-subnet-example-com.id}"]
+  bastions_role_arn            = "${aws_iam_role.bastions-private-shared-subnet-example-com.arn}"
+  bastions_role_name           = "${aws_iam_role.bastions-private-shared-subnet-example-com.name}"
+  cluster_name                 = "private-shared-subnet.example.com"
+  master_security_group_ids    = ["${aws_security_group.masters-private-shared-subnet-example-com.id}"]
+  masters_role_arn             = "${aws_iam_role.masters-private-shared-subnet-example-com.arn}"
+  masters_role_name            = "${aws_iam_role.masters-private-shared-subnet-example-com.name}"
+  node_security_group_ids      = ["${aws_security_group.nodes-private-shared-subnet-example-com.id}"]
+  node_subnet_ids              = ["subnet-12345678"]
+  nodes_role_arn               = "${aws_iam_role.nodes-private-shared-subnet-example-com.arn}"
+  nodes_role_name              = "${aws_iam_role.nodes-private-shared-subnet-example-com.name}"
+  region                       = "us-test-1"
+  subnet_ids                   = ["subnet-12345678", "subnet-abcdef"]
+  subnet_us-test-1a-private_id = "subnet-12345678"
+  subnet_us-test-1a-utility_id = "subnet-abcdef"
+  vpc_id                       = "vpc-12345678"
+}
+
 output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-private-shared-subnet-example-com.id}"]
 }

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -1,3 +1,24 @@
+locals = {
+  bastion_security_group_ids        = ["${aws_security_group.bastion-privatecalico-example-com.id}"]
+  bastions_role_arn                 = "${aws_iam_role.bastions-privatecalico-example-com.arn}"
+  bastions_role_name                = "${aws_iam_role.bastions-privatecalico-example-com.name}"
+  cluster_name                      = "privatecalico.example.com"
+  master_security_group_ids         = ["${aws_security_group.masters-privatecalico-example-com.id}"]
+  masters_role_arn                  = "${aws_iam_role.masters-privatecalico-example-com.arn}"
+  masters_role_name                 = "${aws_iam_role.masters-privatecalico-example-com.name}"
+  node_security_group_ids           = ["${aws_security_group.nodes-privatecalico-example-com.id}"]
+  node_subnet_ids                   = ["${aws_subnet.us-test-1a-privatecalico-example-com.id}"]
+  nodes_role_arn                    = "${aws_iam_role.nodes-privatecalico-example-com.arn}"
+  nodes_role_name                   = "${aws_iam_role.nodes-privatecalico-example-com.name}"
+  region                            = "us-test-1"
+  route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-privatecalico-example-com.id}"
+  route_table_public_id             = "${aws_route_table.privatecalico-example-com.id}"
+  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-privatecalico-example-com.id}"
+  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privatecalico-example-com.id}"
+  vpc_cidr_block                    = "${aws_vpc.privatecalico-example-com.cidr_block}"
+  vpc_id                            = "${aws_vpc.privatecalico-example-com.id}"
+}
+
 output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-privatecalico-example-com.id}"]
 }

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -1,3 +1,24 @@
+locals = {
+  bastion_security_group_ids        = ["${aws_security_group.bastion-privatecanal-example-com.id}"]
+  bastions_role_arn                 = "${aws_iam_role.bastions-privatecanal-example-com.arn}"
+  bastions_role_name                = "${aws_iam_role.bastions-privatecanal-example-com.name}"
+  cluster_name                      = "privatecanal.example.com"
+  master_security_group_ids         = ["${aws_security_group.masters-privatecanal-example-com.id}"]
+  masters_role_arn                  = "${aws_iam_role.masters-privatecanal-example-com.arn}"
+  masters_role_name                 = "${aws_iam_role.masters-privatecanal-example-com.name}"
+  node_security_group_ids           = ["${aws_security_group.nodes-privatecanal-example-com.id}"]
+  node_subnet_ids                   = ["${aws_subnet.us-test-1a-privatecanal-example-com.id}"]
+  nodes_role_arn                    = "${aws_iam_role.nodes-privatecanal-example-com.arn}"
+  nodes_role_name                   = "${aws_iam_role.nodes-privatecanal-example-com.name}"
+  region                            = "us-test-1"
+  route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-privatecanal-example-com.id}"
+  route_table_public_id             = "${aws_route_table.privatecanal-example-com.id}"
+  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-privatecanal-example-com.id}"
+  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privatecanal-example-com.id}"
+  vpc_cidr_block                    = "${aws_vpc.privatecanal-example-com.cidr_block}"
+  vpc_id                            = "${aws_vpc.privatecanal-example-com.id}"
+}
+
 output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-privatecanal-example-com.id}"]
 }

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -1,3 +1,24 @@
+locals = {
+  bastion_security_group_ids        = ["${aws_security_group.bastion-privatedns1-example-com.id}"]
+  bastions_role_arn                 = "${aws_iam_role.bastions-privatedns1-example-com.arn}"
+  bastions_role_name                = "${aws_iam_role.bastions-privatedns1-example-com.name}"
+  cluster_name                      = "privatedns1.example.com"
+  master_security_group_ids         = ["${aws_security_group.masters-privatedns1-example-com.id}"]
+  masters_role_arn                  = "${aws_iam_role.masters-privatedns1-example-com.arn}"
+  masters_role_name                 = "${aws_iam_role.masters-privatedns1-example-com.name}"
+  node_security_group_ids           = ["${aws_security_group.nodes-privatedns1-example-com.id}"]
+  node_subnet_ids                   = ["${aws_subnet.us-test-1a-privatedns1-example-com.id}"]
+  nodes_role_arn                    = "${aws_iam_role.nodes-privatedns1-example-com.arn}"
+  nodes_role_name                   = "${aws_iam_role.nodes-privatedns1-example-com.name}"
+  region                            = "us-test-1"
+  route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-privatedns1-example-com.id}"
+  route_table_public_id             = "${aws_route_table.privatedns1-example-com.id}"
+  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-privatedns1-example-com.id}"
+  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privatedns1-example-com.id}"
+  vpc_cidr_block                    = "${aws_vpc.privatedns1-example-com.cidr_block}"
+  vpc_id                            = "${aws_vpc.privatedns1-example-com.id}"
+}
+
 output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-privatedns1-example-com.id}"]
 }

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -1,3 +1,23 @@
+locals = {
+  bastion_security_group_ids        = ["${aws_security_group.bastion-privatedns2-example-com.id}"]
+  bastions_role_arn                 = "${aws_iam_role.bastions-privatedns2-example-com.arn}"
+  bastions_role_name                = "${aws_iam_role.bastions-privatedns2-example-com.name}"
+  cluster_name                      = "privatedns2.example.com"
+  master_security_group_ids         = ["${aws_security_group.masters-privatedns2-example-com.id}"]
+  masters_role_arn                  = "${aws_iam_role.masters-privatedns2-example-com.arn}"
+  masters_role_name                 = "${aws_iam_role.masters-privatedns2-example-com.name}"
+  node_security_group_ids           = ["${aws_security_group.nodes-privatedns2-example-com.id}"]
+  node_subnet_ids                   = ["${aws_subnet.us-test-1a-privatedns2-example-com.id}"]
+  nodes_role_arn                    = "${aws_iam_role.nodes-privatedns2-example-com.arn}"
+  nodes_role_name                   = "${aws_iam_role.nodes-privatedns2-example-com.name}"
+  region                            = "us-test-1"
+  route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-privatedns2-example-com.id}"
+  route_table_public_id             = "${aws_route_table.privatedns2-example-com.id}"
+  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-privatedns2-example-com.id}"
+  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privatedns2-example-com.id}"
+  vpc_id                            = "vpc-12345678"
+}
+
 output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-privatedns2-example-com.id}"]
 }

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -1,3 +1,24 @@
+locals = {
+  bastion_security_group_ids        = ["${aws_security_group.bastion-privateflannel-example-com.id}"]
+  bastions_role_arn                 = "${aws_iam_role.bastions-privateflannel-example-com.arn}"
+  bastions_role_name                = "${aws_iam_role.bastions-privateflannel-example-com.name}"
+  cluster_name                      = "privateflannel.example.com"
+  master_security_group_ids         = ["${aws_security_group.masters-privateflannel-example-com.id}"]
+  masters_role_arn                  = "${aws_iam_role.masters-privateflannel-example-com.arn}"
+  masters_role_name                 = "${aws_iam_role.masters-privateflannel-example-com.name}"
+  node_security_group_ids           = ["${aws_security_group.nodes-privateflannel-example-com.id}"]
+  node_subnet_ids                   = ["${aws_subnet.us-test-1a-privateflannel-example-com.id}"]
+  nodes_role_arn                    = "${aws_iam_role.nodes-privateflannel-example-com.arn}"
+  nodes_role_name                   = "${aws_iam_role.nodes-privateflannel-example-com.name}"
+  region                            = "us-test-1"
+  route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-privateflannel-example-com.id}"
+  route_table_public_id             = "${aws_route_table.privateflannel-example-com.id}"
+  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-privateflannel-example-com.id}"
+  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privateflannel-example-com.id}"
+  vpc_cidr_block                    = "${aws_vpc.privateflannel-example-com.cidr_block}"
+  vpc_id                            = "${aws_vpc.privateflannel-example-com.id}"
+}
+
 output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-privateflannel-example-com.id}"]
 }

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -1,3 +1,27 @@
+locals = {
+  bastion_security_group_ids        = ["${aws_security_group.bastion-privatekopeio-example-com.id}"]
+  bastions_role_arn                 = "${aws_iam_role.bastions-privatekopeio-example-com.arn}"
+  bastions_role_name                = "${aws_iam_role.bastions-privatekopeio-example-com.name}"
+  cluster_name                      = "privatekopeio.example.com"
+  master_security_group_ids         = ["${aws_security_group.masters-privatekopeio-example-com.id}"]
+  masters_role_arn                  = "${aws_iam_role.masters-privatekopeio-example-com.arn}"
+  masters_role_name                 = "${aws_iam_role.masters-privatekopeio-example-com.name}"
+  node_security_group_ids           = ["${aws_security_group.nodes-privatekopeio-example-com.id}"]
+  node_subnet_ids                   = ["${aws_subnet.us-test-1a-privatekopeio-example-com.id}", "${aws_subnet.us-test-1b-privatekopeio-example-com.id}"]
+  nodes_role_arn                    = "${aws_iam_role.nodes-privatekopeio-example-com.arn}"
+  nodes_role_name                   = "${aws_iam_role.nodes-privatekopeio-example-com.name}"
+  region                            = "us-test-1"
+  route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-privatekopeio-example-com.id}"
+  route_table_private-us-test-1b_id = "${aws_route_table.private-us-test-1b-privatekopeio-example-com.id}"
+  route_table_public_id             = "${aws_route_table.privatekopeio-example-com.id}"
+  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-privatekopeio-example-com.id}"
+  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privatekopeio-example-com.id}"
+  subnet_us-test-1b-private_id      = "${aws_subnet.us-test-1b-privatekopeio-example-com.id}"
+  subnet_us-test-1b-utility_id      = "${aws_subnet.utility-us-test-1b-privatekopeio-example-com.id}"
+  vpc_cidr_block                    = "${aws_vpc.privatekopeio-example-com.cidr_block}"
+  vpc_id                            = "${aws_vpc.privatekopeio-example-com.id}"
+}
+
 output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-privatekopeio-example-com.id}"]
 }

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -1,3 +1,24 @@
+locals = {
+  bastion_security_group_ids        = ["${aws_security_group.bastion-privateweave-example-com.id}"]
+  bastions_role_arn                 = "${aws_iam_role.bastions-privateweave-example-com.arn}"
+  bastions_role_name                = "${aws_iam_role.bastions-privateweave-example-com.name}"
+  cluster_name                      = "privateweave.example.com"
+  master_security_group_ids         = ["${aws_security_group.masters-privateweave-example-com.id}"]
+  masters_role_arn                  = "${aws_iam_role.masters-privateweave-example-com.arn}"
+  masters_role_name                 = "${aws_iam_role.masters-privateweave-example-com.name}"
+  node_security_group_ids           = ["${aws_security_group.nodes-privateweave-example-com.id}"]
+  node_subnet_ids                   = ["${aws_subnet.us-test-1a-privateweave-example-com.id}"]
+  nodes_role_arn                    = "${aws_iam_role.nodes-privateweave-example-com.arn}"
+  nodes_role_name                   = "${aws_iam_role.nodes-privateweave-example-com.name}"
+  region                            = "us-test-1"
+  route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-privateweave-example-com.id}"
+  route_table_public_id             = "${aws_route_table.privateweave-example-com.id}"
+  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-privateweave-example-com.id}"
+  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privateweave-example-com.id}"
+  vpc_cidr_block                    = "${aws_vpc.privateweave-example-com.cidr_block}"
+  vpc_id                            = "${aws_vpc.privateweave-example-com.id}"
+}
+
 output "bastion_security_group_ids" {
   value = ["${aws_security_group.bastion-privateweave-example-com.id}"]
 }

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -1,3 +1,18 @@
+locals = {
+  cluster_name                = "sharedsubnet.example.com"
+  master_security_group_ids   = ["${aws_security_group.masters-sharedsubnet-example-com.id}"]
+  masters_role_arn            = "${aws_iam_role.masters-sharedsubnet-example-com.arn}"
+  masters_role_name           = "${aws_iam_role.masters-sharedsubnet-example-com.name}"
+  node_security_group_ids     = ["${aws_security_group.nodes-sharedsubnet-example-com.id}"]
+  node_subnet_ids             = ["subnet-12345678"]
+  nodes_role_arn              = "${aws_iam_role.nodes-sharedsubnet-example-com.arn}"
+  nodes_role_name             = "${aws_iam_role.nodes-sharedsubnet-example-com.name}"
+  region                      = "us-test-1"
+  subnet_ids                  = ["subnet-12345678"]
+  subnet_us-test-1a-public_id = "subnet-12345678"
+  vpc_id                      = "vpc-12345678"
+}
+
 output "cluster_name" {
   value = "sharedsubnet.example.com"
 }

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -1,3 +1,18 @@
+locals = {
+  cluster_name                = "sharedvpc.example.com"
+  master_security_group_ids   = ["${aws_security_group.masters-sharedvpc-example-com.id}"]
+  masters_role_arn            = "${aws_iam_role.masters-sharedvpc-example-com.arn}"
+  masters_role_name           = "${aws_iam_role.masters-sharedvpc-example-com.name}"
+  node_security_group_ids     = ["${aws_security_group.nodes-sharedvpc-example-com.id}"]
+  node_subnet_ids             = ["${aws_subnet.us-test-1a-sharedvpc-example-com.id}"]
+  nodes_role_arn              = "${aws_iam_role.nodes-sharedvpc-example-com.arn}"
+  nodes_role_name             = "${aws_iam_role.nodes-sharedvpc-example-com.name}"
+  region                      = "us-test-1"
+  route_table_public_id       = "${aws_route_table.sharedvpc-example-com.id}"
+  subnet_us-test-1a-public_id = "${aws_subnet.us-test-1a-sharedvpc-example-com.id}"
+  vpc_id                      = "vpc-12345678"
+}
+
 output "cluster_name" {
   value = "sharedvpc.example.com"
 }


### PR DESCRIPTION
In addition to terraform output{} definitions that are used my the module system, kops will now also generate locals{}, which can the be referenced by terraform files residing in the same module as the kops generated kubernetes.tf

This allows for more flexibility when integrating the kops into existing terraform concepts.