### PR TITLE
Implement delete tasks for openstack provider

### DIFF
--- a/pkg/resources/openstack/BUILD.bazel
+++ b/pkg/resources/openstack/BUILD.bazel
@@ -7,6 +7,11 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/resources:go_default_library",
+        "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/openstack:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers:go_default_library",
+        "//vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks:go_default_library",
+        "//vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets:go_default_library",
     ],
 )

--- a/pkg/resources/openstack/resources.go
+++ b/pkg/resources/openstack/resources.go
@@ -109,7 +109,7 @@ func (os *clusterDiscoveryOS) ListNetwork() ([]*resources.Resource, error) {
 		}
 
 		optSubnet := subnets.ListOpts{
-			NetworkID:  network.ID,
+			NetworkID: network.ID,
 		}
 		subnets, err := os.osCloud.ListSubnets(optSubnet)
 		if err != nil {

--- a/pkg/resources/openstack/resources.go
+++ b/pkg/resources/openstack/resources.go
@@ -17,16 +17,92 @@ limitations under the License.
 package openstack
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
 	"k8s.io/kops/pkg/resources"
+	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 )
 
-type listFn func(openstack.OpenstackCloud, string) ([]*resources.Resource, error)
+type openstackListFn func() ([]*resources.Resource, error)
+
+const (
+	typeSSHKey = "SSHKey"
+)
 
 func ListResources(cloud openstack.OpenstackCloud, clusterName string) (map[string]*resources.Resource, error) {
-	resourceTrackers := make(map[string]*resources.Resource)
+	resources := make(map[string]*resources.Resource)
 
-	// TODO(lmb): Implement resource list
+	os := &clusterDiscoveryOS{
+		cloud:       cloud,
+		osCloud:     cloud,
+		clusterName: clusterName,
+	}
 
+	listFunctions := []openstackListFn{
+		os.ListKeypairs,
+	}
+	for _, fn := range listFunctions {
+		resourceTrackers, err := fn()
+		if err != nil {
+			return nil, err
+		}
+		for _, t := range resourceTrackers {
+			resources[t.Type+":"+t.ID] = t
+		}
+	}
+
+	return resources, nil
+}
+
+type clusterDiscoveryOS struct {
+	cloud       fi.Cloud
+	osCloud     openstack.OpenstackCloud
+	clusterName string
+
+	//instanceTemplates []*compute.InstanceTemplate
+	zones []string
+}
+
+func openstackKeyPairName(org string) string {
+	name := strings.Replace(org, ".", "-", -1)
+	name = strings.Replace(name, ":", "_", -1)
+	return name
+}
+
+func (os *clusterDiscoveryOS) ListKeypairs() ([]*resources.Resource, error) {
+	var resourceTrackers []*resources.Resource
+	ks, err := os.osCloud.ListKeypairs()
+	if err != nil {
+		return resourceTrackers, err
+	}
+
+	for _, key := range ks {
+		prefix := "kubernetes-" + openstackKeyPairName(os.clusterName)
+		if strings.HasPrefix(key.Name, prefix) {
+			resourceTracker := &resources.Resource{
+				Name:    key.Name,
+				ID:      key.Name,
+				Type:    typeSSHKey,
+				Deleter: DeleteSSHKey,
+			}
+			resourceTrackers = append(resourceTrackers, resourceTracker)
+		}
+	}
 	return resourceTrackers, nil
+}
+
+func DeleteSSHKey(cloud fi.Cloud, r *resources.Resource) error {
+	c := cloud.(openstack.OpenstackCloud)
+	name := r.Name
+
+	glog.V(2).Infof("Deleting Openstack Keypair %q", name)
+
+	err := c.DeleteKeyPair(r.Name)
+	if err != nil {
+		return fmt.Errorf("error deleting KeyPair %q: %v", name, err)
+	}
+	return nil
 }

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -18,8 +18,8 @@ package openstack
 
 import (
 	"fmt"
-	"time"
 	"net/http"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/gophercloud/gophercloud"

--- a/upup/pkg/fi/cloudup/openstacktasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/sshkey.go
@@ -45,7 +45,7 @@ func (e *SSHKey) CompareWithID() *string {
 
 func (e *SSHKey) Find(c *fi.Context) (*SSHKey, error) {
 	cloud := c.Cloud.(openstack.OpenstackCloud)
-	rs, err := cloud.ListKeypair(openstackKeyPairName(fi.StringValue(e.Name)))
+	rs, err := cloud.GetKeypair(openstackKeyPairName(fi.StringValue(e.Name)))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Part of issue: #3566 

This contains removing everything what is implemented currently. 

Create cluster:
```
kops create cluster --master-size 3 --cloud openstack --zones zone-1,zone-2,zone-3 --network-cidr=${NETWORKCIDR} --master-count 1 -v 15 --networking calico -t private --image 253a096f-e5f5-47ea-bb2b-52d75509f7fc --node-size 3 --master-volume-size 1 --yes testkops.k8s.local
```

Delete cluster:
```
kops delete cluster --name testkops.k8s.local --yes
```

Example print of deleting stuff:
```
% kops delete cluster --name testkops.k8s.local --yes
I1217 14:24:56.881457   14919 s3context.go:87] Found S3_ENDPOINT="https://s3.ceph.company.com", using as non-AWS S3 backend
TYPE		NAME										ID
Network		testkops.k8s.local								08f37a4a-c15c-4b23-89d9-93a0e24767b9
Router		testkops-k8s-local								590f6863-56b1-4248-859e-071b24801030
Router-IF	590f6863-56b1-4248-859e-071b24801030						0960353c-5e54-4f2d-a395-4ca14ee2d1c7
Router-IF	590f6863-56b1-4248-859e-071b24801030						4ba09f6f-f888-447f-93f8-182a0a68ba9b
Router-IF	590f6863-56b1-4248-859e-071b24801030						6f597ad3-1137-48a0-87c6-945c21518751
Router-IF	590f6863-56b1-4248-859e-071b24801030						acd65b9e-0039-4278-a86c-0f30ea8c6092
Router-IF	590f6863-56b1-4248-859e-071b24801030						dd5ccaa6-a7b7-4860-af6f-3b84212121d2
SSHKey		kubernetes-testkops-k8s-local-bf_55_1b_a8_c8_6f_cc_f8_59_71_a6_39_97_0a_66_10	kubernetes-testkops-k8s-local-bf_55_1b_a8_c8_6f_cc_f8_59_71_a6_39_97_0a_66_10
Subnet		utility-zone-1									acd65b9e-0039-4278-a86c-0f30ea8c6092
Subnet		utility-zone-2									6f597ad3-1137-48a0-87c6-945c21518751
Subnet		utility-zone-3									4ba09f6f-f888-447f-93f8-182a0a68ba9b
Subnet		zone-2										0960353c-5e54-4f2d-a395-4ca14ee2d1c7
Subnet		zone-3										dd5ccaa6-a7b7-4860-af6f-3b84212121d2

SSHKey:kubernetes-testkops-k8s-local-bf_55_1b_a8_c8_6f_cc_f8_59_71_a6_39_97_0a_66_10	ok
Router-IF:0960353c-5e54-4f2d-a395-4ca14ee2d1c7	ok
Router-IF:6f597ad3-1137-48a0-87c6-945c21518751	ok
Router-IF:4ba09f6f-f888-447f-93f8-182a0a68ba9b	ok
Router-IF:acd65b9e-0039-4278-a86c-0f30ea8c6092	ok
Router-IF:dd5ccaa6-a7b7-4860-af6f-3b84212121d2	ok
Router:590f6863-56b1-4248-859e-071b24801030	ok
Subnet:0960353c-5e54-4f2d-a395-4ca14ee2d1c7	ok
Subnet:6f597ad3-1137-48a0-87c6-945c21518751	ok
Subnet:dd5ccaa6-a7b7-4860-af6f-3b84212121d2	ok
Subnet:4ba09f6f-f888-447f-93f8-182a0a68ba9b	ok
Subnet:acd65b9e-0039-4278-a86c-0f30ea8c6092	ok
Network:08f37a4a-c15c-4b23-89d9-93a0e24767b9	ok

Deleted cluster: "testkops.k8s.local"
```

