### PR TITLE
Add autoscaling group ids to terraform module output

### DIFF
--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -1,11 +1,14 @@
 locals = {
+  bastion_autoscaling_group_ids     = ["${aws_autoscaling_group.bastion-bastionuserdata-example-com.id}"]
   bastion_security_group_ids        = ["${aws_security_group.bastion-bastionuserdata-example-com.id}"]
   bastions_role_arn                 = "${aws_iam_role.bastions-bastionuserdata-example-com.arn}"
   bastions_role_name                = "${aws_iam_role.bastions-bastionuserdata-example-com.name}"
   cluster_name                      = "bastionuserdata.example.com"
+  master_autoscaling_group_ids      = ["${aws_autoscaling_group.master-us-test-1a-masters-bastionuserdata-example-com.id}"]
   master_security_group_ids         = ["${aws_security_group.masters-bastionuserdata-example-com.id}"]
   masters_role_arn                  = "${aws_iam_role.masters-bastionuserdata-example-com.arn}"
   masters_role_name                 = "${aws_iam_role.masters-bastionuserdata-example-com.name}"
+  node_autoscaling_group_ids        = ["${aws_autoscaling_group.nodes-bastionuserdata-example-com.id}"]
   node_security_group_ids           = ["${aws_security_group.nodes-bastionuserdata-example-com.id}"]
   node_subnet_ids                   = ["${aws_subnet.us-test-1a-bastionuserdata-example-com.id}"]
   nodes_role_arn                    = "${aws_iam_role.nodes-bastionuserdata-example-com.arn}"
@@ -17,6 +20,10 @@ locals = {
   subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-bastionuserdata-example-com.id}"
   vpc_cidr_block                    = "${aws_vpc.bastionuserdata-example-com.cidr_block}"
   vpc_id                            = "${aws_vpc.bastionuserdata-example-com.id}"
+}
+
+output "bastion_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.bastion-bastionuserdata-example-com.id}"]
 }
 
 output "bastion_security_group_ids" {
@@ -35,6 +42,10 @@ output "cluster_name" {
   value = "bastionuserdata.example.com"
 }
 
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-bastionuserdata-example-com.id}"]
+}
+
 output "master_security_group_ids" {
   value = ["${aws_security_group.masters-bastionuserdata-example-com.id}"]
 }
