### PR TITLE
add kube-proxy hostname override

### DIFF
--- a/pkg/model/components/kubeproxy.go
+++ b/pkg/model/components/kubeproxy.go
@@ -82,5 +82,11 @@ func (b *KubeProxyOptionsBuilder) BuildOptions(o interface{}) error {
 		}
 	}
 
+	if cloudProvider == kops.CloudProviderDO {
+		if config.HostnameOverride == "" {
+			config.HostnameOverride = "@digitalocean"
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
Required so Services with `externalPolicyTraffic: Local` will work. 

https://github.com/kubernetes/kops/issues/2150 