### PR TITLE
Spotinst: Attempt to find a Security Group even without a VPC ID

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -102,7 +102,7 @@ func (e *SecurityGroup) findEc2(c *fi.Context) (*ec2.SecurityGroup, error) {
 		// Find by ID.
 		request.GroupIds = []*string{e.ID}
 
-	} else if fi.StringValue(e.Name) != "" && e.VPC != nil {
+	} else if fi.StringValue(e.Name) != "" && e.VPC != nil && e.VPC.ID != nil {
 		// Find by filters (name and VPC ID).
 		filters := cloud.BuildFilters(e.Name)
 		filters = append(filters, awsup.NewEC2Filter("vpc-id", *e.VPC.ID))

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -96,26 +96,22 @@ func (e *SecurityGroup) Find(c *fi.Context) (*SecurityGroup, error) {
 
 func (e *SecurityGroup) findEc2(c *fi.Context) (*ec2.SecurityGroup, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
-
-	var vpcID *string
-	if e.VPC != nil {
-		vpcID = e.VPC.ID
-	}
-
-	if vpcID == nil {
-		return nil, nil
-	}
-
 	request := &ec2.DescribeSecurityGroupsInput{}
 
 	if fi.StringValue(e.ID) != "" {
+		// Find by ID.
 		request.GroupIds = []*string{e.ID}
-	} else {
-		filters := cloud.BuildFilters(e.Name)
-		filters = append(filters, awsup.NewEC2Filter("vpc-id", *vpcID))
-		filters = append(filters, awsup.NewEC2Filter("group-name", *e.Name))
 
+	} else if fi.StringValue(e.Name) != "" && e.VPC != nil {
+		// Find by filters (name and VPC ID).
+		filters := cloud.BuildFilters(e.Name)
+		filters = append(filters, awsup.NewEC2Filter("vpc-id", *e.VPC.ID))
+		filters = append(filters, awsup.NewEC2Filter("group-name", *e.Name))
 		request.Filters = filters
+
+	} else {
+		// No reason to try.
+		return nil, nil
 	}
 
 	response, err := cloud.EC2().DescribeSecurityGroups(request)


### PR DESCRIPTION
Specifying additional security groups in the InstanceGroup's spec resulted in a spurious change. This happens because of an incorrect value (nil, actually) returns from [this](https://github.com/kubernetes/kops/tree/e5b2b9eddbfa6a257ea1b1b6a6850b1f10316c16/upup/pkg/fi/cloudup/awstasks/securitygroup.go#L100-L107) function, although there is no reason for it to be done this way since the VPC ID is only used in [L115](https://github.com/kubernetes/kops/blob/e5b2b9eddbfa6a257ea1b1b6a6850b1f10316c16/upup/pkg/fi/cloudup/awstasks/securitygroup.go#L115).

This PR eliminates ths spurious change by allowing the find function to be executed even without a VPC ID.

#### Steps to reproduce

1. Edit the instance group by adding an additional security group:

```yaml
apiVersion: kops/v1alpha2
kind: InstanceGroup
spec:
  additionalSecurityGroups:
  - sg-<REDACTED#2>
```

2. Update the cluster. In the logs you'll see thw following change:

```
Elastigroup/nodes.<cluster_name>
        SecurityGroups           [name:nodes.<cluster_name> id:sg-<REDACTED#1>] -> [name:nodes.<cluster_name> id:sg-<REDACTED#1>, name:sg-<REDACTED#2> id:sg-<REDACTED#2>]
```

3. Update the cluster once again and you'll see the same output, which is a result of a spurious change. 