### PR TITLE
Add no_masq_local to weave network options.

### DIFF
--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -59,8 +59,9 @@ type KopeioNetworkingSpec struct {
 
 // WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU       *int32 `json:"mtu,omitempty"`
-	ConnLimit *int32 `json:"connLimit,omitempty"`
+	MTU         *int32 `json:"mtu,omitempty"`
+	ConnLimit   *int32 `json:"connLimit,omitempty"`
+	NoMasqLocal *int32 `json:"noMasqLocal,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -59,8 +59,9 @@ type KopeioNetworkingSpec struct {
 
 // WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU       *int32 `json:"mtu,omitempty"`
-	ConnLimit *int32 `json:"connLimit,omitempty"`
+	MTU         *int32 `json:"mtu,omitempty"`
+	ConnLimit   *int32 `json:"connLimit,omitempty"`
+	NoMasqLocal *int32 `json:"noMasqLocal,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -3294,6 +3294,7 @@ func Convert_kops_UserData_To_v1alpha1_UserData(in *kops.UserData, out *UserData
 func autoConvert_v1alpha1_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveNetworkingSpec, out *kops.WeaveNetworkingSpec, s conversion.Scope) error {
 	out.MTU = in.MTU
 	out.ConnLimit = in.ConnLimit
+	out.NoMasqLocal = in.NoMasqLocal
 	return nil
 }
 
@@ -3305,6 +3306,7 @@ func Convert_v1alpha1_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveN
 func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha1_WeaveNetworkingSpec(in *kops.WeaveNetworkingSpec, out *WeaveNetworkingSpec, s conversion.Scope) error {
 	out.MTU = in.MTU
 	out.ConnLimit = in.ConnLimit
+	out.NoMasqLocal = in.NoMasqLocal
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -3334,6 +3334,15 @@ func (in *WeaveNetworkingSpec) DeepCopyInto(out *WeaveNetworkingSpec) {
 			**out = **in
 		}
 	}
+	if in.NoMasqLocal != nil {
+		in, out := &in.NoMasqLocal, &out.NoMasqLocal
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int32)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -59,8 +59,9 @@ type KopeioNetworkingSpec struct {
 
 // WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU       *int32 `json:"mtu,omitempty"`
-	ConnLimit *int32 `json:"connLimit,omitempty"`
+	MTU         *int32 `json:"mtu,omitempty"`
+	ConnLimit   *int32 `json:"connLimit,omitempty"`
+	NoMasqLocal *int32 `json:"noMasqLocal,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3616,6 +3616,7 @@ func Convert_kops_UserData_To_v1alpha2_UserData(in *kops.UserData, out *UserData
 func autoConvert_v1alpha2_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveNetworkingSpec, out *kops.WeaveNetworkingSpec, s conversion.Scope) error {
 	out.MTU = in.MTU
 	out.ConnLimit = in.ConnLimit
+	out.NoMasqLocal = in.NoMasqLocal
 	return nil
 }
 
@@ -3627,6 +3628,7 @@ func Convert_v1alpha2_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveN
 func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha2_WeaveNetworkingSpec(in *kops.WeaveNetworkingSpec, out *WeaveNetworkingSpec, s conversion.Scope) error {
 	out.MTU = in.MTU
 	out.ConnLimit = in.ConnLimit
+	out.NoMasqLocal = in.NoMasqLocal
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3415,6 +3415,15 @@ func (in *WeaveNetworkingSpec) DeepCopyInto(out *WeaveNetworkingSpec) {
 			**out = **in
 		}
 	}
+	if in.NoMasqLocal != nil {
+		in, out := &in.NoMasqLocal, &out.NoMasqLocal
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int32)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3635,6 +3635,15 @@ func (in *WeaveNetworkingSpec) DeepCopyInto(out *WeaveNetworkingSpec) {
 			**out = **in
 		}
 	}
+	if in.NoMasqLocal != nil {
+		in, out := &in.NoMasqLocal, &out.NoMasqLocal
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int32)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -144,9 +144,9 @@ spec:
             - name: WEAVE_MTU
               value: "{{ .Networking.Weave.MTU }}"
             {{- end }}
-            {{- if .Networking.Weave.NO_MASQ_LOCAL }}
+            {{- if .Networking.Weave.NoMasqLocal }}
             - name: NO_MASQ_LOCAL
-              value: "{{ .Networking.Weave.NO_MASQ_LOCAL }}"
+              value: "{{ .Networking.Weave.NoMasqLocal }}"
             {{- end }}
             {{- if .Networking.Weave.ConnLimit }}
             - name: CONN_LIMIT

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -144,6 +144,10 @@ spec:
             - name: WEAVE_MTU
               value: "{{ .Networking.Weave.MTU }}"
             {{- end }}
+            {{- if .Networking.Weave.NO_MASQ_LOCAL }}
+            - name: NO_MASQ_LOCAL
+              value: "{{ .Networking.Weave.NO_MASQ_LOCAL }}"
+            {{- end }}
             {{- if .Networking.Weave.ConnLimit }}
             - name: CONN_LIMIT
               value: "{{ .Networking.Weave.ConnLimit }}"

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -490,7 +490,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 			"pre-k8s-1.6": "2.3.0-kops.2",
 			"k8s-1.6":     "2.3.0-kops.2",
 			"k8s-1.7":     "2.4.0-kops.1",
-			"k8s-1.8":     "2.4.0-kops.1",
+			"k8s-1.8":     "2.4.0-kops.2",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -90,4 +90,4 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.4.0-kops.1
+    version: 2.4.0-kops.2


### PR DESCRIPTION
This was an option that was added weave > 2.4.0 https://github.com/weaveworks/weave/issues/2924 to use the k8s feature `externalTrafficPolicy: Local` on services to preserve the sourceIp. https://kubernetes.io/docs/tutorials/services/source-ip/