### PR TITLE
Fixed missing closing bracket from MIN_NODES

### DIFF
--- a/addons/cluster-autoscaler/v1.10.0.yaml
+++ b/addons/cluster-autoscaler/v1.10.0.yaml
@@ -155,7 +155,7 @@ spec:
             - --stderrthreshold=info
             - --cloud-provider={{CLOUD_PROVIDER}}
             - --skip-nodes-with-local-storage=false
-            - --nodes={{MIN_NODES}:{{MAX_NODES}}:{{GROUP_NAME}}
+            - --nodes={{MIN_NODES}}:{{MAX_NODES}}:{{GROUP_NAME}}
           env:
             - name: AWS_REGION
               value: {{AWS_REGION}}


### PR DESCRIPTION
MIN_NODES placeholder in YAML file is missing closing "}" which leads to corrupted YAML.