### PR TITLE
Recognize shasum format for hashes

### DIFF
--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -300,7 +300,9 @@ func (a *AssetBuilder) findHash(file *FileAsset) (*hashing.Hash, error) {
 		hashString := strings.TrimSpace(string(b))
 		glog.V(2).Infof("Found hash %q for %q", hashString, u)
 
-		return hashing.FromString(hashString)
+		// Accept a hash string that is `<hash> <filename>`
+		fields := strings.Fields(hashString)
+		return hashing.FromString(fields[0])
 	}
 
 	if a.AssetsLocation != nil && a.AssetsLocation.FileRepository != nil {


### PR DESCRIPTION
The CNI assets have started publishing with shasum files as their
.sha1 files, instead of the bare hashes we use elsewhere.