### PR TITLE
Rationalize deserialiation code

### DIFF
--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -118,11 +118,6 @@ func RunCreate(f *util.Factory, out io.Writer, c *CreateOptions) error {
 		return err
 	}
 
-	// Codecs provides access to encoding and decoding for the scheme
-	codecs := kopscodecs.Codecs //serializer.NewCodecFactory(scheme)
-
-	codec := codecs.UniversalDecoder(kopsapi.SchemeGroupVersion)
-
 	var clusterName = ""
 	//var cSpec = false
 	var sb bytes.Buffer
@@ -147,7 +142,7 @@ func RunCreate(f *util.Factory, out io.Writer, c *CreateOptions) error {
 				Group:   v1alpha1.SchemeGroupVersion.Group,
 				Version: v1alpha1.SchemeGroupVersion.Version,
 			}
-			o, gvk, err := codec.Decode(section, defaults, nil)
+			o, gvk, err := kopscodecs.Decode(section, defaults)
 			if err != nil {
 				return fmt.Errorf("error parsing file %q: %v", f, err)
 			}

--- a/cmd/kops/create_ig.go
+++ b/cmd/kops/create_ig.go
@@ -212,7 +212,7 @@ func RunCreateInstanceGroup(f *util.Factory, cmd *cobra.Command, args []string, 
 			return fmt.Errorf("error launching editor: %v", err)
 		}
 
-		obj, _, err := kopscodecs.ParseVersionedYaml(edited)
+		obj, _, err := kopscodecs.Decode(edited, nil)
 		if err != nil {
 			return fmt.Errorf("error parsing yaml: %v", err)
 		}

