### PR TITLE
add targetRamMb to kubeAPIServer spec

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -264,6 +264,16 @@ spec:
     serviceNodePortRange: 30000-33000
 ```
 
+#### targetRamMb
+
+Memory limit for apiserver in MB (used to configure sizes of caches, etc.)
+
+```yaml
+spec:
+  kubeAPIServer:
+    targetRamMb: 4096
+```
+
 ### externalDns
 
 This block contains configuration options for your `external-DNS` provider.

--- a/nodeup/pkg/model/kube_apiserver_test.go
+++ b/nodeup/pkg/model/kube_apiserver_test.go
@@ -92,6 +92,12 @@ func Test_KubeAPIServer_BuildFlags(t *testing.T) {
 			},
 			"--experimental-encryption-provider-config=/srv/kubernetes/encryptionconfig.yaml --insecure-port=0 --secure-port=0",
 		},
+		{
+			kops.KubeAPIServerConfig{
+				TargetRamMb: 320,
+			},
+			"--insecure-port=0 --secure-port=0 --target-ram-mb=320",
+		},
 	}
 
 	for _, g := range grid {

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -354,6 +354,9 @@ type KubeAPIServerConfig struct {
 	// MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out.
 	// Currently only honored by the watch request handler
 	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`
+
+	// Memory limit for apiserver in MB (used to configure sizes of caches, etc.)
+	TargetRamMb int32 `json:"targetRamMb,omitempty" flag:"target-ram-mb" flag-empty:"0"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -354,6 +354,9 @@ type KubeAPIServerConfig struct {
 	// MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out.
 	// Currently only honored by the watch request handler
 	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`
+
+	// Memory limit for apiserver in MB (used to configure sizes of caches, etc.)
+	TargetRamMb int32 `json:"targetRamMb,omitempty" flag:"target-ram-mb" flag-empty:"0"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -2221,6 +2221,7 @@ func autoConvert_v1alpha1_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.MaxMutatingRequestsInflight = in.MaxMutatingRequestsInflight
 	out.EtcdQuorumRead = in.EtcdQuorumRead
 	out.MinRequestTimeout = in.MinRequestTimeout
+	out.TargetRamMb = in.TargetRamMb
 	return nil
 }
 
@@ -2293,6 +2294,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha1_KubeAPIServerConfig(in *ko
 	out.MaxMutatingRequestsInflight = in.MaxMutatingRequestsInflight
 	out.EtcdQuorumRead = in.EtcdQuorumRead
 	out.MinRequestTimeout = in.MinRequestTimeout
+	out.TargetRamMb = in.TargetRamMb
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -354,6 +354,9 @@ type KubeAPIServerConfig struct {
 	// MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out.
 	// Currently only honored by the watch request handler
 	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`
+
+	// Memory limit for apiserver in MB (used to configure sizes of caches, etc.)
+	TargetRamMb int32 `json:"targetRamMb,omitempty" flag:"target-ram-mb" flag-empty:"0"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2485,6 +2485,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.MaxMutatingRequestsInflight = in.MaxMutatingRequestsInflight
 	out.EtcdQuorumRead = in.EtcdQuorumRead
 	out.MinRequestTimeout = in.MinRequestTimeout
+	out.TargetRamMb = in.TargetRamMb
 	return nil
 }
 
@@ -2557,6 +2558,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.MaxMutatingRequestsInflight = in.MaxMutatingRequestsInflight
 	out.EtcdQuorumRead = in.EtcdQuorumRead
 	out.MinRequestTimeout = in.MinRequestTimeout
+	out.TargetRamMb = in.TargetRamMb
 	return nil
 }
 


### PR DESCRIPTION
This PR adds support for setting targetRamMb in the kube apiserver spec