### PR TITLE
Promote alpha channels to stable

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -34,10 +34,10 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.11.0"
-    recommendedVersion: 1.11.2
+    recommendedVersion: 1.11.5
     requiredVersion: 1.11.0
   - range: ">=1.10.0"
-    recommendedVersion: 1.10.6
+    recommendedVersion: 1.10.11
     requiredVersion: 1.10.0
   - range: ">=1.9.0"
     recommendedVersion: 1.9.10


### PR DESCRIPTION
Update stable channel for CVE-2018-1002105

More details https://github.com/kubernetes/kubernetes/issues/71411