@@ -45,6 +56,10 @@ output "masters_role_arn" {
 
 output "masters_role_name" {
   value = "${aws_iam_role.masters-bastionuserdata-example-com.name}"
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-bastionuserdata-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -1,21 +1,27 @@
 locals = {
-  cluster_name                = "complex.example.com"
-  master_security_group_ids   = ["${aws_security_group.masters-complex-example-com.id}"]
-  masters_role_arn            = "${aws_iam_role.masters-complex-example-com.arn}"
-  masters_role_name           = "${aws_iam_role.masters-complex-example-com.name}"
-  node_security_group_ids     = ["${aws_security_group.nodes-complex-example-com.id}", "sg-exampleid3", "sg-exampleid4"]
-  node_subnet_ids             = ["${aws_subnet.us-test-1a-complex-example-com.id}"]
-  nodes_role_arn              = "${aws_iam_role.nodes-complex-example-com.arn}"
-  nodes_role_name             = "${aws_iam_role.nodes-complex-example-com.name}"
-  region                      = "us-test-1"
-  route_table_public_id       = "${aws_route_table.complex-example-com.id}"
-  subnet_us-test-1a-public_id = "${aws_subnet.us-test-1a-complex-example-com.id}"
-  vpc_cidr_block              = "${aws_vpc.complex-example-com.cidr_block}"
-  vpc_id                      = "${aws_vpc.complex-example-com.id}"
+  cluster_name                 = "complex.example.com"
+  master_autoscaling_group_ids = ["${aws_autoscaling_group.master-us-test-1a-masters-complex-example-com.id}"]
+  master_security_group_ids    = ["${aws_security_group.masters-complex-example-com.id}"]
+  masters_role_arn             = "${aws_iam_role.masters-complex-example-com.arn}"
+  masters_role_name            = "${aws_iam_role.masters-complex-example-com.name}"
+  node_autoscaling_group_ids   = ["${aws_autoscaling_group.nodes-complex-example-com.id}"]
+  node_security_group_ids      = ["${aws_security_group.nodes-complex-example-com.id}", "sg-exampleid3", "sg-exampleid4"]
+  node_subnet_ids              = ["${aws_subnet.us-test-1a-complex-example-com.id}"]
+  nodes_role_arn               = "${aws_iam_role.nodes-complex-example-com.arn}"
+  nodes_role_name              = "${aws_iam_role.nodes-complex-example-com.name}"
+  region                       = "us-test-1"
+  route_table_public_id        = "${aws_route_table.complex-example-com.id}"
+  subnet_us-test-1a-public_id  = "${aws_subnet.us-test-1a-complex-example-com.id}"
+  vpc_cidr_block               = "${aws_vpc.complex-example-com.cidr_block}"
+  vpc_id                       = "${aws_vpc.complex-example-com.id}"
 }
 
 output "cluster_name" {
   value = "complex.example.com"
+}
+
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-complex-example-com.id}"]
 }
 
 output "master_security_group_ids" {
@@ -28,6 +34,10 @@ output "masters_role_arn" {
 
 output "masters_role_name" {
   value = "${aws_iam_role.masters-complex-example-com.name}"
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-complex-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -1,23 +1,33 @@
 locals = {
-  cluster_name                = "existing-iam.example.com"
-  master_security_group_ids   = ["${aws_security_group.masters-existing-iam-example-com.id}"]
-  node_security_group_ids     = ["${aws_security_group.nodes-existing-iam-example-com.id}"]
-  node_subnet_ids             = ["${aws_subnet.us-test-1a-existing-iam-example-com.id}"]
-  region                      = "us-test-1"
-  route_table_public_id       = "${aws_route_table.existing-iam-example-com.id}"
-  subnet_us-test-1a-public_id = "${aws_subnet.us-test-1a-existing-iam-example-com.id}"
-  subnet_us-test-1b-public_id = "${aws_subnet.us-test-1b-existing-iam-example-com.id}"
-  subnet_us-test-1c-public_id = "${aws_subnet.us-test-1c-existing-iam-example-com.id}"
-  vpc_cidr_block              = "${aws_vpc.existing-iam-example-com.cidr_block}"
-  vpc_id                      = "${aws_vpc.existing-iam-example-com.id}"
+  cluster_name                 = "existing-iam.example.com"
+  master_autoscaling_group_ids = ["${aws_autoscaling_group.master-us-test-1a-masters-existing-iam-example-com.id}", "${aws_autoscaling_group.master-us-test-1b-masters-existing-iam-example-com.id}", "${aws_autoscaling_group.master-us-test-1c-masters-existing-iam-example-com.id}"]
+  master_security_group_ids    = ["${aws_security_group.masters-existing-iam-example-com.id}"]
+  node_autoscaling_group_ids   = ["${aws_autoscaling_group.nodes-existing-iam-example-com.id}"]
+  node_security_group_ids      = ["${aws_security_group.nodes-existing-iam-example-com.id}"]
+  node_subnet_ids              = ["${aws_subnet.us-test-1a-existing-iam-example-com.id}"]
+  region                       = "us-test-1"
+  route_table_public_id        = "${aws_route_table.existing-iam-example-com.id}"
+  subnet_us-test-1a-public_id  = "${aws_subnet.us-test-1a-existing-iam-example-com.id}"
+  subnet_us-test-1b-public_id  = "${aws_subnet.us-test-1b-existing-iam-example-com.id}"
+  subnet_us-test-1c-public_id  = "${aws_subnet.us-test-1c-existing-iam-example-com.id}"
+  vpc_cidr_block               = "${aws_vpc.existing-iam-example-com.cidr_block}"
+  vpc_id                       = "${aws_vpc.existing-iam-example-com.id}"
 }
 
 output "cluster_name" {
   value = "existing-iam.example.com"
 }
 
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-existing-iam-example-com.id}", "${aws_autoscaling_group.master-us-test-1b-masters-existing-iam-example-com.id}", "${aws_autoscaling_group.master-us-test-1c-masters-existing-iam-example-com.id}"]
+}
+
 output "master_security_group_ids" {
   value = ["${aws_security_group.masters-existing-iam-example-com.id}"]
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-existing-iam-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -1,21 +1,27 @@
 locals = {
-  cluster_name                = "externallb.example.com"
-  master_security_group_ids   = ["${aws_security_group.masters-externallb-example-com.id}"]
-  masters_role_arn            = "${aws_iam_role.masters-externallb-example-com.arn}"
-  masters_role_name           = "${aws_iam_role.masters-externallb-example-com.name}"
-  node_security_group_ids     = ["${aws_security_group.nodes-externallb-example-com.id}"]
-  node_subnet_ids             = ["${aws_subnet.us-test-1a-externallb-example-com.id}"]
-  nodes_role_arn              = "${aws_iam_role.nodes-externallb-example-com.arn}"
-  nodes_role_name             = "${aws_iam_role.nodes-externallb-example-com.name}"
-  region                      = "us-test-1"
-  route_table_public_id       = "${aws_route_table.externallb-example-com.id}"
-  subnet_us-test-1a-public_id = "${aws_subnet.us-test-1a-externallb-example-com.id}"
-  vpc_cidr_block              = "${aws_vpc.externallb-example-com.cidr_block}"
-  vpc_id                      = "${aws_vpc.externallb-example-com.id}"
+  cluster_name                 = "externallb.example.com"
+  master_autoscaling_group_ids = ["${aws_autoscaling_group.master-us-test-1a-masters-externallb-example-com.id}"]
+  master_security_group_ids    = ["${aws_security_group.masters-externallb-example-com.id}"]
+  masters_role_arn             = "${aws_iam_role.masters-externallb-example-com.arn}"
+  masters_role_name            = "${aws_iam_role.masters-externallb-example-com.name}"
+  node_autoscaling_group_ids   = ["${aws_autoscaling_group.nodes-externallb-example-com.id}"]
+  node_security_group_ids      = ["${aws_security_group.nodes-externallb-example-com.id}"]
+  node_subnet_ids              = ["${aws_subnet.us-test-1a-externallb-example-com.id}"]
+  nodes_role_arn               = "${aws_iam_role.nodes-externallb-example-com.arn}"
+  nodes_role_name              = "${aws_iam_role.nodes-externallb-example-com.name}"
+  region                       = "us-test-1"
+  route_table_public_id        = "${aws_route_table.externallb-example-com.id}"
+  subnet_us-test-1a-public_id  = "${aws_subnet.us-test-1a-externallb-example-com.id}"
+  vpc_cidr_block               = "${aws_vpc.externallb-example-com.cidr_block}"
+  vpc_id                       = "${aws_vpc.externallb-example-com.id}"
 }
 
 output "cluster_name" {
   value = "externallb.example.com"
+}
+
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-externallb-example-com.id}"]
 }
 
 output "master_security_group_ids" {
@@ -28,6 +34,10 @@ output "masters_role_arn" {
 
 output "masters_role_name" {
   value = "${aws_iam_role.masters-externallb-example-com.name}"
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-externallb-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -1,23 +1,29 @@
 locals = {
-  cluster_name                = "ha.example.com"
-  master_security_group_ids   = ["${aws_security_group.masters-ha-example-com.id}"]
-  masters_role_arn            = "${aws_iam_role.masters-ha-example-com.arn}"
-  masters_role_name           = "${aws_iam_role.masters-ha-example-com.name}"
-  node_security_group_ids     = ["${aws_security_group.nodes-ha-example-com.id}"]
-  node_subnet_ids             = ["${aws_subnet.us-test-1a-ha-example-com.id}", "${aws_subnet.us-test-1b-ha-example-com.id}", "${aws_subnet.us-test-1c-ha-example-com.id}"]
-  nodes_role_arn              = "${aws_iam_role.nodes-ha-example-com.arn}"
-  nodes_role_name             = "${aws_iam_role.nodes-ha-example-com.name}"
-  region                      = "us-test-1"
-  route_table_public_id       = "${aws_route_table.ha-example-com.id}"
-  subnet_us-test-1a-public_id = "${aws_subnet.us-test-1a-ha-example-com.id}"
-  subnet_us-test-1b-public_id = "${aws_subnet.us-test-1b-ha-example-com.id}"
-  subnet_us-test-1c-public_id = "${aws_subnet.us-test-1c-ha-example-com.id}"
-  vpc_cidr_block              = "${aws_vpc.ha-example-com.cidr_block}"
-  vpc_id                      = "${aws_vpc.ha-example-com.id}"
+  cluster_name                 = "ha.example.com"
+  master_autoscaling_group_ids = ["${aws_autoscaling_group.master-us-test-1a-masters-ha-example-com.id}", "${aws_autoscaling_group.master-us-test-1b-masters-ha-example-com.id}", "${aws_autoscaling_group.master-us-test-1c-masters-ha-example-com.id}"]
+  master_security_group_ids    = ["${aws_security_group.masters-ha-example-com.id}"]
+  masters_role_arn             = "${aws_iam_role.masters-ha-example-com.arn}"
+  masters_role_name            = "${aws_iam_role.masters-ha-example-com.name}"
+  node_autoscaling_group_ids   = ["${aws_autoscaling_group.nodes-ha-example-com.id}"]
+  node_security_group_ids      = ["${aws_security_group.nodes-ha-example-com.id}"]
+  node_subnet_ids              = ["${aws_subnet.us-test-1a-ha-example-com.id}", "${aws_subnet.us-test-1b-ha-example-com.id}", "${aws_subnet.us-test-1c-ha-example-com.id}"]
+  nodes_role_arn               = "${aws_iam_role.nodes-ha-example-com.arn}"
+  nodes_role_name              = "${aws_iam_role.nodes-ha-example-com.name}"
+  region                       = "us-test-1"
+  route_table_public_id        = "${aws_route_table.ha-example-com.id}"
+  subnet_us-test-1a-public_id  = "${aws_subnet.us-test-1a-ha-example-com.id}"
+  subnet_us-test-1b-public_id  = "${aws_subnet.us-test-1b-ha-example-com.id}"
+  subnet_us-test-1c-public_id  = "${aws_subnet.us-test-1c-ha-example-com.id}"
+  vpc_cidr_block               = "${aws_vpc.ha-example-com.cidr_block}"
+  vpc_id                       = "${aws_vpc.ha-example-com.id}"
 }
 
 output "cluster_name" {
   value = "ha.example.com"
+}
+
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-ha-example-com.id}", "${aws_autoscaling_group.master-us-test-1b-masters-ha-example-com.id}", "${aws_autoscaling_group.master-us-test-1c-masters-ha-example-com.id}"]
 }
 
 output "master_security_group_ids" {
@@ -30,6 +36,10 @@ output "masters_role_arn" {
 
 output "masters_role_name" {
   value = "${aws_iam_role.masters-ha-example-com.name}"
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-ha-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/tests/integration/update_cluster/minimal-141/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-141/kubernetes.tf
@@ -1,21 +1,27 @@
 locals = {
-  cluster_name                = "minimal-141.example.com"
-  master_security_group_ids   = ["${aws_security_group.masters-minimal-141-example-com.id}"]
-  masters_role_arn            = "${aws_iam_role.masters-minimal-141-example-com.arn}"
-  masters_role_name           = "${aws_iam_role.masters-minimal-141-example-com.name}"
-  node_security_group_ids     = ["${aws_security_group.nodes-minimal-141-example-com.id}"]
-  node_subnet_ids             = ["${aws_subnet.us-test-1a-minimal-141-example-com.id}"]
-  nodes_role_arn              = "${aws_iam_role.nodes-minimal-141-example-com.arn}"
-  nodes_role_name             = "${aws_iam_role.nodes-minimal-141-example-com.name}"
-  region                      = "us-test-1"
-  route_table_public_id       = "${aws_route_table.minimal-141-example-com.id}"
-  subnet_us-test-1a-public_id = "${aws_subnet.us-test-1a-minimal-141-example-com.id}"
-  vpc_cidr_block              = "${aws_vpc.minimal-141-example-com.cidr_block}"
-  vpc_id                      = "${aws_vpc.minimal-141-example-com.id}"
+  cluster_name                 = "minimal-141.example.com"
+  master_autoscaling_group_ids = ["${aws_autoscaling_group.master-us-test-1a-masters-minimal-141-example-com.id}"]
+  master_security_group_ids    = ["${aws_security_group.masters-minimal-141-example-com.id}"]
+  masters_role_arn             = "${aws_iam_role.masters-minimal-141-example-com.arn}"
+  masters_role_name            = "${aws_iam_role.masters-minimal-141-example-com.name}"
+  node_autoscaling_group_ids   = ["${aws_autoscaling_group.nodes-minimal-141-example-com.id}"]
+  node_security_group_ids      = ["${aws_security_group.nodes-minimal-141-example-com.id}"]
+  node_subnet_ids              = ["${aws_subnet.us-test-1a-minimal-141-example-com.id}"]
+  nodes_role_arn               = "${aws_iam_role.nodes-minimal-141-example-com.arn}"
+  nodes_role_name              = "${aws_iam_role.nodes-minimal-141-example-com.name}"
+  region                       = "us-test-1"
+  route_table_public_id        = "${aws_route_table.minimal-141-example-com.id}"
+  subnet_us-test-1a-public_id  = "${aws_subnet.us-test-1a-minimal-141-example-com.id}"
+  vpc_cidr_block               = "${aws_vpc.minimal-141-example-com.cidr_block}"
+  vpc_id                       = "${aws_vpc.minimal-141-example-com.id}"
 }
 
 output "cluster_name" {
   value = "minimal-141.example.com"
+}
+
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-minimal-141-example-com.id}"]
 }
 
 output "master_security_group_ids" {
@@ -28,6 +34,10 @@ output "masters_role_arn" {
 
 output "masters_role_name" {
   value = "${aws_iam_role.masters-minimal-141-example-com.name}"
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-minimal-141-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -1,21 +1,27 @@
 locals = {
-  cluster_name                = "minimal.example.com"
-  master_security_group_ids   = ["${aws_security_group.masters-minimal-example-com.id}"]
-  masters_role_arn            = "${aws_iam_role.masters-minimal-example-com.arn}"
-  masters_role_name           = "${aws_iam_role.masters-minimal-example-com.name}"
-  node_security_group_ids     = ["${aws_security_group.nodes-minimal-example-com.id}"]
-  node_subnet_ids             = ["${aws_subnet.us-test-1a-minimal-example-com.id}"]
-  nodes_role_arn              = "${aws_iam_role.nodes-minimal-example-com.arn}"
-  nodes_role_name             = "${aws_iam_role.nodes-minimal-example-com.name}"
-  region                      = "us-test-1"
-  route_table_public_id       = "${aws_route_table.minimal-example-com.id}"
-  subnet_us-test-1a-public_id = "${aws_subnet.us-test-1a-minimal-example-com.id}"
-  vpc_cidr_block              = "${aws_vpc.minimal-example-com.cidr_block}"
-  vpc_id                      = "${aws_vpc.minimal-example-com.id}"
+  cluster_name                 = "minimal.example.com"
+  master_autoscaling_group_ids = ["${aws_autoscaling_group.master-us-test-1a-masters-minimal-example-com.id}"]
+  master_security_group_ids    = ["${aws_security_group.masters-minimal-example-com.id}"]
+  masters_role_arn             = "${aws_iam_role.masters-minimal-example-com.arn}"
+  masters_role_name            = "${aws_iam_role.masters-minimal-example-com.name}"
+  node_autoscaling_group_ids   = ["${aws_autoscaling_group.nodes-minimal-example-com.id}"]
+  node_security_group_ids      = ["${aws_security_group.nodes-minimal-example-com.id}"]
+  node_subnet_ids              = ["${aws_subnet.us-test-1a-minimal-example-com.id}"]
+  nodes_role_arn               = "${aws_iam_role.nodes-minimal-example-com.arn}"
+  nodes_role_name              = "${aws_iam_role.nodes-minimal-example-com.name}"
+  region                       = "us-test-1"
+  route_table_public_id        = "${aws_route_table.minimal-example-com.id}"
+  subnet_us-test-1a-public_id  = "${aws_subnet.us-test-1a-minimal-example-com.id}"
+  vpc_cidr_block               = "${aws_vpc.minimal-example-com.cidr_block}"
+  vpc_id                       = "${aws_vpc.minimal-example-com.id}"
 }
 
 output "cluster_name" {
   value = "minimal.example.com"
+}
+
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-minimal-example-com.id}"]
 }
 
 output "master_security_group_ids" {
@@ -28,6 +34,10 @@ output "masters_role_arn" {
 
 output "masters_role_name" {
   value = "${aws_iam_role.masters-minimal-example-com.name}"
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-minimal-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -1,20 +1,27 @@
 locals = {
-  bastion_security_group_ids   = ["${aws_security_group.bastion-private-shared-subnet-example-com.id}"]
-  bastions_role_arn            = "${aws_iam_role.bastions-private-shared-subnet-example-com.arn}"
-  bastions_role_name           = "${aws_iam_role.bastions-private-shared-subnet-example-com.name}"
-  cluster_name                 = "private-shared-subnet.example.com"
-  master_security_group_ids    = ["${aws_security_group.masters-private-shared-subnet-example-com.id}"]
-  masters_role_arn             = "${aws_iam_role.masters-private-shared-subnet-example-com.arn}"
-  masters_role_name            = "${aws_iam_role.masters-private-shared-subnet-example-com.name}"
-  node_security_group_ids      = ["${aws_security_group.nodes-private-shared-subnet-example-com.id}"]
-  node_subnet_ids              = ["subnet-12345678"]
-  nodes_role_arn               = "${aws_iam_role.nodes-private-shared-subnet-example-com.arn}"
-  nodes_role_name              = "${aws_iam_role.nodes-private-shared-subnet-example-com.name}"
-  region                       = "us-test-1"
-  subnet_ids                   = ["subnet-12345678", "subnet-abcdef"]
-  subnet_us-test-1a-private_id = "subnet-12345678"
-  subnet_us-test-1a-utility_id = "subnet-abcdef"
-  vpc_id                       = "vpc-12345678"
+  bastion_autoscaling_group_ids = ["${aws_autoscaling_group.bastion-private-shared-subnet-example-com.id}"]
+  bastion_security_group_ids    = ["${aws_security_group.bastion-private-shared-subnet-example-com.id}"]
+  bastions_role_arn             = "${aws_iam_role.bastions-private-shared-subnet-example-com.arn}"
+  bastions_role_name            = "${aws_iam_role.bastions-private-shared-subnet-example-com.name}"
+  cluster_name                  = "private-shared-subnet.example.com"
+  master_autoscaling_group_ids  = ["${aws_autoscaling_group.master-us-test-1a-masters-private-shared-subnet-example-com.id}"]
+  master_security_group_ids     = ["${aws_security_group.masters-private-shared-subnet-example-com.id}"]
+  masters_role_arn              = "${aws_iam_role.masters-private-shared-subnet-example-com.arn}"
+  masters_role_name             = "${aws_iam_role.masters-private-shared-subnet-example-com.name}"
+  node_autoscaling_group_ids    = ["${aws_autoscaling_group.nodes-private-shared-subnet-example-com.id}"]
+  node_security_group_ids       = ["${aws_security_group.nodes-private-shared-subnet-example-com.id}"]
+  node_subnet_ids               = ["subnet-12345678"]
+  nodes_role_arn                = "${aws_iam_role.nodes-private-shared-subnet-example-com.arn}"
+  nodes_role_name               = "${aws_iam_role.nodes-private-shared-subnet-example-com.name}"
+  region                        = "us-test-1"
+  subnet_ids                    = ["subnet-12345678", "subnet-abcdef"]
+  subnet_us-test-1a-private_id  = "subnet-12345678"
+  subnet_us-test-1a-utility_id  = "subnet-abcdef"
+  vpc_id                        = "vpc-12345678"
+}
+
+output "bastion_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.bastion-private-shared-subnet-example-com.id}"]
 }
 
 output "bastion_security_group_ids" {
@@ -33,6 +40,10 @@ output "cluster_name" {
   value = "private-shared-subnet.example.com"
 }
 
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-private-shared-subnet-example-com.id}"]
+}
+
 output "master_security_group_ids" {
   value = ["${aws_security_group.masters-private-shared-subnet-example-com.id}"]
 }
@@ -43,6 +54,10 @@ output "masters_role_arn" {
 
 output "masters_role_name" {
   value = "${aws_iam_role.masters-private-shared-subnet-example-com.name}"
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-private-shared-subnet-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -1,11 +1,14 @@
 locals = {
+  bastion_autoscaling_group_ids     = ["${aws_autoscaling_group.bastion-privatecalico-example-com.id}"]
   bastion_security_group_ids        = ["${aws_security_group.bastion-privatecalico-example-com.id}"]
   bastions_role_arn                 = "${aws_iam_role.bastions-privatecalico-example-com.arn}"
   bastions_role_name                = "${aws_iam_role.bastions-privatecalico-example-com.name}"
   cluster_name                      = "privatecalico.example.com"
+  master_autoscaling_group_ids      = ["${aws_autoscaling_group.master-us-test-1a-masters-privatecalico-example-com.id}"]
   master_security_group_ids         = ["${aws_security_group.masters-privatecalico-example-com.id}"]
   masters_role_arn                  = "${aws_iam_role.masters-privatecalico-example-com.arn}"
   masters_role_name                 = "${aws_iam_role.masters-privatecalico-example-com.name}"
+  node_autoscaling_group_ids        = ["${aws_autoscaling_group.nodes-privatecalico-example-com.id}"]
   node_security_group_ids           = ["${aws_security_group.nodes-privatecalico-example-com.id}"]
   node_subnet_ids                   = ["${aws_subnet.us-test-1a-privatecalico-example-com.id}"]
   nodes_role_arn                    = "${aws_iam_role.nodes-privatecalico-example-com.arn}"
@@ -17,6 +20,10 @@ locals = {
   subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privatecalico-example-com.id}"
   vpc_cidr_block                    = "${aws_vpc.privatecalico-example-com.cidr_block}"
   vpc_id                            = "${aws_vpc.privatecalico-example-com.id}"
+}
+
+output "bastion_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.bastion-privatecalico-example-com.id}"]
 }
 
 output "bastion_security_group_ids" {
@@ -35,6 +42,10 @@ output "cluster_name" {
   value = "privatecalico.example.com"
 }
 
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-privatecalico-example-com.id}"]
+}
+
 output "master_security_group_ids" {
   value = ["${aws_security_group.masters-privatecalico-example-com.id}"]
 }
@@ -45,6 +56,10 @@ output "masters_role_arn" {
 
 output "masters_role_name" {
   value = "${aws_iam_role.masters-privatecalico-example-com.name}"
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-privatecalico-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -1,11 +1,14 @@
 locals = {
+  bastion_autoscaling_group_ids     = ["${aws_autoscaling_group.bastion-privatecanal-example-com.id}"]
   bastion_security_group_ids        = ["${aws_security_group.bastion-privatecanal-example-com.id}"]
   bastions_role_arn                 = "${aws_iam_role.bastions-privatecanal-example-com.arn}"
   bastions_role_name                = "${aws_iam_role.bastions-privatecanal-example-com.name}"
   cluster_name                      = "privatecanal.example.com"
+  master_autoscaling_group_ids      = ["${aws_autoscaling_group.master-us-test-1a-masters-privatecanal-example-com.id}"]
   master_security_group_ids         = ["${aws_security_group.masters-privatecanal-example-com.id}"]
   masters_role_arn                  = "${aws_iam_role.masters-privatecanal-example-com.arn}"
   masters_role_name                 = "${aws_iam_role.masters-privatecanal-example-com.name}"
+  node_autoscaling_group_ids        = ["${aws_autoscaling_group.nodes-privatecanal-example-com.id}"]
   node_security_group_ids           = ["${aws_security_group.nodes-privatecanal-example-com.id}"]
   node_subnet_ids                   = ["${aws_subnet.us-test-1a-privatecanal-example-com.id}"]
   nodes_role_arn                    = "${aws_iam_role.nodes-privatecanal-example-com.arn}"
@@ -17,6 +20,10 @@ locals = {
   subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privatecanal-example-com.id}"
   vpc_cidr_block                    = "${aws_vpc.privatecanal-example-com.cidr_block}"
   vpc_id                            = "${aws_vpc.privatecanal-example-com.id}"
+}
+
+output "bastion_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.bastion-privatecanal-example-com.id}"]
 }
 
 output "bastion_security_group_ids" {
@@ -35,6 +42,10 @@ output "cluster_name" {
   value = "privatecanal.example.com"
 }
 
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-privatecanal-example-com.id}"]
+}
+
 output "master_security_group_ids" {
   value = ["${aws_security_group.masters-privatecanal-example-com.id}"]
 }
@@ -45,6 +56,10 @@ output "masters_role_arn" {
 
 output "masters_role_name" {
   value = "${aws_iam_role.masters-privatecanal-example-com.name}"
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-privatecanal-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -1,11 +1,14 @@
 locals = {
+  bastion_autoscaling_group_ids     = ["${aws_autoscaling_group.bastion-privatedns1-example-com.id}"]
   bastion_security_group_ids        = ["${aws_security_group.bastion-privatedns1-example-com.id}"]
   bastions_role_arn                 = "${aws_iam_role.bastions-privatedns1-example-com.arn}"
   bastions_role_name                = "${aws_iam_role.bastions-privatedns1-example-com.name}"
   cluster_name                      = "privatedns1.example.com"
+  master_autoscaling_group_ids      = ["${aws_autoscaling_group.master-us-test-1a-masters-privatedns1-example-com.id}"]
   master_security_group_ids         = ["${aws_security_group.masters-privatedns1-example-com.id}"]
   masters_role_arn                  = "${aws_iam_role.masters-privatedns1-example-com.arn}"
   masters_role_name                 = "${aws_iam_role.masters-privatedns1-example-com.name}"
+  node_autoscaling_group_ids        = ["${aws_autoscaling_group.nodes-privatedns1-example-com.id}"]
   node_security_group_ids           = ["${aws_security_group.nodes-privatedns1-example-com.id}"]
   node_subnet_ids                   = ["${aws_subnet.us-test-1a-privatedns1-example-com.id}"]
   nodes_role_arn                    = "${aws_iam_role.nodes-privatedns1-example-com.arn}"
@@ -17,6 +20,10 @@ locals = {
   subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privatedns1-example-com.id}"
   vpc_cidr_block                    = "${aws_vpc.privatedns1-example-com.cidr_block}"
   vpc_id                            = "${aws_vpc.privatedns1-example-com.id}"
+}
+
+output "bastion_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.bastion-privatedns1-example-com.id}"]
 }
 
 output "bastion_security_group_ids" {
@@ -35,6 +42,10 @@ output "cluster_name" {
   value = "privatedns1.example.com"
 }
 
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-privatedns1-example-com.id}"]
+}
+
 output "master_security_group_ids" {
   value = ["${aws_security_group.masters-privatedns1-example-com.id}"]
 }
