### PR TITLE
Fixed issue when specifying ACM cert and no load balancer is defined

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -1081,7 +1081,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		}
 	}
 
-	if c.APISSLCertificate != "" {
+	if cluster.Spec.API.LoadBalancer != nil && c.APISSLCertificate != "" {
 		cluster.Spec.API.LoadBalancer.SSLCertificate = c.APISSLCertificate
 	}
 


### PR DESCRIPTION
Fixes #5837 by checking if a LoadBalancer is defined before setting the SSLCertificate. While it doesn't make so much sense to specify a SSLCert when not using a LoadBalancer (as in the gossip topologies), the missed check caused a panic. 
