### PR TITLE
Stop rolling update if bastions or masters failed to update

### DIFF
--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -114,7 +114,7 @@ func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*cloudinstances.C
 	// Do not continue update if bastion(s) failed
 	for _, err := range results {
 		if err != nil {
-			return err
+			return fmt.Errorf("bastion not healthy after update, stopping rolling-update: %q", err)
 		}
 	}
 
@@ -169,7 +169,7 @@ func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*cloudinstances.C
 	// Do not continue update if master(s) failed, cluster is potentially in an unhealthy state
 	for _, err := range results {
 		if err != nil {
-			return err
+			return fmt.Errorf("master not healthy after update, stopping rolling-update: %q", err)
 		}
 	}
 


### PR DESCRIPTION
This is part 2 to fix #5410. For context, previous PR: #5445.

This will stop with the rolling update if the bastions or masters fail to update, as it wouldn't be able to actually update properly. In addition, do not continue updating masters if one of them fails, to prevent an outage by failing all masters.