### PR TITLE
Detail Calico BGP route reflector requirements

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -161,7 +161,7 @@ This full node-to-node mesh per L2 network has its scaling challenges for larger
 BGP route reflectors can be used as a replacement to a full mesh, and is useful for scaling up a cluster. BGP route reflectors are recommended once the number of nodes goes above ~50-100.
 The setup of BGP route reflectors is currently out of the scope of kops.
 
-Read more here: [BGP route reflectors](http://docs.projectcalico.org/latest/usage/routereflector/calico-routereflector)
+Read more here: [BGP route reflectors](https://docs.projectcalico.org/latest/usage/routereflector)
 
 
 To enable this mode in a cluster, with Calico as the CNI and Network Policy provider, you must edit the cluster after the previous `kops create ...` command.


### PR DESCRIPTION
As per Lance Robson's( aka @lwr20 ) [message in Slack](https://kubernetes.slack.com/archives/C3QUFP0QM/p1537959279000100?thread_ts=1537951563.000100&cid=C3QUFP0QM), above 50-100 nodes Calico recommends usage of BGP route reflectors:
> Clearly I'm not impartial here, but I can tell you that we test Calico to 5K nodes.
> We recommend BGP route reflectors once you go above ~50-100 nodes (we test up to 100 nodes without RRs).  The reason for RRs is that by default calico sets up BGP connections in a full mesh - clearly the number of connections will scale as the number of nodes squared.  With RRs, the number of BGP connections scales linearly with nodes - but then you have to manage the RRs too.
> The next version of Calico (v3.3 - code is in master already, but not heavily tested yet) will bring a feature to make RRs much easier to deploy - just annotate a few nodes and they become RRs.

Adding this detail to documentation as I recently got a cluster with such issues.