### PR TITLE
coredns should not be running on master by default

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
@@ -95,8 +95,6 @@ spec:
     spec:
       serviceAccountName: coredns
       tolerations:
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
         - key: "CriticalAddonsOnly"
           operator: "Exists"
       containers:


### PR DESCRIPTION
CoreDNS can be scheduled on masters.

The masters are busy enough and coredns shouldn't be running there as well

I have followed https://github.com/coredns/deployment/issues/50