### PR TITLE
Create ExperimentalClusterDNS feature flag

### DIFF
--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -283,11 +283,13 @@ func ValidateCluster(c *kops.Cluster, strict bool) *field.Error {
 			if !serviceClusterIPRange.Contains(ip) {
 				return field.Invalid(fieldSpec.Child("kubeDNS", "serverIP"), address, fmt.Sprintf("ServiceClusterIPRange %q must contain the DNS Server IP %q", c.Spec.ServiceClusterIPRange, address))
 			}
-			if c.Spec.Kubelet != nil && c.Spec.Kubelet.ClusterDNS != c.Spec.KubeDNS.ServerIP {
-				return field.Invalid(fieldSpec.Child("kubeDNS", "serverIP"), address, "Kubelet ClusterDNS did not match cluster kubeDNS.serverIP")
-			}
-			if c.Spec.MasterKubelet != nil && c.Spec.MasterKubelet.ClusterDNS != c.Spec.KubeDNS.ServerIP {
-				return field.Invalid(fieldSpec.Child("kubeDNS", "serverIP"), address, "MasterKubelet ClusterDNS did not match cluster kubeDNS.serverIP")
+			if !featureflag.ExperimentalClusterDNS.Enabled() {
+				if c.Spec.Kubelet != nil && c.Spec.Kubelet.ClusterDNS != c.Spec.KubeDNS.ServerIP {
+					return field.Invalid(fieldSpec.Child("kubeDNS", "serverIP"), address, "Kubelet ClusterDNS did not match cluster kubeDNS.serverIP")
+				}
+				if c.Spec.MasterKubelet != nil && c.Spec.MasterKubelet.ClusterDNS != c.Spec.KubeDNS.ServerIP {
+					return field.Invalid(fieldSpec.Child("kubeDNS", "serverIP"), address, "MasterKubelet ClusterDNS did not match cluster kubeDNS.serverIP")
+				}
 			}
 		}
 

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -37,6 +37,10 @@ func Bool(b bool) *bool {
 	return &b
 }
 
+// ExperimentalClusterDNS allows for setting the kubelet dns flag to experimental values.
+// It allows for experiments with alternative DNS configurations - in particular local proxies.
+var ExperimentalClusterDNS = New("ExperimentalClusterDNS", Bool(false))
+
 // KeepLaunchConfigurations can be set to prevent garbage collection of old launch configurations
 var KeepLaunchConfigurations = New("KeepLaunchConfigurations", Bool(false))
 

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -48,11 +48,6 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.MasterKubelet = &kops.KubeletConfigSpec{}
 	}
 
-	ip, err := WellKnownServiceIP(clusterSpec, 10)
-	if err != nil {
-		return err
-	}
-
 	if clusterSpec.KubeAPIServer != nil && clusterSpec.KubeAPIServer.EnableBootstrapAuthToken != nil {
 		if *clusterSpec.KubeAPIServer.EnableBootstrapAuthToken {
 			if clusterSpec.Kubelet.BootstrapKubeconfig == "" {
@@ -66,9 +61,16 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 	clusterSpec.Kubelet.PodManifestPath = "/etc/kubernetes/manifests"
 	clusterSpec.Kubelet.AllowPrivileged = fi.Bool(true)
 	clusterSpec.Kubelet.LogLevel = fi.Int32(2)
-	clusterSpec.Kubelet.ClusterDNS = ip.String()
 	clusterSpec.Kubelet.ClusterDomain = clusterSpec.ClusterDNSDomain
 	clusterSpec.Kubelet.NonMasqueradeCIDR = clusterSpec.NonMasqueradeCIDR
+
+	if clusterSpec.Kubelet.ClusterDNS == "" {
+		ip, err := WellKnownServiceIP(clusterSpec, 10)
+		if err != nil {
+			return err
+		}
+		clusterSpec.Kubelet.ClusterDNS = ip.String()
+	}
 
 	if b.Context.IsKubernetesLT("1.7") {
 		// babysit-daemons removed in 1.7


### PR DESCRIPTION
This currently just turns off validation of the kubelet cluster dns
flag, which should allow for experimenting with more complicated DNS
configurations such as local proxies, which may address shortcomings
of DNS retries with UDP.

Issue #5584