### PR TITLE
Fail cluster validation for rolling-update if a failure occurs

### DIFF
--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -242,8 +242,13 @@ func (r *RollingUpdateInstanceGroup) ValidateClusterWithDuration(rollingUpdateDa
 }
 
 func (r *RollingUpdateInstanceGroup) tryValidateCluster(rollingUpdateData *RollingUpdateCluster, cluster *api.Cluster, instanceGroupList *api.InstanceGroupList, duration time.Duration, tickDuration time.Duration) bool {
-	if _, err := validation.ValidateCluster(cluster, instanceGroupList, rollingUpdateData.K8sClient); err != nil {
+	result, err := validation.ValidateCluster(cluster, instanceGroupList, rollingUpdateData.K8sClient)
+
+	if err != nil {
 		glog.Infof("Cluster did not validate, will try again in %q until duration %q expires: %v.", tickDuration, duration, err)
+		return false
+	} else if len(result.Failures) > 0 {
+		glog.Infof("Cluster did not pass validation, will try again in %q until duration %q expires: %v.", tickDuration, duration, result.Failures[0].Message)
 		return false
 	} else {
 		glog.Infof("Cluster validated.")


### PR DESCRIPTION
This PR fixes #5410.

Validation errors didn't actually result in a failed validation for rolling updates; this has been fixed now.

I've labeled this WIP though, because even when it has finished trying to validate and timed out, the rolling update will still continue to the next master. There is a TODO in there with the question to bail on error. So I would like to ask whether it's a good idea to add that or not, and if I should add that for all steps (bastion, master, node)?

https://github.com/kubernetes/kops/blob/35b7d5791d7e115bb06ab92869725c69e188535c/pkg/instancegroups/rollingupdate.go#L142