### PR TITLE
More CNI toleration for tainted nodes.

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.10.yaml.template
@@ -62,8 +62,10 @@ spec:
       serviceAccountName: aws-node
       hostNetwork: true
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
       containers:

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.8.yaml.template
@@ -62,8 +62,10 @@ spec:
       serviceAccountName: aws-node
       hostNetwork: true
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
       containers:

--- a/upup/models/cloudup/resources/addons/networking.kope.io/k8s-1.6.yaml
+++ b/upup/models/cloudup/resources/addons/networking.kope.io/k8s-1.6.yaml
@@ -36,8 +36,10 @@ spec:
               readOnly: true
       serviceAccountName: kopeio-networking-agent
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
       volumes:
         - name: lib-modules
           hostPath:

--- a/upup/models/cloudup/resources/addons/networking.romana/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.romana/k8s-1.7.yaml.template
@@ -198,8 +198,10 @@ spec:
           type: spc_t
       serviceAccountName: romana-agent
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
       containers:
       - name: romana-agent
         image: quay.io/romana/agent:v2.0.2

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -466,7 +466,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Kopeio != nil {
 		key := "networking.kope.io"
-		version := "1.0.20180319"
+		version := "1.0.20180319-kops.2"
 
 		{
 			location := key + "/pre-k8s-1.6.yaml"
@@ -749,7 +749,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Romana != nil {
 		key := "networking.romana"
-		version := "v2.0.2"
+		version := "v2.0.2-kops.2"
 
 		{
 			location := key + "/k8s-1.7.yaml"
@@ -769,7 +769,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.AmazonVPC != nil {
 		key := "networking.amazon-vpc-routed-eni"
-		version := "1.0.0-kops.2"
+		version := "1.0.0-kops.3"
 
 		{
 			id := "k8s-1.7"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
@@ -69,11 +69,11 @@ spec:
     name: networking.kope.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.0.20180319
+    version: 1.0.20180319-kops.2
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0'
     manifest: networking.kope.io/k8s-1.6.yaml
     name: networking.kope.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.0.20180319
+    version: 1.0.20180319-kops.2


### PR DESCRIPTION
Similar to #5804 and other tickets referenced there, this PR just modifies tolerations on CNI providers to ensure they run everywhere, including tainted IGs if used. (Where they would not do so without this PR).

I *think* I've updated the metadata correctly, as some lacked the `-kops.#` suffix, so it's been added starting at 2 which seemed right in spirit? Someone smarter than me please let me know if there's some better way to handle that.
