### PR TITLE
Fix a typo in usage of server.go

### DIFF
--- a/node-authorizer/cmd/node-authorizer/server.go
+++ b/node-authorizer/cmd/node-authorizer/server.go
@@ -48,7 +48,7 @@ func addServerCommand() cli.Command {
 			},
 			cli.StringFlag{
 				Name:   "tls-client-ca",
-				Usage:  "file containing the client certifcate authority, required for mutual tls `PATH`",
+				Usage:  "file containing the client certificate authority, required for mutual tls `PATH`",
 				EnvVar: "TLS_CLIENT_CA",
 			},
 			cli.StringFlag{


### PR DESCRIPTION
Line 51: certifcate->certificate