### PR TITLE
WIP: Rename kops API group to be compatible with CRDS: kops.k8s.io

### DIFF
--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -216,7 +216,7 @@ func runCreateClusterIntegrationTest(t *testing.T, srcDir string, version string
 
 	for _, cluster := range clusters.Items {
 		cluster.ObjectMeta.CreationTimestamp = MagicTimestamp
-		actualYAMLBytes, err := kopscodecs.ToVersionedYamlWithVersion(&cluster, schema.GroupVersion{Group: "kops", Version: version})
+		actualYAMLBytes, err := kopscodecs.ToVersionedYamlWithVersion(&cluster, schema.GroupVersion{Group: "kops.k8s.io", Version: version})
 		if err != nil {
 			t.Fatalf("unexpected error serializing cluster: %v", err)
 		}
@@ -235,7 +235,7 @@ func runCreateClusterIntegrationTest(t *testing.T, srcDir string, version string
 	for _, ig := range instanceGroups.Items {
 		ig.ObjectMeta.CreationTimestamp = MagicTimestamp
 
-		actualYAMLBytes, err := kopscodecs.ToVersionedYamlWithVersion(&ig, schema.GroupVersion{Group: "kops", Version: version})
+		actualYAMLBytes, err := kopscodecs.ToVersionedYamlWithVersion(&ig, schema.GroupVersion{Group: "kops.k8s.io", Version: version})
 		if err != nil {
 			t.Fatalf("unexpected error serializing InstanceGroup: %v", err)
 		}

--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -77,6 +77,7 @@ func TestHighAvailabilityGCE(t *testing.T) {
 // TestComplex runs the test on a more complex configuration, intended to hit more of the edge cases
 func TestComplex(t *testing.T) {
 	runTestAWS(t, "complex.example.com", "complex", "v1alpha2", false, 1, true, nil)
+	runTestAWS(t, "complex.example.com", "complex", "legacy-v1alpha2", false, 1, true, nil)
 }
 
 // TestMinimalCloudformation runs the test on a minimum configuration, similar to kops create cluster minimal.example.com --zones us-west-1a

--- a/docs/apireference/build/documents/_generated_cluster_v1alpha2_kops_concept.md
+++ b/docs/apireference/build/documents/_generated_cluster_v1alpha2_kops_concept.md
@@ -7,7 +7,7 @@
 
 ```bdocs-tab:example_yaml
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2019-12-10T22:42:27Z"

--- a/docs/apireference/build/documents/_generated_instancegroup_v1alpha2_kops_concept.md
+++ b/docs/apireference/build/documents/_generated_instancegroup_v1alpha2_kops_concept.md
@@ -7,7 +7,7 @@
 
 ```bdocs-tab:example_yaml
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: null

--- a/docs/apireference/examples/cluster/cluster.yaml
+++ b/docs/apireference/examples/cluster/cluster.yaml
@@ -1,5 +1,5 @@
 sample: |
-  apiVersion: kops/v1alpha2
+  apiVersion: kops.k8s.io/v1alpha2
   kind: Cluster
   metadata:
     creationTimestamp: "2019-12-10T22:42:27Z"

--- a/docs/apireference/examples/instancegroup/instancegroup.yaml
+++ b/docs/apireference/examples/instancegroup/instancegroup.yaml
@@ -1,5 +1,5 @@
 sample: |
-  apiVersion: kops/v1alpha2
+  apiVersion: kops.k8s.io/v1alpha2
   kind: InstanceGroup
   metadata:
     creationTimestamp: null

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -20,7 +20,7 @@ authentication:
 For example:
 
 ```
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   name: cluster.example.com
@@ -48,7 +48,7 @@ authentication:
 For example:
 
 ```
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   name: cluster.example.com

--- a/docs/bastion.md
+++ b/docs/bastion.md
@@ -31,7 +31,7 @@ kops edit ig bastions --name $KOPS_NAME
 You should now be able to edit and configure your bastion instance group.
 
 ```yaml
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2017-01-05T13:37:07Z"

--- a/docs/cluster_template.md
+++ b/docs/cluster_template.md
@@ -9,7 +9,7 @@ This document details the template language used.
 The file passed as `--template` must be a [go template](https://golang.org/pkg/text/template/). Example:
 ```yaml
 # File cluster.tmpl.yaml
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   labels:
@@ -105,7 +105,7 @@ $ kops toolbox template --values dev.yaml --template cluster.yaml --template ins
 The example below assumes you have placed the appropriate files i.e. *(nodes.json, master.json etc)* in to the snippets directory. Note, the namespace of the snippets are flat and always the basename() of the file path; so `snippets/components/docker.options` is still referred to as 'docker.options'.
 
 ```YAML
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   name: {{ .environment }}.{{ .dns_zone }}

--- a/docs/examples/kops-test-route53-subdomain.md
+++ b/docs/examples/kops-test-route53-subdomain.md
@@ -686,7 +686,7 @@ kops edit ig nodes
 An editor (whatever you have on the $EDITOR shell variable) will open with the following text:
 
 ```
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-09-06T13:40:39Z
@@ -708,7 +708,7 @@ spec:
 Let's change minSize and maxSize to "3"
 
 ```
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-09-06T13:40:39Z

--- a/docs/examples/kops-tests-private-net-bastion-host.md
+++ b/docs/examples/kops-tests-private-net-bastion-host.md
@@ -142,7 +142,7 @@ kops create instancegroup bastions --role Bastion --subnet utility-us-east-1a --
 You'll see the following output in your editor when you can change your bastion group size and add more networks.
 
 ```bash
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: null
@@ -320,7 +320,7 @@ kops edit ig bastions --name ${NAME}
 And change minSize/maxSize to 3 (3 instances) and add more subnets:
 
 ```bash
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-08-28T17:05:23Z

--- a/docs/instance_groups.md
+++ b/docs/instance_groups.md
@@ -431,7 +431,7 @@ If you need to add tags on auto scaling groups or instances (propagate ASG tags)
 
 ```
 # Example for nodes
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   labels:
@@ -459,7 +459,7 @@ will rescale the ASG without warning.
 
 ```
 # Example for nodes
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   labels:
@@ -489,7 +489,7 @@ load balancers and Network load balancers.
 
 ```
 # Example ingress nodes
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   labels:
@@ -513,7 +513,7 @@ Detailed-Monitoring will cause the monitoring data to be available every 1 minut
 
 ```
 # Example for nodes
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   labels:

--- a/docs/manifests_and_customizing_via_api.md
+++ b/docs/manifests_and_customizing_via_api.md
@@ -57,7 +57,7 @@ NOTE: If you run `kops get cluster $NAME -o yaml > $NAME.yaml`, you will only ge
 The following is the contents of the exported YAML file.
 
 ```yaml
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-05-04T23:21:47Z
@@ -134,7 +134,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-05-04T23:21:48Z
@@ -155,7 +155,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-05-04T23:21:47Z
@@ -174,7 +174,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-05-04T23:21:47Z
@@ -193,7 +193,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-05-04T23:21:48Z
@@ -212,7 +212,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-05-04T23:21:48Z
@@ -236,7 +236,7 @@ spec:
 With the above YAML file, a user can add configurations that are not available via the command line. For instance, you can add a `maxPrice` value to a new instance group and use spot instances. Also add node and cloud labels for the new instance group.
 
 ```yaml
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-05-04T23:21:48Z
@@ -289,7 +289,7 @@ Please refer to the rolling-update [documentation](cli/kops_rolling-update_clust
 ### Cluster Spec
 
 ```yaml
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-05-04T23:21:47Z
@@ -322,7 +322,7 @@ This command prints the entire YAML configuration. But _do not_ use the full doc
 ### Instance Groups
 
 ```yaml
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-05-04T23:21:48Z

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -28,7 +28,7 @@ Note: it is currently not possible to delete secrets from the keystore that have
 
 ### adding ssh credential from spec file
 ```bash
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: SSHCredential
 metadata:
   labels:

--- a/docs/security_groups.md
+++ b/docs/security_groups.md
@@ -14,7 +14,7 @@ This is due to the lifecycle overrides being used to prevent creation of the Sec
 To do this first specify the Security Groups for the ELB (if you are using a LB) and Instance Groups
 Example:
 ```yaml
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"
@@ -28,7 +28,7 @@ spec:
 .
 .
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"

--- a/docs/tutorial/gce.md
+++ b/docs/tutorial/gce.md
@@ -51,7 +51,7 @@ You can see the details of your Cluster object by doing:
 
 `> kops get cluster --state gs://kubernetes-clusters/ simple.k8s.local -oyaml`
 ```
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-10-03T05:07:27Z

--- a/docs/tutorial/upgrading-kubernetes.md
+++ b/docs/tutorial/upgrading-kubernetes.md
@@ -18,7 +18,7 @@ controlled at the cluster level.  So instead of `kops edit ig <name>`, we `kops 
 # and an empty file will abort the edit. If an error occurs while saving this file will be
 # reopened with the relevant failures.
 #
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-10-04T03:52:25Z

--- a/docs/tutorial/working-with-instancegroups.md
+++ b/docs/tutorial/working-with-instancegroups.md
@@ -22,7 +22,7 @@ should be very familiar to you if you've used `kubectl edit`).  `kops edit ig no
 the InstanceGroup in your editor, looking a bit like this:
 
 ```
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-10-03T15:17:31Z

--- a/nodeup/pkg/model/tests/dockerbuilder/docker_1.12.1/cluster.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/docker_1.12.1/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"

--- a/nodeup/pkg/model/tests/dockerbuilder/logflags/cluster.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/logflags/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"

--- a/nodeup/pkg/model/tests/dockerbuilder/simple/cluster.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/simple/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"

--- a/nodeup/pkg/model/tests/kubelet/featuregates/cluster.yaml
+++ b/nodeup/pkg/model/tests/kubelet/featuregates/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"
@@ -43,7 +43,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"

--- a/pkg/apis/kops/doc.go
+++ b/pkg/apis/kops/doc.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package,register
 
-// +groupName=kops
+// +groupName=kops.k8s.io
 package kops // import "k8s.io/kops/pkg/apis/kops"

--- a/pkg/apis/kops/register.go
+++ b/pkg/apis/kops/register.go
@@ -38,7 +38,7 @@ var (
 //var ParameterCodec = runtime.NewParameterCodec(Scheme)
 
 // GroupName is the group name use in this package
-const GroupName = "kops"
+const GroupName = "kops.k8s.io"
 
 // SchemeGroupVersion is the group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}

--- a/pkg/apis/kops/v1alpha1/doc.go
+++ b/pkg/apis/kops/v1alpha1/doc.go
@@ -19,5 +19,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:defaulter-gen=TypeMeta
 
-// +groupName=kops
+// +groupName=kops.k8s.io
 package v1alpha1

--- a/pkg/apis/kops/v1alpha1/register.go
+++ b/pkg/apis/kops/v1alpha1/register.go
@@ -36,7 +36,7 @@ func init() {
 }
 
 // GroupName is the group name use in this package
-const GroupName = "kops"
+const GroupName = "kops.k8s.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}

--- a/pkg/apis/kops/v1alpha2/doc.go
+++ b/pkg/apis/kops/v1alpha2/doc.go
@@ -19,5 +19,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:defaulter-gen=TypeMeta
 
-// +groupName=kops
+// +groupName=kops.k8s.io
 package v1alpha2 // import "k8s.io/kops/pkg/apis/kops/v1alpha2"

--- a/pkg/apis/kops/v1alpha2/register.go
+++ b/pkg/apis/kops/v1alpha2/register.go
@@ -36,7 +36,7 @@ func init() {
 }
 
 // GroupName is the group name use in this package
-const GroupName = "kops"
+const GroupName = "kops.k8s.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha2"}

--- a/pkg/client/clientset_generated/clientset/typed/kops/internalversion/fake/fake_cluster.go
+++ b/pkg/client/clientset_generated/clientset/typed/kops/internalversion/fake/fake_cluster.go
@@ -34,9 +34,9 @@ type FakeClusters struct {
 	ns   string
 }
 
-var clustersResource = schema.GroupVersionResource{Group: "kops", Version: "", Resource: "clusters"}
+var clustersResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "", Resource: "clusters"}
 
-var clustersKind = schema.GroupVersionKind{Group: "kops", Version: "", Kind: "Cluster"}
+var clustersKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "", Kind: "Cluster"}
 
 // Get takes name of the cluster, and returns the corresponding cluster object, and an error if there is any.
 func (c *FakeClusters) Get(name string, options v1.GetOptions) (result *kops.Cluster, err error) {

--- a/pkg/client/clientset_generated/clientset/typed/kops/internalversion/fake/fake_instancegroup.go
+++ b/pkg/client/clientset_generated/clientset/typed/kops/internalversion/fake/fake_instancegroup.go
@@ -34,9 +34,9 @@ type FakeInstanceGroups struct {
 	ns   string
 }
 
-var instancegroupsResource = schema.GroupVersionResource{Group: "kops", Version: "", Resource: "instancegroups"}
+var instancegroupsResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "", Resource: "instancegroups"}
 
-var instancegroupsKind = schema.GroupVersionKind{Group: "kops", Version: "", Kind: "InstanceGroup"}
+var instancegroupsKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "", Kind: "InstanceGroup"}
 
 // Get takes name of the instanceGroup, and returns the corresponding instanceGroup object, and an error if there is any.
 func (c *FakeInstanceGroups) Get(name string, options v1.GetOptions) (result *kops.InstanceGroup, err error) {

--- a/pkg/client/clientset_generated/clientset/typed/kops/internalversion/fake/fake_keyset.go
+++ b/pkg/client/clientset_generated/clientset/typed/kops/internalversion/fake/fake_keyset.go
@@ -34,9 +34,9 @@ type FakeKeysets struct {
 	ns   string
 }
 
-var keysetsResource = schema.GroupVersionResource{Group: "kops", Version: "", Resource: "keysets"}
+var keysetsResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "", Resource: "keysets"}
 
-var keysetsKind = schema.GroupVersionKind{Group: "kops", Version: "", Kind: "Keyset"}
+var keysetsKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "", Kind: "Keyset"}
 
 // Get takes name of the keyset, and returns the corresponding keyset object, and an error if there is any.
 func (c *FakeKeysets) Get(name string, options v1.GetOptions) (result *kops.Keyset, err error) {

--- a/pkg/client/clientset_generated/clientset/typed/kops/internalversion/fake/fake_sshcredential.go
+++ b/pkg/client/clientset_generated/clientset/typed/kops/internalversion/fake/fake_sshcredential.go
@@ -34,9 +34,9 @@ type FakeSSHCredentials struct {
 	ns   string
 }
 
-var sshcredentialsResource = schema.GroupVersionResource{Group: "kops", Version: "", Resource: "sshcredentials"}
+var sshcredentialsResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "", Resource: "sshcredentials"}
 
-var sshcredentialsKind = schema.GroupVersionKind{Group: "kops", Version: "", Kind: "SSHCredential"}
+var sshcredentialsKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "", Kind: "SSHCredential"}
 
 // Get takes name of the sSHCredential, and returns the corresponding sSHCredential object, and an error if there is any.
 func (c *FakeSSHCredentials) Get(name string, options v1.GetOptions) (result *kops.SSHCredential, err error) {

--- a/pkg/client/clientset_generated/clientset/typed/kops/internalversion/kops_client.go
+++ b/pkg/client/clientset_generated/clientset/typed/kops/internalversion/kops_client.go
@@ -31,7 +31,7 @@ type KopsInterface interface {
 	SSHCredentialsGetter
 }
 
-// KopsClient is used to interact with features provided by the kops group.
+// KopsClient is used to interact with features provided by the kops.k8s.io group.
 type KopsClient struct {
 	restClient rest.Interface
 }
@@ -85,8 +85,8 @@ func setConfigDefaults(config *rest.Config) error {
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
-	if config.GroupVersion == nil || config.GroupVersion.Group != scheme.Scheme.PrioritizedVersionsForGroup("kops")[0].Group {
-		gv := scheme.Scheme.PrioritizedVersionsForGroup("kops")[0]
+	if config.GroupVersion == nil || config.GroupVersion.Group != scheme.Scheme.PrioritizedVersionsForGroup("kops.k8s.io")[0].Group {
+		gv := scheme.Scheme.PrioritizedVersionsForGroup("kops.k8s.io")[0]
 		config.GroupVersion = &gv
 	}
 	config.NegotiatedSerializer = scheme.Codecs

--- a/pkg/client/clientset_generated/clientset/typed/kops/v1alpha1/fake/fake_cluster.go
+++ b/pkg/client/clientset_generated/clientset/typed/kops/v1alpha1/fake/fake_cluster.go
@@ -34,9 +34,9 @@ type FakeClusters struct {
 	ns   string
 }
 
-var clustersResource = schema.GroupVersionResource{Group: "kops", Version: "v1alpha1", Resource: "clusters"}
+var clustersResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "v1alpha1", Resource: "clusters"}
 
-var clustersKind = schema.GroupVersionKind{Group: "kops", Version: "v1alpha1", Kind: "Cluster"}
+var clustersKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "v1alpha1", Kind: "Cluster"}
 
 // Get takes name of the cluster, and returns the corresponding cluster object, and an error if there is any.
 func (c *FakeClusters) Get(name string, options v1.GetOptions) (result *v1alpha1.Cluster, err error) {

--- a/pkg/client/clientset_generated/clientset/typed/kops/v1alpha1/fake/fake_instancegroup.go
+++ b/pkg/client/clientset_generated/clientset/typed/kops/v1alpha1/fake/fake_instancegroup.go
@@ -34,9 +34,9 @@ type FakeInstanceGroups struct {
 	ns   string
 }
 
-var instancegroupsResource = schema.GroupVersionResource{Group: "kops", Version: "v1alpha1", Resource: "instancegroups"}
+var instancegroupsResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "v1alpha1", Resource: "instancegroups"}
 
-var instancegroupsKind = schema.GroupVersionKind{Group: "kops", Version: "v1alpha1", Kind: "InstanceGroup"}
+var instancegroupsKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "v1alpha1", Kind: "InstanceGroup"}
 
 // Get takes name of the instanceGroup, and returns the corresponding instanceGroup object, and an error if there is any.
 func (c *FakeInstanceGroups) Get(name string, options v1.GetOptions) (result *v1alpha1.InstanceGroup, err error) {

--- a/pkg/client/clientset_generated/clientset/typed/kops/v1alpha1/fake/fake_sshcredential.go
+++ b/pkg/client/clientset_generated/clientset/typed/kops/v1alpha1/fake/fake_sshcredential.go
@@ -34,9 +34,9 @@ type FakeSSHCredentials struct {
 	ns   string
 }
 
-var sshcredentialsResource = schema.GroupVersionResource{Group: "kops", Version: "v1alpha1", Resource: "sshcredentials"}
+var sshcredentialsResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "v1alpha1", Resource: "sshcredentials"}
 
-var sshcredentialsKind = schema.GroupVersionKind{Group: "kops", Version: "v1alpha1", Kind: "SSHCredential"}
+var sshcredentialsKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "v1alpha1", Kind: "SSHCredential"}
 
 // Get takes name of the sSHCredential, and returns the corresponding sSHCredential object, and an error if there is any.
 func (c *FakeSSHCredentials) Get(name string, options v1.GetOptions) (result *v1alpha1.SSHCredential, err error) {

--- a/pkg/client/clientset_generated/clientset/typed/kops/v1alpha1/kops_client.go
+++ b/pkg/client/clientset_generated/clientset/typed/kops/v1alpha1/kops_client.go
@@ -32,7 +32,7 @@ type KopsV1alpha1Interface interface {
 	SSHCredentialsGetter
 }
 
-// KopsV1alpha1Client is used to interact with features provided by the kops group.
+// KopsV1alpha1Client is used to interact with features provided by the kops.k8s.io group.
 type KopsV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/pkg/client/clientset_generated/clientset/typed/kops/v1alpha2/fake/fake_cluster.go
+++ b/pkg/client/clientset_generated/clientset/typed/kops/v1alpha2/fake/fake_cluster.go
@@ -34,9 +34,9 @@ type FakeClusters struct {
 	ns   string
 }
 
-var clustersResource = schema.GroupVersionResource{Group: "kops", Version: "v1alpha2", Resource: "clusters"}
+var clustersResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "v1alpha2", Resource: "clusters"}
 
-var clustersKind = schema.GroupVersionKind{Group: "kops", Version: "v1alpha2", Kind: "Cluster"}
+var clustersKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "v1alpha2", Kind: "Cluster"}
 
 // Get takes name of the cluster, and returns the corresponding cluster object, and an error if there is any.
 func (c *FakeClusters) Get(name string, options v1.GetOptions) (result *v1alpha2.Cluster, err error) {

--- a/pkg/client/clientset_generated/clientset/typed/kops/v1alpha2/fake/fake_instancegroup.go
+++ b/pkg/client/clientset_generated/clientset/typed/kops/v1alpha2/fake/fake_instancegroup.go
@@ -34,9 +34,9 @@ type FakeInstanceGroups struct {
 	ns   string
 }
 
-var instancegroupsResource = schema.GroupVersionResource{Group: "kops", Version: "v1alpha2", Resource: "instancegroups"}
+var instancegroupsResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "v1alpha2", Resource: "instancegroups"}
 
-var instancegroupsKind = schema.GroupVersionKind{Group: "kops", Version: "v1alpha2", Kind: "InstanceGroup"}
+var instancegroupsKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "v1alpha2", Kind: "InstanceGroup"}
 
 // Get takes name of the instanceGroup, and returns the corresponding instanceGroup object, and an error if there is any.
 func (c *FakeInstanceGroups) Get(name string, options v1.GetOptions) (result *v1alpha2.InstanceGroup, err error) {

--- a/pkg/client/clientset_generated/clientset/typed/kops/v1alpha2/fake/fake_keyset.go
+++ b/pkg/client/clientset_generated/clientset/typed/kops/v1alpha2/fake/fake_keyset.go
@@ -34,9 +34,9 @@ type FakeKeysets struct {
 	ns   string
 }
 
-var keysetsResource = schema.GroupVersionResource{Group: "kops", Version: "v1alpha2", Resource: "keysets"}
+var keysetsResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "v1alpha2", Resource: "keysets"}
 
-var keysetsKind = schema.GroupVersionKind{Group: "kops", Version: "v1alpha2", Kind: "Keyset"}
+var keysetsKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "v1alpha2", Kind: "Keyset"}
 
 // Get takes name of the keyset, and returns the corresponding keyset object, and an error if there is any.
 func (c *FakeKeysets) Get(name string, options v1.GetOptions) (result *v1alpha2.Keyset, err error) {

--- a/pkg/client/clientset_generated/clientset/typed/kops/v1alpha2/fake/fake_sshcredential.go
+++ b/pkg/client/clientset_generated/clientset/typed/kops/v1alpha2/fake/fake_sshcredential.go
@@ -34,9 +34,9 @@ type FakeSSHCredentials struct {
 	ns   string
 }
 
-var sshcredentialsResource = schema.GroupVersionResource{Group: "kops", Version: "v1alpha2", Resource: "sshcredentials"}
+var sshcredentialsResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "v1alpha2", Resource: "sshcredentials"}
 
-var sshcredentialsKind = schema.GroupVersionKind{Group: "kops", Version: "v1alpha2", Kind: "SSHCredential"}
+var sshcredentialsKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "v1alpha2", Kind: "SSHCredential"}
 
 // Get takes name of the sSHCredential, and returns the corresponding sSHCredential object, and an error if there is any.
 func (c *FakeSSHCredentials) Get(name string, options v1.GetOptions) (result *v1alpha2.SSHCredential, err error) {

--- a/pkg/client/clientset_generated/clientset/typed/kops/v1alpha2/kops_client.go
+++ b/pkg/client/clientset_generated/clientset/typed/kops/v1alpha2/kops_client.go
@@ -33,7 +33,7 @@ type KopsV1alpha2Interface interface {
 	SSHCredentialsGetter
 }
 
-// KopsV1alpha2Client is used to interact with features provided by the kops group.
+// KopsV1alpha2Client is used to interact with features provided by the kops.k8s.io group.
 type KopsV1alpha2Client struct {
 	restClient rest.Interface
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/kops/internalversion/fake/fake_cluster.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/kops/internalversion/fake/fake_cluster.go
@@ -34,9 +34,9 @@ type FakeClusters struct {
 	ns   string
 }
 
-var clustersResource = schema.GroupVersionResource{Group: "kops", Version: "", Resource: "clusters"}
+var clustersResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "", Resource: "clusters"}
 
-var clustersKind = schema.GroupVersionKind{Group: "kops", Version: "", Kind: "Cluster"}
+var clustersKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "", Kind: "Cluster"}
 
 // Get takes name of the cluster, and returns the corresponding cluster object, and an error if there is any.
 func (c *FakeClusters) Get(name string, options v1.GetOptions) (result *kops.Cluster, err error) {

--- a/pkg/client/clientset_generated/internalclientset/typed/kops/internalversion/fake/fake_instancegroup.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/kops/internalversion/fake/fake_instancegroup.go
@@ -34,9 +34,9 @@ type FakeInstanceGroups struct {
 	ns   string
 }
 
-var instancegroupsResource = schema.GroupVersionResource{Group: "kops", Version: "", Resource: "instancegroups"}
+var instancegroupsResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "", Resource: "instancegroups"}
 
-var instancegroupsKind = schema.GroupVersionKind{Group: "kops", Version: "", Kind: "InstanceGroup"}
+var instancegroupsKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "", Kind: "InstanceGroup"}
 
 // Get takes name of the instanceGroup, and returns the corresponding instanceGroup object, and an error if there is any.
 func (c *FakeInstanceGroups) Get(name string, options v1.GetOptions) (result *kops.InstanceGroup, err error) {

--- a/pkg/client/clientset_generated/internalclientset/typed/kops/internalversion/fake/fake_keyset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/kops/internalversion/fake/fake_keyset.go
@@ -34,9 +34,9 @@ type FakeKeysets struct {
 	ns   string
 }
 
-var keysetsResource = schema.GroupVersionResource{Group: "kops", Version: "", Resource: "keysets"}
+var keysetsResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "", Resource: "keysets"}
 
-var keysetsKind = schema.GroupVersionKind{Group: "kops", Version: "", Kind: "Keyset"}
+var keysetsKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "", Kind: "Keyset"}
 
 // Get takes name of the keyset, and returns the corresponding keyset object, and an error if there is any.
 func (c *FakeKeysets) Get(name string, options v1.GetOptions) (result *kops.Keyset, err error) {

--- a/pkg/client/clientset_generated/internalclientset/typed/kops/internalversion/fake/fake_sshcredential.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/kops/internalversion/fake/fake_sshcredential.go
@@ -34,9 +34,9 @@ type FakeSSHCredentials struct {
 	ns   string
 }
 
-var sshcredentialsResource = schema.GroupVersionResource{Group: "kops", Version: "", Resource: "sshcredentials"}
+var sshcredentialsResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "", Resource: "sshcredentials"}
 
-var sshcredentialsKind = schema.GroupVersionKind{Group: "kops", Version: "", Kind: "SSHCredential"}
+var sshcredentialsKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "", Kind: "SSHCredential"}
 
 // Get takes name of the sSHCredential, and returns the corresponding sSHCredential object, and an error if there is any.
 func (c *FakeSSHCredentials) Get(name string, options v1.GetOptions) (result *kops.SSHCredential, err error) {

--- a/pkg/client/clientset_generated/internalclientset/typed/kops/internalversion/kops_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/kops/internalversion/kops_client.go
@@ -31,7 +31,7 @@ type KopsInterface interface {
 	SSHCredentialsGetter
 }
 
-// KopsClient is used to interact with features provided by the kops group.
+// KopsClient is used to interact with features provided by the kops.k8s.io group.
 type KopsClient struct {
 	restClient rest.Interface
 }
@@ -85,8 +85,8 @@ func setConfigDefaults(config *rest.Config) error {
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
-	if config.GroupVersion == nil || config.GroupVersion.Group != scheme.Scheme.PrioritizedVersionsForGroup("kops")[0].Group {
-		gv := scheme.Scheme.PrioritizedVersionsForGroup("kops")[0]
+	if config.GroupVersion == nil || config.GroupVersion.Group != scheme.Scheme.PrioritizedVersionsForGroup("kops.k8s.io")[0].Group {
+		gv := scheme.Scheme.PrioritizedVersionsForGroup("kops.k8s.io")[0]
 		config.GroupVersion = &gv
 	}
 	config.NegotiatedSerializer = scheme.Codecs

--- a/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha1/fake/fake_cluster.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha1/fake/fake_cluster.go
@@ -34,9 +34,9 @@ type FakeClusters struct {
 	ns   string
 }
 
-var clustersResource = schema.GroupVersionResource{Group: "kops", Version: "v1alpha1", Resource: "clusters"}
+var clustersResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "v1alpha1", Resource: "clusters"}
 
-var clustersKind = schema.GroupVersionKind{Group: "kops", Version: "v1alpha1", Kind: "Cluster"}
+var clustersKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "v1alpha1", Kind: "Cluster"}
 
 // Get takes name of the cluster, and returns the corresponding cluster object, and an error if there is any.
 func (c *FakeClusters) Get(name string, options v1.GetOptions) (result *v1alpha1.Cluster, err error) {

--- a/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha1/fake/fake_instancegroup.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha1/fake/fake_instancegroup.go
@@ -34,9 +34,9 @@ type FakeInstanceGroups struct {
 	ns   string
 }
 
-var instancegroupsResource = schema.GroupVersionResource{Group: "kops", Version: "v1alpha1", Resource: "instancegroups"}
+var instancegroupsResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "v1alpha1", Resource: "instancegroups"}
 
-var instancegroupsKind = schema.GroupVersionKind{Group: "kops", Version: "v1alpha1", Kind: "InstanceGroup"}
+var instancegroupsKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "v1alpha1", Kind: "InstanceGroup"}
 
 // Get takes name of the instanceGroup, and returns the corresponding instanceGroup object, and an error if there is any.
 func (c *FakeInstanceGroups) Get(name string, options v1.GetOptions) (result *v1alpha1.InstanceGroup, err error) {

--- a/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha1/fake/fake_sshcredential.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha1/fake/fake_sshcredential.go
@@ -34,9 +34,9 @@ type FakeSSHCredentials struct {
 	ns   string
 }
 
-var sshcredentialsResource = schema.GroupVersionResource{Group: "kops", Version: "v1alpha1", Resource: "sshcredentials"}
+var sshcredentialsResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "v1alpha1", Resource: "sshcredentials"}
 
-var sshcredentialsKind = schema.GroupVersionKind{Group: "kops", Version: "v1alpha1", Kind: "SSHCredential"}
+var sshcredentialsKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "v1alpha1", Kind: "SSHCredential"}
 
 // Get takes name of the sSHCredential, and returns the corresponding sSHCredential object, and an error if there is any.
 func (c *FakeSSHCredentials) Get(name string, options v1.GetOptions) (result *v1alpha1.SSHCredential, err error) {

--- a/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha1/kops_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha1/kops_client.go
@@ -32,7 +32,7 @@ type KopsV1alpha1Interface interface {
 	SSHCredentialsGetter
 }
 
-// KopsV1alpha1Client is used to interact with features provided by the kops group.
+// KopsV1alpha1Client is used to interact with features provided by the kops.k8s.io group.
 type KopsV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha2/fake/fake_cluster.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha2/fake/fake_cluster.go
@@ -34,9 +34,9 @@ type FakeClusters struct {
 	ns   string
 }
 
-var clustersResource = schema.GroupVersionResource{Group: "kops", Version: "v1alpha2", Resource: "clusters"}
+var clustersResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "v1alpha2", Resource: "clusters"}
 
-var clustersKind = schema.GroupVersionKind{Group: "kops", Version: "v1alpha2", Kind: "Cluster"}
+var clustersKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "v1alpha2", Kind: "Cluster"}
 
 // Get takes name of the cluster, and returns the corresponding cluster object, and an error if there is any.
 func (c *FakeClusters) Get(name string, options v1.GetOptions) (result *v1alpha2.Cluster, err error) {

--- a/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha2/fake/fake_instancegroup.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha2/fake/fake_instancegroup.go
@@ -34,9 +34,9 @@ type FakeInstanceGroups struct {
 	ns   string
 }
 
-var instancegroupsResource = schema.GroupVersionResource{Group: "kops", Version: "v1alpha2", Resource: "instancegroups"}
+var instancegroupsResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "v1alpha2", Resource: "instancegroups"}
 
-var instancegroupsKind = schema.GroupVersionKind{Group: "kops", Version: "v1alpha2", Kind: "InstanceGroup"}
+var instancegroupsKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "v1alpha2", Kind: "InstanceGroup"}
 
 // Get takes name of the instanceGroup, and returns the corresponding instanceGroup object, and an error if there is any.
 func (c *FakeInstanceGroups) Get(name string, options v1.GetOptions) (result *v1alpha2.InstanceGroup, err error) {

--- a/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha2/fake/fake_keyset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha2/fake/fake_keyset.go
@@ -34,9 +34,9 @@ type FakeKeysets struct {
 	ns   string
 }
 
-var keysetsResource = schema.GroupVersionResource{Group: "kops", Version: "v1alpha2", Resource: "keysets"}
+var keysetsResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "v1alpha2", Resource: "keysets"}
 
-var keysetsKind = schema.GroupVersionKind{Group: "kops", Version: "v1alpha2", Kind: "Keyset"}
+var keysetsKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "v1alpha2", Kind: "Keyset"}
 
 // Get takes name of the keyset, and returns the corresponding keyset object, and an error if there is any.
 func (c *FakeKeysets) Get(name string, options v1.GetOptions) (result *v1alpha2.Keyset, err error) {

--- a/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha2/fake/fake_sshcredential.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha2/fake/fake_sshcredential.go
@@ -34,9 +34,9 @@ type FakeSSHCredentials struct {
 	ns   string
 }
 
-var sshcredentialsResource = schema.GroupVersionResource{Group: "kops", Version: "v1alpha2", Resource: "sshcredentials"}
+var sshcredentialsResource = schema.GroupVersionResource{Group: "kops.k8s.io", Version: "v1alpha2", Resource: "sshcredentials"}
 
-var sshcredentialsKind = schema.GroupVersionKind{Group: "kops", Version: "v1alpha2", Kind: "SSHCredential"}
+var sshcredentialsKind = schema.GroupVersionKind{Group: "kops.k8s.io", Version: "v1alpha2", Kind: "SSHCredential"}
 
 // Get takes name of the sSHCredential, and returns the corresponding sSHCredential object, and an error if there is any.
 func (c *FakeSSHCredentials) Get(name string, options v1.GetOptions) (result *v1alpha2.SSHCredential, err error) {

--- a/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha2/kops_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/kops/v1alpha2/kops_client.go
@@ -33,7 +33,7 @@ type KopsV1alpha2Interface interface {
 	SSHCredentialsGetter
 }
 
-// KopsV1alpha2Client is used to interact with features provided by the kops group.
+// KopsV1alpha2Client is used to interact with features provided by the kops.k8s.io group.
 type KopsV1alpha2Client struct {
 	restClient rest.Interface
 }

--- a/pkg/kopscodecs/codecs.go
+++ b/pkg/kopscodecs/codecs.go
@@ -19,6 +19,7 @@ package kopscodecs
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 
 	"github.com/golang/glog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,8 +87,43 @@ func ToVersionedJSONWithVersion(obj runtime.Object, version runtime.GroupVersion
 
 // Decode decodes the specified data, with the specified default version
 func Decode(data []byte, defaultReadVersion *schema.GroupVersionKind) (runtime.Object, *schema.GroupVersionKind, error) {
+	data = rewriteAPIGroup(data)
+
 	decoder := decoder()
 
 	object, gvk, err := decoder.Decode(data, defaultReadVersion, nil)
 	return object, gvk, err
+}
+
+// rewriteAPIGroup rewrites the apiVersion from kops/v1alphaN -> kops.k8s.io/v1alphaN
+// This allows us to register as a normal CRD
+func rewriteAPIGroup(y []byte) []byte {
+	changed := false
+
+	lines := bytes.Split(y, []byte("\n"))
+	for i := range lines {
+		if !bytes.Contains(lines[i], []byte("apiVersion:")) {
+			continue
+		}
+
+		{
+			re := regexp.MustCompile("kops/v1alpha1")
+			if re.Match(lines[i]) {
+				lines[i] = re.ReplaceAllLiteral(lines[i], []byte("kops.k8s.io/v1alpha1"))
+				changed = true
+			}
+		}
+
+		{
+			re := regexp.MustCompile("kops/v1alpha2")
+			lines[i] = re.ReplaceAllLiteral(lines[i], []byte("kops.k8s.io/v1alpha2"))
+			changed = true
+		}
+	}
+
+	if changed {
+		y = bytes.Join(lines, []byte("\n"))
+	}
+
+	return y
 }

--- a/pkg/kopscodecs/codecs_test.go
+++ b/pkg/kopscodecs/codecs_test.go
@@ -47,7 +47,7 @@ func TestToVersionedYaml(t *testing.T) {
 				},
 			},
 			expected: heredoc.Doc(`
-			apiVersion: kops/v1alpha2
+			apiVersion: kops.k8s.io/v1alpha2
 			kind: Cluster
 			metadata:
 			  creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/codecs/componentconfig_test.go
+++ b/tests/codecs/componentconfig_test.go
@@ -34,7 +34,7 @@ func TestSerializeEmptyCluster(t *testing.T) {
 	}
 
 	yamlString := string(yaml)
-	expected := `apiVersion: kops/v1alpha2
+	expected := `apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: null

--- a/tests/integration/conversion/integration_test.go
+++ b/tests/integration/conversion/integration_test.go
@@ -38,6 +38,12 @@ func TestConversionMinimal(t *testing.T) {
 
 	runTest(t, "minimal", "v1alpha0", "v1alpha1")
 	runTest(t, "minimal", "v1alpha0", "v1alpha2")
+
+	runTest(t, "minimal", "legacy-v1alpha1", "v1alpha1")
+	runTest(t, "minimal", "legacy-v1alpha1", "v1alpha2")
+
+	runTest(t, "minimal", "legacy-v1alpha2", "v1alpha1")
+	runTest(t, "minimal", "legacy-v1alpha2", "v1alpha2")
 }
 
 func runTest(t *testing.T, srcDir string, fromVersion string, toVersion string) {
@@ -82,7 +88,7 @@ func runTest(t *testing.T, srcDir string, fromVersion string, toVersion string) 
 			t.Fatalf("error parsing file %q: %v", sourcePath, err)
 		}
 
-		expectVersion := fromVersion
+		expectVersion := strings.TrimPrefix(fromVersion, "legacy-")
 		if expectVersion == "v1alpha0" {
 			// Our version before we had v1alpha1
 			expectVersion = "v1alpha1"

--- a/tests/integration/conversion/minimal/legacy-v1alpha1.yaml
+++ b/tests/integration/conversion/minimal/legacy-v1alpha1.yaml
@@ -1,60 +1,62 @@
-apiVersion: kops.k8s.io/v1alpha2
+apiVersion: kops/v1alpha1
 kind: Cluster
 metadata:
-  creationTimestamp: "2016-12-10T22:42:27Z"
+  creationTimestamp: 2016-12-10T22:42:27Z
   name: minimal.example.com
 spec:
-  kubernetesApiAccess:
+  additionalSans:
+  - proxy.api.minimal.example.com
+  addons:
+  - manifest: s3://somebucket/example.yaml
+  adminAccess:
   - 0.0.0.0/0
+  api:
+    dns: {}
+  authorization:
+    alwaysAllow: {}
   channel: stable
   cloudProvider: aws
   configBase: memfs://clusters.example.com/minimal.example.com
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:
-    - instanceGroup: master-us-test-1a
-      name: us-test-1a
+    - name: us-test-1a
+      zone: us-test-1a
     memoryRequest: 100Mi
     name: main
-    provider: Manager
-    backups:
-      backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd-main
-  - cpuRequest: 100m
+  - cpuRequest: 200m
     etcdMembers:
-    - instanceGroup: master-us-test-1a
-      name: us-test-1a
+    - name: us-test-1a
+      zone: us-test-1a
     memoryRequest: 100Mi
     name: events
-    provider: Manager
-    backups:
-      backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
-  kubernetesVersion: v1.12.0
+  iam:
+    legacy: true
+  kubernetesVersion: v1.4.12
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16
   networking:
     kubenet: {}
   nonMasqueradeCIDR: 100.64.0.0/10
-  sshAccess:
-    - 0.0.0.0/0
   topology:
+    dns:
+      type: Public
     masters: public
     nodes: public
-  subnets:
+  zones:
   - cidr: 172.20.32.0/19
     name: us-test-1a
-    type: Public
-    zone: us-test-1a
 
 ---
 
-apiVersion: kops.k8s.io/v1alpha2
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
-  creationTimestamp: "2016-12-10T22:42:28Z"
-  name: nodes
+  creationTimestamp: 2016-12-10T22:42:28Z
   labels:
     kops.k8s.io/cluster: minimal.example.com
+  name: nodes
 spec:
   associatePublicIp: true
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
@@ -62,18 +64,18 @@ spec:
   maxSize: 2
   minSize: 2
   role: Node
-  subnets:
+  zones:
   - us-test-1a
 
 ---
 
-apiVersion: kops.k8s.io/v1alpha2
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
-  creationTimestamp: "2016-12-10T22:42:28Z"
-  name: master-us-test-1a
+  creationTimestamp: 2016-12-10T22:42:28Z
   labels:
     kops.k8s.io/cluster: minimal.example.com
+  name: master-us-test-1a
 spec:
   associatePublicIp: true
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
@@ -81,5 +83,7 @@ spec:
   maxSize: 1
   minSize: 1
   role: Master
-  subnets:
+  zones:
   - us-test-1a
+
+

--- a/tests/integration/conversion/minimal/legacy-v1alpha2.yaml
+++ b/tests/integration/conversion/minimal/legacy-v1alpha2.yaml
@@ -1,11 +1,17 @@
-apiVersion: kops.k8s.io/v1alpha2
+apiVersion: kops/v1alpha2
 kind: Cluster
 metadata:
-  creationTimestamp: "2016-12-10T22:42:27Z"
+  creationTimestamp: 2016-12-10T22:42:27Z
   name: minimal.example.com
 spec:
-  kubernetesApiAccess:
-  - 0.0.0.0/0
+  additionalSans:
+  - proxy.api.minimal.example.com
+  addons:
+  - manifest: s3://somebucket/example.yaml
+  api:
+    dns: {}
+  authorization:
+    alwaysAllow: {}
   channel: stable
   cloudProvider: aws
   configBase: memfs://clusters.example.com/minimal.example.com
@@ -16,19 +22,17 @@ spec:
       name: us-test-1a
     memoryRequest: 100Mi
     name: main
-    provider: Manager
-    backups:
-      backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd-main
-  - cpuRequest: 100m
+  - cpuRequest: 200m
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     memoryRequest: 100Mi
     name: events
-    provider: Manager
-    backups:
-      backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
-  kubernetesVersion: v1.12.0
+  iam:
+    legacy: true
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  kubernetesVersion: v1.4.12
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16
@@ -36,25 +40,27 @@ spec:
     kubenet: {}
   nonMasqueradeCIDR: 100.64.0.0/10
   sshAccess:
-    - 0.0.0.0/0
-  topology:
-    masters: public
-    nodes: public
+  - 0.0.0.0/0
   subnets:
   - cidr: 172.20.32.0/19
     name: us-test-1a
     type: Public
     zone: us-test-1a
+  topology:
+    dns:
+      type: Public
+    masters: public
+    nodes: public
 
 ---
 
 apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
-  creationTimestamp: "2016-12-10T22:42:28Z"
-  name: nodes
+  creationTimestamp: 2016-12-10T22:42:28Z
   labels:
     kops.k8s.io/cluster: minimal.example.com
+  name: nodes
 spec:
   associatePublicIp: true
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
@@ -70,10 +76,10 @@ spec:
 apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
-  creationTimestamp: "2016-12-10T22:42:28Z"
-  name: master-us-test-1a
+  creationTimestamp: 2016-12-10T22:42:28Z
   labels:
     kops.k8s.io/cluster: minimal.example.com
+  name: master-us-test-1a
 spec:
   associatePublicIp: true
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21

--- a/tests/integration/conversion/minimal/v1alpha1.yaml
+++ b/tests/integration/conversion/minimal/v1alpha1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: 2016-12-10T22:42:27Z
@@ -50,7 +50,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2016-12-10T22:42:28Z
@@ -69,7 +69,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2016-12-10T22:42:28Z

--- a/tests/integration/conversion/minimal/v1alpha2.yaml
+++ b/tests/integration/conversion/minimal/v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2016-12-10T22:42:27Z
@@ -54,7 +54,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2016-12-10T22:42:28Z
@@ -73,7 +73,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2016-12-10T22:42:28Z

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -50,7 +50,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -70,7 +70,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -58,7 +58,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -78,7 +78,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -98,7 +98,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -118,7 +118,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -66,7 +66,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -86,7 +86,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -106,7 +106,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -126,7 +126,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -64,7 +64,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -84,7 +84,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -104,7 +104,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -124,7 +124,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -72,7 +72,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -92,7 +92,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -112,7 +112,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -132,7 +132,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -57,7 +57,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -79,7 +79,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -101,7 +101,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -123,7 +123,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -70,7 +70,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -90,7 +90,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -110,7 +110,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -130,7 +130,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -150,7 +150,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -170,7 +170,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -52,7 +52,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -72,7 +72,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -92,7 +92,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -58,7 +58,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -78,7 +78,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -98,7 +98,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/minimal/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -48,7 +48,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -68,7 +68,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -52,7 +52,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -72,7 +72,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -52,7 +52,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -72,7 +72,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -92,7 +92,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -58,7 +58,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -78,7 +78,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -98,7 +98,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -53,7 +53,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -73,7 +73,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/private/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -55,7 +55,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -75,7 +75,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -98,7 +98,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -61,7 +61,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -81,7 +81,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -104,7 +104,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -58,7 +58,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -78,7 +78,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -48,7 +48,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -68,7 +68,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -52,7 +52,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -72,7 +72,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -48,7 +48,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -68,7 +68,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -52,7 +52,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -72,7 +72,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -47,7 +47,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -67,7 +67,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -51,7 +51,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -71,7 +71,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/update_cluster/additional_cidr/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/additional_cidr/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"
@@ -44,7 +44,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"
@@ -63,7 +63,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"

--- a/tests/integration/update_cluster/bastionadditional_user-data/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/bastionadditional_user-data/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-12T04:13:14Z"
@@ -42,7 +42,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -61,7 +61,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -86,7 +86,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-14T15:32:41Z"

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -1,23 +1,23 @@
-apiVersion: kops.k8s.io/v1alpha2
+apiVersion: kops/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"
-  name: additionaluserdata.example.com
+  name: complex.example.com
 spec:
-  additionalPolicies:
-    master: |
-      [
-        {
-          "Action": [ "s3:GetObject" ],
-          "Resource": [ "arn:aws:s3:::somebucket/someobject" ],
-          "Effect": "Allow"
-        }
-      ]
+  api:
+    loadBalancer:
+      type: Public
+      additionalSecurityGroups:
+      - sg-exampleid3
+      - sg-exampleid4
   kubernetesApiAccess:
   - 0.0.0.0/0
   channel: stable
   cloudProvider: aws
-  configBase: memfs://clusters.example.com/additionaluserdata.example.com
+  cloudLabels:
+    Owner: John Doe
+    foo/bar: fib+baz
+  configBase: memfs://clusters.example.com/complex.example.com
   etcdClusters:
   - etcdMembers:
     - instanceGroup: master-us-test-1a
@@ -27,15 +27,20 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubeAPIServer:
+    serviceNodePortRange: 28000-32767
   kubernetesVersion: v1.4.12
-  masterInternalName: api.internal.additionaluserdata.example.com
-  masterPublicName: api.additionaluserdata.example.com
+  masterInternalName: api.internal.complex.example.com
+  masterPublicName: api.complex.example.com
   networkCIDR: 172.20.0.0/16
   networking:
     kubenet: {}
+  nodePortAccess:
+  - 1.2.3.4/32
+  - 10.20.30.0/24
   nonMasqueradeCIDR: 100.64.0.0/10
   sshAccess:
-    - 0.0.0.0/0
+  - 0.0.0.0/0
   topology:
     masters: public
     nodes: public
@@ -47,15 +52,20 @@ spec:
 
 ---
 
-apiVersion: kops.k8s.io/v1alpha2
+apiVersion: kops/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"
   name: nodes
   labels:
-    kops.k8s.io/cluster: additionaluserdata.example.com
+    kops.k8s.io/cluster: complex.example.com
 spec:
+  additionalSecurityGroups:
+  - sg-exampleid3
+  - sg-exampleid4
   associatePublicIp: true
+  suspendProcesses:
+  - AZRebalance
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
   machineType: t2.medium
   maxSize: 2
@@ -63,22 +73,17 @@ spec:
   role: Node
   subnets:
   - us-test-1a
-  additionalUserData:
-  - name: myscript.sh
-    type: text/x-shellscript
-    content: |
-      #!/bin/sh
-      echo "nodes: The time is now $(date -R)!" | tee /root/output.txt
+  detailedInstanceMonitoring: true
 
 ---
 
-apiVersion: kops.k8s.io/v1alpha2
+apiVersion: kops/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"
   name: master-us-test-1a
   labels:
-    kops.k8s.io/cluster: additionaluserdata.example.com
+    kops.k8s.io/cluster: complex.example.com
 spec:
   associatePublicIp: true
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
@@ -88,10 +93,3 @@ spec:
   role: Master
   subnets:
   - us-test-1a
-  additionalUserData:
-  - name: myscript.sh
-    type: text/x-shellscript
-    content: |
-      #!/bin/sh
-      echo "master: The time is now $(date -R)!" | tee /root/output.txt
-

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"
@@ -52,7 +52,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"
@@ -77,7 +77,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"

--- a/tests/integration/update_cluster/existing_iam/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/existing_iam/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -52,7 +52,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -72,7 +72,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -92,7 +92,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -112,7 +112,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/update_cluster/existing_iam_cloudformation/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"
@@ -38,7 +38,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"
@@ -59,7 +59,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"

--- a/tests/integration/update_cluster/existing_sg/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/existing_sg/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"
@@ -57,7 +57,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
@@ -76,7 +76,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
@@ -95,7 +95,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
@@ -115,7 +115,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"

--- a/tests/integration/update_cluster/externallb/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/externallb/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2018-03-20T16:00:27Z"
@@ -38,7 +38,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"
@@ -59,7 +59,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"

--- a/tests/integration/update_cluster/ha/in-v1alpha1.yaml
+++ b/tests/integration/update_cluster/ha/in-v1alpha1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
@@ -49,7 +49,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
@@ -67,7 +67,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
@@ -85,7 +85,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
@@ -103,7 +103,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"

--- a/tests/integration/update_cluster/ha/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/ha/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
@@ -57,7 +57,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
@@ -75,7 +75,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
@@ -93,7 +93,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
@@ -111,7 +111,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"

--- a/tests/integration/update_cluster/ha_gce/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/ha_gce/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -52,7 +52,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -72,7 +72,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -92,7 +92,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z
@@ -112,7 +112,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: 2017-01-01T00:00:00Z

--- a/tests/integration/update_cluster/lifecycle_phases/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/lifecycle_phases/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-12T04:13:14Z"
@@ -42,7 +42,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -61,7 +61,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -81,7 +81,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-14T15:32:41Z"

--- a/tests/integration/update_cluster/minimal-cloudformation/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"
@@ -38,7 +38,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"
@@ -57,7 +57,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"

--- a/tests/integration/update_cluster/minimal/in-v1alpha1.yaml
+++ b/tests/integration/update_cluster/minimal/in-v1alpha1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"
@@ -37,7 +37,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"
@@ -56,7 +56,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"

--- a/tests/integration/update_cluster/minimal/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"
@@ -38,7 +38,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"
@@ -57,7 +57,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"

--- a/tests/integration/update_cluster/private-shared-subnet/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/private-shared-subnet/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-12T04:13:14Z"
@@ -46,7 +46,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -65,7 +65,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -85,7 +85,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-14T15:32:41Z"

--- a/tests/integration/update_cluster/privatecalico/in-v1alpha1.yaml
+++ b/tests/integration/update_cluster/privatecalico/in-v1alpha1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-12T04:13:14Z"
@@ -39,7 +39,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -58,7 +58,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -78,7 +78,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-14T15:32:41Z"

--- a/tests/integration/update_cluster/privatecalico/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatecalico/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-12T04:13:14Z"
@@ -42,7 +42,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -61,7 +61,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -81,7 +81,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-14T15:32:41Z"

--- a/tests/integration/update_cluster/privatecanal/in-v1alpha1.yaml
+++ b/tests/integration/update_cluster/privatecanal/in-v1alpha1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-12T04:13:14Z"
@@ -39,7 +39,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -58,7 +58,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -78,7 +78,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-14T15:32:41Z"

--- a/tests/integration/update_cluster/privatecanal/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatecanal/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-12T04:13:14Z"
@@ -42,7 +42,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -61,7 +61,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -81,7 +81,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-14T15:32:41Z"

--- a/tests/integration/update_cluster/privatedns1/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatedns1/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-12T04:13:14Z"
@@ -45,7 +45,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -64,7 +64,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -84,7 +84,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-14T15:32:41Z"

--- a/tests/integration/update_cluster/privatedns2/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatedns2/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-12T04:13:14Z"
@@ -46,7 +46,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -65,7 +65,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -85,7 +85,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-14T15:32:41Z"

--- a/tests/integration/update_cluster/privateflannel/in-v1alpha1.yaml
+++ b/tests/integration/update_cluster/privateflannel/in-v1alpha1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-12T04:13:14Z"
@@ -40,7 +40,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -59,7 +59,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -79,7 +79,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-14T15:32:41Z"

--- a/tests/integration/update_cluster/privateflannel/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privateflannel/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-12T04:13:14Z"
@@ -43,7 +43,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -62,7 +62,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -82,7 +82,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-14T15:32:41Z"

--- a/tests/integration/update_cluster/privatekopeio/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatekopeio/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-12T04:13:14Z"
@@ -52,7 +52,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -71,7 +71,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -92,7 +92,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-14T15:32:41Z"

--- a/tests/integration/update_cluster/privateweave/in-v1alpha1.yaml
+++ b/tests/integration/update_cluster/privateweave/in-v1alpha1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-12T04:13:14Z"
@@ -39,7 +39,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -58,7 +58,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha1
+apiVersion: kops.k8s.io/v1alpha1
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -78,7 +78,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-14T15:32:41Z"

--- a/tests/integration/update_cluster/privateweave/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privateweave/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-12T04:13:14Z"
@@ -42,7 +42,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -61,7 +61,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-12T04:13:15Z"
@@ -81,7 +81,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-14T15:32:41Z"

--- a/tests/integration/update_cluster/restrict_access/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/restrict_access/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"
@@ -40,7 +40,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"
@@ -59,7 +59,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"

--- a/tests/integration/update_cluster/shared_subnet/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/shared_subnet/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"
@@ -40,7 +40,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"
@@ -59,7 +59,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"

--- a/tests/integration/update_cluster/shared_vpc/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/shared_vpc/in-v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"
@@ -39,7 +39,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"
@@ -58,7 +58,7 @@ spec:
 
 ---
 
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: "2016-12-10T22:42:27Z"

--- a/upup/pkg/fi/vfs_castore_test.go
+++ b/upup/pkg/fi/vfs_castore_test.go
@@ -107,7 +107,7 @@ func TestVFSCAStoreRoundTrip(t *testing.T) {
 		}
 
 		expected := `
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Keyset
 metadata:
   creationTimestamp: null
@@ -166,7 +166,7 @@ spec:
 		}
 
 		expected := `
-apiVersion: kops/v1alpha2
+apiVersion: kops.k8s.io/v1alpha2
 kind: Keyset
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
We will continue to accept the kops/v1alphaN format, but we rewrite it
(via string manipulation) to kops.k8s.io/v1alphaN.

This allows us to register the kops types as CRDs, which in turn should
enable kops server to work without API aggregation, and also reduce our
dependencies on less-stable API machinery.