### PR TITLE
Bump version of amazon-vpc-cni in bootstrapchannelbuilder

### DIFF
--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -837,7 +837,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.AmazonVPC != nil {
 		key := "networking.amazon-vpc-routed-eni"
-		version := "1.0.0-kops.3"
+		version := "1.2.1-kops.1"
 
 		{
 			id := "k8s-1.7"


### PR DESCRIPTION
We need to bump this version whenever we change the manifest, to
ensure that updates are actually applied.  Bump it to catch up.