@@ -45,6 +56,10 @@ output "masters_role_arn" {
 
 output "masters_role_name" {
   value = "${aws_iam_role.masters-privatedns1-example-com.name}"
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-privatedns1-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -1,11 +1,14 @@
 locals = {
+  bastion_autoscaling_group_ids     = ["${aws_autoscaling_group.bastion-privatedns2-example-com.id}"]
   bastion_security_group_ids        = ["${aws_security_group.bastion-privatedns2-example-com.id}"]
   bastions_role_arn                 = "${aws_iam_role.bastions-privatedns2-example-com.arn}"
   bastions_role_name                = "${aws_iam_role.bastions-privatedns2-example-com.name}"
   cluster_name                      = "privatedns2.example.com"
+  master_autoscaling_group_ids      = ["${aws_autoscaling_group.master-us-test-1a-masters-privatedns2-example-com.id}"]
   master_security_group_ids         = ["${aws_security_group.masters-privatedns2-example-com.id}"]
   masters_role_arn                  = "${aws_iam_role.masters-privatedns2-example-com.arn}"
   masters_role_name                 = "${aws_iam_role.masters-privatedns2-example-com.name}"
+  node_autoscaling_group_ids        = ["${aws_autoscaling_group.nodes-privatedns2-example-com.id}"]
   node_security_group_ids           = ["${aws_security_group.nodes-privatedns2-example-com.id}"]
   node_subnet_ids                   = ["${aws_subnet.us-test-1a-privatedns2-example-com.id}"]
   nodes_role_arn                    = "${aws_iam_role.nodes-privatedns2-example-com.arn}"
@@ -16,6 +19,10 @@ locals = {
   subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-privatedns2-example-com.id}"
   subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privatedns2-example-com.id}"
   vpc_id                            = "vpc-12345678"
+}
+
+output "bastion_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.bastion-privatedns2-example-com.id}"]
 }
 
 output "bastion_security_group_ids" {
@@ -34,6 +41,10 @@ output "cluster_name" {
   value = "privatedns2.example.com"
 }
 
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-privatedns2-example-com.id}"]
+}
+
 output "master_security_group_ids" {
   value = ["${aws_security_group.masters-privatedns2-example-com.id}"]
 }
