### PR TITLE
Move node-authorizer config files to /etc/srv/kubernetes/node-authorizer

### DIFF
--- a/docs/node_authorization.md
+++ b/docs/node_authorization.md
@@ -33,7 +33,7 @@ Assuming all the conditions are met a secret token is generated and returned to 
 
 #### **Enabling the Node Authorization Service**
 
-Enabling the node authorization service is as follows; firstly you must enable the feature flag as node authorization is still experimental; export KOPS_FEATURE_FLAGS=EnableNodeAuthorization
+Enabling the node authorization service is as follows; firstly you must enable the feature flag as node authorization is still experimental; `export KOPS_FEATURE_FLAGS=EnableNodeAuthorization`
 
 ```
 # in the cluster spec

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -405,7 +405,7 @@ func ValidateCluster(c *kops.Cluster, strict bool) *field.Error {
 				return field.Invalid(path.Child("tokenTTL"), c.Spec.NodeAuthorization.NodeAuthorizer.TokenTTL, "must be greater than or equal to zero")
 			}
 
-			// @question: we could probably just default theses settings in the model when the node-authorizer is enabled??
+			// @question: we could probably just default these settings in the model when the node-authorizer is enabled??
 			if c.Spec.KubeAPIServer == nil {
 				return field.Invalid(field.NewPath("kubeAPIServer"), c.Spec.KubeAPIServer, "bootstrap token authentication is not enabled in the kube-apiserver")
 			}

--- a/upup/models/cloudup/resources/addons/node-authorizer.addons.k8s.io/k8s-1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-authorizer.addons.k8s.io/k8s-1.10.yaml.template
@@ -148,8 +148,8 @@ spec:
       volumes:
         - name: config
           hostPath:
-            path: /srv/kubernetes/node-authorizer
-            type: DirectoryOrCreate
+            path: /etc/srv/kubernetes/node-authorizer/
+            type: Directory # Don't create, as can't guarantee permissions
       containers:
         - name: {{ $name }}
           image: {{ $na.Image }}
@@ -162,9 +162,9 @@ spec:
             - --feature={{ . }}
             {{- end }}
             - --listen=0.0.0.0:{{ $na.Port }}
-            - --tls-cert=/config/tls.pem
-            - --tls-client-ca=/config/ca.pem
-            - --tls-private-key=/config/tls-key.pem
+            - --tls-cert=/config/tls.crt
+            - --tls-client-ca=/config/ca.crt
+            - --tls-private-key=/config/tls.key
             - --token-ttl={{ $na.TokenTTL.Duration }}
           {{- if $proxy }}
           env:


### PR DESCRIPTION
/srv isn't writeable on Google's COS or other OSes.  Instead we write
to /etc/srv/kubernetes; that should be writeable on all OSes.  This
means we don't need to template the config dir.

Also starting to split files by component, so we write to
/etc/srv/kubernetes/node-authorizer; this means each component can
just mount the directory and get (just) the files it needs.  Should be
simpler and more secure.

Finally, change the extensions that the CreatePrivateKeyPairTask
creates, to better match what we expect elsewhere (.crt and .key).