### PR TITLE
Fix mis-typing in CLI command documentations

### DIFF
--- a/cmd/kops/validate.go
+++ b/cmd/kops/validate.go
@@ -31,7 +31,7 @@ var (
 
 	1. All k8s masters are running and have "Ready" status.
 	2. All k8s nodes are running and have "Ready" status.
-	3. Componentstatues returns healthy for all components.
+	3. Component status returns healthy for all components.
 	4. All pods in the kube-system namespace are running and healthy.
 	`))
 

--- a/docs/cli/kops_validate.md
+++ b/docs/cli/kops_validate.md
@@ -11,7 +11,7 @@ This commands validates the following components:
 
   1. All k8s masters are running and have "Ready" status.  
   2. All k8s nodes are running and have "Ready" status.  
-  3. Componentstatues returns healthy for all components.  
+  3. Component status returns healthy for all components.  
   4. All pods in the kube-system namespace are running and healthy.
 
 ### Examples

--- a/docs/cli/kops_validate_cluster.md
+++ b/docs/cli/kops_validate_cluster.md
@@ -11,7 +11,7 @@ This commands validates the following components:
 
   1. All k8s masters are running and have "Ready" status.  
   2. All k8s nodes are running and have "Ready" status.  
-  3. Componentstatues returns healthy for all components.  
+  3. Component status returns healthy for all components.  
   4. All pods in the kube-system namespace are running and healthy.
 
 ```


### PR DESCRIPTION
I found some mis-typed documentations in CLI.