@@ -44,6 +55,10 @@ output "masters_role_arn" {
 
 output "masters_role_name" {
   value = "${aws_iam_role.masters-privatedns2-example-com.name}"
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-privatedns2-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -1,11 +1,14 @@
 locals = {
+  bastion_autoscaling_group_ids     = ["${aws_autoscaling_group.bastion-privateflannel-example-com.id}"]
   bastion_security_group_ids        = ["${aws_security_group.bastion-privateflannel-example-com.id}"]
   bastions_role_arn                 = "${aws_iam_role.bastions-privateflannel-example-com.arn}"
   bastions_role_name                = "${aws_iam_role.bastions-privateflannel-example-com.name}"
   cluster_name                      = "privateflannel.example.com"
+  master_autoscaling_group_ids      = ["${aws_autoscaling_group.master-us-test-1a-masters-privateflannel-example-com.id}"]
   master_security_group_ids         = ["${aws_security_group.masters-privateflannel-example-com.id}"]
   masters_role_arn                  = "${aws_iam_role.masters-privateflannel-example-com.arn}"
   masters_role_name                 = "${aws_iam_role.masters-privateflannel-example-com.name}"
+  node_autoscaling_group_ids        = ["${aws_autoscaling_group.nodes-privateflannel-example-com.id}"]
   node_security_group_ids           = ["${aws_security_group.nodes-privateflannel-example-com.id}"]
   node_subnet_ids                   = ["${aws_subnet.us-test-1a-privateflannel-example-com.id}"]
   nodes_role_arn                    = "${aws_iam_role.nodes-privateflannel-example-com.arn}"
@@ -17,6 +20,10 @@ locals = {
   subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privateflannel-example-com.id}"
   vpc_cidr_block                    = "${aws_vpc.privateflannel-example-com.cidr_block}"
   vpc_id                            = "${aws_vpc.privateflannel-example-com.id}"
+}
+
+output "bastion_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.bastion-privateflannel-example-com.id}"]
 }
 
 output "bastion_security_group_ids" {
@@ -35,6 +42,10 @@ output "cluster_name" {
   value = "privateflannel.example.com"
 }
 
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-privateflannel-example-com.id}"]
+}
+
 output "master_security_group_ids" {
   value = ["${aws_security_group.masters-privateflannel-example-com.id}"]
 }
