### PR TITLE
Spotinst: Bump controller image

### DIFF
--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.8.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.8.0.yaml.template
@@ -97,7 +97,7 @@ spec:
     spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
-        image: spotinst/kubernetes-cluster-controller:1.0.16
+        image: spotinst/kubernetes-cluster-controller:1.0.18
         imagePullPolicy: Always
         env:
         - name: SPOTINST_TOKEN

--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.9.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.9.0.yaml.template
@@ -97,7 +97,7 @@ spec:
     spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
-        image: spotinst/kubernetes-cluster-controller:1.0.16
+        image: spotinst/kubernetes-cluster-controller:1.0.18
         imagePullPolicy: Always
         env:
         - name: SPOTINST_TOKEN

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -447,7 +447,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if featureflag.Spotinst.Enabled() {
 		key := "spotinst-kubernetes-cluster-controller.addons.k8s.io"
-		version := "1.0.16"
+		version := "1.0.18"
 
 		{
 			id := "v1.8.0"


### PR DESCRIPTION
This PR bumps the Spotinst cluster controller to version 1.0.18.