### PR TITLE
Correct the `maxSize` in the cluster template example

### DIFF
--- a/docs/cluster_template.md
+++ b/docs/cluster_template.md
@@ -20,7 +20,7 @@ spec:
   kubernetesVersion: {{.kubernetesVersion}
   machineType: m4.large
   maxPrice: "0.5"
-  maxSize: 2
+  maxSize: 20
   minSize: 15
   role: Node
   rootVolumeSize: 100


### PR DESCRIPTION
It doesn't make logical sense for the `maxSize` to be less than the `minSize`