### PR TITLE
fix to allow multiple node roles

### DIFF
--- a/cmd/kops/validate_cluster.go
+++ b/cmd/kops/validate_cluster.go
@@ -202,12 +202,12 @@ func validateClusterOutputTable(result *validation.ValidationCluster, cluster *a
 			return n.Status
 		})
 
-		nodeTable.AddColumn("ROLE", func(n *validation.ValidationNode) string {
-			return n.Role
+		nodeTable.AddColumn("ROLES", func(n *validation.ValidationNode) string {
+			return n.Roles
 		})
 
 		fmt.Fprintln(out, "\nNODE STATUS")
-		if err := nodeTable.Render(result.Nodes, out, "NAME", "ROLE", "READY"); err != nil {
+		if err := nodeTable.Render(result.Nodes, out, "NAME", "ROLES", "READY"); err != nil {
 			return fmt.Errorf("cannot render nodes for %q: %v", cluster.Name, err)
 		}
 	}

--- a/dns-controller/pkg/watchers/node.go
+++ b/dns-controller/pkg/watchers/node.go
@@ -18,6 +18,7 @@ package watchers
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/kops/dns-controller/pkg/dns"
@@ -220,9 +221,11 @@ func (c *NodeController) updateNodeRecords(node *v1.Node) string {
 	// node/role=<role>/external -> ExternalIP
 	// node/role=<role>/internal -> InternalIP
 	{
-		role := kopsutil.GetNodeRole(node)
-		// Default to node
-		if role == "" {
+		role := kopsutil.GetNodeRoles(node)
+		// Only "master" or "node" is useful here
+		if strings.Contains(role, "master") {
+			role = "master"
+		} else {
 			role = "node"
 		}
 

--- a/pkg/apis/kops/util/labels.go
+++ b/pkg/apis/kops/util/labels.go
@@ -22,18 +22,21 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-func GetNodeRole(node *v1.Node) string {
-	role := ""
+func GetNodeRoles(node *v1.Node) string {
+	keyRoles := make([]string, 0)
+
 	// Newer labels
 	for k := range node.Labels {
 		if strings.HasPrefix(k, "node-role.kubernetes.io/") {
-			role = strings.TrimPrefix(k, "node-role.kubernetes.io/")
+			keyRoles = append(keyRoles, strings.TrimPrefix(k, "node-role.kubernetes.io/"))
 		}
 	}
+
 	// Older label
-	if role == "" {
-		role = node.Labels["kubernetes.io/role"]
+	if len(keyRoles) == 0 {
+		keyRoles = append(keyRoles, node.Labels["kubernetes.io/role"])
 	}
 
-	return role
+	roles := strings.Join(keyRoles, ",")
+	return roles
 }


### PR DESCRIPTION
This PR closes #5871: Only one role per node is allowed. 

With this change it's possible to add labels like: `node-role.kubernetes.io/spot: ""` that, for example [k8s-spot-rescheduler](https://github.com/pusher/k8s-spot-rescheduler) use.