### PR TITLE
Use a single command in Linux install instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -25,7 +25,7 @@ You can also [install from source](development/building.md).
 From Github:
 
 ```bash
-wget -O kops https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-linux-amd64
+curl -Lo kops https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-linux-amd64
 chmod +x ./kops
 sudo mv ./kops /usr/local/bin/
 ```
@@ -58,7 +58,7 @@ sudo mv ./kubectl /usr/local/bin/kubectl
 From the [official kubernetes kubectl release](https://kubernetes.io/docs/tasks/tools/install-kubectl/):
 
 ```
-wget -O kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
 chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin/kubectl
 ```


### PR DESCRIPTION
cURL and Wget are both great commands, but the Linux install instructions should stick to just using one.

Similar to https://github.com/kubernetes/kops/pull/5901, which changed this for MacOS.