### PR TITLE
Add suggested alias for bazelrc import location

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+import %workspace%/tools/bazel.rc

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,1 +1,6 @@
+# TODO: Remove once we expect everyone is running bazel >= 0.18
+# (This is the "legacy" location for bazel.rc)
+# (See https://github.com/bazelbuild/bazel/issues/6319)
+
+
 build --workspace_status_command=./tools/get_workspace_status.sh


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/6319

The default bazelrc location is changing.  So that we don't break
during the transition, we set up an alias so that bazel versions that
load from the new location are redirected to the old location.

Also add a TODO to move to the new location once bazel 0.18 is
prevalent.