### PR TITLE
Simplify makefile for update-machine-types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -786,6 +786,6 @@ build-docs:
 
 .PHONY: update-machine-types
 update-machine-types: #Update machine_types.go
-	go build -o hack/machine_types/machine_types  ${KOPS_ROOT}/hack/machine_types/machine_types.go ${KOPS_ROOT}/hack/machine_types/vpc_ip_resource_limit.go
+	go build -o hack/machine_types/machine_types  ${KOPS_ROOT}/hack/machine_types/
 	hack/machine_types/machine_types --out upup/pkg/fi/cloudup/awsup/machine_types.go
 	go fmt upup/pkg/fi/cloudup/awsup/machine_types.go


### PR DESCRIPTION
No real need to list the go files, we can just specify the package.