### PR TITLE
Fixes spurious LoadBalancer change when using ACM Certificate

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/load_balancer.go
@@ -311,6 +311,7 @@ func (e *LoadBalancer) Find(c *fi.Context) (*LoadBalancer, error) {
 
 		actualListener := &LoadBalancerListener{}
 		actualListener.InstancePort = int(aws.Int64Value(l.InstancePort))
+		actualListener.SSLCertificateID = aws.StringValue(l.SSLCertificateId)
 		actual.Listeners[loadBalancerPort] = actualListener
 	}
 


### PR DESCRIPTION
When using `.spec.api.loadBalancer.sslCertificate`, subsequent `kops update cluster` report the following spurious change after the certificate has already been attached to the listener:
```
Will modify resources:
  LoadBalancer/api.$CLUSTER_NAME
  	Listeners           	 {443: {"InstancePort":443,"SSLCertificateID":""}} -> {443: {"InstancePort":443,"SSLCertificateID":"arn:aws:acm:us-east-1:000000000000:certificate/..."}}
```

This is because we werent keeping track of the ACM Certificate when describing the "actual" load balancer status.

This fixes that behavior, and now kops accurately reports no changes to be made. I also confirmed that `update cluster` continues to work on clusters that dont specify an `sslCertificate`.