### PR TITLE
Add portmap CNI plugin for k8s >= 1.9

### DIFF
--- a/nodeup/pkg/model/network.go
+++ b/nodeup/pkg/model/network.go
@@ -47,6 +47,10 @@ func (b *NetworkBuilder) Build(c *fi.ModelBuilderContext) error {
 		assetNames = append(assetNames, "bridge", "host-local", "loopback", "ptp")
 		// Do we need tuning?
 
+		if b.IsKubernetesGTE("1.9") {
+			assetNames = append(assetNames, "portmap")
+		}
+
 		// TODO: Only when using flannel ?
 		assetNames = append(assetNames, "flannel")
 	} else if networking.Kopeio != nil {


### PR DESCRIPTION
Older CNI versions don't have the portmap plugin, but we should make
it available.