### PR TITLE
Fix metrics server addon

### DIFF
--- a/addons/metrics-server/v1.8.x.yaml
+++ b/addons/metrics-server/v1.8.x.yaml
@@ -138,6 +138,9 @@ spec:
       - name: metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: Always
+        command:
+            - /metrics-server
+            - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
         volumeMounts:
         - name: tmp-dir
           mountPath: /tmp

--- a/addons/metrics-server/v1.8.x.yaml
+++ b/addons/metrics-server/v1.8.x.yaml
@@ -141,6 +141,7 @@ spec:
         command:
             - /metrics-server
             - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
+            - --kubelet-insecure-tls
         volumeMounts:
         - name: tmp-dir
           mountPath: /tmp


### PR DESCRIPTION
All the details are in the commit messages. I think this:

* Closes https://github.com/kubernetes/kops/issues/5770.
* Closes https://github.com/kubernetes/kops/issues/6160 (possibly, that issue has very little detail).

Fixes to issues caused by changes in v0.3.x, see release notes:

* https://github.com/kubernetes-incubator/metrics-server/releases/tag/v0.3.0
* https://github.com/kubernetes-incubator/metrics-server/releases/tag/v0.3.1

Main issue is that in 0.3.x, the secure kubelet port with auth is enabled by default. Use of the insecure port is deprecated and may even be removed as soon as the next release.

That said, metrics-server now uses webhook authentication so kubelet would need webhook authentication enabled (which we don’t). This flag enables, that serviceaccount tokens to be used to authenticate against the kubelet: See:

* https://kubernetes.io/docs/reference/access-authn-authz/webhook/
* kubernetes#5508
* kubernetes#5176 (comment)
* kubernetes-incubator/metrics-server#175

Currently, even if we were to use certificates, this provides a challenge since metrics server will generate it’s own self-signed certificates since we don’t set `--tls-cert-file` and `--tls-private-key-file`. Related:

* kubernetes-incubator/metrics-server#25
* kubernetes-incubator/metrics-server#146

That said, based on the comment in https://github.com/kubernetes/kops/commit/8ba93eeda5f5fb660367c0da8d454f98e38aba28, do you think it's worth enabling webhook authentication on kubelet instead of doing it this way?