### PR TITLE
Bump Weave Net to v2.4.0

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -238,5 +238,6 @@ spec:
         - name: xtables-lock
           hostPath:
             path: /run/xtables.lock
+            type: FileOrCreate
   updateStrategy:
     type: RollingUpdate

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -486,8 +486,12 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Weave != nil {
 		key := "networking.weave"
-		// 2.3.0-kops.1 = 2.3.0, kops packaging version 1.
-		version := "2.3.0-kops.1"
+		versions := map[string]string{
+			"pre-k8s-1.6": "2.3.0-kops.1",
+			"k8s-1.6":     "2.3.0-kops.1",
+			"k8s-1.7":     "2.4.0-kops.1",
+			"k8s-1.8":     "2.4.0-kops.1",
+		}
 
 		{
 			location := key + "/pre-k8s-1.6.yaml"
@@ -495,7 +499,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
-				Version:           fi.String(version),
+				Version:           fi.String(versions[id]),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
 				KubernetesVersion: "<1.6.0",
@@ -510,7 +514,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
-				Version:           fi.String(version),
+				Version:           fi.String(versions[id]),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
 				KubernetesVersion: ">=1.6.0 <1.7.0",
@@ -525,10 +529,25 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
-				Version:           fi.String(version),
+				Version:           fi.String(versions[id]),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.7.0",
+				KubernetesVersion: ">=1.7.0 <1.8.0",
+				Id:                id,
+			})
+			manifests[key+"-"+id] = "addons/" + location
+		}
+
+		{
+			location := key + "/k8s-1.8.yaml"
+			id := "k8s-1.8"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(versions[id]),
+				Selector:          networkingSelector,
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.8.0",
 				Id:                id,
 			})
 			manifests[key+"-"+id] = "addons/" + location

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -78,9 +78,16 @@ spec:
       role.kubernetes.io/networking: "1"
     version: 2.3.0-kops.1
   - id: k8s-1.7
-    kubernetesVersion: '>=1.7.0'
+    kubernetesVersion: '>=1.7.0 <1.8.0'
     manifest: networking.weave/k8s-1.7.yaml
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.3.0-kops.1
+    version: 2.4.0-kops.1
+  - id: k8s-1.8
+    kubernetesVersion: '>=1.8.0'
+    manifest: networking.weave/k8s-1.8.yaml
+    name: networking.weave
+    selector:
+      role.kubernetes.io/networking: "1"
+    version: 2.4.0-kops.1


### PR DESCRIPTION
- New manifest for k8s 1.8.0 due to FileOrCreate mount type.
- RBAC for updating NetworkUnavailable node status.
- Dropped support for legacy NetworkPolicy (k8s pre-1.7).

```
$ diff upup/models/cloudup/resources/addons/networking.weave/k8s-1.{7,8}.yaml.template
240a241
>             type: FileOrCreate

```

Full changelog: https://github.com/weaveworks/weave/releases/tag/v2.4.0