### PR TITLE
Avoid using which, CoreOS doesn't always have it

### DIFF
--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -77,19 +77,20 @@ download-or-bust() {
 
       if [[ -e "${file}" ]]; then
         echo "== File exists for ${url} =="
-      elif [[ $(which curl) ]]; then
+
+      # CoreOS runs this script in a container without which (but has curl)
+      # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+      # So we default to wget unless we see curl
+      elif [[ $(curl --version) ]]; then
         if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
           echo "== Failed to curl ${url}. Retrying. =="
           break
         fi
-      elif [[ $(which wget ) ]]; then
+      else
         if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
           echo "== Failed to wget ${url}. Retrying. =="
           break
         fi
-      else
-        echo "== Could not find curl or wget. Retrying. =="
-        break
       fi
 
       if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then

--- a/pkg/model/tests/data/bootstrapscript_0.txt
+++ b/pkg/model/tests/data/bootstrapscript_0.txt
@@ -66,19 +66,20 @@ download-or-bust() {
 
       if [[ -e "${file}" ]]; then
         echo "== File exists for ${url} =="
-      elif [[ $(which curl) ]]; then
+
+      # CoreOS runs this script in a container without which (but has curl)
+      # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+      # So we default to wget unless we see curl
+      elif [[ $(curl --version) ]]; then
         if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
           echo "== Failed to curl ${url}. Retrying. =="
           break
         fi
-      elif [[ $(which wget ) ]]; then
+      else
         if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
           echo "== Failed to wget ${url}. Retrying. =="
           break
         fi
-      else
-        echo "== Could not find curl or wget. Retrying. =="
-        break
       fi
 
       if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then

--- a/pkg/model/tests/data/bootstrapscript_1.txt
+++ b/pkg/model/tests/data/bootstrapscript_1.txt
@@ -66,19 +66,20 @@ download-or-bust() {
 
       if [[ -e "${file}" ]]; then
         echo "== File exists for ${url} =="
-      elif [[ $(which curl) ]]; then
+
+      # CoreOS runs this script in a container without which (but has curl)
+      # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+      # So we default to wget unless we see curl
+      elif [[ $(curl --version) ]]; then
         if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
           echo "== Failed to curl ${url}. Retrying. =="
           break
         fi
-      elif [[ $(which wget ) ]]; then
+      else
         if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
           echo "== Failed to wget ${url}. Retrying. =="
           break
         fi
-      else
-        echo "== Could not find curl or wget. Retrying. =="
-        break
       fi
 
       if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then

--- a/pkg/model/tests/data/bootstrapscript_2.txt
+++ b/pkg/model/tests/data/bootstrapscript_2.txt
@@ -66,19 +66,20 @@ download-or-bust() {
 
       if [[ -e "${file}" ]]; then
         echo "== File exists for ${url} =="
-      elif [[ $(which curl) ]]; then
+
+      # CoreOS runs this script in a container without which (but has curl)
+      # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+      # So we default to wget unless we see curl
+      elif [[ $(curl --version) ]]; then
         if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
           echo "== Failed to curl ${url}. Retrying. =="
           break
         fi
-      elif [[ $(which wget ) ]]; then
+      else
         if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
           echo "== Failed to wget ${url}. Retrying. =="
           break
         fi
-      else
-        echo "== Could not find curl or wget. Retrying. =="
-        break
       fi
 
       if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then

--- a/pkg/model/tests/data/bootstrapscript_3.txt
+++ b/pkg/model/tests/data/bootstrapscript_3.txt
@@ -66,19 +66,20 @@ download-or-bust() {
 
       if [[ -e "${file}" ]]; then
         echo "== File exists for ${url} =="
-      elif [[ $(which curl) ]]; then
+
+      # CoreOS runs this script in a container without which (but has curl)
+      # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+      # So we default to wget unless we see curl
+      elif [[ $(curl --version) ]]; then
         if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
           echo "== Failed to curl ${url}. Retrying. =="
           break
         fi
-      elif [[ $(which wget ) ]]; then
+      else
         if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
           echo "== Failed to wget ${url}. Retrying. =="
           break
         fi
-      else
-        echo "== Could not find curl or wget. Retrying. =="
-        break
       fi
 
       if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then

--- a/pkg/model/tests/data/bootstrapscript_4.txt
+++ b/pkg/model/tests/data/bootstrapscript_4.txt
@@ -66,19 +66,20 @@ download-or-bust() {
 
       if [[ -e "${file}" ]]; then
         echo "== File exists for ${url} =="
-      elif [[ $(which curl) ]]; then
+
+      # CoreOS runs this script in a container without which (but has curl)
+      # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+      # So we default to wget unless we see curl
+      elif [[ $(curl --version) ]]; then
         if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
           echo "== Failed to curl ${url}. Retrying. =="
           break
         fi
-      elif [[ $(which wget ) ]]; then
+      else
         if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
           echo "== Failed to wget ${url}. Retrying. =="
           break
         fi
-      else
-        echo "== Could not find curl or wget. Retrying. =="
-        break
       fi
 
       if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then

--- a/pkg/model/tests/data/bootstrapscript_5.txt
+++ b/pkg/model/tests/data/bootstrapscript_5.txt
@@ -66,19 +66,20 @@ download-or-bust() {
 
       if [[ -e "${file}" ]]; then
         echo "== File exists for ${url} =="
-      elif [[ $(which curl) ]]; then
+
+      # CoreOS runs this script in a container without which (but has curl)
+      # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+      # So we default to wget unless we see curl
+      elif [[ $(curl --version) ]]; then
         if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
           echo "== Failed to curl ${url}. Retrying. =="
           break
         fi
-      elif [[ $(which wget ) ]]; then
+      else
         if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
           echo "== Failed to wget ${url}. Retrying. =="
           break
         fi
-      else
-        echo "== Could not find curl or wget. Retrying. =="
-        break
       fi
 
       if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then

--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
@@ -51,19 +51,20 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
 
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
-        elif [[ $(which curl) ]]; then
+
+        # CoreOS runs this script in a container without which (but has curl)
+        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+        # So we default to wget unless we see curl
+        elif [[ $(curl --version) ]]; then
           if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
             echo "== Failed to curl ${url}. Retrying. =="
             break
           fi
-        elif [[ $(which wget ) ]]; then
+        else
           if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
             echo "== Failed to wget ${url}. Retrying. =="
             break
           fi
-        else
-          echo "== Could not find curl or wget. Retrying. =="
-          break
         fi
 
         if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
@@ -327,19 +328,20 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
 
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
-        elif [[ $(which curl) ]]; then
+
+        # CoreOS runs this script in a container without which (but has curl)
+        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+        # So we default to wget unless we see curl
+        elif [[ $(curl --version) ]]; then
           if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
             echo "== Failed to curl ${url}. Retrying. =="
             break
           fi
-        elif [[ $(which wget ) ]]; then
+        else
           if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
             echo "== Failed to wget ${url}. Retrying. =="
             break
           fi
-        else
-          echo "== Could not find curl or wget. Retrying. =="
-          break
         fi
 
         if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -60,19 +60,20 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
 
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
-        elif [[ $(which curl) ]]; then
+
+        # CoreOS runs this script in a container without which (but has curl)
+        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+        # So we default to wget unless we see curl
+        elif [[ $(curl --version) ]]; then
           if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
             echo "== Failed to curl ${url}. Retrying. =="
             break
           fi
-        elif [[ $(which wget ) ]]; then
+        else
           if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
             echo "== Failed to wget ${url}. Retrying. =="
             break
           fi
-        else
-          echo "== Could not find curl or wget. Retrying. =="
-          break
         fi
 
         if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
@@ -357,19 +358,20 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
 
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
-        elif [[ $(which curl) ]]; then
+
+        # CoreOS runs this script in a container without which (but has curl)
+        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+        # So we default to wget unless we see curl
+        elif [[ $(curl --version) ]]; then
           if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
             echo "== Failed to curl ${url}. Retrying. =="
             break
           fi
-        elif [[ $(which wget ) ]]; then
+        else
           if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
             echo "== Failed to wget ${url}. Retrying. =="
             break
           fi
-        else
-          echo "== Could not find curl or wget. Retrying. =="
-          break
         fi
 
         if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -51,19 +51,20 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
 
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
-        elif [[ $(which curl) ]]; then
+
+        # CoreOS runs this script in a container without which (but has curl)
+        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+        # So we default to wget unless we see curl
+        elif [[ $(curl --version) ]]; then
           if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
             echo "== Failed to curl ${url}. Retrying. =="
             break
           fi
-        elif [[ $(which wget ) ]]; then
+        else
           if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
             echo "== Failed to wget ${url}. Retrying. =="
             break
           fi
-        else
-          echo "== Could not find curl or wget. Retrying. =="
-          break
         fi
 
         if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
@@ -327,19 +328,20 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
 
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
-        elif [[ $(which curl) ]]; then
+
+        # CoreOS runs this script in a container without which (but has curl)
+        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+        # So we default to wget unless we see curl
+        elif [[ $(curl --version) ]]; then
           if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
             echo "== Failed to curl ${url}. Retrying. =="
             break
           fi
-        elif [[ $(which wget ) ]]; then
+        else
           if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
             echo "== Failed to wget ${url}. Retrying. =="
             break
           fi
-        else
-          echo "== Could not find curl or wget. Retrying. =="
-          break
         fi
 
         if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -51,19 +51,20 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
 
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
-        elif [[ $(which curl) ]]; then
+
+        # CoreOS runs this script in a container without which (but has curl)
+        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+        # So we default to wget unless we see curl
+        elif [[ $(curl --version) ]]; then
           if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
             echo "== Failed to curl ${url}. Retrying. =="
             break
           fi
-        elif [[ $(which wget ) ]]; then
+        else
           if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
             echo "== Failed to wget ${url}. Retrying. =="
             break
           fi
-        else
-          echo "== Could not find curl or wget. Retrying. =="
-          break
         fi
 
         if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
@@ -347,19 +348,20 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
 
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
-        elif [[ $(which curl) ]]; then
+
+        # CoreOS runs this script in a container without which (but has curl)
+        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+        # So we default to wget unless we see curl
+        elif [[ $(curl --version) ]]; then
           if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
             echo "== Failed to curl ${url}. Retrying. =="
             break
           fi
-        elif [[ $(which wget ) ]]; then
+        else
           if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
             echo "== Failed to wget ${url}. Retrying. =="
             break
           fi
-        else
-          echo "== Could not find curl or wget. Retrying. =="
-          break
         fi
 
         if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -51,19 +51,20 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
 
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
-        elif [[ $(which curl) ]]; then
+
+        # CoreOS runs this script in a container without which (but has curl)
+        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+        # So we default to wget unless we see curl
+        elif [[ $(curl --version) ]]; then
           if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
             echo "== Failed to curl ${url}. Retrying. =="
             break
           fi
-        elif [[ $(which wget ) ]]; then
+        else
           if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
             echo "== Failed to wget ${url}. Retrying. =="
             break
           fi
-        else
-          echo "== Could not find curl or wget. Retrying. =="
-          break
         fi
 
         if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
@@ -327,19 +328,20 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
 
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
-        elif [[ $(which curl) ]]; then
+
+        # CoreOS runs this script in a container without which (but has curl)
+        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
+        # So we default to wget unless we see curl
+        elif [[ $(curl --version) ]]; then
           if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
             echo "== Failed to curl ${url}. Retrying. =="
             break
           fi
-        elif [[ $(which wget ) ]]; then
+        else
           if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
             echo "== Failed to wget ${url}. Retrying. =="
             break
           fi
-        else
-          echo "== Could not find curl or wget. Retrying. =="
-          break
         fi
 
         if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then


### PR DESCRIPTION
We just try executing `curl --version` instead, and fall back to wget.
We can't use `wget --version` because busybox wget doesn't support
`--version`.