@@ -45,6 +56,10 @@ output "masters_role_arn" {
 
 output "masters_role_name" {
   value = "${aws_iam_role.masters-privateflannel-example-com.name}"
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-privateflannel-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -1,11 +1,14 @@
 locals = {
+  bastion_autoscaling_group_ids     = ["${aws_autoscaling_group.bastion-privatekopeio-example-com.id}"]
   bastion_security_group_ids        = ["${aws_security_group.bastion-privatekopeio-example-com.id}"]
   bastions_role_arn                 = "${aws_iam_role.bastions-privatekopeio-example-com.arn}"
   bastions_role_name                = "${aws_iam_role.bastions-privatekopeio-example-com.name}"
   cluster_name                      = "privatekopeio.example.com"
+  master_autoscaling_group_ids      = ["${aws_autoscaling_group.master-us-test-1a-masters-privatekopeio-example-com.id}"]
   master_security_group_ids         = ["${aws_security_group.masters-privatekopeio-example-com.id}"]
   masters_role_arn                  = "${aws_iam_role.masters-privatekopeio-example-com.arn}"
   masters_role_name                 = "${aws_iam_role.masters-privatekopeio-example-com.name}"
+  node_autoscaling_group_ids        = ["${aws_autoscaling_group.nodes-privatekopeio-example-com.id}"]
   node_security_group_ids           = ["${aws_security_group.nodes-privatekopeio-example-com.id}"]
   node_subnet_ids                   = ["${aws_subnet.us-test-1a-privatekopeio-example-com.id}", "${aws_subnet.us-test-1b-privatekopeio-example-com.id}"]
   nodes_role_arn                    = "${aws_iam_role.nodes-privatekopeio-example-com.arn}"
@@ -20,6 +23,10 @@ locals = {
   subnet_us-test-1b-utility_id      = "${aws_subnet.utility-us-test-1b-privatekopeio-example-com.id}"
   vpc_cidr_block                    = "${aws_vpc.privatekopeio-example-com.cidr_block}"
   vpc_id                            = "${aws_vpc.privatekopeio-example-com.id}"
+}
+
+output "bastion_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.bastion-privatekopeio-example-com.id}"]
 }
 
 output "bastion_security_group_ids" {
@@ -38,6 +45,10 @@ output "cluster_name" {
   value = "privatekopeio.example.com"
 }
 
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-privatekopeio-example-com.id}"]
+}
+
 output "master_security_group_ids" {
   value = ["${aws_security_group.masters-privatekopeio-example-com.id}"]
 }
