### PR TITLE
Fix s3 encryption role

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -314,7 +314,7 @@ func (b *PolicyBuilder) AddS3Permissions(p *Policy) (*Policy, error) {
 
 			p.Statement = append(p.Statement, &Statement{
 				Effect: StatementEffectAllow,
-				Action: stringorslice.Of("s3:GetBucketLocation", "s3:ListBucket"),
+				Action: stringorslice.Of("s3:GetBucketLocation", "s3:GetEncryptionConfiguration", "s3:ListBucket"),
 				Resource: stringorslice.Slice([]string{
 					strings.Join([]string{b.IAMPrefix(), ":s3:::", s3Path.Bucket()}, ""),
 				}),

--- a/pkg/model/iam/tests/iam_builder_master_legacy.json
+++ b/pkg/model/iam/tests/iam_builder_master_legacy.json
@@ -48,6 +48,7 @@
       "Effect": "Allow",
       "Action": [
         "s3:GetBucketLocation",
+        "s3:GetEncryptionConfiguration",
         "s3:ListBucket"
       ],
       "Resource": [

--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -138,6 +138,7 @@
       "Effect": "Allow",
       "Action": [
         "s3:GetBucketLocation",
+        "s3:GetEncryptionConfiguration",
         "s3:ListBucket"
       ],
       "Resource": [

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -138,6 +138,7 @@
       "Effect": "Allow",
       "Action": [
         "s3:GetBucketLocation",
+        "s3:GetEncryptionConfiguration",
         "s3:ListBucket"
       ],
       "Resource": [

--- a/pkg/model/iam/tests/iam_builder_node_legacy.json
+++ b/pkg/model/iam/tests/iam_builder_node_legacy.json
@@ -15,6 +15,7 @@
       "Effect": "Allow",
       "Action": [
         "s3:GetBucketLocation",
+        "s3:GetEncryptionConfiguration",
         "s3:ListBucket"
       ],
       "Resource": [

--- a/pkg/model/iam/tests/iam_builder_node_strict.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict.json
@@ -15,6 +15,7 @@
       "Effect": "Allow",
       "Action": [
         "s3:GetBucketLocation",
+        "s3:GetEncryptionConfiguration",
         "s3:ListBucket"
       ],
       "Resource": [

--- a/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
@@ -15,6 +15,7 @@
       "Effect": "Allow",
       "Action": [
         "s3:GetBucketLocation",
+        "s3:GetEncryptionConfiguration",
         "s3:ListBucket"
       ],
       "Resource": [


### PR DESCRIPTION
4235 added checking for a bucket policy, but didn't appear to update the master node role. This updates the role, and is intended to fix 6014.