### PR TITLE
Clarify license statement for nvidia-bootstrap hook

### DIFF
--- a/hooks/nvidia-bootstrap/README.md
+++ b/hooks/nvidia-bootstrap/README.md
@@ -1,6 +1,8 @@
 ## NVIDIA Driver Installation
 
-Using this hook indicates that you agree to the [license](http://www.nvidia.com/content/DriverDownload-March2009/licence.php?lang=us)
+The source code within this directory is provided under the [Apache License, version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+Note that the NVIDIA software installed by this hook's container may be subject to [NVIDIA's own license terms](http://www.nvidia.com/content/DriverDownload-March2009/licence.php?lang=us).
 
 This is an experimental hook for installing the nvidia drivers as part of the kops boot process.
 


### PR DESCRIPTION
This is meant to clarify a license statement in the nvidia-bootstrap hook's README file. 

@vishh @justinsb This relates to our earlier discussion in steering: https://github.com/kubernetes/steering/issues/57#issuecomment-408975321

cc @nikhita 

