### PR TITLE
Make kuberouter more configurable

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -526,6 +526,7 @@ func (c *Cluster) FillDefaults() error {
 	} else if c.Spec.Networking.Canal != nil {
 		// OK
 	} else if c.Spec.Networking.Kuberouter != nil {
+		c.Spec.Networking.Kuberouter.LivenessProbeEnabled = true
 		// OK
 	} else if c.Spec.Networking.Romana != nil {
 		// OK

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -526,7 +526,6 @@ func (c *Cluster) FillDefaults() error {
 	} else if c.Spec.Networking.Canal != nil {
 		// OK
 	} else if c.Spec.Networking.Kuberouter != nil {
-		c.Spec.Networking.Kuberouter.LivenessProbeEnabled = true
 		// OK
 	} else if c.Spec.Networking.Romana != nil {
 		// OK

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -116,6 +116,18 @@ type CanalNetworkingSpec struct {
 
 // KuberouterNetworkingSpec declares that we want Kube-router networking
 type KuberouterNetworkingSpec struct {
+	// The container image name to use, which by default is:
+	// cloudnativelabs/kube-router:v0.1.0
+	ImageName string `json:"imageName,omitempty"`
+	// PrometheusMetricsPort is the TCP port that the Prometheus
+	// metrics server should bind to (default: 12013)
+	PrometheusMetricsPort int32 `json:"prometheusMetricsPort,omitempty"`
+	// LivenessProbeEnabled if livenessProbe is enabled (default: true)
+	LivenessProbeEnabled bool `json:"livenessProbeEnabled,omitempty"`
+	// LivenessProbeInitialDelay livenessProbe initialDelay (default: 10)
+	LivenessProbeInitialDelay bool `json:"livenessProbeInitialDelay,omitempty"`
+	// LivenessProbePeriodSeconds livenessProbe periodSeconds (default: 3)
+	LivenessProbePeriodSeconds bool `json:"livenessProbePeriodSeconds,omitempty"`
 }
 
 // RomanaNetworkingSpec declares that we want Romana networking

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -122,8 +122,8 @@ type KuberouterNetworkingSpec struct {
 	// PrometheusMetricsPort is the TCP port that the Prometheus
 	// metrics server should bind to (default: 12013)
 	PrometheusMetricsPort int32 `json:"prometheusMetricsPort,omitempty"`
-	// LivenessProbeEnabled if livenessProbe is enabled (default: true)
-	LivenessProbeEnabled bool `json:"livenessProbeEnabled,omitempty"`
+	// LivenessProbeDisabled if livenessProbe is disabled (default: false)
+	LivenessProbeDisabled bool `json:"livenessProbeDisabled,omitempty"`
 	// LivenessProbeInitialDelay livenessProbe initialDelay (default: 10)
 	LivenessProbeInitialDelay bool `json:"livenessProbeInitialDelay,omitempty"`
 	// LivenessProbePeriodSeconds livenessProbe periodSeconds (default: 3)

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -116,6 +116,18 @@ type CanalNetworkingSpec struct {
 
 // KuberouterNetworkingSpec declares that we want Kube-router networking
 type KuberouterNetworkingSpec struct {
+	// The container image name to use, which by default is:
+	// cloudnativelabs/kube-router:v0.1.0
+	ImageName string `json:"imageName,omitempty"`
+	// PrometheusMetricsPort is the TCP port that the Prometheus
+	// metrics server should bind to (default: 12013)
+	PrometheusMetricsPort int32 `json:"prometheusMetricsPort,omitempty"`
+	// LivenessProbeEnabled if livenessProbe is enabled (default: true)
+	LivenessProbeEnabled bool `json:"livenessProbeEnabled,omitempty"`
+	// LivenessProbeInitialDelay livenessProbe initialDelay (default: 10)
+	LivenessProbeInitialDelay bool `json:"livenessProbeInitialDelay,omitempty"`
+	// LivenessProbePeriodSeconds livenessProbe periodSeconds (default: 3)
+	LivenessProbePeriodSeconds bool `json:"livenessProbePeriodSeconds,omitempty"`
 }
 
 // RomanaNetworkingSpec declares that we want Romana networking

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -122,8 +122,8 @@ type KuberouterNetworkingSpec struct {
 	// PrometheusMetricsPort is the TCP port that the Prometheus
 	// metrics server should bind to (default: 12013)
 	PrometheusMetricsPort int32 `json:"prometheusMetricsPort,omitempty"`
-	// LivenessProbeEnabled if livenessProbe is enabled (default: true)
-	LivenessProbeEnabled bool `json:"livenessProbeEnabled,omitempty"`
+	// LivenessProbeDisabled if livenessProbe is disabled (default: false)
+	LivenessProbeDisabled bool `json:"livenessProbeDisabled,omitempty"`
 	// LivenessProbeInitialDelay livenessProbe initialDelay (default: 10)
 	LivenessProbeInitialDelay bool `json:"livenessProbeInitialDelay,omitempty"`
 	// LivenessProbePeriodSeconds livenessProbe periodSeconds (default: 3)

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -2700,6 +2700,11 @@ func Convert_kops_KubenetNetworkingSpec_To_v1alpha1_KubenetNetworkingSpec(in *ko
 }
 
 func autoConvert_v1alpha1_KuberouterNetworkingSpec_To_kops_KuberouterNetworkingSpec(in *KuberouterNetworkingSpec, out *kops.KuberouterNetworkingSpec, s conversion.Scope) error {
+	out.ImageName = in.ImageName
+	out.PrometheusMetricsPort = in.PrometheusMetricsPort
+	out.LivenessProbeEnabled = in.LivenessProbeEnabled
+	out.LivenessProbeInitialDelay = in.LivenessProbeInitialDelay
+	out.LivenessProbePeriodSeconds = in.LivenessProbePeriodSeconds
 	return nil
 }
 
@@ -2709,6 +2714,11 @@ func Convert_v1alpha1_KuberouterNetworkingSpec_To_kops_KuberouterNetworkingSpec(
 }
 
 func autoConvert_kops_KuberouterNetworkingSpec_To_v1alpha1_KuberouterNetworkingSpec(in *kops.KuberouterNetworkingSpec, out *KuberouterNetworkingSpec, s conversion.Scope) error {
+	out.ImageName = in.ImageName
+	out.PrometheusMetricsPort = in.PrometheusMetricsPort
+	out.LivenessProbeEnabled = in.LivenessProbeEnabled
+	out.LivenessProbeInitialDelay = in.LivenessProbeInitialDelay
+	out.LivenessProbePeriodSeconds = in.LivenessProbePeriodSeconds
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -2702,7 +2702,7 @@ func Convert_kops_KubenetNetworkingSpec_To_v1alpha1_KubenetNetworkingSpec(in *ko
 func autoConvert_v1alpha1_KuberouterNetworkingSpec_To_kops_KuberouterNetworkingSpec(in *KuberouterNetworkingSpec, out *kops.KuberouterNetworkingSpec, s conversion.Scope) error {
 	out.ImageName = in.ImageName
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
-	out.LivenessProbeEnabled = in.LivenessProbeEnabled
+	out.LivenessProbeDisabled = in.LivenessProbeDisabled
 	out.LivenessProbeInitialDelay = in.LivenessProbeInitialDelay
 	out.LivenessProbePeriodSeconds = in.LivenessProbePeriodSeconds
 	return nil
@@ -2716,7 +2716,7 @@ func Convert_v1alpha1_KuberouterNetworkingSpec_To_kops_KuberouterNetworkingSpec(
 func autoConvert_kops_KuberouterNetworkingSpec_To_v1alpha1_KuberouterNetworkingSpec(in *kops.KuberouterNetworkingSpec, out *KuberouterNetworkingSpec, s conversion.Scope) error {
 	out.ImageName = in.ImageName
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
-	out.LivenessProbeEnabled = in.LivenessProbeEnabled
+	out.LivenessProbeDisabled = in.LivenessProbeDisabled
 	out.LivenessProbeInitialDelay = in.LivenessProbeInitialDelay
 	out.LivenessProbePeriodSeconds = in.LivenessProbePeriodSeconds
 	return nil

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -116,6 +116,18 @@ type CanalNetworkingSpec struct {
 
 // KuberouterNetworkingSpec declares that we want Kube-router networking
 type KuberouterNetworkingSpec struct {
+	// The container image name to use, which by default is:
+	// cloudnativelabs/kube-router:v0.1.0
+	ImageName string `json:"imageName,omitempty"`
+	// PrometheusMetricsPort is the TCP port that the Prometheus
+	// metrics server should bind to (default: 12013)
+	PrometheusMetricsPort int32 `json:"prometheusMetricsPort,omitempty"`
+	// LivenessProbeEnabled if livenessProbe is enabled (default: true)
+	LivenessProbeEnabled bool `json:"livenessProbeEnabled,omitempty"`
+	// LivenessProbeInitialDelay livenessProbe initialDelay (default: 10)
+	LivenessProbeInitialDelay bool `json:"livenessProbeInitialDelay,omitempty"`
+	// LivenessProbePeriodSeconds livenessProbe periodSeconds (default: 3)
+	LivenessProbePeriodSeconds bool `json:"livenessProbePeriodSeconds,omitempty"`
 }
 
 // RomanaNetworkingSpec declares that we want Romana networking

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -122,8 +122,8 @@ type KuberouterNetworkingSpec struct {
 	// PrometheusMetricsPort is the TCP port that the Prometheus
 	// metrics server should bind to (default: 12013)
 	PrometheusMetricsPort int32 `json:"prometheusMetricsPort,omitempty"`
-	// LivenessProbeEnabled if livenessProbe is enabled (default: true)
-	LivenessProbeEnabled bool `json:"livenessProbeEnabled,omitempty"`
+	// LivenessProbeDisabled if livenessProbe is disabled (default: false)
+	LivenessProbeDisabled bool `json:"livenessProbeDisabled,omitempty"`
 	// LivenessProbeInitialDelay livenessProbe initialDelay (default: 10)
 	LivenessProbeInitialDelay bool `json:"livenessProbeInitialDelay,omitempty"`
 	// LivenessProbePeriodSeconds livenessProbe periodSeconds (default: 3)

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2964,6 +2964,11 @@ func Convert_kops_KubenetNetworkingSpec_To_v1alpha2_KubenetNetworkingSpec(in *ko
 }
 
 func autoConvert_v1alpha2_KuberouterNetworkingSpec_To_kops_KuberouterNetworkingSpec(in *KuberouterNetworkingSpec, out *kops.KuberouterNetworkingSpec, s conversion.Scope) error {
+	out.ImageName = in.ImageName
+	out.PrometheusMetricsPort = in.PrometheusMetricsPort
+	out.LivenessProbeEnabled = in.LivenessProbeEnabled
+	out.LivenessProbeInitialDelay = in.LivenessProbeInitialDelay
+	out.LivenessProbePeriodSeconds = in.LivenessProbePeriodSeconds
 	return nil
 }
 
@@ -2973,6 +2978,11 @@ func Convert_v1alpha2_KuberouterNetworkingSpec_To_kops_KuberouterNetworkingSpec(
 }
 
 func autoConvert_kops_KuberouterNetworkingSpec_To_v1alpha2_KuberouterNetworkingSpec(in *kops.KuberouterNetworkingSpec, out *KuberouterNetworkingSpec, s conversion.Scope) error {
+	out.ImageName = in.ImageName
+	out.PrometheusMetricsPort = in.PrometheusMetricsPort
+	out.LivenessProbeEnabled = in.LivenessProbeEnabled
+	out.LivenessProbeInitialDelay = in.LivenessProbeInitialDelay
+	out.LivenessProbePeriodSeconds = in.LivenessProbePeriodSeconds
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2966,7 +2966,7 @@ func Convert_kops_KubenetNetworkingSpec_To_v1alpha2_KubenetNetworkingSpec(in *ko
 func autoConvert_v1alpha2_KuberouterNetworkingSpec_To_kops_KuberouterNetworkingSpec(in *KuberouterNetworkingSpec, out *kops.KuberouterNetworkingSpec, s conversion.Scope) error {
 	out.ImageName = in.ImageName
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
-	out.LivenessProbeEnabled = in.LivenessProbeEnabled
+	out.LivenessProbeDisabled = in.LivenessProbeDisabled
 	out.LivenessProbeInitialDelay = in.LivenessProbeInitialDelay
 	out.LivenessProbePeriodSeconds = in.LivenessProbePeriodSeconds
 	return nil
@@ -2980,7 +2980,7 @@ func Convert_v1alpha2_KuberouterNetworkingSpec_To_kops_KuberouterNetworkingSpec(
 func autoConvert_kops_KuberouterNetworkingSpec_To_v1alpha2_KuberouterNetworkingSpec(in *kops.KuberouterNetworkingSpec, out *KuberouterNetworkingSpec, s conversion.Scope) error {
 	out.ImageName = in.ImageName
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
-	out.LivenessProbeEnabled = in.LivenessProbeEnabled
+	out.LivenessProbeDisabled = in.LivenessProbeDisabled
 	out.LivenessProbeInitialDelay = in.LivenessProbeInitialDelay
 	out.LivenessProbePeriodSeconds = in.LivenessProbePeriodSeconds
 	return nil

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
@@ -37,24 +37,26 @@ spec:
     spec:
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router:v0.1.0
+        image: {{- or .Networking.Kuberouter.ImageName "cloudnativelabs/kube-router:v0.1.0" }}
         args:
         - --run-router=true
         - --run-firewall=true
         - --run-service-proxy=true
-        - --metrics-port=12013
+        - --metrics-port={{- or .Networking.Kuberouter.PrometheusMetricsPort "12013" }}
         - --kubeconfig=/var/lib/kube-router/kubeconfig
         env:
         - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        {{- if eq .Networking.Kuberouter.LivenessProbeEnabled "true" }}
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
-          initialDelaySeconds: 10
-          periodSeconds: 3
+          initialDelaySeconds: {{- or .Networking.Kuberouter.LivenessProbeInitialDelay "10" }}
+          periodSeconds: {{- or .Networking.Kuberouter.LivenessProbePeriodSeconds "3" }}
+        {{- end }}
         resources:
           requests:
             cpu: 100m

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
@@ -49,7 +49,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        {{- if eq .Networking.Kuberouter.LivenessProbeEnabled "true" }}
+        {{- if ne .Networking.Kuberouter.LivenessProbeDisabled "false" }}
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Making kube-router a bit more configurable
- Image name
- Liveness check
- Prometheus port