### PR TITLE
Include name of unhealthy component in validation error

### DIFF
--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -167,7 +167,7 @@ func (v *ValidationCluster) collectComponentFailures(client kubernetes.Interface
 				v.addError(&ValidationError{
 					Kind:    "ComponentStatus",
 					Name:    component.Name,
-					Message: "component is unhealthy",
+					Message: fmt.Sprintf("component %q is unhealthy", component.Name),
 				})
 			}
 		}


### PR DESCRIPTION
Rolling-update just prints the message, and indeed I think the message
should be self-contained.