### PR TITLE
Update golang version to 1.10.3, for k8s 1.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ GCS_URL=$(GCS_LOCATION:gs://%=https://storage.googleapis.com/%)
 LATEST_FILE?=latest-ci.txt
 GOPATH_1ST:=$(shell go env | grep GOPATH | cut -f 2 -d \")
 UNIQUE:=$(shell date +%s)
-GOVERSION=1.9.3
+GOVERSION=1.10.3
 BUILD=$(GOPATH_1ST)/src/k8s.io/kops/.build
 LOCAL=$(BUILD)/local
 BINDATA_TARGETS=upup/models/bindata.go
@@ -198,7 +198,7 @@ upup/models/bindata.go: ${GOBINDATA} ${UPUP_MODELS_BINDATA_SOURCES}
 
 # Build in a docker container with golang 1.X
 # Used to test we have not broken 1.X
-# 1.9 is preferred, 1.10 is likely to be the default soon.  1.8 is best-effort
+# 1.10 is the default for k8s 1.11.  Others are best-effort
 .PHONY: check-builds-in-go18
 check-builds-in-go18:
 	# Note we only check that kops builds; we know the tests don't compile because of type aliasing in uber zap

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,7 +18,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_too
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.9.3",
+    go_version = "1.10.3",
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")

--- a/images/dns-controller-builder/Dockerfile
+++ b/images/dns-controller-builder/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install --yes --reinstall lsb-base \
   && rm -rf /var/lib/apt/lists/*
 
 # Install golang
-RUN curl -L https://storage.googleapis.com/golang/go1.9.3.linux-amd64.tar.gz | tar zx -C /usr/local
+RUN curl -L https://storage.googleapis.com/golang/go1.10.3.linux-amd64.tar.gz | tar zx -C /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 COPY onbuild.sh /onbuild.sh

--- a/images/protokube-builder/Dockerfile
+++ b/images/protokube-builder/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install --yes --reinstall lsb-base \
   && rm -rf /var/lib/apt/lists/*
 
 # Install golang
-RUN curl -L https://storage.googleapis.com/golang/go1.9.3.linux-amd64.tar.gz | tar zx -C /usr/local
+RUN curl -L https://storage.googleapis.com/golang/go1.10.3.linux-amd64.tar.gz | tar zx -C /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 COPY onbuild.sh /onbuild.sh


### PR DESCRIPTION
k8s 1.11 is tested when built with go 1.10.3