### PR TITLE
Fix GCE instance lookup during validation

### DIFF
--- a/upup/pkg/fi/cloudup/gce/instancegroups.go
+++ b/upup/pkg/fi/cloudup/gce/instancegroups.go
@@ -100,7 +100,16 @@ func getCloudGroups(c GCECloud, cluster *kops.Cluster, instancegroups []*kops.In
 
 	project := c.Project()
 	ctx := context.Background()
-	nodesByProviderID := cloudinstances.GetNodeMap(nodes, cluster)
+
+	nodesByExternalID := make(map[string]*v1.Node)
+	nodesByProviderID := make(map[string]*v1.Node)
+
+	for i := range nodes {
+		node := &nodes[i]
+		//ExternalID is deprecated in kubernetes 1.11 https://github.com/kubernetes/kubernetes/pull/61877
+		nodesByExternalID[node.Spec.ExternalID] = node
+		nodesByProviderID[node.Spec.ProviderID] = node
+	}
 
 	// There is some code duplication with resources/gce.go here, but more in the structure than a straight copy-paste
 
@@ -171,7 +180,19 @@ func getCloudGroups(c GCECloud, cluster *kops.Cluster, instancegroups []*kops.In
 						CloudInstanceGroup: g,
 					}
 
-					node := nodesByProviderID[strconv.FormatUint(i.Id, 10)]
+					// Try first by provider ID
+					name := LastComponent(id)
+					providerID := "gce://" + project + "/" + zoneName + "/" + name
+					node := nodesByProviderID[providerID]
+
+					// fall back to lookup by external id
+					if node == nil {
+						glog.V(8).Infof("unable to find node by provider id %q, falling back to legacy external id", providerID)
+
+						externalID := strconv.FormatUint(i.Id, 10)
+						node = nodesByExternalID[externalID]
+					}
+
 					if node != nil {
 						cm.Node = node
 					} else {


### PR DESCRIPTION
ExternalID was deprecated and replaced by ProviderID, but the value of
ProviderID on GCE seems to have switched from instance ID to instance
Name.  Adopt a fallback matching strategy.