### PR TITLE
cilium: Fix Prometheus serve addr flag

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
@@ -243,7 +243,7 @@ spec:
           - "{{ .PrefilterDevice }}"
 {{ end }}
 {{ if ne .PrometheusServeAddr "" }}
-          - "--prefilter-device"
+          - "--prometheus-serve-addr"
           - "{{ .PrometheusServeAddr }}"
 {{ end }}
 {{ if .Restore}}


### PR DESCRIPTION
While checking for Cilium customization flags I've noticed this incorrect flag in the template.