### PR TITLE
Added documentation for Api server LB Certificate

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -46,6 +46,15 @@ spec:
       idleTimeoutSeconds: 300
 ```
 
+You can use a valid SSL Certificate for your API Server Load Balancer. Currently, only AWS is supported:
+
+```yaml
+spec:
+  api:
+    loadBalancer:
+      sslCertificate: arn:aws:acm:<region>:<accountId>:certificate/<uuid>
+```
+
 ### etcdClusters v3 & tls
 
 Although kops doesn't presently default to etcd3, it is possible to turn on both v3 and TLS authentication for communication amongst cluster members. These options may be enabled via the cluster spec (manifests only i.e. no command line options as yet). An upfront warning; at present no upgrade path exists for migrating from v2 to v3 so **DO NOT** try to enable this on a v2 running cluster as it must be done on cluster creation. The below example snippet assumes a HA cluster of three masters.


### PR DESCRIPTION
This feature was added by the PR #5414 and it is available at release 1.10.0 but there's no related documentation yet available.