### PR TITLE
Added "--no-ssh-key" option

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -166,6 +166,8 @@ type ClusterSpec struct {
 	EncryptionConfig *bool `json:"encryptionConfig,omitempty"`
 	// Target allows for us to nest extra config for targets such as terraform
 	Target *TargetSpec `json:"target,omitempty"`
+	// If set true, do not include SSH key
+	NoSSHKey bool `json:"noSSHKey,omitempty"`
 }
 
 // NodeAuthorizationSpec is used to node authorization

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -165,6 +165,8 @@ type ClusterSpec struct {
 	EncryptionConfig *bool `json:"encryptionConfig,omitempty"`
 	// Target allows for us to nest extra config for targets such as terraform
 	Target *TargetSpec `json:"target,omitempty"`
+	// If set false, do not include SSH key
+	NoSSHKey bool `json:"noSSHKey,omitempty"`
 }
 
 // NodeAuthorizationSpec is used to node authorization

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1071,6 +1071,7 @@ func autoConvert_v1alpha1_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 	} else {
 		out.Target = nil
 	}
+	out.NoSSHKey = in.NoSSHKey
 	return nil
 }
 
@@ -1337,6 +1338,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha1_ClusterSpec(in *kops.ClusterSpec, 
 	} else {
 		out.Target = nil
 	}
+	out.NoSSHKey = in.NoSSHKey
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -166,6 +166,8 @@ type ClusterSpec struct {
 	EncryptionConfig *bool `json:"encryptionConfig,omitempty"`
 	// Target allows for us to nest extra config for targets such as terraform
 	Target *TargetSpec `json:"target,omitempty"`
+	// If set false, do not include SSH key
+	NoSSHKey bool `json:"noSSHKey,omitempty"`
 }
 
 // NodeAuthorizationSpec is used to node authorization

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1118,6 +1118,7 @@ func autoConvert_v1alpha2_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 	} else {
 		out.Target = nil
 	}
+	out.NoSSHKey = in.NoSSHKey
 	return nil
 }
 
@@ -1399,6 +1400,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, 
 	} else {
 		out.Target = nil
 	}
+	out.NoSSHKey = in.NoSSHKey
 	return nil
 }
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -103,6 +103,10 @@ func validateClusterSpec(spec *kops.ClusterSpec, fieldPath *field.Path) field.Er
 		}
 	}
 
+	if spec.NoSSHKey {
+		//?
+	}
+
 	return allErrs
 }
 

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -115,8 +115,10 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 				t.SecurityGroups = append(t.SecurityGroups, sgTask)
 			}
 
-			if t.SSHKey, err = b.LinkToSSHKey(); err != nil {
-				return err
+			if !b.Cluster.Spec.NoSSHKey {
+				if t.SSHKey, err = b.LinkToSSHKey(); err != nil {
+					return err
+				}
 			}
 
 			if t.UserData, err = b.BootstrapScript.ResourceNodeUp(ig, b.Cluster); err != nil {

--- a/upup/pkg/fi/cloudup/populatecluster_test.go
+++ b/upup/pkg/fi/cloudup/populatecluster_test.go
@@ -529,3 +529,19 @@ func TestPopulateCluster_KubeController_Fail(t *testing.T) {
 		t.Fatalf("AttachDetachReconcileSyncPeriodh is not supported in 1.4.7")
 	}
 }
+
+func TestPopulateCluster_NoSSHKey(t *testing.T) {
+	c := buildMinimalCluster()
+	c.Spec.NoSSHKey = true
+
+	err := PerformAssignments(c)
+	if err != nil {
+		t.Fatalf("error from PerformAssignments: %v", err)
+	}
+
+	full, err := build(c)
+
+	if full.Spec.NoSSHKey != true {
+		t.Fatalf("Unexpected NoSSHKey: %v", full.Spec.NoSSHKey)
+	}
+}


### PR DESCRIPTION
Specify this option to exclude SSH key from generated configuration

I'm in a scenario where we deploy an image (or use additional user data) that includes a service for SSH key management and would like to output configuration without any ssh key configuration.

A couple of issues including #2803 predates this PR