### PR TITLE
Node Authorizer Fixes

### DIFF
--- a/node-authorizer/cmd/node-authorizer/BUILD.bazel
+++ b/node-authorizer/cmd/node-authorizer/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//node-authorizer/pkg/authorizers/aws:go_default_library",
         "//node-authorizer/pkg/client:go_default_library",
         "//node-authorizer/pkg/server:go_default_library",
+        "//node-authorizer/pkg/utils:go_default_library",
         "//vendor/github.com/urfave/cli:go_default_library",
     ],
 )

--- a/node-authorizer/cmd/node-authorizer/server.go
+++ b/node-authorizer/cmd/node-authorizer/server.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/kops/node-authorizer/pkg/authorizers/alwaysallow"
 	"k8s.io/kops/node-authorizer/pkg/authorizers/aws"
 	"k8s.io/kops/node-authorizer/pkg/server"
+	"k8s.io/kops/node-authorizer/pkg/utils"
 
-	"github.com/gambol99/aws-sso/pkg/utils"
 	"github.com/urfave/cli"
 )
 

--- a/node-authorizer/cmd/node-authorizer/server.go
+++ b/node-authorizer/cmd/node-authorizer/server.go
@@ -170,7 +170,7 @@ func waitForCertificates(files []string, timeout time.Duration) error {
 				if utils.FileExists(x) {
 					break
 				}
-				fmt.Printf("waiting for file: %s to appear, timeouts in %s", x, expires.Sub(time.Now()))
+				fmt.Printf("waiting for file: %s to appear, timeouts in %s\n", x, expires.Sub(time.Now()))
 				time.Sleep(5 * time.Second)
 			}
 		}

--- a/node-authorizer/cmd/node-authorizer/server.go
+++ b/node-authorizer/cmd/node-authorizer/server.go
@@ -153,7 +153,7 @@ func actionServerCommand(ctx *cli.Context) error {
 	return svc.Run()
 }
 
