### PR TITLE
Don't assume that we only have one subnet per AZ

### DIFF
--- a/pkg/model/network.go
+++ b/pkg/model/network.go
@@ -202,6 +202,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 
 		subnet := &awstasks.Subnet{
 			Name:             s(subnetName),
+			ShortName:        s(subnetSpec.Name),
 			Lifecycle:        b.Lifecycle,
 			VPC:              b.LinkToVPC(),
 			AvailabilityZone: s(subnetSpec.Zone),

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -16,8 +16,8 @@ locals = {
   region                            = "us-test-1"
   route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-bastionuserdata-example-com.id}"
   route_table_public_id             = "${aws_route_table.bastionuserdata-example-com.id}"
-  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-bastionuserdata-example-com.id}"
-  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-bastionuserdata-example-com.id}"
+  subnet_us-test-1a_id              = "${aws_subnet.us-test-1a-bastionuserdata-example-com.id}"
+  subnet_utility-us-test-1a_id      = "${aws_subnet.utility-us-test-1a-bastionuserdata-example-com.id}"
   vpc_cidr_block                    = "${aws_vpc.bastionuserdata-example-com.cidr_block}"
   vpc_id                            = "${aws_vpc.bastionuserdata-example-com.id}"
 }
@@ -90,11 +90,11 @@ output "route_table_public_id" {
   value = "${aws_route_table.bastionuserdata-example-com.id}"
 }
 