--- a/cmd/kops/delete.go
+++ b/cmd/kops/delete.go
@@ -97,9 +97,6 @@ func NewCmdDelete(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunDelete(factory *util.Factory, out io.Writer, d *DeleteOptions) error {
-	// Codecs provides access to encoding and decoding for the scheme
-	codec := kopscodecs.Codecs.UniversalDecoder(kopsapi.SchemeGroupVersion)
-
 	// We could have more than one cluster in a manifest so we are using a set
 	deletedClusters := sets.NewString()
 
@@ -124,7 +121,7 @@ func RunDelete(factory *util.Factory, out io.Writer, d *DeleteOptions) error {
 				Group:   v1alpha1.SchemeGroupVersion.Group,
 				Version: v1alpha1.SchemeGroupVersion.Version,
 			}
-			o, gvk, err := codec.Decode(section, defaults, nil)
+			o, gvk, err := kopscodecs.Decode(section, defaults)
 			if err != nil {
 				return fmt.Errorf("error parsing file %q: %v", f, err)
 			}

--- a/cmd/kops/edit_cluster.go
+++ b/cmd/kops/edit_cluster.go
@@ -167,7 +167,7 @@ func RunEditCluster(f *util.Factory, cmd *cobra.Command, args []string, out io.W
 			return nil
 		}
 
-		newObj, _, err := kopscodecs.ParseVersionedYaml(edited)
+		newObj, _, err := kopscodecs.Decode(edited, nil)
 		if err != nil {
 			return preservedFile(fmt.Errorf("error parsing config: %s", err), file, out)
 		}

--- a/cmd/kops/edit_instancegroup.go
+++ b/cmd/kops/edit_instancegroup.go
@@ -142,7 +142,7 @@ func RunEditInstanceGroup(f *util.Factory, cmd *cobra.Command, args []string, ou
 		return nil
 	}
 
-	newObj, _, err := kopscodecs.ParseVersionedYaml(edited)
+	newObj, _, err := kopscodecs.Decode(edited, nil)
 	if err != nil {
 		return fmt.Errorf("error parsing InstanceGroup: %v", err)
 	}

--- a/cmd/kops/replace.go
+++ b/cmd/kops/replace.go
@@ -94,11 +94,6 @@ func RunReplace(f *util.Factory, cmd *cobra.Command, out io.Writer, c *replaceOp
 		return err
 	}
 
-	// Codecs provides access to encoding and decoding for the scheme
-	codecs := kopscodecs.Codecs //serializer.NewCodecFactory(scheme)
-
-	codec := codecs.UniversalDecoder(kopsapi.SchemeGroupVersion)
-
 	for _, f := range c.Filenames {
 		var contents []byte
 		if f == "-" {
@@ -115,7 +110,7 @@ func RunReplace(f *util.Factory, cmd *cobra.Command, out io.Writer, c *replaceOp
 		sections := bytes.Split(contents, []byte("\n---\n"))
 
 		for _, section := range sections {
-			o, gvk, err := codec.Decode(section, nil, nil)
+			o, gvk, err := kopscodecs.Decode(section, nil)
 			if err != nil {
 				return fmt.Errorf("error parsing file %q: %v", f, err)
 			}

--- a/pkg/client/simple/vfsclientset/commonvfs.go
+++ b/pkg/client/simple/vfsclientset/commonvfs.go
@@ -44,7 +44,6 @@ type ValidationFunction func(o runtime.Object) error
 type commonVFS struct {
 	kind               string
 	basePath           vfs.Path
-	decoder            runtime.Decoder
 	encoder            runtime.Encoder
 	defaultReadVersion *schema.GroupVersionKind
 	validate           ValidationFunction
@@ -57,7 +56,6 @@ func (c *commonVFS) init(kind string, basePath vfs.Path, storeVersion runtime.Gr
 		glog.Fatalf("no YAML serializer registered")
 	}
 	c.encoder = codecs.EncoderForVersion(yaml.Serializer, storeVersion)
-	c.decoder = codecs.DecoderToVersion(yaml.Serializer, kops.SchemeGroupVersion)
 
 	c.kind = kind
 	c.basePath = basePath
@@ -126,7 +124,7 @@ func (c *commonVFS) readConfig(configPath vfs.Path) (runtime.Object, error) {
 		return nil, fmt.Errorf("error reading %s: %v", configPath, err)
 	}
 
-	object, _, err := c.decoder.Decode(data, c.defaultReadVersion, nil)
+	object, _, err := kopscodecs.Decode(data, c.defaultReadVersion)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing %s: %v", configPath, err)
 	}

--- a/pkg/kopscodecs/codecs.go
+++ b/pkg/kopscodecs/codecs.go
@@ -84,6 +84,10 @@ func ToVersionedJSONWithVersion(obj runtime.Object, version runtime.GroupVersion
 	return w.Bytes(), nil
 }
 
-func ParseVersionedYaml(data []byte) (runtime.Object, *schema.GroupVersionKind, error) {
-	return decoder().Decode(data, nil, nil)
+// Decode decodes the specified data, with the specified default version
+func Decode(data []byte, defaultReadVersion *schema.GroupVersionKind) (runtime.Object, *schema.GroupVersionKind, error) {
+	decoder := decoder()
+
+	object, gvk, err := decoder.Decode(data, defaultReadVersion, nil)
+	return object, gvk, err
 }

--- a/pkg/testutils/modelharness.go
+++ b/pkg/testutils/modelharness.go
@@ -49,18 +49,13 @@ func LoadModel(basedir string) (*Model, error) {
 
 	spec := &Model{}
 
-	// Codecs provides access to encoding and decoding for the scheme
-	codecs := kopscodecs.Codecs
-
-	codec := codecs.UniversalDecoder(kops.SchemeGroupVersion)
-
 	sections := bytes.Split(clusterYaml, []byte("\n---\n"))
 	for _, section := range sections {
 		defaults := &schema.GroupVersionKind{
 			Group:   v1alpha2.SchemeGroupVersion.Group,
 			Version: v1alpha2.SchemeGroupVersion.Version,
 		}
-		o, gvk, err := codec.Decode(section, defaults, nil)
+		o, gvk, err := kopscodecs.Decode(section, defaults)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing file %v", err)
 		}

--- a/tests/integration/conversion/BUILD.bazel
+++ b/tests/integration/conversion/BUILD.bazel
@@ -7,7 +7,6 @@ go_test(
         "exported_testdata",  # keep
     ],
     deps = [
-        "//pkg/apis/kops:go_default_library",
         "//pkg/apis/kops/v1alpha1:go_default_library",
         "//pkg/apis/kops/v1alpha2:go_default_library",
         "//pkg/diff:go_default_library",

--- a/tests/integration/conversion/integration_test.go
+++ b/tests/integration/conversion/integration_test.go
@@ -25,7 +25,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/v1alpha1"
 	"k8s.io/kops/pkg/apis/kops/v1alpha2"
 	"k8s.io/kops/pkg/diff"
@@ -54,8 +53,6 @@ func runTest(t *testing.T, srcDir string, fromVersion string, toVersion string) 
 		t.Fatalf("unexpected error reading expectedPath %q: %v", expectedPath, err)
 	}
 
-	codec := kopscodecs.Codecs.UniversalDecoder(kops.SchemeGroupVersion)
-
 	defaults := &schema.GroupVersionKind{
 		Group:   v1alpha1.SchemeGroupVersion.Group,
 		Version: v1alpha1.SchemeGroupVersion.Version,
@@ -77,12 +74,10 @@ func runTest(t *testing.T, srcDir string, fromVersion string, toVersion string) 
 		t.Fatalf("unknown version %q", toVersion)
 	}
 
-	//decoder := k8sapi.Codecs.DecoderToVersion(yaml.Serializer, kops.SchemeGroupVersion)
-
 	var actual []string
 
 	for _, s := range strings.Split(string(sourceBytes), "\n---\n") {
-		o, gvk, err := codec.Decode([]byte(s), defaults, nil)
+		o, gvk, err := kopscodecs.Decode([]byte(s), defaults)
 		if err != nil {
 			t.Fatalf("error parsing file %q: %v", sourcePath, err)
 		}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
@@ -56,7 +56,7 @@ func runChannelBuilderTest(t *testing.T, key string) {
 	if err != nil {
 		t.Fatalf("error reading cluster yaml file %q: %v", clusterYamlPath, err)
 	}
-	obj, _, err := kopscodecs.ParseVersionedYaml(clusterYaml)
+	obj, _, err := kopscodecs.Decode(clusterYaml, nil)
 	if err != nil {
 		t.Fatalf("error parsing cluster yaml %q: %v", clusterYamlPath, err)
 	}

--- a/upup/pkg/fi/vfs_castore.go
+++ b/upup/pkg/fi/vfs_castore.go
@@ -217,16 +217,9 @@ func (c *VFSCAStore) buildPrivateKeyPath(name string, id string) vfs.Path {
 }
 
 func (c *VFSCAStore) parseKeysetYaml(data []byte) (*kops.Keyset, KeysetFormat, error) {
-	codecs := kopscodecs.Codecs
-	yaml, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), "application/yaml")
-	if !ok {
-		glog.Fatalf("no YAML serializer registered")
-	}
-	decoder := codecs.DecoderToVersion(yaml.Serializer, kops.SchemeGroupVersion)
-
 	defaultReadVersion := v1alpha2.SchemeGroupVersion.WithKind("Keyset")
 
-	object, gvk, err := decoder.Decode(data, &defaultReadVersion, nil)
+	object, gvk, err := kopscodecs.Decode(data, &defaultReadVersion)
 	if err != nil {
 		return nil, "", fmt.Errorf("error parsing keyset: %v", err)
 	}


### PR DESCRIPTION
Put it all through kopscodecs.Decode, so that we can rewrite the API
group more easily in a subsequent PR.