### PR TITLE
Cni toleration for tainted nodes

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.7.yaml.template
@@ -64,6 +64,8 @@ spec:
       tolerations:
       - effect: NoSchedule
         operator: Exists
+      - effect: NoExecute
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
       containers:

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
@@ -388,13 +388,17 @@ spec:
         {{- end }}
       tolerations:
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
       # Mark cilium's pod as critical for rescheduling
       - key: CriticalAddonsOnly
         operator: "Exists"
+      - effect: NoExecute
+        operator: Exists
+      # Allow the pod to run on all nodes.  This is required
+      # for cluster communication
+      - effect: NoSchedule
+        operator: Exists
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -740,7 +740,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.AmazonVPC != nil {
 		key := "networking.amazon-vpc-routed-eni"
-		version := "1.0.0-kops.1"
+		version := "1.0.0-kops.2"
 
 		{
 			id := "k8s-1.7"
@@ -760,7 +760,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Cilium != nil {
 		key := "networking.cilium.io"
-		version := "v1.0-kops.1"
+		version := "v1.0-kops.2"
 
 		{
 			id := "k8s-1.7"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -69,4 +69,4 @@ spec:
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: v1.0-kops.1
+    version: v1.0-kops.2


### PR DESCRIPTION
Related to #5730, replaces #5802 (mistakenly issued against release-1.10 branch)

This increases the tolerations for the two CNIs in the subject to allow them to deploy/work on clusters with instance groups that have a taint to them.

Note: I've not been able to test this in a build due to other apparent issues in the build (I am new to this codebase), but have verified that patching these manifests after the fact addresses the stated issue.

As mentioned in the other ticket, this is very similar changes made for other CNI providers as follows:

Canal: #3802, #3142
Calico: #3097

