### PR TITLE
Add missing error handling when reading stdin

### DIFF
--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -131,11 +131,10 @@ func RunCreate(f *util.Factory, out io.Writer, c *CreateOptions) error {
 	for _, f := range c.Filenames {
 		var contents []byte
 		if f == "-" {
-			file := os.Stdin
-			defer file.Close()
-			buf := new(bytes.Buffer)
-			buf.ReadFrom(file)
-			contents = buf.Bytes()
+			contents, err = ConsumeStdin()
+			if err != nil {
+				return err
+			}
 		} else {
 			contents, err = vfs.Context.ReadFile(f)
 			if err != nil {
@@ -245,4 +244,16 @@ func RunCreate(f *util.Factory, out io.Writer, c *CreateOptions) error {
 		}
 	}
 	return nil
+}
+
+// ConsumeStdin reads all the bytes available from stdin
+func ConsumeStdin() ([]byte, error) {
+	file := os.Stdin
+	buf := new(bytes.Buffer)
+	_, err := buf.ReadFrom(file)
+	if err != nil {
+		return nil, fmt.Errorf("error reading stdin: %v", err)
+	}
+
+	return buf.Bytes(), nil
 }

--- a/cmd/kops/replace.go
+++ b/cmd/kops/replace.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -103,11 +102,10 @@ func RunReplace(f *util.Factory, cmd *cobra.Command, out io.Writer, c *replaceOp
 	for _, f := range c.Filenames {
 		var contents []byte
 		if f == "-" {
-			file := os.Stdin
-			defer file.Close()
-			buf := new(bytes.Buffer)
-			buf.ReadFrom(file)
-			contents = buf.Bytes()
+			contents, err = ConsumeStdin()
+			if err != nil {
+				return err
+			}
 		} else {
 			contents, err = vfs.Context.ReadFile(f)
 			if err != nil {


### PR DESCRIPTION
I'm guessing that if a pipe breaks that we wouldn't handle it
correctly otherwise.