### PR TITLE
Adding describe launch config to autoscaler permissions

### DIFF
--- a/addons/cluster-autoscaler/cluster-autoscaler.sh
+++ b/addons/cluster-autoscaler/cluster-autoscaler.sh
@@ -61,6 +61,7 @@ cat > asg-policy.json << EOF
             "Action": [
                 "autoscaling:DescribeAutoScalingGroups",
                 "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeLaunchConfigurations",
                 "autoscaling:DescribeTags",
                 "autoscaling:SetDesiredCapacity",
                 "autoscaling:TerminateInstanceInAutoScalingGroup"


### PR DESCRIPTION
This is needed to scale up with

k8s.gcr.io/cluster-autoscaler:v1.2.3