### PR TITLE
Cherry pick of #5513 onto release-1.10

### DIFF
--- a/cmd/kops/BUILD.bazel
+++ b/cmd/kops/BUILD.bazel
@@ -112,6 +112,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/plugin/pkg/client/auth:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/util/homedir:go_default_library",
         "//vendor/k8s.io/helm/pkg/strvals:go_default_library",

--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kops/cmd/kops/util"
 	api "k8s.io/kops/pkg/apis/kops"


### PR DESCRIPTION
Backporting #5513 into 1.10

```
Without this change, for example, kops connections using OIDC to the
cluster will receive this error message:

> cannot build kube client for "$CLUSTER_NAME": No Auth Provider found
> for name "oidc"

kubernetes/client-go#345 suggests importing the package path
`plugin/pkg/client/auth/oidc` from `client-go`, but looking at the code
`plugin/pkg/client/auth` will actually handle loading all known auth
plugins for us.
```