### PR TITLE
Add configurable conntrack settings

### DIFF
--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -158,6 +158,11 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 		resourceLimits["memory"] = memoryLimit
 	}
 
+	if c.ConntrackMaxPerCore == nil {
+		defaultConntrackMaxPerCore := int32(131072)
+		c.ConntrackMaxPerCore = &defaultConntrackMaxPerCore
+	}
+
 	flags, err := flagbuilder.BuildFlagsList(c)
 	if err != nil {
 		return nil, fmt.Errorf("error building kubeproxy flags: %v", err)
@@ -165,7 +170,6 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 	image := c.Image
 
 	flags = append(flags, []string{
-		"--conntrack-max-per-core=131072",
 		"--kubeconfig=/var/lib/kube-proxy/kubeconfig",
 		"--oom-score-adj=-998",
 		`--resource-container=""`}...)

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -200,6 +200,10 @@ type KubeProxyConfig struct {
 	ProxyMode string `json:"proxyMode,omitempty" flag:"proxy-mode"`
 	// FeatureGates is a series of key pairs used to switch on features for the proxy
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
+	// Maximum number of NAT connections to track per CPU core (default: 131072)
+	ConntrackMaxPerCore *int32 `json:"conntrackMaxPerCore,omitempty" flag:"conntrack-max-per-core"`
+	// Minimum number of conntrack entries to allocate, regardless of conntrack-max-per-core
+	ConntrackMin *int32 `json:"conntrackMin,omitempty" flag:"conntrack-min"`
 }
 
 // KubeAPIServerConfig defines the configuration for the kube api

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -200,6 +200,10 @@ type KubeProxyConfig struct {
 	ProxyMode string `json:"proxyMode,omitempty" flag:"proxy-mode"`
 	// FeatureGates is a series of key pairs used to switch on features for the proxy
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
+	// Maximum number of NAT connections to track per CPU core (default: 131072)
+	ConntrackMaxPerCore *int32 `json:"conntrackMaxPerCore,omitempty" flag:"conntrack-max-per-core"`
+	// Minimum number of conntrack entries to allocate, regardless of conntrack-max-per-core
+	ConntrackMin *int32 `json:"conntrackMin,omitempty" flag:"conntrack-min"`
 }
 
 // KubeAPIServerConfig defines the configuration for the kube api

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -438,11 +438,11 @@ func Convert_kops_CNINetworkingSpec_To_v1alpha1_CNINetworkingSpec(in *kops.CNINe
 func autoConvert_v1alpha1_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *CalicoNetworkingSpec, out *kops.CalicoNetworkingSpec, s conversion.Scope) error {
 	out.CrossSubnet = in.CrossSubnet
 	out.LogSeverityScreen = in.LogSeverityScreen
+	out.MTU = in.MTU
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
-	out.MTU = in.MTU
 	return nil
 }
 
@@ -454,11 +454,11 @@ func Convert_v1alpha1_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *Cali
 func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha1_CalicoNetworkingSpec(in *kops.CalicoNetworkingSpec, out *CalicoNetworkingSpec, s conversion.Scope) error {
 	out.CrossSubnet = in.CrossSubnet
 	out.LogSeverityScreen = in.LogSeverityScreen
+	out.MTU = in.MTU
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
-	out.MTU = in.MTU
 	return nil
 }
 
@@ -2375,6 +2375,8 @@ func autoConvert_v1alpha1_KubeProxyConfig_To_kops_KubeProxyConfig(in *KubeProxyC
 	out.Enabled = in.Enabled
 	out.ProxyMode = in.ProxyMode
 	out.FeatureGates = in.FeatureGates
+	out.ConntrackMaxPerCore = in.ConntrackMaxPerCore
+	out.ConntrackMin = in.ConntrackMin
 	return nil
 }
 
@@ -2397,6 +2399,8 @@ func autoConvert_kops_KubeProxyConfig_To_v1alpha1_KubeProxyConfig(in *kops.KubeP
 	out.Enabled = in.Enabled
 	out.ProxyMode = in.ProxyMode
 	out.FeatureGates = in.FeatureGates
+	out.ConntrackMaxPerCore = in.ConntrackMaxPerCore
+	out.ConntrackMin = in.ConntrackMin
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2352,6 +2352,24 @@ func (in *KubeProxyConfig) DeepCopyInto(out *KubeProxyConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.ConntrackMaxPerCore != nil {
+		in, out := &in.ConntrackMaxPerCore, &out.ConntrackMaxPerCore
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int32)
+			**out = **in
+		}
+	}
+	if in.ConntrackMin != nil {
+		in, out := &in.ConntrackMin, &out.ConntrackMin
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int32)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -200,6 +200,10 @@ type KubeProxyConfig struct {
 	ProxyMode string `json:"proxyMode,omitempty" flag:"proxy-mode"`
 	// FeatureGates is a series of key pairs used to switch on features for the proxy
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
+	// Maximum number of NAT connections to track per CPU core (default: 131072)
+	ConntrackMaxPerCore *int32 `json:"conntrackMaxPerCore,omitempty" flag:"conntrack-max-per-core"`
+	// Minimum number of conntrack entries to allocate, regardless of conntrack-max-per-core
+	ConntrackMin *int32 `json:"conntrackMin,omitempty" flag:"conntrack-min"`
 }
 
 // KubeAPIServerConfig defines the configuration for the kube api

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -474,11 +474,11 @@ func Convert_kops_CNINetworkingSpec_To_v1alpha2_CNINetworkingSpec(in *kops.CNINe
 func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *CalicoNetworkingSpec, out *kops.CalicoNetworkingSpec, s conversion.Scope) error {
 	out.CrossSubnet = in.CrossSubnet
 	out.LogSeverityScreen = in.LogSeverityScreen
+	out.MTU = in.MTU
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
-	out.MTU = in.MTU
 	return nil
 }
 
@@ -490,11 +490,11 @@ func Convert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *Cali
 func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *kops.CalicoNetworkingSpec, out *CalicoNetworkingSpec, s conversion.Scope) error {
 	out.CrossSubnet = in.CrossSubnet
 	out.LogSeverityScreen = in.LogSeverityScreen
+	out.MTU = in.MTU
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
-	out.MTU = in.MTU
 	return nil
 }
 
