### PR TITLE
Basic validation for imagetype for NVME enabled instances

### DIFF
--- a/pkg/apis/kops/validation/BUILD.bazel
+++ b/pkg/apis/kops/validation/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/pkg/apis/kops/validation/aws.go
+++ b/pkg/apis/kops/validation/aws.go
@@ -19,6 +19,8 @@ package validation
 import (
 	"strings"
 
+	"fmt"
+	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kops/pkg/apis/kops"
@@ -43,6 +45,8 @@ func awsValidateInstanceGroup(ig *kops.InstanceGroup) field.ErrorList {
 	allErrs = append(allErrs, awsValidateAdditionalSecurityGroups(field.NewPath("spec", "additionalSecurityGroups"), ig.Spec.AdditionalSecurityGroups)...)
 
 	allErrs = append(allErrs, awsValidateMachineType(field.NewPath(ig.GetName(), "spec", "machineType"), ig.Spec.MachineType)...)
+
+	allErrs = append(allErrs, awsValidateAMIforNVMe(field.NewPath(ig.GetName(), "spec", "machineType"), ig)...)
 
 	return allErrs
 }
@@ -77,5 +81,26 @@ func awsValidateMachineType(fieldPath *field.Path, machineType string) field.Err
 		}
 	}
 
+	return allErrs
+}
+
+// TODO: make image validation smarter? graduate from jessie to stretch? This is quick and dirty because we keep getting reports
+func awsValidateAMIforNVMe(fieldPath *field.Path, ig *kops.InstanceGroup) field.ErrorList {
+	// TODO: how can we put this list somewhere better?
+	NVMe_INSTANCE_PREFIXES := []string{"P3", "C5", "M5", "H1", "I3"}
+
+	allErrs := field.ErrorList{}
+
+	for _, prefix := range NVMe_INSTANCE_PREFIXES {
+		if strings.Contains(strings.ToUpper(ig.Spec.MachineType), strings.ToUpper(prefix)) {
+			glog.V(2).Infof("machineType %s requires an image based on stretch to operate. Trying to check compatibility", ig.Spec.MachineType)
+			if strings.Contains(ig.Spec.Image, "jessie") {
+				errString := fmt.Sprintf("%s cannot use machineType %s with image based on Debian jessie.", ig.Name, ig.Spec.MachineType)
+				allErrs = append(allErrs, field.Forbidden(fieldPath, errString))
+				continue
+			}
+		}
+
+	}
 	return allErrs
 }

--- a/pkg/apis/kops/validation/aws_test.go
+++ b/pkg/apis/kops/validation/aws_test.go
@@ -70,6 +70,38 @@ func TestValidateInstanceGroupSpec(t *testing.T) {
 			},
 			ExpectedErrors: []string{"Invalid value::test-nodes.spec.machineType"},
 		},
+		{
+			Input: kops.InstanceGroupSpec{
+				MachineType: "m5.large",
+				Image:       "k8s-1.9-debian-stretch-amd64-hvm-ebs-2018-03-11",
+			},
+			ExpectedErrors: []string{},
+		},
+		{
+			Input: kops.InstanceGroupSpec{
+				MachineType: "m5.large",
+				Image:       "k8s-1.9-debian-jessie-amd64-hvm-ebs-2018-03-11",
+			},
+			ExpectedErrors: []string{
+				"Forbidden::test-nodes.spec.machineType",
+			},
+		},
+		{
+			Input: kops.InstanceGroupSpec{
+				MachineType: "c5.large",
+				Image:       "k8s-1.9-debian-stretch-amd64-hvm-ebs-2018-03-11",
+			},
+			ExpectedErrors: []string{},
+		},
+		{
+			Input: kops.InstanceGroupSpec{
+				MachineType: "c5.large",
+				Image:       "k8s-1.9-debian-jessie-amd64-hvm-ebs-2018-03-11",
+			},
+			ExpectedErrors: []string{
+				"Forbidden::test-nodes.spec.machineType",
+			},
+		},
 	}
 	for _, g := range grid {
 		ig := &kops.InstanceGroup{


### PR DESCRIPTION
replaces #5653 