### PR TITLE
Generate much smaller keys in integration tests

### DIFF
--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/apis/kops/v1alpha2:go_default_library",
         "//pkg/diff:go_default_library",
         "//pkg/kopscodecs:go_default_library",
+        "//pkg/pki:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//upup/pkg/fi/cloudup/gce:go_default_library",


### PR DESCRIPTION
We expose the default key size, and temporarily set it to 512 (from
2048) during testing.  This is much faster, and key generation was the
primary bottleneck.