### PR TITLE
Allow for some coredns customization

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -328,6 +328,8 @@ type KubeDNSConfig struct {
 	CacheMaxSize int `json:"cacheMaxSize,omitempty"`
 	// CacheMaxConcurrent is the maximum number of concurrent queries for dnsmasq
 	CacheMaxConcurrent int `json:"cacheMaxConcurrent,omitempty"`
+	// Corefile sets CoreDNS Corefile configuration
+	Corefile Corefile `json:"corefile,omitempty"`
 	// Domain is the dns domain
 	Domain string `json:"domain,omitempty"`
 	// Image is the name of the docker image to run - @deprecated as this is now in the addon
@@ -342,6 +344,12 @@ type KubeDNSConfig struct {
 	StubDomains map[string][]string `json:"stubDomains,omitempty"`
 	// UpstreamNameservers sets the upstream nameservers for queries not on the cluster domain
 	UpstreamNameservers []string `json:"upstreamNameservers,omitempty"`
+}
+
+// Corefile defines the Coredns Corefile configuration
+type Corefile struct {
+	EnableAutopath bool   `json:"enableAutopath,omitempty"`
+	Cache          string `json:"corefile,omitempty"`
 }
 
 // ExternalDNSConfig are options of the dns-controller

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -328,6 +328,8 @@ type KubeDNSConfig struct {
 	CacheMaxSize int `json:"cacheMaxSize,omitempty"`
 	// CacheMaxConcurrent is the maximum number of concurrent queries for dnsmasq
 	CacheMaxConcurrent int `json:"cacheMaxConcurrent,omitempty"`
+	// CoreDNSVersion sets the image version
+	CoreDNSVersion string `json:"coreDNSVersion,omitempty"`
 	// Corefile sets CoreDNS Corefile configuration
 	Corefile Corefile `json:"corefile,omitempty"`
 	// Domain is the dns domain

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -327,6 +327,10 @@ type KubeDNSConfig struct {
 	CacheMaxSize int `json:"cacheMaxSize,omitempty"`
 	// CacheMaxConcurrent is the maximum number of concurrent queries for dnsmasq
 	CacheMaxConcurrent int `json:"cacheMaxConcurrent,omitempty"`
+	// CoreDNSVersion sets the image version
+	CoreDNSVersion string `json:"coreDNSVersion,omitempty"`
+	// Corefile sets CoreDNS Corefile configuration
+	Corefile Corefile `json:"corefile,omitempty"`
 	// Domain is the dns domain
 	Domain string `json:"domain,omitempty"`
 	// Image is the name of the docker image to run - @deprecated as this is now in the addon
@@ -341,6 +345,12 @@ type KubeDNSConfig struct {
 	StubDomains map[string][]string `json:"stubDomains,omitempty"`
 	// UpstreamNameservers sets the upstream nameservers for queries not on the cluster domain
 	UpstreamNameservers []string `json:"upstreamNameservers,omitempty"`
+}
+
+// Corefile defines the Coredns Corefile configuration
+type Corefile struct {
+	EnableAutopath bool   `json:"enableAutopath,omitempty"`
+	Cache          string `json:"corefile,omitempty"`
 }
 
 // ExternalDNSConfig are options of the dns-controller

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -328,6 +328,8 @@ type KubeDNSConfig struct {
 	CacheMaxSize int `json:"cacheMaxSize,omitempty"`
 	// CacheMaxConcurrent is the maximum number of concurrent queries for dnsmasq
 	CacheMaxConcurrent int `json:"cacheMaxConcurrent,omitempty"`
+	// Corefile sets CoreDNS Corefile configuration
+	Corefile Corefile `json:"corefile,omitempty"`
 	// Domain is the dns domain
 	Domain string `json:"domain,omitempty"`
 	// Image is the name of the docker image to run - @deprecated as this is now in the addon
@@ -342,6 +344,12 @@ type KubeDNSConfig struct {
 	StubDomains map[string][]string `json:"stubDomains,omitempty"`
 	// UpstreamNameservers sets the upstream nameservers for queries not on the cluster domain
 	UpstreamNameservers []string `json:"upstreamNameservers,omitempty"`
+}
+
+// Corefile defines the Coredns Corefile configuration
+type Corefile struct {
+	EnableAutopath bool   `json:"enableAutopath,omitempty"`
+	Cache          string `json:"corefile,omitempty"`
 }
 
 // ExternalDNSConfig are options of the dns-controller

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -328,6 +328,8 @@ type KubeDNSConfig struct {
 	CacheMaxSize int `json:"cacheMaxSize,omitempty"`
 	// CacheMaxConcurrent is the maximum number of concurrent queries for dnsmasq
 	CacheMaxConcurrent int `json:"cacheMaxConcurrent,omitempty"`
+	// CoreDNSVersion sets the image version
+	CoreDNSVersion string `json:"coreDNSVersion,omitempty"`
 	// Corefile sets CoreDNS Corefile configuration
 	Corefile Corefile `json:"corefile,omitempty"`
 	// Domain is the dns domain

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -62,5 +62,9 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.KubeDNS.Cache = "30"
 	}
 
+	if clusterSpec.KubeDNS.CoreDNSVersion == "" {
+		clusterSpec.KubeDNS.CoreDNSVersion = "1.2.2"
+	}
+
 	return nil
 }

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -58,8 +58,8 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.KubeDNS.Domain = clusterSpec.ClusterDNSDomain
 	}
 
-	if clusterSpec.KubeDNS.Cache == "" {
-		clusterSpec.KubeDNS.Cache = "30"
+	if clusterSpec.KubeDNS.Corefile.Cache == "" {
+		clusterSpec.KubeDNS.Corefile.Cache = "30"
 	}
 
 	if clusterSpec.KubeDNS.CoreDNSVersion == "" {

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -58,5 +58,9 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.KubeDNS.Domain = clusterSpec.ClusterDNSDomain
 	}
 
+	if clusterSpec.KubeDNS.Cache == "" {
+		clusterSpec.KubeDNS.Cache = "30"
+	}
+
 	return nil
 }

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
@@ -105,7 +105,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.2.2
+        image: k8s.gcr.io/coredns:{{ KubeDNS.CoreDNSVersion }}
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
@@ -62,10 +62,13 @@ data:
           upstream
           fallthrough in-addr.arpa ip6.arpa
         }
+        {{ if KubeDNS.Corefile.EnableAutopath -}}
+        autpath @kubernetes
+        {{- end -}}
         prometheus :9153
         proxy . /etc/resolv.conf
         loop
-        cache 30
+        cache {{ KubeDNS.Corefile.Cache }}
         loadbalance
         reload
     }
@@ -84,7 +87,8 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
+      maxSurge: 10%
+      maxUnavailable: 0
   selector:
     matchLabels:
       k8s-app: kube-dns

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -211,7 +211,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 	if kubeDNS.Provider == "CoreDNS" {
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.2.2-kops.1"
+			version := "1.2.2-kops.2"
 
 			{
 				location := key + "/k8s-1.6.yaml"


### PR DESCRIPTION
I wanted to be able to enable autopath config and thought I would also try and fix #5773 along the way and add a few other minor changes. Imo the update strategy of kube-dns made more sense to have maxUnavailable set to 0. What do you think?

I also haven't tested the cache setting, but I think by having it a string, the full control should be possible including the extended config
```
cache [TTL] [ZONES...] {
    success CAPACITY [TTL]
    denial CAPACITY [TTL]
    prefetch AMOUNT [[DURATION] [PERCENTAGE%]]
}
```
by just using a yaml multi-line string.

This is the first PR of this nature that I have done btw, so hope modified everything at the right place.