### PR TITLE
Updating image and docs for metrics-server add-on

### DIFF
--- a/addons/metrics-server/README.md
+++ b/addons/metrics-server/README.md
@@ -1,9 +1,27 @@
 # Kubernetes Metrics Server
 
+## User guide
+
+You can find the user guide in
+[the official Kubernetes documentation](https://kubernetes.io/docs/tasks/debug-application-cluster/core-metrics-pipeline/).
+
+## Design
+
+The detailed design of the project can be found in the following docs:
+
+- [Metrics API](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/resource-metrics-api.md)
+- [Metrics Server](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/metrics-server.md)
+
+For the broader view of monitoring in Kubernetes take a look into
+[Monitoring architecture](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/monitoring_architecture.md)
+
+## Deployment
+
 Compatibility matrix:
 
 Metrics Server | Metrics API group/version | Supported Kubernetes version
 ---------------|---------------------------|-----------------------------
+0.3.x          | `metrics.k8s.io/v1beta1`  | 1.8+
 0.2.x          | `metrics.k8s.io/v1beta1`  | 1.8+
 0.1.x          | `metrics/v1alpha1`        | 1.7
 
@@ -18,3 +36,44 @@ $ kubectl apply -f https://raw.githubusercontent.com/kubernetes/kops/master/addo
 # Kubernetes 1.8+
 $ kubectl apply -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/metrics-server/v1.8.x.yaml
 ```
+
+## Flags
+
+Metrics Server supports all the standard Kubernetes API server flags, as
+well as the standard Kubernetes `glog` logging flags.  The most
+commonly-used ones are:
+
+- `--logtostderr`: log to standard error instead of files in the
+  container.  You generally want this on.
+
+- `--v=<X>`: set log verbosity.  It's generally a good idea to run a log
+  level 1 or 2 unless you're encountering errors.  At log level 10, large
+  amounts of diagnostic information will be reported, include API request
+  and response bodies, and raw metric results from Kubelet.
+
+- `--secure-port=<port>`: set the secure port.  If you're not running as
+  root, you'll want to set this to something other than the default (port
+  443).
+
+- `--tls-cert-file`, `--tls-private-key-file`: the serving certificate and
+  key files.  If not specified, self-signed certificates will be
+  generated, but it's recommended that you use non-self-signed
+  certificates in production.
+
+Additionally, Metrics Server defines a number of flags for configuring its
+behavior:
+
+- `--metric-resolution=<duration>`: the interval at which metrics will be
+  scraped from Kubelets (defaults to 60s).
+
+- `--kubelet-insecure-tls`: skip verifying Kubelet CA certificates.  Not
+  recommended for production usage, but can be useful in test clusters
+  with self-signed Kubelet serving certificates.
+
+- `--kubelet-port`: the port to use to connect to the Kubelet (defaults to
+  the default secure Kubelet port, 10250).
+
+- `--kubelet-preferred-address-types`: the order in which to consider
+  different Kubelet node address types when connecting to Kubelet.
+  Functions similarly to the flag of the same name on the API server.
+s

--- a/addons/metrics-server/v1.8.x.yaml
+++ b/addons/metrics-server/v1.8.x.yaml
@@ -57,6 +57,19 @@ rules:
       - list
       - watch
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:aggregated-metrics-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -99,7 +112,7 @@ spec:
       protocol: TCP
       targetPort: 443
 ---
-apiVersion: apps/v1beta2
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: metrics-server
@@ -117,17 +130,14 @@ spec:
         k8s-app: metrics-server
     spec:
       serviceAccountName: metrics-server
+      volumes:
+      # mount in tmp so we can safely use from-scratch images and/or read-only containers
+      - name: tmp-dir
+        emptyDir: {}
       containers:
-        - name: metrics-server
-          image: gcr.io/google_containers/metrics-server-amd64:v0.2.1
-          imagePullPolicy: Always
-          command:
-            - /metrics-server
-            - --source=kubernetes.summary_api:''
-          resources:
-            requests:
-              cpu: 20m
-              memory: 200Mi
-            limits:
-              cpu: 100m
-              memory: 500Mi
+      - name: metrics-server
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: tmp-dir
+          mountPath: /tmp


### PR DESCRIPTION
Updating image to `v0.3.1` and adding more information to README on custom args. All this is the latest info from https://github.com/kubernetes-incubator/metrics-server/

EDIT: Changed image from `k8s.gcr.io/metrics-server-amd64:v0.3.1` to `gcr.io/google_containers/metrics-server-amd64:v0.3.1` as that is the official location of the production helm chart images.