### PR TITLE
Adding support for the new Stockholm region

### DIFF
--- a/upup/pkg/fi/cloud.go
+++ b/upup/pkg/fi/cloud.go
@@ -89,6 +89,10 @@ var zonesToCloud = map[string]kops.CloudProviderID{
 	"ca-central-1a": kops.CloudProviderAWS,
 	"ca-central-1b": kops.CloudProviderAWS,
 
+	"eu-north-1a": kops.CloudProviderAWS,
+	"eu-north-1b": kops.CloudProviderAWS,
+	"eu-north-1c": kops.CloudProviderAWS,
+
 	"eu-west-1a": kops.CloudProviderAWS,
 	"eu-west-1b": kops.CloudProviderAWS,
 	"eu-west-1c": kops.CloudProviderAWS,


### PR DESCRIPTION
Adding support for the new [Stockholm](https://aws.amazon.com/blogs/aws/now-open-aws-europe-stockholm-region/) region.