### PR TITLE
Remove _kubernetes_master tag

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -42,10 +42,12 @@ type NodeupModelContext struct {
 	Cluster       *kops.Cluster
 	Distribution  distros.Distribution
 	InstanceGroup *kops.InstanceGroup
-	IsMaster      bool
 	KeyStore      fi.CAStore
 	NodeupConfig  *nodeup.Config
 	SecretStore   fi.SecretStore
+
+	// IsMaster is true if the InstanceGroup has a role of master (populated by Init)
+	IsMaster bool
 
 	kubernetesVersion semver.Version
 }
@@ -57,6 +59,12 @@ func (c *NodeupModelContext) Init() error {
 		return fmt.Errorf("unable to parse KubernetesVersion %q", c.Cluster.Spec.KubernetesVersion)
 	}
 	c.kubernetesVersion = *k8sVersion
+
+	if c.InstanceGroup == nil {
+		glog.Warningf("cannot determine role, InstanceGroup not set")
+	} else if c.InstanceGroup.Spec.Role == kops.InstanceGroupRoleMaster {
+		c.IsMaster = true
+	}
 
 	return nil
 }

--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
@@ -264,7 +264,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
   Tags:
   - _automatic_upgrades
   - _aws
-  - _kubernetes_master
   channels:
   - memfs://clusters.example.com/additionalcidr.example.com/addons/bootstrap-channel.yaml
   protokubeImage:

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -273,7 +273,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
   Tags:
   - _automatic_upgrades
   - _aws
-  - _kubernetes_master
   channels:
   - memfs://clusters.example.com/additionaluserdata.example.com/addons/bootstrap-channel.yaml
   protokubeImage:

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -264,7 +264,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   Tags:
   - _automatic_upgrades
   - _aws
-  - _kubernetes_master
   channels:
   - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml
   protokubeImage:

--- a/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_master-us-west-2a.masters.k8s-iam.us-west-2.td.priv_user_data
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_master-us-west-2a.masters.k8s-iam.us-west-2.td.priv_user_data
@@ -281,7 +281,6 @@ InstanceGroupName: master-us-west-2a
 Tags:
 - _automatic_upgrades
 - _aws
-- _kubernetes_master
 - _networking_cni
 channels:
 - s3://tune-k8s-kops-test/k8s-iam.us-west-2.td.priv/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -284,7 +284,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
   Tags:
   - _automatic_upgrades
   - _aws
-  - _kubernetes_master
   channels:
   - memfs://clusters.example.com/externallb.example.com/addons/bootstrap-channel.yaml
   protokubeImage:

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -264,7 +264,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   Tags:
   - _automatic_upgrades
   - _aws
-  - _kubernetes_master
   channels:
   - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml
   protokubeImage:

--- a/upup/pkg/fi/cloudup/tagbuilder.go
+++ b/upup/pkg/fi/cloudup/tagbuilder.go
@@ -96,20 +96,6 @@ func buildCloudupTags(cluster *api.Cluster) (sets.String, error) {
 func buildNodeupTags(role api.InstanceGroupRole, cluster *api.Cluster, clusterTags sets.String) (sets.String, error) {
 	tags := sets.NewString()
 
-	switch role {
-	case api.InstanceGroupRoleNode:
-		// No tags
-
-	case api.InstanceGroupRoleMaster:
-		tags.Insert("_kubernetes_master")
-
-	case api.InstanceGroupRoleBastion:
-		// No tags
-
-	default:
-		return nil, fmt.Errorf("Unrecognized role: %v", role)
-	}
-
 	switch fi.StringValue(cluster.Spec.UpdatePolicy) {
 	case "": // default
 		tags.Insert("_automatic_upgrades")

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -48,8 +48,6 @@ import (
 // MaxTaskDuration is the amount of time to keep trying for; we retry for a long time - there is not really any great fallback
 const MaxTaskDuration = 365 * 24 * time.Hour
 
-const TagMaster = "_kubernetes_master"
-
 // NodeUpCommand the configiruation for nodeup
 type NodeUpCommand struct {
 	CacheDir       string
@@ -183,7 +181,6 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 		Cluster:       c.cluster,
 		Distribution:  distribution,
 		InstanceGroup: c.instanceGroup,
-		IsMaster:      nodeTags.Has(TagMaster),
 		NodeupConfig:  c.config,
 	}
 


### PR DESCRIPTION
We can get the master role just as readily from the InstanceGroup spec