### PR TITLE
Move alpha channels to stable and update alpha

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -35,13 +35,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.10.0"
-    recommendedVersion: 1.10.3
+    recommendedVersion: 1.10.5
     requiredVersion: 1.10.0
   - range: ">=1.9.0"
-    recommendedVersion: 1.9.8
+    recommendedVersion: 1.9.9
     requiredVersion: 1.9.0
   - range: ">=1.8.0"
-    recommendedVersion: 1.8.13
+    recommendedVersion: 1.8.15
     requiredVersion: 1.8.0
   - range: ">=1.7.0"
     recommendedVersion: 1.7.16

--- a/channels/stable
+++ b/channels/stable
@@ -35,10 +35,10 @@ spec:
     recommendedVersion: 1.10.3
     requiredVersion: 1.10.0
   - range: ">=1.9.0"
-    recommendedVersion: 1.9.6
+    recommendedVersion: 1.9.8
     requiredVersion: 1.9.0
   - range: ">=1.8.0"
-    recommendedVersion: 1.8.11
+    recommendedVersion: 1.8.13
     requiredVersion: 1.8.0
   - range: ">=1.7.0"
     recommendedVersion: 1.7.16


### PR DESCRIPTION
Since these have been stable for quite awhile, it's probably time to move alpha to the latest.