### PR TITLE
Fix for when node and master use the same SG.

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -81,8 +81,9 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			if ig.Spec.SecurityGroupOverride != nil {
 				glog.V(1).Infof("WARNING: You are overwriting the Instance Groups, Security Group. When this is done you are responsible for ensure the correct rules!")
 
+				sgName := fmt.Sprintf("%v-%v", fi.StringValue(ig.Spec.SecurityGroupOverride), ig.Spec.Role)
 				sgLink = &awstasks.SecurityGroup{
-					Name:   ig.Spec.SecurityGroupOverride,
+					Name:   &sgName,
 					ID:     ig.Spec.SecurityGroupOverride,
 					Shared: fi.Bool(true),
 				}

--- a/pkg/model/firewall.go
+++ b/pkg/model/firewall.go
@@ -483,8 +483,9 @@ func (b *KopsModelContext) GetSecurityGroups(role kops.InstanceGroupRole) ([]Sec
 		}
 		done[name] = true
 
+		sgName := fmt.Sprintf("%v-%v", fi.StringValue(ig.Spec.SecurityGroupOverride), role)
 		t := &awstasks.SecurityGroup{
-			Name:        ig.Spec.SecurityGroupOverride,
+			Name:        &sgName,
 			ID:          ig.Spec.SecurityGroupOverride,
 			VPC:         b.LinkToVPC(),
 			Shared:      fi.Bool(true),


### PR DESCRIPTION
When using SG Overrides the task name should be unique. Given that someone may choose to use the same SG for master/nodes/bastion we append the role make to the SG ID to make the task unique.