### PR TITLE
Fixes go vet complains

### DIFF
--- a/dns-controller/cmd/dns-controller/main.go
+++ b/dns-controller/cmd/dns-controller/main.go
@@ -181,7 +181,7 @@ func main() {
 
 // initializeWatchers is responsible for creating the watchers
 func initializeWatchers(client kubernetes.Interface, dnsctl *dns.DNSController, namespace string, watchIngress bool) error {
-	glog.V(1).Info("initializing the watch controllers, namespace: %q", namespace)
+	glog.V(1).Infof("initializing the watch controllers, namespace: %q", namespace)
 
 	nodeController, err := watchers.NewNodeController(client, dnsctl)
 	if err != nil {

--- a/dns-controller/pkg/dns/dnscontroller.go
+++ b/dns-controller/pkg/dns/dnscontroller.go
@@ -600,7 +600,7 @@ func (s *DNSControllerScope) Replace(recordName string, records []Record) {
 		delete(s.Records, recordName)
 	} else {
 		if recordsSliceEquals(existing, records) {
-			glog.V(6).Infof("skipping spurious update of record %s/%s=%s", s.ScopeName, recordName, records)
+			glog.V(6).Infof("skipping spurious update of record %s/%s=%+v", s.ScopeName, recordName, records)
 			return
 		}
 

--- a/pkg/acls/s3/storage.go
+++ b/pkg/acls/s3/storage.go
@@ -59,7 +59,7 @@ func (s *s3PublicAclStrategy) GetACL(p vfs.Path, cluster *kops.Cluster) (vfs.ACL
 	// We are checking that the file repository url is in S3
 	_, err = vfs.VFSPath(fileRepository)
 	if err != nil {
-		glog.V(8).Infof("path %q is not inside of a s3 bucket", u.String)
+		glog.V(8).Infof("path %q is not inside of a s3 bucket", u.String())
 		return nil, nil
 	}
 

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -196,7 +196,7 @@ func Test_Validate_DockerConfig_Storage(t *testing.T) {
 		config := &kops.DockerConfig{Storage: &name}
 		errs := ValidateDockerConfig(config, field.NewPath("docker"))
 		if len(errs) != 1 {
-			t.Fatalf("Expected errors validating DockerConfig %q", config)
+			t.Fatalf("Expected errors validating DockerConfig %+v", config)
 		}
 		if errs[0].Field != "docker.storage" || errs[0].Type != field.ErrorTypeNotSupported {
 			t.Fatalf("Not the expected error validating DockerConfig %q", errs)

--- a/pkg/kubemanifest/visitor.go
+++ b/pkg/kubemanifest/visitor.go
@@ -32,12 +32,12 @@ func (m *visitorBase) VisitString(path []string, v string, mutator func(string))
 }
 
 func (m *visitorBase) VisitBool(path []string, v bool, mutator func(bool)) error {
-	glog.V(10).Infof("string value at %s: %s", strings.Join(path, "."), v)
+	glog.V(10).Infof("string value at %s: %v", strings.Join(path, "."), v)
 	return nil
 }
 
 func (m *visitorBase) VisitFloat64(path []string, v float64, mutator func(float64)) error {
-	glog.V(10).Infof("float64 value at %s: %s", strings.Join(path, "."), v)
+	glog.V(10).Infof("float64 value at %s: %f", strings.Join(path, "."), v)
 	return nil
 }
 

--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -1303,14 +1303,14 @@ func extractClusterName(userData string) string {
 		line = strings.TrimSpace(line)
 		line = strings.Trim(line, "'\"")
 		if clusterName != "" && clusterName != line {
-			glog.Warning("cannot uniquely determine cluster-name, found %q and %q", line, clusterName)
+			glog.Warningf("cannot uniquely determine cluster-name, found %q and %q", line, clusterName)
 			return ""
 		}
 		clusterName = line
 
 	}
 	if err := scanner.Err(); err != nil {
-		glog.Warning("error scanning UserData: %v", err)
+		glog.Warningf("error scanning UserData: %v", err)
 		return ""
 	}
 

--- a/upup/pkg/fi/cloudup/alitasks/disk.go
+++ b/upup/pkg/fi/cloudup/alitasks/disk.go
@@ -73,7 +73,7 @@ func (d *Disk) Find(c *fi.Context) (*Disk, error) {
 		return nil, nil
 	}
 	if len(responseDisks) > 1 {
-		glog.V(4).Info("The number of specified disk with the same name and ClusterTags exceeds 1, diskName:%q", *d.Name)
+		glog.V(4).Infof("The number of specified disk with the same name and ClusterTags exceeds 1, diskName:%q", *d.Name)
 	}
 
 	glog.V(2).Infof("found matching Disk with name: %q", *d.Name)
@@ -88,7 +88,7 @@ func (d *Disk) Find(c *fi.Context) (*Disk, error) {
 	tags, err := cloud.GetTags(fi.StringValue(actual.DiskId), DiskResource)
 
 	if err != nil {
-		glog.V(4).Info("Error getting tags on resourceId:%q", *actual.DiskId)
+		glog.V(4).Infof("Error getting tags on resourceId:%q", *actual.DiskId)
 	}
 	actual.Tags = tags
 

--- a/upup/pkg/fi/cloudup/alitasks/launchconfiguration.go
+++ b/upup/pkg/fi/cloudup/alitasks/launchconfiguration.go
@@ -86,7 +86,7 @@ func (l *LaunchConfiguration) Find(c *fi.Context) (*LaunchConfiguration, error) 
 		return nil, nil
 	}
 	if len(configList) > 1 {
-		glog.V(4).Info("The number of specified ScalingConfigurations with the same name and ScalingGroupId exceeds 1, diskName:%q", *l.Name)
+		glog.V(4).Infof("The number of specified ScalingConfigurations with the same name and ScalingGroupId exceeds 1, diskName:%q", *l.Name)
 	}
 
 	glog.V(2).Infof("found matching LaunchConfiguration: %q", *l.Name)

--- a/upup/pkg/fi/cloudup/alitasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/alitasks/loadbalancer.go
@@ -68,7 +68,7 @@ func (l *LoadBalancer) Find(c *fi.Context) (*LoadBalancer, error) {
 		return nil, nil
 	}
 	if len(responseLoadBalancers) > 1 {
-		glog.V(4).Info("The number of specified loadbalancer with the same name exceeds 1, loadbalancerName:%q", *l.Name)
+		glog.V(4).Infof("The number of specified loadbalancer with the same name exceeds 1, loadbalancerName:%q", *l.Name)
 	}
 
 	glog.V(2).Infof("found matching LoadBalancer: %q", *l.Name)
@@ -122,7 +122,7 @@ func (l *LoadBalancer) FindIPAddress(context *fi.Context) (*string, error) {
 		return nil, nil
 	}
 	if len(responseLoadBalancers) > 1 {
-		glog.V(4).Info("The number of specified loadbalancer with the same name exceeds 1, loadbalancerName:%q", *l.Name)
+		glog.V(4).Infof("The number of specified loadbalancer with the same name exceeds 1, loadbalancerName:%q", *l.Name)
 	}
 
 	address := responseLoadBalancers[0].Address

--- a/upup/pkg/fi/cloudup/alitasks/scalinggroup.go
+++ b/upup/pkg/fi/cloudup/alitasks/scalinggroup.go
@@ -68,7 +68,7 @@ func (s *ScalingGroup) Find(c *fi.Context) (*ScalingGroup, error) {
 	}
 
 	if len(groupList) > 1 {
-		glog.V(4).Info("The number of specified scalingGroup with the same name and ClusterTags exceeds 1, diskName:%q", *s.Name)
+		glog.V(4).Infof("The number of specified scalingGroup with the same name and ClusterTags exceeds 1, diskName:%q", *s.Name)
 	}
 
 	glog.V(2).Infof("found matching ScalingGroup with Name: %q", *s.Name)

--- a/upup/pkg/fi/cloudup/aliup/ali_cloud.go
+++ b/upup/pkg/fi/cloudup/aliup/ali_cloud.go
@@ -215,7 +215,7 @@ func (c *aliCloudImplementation) CreateTags(resourceId string, resourceType stri
 	if len(tags) == 0 {
 		return nil
 	} else if len(tags) > 10 {
-		glog.V(4).Info("The number of specified resource's tags exceeds 10, resourceId:%q", resourceId)
+		glog.V(4).Infof("The number of specified resource's tags exceeds 10, resourceId:%q", resourceId)
 	}
 	if resourceId == "" {
 		return errors.New("resourceId not provided to CreateTags")
@@ -287,7 +287,7 @@ func (c *aliCloudImplementation) GetApiIngressStatus(cluster *kops.Cluster) ([]k
 		return nil, nil
 	}
 	if len(responseLoadBalancers) > 1 {
-		glog.V(4).Info("The number of specified loadbalancer with the same name exceeds 1, loadbalancerName:%q", name)
+		glog.V(4).Infof("The number of specified loadbalancer with the same name exceeds 1, loadbalancerName:%q", name)
 	}
 
 	address := responseLoadBalancers[0].Address

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -1018,11 +1018,11 @@ func ValidateZones(zones []string, cloud AWSCloud) error {
 		}
 
 		for _, message := range z.Messages {
-			glog.Warningf("Zone %q has message: %q", aws.StringValue(message.Message))
+			glog.Warningf("Zone %q has message: %q", zone, aws.StringValue(message.Message))
 		}
 
 		if aws.StringValue(z.State) != "available" {
-			glog.Warningf("Zone %q has state %q", aws.StringValue(z.State))
+			glog.Warningf("Zone %q has state %q", zone, aws.StringValue(z.State))
 		}
 	}
 

--- a/upup/pkg/fi/files_owner.go
+++ b/upup/pkg/fi/files_owner.go
@@ -53,7 +53,7 @@ func EnsureFileOwner(destPath string, owner string, groupName string) (bool, err
 		return changed, nil
 	}
 
-	glog.Infof("Changing file owner/group for %q to %s:%s", destPath, owner, group)
+	glog.Infof("Changing file owner/group for %q to %s:%+v", destPath, owner, group)
 	err = os.Lchown(destPath, user.Uid, group.Gid)
 	if err != nil {
 		return changed, fmt.Errorf("error setting file owner/group for %q: %v", destPath, err)

--- a/upup/pkg/fi/fitasks/keypair.go
+++ b/upup/pkg/fi/fitasks/keypair.go
@@ -263,7 +263,7 @@ func (e *Keypair) BuildCertificateTemplate() (*x509.Certificate, error) {
 	}
 
 	if len(subjectPkix.ToRDNSequence()) == 0 {
-		return nil, fmt.Errorf("Subject name was empty for SSL keypair %q", e.Name)
+		return nil, fmt.Errorf("Subject name was empty for SSL keypair %q", *e.Name)
 	}
 
 	template.Subject = *subjectPkix

--- a/upup/pkg/fi/nodeup/nodetasks/file.go
+++ b/upup/pkg/fi/nodeup/nodetasks/file.go
@@ -310,7 +310,7 @@ func (_ *File) RenderCloudInit(t *cloudinit.CloudInitTarget, a, e, changes *File
 	dirMode := os.FileMode(0755)
 	fileMode, err := fi.ParseFileMode(fi.StringValue(e.Mode), 0644)
 	if err != nil {
-		return fmt.Errorf("invalid file mode for %q: %q", e.Path, e.Mode)
+		return fmt.Errorf("invalid file mode for %s: %q", e.Path, *e.Mode)
 	}
 
 	if e.Type == FileType_Symlink {

--- a/upup/pkg/fi/users.go
+++ b/upup/pkg/fi/users.go
@@ -54,18 +54,18 @@ func parseUsers() (map[string]*User, error) {
 		tokens := strings.Split(line, ":")
 
 		if len(tokens) < 7 {
-			glog.Warning("Ignoring malformed /etc/passwd line (too few tokens): %q", line)
+			glog.Warningf("Ignoring malformed /etc/passwd line (too few tokens): %q\n", line)
 			continue
 		}
 
 		uid, err := strconv.Atoi(tokens[2])
 		if err != nil {
-			glog.Warning("Ignoring malformed /etc/passwd line (bad uid): %q", line)
+			glog.Warningf("Ignoring malformed /etc/passwd line (bad uid): %q", line)
 			continue
 		}
 		gid, err := strconv.Atoi(tokens[3])
 		if err != nil {
-			glog.Warning("Ignoring malformed /etc/passwd line (bad gid): %q", line)
+			glog.Warningf("Ignoring malformed /etc/passwd line (bad gid): %q", line)
 			continue
 		}
 
@@ -126,13 +126,13 @@ func parseGroups() (map[string]*Group, error) {
 		tokens := strings.Split(line, ":")
 
 		if len(tokens) < 4 {
-			glog.Warning("Ignoring malformed /etc/group line (too few tokens): %q", line)
+			glog.Warningf("Ignoring malformed /etc/group line (too few tokens): %q", line)
 			continue
 		}
 
 		gid, err := strconv.Atoi(tokens[2])
 		if err != nil {
-			glog.Warning("Ignoring malformed /etc/group line (bad gid): %q", line)
+			glog.Warningf("Ignoring malformed /etc/group line (bad gid): %q", line)
 			continue
 		}
 


### PR DESCRIPTION
When try `make govet` on `go1.11beta1`. It complains many things
related to invalid string formatting:

```
pkg/kubemanifest/visitor.go:35: Verbose.Infof format %s has arg v of wrong type bool
pkg/kubemanifest/visitor.go:40: Verbose.Infof format %s has arg v of wrong type float64
upup/pkg/fi/cloudup/alitasks/disk.go:76: Verbose.Info call has possible formatting directive %q
upup/pkg/fi/cloudup/alitasks/disk.go:91: Verbose.Info call has possible formatting directive %q
upup/pkg/fi/cloudup/alitasks/launchconfiguration.go:89: Verbose.Info call has possible formatting directive %q
upup/pkg/fi/cloudup/alitasks/loadbalancer.go:71: Verbose.Info call has possible formatting directive %q
upup/pkg/fi/cloudup/alitasks/loadbalancer.go:125: Verbose.Info call has possible formatting directive %q
upup/pkg/fi/cloudup/alitasks/scalinggroup.go:71: Verbose.Info call has possible formatting directive %q
dns-controller/pkg/dns/dnscontroller.go:603: Verbose.Infof format %s has arg records of wrong type []dns.Record
dns-controller/cmd/dns-controller/main.go:184: Verbose.Info call has possible formatting directive %q
pkg/acls/s3/storage.go:62: Verbose.Infof format %q arg u.String is a func value, not called
pkg/apis/kops/validation/validation_test.go:199: T.Fatalf format %q has arg config of wrong type *k8s.io/kops/pkg/apis/kops.DockerConfig
pkg/resources/aws/aws.go:1306: Warning call has possible formatting directive %q
pkg/resources/aws/aws.go:1313: Warning call has possible formatting directive %v
upup/pkg/fi/cloudup/aliup/ali_cloud.go:218: Verbose.Info call has possible formatting directive %q
upup/pkg/fi/cloudup/aliup/ali_cloud.go:290: Verbose.Info call has possible formatting directive %q
upup/pkg/fi/fitasks/keypair.go:266: Errorf format %q has arg e.Name of wrong type *string
upup/pkg/fi/files_owner.go:56: Infof format %s has arg group of wrong type *fi.Group
upup/pkg/fi/users.go:57: Warning call has possible formatting directive %q
upup/pkg/fi/users.go:63: Warning call has possible formatting directive %q
upup/pkg/fi/users.go:68: Warning call has possible formatting directive %q
upup/pkg/fi/users.go:129: Warning call has possible formatting directive %q
upup/pkg/fi/users.go:135: Warning call has possible formatting directive %q
upup/pkg/fi/nodeup/nodetasks/file.go:313: Errorf format %q has arg e.Mode of wrong type *string
upup/pkg/fi/cloudup/awsup/aws_cloud.go:1021: Warningf format %q reads arg #2, but call has 1 arg
upup/pkg/fi/cloudup/awsup/aws_cloud.go:1025: Warningf format %q reads arg #2, but call has 1 arg
```