### PR TITLE
Only use SSL for ELB if certificate configured

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/load_balancer.go
@@ -78,13 +78,21 @@ type LoadBalancerListener struct {
 }
 
 func (e *LoadBalancerListener) mapToAWS(loadBalancerPort int64) *elb.Listener {
-	return &elb.Listener{
+	l := &elb.Listener{
 		LoadBalancerPort: aws.Int64(loadBalancerPort),
-		Protocol:         aws.String("SSL"),
-		InstanceProtocol: aws.String("SSL"),
 		InstancePort:     aws.Int64(int64(e.InstancePort)),
-		SSLCertificateId: aws.String(e.SSLCertificateID),
 	}
+
+	if e.SSLCertificateID != "" {
+		l.Protocol = aws.String("SSL")
+		l.InstanceProtocol = aws.String("SSL")
+		l.SSLCertificateId = aws.String(e.SSLCertificateID)
+	} else {
+		l.Protocol = aws.String("TCP")
+		l.InstanceProtocol = aws.String("TCP")
+	}
+
+	return l
 }
 
 var _ fi.HasDependencies = &LoadBalancerListener{}


### PR DESCRIPTION
Support for certificates was added recently, but we only want to do
decryption at the ELB if a certificate is installed (we can't decrypt
at the ELB without a certificate)