### PR TITLE
kops version: Add --short flag, use it to get version in scripts

### DIFF
--- a/cmd/kops/root.go
+++ b/cmd/kops/root.go
@@ -147,6 +147,7 @@ func NewCmdRoot(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.AddCommand(NewCmdSet(f, out))
 	cmd.AddCommand(NewCmdToolbox(f, out))
 	cmd.AddCommand(NewCmdValidate(f, out))
+	cmd.AddCommand(NewCmdVersion(f, out))
 
 	return cmd
 }

--- a/cmd/kops/version.go
+++ b/cmd/kops/version.go
@@ -17,10 +17,11 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
+	"io"
 
 	"github.com/spf13/cobra"
-	"k8s.io/kops"
+	"k8s.io/kops/cmd/kops/util"
+	"k8s.io/kops/pkg/commands"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 )
@@ -35,37 +36,25 @@ var (
 	versionShort = i18n.T(`Print the kops version information.`)
 )
 
-type VersionCmd struct {
-	cobraCommand *cobra.Command
-}
+// NewCmdVersion builds a cobra command for the kops version command
+func NewCmdVersion(f *util.Factory, out io.Writer) *cobra.Command {
+	options := &commands.VersionOptions{}
 
-var versionCmd = VersionCmd{
-	cobraCommand: &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "version",
 		Short:   versionShort,
 		Long:    versionLong,
 		Example: versionExample,
-	},
-}
-
-func init() {
-	cmd := versionCmd.cobraCommand
-	rootCommand.cobraCommand.AddCommand(cmd)
+	}
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		err := versionCmd.Run()
+		err := commands.RunVersion(f, out, options)
 		if err != nil {
 			exitWithError(err)
 		}
 	}
-}
 
-func (c *VersionCmd) Run() error {
-	s := "Version " + kops.Version
-	if kops.GitVersion != "" {
-		s += " (git-" + kops.GitVersion + ")"
-	}
-	fmt.Println(s)
+	cmd.Flags().BoolVar(&options.Short, "short", options.Short, "only print the main kops version, useful for scripting")
 
-	return nil
+	return cmd
 }

--- a/docs/cli/kops_version.md
+++ b/docs/cli/kops_version.md
@@ -22,7 +22,8 @@ kops version [flags]
 ### Options
 
 ```
-  -h, --help   help for version
+  -h, --help    help for version
+      --short   only print the main kops version, useful for scripting
 ```
 
 ### Options inherited from parent commands

--- a/docs/development/adding_a_feature.md
+++ b/docs/development/adding_a_feature.md
@@ -188,6 +188,7 @@ and then push nodeup using:
 export S3_BUCKET_NAME=<yourbucketname>
 make kops-install dev-upload UPLOAD_DEST=s3://${S3_BUCKET_NAME}
 
+KOPS_VERSION=`bazel run //cmd/kops version -- --short`
 export KOPS_BASE_URL=https://${S3_BUCKET_NAME}.s3.amazonaws.com/kops/${KOPS_VERSION}/
 kops create cluster <clustername> --zones us-east-1b
 ...

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -77,7 +77,7 @@ To use S3:
 export S3_BUCKET_NAME=<yourbucketname>
 make kops-install dev-upload UPLOAD_DEST=s3://${S3_BUCKET_NAME}
 
-KOPS_VERSION=`bazel run //cmd/kops version | cut -f2 -d ' '`
+KOPS_VERSION=`bazel run //cmd/kops version -- --short`
 export KOPS_BASE_URL=https://${S3_BUCKET_NAME}.s3.amazonaws.com/kops/${KOPS_VERSION}/
 ```
 
@@ -86,7 +86,7 @@ To use GCS:
 export GCS_BUCKET_NAME=kops-dev-${USER}
 make kops-install dev-upload UPLOAD_DEST=gs://${GCS_BUCKET_NAME}
 
-KOPS_VERSION=`bazel run //cmd/kops version | cut -f2 -d ' '`
+KOPS_VERSION=`bazel run //cmd/kops version -- --short`
 export KOPS_BASE_URL=https://${GCS_BUCKET_NAME}.storage.googleapis.com/kops/${KOPS_VERSION}/
 ```
 

--- a/hack/dev-build.sh
+++ b/hack/dev-build.sh
@@ -100,8 +100,8 @@ make && UPLOAD_DEST=s3://${NODEUP_BUCKET} make upload
 # removing make test since it relies on the files in the bucket
 # && make test
 
-KOPS_CHANNEL=$(kops version | awk '{ print $2 }' |sed 's/\+/%2B/')
-KOPS_BASE_URL="http://${NODEUP_BUCKET}.s3.amazonaws.com/kops/${KOPS_CHANNEL}/"
+KOPS_VERSION=$(kops version --short)
+KOPS_BASE_URL="http://${NODEUP_BUCKET}.s3.amazonaws.com/kops/${KOPS_VERSION}/"
 
 echo "KOPS_BASE_URL=${KOPS_BASE_URL}"
 echo "NODEUP_URL=${KOPS_BASE_URL}linux/amd64/nodeup"

--- a/pkg/commands/BUILD.bazel
+++ b/pkg/commands/BUILD.bazel
@@ -6,10 +6,12 @@ go_library(
         "helpers_readwrite.go",
         "set_cluster.go",
         "status_discovery.go",
+        "version.go",
     ],
     importpath = "k8s.io/kops/pkg/commands",
     visibility = ["//visibility:public"],
     deps = [
+        "//:go_default_library",
         "//cmd/kops/util:go_default_library",
         "//pkg/apis/kops:go_default_library",
         "//pkg/apis/kops/validation:go_default_library",

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"fmt"
+	"io"
+
+	"k8s.io/kops"
+	"k8s.io/kops/cmd/kops/util"
+)
+
+type VersionOptions struct {
+	Short bool
+}
+
+// RunVersion implements the version command logic
+func RunVersion(f *util.Factory, out io.Writer, options *VersionOptions) error {
+	var s string
+	if options.Short {
+		s = kops.Version
+	} else {
+		s = "Version " + kops.Version
+		if kops.GitVersion != "" {
+			s += " (git-" + kops.GitVersion + ")"
+		}
+	}
+
+	_, err := fmt.Fprintf(out, "%s\n", s)
+	return err
+}


### PR DESCRIPTION
We upload to a location that includes the version, but we need to
specify the version in KOPS_BASE_URL.  We expose an option to make
`kops version` more amenable to this scripting.