@@ -48,6 +59,10 @@ output "masters_role_arn" {
 
 output "masters_role_name" {
   value = "${aws_iam_role.masters-privatekopeio-example-com.name}"
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-privatekopeio-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -1,11 +1,14 @@
 locals = {
+  bastion_autoscaling_group_ids     = ["${aws_autoscaling_group.bastion-privateweave-example-com.id}"]
   bastion_security_group_ids        = ["${aws_security_group.bastion-privateweave-example-com.id}"]
   bastions_role_arn                 = "${aws_iam_role.bastions-privateweave-example-com.arn}"
   bastions_role_name                = "${aws_iam_role.bastions-privateweave-example-com.name}"
   cluster_name                      = "privateweave.example.com"
+  master_autoscaling_group_ids      = ["${aws_autoscaling_group.master-us-test-1a-masters-privateweave-example-com.id}"]
   master_security_group_ids         = ["${aws_security_group.masters-privateweave-example-com.id}"]
   masters_role_arn                  = "${aws_iam_role.masters-privateweave-example-com.arn}"
   masters_role_name                 = "${aws_iam_role.masters-privateweave-example-com.name}"
+  node_autoscaling_group_ids        = ["${aws_autoscaling_group.nodes-privateweave-example-com.id}"]
   node_security_group_ids           = ["${aws_security_group.nodes-privateweave-example-com.id}"]
   node_subnet_ids                   = ["${aws_subnet.us-test-1a-privateweave-example-com.id}"]
   nodes_role_arn                    = "${aws_iam_role.nodes-privateweave-example-com.arn}"
@@ -17,6 +20,10 @@ locals = {
   subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privateweave-example-com.id}"
   vpc_cidr_block                    = "${aws_vpc.privateweave-example-com.cidr_block}"
   vpc_id                            = "${aws_vpc.privateweave-example-com.id}"
+}
+
+output "bastion_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.bastion-privateweave-example-com.id}"]
 }
 
 output "bastion_security_group_ids" {
@@ -35,6 +42,10 @@ output "cluster_name" {
   value = "privateweave.example.com"
 }
 
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-privateweave-example-com.id}"]
+}
+
 output "master_security_group_ids" {
   value = ["${aws_security_group.masters-privateweave-example-com.id}"]
 }
