### PR TITLE
Mount etc-hosts in calico-kube-controller

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7.yaml.template
@@ -360,7 +360,13 @@ spec:
               value: /certs/calico-client-key.pem
             - name: ETCD_CA_CERT_FILE
               value: /certs/ca.pem
+            {{- end }}
           volumeMounts:
+            # Necessary for gossip based DNS
+            - mountPath: /etc/hosts
+              name: etc-hosts
+              readOnly: true
+            {{- if eq $etcd_scheme "https" }}
             - mountPath: /certs
               name: calico
               readOnly: true


### PR DESCRIPTION
Testing done:

1. Verfied that when a new cluster is created, the `calico-kube-controllers` deployment bind mounts /etc/hosts from the host.

Refs #5934