### PR TITLE
Canal Manifest Fix (Kubernetes >= v1.12.0)

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.8.yaml.template
@@ -272,7 +272,6 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global Felix Configuration
 kind: CustomResourceDefinition
 metadata:
    name: globalfelixconfigs.crd.projectcalico.org
@@ -288,7 +287,6 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global BGP Configuration
 kind: CustomResourceDefinition
 metadata:
   name: globalbgpconfigs.crd.projectcalico.org
@@ -304,7 +302,6 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico IP Pools
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
@@ -320,7 +317,6 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global Network Policies
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -649,7 +649,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		versions := map[string]string{
 			"pre-k8s-1.6": "2.4.2-kops.2",
 			"k8s-1.6":     "2.4.2-kops.2",
-			"k8s-1.8":     "2.6.7-kops.2",
+			"k8s-1.8":     "2.6.7-kops.3",
 		}
 
 		{


### PR DESCRIPTION
So the current canal manifest contains a 'description' field which as far as I can tell from the 
API documentation never existed (in apimachinery). Previous versions probably ignored the field but while testing v1.12.1 I noticed canal no longer deployed correctly due to the validation error. I've bumped the versions and removed the field from the manifest; this shouldn't have any impact on those already deployed, but as an alternative we could copy and paste 1.8 manifest, add an exclusion in the [bootstrapchannelbuilder.go](https://github.com/kubernetes/kops/blob/master/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go#L685-L699) to use >1.8.0 <=1.12.0 etc and use new manifest for >=1.12.0 (if you get what i know :-))

Post removing the `description` field the networking works again .. 

```shell
$ kubectl -n kube-system get no
NAME                                           STATUS    ROLES     AGE       VERSION
ip-10-250-100-205.eu-west-2.compute.internal   Ready     node      7m        v1.12.1
ip-10-250-101-235.eu-west-2.compute.internal   Ready     node      7m        v1.12.1
ip-10-250-31-88.eu-west-2.compute.internal     Ready     master    10m       v1.12.1
ip-10-250-32-8.eu-west-2.compute.internal      Ready     master    10m       v1.12.1
ip-10-250-33-116.eu-west-2.compute.internal    Ready     master    10m       v1.12.1
```