-// waitForCertificates is responisble for waiting for the certificates to appear
+// waitForCertificates is responsible for waiting for the certificates to appear
 func waitForCertificates(files []string, timeout time.Duration) error {
 	doneCh := make(chan struct{}, 0)
 

--- a/node-authorizer/pkg/utils/misc.go
+++ b/node-authorizer/pkg/utils/misc.go
@@ -19,6 +19,7 @@ package utils
 import (
 	crypto_rand "crypto/rand"
 	"encoding/hex"
+	"os"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -32,6 +33,15 @@ func GetKubernetesClient() (kubernetes.Interface, error) {
 	}
 
 	return kubernetes.NewForConfig(config)
+}
+
+// FileExists checks if the file exists
+func FileExists(filename string) bool {
+	if _, err := os.Stat(filename); !os.IsNotExist(err) {
+		return true
+	}
+
+	return false
 }
 
 // RandomBytes generates some random bytes

--- a/node-authorizer/pkg/utils/misc.go
+++ b/node-authorizer/pkg/utils/misc.go
@@ -37,11 +37,11 @@ func GetKubernetesClient() (kubernetes.Interface, error) {
 
 // FileExists checks if the file exists
 func FileExists(filename string) bool {
-	if _, err := os.Stat(filename); !os.IsNotExist(err) {
-		return true
+	if _, err := os.Stat(filename); err != nil {
+		return false
 	}
 
-	return false
+	return true
 }
 
 // RandomBytes generates some random bytes

--- a/pkg/model/components/node-authorizer/options.go
+++ b/pkg/model/components/node-authorizer/options.go
@@ -100,5 +100,5 @@ func GetNodeAuthorizerImage() string {
 		return v
 	}
 
-	return "quay.io/gambol99/node-authorizer:v0.0.1@sha256:3ff243f5af76a73b6faaa6a0b0be8e3882dd1e7ffea6bacda9bede2273446059"
+	return "quay.io/gambol99/node-authorizer:v0.0.2@sha256:4a9f17072cb937ccbe3042add3e7da8152a7f35ffbdf8b96ae49306f6b59c080"
 }

--- a/pkg/model/components/node-authorizer/options.go
+++ b/pkg/model/components/node-authorizer/options.go
@@ -100,5 +100,5 @@ func GetNodeAuthorizerImage() string {
 		return v
 	}
 
-	return "quay.io/gambol99/node-authorizer:v0.0.2@sha256:4a9f17072cb937ccbe3042add3e7da8152a7f35ffbdf8b96ae49306f6b59c080"
+	return "quay.io/gambol99/node-authorizer:v0.0.2@sha256:78c20c69187d3098e196e2b645d0571aeef377adc5cbd89684023ec668306268"
 }

--- a/upup/models/cloudup/resources/addons/node-authorizer.addons.k8s.io/k8s-1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-authorizer.addons.k8s.io/k8s-1.10.yaml.template
@@ -147,7 +147,7 @@ spec:
         - name: config
           hostPath:
             path: /srv/kubernetes/node-authorizer
-            type: Directory
+            type: DirectoryOrCreate
       containers:
         - name: {{ $name }}
           image: {{ $na.Image }}

--- a/upup/models/cloudup/resources/addons/node-authorizer.addons.k8s.io/k8s-1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-authorizer.addons.k8s.io/k8s-1.10.yaml.template
@@ -171,20 +171,6 @@ spec:
             requests:
               cpu: 10m
               memory: 10Mi
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: {{ $na.Port }}
-              scheme: HTTPS
-            periodSeconds: 10
-            initialDelaySeconds: 10
-            failureThreshold: 5
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: {{ $na.Port }}
-              scheme: HTTPS
-            periodSeconds: 10
           volumeMounts:
             - mountPath: /config
               readOnly: true

--- a/upup/models/cloudup/resources/addons/node-authorizer.addons.k8s.io/k8s-1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-authorizer.addons.k8s.io/k8s-1.10.yaml.template
@@ -152,18 +152,18 @@ spec:
         - name: {{ $name }}
           image: {{ $na.Image }}
           args:
-          - server
-          - --authorization-timeout={{ $na.Timeout.Duration }}
-          - --authorizer={{ $na.Authorizer }}
-          - --cluster-name={{ ClusterName }}
-          {{- range $na.Features }}
-          - --feature={{ . }}
-          {{- end }}
-          - --listen=0.0.0.0:{{ $na.Port }}
-          - --tls-cert=/config/tls.pem
-          - --tls-client-ca=/config/ca.pem
-          - --tls-private-key=/config/tls-key.pem
-          - --token-ttl={{ $na.TokenTTL.Duration }}
+            - server
+            - --authorization-timeout={{ $na.Timeout.Duration }}
+            - --authorizer={{ $na.Authorizer }}
+            - --cluster-name={{ ClusterName }}
+            {{- range $na.Features }}
+            - --feature={{ . }}
+            {{- end }}
+            - --listen=0.0.0.0:{{ $na.Port }}
+            - --tls-cert=/config/tls.pem
+            - --tls-client-ca=/config/ca.pem
+            - --tls-private-key=/config/tls-key.pem
+            - --token-ttl={{ $na.TokenTTL.Duration }}
           resources:
             limits:
               cpu: 100m

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -150,7 +150,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 	if b.cluster.Spec.NodeAuthorization != nil {
 		{
 			key := "node-authorizer.addons.k8s.io"
-			version := "v0.0.1"
+			version := "v0.0.2"
 
 			{
 				location := key + "/k8s-1.10.yaml"


### PR DESCRIPTION
This PR adds a number of fixes for rolling out the node authorizer from a previous version. This main issue is caused by the fact the node-authorizer, a daemonset on the master nodes, is rolled to all nodes regardless of if it's been updated or now. Thus master nodes which have not been rolled yet and thus haven't pulled down the certificates via nodeup will fail. This causes the validation code which checks for failing pods in the `kube-system` namespace to fail, even though everything is fine. 