### PR TITLE
Update Weave Net to version 2.5.0

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -155,7 +155,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.4.1'
+          image: 'weaveworks/weave-kube:2.5.0'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -193,7 +193,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.4.1'
+          image: 'weaveworks/weave-npc:2.5.0'
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -159,7 +159,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.4.1'
+          image: 'weaveworks/weave-kube:2.5.0'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -197,7 +197,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.4.1'
+          image: 'weaveworks/weave-npc:2.5.0'
           resources:
             requests:
               cpu: 50m

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -539,8 +539,8 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		versions := map[string]string{
 			"pre-k8s-1.6": "2.3.0-kops.2",
 			"k8s-1.6":     "2.3.0-kops.2",
-			"k8s-1.7":     "2.4.1-kops.1",
-			"k8s-1.8":     "2.4.1-kops.1",
+			"k8s-1.7":     "2.5.0-kops.1",
+			"k8s-1.8":     "2.5.0-kops.1",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -83,11 +83,11 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.4.1-kops.1
+    version: 2.5.0-kops.1
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0'
     manifest: networking.weave/k8s-1.8.yaml
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.4.1-kops.1
+    version: 2.5.0-kops.1


### PR DESCRIPTION
This release adds support for Kubernetes `hostPort` mapping and the `ipBlock` NetworkPolicy feature, plus many other improvements.

Release notes https://github.com/weaveworks/weave/releases/tag/v2.5.0
