### PR TITLE
Use portable shebang for hack scripts

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2016 The Kubernetes Authors.
 #

--- a/hack/dev-build.sh
+++ b/hack/dev-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 The Kubernetes Authors.
 #

--- a/hack/make-apimachinery.sh
+++ b/hack/make-apimachinery.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2016 The Kubernetes Authors.
 #

--- a/hack/make-gendocs.sh
+++ b/hack/make-gendocs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2016 The Kubernetes Authors.
 #

--- a/hack/new-iam-user.sh
+++ b/hack/new-iam-user.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 The Kubernetes Authors.
 #

--- a/hack/update-header.sh
+++ b/hack/update-header.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2016 The Kubernetes Authors.
 #

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2014 The Kubernetes Authors.
 #

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2016 The Kubernetes Authors.
 #

--- a/hack/verify-packages.sh
+++ b/hack/verify-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2016 The Kubernetes Authors.
 #


### PR DESCRIPTION
`#!/usr/bin/env bash` is a portable alternative for systems that do not have a `/bin/bash` (like NixOS)