### PR TITLE
Update Weave Net to version 2.4.1

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -155,7 +155,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.4.0'
+          image: 'weaveworks/weave-kube:2.4.1'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -193,7 +193,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.4.0'
+          image: 'weaveworks/weave-npc:2.4.1'
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -155,7 +155,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.4.0'
+          image: 'weaveworks/weave-kube:2.4.1'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -193,7 +193,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.4.0'
+          image: 'weaveworks/weave-npc:2.4.1'
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
Includes bug fixes to the deleted-node cleanup code.  Those bugs have hit people with auto-scaling groups that go up and down - definitely a recommended update in this case.

Release notes https://github.com/weaveworks/weave/releases/tag/v2.4.1
