### PR TITLE
Allow kubelet to run kubectl drain

### DIFF
--- a/upup/models/cloudup/resources/addons/rbac.addons.k8s.io/k8s-1.8.yaml
+++ b/upup/models/cloudup/resources/addons/rbac.addons.k8s.io/k8s-1.8.yaml
@@ -19,3 +19,20 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: kubelet
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubelet-cluster-view
+  labels:
+    k8s-addon: rbac.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: kubelet


### PR DESCRIPTION
kubectl drain can be run using the kubelet user prior to shutdown,
but only if the kubelet user is allowed to view daemonsets. Applying
the view permission to kubelet seems to be a safe, simple way of
achieving this

With this change, if kubectl is installed, the following works:

```
kubectl drain --ignore-daemonsets=true $(hostname -f) --kubeconfig /var/lib/kubelet/kubeconfig
```