-output "subnet_us-test-1a-private_id" {
+output "subnet_us-test-1a_id" {
   value = "${aws_subnet.us-test-1a-bastionuserdata-example-com.id}"
 }
 
-output "subnet_us-test-1a-utility_id" {
+output "subnet_utility-us-test-1a_id" {
   value = "${aws_subnet.utility-us-test-1a-bastionuserdata-example-com.id}"
 }
 

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -11,7 +11,7 @@ locals = {
   nodes_role_name              = "${aws_iam_role.nodes-complex-example-com.name}"
   region                       = "us-test-1"
   route_table_public_id        = "${aws_route_table.complex-example-com.id}"
-  subnet_us-test-1a-public_id  = "${aws_subnet.us-test-1a-complex-example-com.id}"
+  subnet_us-test-1a_id         = "${aws_subnet.us-test-1a-complex-example-com.id}"
   vpc_cidr_block               = "${aws_vpc.complex-example-com.cidr_block}"
   vpc_id                       = "${aws_vpc.complex-example-com.id}"
 }
@@ -64,7 +64,7 @@ output "route_table_public_id" {
   value = "${aws_route_table.complex-example-com.id}"
 }
 
-output "subnet_us-test-1a-public_id" {
+output "subnet_us-test-1a_id" {
   value = "${aws_subnet.us-test-1a-complex-example-com.id}"
 }
 

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -7,9 +7,9 @@ locals = {
   node_subnet_ids              = ["${aws_subnet.us-test-1a-existing-iam-example-com.id}"]
   region                       = "us-test-1"
   route_table_public_id        = "${aws_route_table.existing-iam-example-com.id}"
-  subnet_us-test-1a-public_id  = "${aws_subnet.us-test-1a-existing-iam-example-com.id}"
-  subnet_us-test-1b-public_id  = "${aws_subnet.us-test-1b-existing-iam-example-com.id}"
-  subnet_us-test-1c-public_id  = "${aws_subnet.us-test-1c-existing-iam-example-com.id}"
+  subnet_us-test-1a_id         = "${aws_subnet.us-test-1a-existing-iam-example-com.id}"
+  subnet_us-test-1b_id         = "${aws_subnet.us-test-1b-existing-iam-example-com.id}"
+  subnet_us-test-1c_id         = "${aws_subnet.us-test-1c-existing-iam-example-com.id}"
   vpc_cidr_block               = "${aws_vpc.existing-iam-example-com.cidr_block}"
   vpc_id                       = "${aws_vpc.existing-iam-example-com.id}"
 }
@@ -46,15 +46,15 @@ output "route_table_public_id" {
   value = "${aws_route_table.existing-iam-example-com.id}"
 }
 
-output "subnet_us-test-1a-public_id" {
+output "subnet_us-test-1a_id" {
   value = "${aws_subnet.us-test-1a-existing-iam-example-com.id}"
 }
 
-output "subnet_us-test-1b-public_id" {
+output "subnet_us-test-1b_id" {
   value = "${aws_subnet.us-test-1b-existing-iam-example-com.id}"
 }
 
-output "subnet_us-test-1c-public_id" {
+output "subnet_us-test-1c_id" {
   value = "${aws_subnet.us-test-1c-existing-iam-example-com.id}"
 }
 

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -11,7 +11,7 @@ locals = {
   nodes_role_name              = "${aws_iam_role.nodes-externallb-example-com.name}"
   region                       = "us-test-1"
   route_table_public_id        = "${aws_route_table.externallb-example-com.id}"
-  subnet_us-test-1a-public_id  = "${aws_subnet.us-test-1a-externallb-example-com.id}"
+  subnet_us-test-1a_id         = "${aws_subnet.us-test-1a-externallb-example-com.id}"
   vpc_cidr_block               = "${aws_vpc.externallb-example-com.cidr_block}"
   vpc_id                       = "${aws_vpc.externallb-example-com.id}"
 }
@@ -64,7 +64,7 @@ output "route_table_public_id" {
   value = "${aws_route_table.externallb-example-com.id}"
 }
 
-output "subnet_us-test-1a-public_id" {
+output "subnet_us-test-1a_id" {
   value = "${aws_subnet.us-test-1a-externallb-example-com.id}"
 }
 

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -11,9 +11,9 @@ locals = {
   nodes_role_name              = "${aws_iam_role.nodes-ha-example-com.name}"
   region                       = "us-test-1"
   route_table_public_id        = "${aws_route_table.ha-example-com.id}"
-  subnet_us-test-1a-public_id  = "${aws_subnet.us-test-1a-ha-example-com.id}"
-  subnet_us-test-1b-public_id  = "${aws_subnet.us-test-1b-ha-example-com.id}"
-  subnet_us-test-1c-public_id  = "${aws_subnet.us-test-1c-ha-example-com.id}"
+  subnet_us-test-1a_id         = "${aws_subnet.us-test-1a-ha-example-com.id}"
+  subnet_us-test-1b_id         = "${aws_subnet.us-test-1b-ha-example-com.id}"
+  subnet_us-test-1c_id         = "${aws_subnet.us-test-1c-ha-example-com.id}"
   vpc_cidr_block               = "${aws_vpc.ha-example-com.cidr_block}"
   vpc_id                       = "${aws_vpc.ha-example-com.id}"
 }
@@ -66,15 +66,15 @@ output "route_table_public_id" {
   value = "${aws_route_table.ha-example-com.id}"
 }
 
-output "subnet_us-test-1a-public_id" {
+output "subnet_us-test-1a_id" {
   value = "${aws_subnet.us-test-1a-ha-example-com.id}"
 }
 
-output "subnet_us-test-1b-public_id" {
+output "subnet_us-test-1b_id" {
   value = "${aws_subnet.us-test-1b-ha-example-com.id}"
 }
 
-output "subnet_us-test-1c-public_id" {
+output "subnet_us-test-1c_id" {
   value = "${aws_subnet.us-test-1c-ha-example-com.id}"
 }
 

--- a/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
+++ b/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
@@ -3,8 +3,8 @@ locals = {
   region                            = "us-test-1"
   route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-lifecyclephases-example-com.id}"
   route_table_public_id             = "${aws_route_table.lifecyclephases-example-com.id}"
-  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-lifecyclephases-example-com.id}"
-  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-lifecyclephases-example-com.id}"
+  subnet_us-test-1a_id              = "${aws_subnet.us-test-1a-lifecyclephases-example-com.id}"
+  subnet_utility-us-test-1a_id      = "${aws_subnet.utility-us-test-1a-lifecyclephases-example-com.id}"
   vpc_cidr_block                    = "${aws_vpc.lifecyclephases-example-com.cidr_block}"
   vpc_id                            = "${aws_vpc.lifecyclephases-example-com.id}"
 }
@@ -25,11 +25,11 @@ output "route_table_public_id" {
   value = "${aws_route_table.lifecyclephases-example-com.id}"
 }
 
-output "subnet_us-test-1a-private_id" {
+output "subnet_us-test-1a_id" {
   value = "${aws_subnet.us-test-1a-lifecyclephases-example-com.id}"
 }
 
-output "subnet_us-test-1a-utility_id" {
+output "subnet_utility-us-test-1a_id" {
   value = "${aws_subnet.utility-us-test-1a-lifecyclephases-example-com.id}"
 }
 

--- a/tests/integration/update_cluster/minimal-141/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-141/kubernetes.tf
@@ -11,7 +11,7 @@ locals = {
   nodes_role_name              = "${aws_iam_role.nodes-minimal-141-example-com.name}"
   region                       = "us-test-1"
   route_table_public_id        = "${aws_route_table.minimal-141-example-com.id}"
-  subnet_us-test-1a-public_id  = "${aws_subnet.us-test-1a-minimal-141-example-com.id}"
+  subnet_us-test-1a_id         = "${aws_subnet.us-test-1a-minimal-141-example-com.id}"
   vpc_cidr_block               = "${aws_vpc.minimal-141-example-com.cidr_block}"
   vpc_id                       = "${aws_vpc.minimal-141-example-com.id}"
 }
@@ -64,7 +64,7 @@ output "route_table_public_id" {
   value = "${aws_route_table.minimal-141-example-com.id}"
 }
 
-output "subnet_us-test-1a-public_id" {
+output "subnet_us-test-1a_id" {
   value = "${aws_subnet.us-test-1a-minimal-141-example-com.id}"
 }
 

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -11,7 +11,7 @@ locals = {
   nodes_role_name              = "${aws_iam_role.nodes-minimal-example-com.name}"
   region                       = "us-test-1"
   route_table_public_id        = "${aws_route_table.minimal-example-com.id}"
-  subnet_us-test-1a-public_id  = "${aws_subnet.us-test-1a-minimal-example-com.id}"
+  subnet_us-test-1a_id         = "${aws_subnet.us-test-1a-minimal-example-com.id}"
   vpc_cidr_block               = "${aws_vpc.minimal-example-com.cidr_block}"
   vpc_id                       = "${aws_vpc.minimal-example-com.id}"
 }
@@ -64,7 +64,7 @@ output "route_table_public_id" {
   value = "${aws_route_table.minimal-example-com.id}"
 }
 
-output "subnet_us-test-1a-public_id" {
+output "subnet_us-test-1a_id" {
   value = "${aws_subnet.us-test-1a-minimal-example-com.id}"
 }
 

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -15,8 +15,8 @@ locals = {
   nodes_role_name               = "${aws_iam_role.nodes-private-shared-subnet-example-com.name}"
   region                        = "us-test-1"
   subnet_ids                    = ["subnet-12345678", "subnet-abcdef"]
-  subnet_us-test-1a-private_id  = "subnet-12345678"
-  subnet_us-test-1a-utility_id  = "subnet-abcdef"
+  subnet_us-test-1a_id          = "subnet-12345678"
+  subnet_utility-us-test-1a_id  = "subnet-abcdef"
   vpc_id                        = "vpc-12345678"
 }
 
@@ -84,11 +84,11 @@ output "subnet_ids" {
   value = ["subnet-12345678", "subnet-abcdef"]
 }
 
-output "subnet_us-test-1a-private_id" {
+output "subnet_us-test-1a_id" {
   value = "subnet-12345678"
 }
 
-output "subnet_us-test-1a-utility_id" {
+output "subnet_utility-us-test-1a_id" {
   value = "subnet-abcdef"
 }
 

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -16,8 +16,8 @@ locals = {
   region                            = "us-test-1"
   route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-privatecalico-example-com.id}"
   route_table_public_id             = "${aws_route_table.privatecalico-example-com.id}"
-  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-privatecalico-example-com.id}"
-  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privatecalico-example-com.id}"
+  subnet_us-test-1a_id              = "${aws_subnet.us-test-1a-privatecalico-example-com.id}"
+  subnet_utility-us-test-1a_id      = "${aws_subnet.utility-us-test-1a-privatecalico-example-com.id}"
   vpc_cidr_block                    = "${aws_vpc.privatecalico-example-com.cidr_block}"
   vpc_id                            = "${aws_vpc.privatecalico-example-com.id}"
 }
@@ -90,11 +90,11 @@ output "route_table_public_id" {
   value = "${aws_route_table.privatecalico-example-com.id}"
 }
 
-output "subnet_us-test-1a-private_id" {
+output "subnet_us-test-1a_id" {
   value = "${aws_subnet.us-test-1a-privatecalico-example-com.id}"
 }
 
-output "subnet_us-test-1a-utility_id" {
+output "subnet_utility-us-test-1a_id" {
   value = "${aws_subnet.utility-us-test-1a-privatecalico-example-com.id}"
 }
 

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -16,8 +16,8 @@ locals = {
   region                            = "us-test-1"
   route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-privatecanal-example-com.id}"
   route_table_public_id             = "${aws_route_table.privatecanal-example-com.id}"
-  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-privatecanal-example-com.id}"
-  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privatecanal-example-com.id}"
+  subnet_us-test-1a_id              = "${aws_subnet.us-test-1a-privatecanal-example-com.id}"
+  subnet_utility-us-test-1a_id      = "${aws_subnet.utility-us-test-1a-privatecanal-example-com.id}"
   vpc_cidr_block                    = "${aws_vpc.privatecanal-example-com.cidr_block}"
   vpc_id                            = "${aws_vpc.privatecanal-example-com.id}"
 }
@@ -90,11 +90,11 @@ output "route_table_public_id" {
   value = "${aws_route_table.privatecanal-example-com.id}"
 }
 
-output "subnet_us-test-1a-private_id" {
+output "subnet_us-test-1a_id" {
   value = "${aws_subnet.us-test-1a-privatecanal-example-com.id}"
 }
 
-output "subnet_us-test-1a-utility_id" {
+output "subnet_utility-us-test-1a_id" {
   value = "${aws_subnet.utility-us-test-1a-privatecanal-example-com.id}"
 }
 

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -16,8 +16,8 @@ locals = {
   region                            = "us-test-1"
   route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-privatedns1-example-com.id}"
   route_table_public_id             = "${aws_route_table.privatedns1-example-com.id}"
-  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-privatedns1-example-com.id}"
-  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privatedns1-example-com.id}"
+  subnet_us-test-1a_id              = "${aws_subnet.us-test-1a-privatedns1-example-com.id}"
+  subnet_utility-us-test-1a_id      = "${aws_subnet.utility-us-test-1a-privatedns1-example-com.id}"
   vpc_cidr_block                    = "${aws_vpc.privatedns1-example-com.cidr_block}"
   vpc_id                            = "${aws_vpc.privatedns1-example-com.id}"
 }
@@ -90,11 +90,11 @@ output "route_table_public_id" {
   value = "${aws_route_table.privatedns1-example-com.id}"
 }
 
-output "subnet_us-test-1a-private_id" {
+output "subnet_us-test-1a_id" {
   value = "${aws_subnet.us-test-1a-privatedns1-example-com.id}"
 }
 
-output "subnet_us-test-1a-utility_id" {
+output "subnet_utility-us-test-1a_id" {
   value = "${aws_subnet.utility-us-test-1a-privatedns1-example-com.id}"
 }
 

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -16,8 +16,8 @@ locals = {
   region                            = "us-test-1"
   route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-privatedns2-example-com.id}"
   route_table_public_id             = "${aws_route_table.privatedns2-example-com.id}"
-  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-privatedns2-example-com.id}"
-  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privatedns2-example-com.id}"
+  subnet_us-test-1a_id              = "${aws_subnet.us-test-1a-privatedns2-example-com.id}"
+  subnet_utility-us-test-1a_id      = "${aws_subnet.utility-us-test-1a-privatedns2-example-com.id}"
   vpc_id                            = "vpc-12345678"
 }
 
@@ -89,11 +89,11 @@ output "route_table_public_id" {
   value = "${aws_route_table.privatedns2-example-com.id}"
 }
 
-output "subnet_us-test-1a-private_id" {
+output "subnet_us-test-1a_id" {
   value = "${aws_subnet.us-test-1a-privatedns2-example-com.id}"
 }
 
-output "subnet_us-test-1a-utility_id" {
+output "subnet_utility-us-test-1a_id" {
   value = "${aws_subnet.utility-us-test-1a-privatedns2-example-com.id}"
 }
 

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -16,8 +16,8 @@ locals = {
   region                            = "us-test-1"
   route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-privateflannel-example-com.id}"
   route_table_public_id             = "${aws_route_table.privateflannel-example-com.id}"
-  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-privateflannel-example-com.id}"
-  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privateflannel-example-com.id}"
+  subnet_us-test-1a_id              = "${aws_subnet.us-test-1a-privateflannel-example-com.id}"
+  subnet_utility-us-test-1a_id      = "${aws_subnet.utility-us-test-1a-privateflannel-example-com.id}"
   vpc_cidr_block                    = "${aws_vpc.privateflannel-example-com.cidr_block}"
   vpc_id                            = "${aws_vpc.privateflannel-example-com.id}"
 }
@@ -90,11 +90,11 @@ output "route_table_public_id" {
   value = "${aws_route_table.privateflannel-example-com.id}"
 }
 
-output "subnet_us-test-1a-private_id" {
+output "subnet_us-test-1a_id" {
   value = "${aws_subnet.us-test-1a-privateflannel-example-com.id}"
 }
 
-output "subnet_us-test-1a-utility_id" {
+output "subnet_utility-us-test-1a_id" {
   value = "${aws_subnet.utility-us-test-1a-privateflannel-example-com.id}"
 }
 

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -17,10 +17,10 @@ locals = {
   route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-privatekopeio-example-com.id}"
   route_table_private-us-test-1b_id = "${aws_route_table.private-us-test-1b-privatekopeio-example-com.id}"
   route_table_public_id             = "${aws_route_table.privatekopeio-example-com.id}"
-  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-privatekopeio-example-com.id}"
-  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privatekopeio-example-com.id}"
-  subnet_us-test-1b-private_id      = "${aws_subnet.us-test-1b-privatekopeio-example-com.id}"
-  subnet_us-test-1b-utility_id      = "${aws_subnet.utility-us-test-1b-privatekopeio-example-com.id}"
+  subnet_us-test-1a_id              = "${aws_subnet.us-test-1a-privatekopeio-example-com.id}"
+  subnet_us-test-1b_id              = "${aws_subnet.us-test-1b-privatekopeio-example-com.id}"
+  subnet_utility-us-test-1a_id      = "${aws_subnet.utility-us-test-1a-privatekopeio-example-com.id}"
+  subnet_utility-us-test-1b_id      = "${aws_subnet.utility-us-test-1b-privatekopeio-example-com.id}"
   vpc_cidr_block                    = "${aws_vpc.privatekopeio-example-com.cidr_block}"
   vpc_id                            = "${aws_vpc.privatekopeio-example-com.id}"
 }
@@ -97,19 +97,19 @@ output "route_table_public_id" {
   value = "${aws_route_table.privatekopeio-example-com.id}"
 }
 
-output "subnet_us-test-1a-private_id" {
+output "subnet_us-test-1a_id" {
   value = "${aws_subnet.us-test-1a-privatekopeio-example-com.id}"
 }
 
-output "subnet_us-test-1a-utility_id" {
-  value = "${aws_subnet.utility-us-test-1a-privatekopeio-example-com.id}"
-}
-
-output "subnet_us-test-1b-private_id" {
+output "subnet_us-test-1b_id" {
   value = "${aws_subnet.us-test-1b-privatekopeio-example-com.id}"
 }
 
-output "subnet_us-test-1b-utility_id" {
+output "subnet_utility-us-test-1a_id" {
+  value = "${aws_subnet.utility-us-test-1a-privatekopeio-example-com.id}"
+}
+
+output "subnet_utility-us-test-1b_id" {
   value = "${aws_subnet.utility-us-test-1b-privatekopeio-example-com.id}"
 }
 

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -16,8 +16,8 @@ locals = {
   region                            = "us-test-1"
   route_table_private-us-test-1a_id = "${aws_route_table.private-us-test-1a-privateweave-example-com.id}"
   route_table_public_id             = "${aws_route_table.privateweave-example-com.id}"
-  subnet_us-test-1a-private_id      = "${aws_subnet.us-test-1a-privateweave-example-com.id}"
-  subnet_us-test-1a-utility_id      = "${aws_subnet.utility-us-test-1a-privateweave-example-com.id}"
+  subnet_us-test-1a_id              = "${aws_subnet.us-test-1a-privateweave-example-com.id}"
+  subnet_utility-us-test-1a_id      = "${aws_subnet.utility-us-test-1a-privateweave-example-com.id}"
   vpc_cidr_block                    = "${aws_vpc.privateweave-example-com.cidr_block}"
   vpc_id                            = "${aws_vpc.privateweave-example-com.id}"
 }
@@ -90,11 +90,11 @@ output "route_table_public_id" {
   value = "${aws_route_table.privateweave-example-com.id}"
 }
 
-output "subnet_us-test-1a-private_id" {
+output "subnet_us-test-1a_id" {
   value = "${aws_subnet.us-test-1a-privateweave-example-com.id}"
 }
 
-output "subnet_us-test-1a-utility_id" {
+output "subnet_utility-us-test-1a_id" {
   value = "${aws_subnet.utility-us-test-1a-privateweave-example-com.id}"
 }
 

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -11,7 +11,7 @@ locals = {
   nodes_role_name              = "${aws_iam_role.nodes-sharedsubnet-example-com.name}"
   region                       = "us-test-1"
   subnet_ids                   = ["subnet-12345678"]
-  subnet_us-test-1a-public_id  = "subnet-12345678"
+  subnet_us-test-1a_id         = "subnet-12345678"
   vpc_id                       = "vpc-12345678"
 }
 
@@ -63,7 +63,7 @@ output "subnet_ids" {
   value = ["subnet-12345678"]
 }
 
-output "subnet_us-test-1a-public_id" {
+output "subnet_us-test-1a_id" {
   value = "subnet-12345678"
 }
 

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -11,7 +11,7 @@ locals = {
   nodes_role_name              = "${aws_iam_role.nodes-sharedvpc-example-com.name}"
   region                       = "us-test-1"
   route_table_public_id        = "${aws_route_table.sharedvpc-example-com.id}"
-  subnet_us-test-1a-public_id  = "${aws_subnet.us-test-1a-sharedvpc-example-com.id}"
+  subnet_us-test-1a_id         = "${aws_subnet.us-test-1a-sharedvpc-example-com.id}"
   vpc_id                       = "vpc-12345678"
 }
 
@@ -63,7 +63,7 @@ output "route_table_public_id" {
   value = "${aws_route_table.sharedvpc-example-com.id}"
 }
 
-output "subnet_us-test-1a-public_id" {
+output "subnet_us-test-1a_id" {
   value = "${aws_subnet.us-test-1a-sharedvpc-example-com.id}"
 }
 


### PR DESCRIPTION
I made a mistaken assumption in
dde2100a198d300f5a3529f0121f3251ed05a607 that we only had one subnet
per AZ, but as demonstrated in #5587 this was not the case.

What I was trying to achieve was not to include the cluster name, so
for the case of subnets this commit just uses the subnet name from the
cluster spec, which should be unique and stable.  That is hopefully at
least as meaningful.

Thankfully we hadn't released a version with the erroneous naming.

Fix #5587