@@ -45,6 +56,10 @@ output "masters_role_arn" {
 
 output "masters_role_name" {
   value = "${aws_iam_role.masters-privateweave-example-com.name}"
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-privateweave-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -1,20 +1,26 @@
 locals = {
-  cluster_name                = "sharedsubnet.example.com"
-  master_security_group_ids   = ["${aws_security_group.masters-sharedsubnet-example-com.id}"]
-  masters_role_arn            = "${aws_iam_role.masters-sharedsubnet-example-com.arn}"
-  masters_role_name           = "${aws_iam_role.masters-sharedsubnet-example-com.name}"
-  node_security_group_ids     = ["${aws_security_group.nodes-sharedsubnet-example-com.id}"]
-  node_subnet_ids             = ["subnet-12345678"]
-  nodes_role_arn              = "${aws_iam_role.nodes-sharedsubnet-example-com.arn}"
-  nodes_role_name             = "${aws_iam_role.nodes-sharedsubnet-example-com.name}"
-  region                      = "us-test-1"
-  subnet_ids                  = ["subnet-12345678"]
-  subnet_us-test-1a-public_id = "subnet-12345678"
-  vpc_id                      = "vpc-12345678"
+  cluster_name                 = "sharedsubnet.example.com"
+  master_autoscaling_group_ids = ["${aws_autoscaling_group.master-us-test-1a-masters-sharedsubnet-example-com.id}"]
+  master_security_group_ids    = ["${aws_security_group.masters-sharedsubnet-example-com.id}"]
+  masters_role_arn             = "${aws_iam_role.masters-sharedsubnet-example-com.arn}"
+  masters_role_name            = "${aws_iam_role.masters-sharedsubnet-example-com.name}"
+  node_autoscaling_group_ids   = ["${aws_autoscaling_group.nodes-sharedsubnet-example-com.id}"]
+  node_security_group_ids      = ["${aws_security_group.nodes-sharedsubnet-example-com.id}"]
+  node_subnet_ids              = ["subnet-12345678"]
+  nodes_role_arn               = "${aws_iam_role.nodes-sharedsubnet-example-com.arn}"
+  nodes_role_name              = "${aws_iam_role.nodes-sharedsubnet-example-com.name}"
+  region                       = "us-test-1"
+  subnet_ids                   = ["subnet-12345678"]
+  subnet_us-test-1a-public_id  = "subnet-12345678"
+  vpc_id                       = "vpc-12345678"
 }
 
 output "cluster_name" {
   value = "sharedsubnet.example.com"
+}
+
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-sharedsubnet-example-com.id}"]
 }
 
 output "master_security_group_ids" {
@@ -27,6 +33,10 @@ output "masters_role_arn" {
 
 output "masters_role_name" {
   value = "${aws_iam_role.masters-sharedsubnet-example-com.name}"
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-sharedsubnet-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -1,20 +1,26 @@
 locals = {
-  cluster_name                = "sharedvpc.example.com"
-  master_security_group_ids   = ["${aws_security_group.masters-sharedvpc-example-com.id}"]
-  masters_role_arn            = "${aws_iam_role.masters-sharedvpc-example-com.arn}"
-  masters_role_name           = "${aws_iam_role.masters-sharedvpc-example-com.name}"
-  node_security_group_ids     = ["${aws_security_group.nodes-sharedvpc-example-com.id}"]
-  node_subnet_ids             = ["${aws_subnet.us-test-1a-sharedvpc-example-com.id}"]
-  nodes_role_arn              = "${aws_iam_role.nodes-sharedvpc-example-com.arn}"
-  nodes_role_name             = "${aws_iam_role.nodes-sharedvpc-example-com.name}"
-  region                      = "us-test-1"
-  route_table_public_id       = "${aws_route_table.sharedvpc-example-com.id}"
-  subnet_us-test-1a-public_id = "${aws_subnet.us-test-1a-sharedvpc-example-com.id}"
-  vpc_id                      = "vpc-12345678"
+  cluster_name                 = "sharedvpc.example.com"
+  master_autoscaling_group_ids = ["${aws_autoscaling_group.master-us-test-1a-masters-sharedvpc-example-com.id}"]
+  master_security_group_ids    = ["${aws_security_group.masters-sharedvpc-example-com.id}"]
+  masters_role_arn             = "${aws_iam_role.masters-sharedvpc-example-com.arn}"
+  masters_role_name            = "${aws_iam_role.masters-sharedvpc-example-com.name}"
+  node_autoscaling_group_ids   = ["${aws_autoscaling_group.nodes-sharedvpc-example-com.id}"]
+  node_security_group_ids      = ["${aws_security_group.nodes-sharedvpc-example-com.id}"]
+  node_subnet_ids              = ["${aws_subnet.us-test-1a-sharedvpc-example-com.id}"]
+  nodes_role_arn               = "${aws_iam_role.nodes-sharedvpc-example-com.arn}"
+  nodes_role_name              = "${aws_iam_role.nodes-sharedvpc-example-com.name}"
+  region                       = "us-test-1"
+  route_table_public_id        = "${aws_route_table.sharedvpc-example-com.id}"
+  subnet_us-test-1a-public_id  = "${aws_subnet.us-test-1a-sharedvpc-example-com.id}"
+  vpc_id                       = "vpc-12345678"
 }
 
 output "cluster_name" {
   value = "sharedvpc.example.com"
+}
+
+output "master_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.master-us-test-1a-masters-sharedvpc-example-com.id}"]
 }
 
 output "master_security_group_ids" {
@@ -27,6 +33,10 @@ output "masters_role_arn" {
 
 output "masters_role_name" {
   value = "${aws_iam_role.masters-sharedvpc-example-com.name}"
+}
+
+output "node_autoscaling_group_ids" {
+  value = ["${aws_autoscaling_group.nodes-sharedvpc-example-com.id}"]
 }
 
 output "node_security_group_ids" {

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -413,6 +413,9 @@ func (_ *AutoscalingGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, c
 					return err
 				}
 			}
+			if err := t.AddOutputVariableArray(role+"_autoscaling_group_ids", e.TerraformLink()); err != nil {
+				return err
+			}
 		}
 
 		if role == "node" {


### PR DESCRIPTION
A typical use case for this is linking the node autoscaling group to a separate AWS application load balancer that is terraform managed, eg. because has additional / specific SSL certs installed.