### PR TITLE
dns-controller: allow configuring DNS update interval

### DIFF
--- a/dns-controller/cmd/dns-controller/main.go
+++ b/dns-controller/cmd/dns-controller/main.go
@@ -57,6 +57,7 @@ func main() {
 	var dnsServer, dnsProviderID, gossipListen, gossipSecret, watchNamespace, metricsListen string
 	var gossipSeeds, zones []string
 	var watchIngress bool
+	var updateInterval int
 
 	// Be sure to get the glog flags
 	glog.Flush()
@@ -71,6 +72,7 @@ func main() {
 	flags.StringVar(&watchNamespace, "watch-namespace", "", "Limits the functionality for pods, services and ingress to specific namespace, by default all")
 	flag.IntVar(&route53.MaxBatchSize, "route53-batch-size", route53.MaxBatchSize, "Maximum number of operations performed per changeset batch")
 	flag.StringVar(&metricsListen, "metrics-listen", "", "The address on which to listen for Prometheus metrics.")
+	flags.IntVar(&updateInterval, "update-interval", 5, "Configure interval at which to update DNS records.")
 
 	// Trick to avoid 'logging before flag.Parse' warning
 	flag.CommandLine.Parse([]string{})
@@ -163,7 +165,7 @@ func main() {
 		dnsProviders = append(dnsProviders, dnsProvider)
 	}
 
-	dnsController, err := dns.NewDNSController(dnsProviders, zoneRules)
+	dnsController, err := dns.NewDNSController(dnsProviders, zoneRules, updateInterval)
 	if err != nil {
 		glog.Errorf("Error building DNS controller: %v", err)
 		os.Exit(1)

--- a/dns-controller/pkg/dns/dnscontroller.go
+++ b/dns-controller/pkg/dns/dnscontroller.go
@@ -55,6 +55,9 @@ type DNSController struct {
 
 	// changeCount is a change-counter, which helps us avoid computation when nothing has changed
 	changeCount uint64
+
+	// update loop frequency (seconds)
+	updateInterval time.Duration
 }
 
 // DNSController is a Context
@@ -81,16 +84,17 @@ type DNSControllerScope struct {
 var _ Scope = &DNSControllerScope{}
 
 // NewDnsController creates a DnsController
-func NewDNSController(dnsProviders []dnsprovider.Interface, zoneRules *ZoneRules) (*DNSController, error) {
+func NewDNSController(dnsProviders []dnsprovider.Interface, zoneRules *ZoneRules, updateInterval int) (*DNSController, error) {
 	dnsCache, err := newDNSCache(dnsProviders)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing DNS cache: %v", err)
 	}
 
 	c := &DNSController{
-		scopes:    make(map[string]*DNSControllerScope),
-		zoneRules: zoneRules,
-		dnsCache:  dnsCache,
+		scopes:         make(map[string]*DNSControllerScope),
+		zoneRules:      zoneRules,
+		dnsCache:       dnsCache,
+		updateInterval: time.Duration(updateInterval) * time.Second,
 	}
 
 	return c, nil
@@ -117,10 +121,10 @@ func (c *DNSController) runWatcher(stopCh <-chan struct{}) {
 
 		if err != nil {
 			glog.Warningf("Unexpected error in DNS controller, will retry: %v", err)
-			time.Sleep(10 * time.Second)
+			time.Sleep(2 * c.updateInterval)
 		} else {
 			// Simple debouncing; DNS servers are typically pretty slow anyway
-			time.Sleep(5 * time.Second)
+			time.Sleep(c.updateInterval)
 		}
 	}
 }

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -64,6 +64,7 @@ func run() error {
 	var cloud, clusterID, dnsServer, dnsProviderID, dnsInternalSuffix, gossipSecret, gossipListen string
 	var flagChannels, tlsCert, tlsKey, tlsCA, peerCert, peerKey, peerCA string
 	var etcdBackupImage, etcdBackupStore, etcdImageSource, etcdElectionTimeout, etcdHeartbeatInterval string
+	var dnsUpdateInterval int
 
 	flag.BoolVar(&applyTaints, "apply-taints", applyTaints, "Apply taints to nodes based on the role")
 	flag.BoolVar(&containerized, "containerized", containerized, "Set if we are running containerized.")
@@ -73,6 +74,7 @@ func run() error {
 	flag.StringVar(&clusterID, "cluster-id", clusterID, "Cluster ID")
 	flag.StringVar(&dnsInternalSuffix, "dns-internal-suffix", dnsInternalSuffix, "DNS suffix for internal domain names")
 	flag.StringVar(&dnsServer, "dns-server", dnsServer, "DNS Server")
+	flags.IntVar(&dnsUpdateInterval, "dns-update-interval", 5, "Configure interval at which to update DNS records.")
 	flag.StringVar(&flagChannels, "channels", flagChannels, "channels to install")
 	flag.StringVar(&gossipListen, "gossip-listen", "0.0.0.0:3999", "address:port on which to bind for gossip")
 	flag.StringVar(&peerCA, "peer-ca", peerCA, "Path to a file containing the peer ca in PEM format")
@@ -298,7 +300,7 @@ func run() error {
 				return fmt.Errorf("unexpected zone flags: %q", err)
 			}
 
-			dnsController, err = dns.NewDNSController([]dnsprovider.Interface{dnsProvider}, zoneRules)
+			dnsController, err = dns.NewDNSController([]dnsprovider.Interface{dnsProvider}, zoneRules, dnsUpdateInterval)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Given enough DNS records, and with update batching, Route53 will throttle API calls. We set this in our forked DNS controller to 30 seconds to avoid throttling.