### PR TITLE
Spotinst: Do not log unmatched groups as warning messages

### DIFF
--- a/pkg/resources/spotinst/resources.go
+++ b/pkg/resources/spotinst/resources.go
@@ -106,7 +106,7 @@ func GetCloudGroups(svc Service, cluster *kops.Cluster, instancegroups []*kops.I
 
 		if instancegroup == nil {
 			if warnUnmatched {
-				glog.Warningf("Found group with no corresponding instance group %q", group.Name())
+				glog.V(2).Infof("Found group with no corresponding instance group %q", group.Name())
 			}
 			continue
 		}


### PR DESCRIPTION
When executing `kops rolling-update cluster` without instance group name/role, if the user has multiple Elastigroups that aren't managed by kops, kops prints a lot of less than worthwhile warning messages:

```
W1030 21:29:37.226502 21141 resources.go:109] Found group with no corresponding instance group "name-of-the-elastigroup"
```

This PR changes the logging level from Warning to Info.