### PR TITLE
v0.2.1 doesnt work in AWS EKS based environment

### DIFF
--- a/addons/metrics-server/v1.8.x.yaml
+++ b/addons/metrics-server/v1.8.x.yaml
@@ -119,7 +119,7 @@ spec:
       serviceAccountName: metrics-server
       containers:
         - name: metrics-server
-          image: gcr.io/google_containers/metrics-server-amd64:v0.2.1
+          image: k8s.gcr.io/metrics-server-amd64:v0.3.1
           imagePullPolicy: Always
           command:
             - /metrics-server


### PR DESCRIPTION
Existing image doesnt work and the metrics server keeps crashing. Found the correct image tag from 
https://github.com/kubernetes-incubator/metrics-server/blob/master/deploy/1.8%2B/metrics-server-deployment.yaml