### PR TITLE
machine-types: remove duplicate dedup

### DIFF
--- a/hack/machine_types/machine_types.go
+++ b/hack/machine_types/machine_types.go
@@ -262,14 +262,7 @@ func run() error {
 
 	for _, f := range sortedFamilies {
 		output = output + fmt.Sprintf("\n// %s family", f)
-		previousMachine := ""
 		for _, m := range machines {
-			// Ignore duplicates
-			if m.Name == previousMachine {
-				continue
-			}
-			previousMachine = m.Name
-
 			if family := strings.Split(m.Name, ".")[0]; family == f {
 				var ecu string
 				if m.Burstable {


### PR DESCRIPTION
PR #6058 addded dedup in a better way than I had previously done, so
remove my more complicated and now superfluous second dedup.