### PR TITLE
Small typo fix

### DIFF
--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -72,7 +72,7 @@ var (
 	kops create ig --name=k8s-cluster.example.com node-example \
 		--role node --subnet my-subnet-name
 
-	# Create an new ssh public key called admin.
+	# Create a new ssh public key called admin.
 	kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \
 		--name k8s-cluster.example.com --state s3://example.com
 	`))

--- a/cmd/kops/create_secret.go
+++ b/cmd/kops/create_secret.go
@@ -30,7 +30,7 @@ var (
 	Create a secret`))
 
 	createSecretExample = templates.Examples(i18n.T(`
-	# Create an new ssh public key called admin.
+	# Create a new ssh public key called admin.
 	kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \
 		--name k8s-cluster.example.com --state s3://example.com
 

--- a/cmd/kops/create_secret_dockerconfig.go
+++ b/cmd/kops/create_secret_dockerconfig.go
@@ -37,7 +37,7 @@ var (
 	Use update to modify it, this command will only create a new entry.`))
 
 	createSecretDockerconfigExample = templates.Examples(i18n.T(`
-	# Create an new docker config.
+	# Create a new docker config.
 	kops create secret dockerconfig -f /path/to/docker/config.json \
 		--name k8s-cluster.example.com --state s3://example.com
 	# Replace an existing docker config secret.

--- a/cmd/kops/create_secret_sshpublickey.go
+++ b/cmd/kops/create_secret_sshpublickey.go
@@ -34,7 +34,7 @@ var (
 	key is not updated by this command.`))
 
 	createSecretSSHPublicKeyExample = templates.Examples(i18n.T(`
-	# Create an new ssh public key called admin.
+	# Create a new ssh public key called admin.
 	kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \
 		--name k8s-cluster.example.com --state s3://example.com
 	`))

--- a/docs/cli/kops_create.md
+++ b/docs/cli/kops_create.md
@@ -41,7 +41,7 @@ kops create -f FILENAME [flags]
   kops create ig --name=k8s-cluster.example.com node-example \
   --role node --subnet my-subnet-name
   
-  # Create an new ssh public key called admin.
+  # Create a new ssh public key called admin.
   kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \
   --name k8s-cluster.example.com --state s3://example.com
 ```

--- a/docs/cli/kops_create_secret.md
+++ b/docs/cli/kops_create_secret.md
@@ -12,7 +12,7 @@ Create a secret
 ### Examples
 
 ```
-  # Create an new ssh public key called admin.
+  # Create a new ssh public key called admin.
   kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \
   --name k8s-cluster.example.com --state s3://example.com
   
@@ -50,6 +50,6 @@ Create a secret
 * [kops create secret dockerconfig](kops_create_secret_dockerconfig.md)	 - Create a docker config.
 * [kops create secret encryptionconfig](kops_create_secret_encryptionconfig.md)	 - Create an encryption config.
 * [kops create secret keypair](kops_create_secret_keypair.md)	 - Create a secret keypair.
-* [kops create secret sshpublickey](kops_create_secret_sshpublickey.md)	 - Create a ssh public key.
+* [kops create secret sshpublickey](kops_create_secret_sshpublickey.md)	 - Create an ssh public key.
 * [kops create secret weavepassword](kops_create_secret_weavepassword.md)	 - Create a weave encryption config.
 

--- a/docs/cli/kops_create_secret_dockerconfig.md
+++ b/docs/cli/kops_create_secret_dockerconfig.md
@@ -16,7 +16,7 @@ kops create secret dockerconfig [flags]
 ### Examples
 
 ```
-  # Create an new docker config.
+  # Create a new docker config.
   kops create secret dockerconfig -f /path/to/docker/config.json \
   --name k8s-cluster.example.com --state s3://example.com
   # Replace an existing docker config secret.

--- a/docs/cli/kops_create_secret_sshpublickey.md
+++ b/docs/cli/kops_create_secret_sshpublickey.md
@@ -3,7 +3,7 @@
 
 ## kops create secret sshpublickey
 
-Create a ssh public key.
+Create an ssh public key.
 
 ### Synopsis
 
@@ -16,7 +16,7 @@ kops create secret sshpublickey [flags]
 ### Examples
 
 ```
-  # Create an new ssh public key called admin.
+  # Create a new ssh public key called admin.
   kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \
   --name k8s-cluster.example.com --state s3://example.com
 ```


### PR DESCRIPTION
Fix the typos :
 "a ssh"->"an ssh"
"an new ssh"->"a new ssh"