### PR TITLE
Add Docker 18.06.1 for Debian Stretch

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -526,6 +526,19 @@ var dockerVersions = []dockerVersion{
 		//Depends: iptables, init-system-helpers, lsb-base, libapparmor1, libc6, libdevmapper1.02.1, libltdl7, libeseccomp2, libsystemd0
 		//Recommends: aufs-tools, ca-certificates, cgroupfs-mount | cgroup-lite, git, xz-utils, apparmor
 	},
+	
+	// 18.06.1 - Debian Stretch
+	{
+		
+		DockerVersion: "18.06.1",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionDebian9},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "18.06.1~ce-0~debian",
+		Source:        "https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_18.06.1~ce~3-0~debian_amd64.deb",
+		Hash:          "18473b80e61b6d4eb8b52d87313abd71261287e5",
+		Dependencies:  []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
+	},
 }
 
 func (d *dockerVersion) matches(arch Architecture, dockerVersion string, distro distros.Distribution) bool {


### PR DESCRIPTION
Add Docker 18.06.1 - Debian Stretch.. 

Docker 17.03 and 17.09 have bugs that can result in pods failing to terminate due to GRPC errors and PLEG errors.. We hit both bugs after the upgrade to kubernetes 1.10.x from 1.9.x.. Upgrading to 18.06.1 in our clusters has resolved these issues, and we have seen no issues. We have been runnning 18.06.1 across 15 clusters with k8s 10.0.6. 


See issue, for other reports of this. 
https://github.com/kubernetes/kops/issues/5747

