### PR TITLE
AWS VPC Daemonset Correctly Tolerate Node Taints

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.7.yaml.template
@@ -62,8 +62,8 @@ spec:
       serviceAccountName: aws-node
       hostNetwork: true
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
       containers:


### PR DESCRIPTION
Hello maintainers! 

The tolerations on the AWS VPC CNI Daemonset do not work correctly with user-provided node taints. For example, we run GPU nodes in our cluster and have node-taints so that only GPU workloads can run on these nodes. The current VPC CNI Daemonset settings do not tolerate these taints, so whenever we upgrade our cluster the CNI Pods stop running on these nodes. This patch fixes the taints so that they correctly ignore "NoSchedule" across the cluster, [similar to what other CNI Daemonsets such as Weave do](https://github.com/kubernetes/kops/blob/02daea62ae14664bcd7ce799da01ea54ea3421f4/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template#L190).