### PR TITLE
Fix typos issues in upup files

### DIFF
--- a/protokube/pkg/protokube/kube_boot.go
+++ b/protokube/pkg/protokube/kube_boot.go
@@ -63,7 +63,7 @@ type KubeBoot struct {
 	EtcdBackupStore string
 	// Etcd container registry location.
 	EtcdImageSource string
-	// EtcdElectionTimeout is is the leader election timeout
+	// EtcdElectionTimeout is the leader election timeout
 	EtcdElectionTimeout string
 	// EtcdHeartbeatInterval is the heartbeat interval
 	EtcdHeartbeatInterval string

--- a/upup/pkg/fi/assettasks/copyfile.go
+++ b/upup/pkg/fi/assettasks/copyfile.go
@@ -190,7 +190,7 @@ func writeFile(c *fi.Context, p vfs.Path, data []byte) error {
 	return nil
 }
 
-// buildVFSPath task a recognizable https url and transforms that URL into the equivalent url with the the object
+// buildVFSPath task a recognizable https url and transforms that URL into the equivalent url with the object
 // store prefix.
 func buildVFSPath(target string) (string, error) {
 	if !strings.Contains(target, "://") || strings.HasPrefix(target, "memfs://") {

--- a/upup/pkg/fi/cloudup/gcetasks/storagebucketacl.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storagebucketacl.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
 )
 
-// StorageBucketAcl represents an ACL rule on a google cloud storage storage bucket
+// StorageBucketAcl represents an ACL rule on a google cloud storage bucket
 //go:generate fitask -type=StorageBucketAcl
 type StorageBucketAcl struct {
 	Name      *string

--- a/upup/pkg/fi/cloudup/gcetasks/storagebucketiam.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storagebucketiam.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
 )
 
-// StorageBucketIam represents an IAM policy on a google cloud storage storage bucket
+// StorageBucketIam represents an IAM policy on a google cloud storage bucket
 //go:generate fitask -type=StorageBucketIam
 type StorageBucketIam struct {
 	Name      *string

--- a/upup/pkg/fi/cloudup/gcetasks/storageobjectacl.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storageobjectacl.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
 )
 
-// StorageObjectAcl represents an ACL rule on a google cloud storage storage object
+// StorageObjectAcl represents an ACL rule on a google cloud storage object
 //go:generate fitask -type=StorageObjectAcl
 type StorageObjectAcl struct {
 	Name      *string

--- a/upup/pkg/fi/cloudup/networking.go
+++ b/upup/pkg/fi/cloudup/networking.go
@@ -114,7 +114,7 @@ const (
 	defaultCNIAssetK8s1_6           = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz"
 	defaultCNIAssetHashStringK8s1_6 = "1d9788b0f5420e1a219aad2cb8681823fc515e7c"
 
-	// defaultCNIAssetK8s1_9 is the CNI tarball for for 1.9.x k8s.
+	// defaultCNIAssetK8s1_9 is the CNI tarball for 1.9.x k8s.
 	defaultCNIAssetK8s1_9           = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz"
 	defaultCNIAssetHashStringK8s1_9 = "d595d3ded6499a64e8dac02466e2f5f2ce257c9f"
 


### PR DESCRIPTION
Fix typos issues in below files:

1. protokube/pkg/protokube/kube_boot.go
2. upup/pkg/fi/assettasks/copyfile.go
3. upup/pkg/fi/cloudup/gcetasks/storagebucketacl.go
4. upup/pkg/fi/cloudup/gcetasks/storagebucketiam.go
5. upup/pkg/fi/cloudup/gcetasks/storageobjectacl.go
6. upup/pkg/fi/cloudup/networking.go