### PR TITLE
bazel: cleanup gobindata generation

### DIFF
--- a/upup/models/BUILD.bazel
+++ b/upup/models/BUILD.bazel
@@ -17,11 +17,9 @@ go_library(
 genrule(
     name = "bindata",
     srcs = glob(
-        ["**"],
-        exclude = [
-            "bindata.go",
-            "vfs.go",
-            "BUILD.bazel",
+        [
+            "cloudup/**",
+            "nodeup/**",
         ],
     ),
     outs = ["bindata.go"],


### PR DESCRIPTION
Be sure to reference the version we're actually building, and simplify
the exclusion logic.