### PR TITLE
Introduce a global backoff to rate limit failed image downloads

### DIFF
--- a/hack/.packages
+++ b/hack/.packages
@@ -56,6 +56,7 @@ k8s.io/kops/pkg/apiserver/cmd/server
 k8s.io/kops/pkg/apiserver/registry/cluster
 k8s.io/kops/pkg/apiserver/registry/instancegroup
 k8s.io/kops/pkg/assets
+k8s.io/kops/pkg/backoff
 k8s.io/kops/pkg/bundle
 k8s.io/kops/pkg/client/clientset_generated/clientset
 k8s.io/kops/pkg/client/clientset_generated/clientset/fake

--- a/pkg/backoff/BUILD.bazel
+++ b/pkg/backoff/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["global.go"],
+    importpath = "k8s.io/kops/pkg/backoff",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/golang/glog:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["backoff_test.go"],
+    embed = [":go_default_library"],
+)

--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backoff
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBackoff(t *testing.T) {
+	expected := []time.Duration{
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		16 * time.Second,
+		32 * time.Second,
+		64 * time.Second,
+		128 * time.Second,
+		256 * time.Second,
+		5 * time.Minute,
+		5 * time.Minute,
+		5 * time.Minute,
+		5 * time.Minute,
+	}
+
+	for i := range expected {
+		actual := computeBackoff()
+		if actual != expected[i] {
+			t.Fatalf("unexpected backoff @%d: %v", i, actual)
+		}
+	}
+}

--- a/pkg/backoff/global.go
+++ b/pkg/backoff/global.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backoff
+
+import (
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+// globalBackoffMutex guards globalBackoff
+var globalBackoffMutex sync.Mutex
+
+// globalBackoff is the current backoff value
+var globalBackoff = 1 * time.Second
+
+// maxGlobalBackoff value is the maximum wait time
+const maxGlobalBackoff = 5 * time.Minute
+
+// DoGlobalBackoff performs a sleep with a pretty slow backoff.
+// The primary use is to rate-limit repeated downloads, to prevent runaway bandwidth bills
+func DoGlobalBackoff(err error) {
+	pause := computeBackoff()
+
+	glog.Warningf("inserting rate-limiting pause of %v after error: %v", pause, err)
+	time.Sleep(pause)
+}
+
+// computeBackoff computes the next backoff value, by doubling the backoff value, capping it at maxGlobalBackoff
+func computeBackoff() time.Duration {
+	globalBackoffMutex.Lock()
+	defer globalBackoffMutex.Unlock()
+
+	v := globalBackoff
+	v = v + v
+	if v > maxGlobalBackoff {
+		v = maxGlobalBackoff
+	}
+	globalBackoff = v
+
+	return v
+}

--- a/upup/pkg/fi/nodeup/nodetasks/BUILD.bazel
+++ b/upup/pkg/fi/nodeup/nodetasks/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     importpath = "k8s.io/kops/upup/pkg/fi/nodeup/nodetasks",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/backoff:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/nodeup/cloudinit:go_default_library",
         "//upup/pkg/fi/nodeup/local:go_default_library",

--- a/upup/pkg/fi/nodeup/nodetasks/load_image.go
+++ b/upup/pkg/fi/nodeup/nodetasks/load_image.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	"k8s.io/kops/pkg/backoff"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/cloudinit"
 	"k8s.io/kops/upup/pkg/fi/nodeup/local"
@@ -82,6 +83,8 @@ func (_ *LoadImageTask) RenderLocal(t *local.LocalTarget, a, e, changes *LoadIma
 	localFile := path.Join(t.CacheDir, hash.String()+"_"+utils.SanitizeString(url))
 	_, err = fi.DownloadURL(url, localFile, hash)
 	if err != nil {
+		// Hack to try to avoid failed downloads causing massive bandwidth bills
+		backoff.DoGlobalBackoff(fmt.Errorf("failed to download image %s: %v", url, err))
 		return err
 	}
 


### PR DESCRIPTION
This should help with runaway downloads of protokube.tar.gz