### PR TITLE
Fix some typos in files

### DIFF
--- a/docs/single-to-multi-master.md
+++ b/docs/single-to-multi-master.md
@@ -292,7 +292,7 @@ and not during a future upgrade or, worse, during a master failure.
 
 In case you failed to upgrade to multi-master you will need to restore from the backup you have taken previously.
 
-Take extra care becase kops will not start etcd and etcd-events with the same ID on <master-b> an/or <master-c> for example but will mix them (ex: etcd-b and etcd-events-c on <master-b> & etcd-c and etcd-events-b on <master-c> ); this can be double checked in Route53 where kops will create DNS records for your services.
+Take extra care because kops will not start etcd and etcd-events with the same ID on <master-b> an/or <master-c> for example but will mix them (ex: etcd-b and etcd-events-c on <master-b> & etcd-c and etcd-events-b on <master-c> ); this can be double checked in Route53 where kops will create DNS records for your services.
 
 If your 2nd spinned master failed and cluster becomes inconsistent edit the corresponding kops master instancegroup and switch ``MinSize`` and ``MaxSize`` to "0" and run an update on your cluster.
 

--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -102,7 +102,7 @@ func (b *KubeProxyBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-// buildPod is responsble constructing the pod spec
+// buildPod is responsible constructing the pod spec
 func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 	c := b.Cluster.Spec.KubeProxy
 	if c == nil {

--- a/upup/pkg/fi/fitasks/mirrorsecrets.go
+++ b/upup/pkg/fi/fitasks/mirrorsecrets.go
@@ -57,7 +57,7 @@ func (e *MirrorSecrets) Find(c *fi.Context) (*MirrorSecrets, error) {
 	return nil, nil
 }
 
-// Run implemements fi.Task::Run
+// Run implements fi.Task::Run
 func (e *MirrorSecrets) Run(c *fi.Context) error {
 	return fi.DefaultDeltaRunMethod(e, c)
 }


### PR DESCRIPTION
Fix some typos in files:

1. docs/single-to-multi-master.md
2. nodeup/pkg/model/kube_proxy.go
3. upup/pkg/fi/fitasks/mirrorsecrets.go