### PR TITLE
Automated cherry pick of #6156: Fix Calico upgrade job to use the correct version

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7-v3.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7-v3.yaml.template
@@ -578,7 +578,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: calico-complete-upgrade
+  name: calico-complete-upgrade-v331
   namespace: kube-system
   labels:
     role.kubernetes.io/networking: "1"
@@ -597,7 +597,7 @@ spec:
           command: ['/bin/sh', '-c', '/completion-job.sh']
           env:
             - name: EXPECTED_NODE_IMAGE
-              value: quay.io/calico/node:v3.1.1
+              value: quay.io/calico/node:v3.3.1
             # The location of the Calico etcd cluster.
             - name: CALICO_ETCD_ENDPOINTS
               valueFrom:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -645,7 +645,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 			"pre-k8s-1.6": "2.4.2-kops.1",
 			"k8s-1.6":     "2.6.9-kops.1",
 			"k8s-1.7":     "2.6.9-kops.1",
-			"k8s-1.7-v3":  "3.3.1-kops.2",
+			"k8s-1.7-v3":  "3.3.1-kops.3",
 		}
 
 		if b.cluster.Spec.Networking.Calico.MajorVersion == "v3" {


### PR DESCRIPTION
Cherry pick of #6156 on release-1.11.

#6156: Fix Calico upgrade job to use the correct version