### PR TITLE
Field names are case-sensitive again

### DIFF
--- a/docs/releases/1.11-NOTES.md
+++ b/docs/releases/1.11-NOTES.md
@@ -2,9 +2,16 @@
 
 # Significant changes
 
-* kops will attempt to remove NLBs (also known as ELB v2) that are tagged as
-  created by the cluster.  Please double-check the preview from `kops delete
-  cluster` before allowing deletion.
+* kops will attempt to remove NLBs (also known as ELB v2) that are
+  tagged as created by the cluster.  Please double-check the preview
+  from `kops delete cluster` before allowing deletion.
+
+* JSON & YAML field names in the kops objects are case-sensitive.
+  This was a regression across the kubernetes API libraries as
+  observed [kubernetes#64612](https://github.com/kubernetes/kubernetes/issues/64612).
+  Please double-check that you are using the correct field names if
+  you are constructing YAML / JSON outside of kops.
+
 
 # Required Actions
 

--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -213,8 +213,8 @@ func AWSNodeUpTemplate(ig *kops.InstanceGroup) (string, error) {
 			}
 		}
 
-		for _, UserDataInfo := range ig.Spec.AdditionalUserData {
-			err = writeUserDataPart(mimeWriter, UserDataInfo.Name, UserDataInfo.Type, []byte(UserDataInfo.Content))
+		for _, d := range ig.Spec.AdditionalUserData {
+			err = writeUserDataPart(mimeWriter, d.Name, d.Type, []byte(d.Content))
 			if err != nil {
 				return "", err
 			}

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -292,7 +292,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
   Mime-Version: 1.0
 
   #!/bin/sh
-  echo "Hello World.  The time is now $(date -R)!" | tee /root/output.txt
+  echo "master: The time is now $(date -R)!" | tee /root/output.txt
 
   --MIMEBOUNDARY--
 
@@ -521,6 +521,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
   Mime-Version: 1.0
 
   #!/bin/sh
-  echo "Hello World.  The time is now $(date -R)!" | tee /root/output.txt
+  echo "nodes: The time is now $(date -R)!" | tee /root/output.txt
 
   --MIMEBOUNDARY--

--- a/tests/integration/update_cluster/additional_user-data/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/additional_user-data/in-v1alpha2.yaml
@@ -63,12 +63,12 @@ spec:
   role: Node
   subnets:
   - us-test-1a
-  additionaluserdata:
+  additionalUserData:
   - name: myscript.sh
     type: text/x-shellscript
     content: |
       #!/bin/sh
-      echo "Hello World.  The time is now $(date -R)!" | tee /root/output.txt
+      echo "nodes: The time is now $(date -R)!" | tee /root/output.txt
 
 ---
 
@@ -88,10 +88,10 @@ spec:
   role: Master
   subnets:
   - us-test-1a
-  additionaluserdata:
+  additionalUserData:
   - name: myscript.sh
     type: text/x-shellscript
     content: |
       #!/bin/sh
-      echo "Hello World.  The time is now $(date -R)!" | tee /root/output.txt
+      echo "master: The time is now $(date -R)!" | tee /root/output.txt
 


### PR DESCRIPTION
(This is part of the larger k8s 1.11 update in #5823, but splitting it
out because it's important)

There was a regression in apimachinery which meant that kubernetes
tolerated field names with incorrect case.  Upstream bug is
https://github.com/kubernetes/kubernetes/issues/64612

Syncing up with latest kubernetes will mean we get the same breaking
change as kubernetes has/had.  It should only affect people that are
manually building YAML / JSON.

Added as a significant item to release notes.