### PR TITLE
kops set: fix example

### DIFF
--- a/cmd/kops/set.go
+++ b/cmd/kops/set.go
@@ -33,7 +33,7 @@ var (
 
 	setExample = templates.Examples(i18n.T(`
     # Set cluster to run kubernetes version 1.10.0
-    kops set cluster k8s-cluster.example.com cluster.spec.kubernetesVersion=1.10.0
+    kops set cluster k8s-cluster.example.com spec.kubernetesVersion=1.10.0
 	`))
 )
 

--- a/docs/cli/kops_set.md
+++ b/docs/cli/kops_set.md
@@ -15,7 +15,7 @@ kops set does not update the cloud resources, to apply the changes use "kops upd
 
 ```
   # Set cluster to run kubernetes version 1.10.0
-  kops set cluster k8s-cluster.example.com cluster.spec.kubernetesVersion=1.10.0
+  kops set cluster k8s-cluster.example.com spec.kubernetesVersion=1.10.0
 ```
 
 ### Options


### PR DESCRIPTION
The example included an incorrect field specifier.