### PR TITLE
Promote kubernetes versions from alpha to stable

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -31,11 +31,14 @@ spec:
     networking:
       kubenet: {}
   kubernetesVersions:
+  - range: ">=1.11.0"
+    recommendedVersion: 1.11.2
+    requiredVersion: 1.11.0
   - range: ">=1.10.0"
-    recommendedVersion: 1.10.5
+    recommendedVersion: 1.10.6
     requiredVersion: 1.10.0
   - range: ">=1.9.0"
-    recommendedVersion: 1.9.9
+    recommendedVersion: 1.9.10
     requiredVersion: 1.9.0
   - range: ">=1.8.0"
     recommendedVersion: 1.8.15
@@ -53,18 +56,22 @@ spec:
     recommendedVersion: 1.4.12
     requiredVersion: 1.4.2
   kopsVersions:
+  - range: ">=1.11.0-alpha.1"
+    #recommendedVersion: "1.10.0"
+    #requiredVersion: 1.10.0
+    kubernetesVersion: 1.11.2
   - range: ">=1.10.0-alpha.1"
     recommendedVersion: "1.10.0"
     #requiredVersion: 1.10.0
-    kubernetesVersion: 1.10.3
+    kubernetesVersion: 1.10.6
   - range: ">=1.9.0-alpha.1"
     recommendedVersion: 1.9.2
     #requiredVersion: 1.9.0
-    kubernetesVersion: 1.9.8
+    kubernetesVersion: 1.9.10
   - range: ">=1.8.0-alpha.1"
     recommendedVersion: 1.8.1
     requiredVersion: 1.7.1
-    kubernetesVersion: 1.8.13
+    kubernetesVersion: 1.8.15
   - range: ">=1.7.0-alpha.1"
     recommendedVersion: 1.8.1
     requiredVersion: 1.7.1


### PR DESCRIPTION
Kubernetes versions:
* 1.11.2 (for not-yet unreleased kops 1.11)
* 1.10.6
* 1.9.10