### PR TITLE
Setting the manifest directory when it is required by kubelet

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -88,7 +88,15 @@ func (b *KubeletBuilder) Build(c *fi.ModelBuilderContext) error {
 			Mode:     s("0755"),
 		})
 	}
-
+	{
+		if kubeletConfig.PodManifestPath != "" {
+			t, err := b.buildManifestDirectory(kubeletConfig)
+			if err != nil {
+				return err
+			}
+			c.AddTask(t)
+		}
+	}
 	{
 		// @check if bootstrap tokens are enabled and create the appropreiate certificates
 		if b.UseBootstrapTokens() {
@@ -147,6 +155,16 @@ func (b *KubeletBuilder) kubeletPath() string {
 		kubeletCommand = "/home/kubernetes/bin/kubelet"
 	}
 	return kubeletCommand
+}
+
+// buildManifestDirectory creates the directory where kubelet expects static manifests to reside
+func (b *KubeletBuilder) buildManifestDirectory(kubeletConfig *kops.KubeletConfigSpec) (*nodetasks.File, error) {
+	directory := &nodetasks.File{
+		Path: kubeletConfig.PodManifestPath,
+		Type: nodetasks.FileType_Directory,
+		Mode: s("0755"),
+	}
+	return directory, nil
 }
 
 // buildSystemdEnvironmentFile renders the environment file for the kubelet

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -182,6 +182,15 @@ func Test_RunKubeletBuilder(t *testing.T) {
 	}
 	context.AddTask(fileTask)
 
+	{
+		task, err := builder.buildManifestDirectory(kubeletConfig)
+		if err != nil {
+			t.Fatalf("error from KubeletBuilder buildManifestDirectory: %v", err)
+			return
+		}
+		context.AddTask(task)
+	}
+
 	testutils.ValidateTasks(t, basedir, context)
 }
 

--- a/nodeup/pkg/model/tests/kubelet/featuregates/cluster.yaml
+++ b/nodeup/pkg/model/tests/kubelet/featuregates/cluster.yaml
@@ -22,6 +22,7 @@ spec:
     featureGates:
       ExperimentalCriticalPodAnnotation: "true"
       AllowExtTrafficLocalEndpoints: "false"
+    podManifestPath: "/etc/kubernetes/manifests"
   kubernetesVersion: v1.5.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com

--- a/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
@@ -1,5 +1,9 @@
+mode: "0755"
+path: /etc/kubernetes/manifests
+type: directory
+---
 contents: |
-  DAEMON_ARGS="--feature-gates=AllowExtTrafficLocalEndpoints=false,ExperimentalCriticalPodAnnotation=true --node-labels=kubernetes.io/role=node,node-role.kubernetes.io/node= --cni-bin-dir=/opt/cni/bin/ --cni-conf-dir=/etc/cni/net.d/ --network-plugin-dir=/opt/cni/bin/"
+  DAEMON_ARGS="--feature-gates=AllowExtTrafficLocalEndpoints=false,ExperimentalCriticalPodAnnotation=true --node-labels=kubernetes.io/role=node,node-role.kubernetes.io/node= --pod-manifest-path=/etc/kubernetes/manifests --cni-bin-dir=/opt/cni/bin/ --cni-conf-dir=/etc/cni/net.d/ --network-plugin-dir=/opt/cni/bin/"
   HOME="/root"
 path: /etc/sysconfig/kubelet
 type: file


### PR DESCRIPTION
This PR satisfies https://github.com/kubernetes/kops/issues/5463.  The manifest directory will be setup by nodeup when it is configuring kubelet.  Kubelet itself needs the directory set, and nodeup is currently configuring kubelet.