### PR TITLE
Update default etcd version from 2.2.1 to 3.2.18

### DIFF
--- a/pkg/apiserver/cmd/server/start.go
+++ b/pkg/apiserver/cmd/server/start.go
@@ -58,7 +58,7 @@ func NewCommandStartKopsServer(out, err io.Writer) *cobra.Command {
 		StdOut: out,
 		StdErr: err,
 	}
-	o.RecommendedOptions.Etcd.StorageConfig.Type = storagebackend.StorageTypeETCD2
+	o.RecommendedOptions.Etcd.StorageConfig.Type = storagebackend.StorageTypeETCD3
 	o.RecommendedOptions.Etcd.StorageConfig.Codec = apiserver.Codecs.LegacyCodec(v1alpha2.SchemeGroupVersion)
 	//o.SecureServing.ServingOptions.BindPort = 443
 

--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -32,7 +32,7 @@ type EtcdOptionsBuilder struct {
 
 var _ loader.OptionsBuilder = &EtcdOptionsBuilder{}
 
-const DefaultEtcdVersion = "2.2.1"
+const DefaultEtcdVersion = "3.2.18"
 
 // BuildOptions is responsible for filling in the defaults for the etcd cluster model
 func (b *EtcdOptionsBuilder) BuildOptions(o interface{}) error {

--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -36,7 +36,7 @@ func (b *EtcdManagerOptionsBuilder) BuildOptions(o interface{}) error {
 
 	for _, etcdCluster := range clusterSpec.EtcdClusters {
 		if etcdCluster.Version == "" {
-			etcdCluster.Version = "2.2.1"
+			etcdCluster.Version = "3.2.18"
 		}
 
 		if etcdCluster.Manager != nil {

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -86,7 +86,7 @@ func run() error {
 	flags.StringVar(&dnsProviderID, "dns", "aws-route53", "DNS provider we should use (aws-route53, google-clouddns, coredns, digitalocean)")
 	flags.StringVar(&etcdBackupImage, "etcd-backup-image", "", "Set to override the image for (experimental) etcd backups")
 	flags.StringVar(&etcdBackupStore, "etcd-backup-store", "", "Set to enable (experimental) etcd backups")
-	flags.StringVar(&etcdImageSource, "etcd-image", "k8s.gcr.io/etcd:2.2.1", "Etcd Source Container Registry")
+	flags.StringVar(&etcdImageSource, "etcd-image", "k8s.gcr.io/etcd:3.2.18", "Etcd Source Container Registry")
 	flags.StringVar(&etcdElectionTimeout, "etcd-election-timeout", etcdElectionTimeout, "time in ms for an election to timeout")
 	flags.StringVar(&etcdHeartbeatInterval, "etcd-heartbeat-interval", etcdHeartbeatInterval, "time in ms of a heartbeat interval")
 	flags.StringVar(&gossipSecret, "gossip-secret", gossipSecret, "Secret to use to secure gossip")

--- a/protokube/tests/integration/build_etcd_manifest/main/etcd_env_vars.yaml
+++ b/protokube/tests/integration/build_etcd_manifest/main/etcd_env_vars.yaml
@@ -3,7 +3,7 @@ clusterName: etcd-main
 clusterToken: token-main
 cpuRequest: "200m"
 dataDirName: data-main
-imageSource: k8s.gcr.io/etcd:2.2.1
+imageSource: k8s.gcr.io/etcd:3.2.18
 logFile: /var/log/etcd.log
 peerPort: 2380
 podName: etcd-server-main
@@ -62,7 +62,7 @@ spec:
       value: "100"
     - name: ETCD_INITIAL_CLUSTER
       value: node0=http://node0.internal:2380,node1=http://node1.internal:2380,node2=http://node2.internal:2380
-    image: k8s.gcr.io/etcd:2.2.1
+    image: k8s.gcr.io/etcd:3.2.18
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/protokube/tests/integration/build_etcd_manifest/main/non_tls.yaml
+++ b/protokube/tests/integration/build_etcd_manifest/main/non_tls.yaml
@@ -3,7 +3,7 @@ clusterName: etcd-main
 clusterToken: token-main
 cpuRequest: "200m"
 dataDirName: data-main
-imageSource: k8s.gcr.io/etcd:2.2.1
+imageSource: k8s.gcr.io/etcd:3.2.18
 logFile: /var/log/etcd.log
 peerPort: 2380
 podName: etcd-server-main
@@ -56,7 +56,7 @@ spec:
       value: token-main
     - name: ETCD_INITIAL_CLUSTER
       value: node0=http://node0.internal:2380,node1=http://node1.internal:2380,node2=http://node2.internal:2380
-    image: k8s.gcr.io/etcd:2.2.1
+    image: k8s.gcr.io/etcd:3.2.18
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/protokube/tests/integration/build_etcd_manifest/main/tls.yaml
+++ b/protokube/tests/integration/build_etcd_manifest/main/tls.yaml
@@ -6,7 +6,7 @@ clusterName: etcd-main
 clusterToken: token-main
 cpuRequest: "200m"
 dataDirName: data-main
-imageSource: k8s.gcr.io/etcd:2.2.1
+imageSource: k8s.gcr.io/etcd:3.2.18
 logFile: /var/log/etcd.log
 peerCA: /srv/kubernetes/ca.crt
 peerCert: /srv/kubernetes/etcd.pem
@@ -74,7 +74,7 @@ spec:
       value: /srv/kubernetes/etcd-key.pem
     - name: ETCD_INITIAL_CLUSTER
       value: node0=https://node0.internal:2380,node1=https://node1.internal:2380,node2=https://node2.internal:2380
-    image: k8s.gcr.io/etcd:2.2.1
+    image: k8s.gcr.io/etcd:3.2.18
     livenessProbe:
       initialDelaySeconds: 15
       tcpSocket:

--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
@@ -151,11 +151,11 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
   encryptionConfig: null
   etcdClusters:
     events:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      image: gcr.io/google_containers/etcd:3.2.18
+      version: 3.2.18
     main:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      image: gcr.io/google_containers/etcd:3.2.18
+      version: 3.2.18
   kubeAPIServer:
     address: 127.0.0.1
     admissionControl:

--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
@@ -178,7 +178,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
     logLevel: 2
     securePort: 443
     serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd2
+    storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
     attachDetachReconcileSyncPeriod: 1m0s

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -187,7 +187,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
     logLevel: 2
     securePort: 443
     serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd2
+    storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
     attachDetachReconcileSyncPeriod: 1m0s

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -160,11 +160,11 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
   encryptionConfig: null
   etcdClusters:
     events:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      image: gcr.io/google_containers/etcd:3.2.18
+      version: 3.2.18
     main:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      image: gcr.io/google_containers/etcd:3.2.18
+      version: 3.2.18
   kubeAPIServer:
     address: 127.0.0.1
     admissionControl:

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -178,7 +178,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     logLevel: 2
     securePort: 443
     serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd2
+    storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
     attachDetachReconcileSyncPeriod: 1m0s

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -151,11 +151,11 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   encryptionConfig: null
   etcdClusters:
     events:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      image: gcr.io/google_containers/etcd:3.2.18
+      version: 3.2.18
     main:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      image: gcr.io/google_containers/etcd:3.2.18
+      version: 3.2.18
   kubeAPIServer:
     address: 127.0.0.1
     admissionControl:

--- a/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_master-us-west-2a.masters.k8s-iam.us-west-2.td.priv_user_data
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_master-us-west-2a.masters.k8s-iam.us-west-2.td.priv_user_data
@@ -196,7 +196,7 @@ kubeAPIServer:
   - X-Remote-User
   securePort: 443
   serviceClusterIPRange: 100.64.0.0/13
-  storageBackend: etcd2
+  storageBackend: etcd3
 kubeControllerManager:
   allocateNodeCIDRs: true
   attachDetachReconcileSyncPeriod: 1m0s

--- a/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_master-us-west-2a.masters.k8s-iam.us-west-2.td.priv_user_data
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_master-us-west-2a.masters.k8s-iam.us-west-2.td.priv_user_data
@@ -154,9 +154,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 2.2.1
+    version: 3.2.18
   main:
-    version: 2.2.1
+    version: 3.2.18
 kubeAPIServer:
   address: 127.0.0.1
   admissionControl:

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -198,7 +198,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
     - X-Remote-User
     securePort: 443
     serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd2
+    storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
     attachDetachReconcileSyncPeriod: 1m0s

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -155,11 +155,11 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
   encryptionConfig: null
   etcdClusters:
     events:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      image: gcr.io/google_containers/etcd:3.2.18
+      version: 3.2.18
     main:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      image: gcr.io/google_containers/etcd:3.2.18
+      version: 3.2.18
   kubeAPIServer:
     address: 127.0.0.1
     admissionControl:

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -178,7 +178,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     logLevel: 2
     securePort: 443
     serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd2
+    storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
     attachDetachReconcileSyncPeriod: 1m0s

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -151,11 +151,11 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   encryptionConfig: null
   etcdClusters:
     events:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      image: gcr.io/google_containers/etcd:3.2.18
+      version: 3.2.18
     main:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      image: gcr.io/google_containers/etcd:3.2.18
+      version: 3.2.18
   kubeAPIServer:
     address: 127.0.0.1
     admissionControl:

--- a/upup/pkg/fi/cloudup/populatecluster_test.go
+++ b/upup/pkg/fi/cloudup/populatecluster_test.go
@@ -165,7 +165,7 @@ func TestPopulateCluster_StorageDefault(t *testing.T) {
 		t.Fatalf("Unexpected error from PopulateCluster: %v", err)
 	}
 
-	if fi.StringValue(full.Spec.KubeAPIServer.StorageBackend) != "etcd2" {
+	if fi.StringValue(full.Spec.KubeAPIServer.StorageBackend) != "etcd3" {
 		t.Fatalf("Unexpected StorageBackend: %v", full.Spec.KubeAPIServer.StorageBackend)
 	}
 }


### PR DESCRIPTION
This PR updates the default etcd version from 2.2.1 to the default as defined [here](https://github.com/kubernetes/kubernetes/blob/v1.11.0/cmd/kubeadm/app/constants/constants.go#L229), which is 3.2.18 for K8s 1.11