### PR TITLE
Fix build: prevent verify-misspelling failing on releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -517,12 +517,16 @@ verify-gofmt:
 verify-packages: ${BINDATA_TARGETS}
 	hack/verify-packages.sh
 
+# find release notes, remove PR titles and output the rest to .build, then run misspell on all files
 .PHONY: verify-misspelling
 verify-misspelling:
 	@which misspell 2>/dev/null ; if [ $$? -eq 1 ]; then \
 		go get -u github.com/client9/misspell/cmd/misspell; \
 	fi
-	@find . -type f \( -name "*.go*" -o -name "*.md*" \) -a \( -not -path "./vendor/*" -not -path "./_vendor/*" \) | \
+	@mkdir -p .build/docs
+	@find . -type f \( -name "*.go*" -o -name "*.md*" \) -a -path "./docs/releases/*" -exec basename {} \; | \
+		xargs -I{} sh -c 'sed -e "/^\* .*github.com\/kubernetes\/kops\/pull/d" docs/releases/{} > .build/docs/$(basename {})'
+	@find . -type f \( -name "*.go*" -o -name "*.md*" \) -a \( -not -path "./vendor/*" -not -path "./_vendor/*" -not -path "./docs/releases/*" \) | \
 		sed -e /README-ES.md/d -e /node_modules/d | \
 		xargs misspell -error
 


### PR DESCRIPTION
Removes pull request subjects from release notes and checks the remainder of text.

I'd say the pull requests should be listed with the original subjects, even if they include a typo. Very likely the typos are even intentional, such as in 

> * [instance_groups.md] typo: recieve->receive AdamDang 5152

It lists files in `docs/releases` and for each release, it removes lines matching a pull request. Intentionally the files are not changed inplace, as I feel running tests should not change any files. Instead, it writes to `.build/docs`, because a/ it's already git ignored b/ gets cleaned with `make clean`

The bash is slightly more convoluted than it seemingly has to be, but it's an intentional workaround macOS sed and it's wrong behavior with `-i''`.

This changes the output of the misspell command, which may be confusing:
```console
$ make verify-misspelling
./.build/docs/1.10-NOTES.md:50:28: "foo" is a misspelling of "bar"
make: *** [verify-misspelling] Error 1
```
Note that it says `./.build/docs/1.10-NOTES.md` instead of `./docs/releases/1.10-NOTES.md`