### PR TITLE
Move CloudProviderID consts into a block

### DIFF
--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -248,13 +248,15 @@ func FindKopsVersionSpec(versions []KopsVersionSpec, version semver.Version) *Ko
 
 type CloudProviderID string
 
-const CloudProviderAWS CloudProviderID = "aws"
-const CloudProviderBareMetal CloudProviderID = "baremetal"
-const CloudProviderGCE CloudProviderID = "gce"
-const CloudProviderDO CloudProviderID = "digitalocean"
-const CloudProviderVSphere CloudProviderID = "vsphere"
-const CloudProviderOpenstack CloudProviderID = "openstack"
-const CloudProviderALI CloudProviderID = "alicloud"
+const (
+	CloudProviderALI       CloudProviderID = "alicloud"
+	CloudProviderAWS       CloudProviderID = "aws"
+	CloudProviderBareMetal CloudProviderID = "baremetal"
+	CloudProviderDO        CloudProviderID = "digitalocean"
+	CloudProviderGCE       CloudProviderID = "gce"
+	CloudProviderOpenstack CloudProviderID = "openstack"
+	CloudProviderVSphere   CloudProviderID = "vsphere"
+)
 
 // FindImage returns the image for the cloudprovider, or nil if none found
 func (c *Channel) FindImage(provider CloudProviderID, kubernetesVersion semver.Version) *ChannelImageSpec {


### PR DESCRIPTION
Trivial change to improve the readability of cloud provider id constants.

I'll be working on OpenStack support soon, so mostly wanted to test out the PR process. :)