### PR TITLE
Add stdin input for secrets

### DIFF
--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -244,16 +243,4 @@ func RunCreate(f *util.Factory, out io.Writer, c *CreateOptions) error {
 		}
 	}
 	return nil
-}
-
-// ConsumeStdin reads all the bytes available from stdin
-func ConsumeStdin() ([]byte, error) {
-	file := os.Stdin
-	buf := new(bytes.Buffer)
-	_, err := buf.ReadFrom(file)
-	if err != nil {
-		return nil, fmt.Errorf("error reading stdin: %v", err)
-	}
-
-	return buf.Bytes(), nil
 }

--- a/cmd/kops/create_secret_weave_encryptionconfig.go
+++ b/cmd/kops/create_secret_weave_encryptionconfig.go
@@ -45,6 +45,9 @@ var (
 	# Install a specific weave password.
 	kops create secret weavepassword -f /path/to/weavepassword \
 		--name k8s-cluster.example.com --state s3://example.com
+	# Install a specific weave password via stdin.
+	kops create secret weavepassword -f - \
+		--name k8s-cluster.example.com --state s3://example.com	
 	# Replace an existing weavepassword secret.
 	kops create secret weavepassword -f /path/to/weavepassword --force \
 		--name k8s-cluster.example.com --state s3://example.com
@@ -112,9 +115,18 @@ func RunCreateSecretWeaveEncryptionConfig(f *util.Factory, options *CreateSecret
 	}
 
 	if options.WeavePasswordFilePath != "" {
-		data, err := ioutil.ReadFile(options.WeavePasswordFilePath)
-		if err != nil {
-			return fmt.Errorf("error reading weave password file %v: %v", options.WeavePasswordFilePath, err)
+		var data []byte
+		if options.WeavePasswordFilePath == "-" {
+			data, err = ConsumeStdin()
+			if err != nil {
+				return fmt.Errorf("error reading weave password file from stdin: %v", err)
+			}
+		} else {
+			data, err = ioutil.ReadFile(options.WeavePasswordFilePath)
+			if err != nil {
+				return fmt.Errorf("error reading weave password file %v: %v", options.WeavePasswordFilePath, err)
+			}
+
 		}
 
 		secret.Data = data

--- a/cmd/kops/root.go
+++ b/cmd/kops/root.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	goflag "flag"
 	"fmt"
 	"io"
@@ -325,4 +326,15 @@ func GetCluster(factory Factory, clusterName string) (*kopsapi.Cluster, error) {
 		return nil, fmt.Errorf("cluster name did not match expected name: %v vs %v", clusterName, cluster.ObjectMeta.Name)
 	}
 	return cluster, nil
+}
+
+// ConsumeStdin reads all the bytes available from stdin
+func ConsumeStdin() ([]byte, error) {
+	file := os.Stdin
+	buf := new(bytes.Buffer)
+	_, err := buf.ReadFrom(file)
+	if err != nil {
+		return nil, fmt.Errorf("error reading stdin: %v", err)
+	}
+	return buf.Bytes(), nil
 }

--- a/docs/apireference/openapi-spec/swagger.json
+++ b/docs/apireference/openapi-spec/swagger.json
@@ -3,6 +3,7 @@
     "/apis",
     "/apis/kops",
     "/apis/kops/v1alpha2",
+    "/metrics",
     "/version"
   ]
 }

--- a/docs/cli/kops_create_secret_dockerconfig.md
+++ b/docs/cli/kops_create_secret_dockerconfig.md
@@ -19,6 +19,9 @@ kops create secret dockerconfig [flags]
   # Create a new docker config.
   kops create secret dockerconfig -f /path/to/docker/config.json \
   --name k8s-cluster.example.com --state s3://example.com
+  # Create a docker config via stdin.
+  generate-docker-config.sh | kops create secret dockerconfig -f - \
+  --name k8s-cluster.example.com --state s3://example.com
   # Replace an existing docker config secret.
   kops create secret dockerconfig -f /path/to/docker/config.json --force \
   --name k8s-cluster.example.com --state s3://example.com

--- a/docs/cli/kops_create_secret_encryptionconfig.md
+++ b/docs/cli/kops_create_secret_encryptionconfig.md
@@ -19,6 +19,9 @@ kops create secret encryptionconfig [flags]
   # Create a new encryption config.
   kops create secret encryptionconfig -f config.yaml \
   --name k8s-cluster.example.com --state s3://example.com
+  # Create a new encryption config via stdin.
+  generate-encryption-config.sh | kops create secret encryptionconfig -f - \
+  --name k8s-cluster.example.com --state s3://example.com
   # Replace an existing encryption config secret.
   kops create secret encryptionconfig -f config.yaml --force \
   --name k8s-cluster.example.com --state s3://example.com

--- a/docs/cli/kops_create_secret_weavepassword.md
+++ b/docs/cli/kops_create_secret_weavepassword.md
@@ -26,6 +26,9 @@ kops create secret weavepassword [flags]
   # Install a specific weave password.
   kops create secret weavepassword -f /path/to/weavepassword \
   --name k8s-cluster.example.com --state s3://example.com
+  # Install a specific weave password via stdin.
+  kops create secret weavepassword -f - \
+  --name k8s-cluster.example.com --state s3://example.com
   # Replace an existing weavepassword secret.
   kops create secret weavepassword -f /path/to/weavepassword --force \
   --name k8s-cluster.example.com --state s3://example.com

--- a/docs/cli/kops_delete.md
+++ b/docs/cli/kops_delete.md
@@ -19,6 +19,9 @@ kops delete -f FILENAME [--yes] [flags]
   # Delete a cluster using a manifest file
   kops delete -f my-cluster.yaml
   
+  # Delete a cluster using a pasted manifest file from stdin.
+  pbpaste | kops delete -f -
+  
   # Delete a cluster in AWS.
   kops delete cluster --name=k8s.example.com --state=s3://kops-state-1234
   


### PR DESCRIPTION
This PR allows for stdin input for creating kops secrets.

Now where a secret can be created via file, it can be created via stdin.

Example:

`encryption-config-generator.sh | kops create encryptionconfig -f -`