### PR TITLE
Mention about possible state store vendors in error message

### DIFF
--- a/cmd/kops/util/factory.go
+++ b/cmd/kops/util/factory.go
@@ -53,12 +53,12 @@ func NewFactory(options *FactoryOptions) *Factory {
 
 const (
 	STATE_ERROR = `Please set the --state flag or export KOPS_STATE_STORE.
-A valid value follows the format s3://<bucket>.
-A s3 bucket is required to store cluster state information.`
+For example, a valid value follows the format s3://<bucket>.
+You can find the supported stores in https://github.com/kubernetes/kops/blob/master/docs/state.md.`
 
-	INVALID_STATE_ERROR = `Unable to read state store s3 bucket.
-Please use a valid s3 bucket uri when setting --state or KOPS_STATE_STORE env var.
-A valid value follows the format s3://<bucket>.
+	INVALID_STATE_ERROR = `Unable to read state store.
+Please use a valid state store when setting --state or KOPS_STATE_STORE env var.
+For example, a valid value follows the format s3://<bucket>.
 Trailing slash will be trimmed.`
 )
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -32,9 +32,7 @@ There are two primary types:
 
 ## State Store
 
-The API objects are currently stored in an abstraction called a "state store", and currently the only implemented
-storage is an S3 bucket.  The storage of files in the S3 bucket is an implementation detail.  Expect more state
-stores soon.  For example, it might be convenient to put the InstanceGroup into the kubernetes API itself.
+The API objects are currently stored in an abstraction called a "state store".  [state.md](/docs/state.md) has more detail.
 
 ## Configuration inference
 


### PR DESCRIPTION
When missed --state flag or specified invalid format, error message
asks us to use **s3 bucket**.

e.g:

```
$ kops create cluster --name foo --zones $ZONE  --project=${PROJECT} --state=foo

State Store: Invalid value: "foo": Unable to read state store s3 bucket.
Please use a valid s3 bucket uri when setting --state or KOPS_STATE_STORE env var.
A valid value follows the format s3://<bucket>.
Trailing slash will be trimmed.
```

The state store supports some vendors now, hence, this patch updates
the message.