### PR TITLE
Stop cloudformation output switching to literal quotes

### DIFF
--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -295,7 +295,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
   echo "master: The time is now $(date -R)!" | tee /root/output.txt
 
   --MIMEBOUNDARY--
-
 Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Properties.UserData: |
   Content-Type: multipart/mixed; boundary="MIMEBOUNDARY"
   MIME-Version: 1.0


### PR DESCRIPTION
yaml can't store the \r character, so we strip the \r characters in
the expected output to keep the yaml output in block-quote style.
    
Also don't Fatalf out of an error, rather Errorf so we print all
problems.
