### PR TITLE
Use hostPID: true with etcd-manager

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -175,6 +175,7 @@ spec:
     - mountPath: /etc/hosts
       name: hosts
   hostNetwork: true
+  hostPID: true # helps with mounting volumes from inside a container
   volumes:
   - hostPath:
       path: /

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -58,6 +58,7 @@ Contents:
         - mountPath: /var/log/etcd.log
           name: varlogetcd
       hostNetwork: true
+      hostPID: true
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
@@ -119,6 +120,7 @@ Contents:
         - mountPath: /var/log/etcd.log
           name: varlogetcd
       hostNetwork: true
+      hostPID: true
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists


### PR DESCRIPTION
Addresses issues with mounting inside a container with systemd
("Failed to add PIDs to scope's control group: Invalid argument")