### PR TITLE
[monitoring-standalone] Add kubernetes 1.7 version

### DIFF
--- a/addons/monitoring-standalone/addon.yaml
+++ b/addons/monitoring-standalone/addon.yaml
@@ -19,7 +19,11 @@ spec:
     selector:
       k8s-addon: monitoring-standalone.addons.k8s.io
     manifest: v1.6.0.yaml
-    kubernetesVersion: ">=1.6.0"
+  - version: 1.7.0
+    selector:
+      k8s-addon: monitoring-standalone.addons.k8s.io
+    manifest: v1.7.0.yaml
+    kubernetesVersion: ">=1.7.0"
   - version: 1.11.0
     selector:
       k8s-addon: monitoring-standalone.addons.k8s.io


### PR DESCRIPTION
## Problem

- For some reason, kubernetes 1.7 version has been deleted from addons.yaml.
- Installing `monitoring-standalone` with 1.6 config file failed with the following error
![](https://i.imgur.com/wSJCL0H.jpg)

## Solution

- Add support for kubernetes 1.7 version in addons.yaml