### PR TITLE
increase docker-healthcheck respose timeout

### DIFF
--- a/upup/models/nodeup/docker/_systemd/_debian_family/files/opt/kubernetes/helpers/docker-healthcheck
+++ b/upup/models/nodeup/docker/_systemd/_debian_family/files/opt/kubernetes/helpers/docker-healthcheck
@@ -17,7 +17,7 @@
 # This script is intended to be run periodically, to check the health
 # of docker.  If it detects a failure, it will restart docker using systemctl.
 
-if timeout 10 docker ps > /dev/null; then
+if timeout 60 docker ps > /dev/null; then
   echo "docker healthy"
   exit 0
 fi
@@ -26,18 +26,24 @@ echo "docker failed"
 echo "Giving docker 30 seconds grace before restarting"
 sleep 30
 
-if timeout 10 docker ps > /dev/null; then
+if timeout 60 docker ps > /dev/null; then
   echo "docker recovered"
   exit 0
 fi
 
-echo "docker still down; triggering docker restart"
-systemctl restart docker
+echo "docker still unresposive; triggering docker restart"
+systemctl stop docker
 
-echo "Waiting 60 seconds to give docker time to start"
+echo "wait all tcp sockets to close"
+sleep `cat /proc/sys/net/ipv4/tcp_fin_timeout`
+
+sleep 10
+systemctl start docker
+
+echo "Waiting 120 seconds to give docker time to start"
 sleep 60
 
-if timeout 10 docker ps > /dev/null; then
+if timeout 60 docker ps > /dev/null; then
   echo "docker recovered"
   exit 0
 fi


### PR DESCRIPTION
In case of increased I/O load, the 10sec timeout is not enough on small / heavily loaded systems thus I propose the 60sec. The kubelet timeout is 2m (120sec) by default to detect health problems. Secondly, the docker restart can load heavily the host OS even huge systems because of many pods initialization at the same time. Continuous dockerd restart loop - a deadlock of node - is observed. Thirdly, because of the forcibly closed sockets and the kernel TCP TIME_WAIT value, the TCP sockets are not usable immediately with a "restart", wait for FIN_TIMEOUT is necessary before start services.
Workaround #1 for: https://github.com/kubernetes/kops/issues/5434