### PR TITLE
autoscaler setup: Use set -x to stop execution if errors are encountered

### DIFF
--- a/addons/cluster-autoscaler/cluster-autoscaler.sh
+++ b/addons/cluster-autoscaler/cluster-autoscaler.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 #Set all the variables in this section
 CLUSTER_NAME="myfirstcluster.k8s.local"
 CLOUD_PROVIDER=aws


### PR DESCRIPTION
I think this is especially important in this script because variables that are set incorrectly can easily add unwanted resources to the cluster, or add it to the wrong cluster!