### PR TITLE
fix(addons/cluster-autoscaler) typo on --nodes flag

### DIFF
--- a/addons/cluster-autoscaler/v1.10.0.yaml
+++ b/addons/cluster-autoscaler/v1.10.0.yaml
@@ -155,7 +155,7 @@ spec:
             - --stderrthreshold=info
             - --cloud-provider={{CLOUD_PROVIDER}}
             - --skip-nodes-with-local-storage=false
-            - --nodes={{MIN_NODES}:{{MAX_NODES}}:{{GROUP_NAME}}
+            - --nodes={{MIN_NODES}}:{{MAX_NODES}}:{{GROUP_NAME}}
           env:
             - name: AWS_REGION
               value: {{AWS_REGION}}


### PR DESCRIPTION
It's missing a `}` on `MIN_NODES` variable for `--nodes` flag.


```
v1.10.0.yaml:             - --nodes={{MIN_NODES}:{{MAX_NODES}}:{{GROUP_NAME}}
```
```
v1.4.0.yaml:              - --nodes={{MIN_NODES}}:{{MAX_NODES}}:{{GROUP_NAME}}
v1.6.0.yaml:              - --nodes={{MIN_NODES}}:{{MAX_NODES}}:{{GROUP_NAME}}
v1.8.0.yaml:              - --nodes={{MIN_NODES}}:{{MAX_NODES}}:{{GROUP_NAME}}
```