### PR TITLE
add wider tolerations to the kube-router daemonset

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
@@ -93,7 +93,6 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
         operator: Exists
       volumes:
       - hostPath:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -681,7 +681,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Kuberouter != nil {
 		key := "networking.kuberouter"
-		version := "0.1.1-kops.2"
+		version := "0.1.1-kops.3"
 
 		{
 			location := key + "/k8s-1.6.yaml"


### PR DESCRIPTION
As also noted in #2857 for the calico-node daemonset, the kube-router daemonset also needs to be modified to accept nodes with custom taints to an instance group. With the kube-router plugin and custom taints added, I get these errors:

```   
KubeletNotReady              runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:docker: network plugin is not ready: cni config uninitialized
```
Adding wider tolerations seem to resolve the issue and the nodes get added.