### PR TITLE
Add ssh user to kops toolbox dump

### DIFF
--- a/pkg/resources/dumpmodel.go
+++ b/pkg/resources/dumpmodel.go
@@ -21,6 +21,7 @@ type Instance struct {
 	Name            string   `json:"name,omitempty"`
 	PublicAddresses []string `json:"publicAddresses,omitempty"`
 	Roles           []string `json:"roles,omitempty"`
+	SSHUser         string   `json:"sshUser,omitempty"`
 }
 
 // Subnet is the type for an subnetwork in a dump

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -81,9 +81,10 @@ const TagNameKopsRole = "kubernetes.io/kops/role"
 const TagNameClusterOwnershipPrefix = "kubernetes.io/cluster/"
 
 const (
-	WellKnownAccountKopeio = "383156758163"
-	WellKnownAccountRedhat = "309956199498"
-	WellKnownAccountCoreOS = "595879546273"
+	WellKnownAccountKopeio             = "383156758163"
+	WellKnownAccountRedhat             = "309956199498"
+	WellKnownAccountCoreOS             = "595879546273"
+	WellKnownAccountAmazonSystemLinux2 = "137112412989"
 )
 
 type AWSCloud interface {


### PR DESCRIPTION
Where we can identify the SSH user to use, we can include it in kops
toolbox dump.  This is a precursor to trying to better understand
what's in an image (warnings about NVME or network drivers, or showing
the correct SSH username)