### PR TITLE
Bump channels and bump alpha to latest

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -34,13 +34,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.12.0"
-    recommendedVersion: 1.12.3
+    recommendedVersion: 1.12.4
     requiredVersion: 1.12.0
   - range: ">=1.11.0"
-    recommendedVersion: 1.11.5
+    recommendedVersion: 1.11.6
     requiredVersion: 1.11.0
   - range: ">=1.10.0"
-    recommendedVersion: 1.10.11
+    recommendedVersion: 1.10.12
     requiredVersion: 1.10.0
   - range: ">=1.9.0"
     recommendedVersion: 1.9.11

--- a/channels/stable
+++ b/channels/stable
@@ -34,7 +34,7 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.11.0"
-    recommendedVersion: 1.11.5
+    recommendedVersion: 1.11.6
     requiredVersion: 1.11.0
   - range: ">=1.10.0"
     recommendedVersion: 1.10.11


### PR DESCRIPTION
Bump 1.11 since https://github.com/kubernetes/kubernetes/pull/70154 was released in 1.11.6 and bump alphas to latest.