### PR TITLE
Correct Spelling of "kubernetesVersion"

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,17 +1,17 @@
 ## Upgrading Kubernetes
 
-Upgrading Kubernetes is easy with kops. The cluster spec contains a `KubernetesVersion`, so you can simply edit it with `kops edit`, and apply the updated configuration to your cluster.
+Upgrading Kubernetes is easy with kops. The cluster spec contains a `kubernetesVersion`, so you can simply edit it with `kops edit`, and apply the updated configuration to your cluster.
 
 The `kops upgrade` command also automates checking for and applying updates.
 
-It is recommended to run the latest version of Kops to ensure compatibility with the target KubernetesVersion. When applying a Kubernetes minor version upgrade (e.g. `v1.5.3` to `v1.6.0`), you should confirm that the target KubernetesVersion is compatible with the [current Kops release](https://github.com/kubernetes/kops/releases).
+It is recommended to run the latest version of Kops to ensure compatibility with the target kubernetesVersion. When applying a Kubernetes minor version upgrade (e.g. `v1.5.3` to `v1.6.0`), you should confirm that the target kubernetesVersion is compatible with the [current Kops release](https://github.com/kubernetes/kops/releases).
 
 Note: if you want to upgrade from a `kube-up` installation, please see the instructions for [how to upgrade kubernetes installed with kube-up](cluster_upgrades_and_migrations.md).
 
 ### Manual update
 
 * `kops edit cluster $NAME`
-* set the KubernetesVersion to the target version (e.g. `v1.3.5`)
+* set the kubernetesVersion to the target version (e.g. `v1.3.5`)
 * `kops update cluster $NAME` to preview, then `kops update cluster $NAME --yes`
 * `kops rolling-update cluster $NAME` to preview, then `kops rolling-update cluster $NAME --yes`
 
@@ -31,7 +31,7 @@ Upgrade uses the latest Kubernetes version considered stable by kops, defined in
 ### Terraform Users
 
 * `kops edit cluster $NAME`
-* set the KubernetesVersion to the target version (e.g. `v1.3.5`)
+* set the kubernetesVersion to the target version (e.g. `v1.3.5`)
 * NOTE: The next 3 steps must all be ran in the same directory
 * `kops update cluster $NAME --target=terraform`
 * `terraform plan`


### PR DESCRIPTION
Should be crosschecked by someone, but at least in my cluster spec the spelling is "kubernetesVersion" (non-capitalized start of word).