### PR TITLE
amazon-vpc-routed-eni cloudprovider check

### DIFF
--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -570,7 +570,7 @@ func ValidateCluster(c *kops.Cluster, strict bool) *field.Error {
 	}
 
 	if c.Spec.Networking != nil && c.Spec.Networking.AmazonVPC != nil &&
-		c.Spec.Kubelet != nil && (c.Spec.Kubelet.CloudProvider != "aws") {
+		(c.Spec.CloudProvider != "aws") {
 		return field.Invalid(fieldSpec.Child("Networking"), "amazon-vpc-routed-eni", "amazon-vpc-routed-eni networking is supported only in AWS")
 	}
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kops/issues/5537

Should be safe to just check cloud provider.  This specific case happens when kubelet values are overridden. Checking at the cluster spec level should be fine instead.