### PR TITLE
fix(docs): fix the compatibility matrics on hpa.md

### DIFF
--- a/docs/horizontal_pod_autoscaling.md
+++ b/docs/horizontal_pod_autoscaling.md
@@ -68,6 +68,7 @@ compatibility matrix is as follows:
 
 Metrics Server | Metrics API group/version | Supported Kubernetes version
 ---------------|---------------------------|-----------------------------
+0.3.x          | `metrics.k8s.io/v1beta1`  | 1.8+
 0.2.x          | `metrics.k8s.io/v1beta1`  | 1.8+
 0.1.x          | `metrics/v1alpha1`        | 1.7
 


### PR DESCRIPTION
Add new metrics-server version to the compatibility matrics on the horizontal_pod_autoscaling.md docs.