### PR TITLE
Fix interactive rolling update silently ignored

### DIFF
--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -182,7 +182,6 @@ func (r *RollingUpdateInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpd
 			continue
 		} else if rollingUpdateData.CloudOnly {
 			glog.Warningf("Not validating cluster as cloudonly flag is set.")
-			continue
 
 		} else if featureflag.DrainAndValidateRollingUpdate.Enabled() {
 			glog.Infof("Validating the cluster.")
@@ -196,15 +195,16 @@ func (r *RollingUpdateInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpd
 
 				glog.Warningf("Cluster validation failed after removing instance, proceeding since fail-on-validate is set to false: %v", err)
 			}
-			if rollingUpdateData.Interactive {
-				stopPrompting, err := promptInteractive(nodeName)
-				if err != nil {
-					return err
-				}
-				if stopPrompting {
-					// Is a pointer to a struct, changes here push back into the original
-					rollingUpdateData.Interactive = false
-				}
+		}
+
+		if rollingUpdateData.Interactive {
+			stopPrompting, err := promptInteractive(nodeName)
+			if err != nil {
+				return err
+			}
+			if stopPrompting {
+				// Is a pointer to a struct, changes here push back into the original
+				rollingUpdateData.Interactive = false
 			}
 		}
 	}

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -67,10 +67,14 @@ func NewRollingUpdateInstanceGroup(cloud fi.Cloud, cloudGroup *cloudinstances.Cl
 }
 
 // promptInteractive asks the user to continue, mostly copied from vendor/google.golang.org/api/examples/gmail.go.
-func promptInteractive(upgradedHost string) (stopPrompting bool, err error) {
+func promptInteractive(upgradedHostId, upgradedHostName string) (stopPrompting bool, err error) {
 	stopPrompting = false
 	scanner := bufio.NewScanner(os.Stdin)
-	glog.Infof("Pausing after finished %q", upgradedHost)
+	if upgradedHostName != "" {
+		glog.Infof("Pausing after finished %q, node %q", upgradedHostId, upgradedHostName)
+	} else {
+		glog.Infof("Pausing after finished %q", upgradedHostId)
+	}
 	fmt.Print("Continue? (Y)es, (N)o, (A)lwaysYes: [Y] ")
 	scanner.Scan()
 	err = scanner.Err()
@@ -198,7 +202,7 @@ func (r *RollingUpdateInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpd
 		}
 
 		if rollingUpdateData.Interactive {
-			stopPrompting, err := promptInteractive(nodeName)
+			stopPrompting, err := promptInteractive(u.ID, nodeName)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This improves on #4166 (*Interactive cli opt*) by adding `--interactive` support for rolling updates in `--cloudonly` mode and for feature flag `DrainAndValidateRollingUpdate` disabled. Without this fix, the interactive flag is silently ignored.

Why is this change needed: it's not currently obvious the interactive mode does not always work. Also, I'd say interactive rolling update is *most useful* when the validation is turned off or the upgrade is cloud only.

Originally there were four (!) cases with only the penultimate one using the interactive prompt:
- bastion upgrade
- cluster instance with cloudonly
- cluster instance with validation
- cluster instance with validation turned off

This PR only adds the prompt after removing any cluster node. Bastion nodes still do not prompt.

As for the implementation:
- The first commit puts the prompt as the very last step for each node. I've intentionally left the `continue` after bastion upgrade to not trigger the prompt.
- The second commit as merely cosmetical and make output consistent with `DeleteInstance` method

Tests: there were no tests in the original pr #4166 and I'm not quite sure how to test this on CI. I've run the upgrade locally though and the command works as expected.

/area rolling-update
