### PR TITLE
fixed MIN_NODES missing closing bracket

### DIFF
--- a/addons/cluster-autoscaler/v1.10.0.yaml
+++ b/addons/cluster-autoscaler/v1.10.0.yaml
@@ -155,7 +155,7 @@ spec:
             - --stderrthreshold=info
             - --cloud-provider={{CLOUD_PROVIDER}}
             - --skip-nodes-with-local-storage=false
-            - --nodes={{MIN_NODES}:{{MAX_NODES}}:{{GROUP_NAME}}
+            - --nodes={{MIN_NODES}}:{{MAX_NODES}}:{{GROUP_NAME}}
           env:
             - name: AWS_REGION
               value: {{AWS_REGION}}


### PR DESCRIPTION
I was wondering why my sed failed in a script that had been working.  