### PR TITLE
add portmap to installed CNI plug-ins

### DIFF
--- a/nodeup/pkg/model/network.go
+++ b/nodeup/pkg/model/network.go
@@ -44,7 +44,7 @@ func (b *NetworkBuilder) Build(c *fi.ModelBuilderContext) error {
 		// external is based on kubenet
 		assetNames = append(assetNames, "bridge", "host-local", "loopback")
 	} else if networking.CNI != nil || networking.Weave != nil || networking.Flannel != nil || networking.Calico != nil || networking.Canal != nil || networking.Kuberouter != nil || networking.Romana != nil || networking.AmazonVPC != nil || networking.Cilium != nil {
-		assetNames = append(assetNames, "bridge", "host-local", "loopback", "ptp")
+		assetNames = append(assetNames, "bridge", "host-local", "loopback", "portmap", "ptp")
 		// Do we need tuning?
 
 		// TODO: Only when using flannel ?


### PR DESCRIPTION
kops does not install `portmap` CNI by default to `/opt/cni/bin/`.

Most CNI plugins can work with `portmap`. It would simplify if kops can install the `portmap` as well. 

https://github.com/weaveworks/weave/issues/3016
https://github.com/kubernetes/kops/issues/4570