### PR TITLE
Allow ContainerProxy to be used in conjunction with mirrorRegistry

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -589,3 +589,22 @@ spec:
   assets:
     containerProxy: proxy.example.com
 ```
+
+###### Using containerProxy in conjunction with docker.mirrorRegistry
+
+The containerProxy setting can be used in conjunction with the docker.mirrorRegistry.
+If set, kops will not remap images that are supposed to be pulled from the Docker Hub
+to be pulled through the proxy but will instead configure docker to handle these
+through the mirror.
+
+This is useful in cases where the proxy cannot or should not handle pulling Docker Hub
+images as well as Kubernets private registry images.
+
+```yaml
+spec:
+  assets:
+    containerProxy: proxy.example.com
+  docker:
+    registryMirrors:
+    - https://registry.example.com
+```

--- a/pkg/assets/builder_test.go
+++ b/pkg/assets/builder_test.go
@@ -130,3 +130,45 @@ func TestValidate_RemapImage_ContainerProxy_AppliesToImagesWithTags(t *testing.T
 		t.Errorf("Error remapping image (Expecting: %s, got %s)", expected, remapped)
 	}
 }
+
+func TestValidate_RemapImage_ContainerProxy_DoesNotApplyToSimplifiedDockerHubIfRegistryMirrorIsSet(t *testing.T) {
+	builder := buildAssetBuilder(t)
+
+	proxyURL := "proxy.example.com/"
+	image := "debian"
+	expected := image
+
+	builder.AssetsLocation.ContainerProxy = &proxyURL
+	builder.UseDockerRegistryMirror = true
+
+	remapped, err := builder.RemapImage(image)
+	if err != nil {
+		t.Error("Error remapping image", err)
+	}
+
+	if remapped != expected {
+		t.Errorf("Error remapping image (Expecting: %s, got %s)", expected, remapped)
+	}
+}
+
+func TestValidate_RemapImage_ContainerProxy_AppliesToSimplifiedKubernetesURLIfRegistryMirrorIsSet(t *testing.T) {
+	builder := buildAssetBuilder(t)
+
+	proxyURL := "proxy.example.com/"
+	image := "k8s.gcr.io/kube-apiserver"
+	expected := "proxy.example.com/kube-apiserver"
+	version, _ := util.ParseKubernetesVersion("1.10")
+
+	builder.AssetsLocation.ContainerProxy = &proxyURL
+	builder.UseDockerRegistryMirror = true
+	builder.KubernetesVersion = *version
+
+	remapped, err := builder.RemapImage(image)
+	if err != nil {
+		t.Error("Error remapping image", err)
+	}
+
+	if remapped != expected {
+		t.Errorf("Error remapping image (Expecting: %s, got %s)", expected, remapped)
+	}
+}


### PR DESCRIPTION
This makes it easier to fit the containerProxy feature into an existing setup where a registry mirror already exists.
It can also enable simplify proxy setup by reducung the number of sources the proxy needs to handle.