### PR TITLE
Put new kops versions into channels

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -57,11 +57,11 @@ spec:
     requiredVersion: 1.4.2
   kopsVersions:
   - range: ">=1.10.0-alpha.1"
-    recommendedVersion: "1.10.0-alpha.1"
+    recommendedVersion: "1.10.0-beta.1"
     #requiredVersion: 1.10.0
     kubernetesVersion: 1.10.3
   - range: ">=1.9.0-alpha.1"
-    recommendedVersion: 1.9.1
+    recommendedVersion: 1.9.2
     #requiredVersion: 1.9.0
     kubernetesVersion: 1.9.8
   - range: ">=1.8.0-alpha.1"

--- a/channels/stable
+++ b/channels/stable
@@ -54,7 +54,7 @@ spec:
     requiredVersion: 1.4.2
   kopsVersions:
   - range: ">=1.10.0-alpha.1"
-    recommendedVersion: "1.10.0-alpha.1"
+    recommendedVersion: "1.10.0-beta.1"
     #requiredVersion: 1.10.0
     kubernetesVersion: 1.10.3
   - range: ">=1.9.0-alpha.1"


### PR DESCRIPTION
* 1.9.2 goes into the alpha channel
* 1.10 is prerelease, so 1.10.0-beta.1 goes into both channels.