### PR TITLE
Node mode controllers

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -377,7 +377,7 @@ type KubeControllerManagerConfig struct {
 	// ConfigureCloudRoutes enables CIDRs allocated with to be configured on the cloud provider.
 	ConfigureCloudRoutes *bool `json:"configureCloudRoutes,omitempty" flag:"configure-cloud-routes"`
 	// Controllers is a list of controllers to enable on the controller-manager
-	Controllers *[]string `json:"controllers,omitempty" flag:"controllers"`
+	Controllers []string `json:"controllers,omitempty" flag:"controllers"`
 	// CIDRAllocatorType specifies the type of CIDR allocator to use.
 	CIDRAllocatorType *string `json:"cidrAllocatorType,omitempty" flag:"cidr-allocator-type"`
 	// rootCAFile is the root certificate authority will be included in service account's token secret. This must be a valid PEM-encoded CA bundle.

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -377,7 +377,7 @@ type KubeControllerManagerConfig struct {
 	// ConfigureCloudRoutes enables CIDRs allocated with to be configured on the cloud provider.
 	ConfigureCloudRoutes *bool `json:"configureCloudRoutes,omitempty" flag:"configure-cloud-routes"`
 	// Controllers is a list of controllers to enable on the controller-manager
-	Controllers *[]string `json:"controllers,omitempty" flag:"controllers"`
+	Controllers []string `json:"controllers,omitempty" flag:"controllers"`
 	// CIDRAllocatorType specifies the type of CIDR allocator to use.
 	CIDRAllocatorType *string `json:"cidrAllocatorType,omitempty" flag:"cidr-allocator-type"`
 	// rootCAFile is the root certificate authority will be included in service account's token secret. This must be a valid PEM-encoded CA bundle.

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2199,16 +2199,8 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 	}
 	if in.Controllers != nil {
 		in, out := &in.Controllers, &out.Controllers
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new([]string)
-			if **in != nil {
-				in, out := *in, *out
-				*out = make([]string, len(*in))
-				copy(*out, *in)
-			}
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.CIDRAllocatorType != nil {
 		in, out := &in.CIDRAllocatorType, &out.CIDRAllocatorType

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -377,7 +377,7 @@ type KubeControllerManagerConfig struct {
 	// ConfigureCloudRoutes enables CIDRs allocated with to be configured on the cloud provider.
 	ConfigureCloudRoutes *bool `json:"configureCloudRoutes,omitempty" flag:"configure-cloud-routes"`
 	// Controllers is a list of controllers to enable on the controller-manager
-	Controllers *[]string `json:"controllers,omitempty" flag:"controllers"`
+	Controllers []string `json:"controllers,omitempty" flag:"controllers"`
 	// CIDRAllocatorType specifies the type of CIDR allocator to use.
 	CIDRAllocatorType *string `json:"cidrAllocatorType,omitempty" flag:"cidr-allocator-type"`
 	// rootCAFile is the root certificate authority will be included in service account's token secret. This must be a valid PEM-encoded CA bundle.

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2280,16 +2280,8 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 	}
 	if in.Controllers != nil {
 		in, out := &in.Controllers, &out.Controllers
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new([]string)
-			if **in != nil {
-				in, out := *in, *out
-				*out = make([]string, len(*in))
-				copy(*out, *in)
-			}
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.CIDRAllocatorType != nil {
 		in, out := &in.CIDRAllocatorType, &out.CIDRAllocatorType

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2468,16 +2468,8 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 	}
 	if in.Controllers != nil {
 		in, out := &in.Controllers, &out.Controllers
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new([]string)
-			if **in != nil {
-				in, out := *in, *out
-				*out = make([]string, len(*in))
-				copy(*out, *in)
-			}
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.CIDRAllocatorType != nil {
 		in, out := &in.CIDRAllocatorType, &out.CIDRAllocatorType

--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -167,5 +167,13 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 		}
 	}
 
+	// @check if the node authorization is enabled and if so enable the tokencleaner controller (disabled by default)
+	// This is responsible for cleaning up bootstrap tokens which have expired
+	if b.Context.IsKubernetesGTE("1.10") {
+		if fi.BoolValue(clusterSpec.KubeAPIServer.EnableBootstrapAuthToken) && len(kcm.Controllers) <= 0 {
+			kcm.Controllers = []string{"*", "tokencleaner"}
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
- Changing the `controllers` flag to a `[]string`, not the last PR wouldn't have worked as the `flagbuilder` does not handle pointers to a string slice.
- Defaulting to adding the tokencleaner if the bootstrap tokens are enabled