### PR TITLE
Spotinst: Skip the creation of LoadBalancerAttachment tasks if Spotinst is enabled

### DIFF
--- a/pkg/model/awsmodel/BUILD.bazel
+++ b/pkg/model/awsmodel/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//pkg/dns:go_default_library",
+        "//pkg/featureflag:go_default_library",
         "//pkg/model:go_default_library",
         "//pkg/model/defaults:go_default_library",
         "//upup/pkg/fi:go_default_library",

--- a/pkg/model/bastion.go
+++ b/pkg/model/bastion.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
 )
@@ -236,18 +237,23 @@ func (b *BastionModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		c.AddTask(elb)
 	}
 
-	for _, ig := range bastionInstanceGroups {
-		// We build the ASG when we iterate over the instance groups
+	// When Spotinst Elastigroups are used, there is no need to create
+	// a separate task for the attachment of the load balancer since this
+	// is already done as part of the Elastigroup's creation, if needed.
+	if !featureflag.Spotinst.Enabled() {
+		for _, ig := range bastionInstanceGroups {
+			// We build the ASG when we iterate over the instance groups
 
-		// Attach the ELB to the ASG
-		t := &awstasks.LoadBalancerAttachment{
-			Name:      s("bastion-elb-attachment"),
-			Lifecycle: b.Lifecycle,
+			// Attach the ELB to the ASG
+			t := &awstasks.LoadBalancerAttachment{
+				Name:      s("bastion-elb-attachment"),
+				Lifecycle: b.Lifecycle,
 
-			LoadBalancer:     elb,
-			AutoscalingGroup: b.LinkToAutoscalingGroup(ig),
+				LoadBalancer:     elb,
+				AutoscalingGroup: b.LinkToAutoscalingGroup(ig),
+			}
+			c.AddTask(t)
 		}
-		c.AddTask(t)
 	}
 
 	bastionPublicName := ""


### PR DESCRIPTION
Creating a new cluster using a private topology fails with the following error message if the Spotinst integration is enabled.

Command:
```
KOPS_FEATURE_FLAGS="+Spotinst" kops create cluster ... --topology private
```

Error:
```
error building tasks: unexpected error resolving task "LoadBalancerAttachment/api-master-us-west-2a": Unable to find task "AutoscalingGroup/master-us-west-2a.masters.kops.ek8s.com", referenced from LoadBalancerAttachment/api-master-us-west-2a:.AutoscalingGroup
```

This PR fixes the error by skipping the creation of `LoadBalancerAttachment` tasks since this is already done as part of the Elastigroup's creation, if needed.