### PR TITLE
Cni tolerations for Cilium and AmazonVPC

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.7.yaml.template
@@ -62,8 +62,10 @@ spec:
       serviceAccountName: aws-node
       hostNetwork: true
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
       containers:

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
@@ -388,13 +388,17 @@ spec:
         {{- end }}
       tolerations:
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
       # Mark cilium's pod as critical for rescheduling
       - key: CriticalAddonsOnly
         operator: "Exists"
+      - effect: NoExecute
+        operator: Exists
+      # Allow the pod to run on all nodes.  This is required
+      # for cluster communication
+      - effect: NoSchedule
+        operator: Exists
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Related to #5730 

This increases the tolerations for the two CNIs in the subject to allow them to deploy/work on clusters with instance groups that have a taint to them.

Note: I've not been able to test this in a build due to other apparent issues in the build (I am new to this codebase), but have verified that patching these manifests after the fact addresses the stated issue.

As mentioned in the other ticket, this is very similar changes made for other CNI providers as follows:

Canal: #3802, #3142
Calico: #3097