### PR TITLE
Revert "Apply cloud labels into ELB"

### DIFF
--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -228,8 +228,6 @@ resource "aws_elb" "api-complex-example-com" {
   tags = {
     KubernetesCluster = "complex.example.com"
     Name              = "api.complex.example.com"
-    Owner             = "John Doe"
-    "foo/bar"         = "fib+baz"
   }
 }
 

--- a/upup/pkg/fi/cloudup/utils.go
+++ b/upup/pkg/fi/cloudup/utils.go
@@ -80,9 +80,6 @@ func BuildCloud(cluster *kops.Cluster) (fi.Cloud, error) {
 			}
 
 			cloudTags := map[string]string{awsup.TagClusterName: cluster.ObjectMeta.Name}
-			for k, v := range cluster.Spec.CloudLabels {
-				cloudTags[k] = v
-			}
 
 			awsCloud, err := awsup.NewAWSCloud(region, cloudTags)
 			if err != nil {


### PR DESCRIPTION
This reverts commit b52c945f9fca68d2c8685800736e94b7598fe4a3.

Adding the cloud label here means adding cloud labels everywhere. This causes resources which we're created by a previous kops binary _(thus not tagged)_ not to be found and hence marked as creating, duplicated the resources. 