@@ -2639,6 +2639,8 @@ func autoConvert_v1alpha2_KubeProxyConfig_To_kops_KubeProxyConfig(in *KubeProxyC
 	out.Enabled = in.Enabled
 	out.ProxyMode = in.ProxyMode
 	out.FeatureGates = in.FeatureGates
+	out.ConntrackMaxPerCore = in.ConntrackMaxPerCore
+	out.ConntrackMin = in.ConntrackMin
 	return nil
 }
 
@@ -2661,6 +2663,8 @@ func autoConvert_kops_KubeProxyConfig_To_v1alpha2_KubeProxyConfig(in *kops.KubeP
 	out.Enabled = in.Enabled
 	out.ProxyMode = in.ProxyMode
 	out.FeatureGates = in.FeatureGates
+	out.ConntrackMaxPerCore = in.ConntrackMaxPerCore
+	out.ConntrackMin = in.ConntrackMin
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2433,6 +2433,24 @@ func (in *KubeProxyConfig) DeepCopyInto(out *KubeProxyConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.ConntrackMaxPerCore != nil {
+		in, out := &in.ConntrackMaxPerCore, &out.ConntrackMaxPerCore
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int32)
+			**out = **in
+		}
+	}
+	if in.ConntrackMin != nil {
+		in, out := &in.ConntrackMin, &out.ConntrackMin
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int32)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2621,6 +2621,24 @@ func (in *KubeProxyConfig) DeepCopyInto(out *KubeProxyConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.ConntrackMaxPerCore != nil {
+		in, out := &in.ConntrackMaxPerCore, &out.ConntrackMaxPerCore
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int32)
+			**out = **in
+		}
+	}
+	if in.ConntrackMin != nil {
+		in, out := &in.ConntrackMin, &out.ConntrackMin
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int32)
+			**out = **in
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
This PR allows adjusting kube-proxy's `conntrack-max-per-core` and `conntrack-min` in clusterspec for kube-proxy. 

Specifically, I need this for testing fixes for this dns issue (https://github.com/kubernetes/kops/issues/5283 and https://github.com/kubernetes/kubernetes/issues/45976#issuecomment-405295649)