### PR TITLE
Automated cherry pick of #6175: Fix for when node and master use the same SG.

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -81,8 +81,9 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			if ig.Spec.SecurityGroupOverride != nil {
 				glog.V(1).Infof("WARNING: You are overwriting the Instance Groups, Security Group. When this is done you are responsible for ensure the correct rules!")
 
+				sgName := fmt.Sprintf("%v-%v", fi.StringValue(ig.Spec.SecurityGroupOverride), ig.Spec.Role)
 				sgLink = &awstasks.SecurityGroup{
-					Name:   ig.Spec.SecurityGroupOverride,
+					Name:   &sgName,
 					ID:     ig.Spec.SecurityGroupOverride,
 					Shared: fi.Bool(true),
 				}

--- a/pkg/model/firewall.go
+++ b/pkg/model/firewall.go
@@ -483,8 +483,9 @@ func (b *KopsModelContext) GetSecurityGroups(role kops.InstanceGroupRole) ([]Sec
 		}
 		done[name] = true
 
+		sgName := fmt.Sprintf("%v-%v", fi.StringValue(ig.Spec.SecurityGroupOverride), role)
 		t := &awstasks.SecurityGroup{
-			Name:        ig.Spec.SecurityGroupOverride,
+			Name:        &sgName,
 			ID:          ig.Spec.SecurityGroupOverride,
 			VPC:         b.LinkToVPC(),
 			Shared:      fi.Bool(true),


### PR DESCRIPTION
Cherry pick of #6175 on release-1.11.

#6175: Fix for when node and master use the same SG.