### PR TITLE
Service Address Check

### DIFF
--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -280,7 +280,7 @@ func ValidateCluster(c *kops.Cluster, strict bool) *field.Error {
 			if ip == nil {
 				return field.Invalid(fieldSpec.Child("kubeDNS", "serverIP"), address, "Cluster had an invalid kubeDNS.serverIP")
 			}
-			if !serviceClusterIPRange.Contains(ip) {
+			if serviceClusterIPRange != nil && !serviceClusterIPRange.Contains(ip) {
 				return field.Invalid(fieldSpec.Child("kubeDNS", "serverIP"), address, fmt.Sprintf("ServiceClusterIPRange %q must contain the DNS Server IP %q", c.Spec.ServiceClusterIPRange, address))
 			}
 			if !featureflag.ExperimentalClusterDNS.Enabled() {


### PR DESCRIPTION
The current implementation assumes you have specified a service address within your config rather than using filled in defaults. This PR only checks when service address has been specified. Alternatively if people feel that this should be 'enforced', at the very least we should check the reference is not nil so we don't throw a panic.

Note, serviceClusterIPRange is set above here https://github.com/kubernetes/kops/blob/master/pkg/apis/kops/validation/legacy.go#L210