### PR TITLE
feat(cmd/kops/create_cluster): default to kubelet anonymousAuth true

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -987,6 +987,12 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		cluster.Spec.MasterPublicName = c.MasterPublicName
 	}
 
+	// Default to kubelet auth being turned off
+	if cluster.Spec.Kubelet == nil {
+		cluster.Spec.Kubelet = &api.KubeletConfigSpec{}
+	}
+	cluster.Spec.Kubelet.AnonymousAuth = fi.Bool(true)
+
 	// Populate the API access, so that it can be discoverable
 	// TODO: This is the same code as in defaults - try to dedup?
 	if cluster.Spec.API == nil {


### PR DESCRIPTION
**What this PR does**: Turns on `anonymousAuth` by default on new cluster creation

**Why**: It's _extremely_ dangerous to have this on by default _and_ not have it in bold letters on the README.md that it's off by default. It's very easy to overlook this as a "newbie" or somebody who skims through stuff (not saying that's OK, but people will be that way regardless). So, this introduces turning it off on new cluster creation by default

**Notes**: I'm sure this probably isn't the best place to do this, but it seemed like it probably was. I could also see it being moved to `pkg/apis/kops/apiserver.go` as well. 