### PR TITLE
Flush iptables before restarting docker service

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -838,6 +838,7 @@ func (b *DockerBuilder) buildContainerOSConfigurationDropIn(c *fi.ModelBuilderCo
 		Type:       nodetasks.FileType_File,
 		OnChangeExecute: [][]string{
 			{"systemctl", "daemon-reload"},
+			{"iptables", "--flush"},
 			{"systemctl", "restart", "docker.service"},
 			// We need to restart kops-configuration service since nodeup needs to load images
 			// into docker with the new overlay storage. Restart is on the background because


### PR DESCRIPTION
When docker initially starts on a node (prior to kops bootstrap), iptables rules are inserted with default ACCEPT rules. The nodeup process kicks in as part of the bootstrap script and will load custom configuration (such as docker options), before restarting the docker service. The docker option `--iptables=false` has no effect following the service restart as the rules have already been added.

This PR forces a flush of the iptables rules before restarting the docker service. The rules should be re-added if the `--iptables` flag is not provided.