### PR TITLE
Suggestion to fix #6050

### DIFF
--- a/docs/apireference/build/index.html
+++ b/docs/apireference/build/index.html
@@ -1707,6 +1707,10 @@ Appears In:
 <td>DefaultUlimit is the ulimits for containers</td>
 </tr>
 <tr>
+<td>fixedCidrV6 <br /> <em>string</em></td>
+<td>IPv6 subnet for fixed IPs</td>
+</tr>
+<tr>
 <td>hosts <br /> <em>string array</em></td>
 <td>Hosts enables you to configure the endpoints the docker daemon listens on i.e tcp://0.0.0.0.2375 or unix:///var/run/docker.sock etc</td>
 </tr>
@@ -1721,6 +1725,10 @@ Appears In:
 <tr>
 <td>ipTables <br /> <em>boolean</em></td>
 <td>IPtables enables addition of iptables rules</td>
+</tr>
+<tr>
+<td>ipv6 <br /> <em>boolean</em></td>
+<td>Enable IPv6 networking</td>
 </tr>
 <tr>
 <td>liveRestore <br /> <em>boolean</em></td>

--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -116,6 +116,13 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"")
 	}
 
+	if *b.Cluster.Spec.Docker.IPv6 {
+		sysctls = append(sysctls,
+			"# IPv6 accept Router Advertisements even if forwarding is enabled",
+			"net.ipv6.conf.eth0.accept_ra=2",
+			"")
+	}
+
 	sysctls = append(sysctls,
 		"# Prevent docker from changing iptables: https://github.com/kubernetes/kubernetes/issues/40182",
 		"net.ipv4.ip_forward=1",

--- a/pkg/apis/kops/dockerconfig.go
+++ b/pkg/apis/kops/dockerconfig.go
@@ -30,12 +30,16 @@ type DockerConfig struct {
 	DefaultUlimit []string `json:"defaultUlimit,omitempty" flag:"default-ulimit,repeat"`
 	// ExecRoot is the root directory for execution state files (default "/var/run/docker")
 	ExecRoot *string `json:"execRoot,omitempty" flag:"exec-root"`
+	// IPv6 subnet for fixed IPs
+	FixedCidrV6 *string `json:"fixedCidrV6,omitempty" flag:"fixed-cidr-v6"`
 	// Hosts enables you to configure the endpoints the docker daemon listens on i.e tcp://0.0.0.0.2375 or unix:///var/run/docker.sock etc
 	Hosts []string `json:"hosts,omitempty" flag:"host,repeat"`
 	// IPMasq enables ip masquerading for containers
 	IPMasq *bool `json:"ipMasq,omitempty" flag:"ip-masq"`
 	// IPtables enables addition of iptables rules
 	IPTables *bool `json:"ipTables,omitempty" flag:"iptables"`
+	// Enable IPv6 networking
+	IPv6 *bool `json:"ipv6,omitempty" flag:"ipv6"`
 	// InsecureRegistry enable insecure registry communication @question according to dockers this a list??
 	InsecureRegistry *string `json:"insecureRegistry,omitempty" flag:"insecure-registry"`
 	// LiveRestore enables live restore of docker when containers are still running

--- a/pkg/apis/kops/v1alpha1/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha1/dockerconfig.go
@@ -30,12 +30,16 @@ type DockerConfig struct {
 	DefaultUlimit []string `json:"defaultUlimit,omitempty" flag:"default-ulimit,repeat"`
 	// ExecRoot is the root directory for execution state files (default "/var/run/docker")
 	ExecRoot *string `json:"execRoot,omitempty" flag:"exec-root"`
+	// IPv6 subnet for fixed IPs
+	FixedCidrV6 *string `json:"fixedCidrV6,omitempty" flag:"fixed-cidr-v6"`
 	// Hosts enables you to configure the endpoints the docker daemon listens on i.e tcp://0.0.0.0.2375 or unix:///var/run/docker.sock etc
 	Hosts []string `json:"hosts,omitempty" flag:"host,repeat"`
 	// IPMasq enables ip masquerading for containers
 	IPMasq *bool `json:"ipMasq,omitempty" flag:"ip-masq"`
 	// IPtables enables addition of iptables rules
 	IPTables *bool `json:"ipTables,omitempty" flag:"iptables"`
+	// Enable IPv6 networking
+	IPv6 *bool `json:"ipv6,omitempty" flag:"ipv6"`
 	// InsecureRegistry enable insecure registry communication @question according to dockers this a list??
 	InsecureRegistry *string `json:"insecureRegistry,omitempty" flag:"insecure-registry"`
 	// LiveRestore enables live restore of docker when containers are still running

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1389,9 +1389,11 @@ func autoConvert_v1alpha1_DockerConfig_To_kops_DockerConfig(in *DockerConfig, ou
 	out.DataRoot = in.DataRoot
 	out.DefaultUlimit = in.DefaultUlimit
 	out.ExecRoot = in.ExecRoot
+	out.FixedCidrV6 = in.FixedCidrV6
 	out.Hosts = in.Hosts
 	out.IPMasq = in.IPMasq
 	out.IPTables = in.IPTables
+	out.IPv6 = in.IPv6
 	out.InsecureRegistry = in.InsecureRegistry
 	out.LiveRestore = in.LiveRestore
 	out.LogDriver = in.LogDriver
@@ -1418,9 +1420,11 @@ func autoConvert_kops_DockerConfig_To_v1alpha1_DockerConfig(in *kops.DockerConfi
 	out.DataRoot = in.DataRoot
 	out.DefaultUlimit = in.DefaultUlimit
 	out.ExecRoot = in.ExecRoot
+	out.FixedCidrV6 = in.FixedCidrV6
 	out.Hosts = in.Hosts
 	out.IPMasq = in.IPMasq
 	out.IPTables = in.IPTables
+	out.IPv6 = in.IPv6
 	out.InsecureRegistry = in.InsecureRegistry
 	out.LiveRestore = in.LiveRestore
 	out.LogDriver = in.LogDriver

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -1095,6 +1095,15 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 			**out = **in
 		}
 	}
+	if in.FixedCidrV6 != nil {
+		in, out := &in.FixedCidrV6, &out.FixedCidrV6
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
 	if in.Hosts != nil {
 		in, out := &in.Hosts, &out.Hosts
 		*out = make([]string, len(*in))
@@ -1111,6 +1120,15 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 	}
 	if in.IPTables != nil {
 		in, out := &in.IPTables, &out.IPTables
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
+	if in.IPv6 != nil {
+		in, out := &in.IPv6, &out.IPv6
 		if *in == nil {
 			*out = nil
 		} else {

--- a/pkg/apis/kops/v1alpha2/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha2/dockerconfig.go
@@ -30,12 +30,16 @@ type DockerConfig struct {
 	DefaultUlimit []string `json:"defaultUlimit,omitempty" flag:"default-ulimit,repeat"`
 	// ExecRoot is the root directory for execution state files (default "/var/run/docker")
 	ExecRoot *string `json:"execRoot,omitempty" flag:"exec-root"`
+	// IPv6 subnet for fixed IPs
+	FixedCidrV6 *string `json:"fixedCidrV6,omitempty" flag:"fixed-cidr-v6"`
 	// Hosts enables you to configure the endpoints the docker daemon listens on i.e tcp://0.0.0.0.2375 or unix:///var/run/docker.sock etc
 	Hosts []string `json:"hosts,omitempty" flag:"host,repeat"`
 	// IPMasq enables ip masquerading for containers
 	IPMasq *bool `json:"ipMasq,omitempty" flag:"ip-masq"`
 	// IPtables enables addition of iptables rules
 	IPTables *bool `json:"ipTables,omitempty" flag:"iptables"`
+	// Enable IPv6 networking
+	IPv6 *bool `json:"ipv6,omitempty" flag:"ipv6"`
 	// InsecureRegistry enable insecure registry communication @question according to dockers this a list??
 	InsecureRegistry *string `json:"insecureRegistry,omitempty" flag:"insecure-registry"`
 	// LiveRestore enables live restore of docker when containers are still running

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1490,9 +1490,11 @@ func autoConvert_v1alpha2_DockerConfig_To_kops_DockerConfig(in *DockerConfig, ou
 	out.DataRoot = in.DataRoot
 	out.DefaultUlimit = in.DefaultUlimit
 	out.ExecRoot = in.ExecRoot
+	out.FixedCidrV6 = in.FixedCidrV6
 	out.Hosts = in.Hosts
 	out.IPMasq = in.IPMasq
 	out.IPTables = in.IPTables
+	out.IPv6 = in.IPv6
 	out.InsecureRegistry = in.InsecureRegistry
 	out.LiveRestore = in.LiveRestore
 	out.LogDriver = in.LogDriver
@@ -1519,9 +1521,11 @@ func autoConvert_kops_DockerConfig_To_v1alpha2_DockerConfig(in *kops.DockerConfi
 	out.DataRoot = in.DataRoot
 	out.DefaultUlimit = in.DefaultUlimit
 	out.ExecRoot = in.ExecRoot
+	out.FixedCidrV6 = in.FixedCidrV6
 	out.Hosts = in.Hosts
 	out.IPMasq = in.IPMasq
 	out.IPTables = in.IPTables
+	out.IPv6 = in.IPv6
 	out.InsecureRegistry = in.InsecureRegistry
 	out.LiveRestore = in.LiveRestore
 	out.LogDriver = in.LogDriver

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1062,6 +1062,15 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 			**out = **in
 		}
 	}
+	if in.FixedCidrV6 != nil {
+		in, out := &in.FixedCidrV6, &out.FixedCidrV6
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
 	if in.Hosts != nil {
 		in, out := &in.Hosts, &out.Hosts
 		*out = make([]string, len(*in))
@@ -1078,6 +1087,15 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 	}
 	if in.IPTables != nil {
 		in, out := &in.IPTables, &out.IPTables
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
+	if in.IPv6 != nil {
+		in, out := &in.IPv6, &out.IPv6
 		if *in == nil {
 			*out = nil
 		} else {

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -1190,6 +1190,15 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 			**out = **in
 		}
 	}
+	if in.FixedCidrV6 != nil {
+		in, out := &in.FixedCidrV6, &out.FixedCidrV6
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
 	if in.Hosts != nil {
 		in, out := &in.Hosts, &out.Hosts
 		*out = make([]string, len(*in))
@@ -1206,6 +1215,15 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 	}
 	if in.IPTables != nil {
 		in, out := &in.IPTables, &out.IPTables
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
+	if in.IPv6 != nil {
+		in, out := &in.IPv6, &out.IPv6
 		if *in == nil {
 			*out = nil
 		} else {

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -25710,6 +25710,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "",
 							},
 						},
+						"fixedCidrV6": {
+							SchemaProps: spec.SchemaProps{
+								Description: "IPv6 subnet for fixed IPs",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 						"networkCIDR": {
 							SchemaProps: spec.SchemaProps{
 								Description: "NetworkCIDR is the CIDR used for the AWS VPC Network, or otherwise allocated to k8s This is a real CIDR, not the internal k8s network On AWS, it maps to the VPC CIDR.  It is not required on GCE.",
@@ -25742,6 +25749,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							SchemaProps: spec.SchemaProps{
 								Description: "Topology defines the type of network topology to use on the cluster - default public This is heavily weighted towards AWS for the time being, but should also be agnostic enough to port out to GCE later if needed",
 								Ref:         ref("k8s.io/kops/pkg/apis/kops/v1alpha1.TopologySpec"),
+							},
+						},
+						"ipv6": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Enable IPv6 networking",
+								Type:        []string{"boolean"},
+								Format:      "",
 							},
 						},
 						"secretStore": {


### PR DESCRIPTION
As described in issue #6050 I am creating a PR to suggest a change. This is the first time I am looking to the code of `kops` and did this set of changes quickly on my laptop to make sure this was enough to get it working as expected and it is.

Changes made in this PR are here to achieve what is described in the issue: please read it to understand what is done here.

I am aware this might not be the perfect PR since I did not add any unit test for those changes (well, I looked for it and for similar parts of the code, like for the `defaultUlimit` parameter and could not find any). Sorry about that.



PS : Furthermore I have the feeling that many more docker options (see list https://docs.docker.com/engine/reference/commandline/dockerd/) might be useful to people and that it could be nice to be able to pass them via a generic entry in the yaml spec together with sysctl options like:
```
spec:
  dockerOptions:
  - "--ipv6"
  - "true"
  - "--fixed-cidr-v6"
  - "2001:db8:1::/64"
  sysctls:
  - name: "net.ipv6.conf.eth0.accept_ra"
    value: "2"
```

This is another way (not the one I opted for in this PR) to get #6050 fixed and many other future requirements without adding too much complexity (and copy/pasting) in the code.