### PR TITLE
Explicitly install conntrack

### DIFF
--- a/images/utils-builder/Dockerfile
+++ b/images/utils-builder/Dockerfile
@@ -19,7 +19,7 @@ RUN echo "deb-src http://security.debian.org/ jessie/updates main" >> /etc/apt/s
 RUN echo "deb-src http://ftp.us.debian.org/debian/ jessie main" >> /etc/apt/sources.list
 
 RUN apt-get update && apt-get install --yes dpkg-dev bash \
-  && apt-get build-dep --yes socat \
+  && apt-get build-dep --yes socat conntrack \
   && apt-get clean
 
 RUN mkdir /socat
@@ -29,5 +29,13 @@ RUN cd /socat; \
     CFLAGS=-static LDFLAGS=-static CPPFLAGS=-static CFLAGS_APPEND=-static \
     LDFLAGS_APPEND=-static CPPFLAGS_APPEND=-static \
     apt-get source --build socat
+
+RUN mkdir /conntrack
+
+# Note that this approach does _not_ include libssl, but we don't need it for kubernetes anyway
+RUN cd /conntrack; \
+    CFLAGS=-static LDFLAGS=-static CPPFLAGS=-static CFLAGS_APPEND=-static \
+    LDFLAGS_APPEND=-static CPPFLAGS_APPEND=-static \
+    apt-get source --build conntrack
 
 COPY extract.sh /extract.sh

--- a/images/utils-builder/README.md
+++ b/images/utils-builder/README.md
@@ -1,1 +1,1 @@
-This docker image builds statically linked binaries, in particular socat for use on CoreOS.
+This docker image builds statically linked binaries, in particular socat and conntrack for use on CoreOS.

--- a/images/utils-builder/extract.sh
+++ b/images/utils-builder/extract.sh
@@ -19,6 +19,7 @@ rm -rf /utils
 
 mkdir -p /utils
 cp /socat/socat-*/debian/socat/usr/bin/socat /utils/socat
+cp /conntrack/conntrack-*/debian/conntrack/usr/sbin/conntrack /utils/conntrack
 #(sha1sum /utils/socat | cut -d' ' -f1) > /utils/socat.sha1
 
 tar cvfz /utils.tar.gz /utils

--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -33,12 +33,15 @@ var _ fi.ModelBuilder = &DockerBuilder{}
 // Build is responsible for installing packages
 func (b *PackagesBuilder) Build(c *fi.ModelBuilderContext) error {
 	// kubelet needs:
+	//   conntrack  - kops #5671
 	//   ebtables - kops #1711
 	//   ethtool - kops #1830
 	if b.Distribution.IsDebianFamily() {
+		c.AddTask(&nodetasks.Package{Name: "conntrack"})
 		c.AddTask(&nodetasks.Package{Name: "ebtables"})
 		c.AddTask(&nodetasks.Package{Name: "ethtool"})
 	} else if b.Distribution.IsRHELFamily() {
+		c.AddTask(&nodetasks.Package{Name: "conntrack-tools"})
 		c.AddTask(&nodetasks.Package{Name: "ebtables"})
 		c.AddTask(&nodetasks.Package{Name: "ethtool"})
 		c.AddTask(&nodetasks.Package{Name: "socat"})

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1081,8 +1081,9 @@ func (c *ApplyClusterCmd) AddFileAssets(assetBuilder *assets.AssetBuilder) error
 
 	// TODO figure out if we can only do this for CoreOS only and GCE Container OS
 	// TODO It is very difficult to pre-determine what OS an ami is, and if that OS needs socat
-	// At this time we just copy the socat binary to all distros.  Most distros will be there own
-	// socat binary.  Container operating systems like CoreOS need to have socat added to them.
+	// At this time we just copy the socat and conntrack binaries to all distros.
+	// Most distros will have there own socat and conntrack binary.
+	// Container operating systems like CoreOS need to have socat and conntrack added to them.
 	{
 		utilsLocation, hash, err := KopsFileUrl("linux/amd64/utils.tar.gz", assetBuilder)
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kops/issues/5671

Explicitly install conntrack on debian and rhel distros and using a static binary on CoreOS.