### PR TITLE
Fix alternative AWS partitions in custom instance profiles

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -100,10 +100,11 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:bec386c02055f020566931a5dae08ec5582f1488f50b18d767d5c0edba71c434"
+  digest = "1:bc64ec2fe484ee175b0bd8f9306ff392d8b730ebf2de85a736bfa145be6cce13"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
+    "aws/arn",
     "aws/awserr",
     "aws/awsutil",
     "aws/client",
@@ -2173,6 +2174,7 @@
     "github.com/MakeNowJust/heredoc",
     "github.com/Masterminds/sprig",
     "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/arn",
     "github.com/aws/aws-sdk-go/aws/awserr",
     "github.com/aws/aws-sdk-go/aws/client",
     "github.com/aws/aws-sdk-go/aws/credentials",

--- a/pkg/apis/kops/validation/BUILD.bazel
+++ b/pkg/apis/kops/validation/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/util/subnet:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/arn:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/validation:go_default_library",

--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -88,6 +88,16 @@ func TestValidateInstanceProfile(t *testing.T) {
 		},
 		{
 			Input: &kops.IAMProfileSpec{
+				Profile: s("arn:aws-cn:iam::123456789012:instance-profile/has/path/S3Access"),
+			},
+		},
+		{
+			Input: &kops.IAMProfileSpec{
+				Profile: s("arn:aws-us-gov:iam::123456789012:instance-profile/has/path/S3Access"),
+			},
+		},
+		{
+			Input: &kops.IAMProfileSpec{
 				Profile: s("42"),
 			},
 			ExpectedErrors: []string{"Invalid value::IAMProfile.Profile"},

--- a/vendor/github.com/aws/aws-sdk-go/aws/arn/BUILD.bazel
+++ b/vendor/github.com/aws/aws-sdk-go/aws/arn/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["arn.go"],
+    importmap = "k8s.io/kops/vendor/github.com/aws/aws-sdk-go/aws/arn",
+    importpath = "github.com/aws/aws-sdk-go/aws/arn",
+    visibility = ["//visibility:public"],
+)

--- a/vendor/github.com/aws/aws-sdk-go/aws/arn/arn.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/arn/arn.go
@@ -1,0 +1,86 @@
+// Package arn provides a parser for interacting with Amazon Resource Names.
+package arn
+
+import (
+	"errors"
+	"strings"
+)
+
+const (
+	arnDelimiter = ":"
+	arnSections  = 6
+	arnPrefix    = "arn:"
+
+	// zero-indexed
+	sectionPartition = 1
+	sectionService   = 2
+	sectionRegion    = 3
+	sectionAccountID = 4
+	sectionResource  = 5
+
+	// errors
+	invalidPrefix   = "arn: invalid prefix"
+	invalidSections = "arn: not enough sections"
+)
+
+// ARN captures the individual fields of an Amazon Resource Name.
+// See http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html for more information.
+type ARN struct {
+	// The partition that the resource is in. For standard AWS regions, the partition is "aws". If you have resources in
+	// other partitions, the partition is "aws-partitionname". For example, the partition for resources in the China
+	// (Beijing) region is "aws-cn".
+	Partition string
+
+	// The service namespace that identifies the AWS product (for example, Amazon S3, IAM, or Amazon RDS). For a list of
+	// namespaces, see
+	// http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces.
+	Service string
+
+	// The region the resource resides in. Note that the ARNs for some resources do not require a region, so this
+	// component might be omitted.
+	Region string
+
+	// The ID of the AWS account that owns the resource, without the hyphens. For example, 123456789012. Note that the
+	// ARNs for some resources don't require an account number, so this component might be omitted.
+	AccountID string
+
+	// The content of this part of the ARN varies by service. It often includes an indicator of the type of resource —
+	// for example, an IAM user or Amazon RDS database - followed by a slash (/) or a colon (:), followed by the
+	// resource name itself. Some services allows paths for resource names, as described in
+	// http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-paths.
+	Resource string
+}
+
+// Parse parses an ARN into its constituent parts.
+//
+// Some example ARNs:
+// arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/My App/MyEnvironment
+// arn:aws:iam::123456789012:user/David
+// arn:aws:rds:eu-west-1:123456789012:db:mysql-db
+// arn:aws:s3:::my_corporate_bucket/exampleobject.png
+func Parse(arn string) (ARN, error) {
+	if !strings.HasPrefix(arn, arnPrefix) {
+		return ARN{}, errors.New(invalidPrefix)
+	}
+	sections := strings.SplitN(arn, arnDelimiter, arnSections)
+	if len(sections) != arnSections {
+		return ARN{}, errors.New(invalidSections)
+	}
+	return ARN{
+		Partition: sections[sectionPartition],
+		Service:   sections[sectionService],
+		Region:    sections[sectionRegion],
+		AccountID: sections[sectionAccountID],
+		Resource:  sections[sectionResource],
+	}, nil
+}
+
+// String returns the canonical representation of the ARN
+func (arn ARN) String() string {
+	return arnPrefix +
+		arn.Partition + arnDelimiter +
+		arn.Service + arnDelimiter +
+		arn.Region + arnDelimiter +
+		arn.AccountID + arnDelimiter +
+		arn.Resource
+}


### PR DESCRIPTION
This allows the use of custom IAM roles and instance profiles in AWS China and GovCloud (see the [partition field here](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-arns)). Rather than relying on our own regex, I figured its more sustainable to use the SDK's ARN parser.

Confirmed the new test cases fail without the fix in place:
```
--- FAIL: TestValidateInstanceProfile (0.00s)
    validation_test.go:87: unexpected errors from &{%!q(*string=0xc00041ed60)}: [IAMProfile.Profile: Invalid value: "arn:aws-cn:iam::123456789012:instance-profile/has/path/S3Access": Instance Group IAM Instance Profile must be a valid aws arn such as arn:aws:iam::123456789012:instance-profile/KopsExampleRole]
    validation_test.go:87: unexpected errors from &{%!q(*string=0xc00041ed70)}: [IAMProfile.Profile: Invalid value: "arn:aws-us-gov:iam::123456789012:instance-profile/has/path/S3Access": Instance Group IAM Instance Profile must be a valid aws arn such as arn:aws:iam::123456789012:instance-profile/KopsExampleRole]
```

Closes #6215


I searched through the rest of the code base and didn't see any other references to ARN regex parsing.