### PR TITLE
Update apimachinery for k8s 1.12

### DIFF
--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -854,12 +854,8 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 	}
 	if in.Experimental != nil {
 		in, out := &in.Experimental, &out.Experimental
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.Hosts != nil {
 		in, out := &in.Hosts, &out.Hosts
@@ -903,12 +899,8 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 	}
 	if in.MetricsAddress != nil {
 		in, out := &in.MetricsAddress, &out.MetricsAddress
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	if in.MTU != nil {
 		in, out := &in.MTU, &out.MTU

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -827,12 +827,8 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 	}
 	if in.Experimental != nil {
 		in, out := &in.Experimental, &out.Experimental
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.Hosts != nil {
 		in, out := &in.Hosts, &out.Hosts
@@ -876,12 +872,8 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 	}
 	if in.MetricsAddress != nil {
 		in, out := &in.MetricsAddress, &out.MetricsAddress
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	if in.MTU != nil {
 		in, out := &in.MTU, &out.MTU

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -950,12 +950,8 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 	}
 	if in.Experimental != nil {
 		in, out := &in.Experimental, &out.Experimental
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.Hosts != nil {
 		in, out := &in.Hosts, &out.Hosts
@@ -999,12 +995,8 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 	}
 	if in.MetricsAddress != nil {
 		in, out := &in.MetricsAddress, &out.MetricsAddress
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	if in.MTU != nil {
 		in, out := &in.MTU, &out.MTU


### PR DESCRIPTION
Looks like some (slightly) more efficient deepcopy code, which just
needed regeneration.