### PR TITLE
Update k8s-ec2-srcdst to v0.2.2

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7.yaml.template
@@ -519,7 +519,7 @@ spec:
         operator: Exists
       serviceAccountName: k8s-ec2-srcdst
       containers:
-        - image: ottoyiu/k8s-ec2-srcdst:v0.2.1
+        - image: ottoyiu/k8s-ec2-srcdst:v0.2.2
           name: k8s-ec2-srcdst
           resources:
             requests:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -594,7 +594,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		versions := map[string]string{
 			"pre-k8s-1.6": "2.4.2-kops.1",
 			"k8s-1.6":     "2.6.7-kops.2",
-			"k8s-1.7":     "2.6.7-kops.2",
+			"k8s-1.7":     "2.6.7-kops.3",
 		}
 
 		{


### PR DESCRIPTION
v0.2.2 fixes a bug where [k8s-ec2-srcdst can crash on node deletion](https://github.com/ottoyiu/k8s-ec2-srcdst/issues/9).

This crash causes SourceDestinationCheck to remain set to true on
nodes created after this check. Such nodes cannot talk to calico
destinations in the *same* subnet.

Fixes kubernetes/kubernetes#66432