### PR TITLE
Always log when a retry loop fails

### DIFF
--- a/util/pkg/vfs/context.go
+++ b/util/pkg/vfs/context.go
@@ -228,7 +228,7 @@ func RetryWithBackoff(backoff wait.Backoff, condition func() (bool, error)) (boo
 		}
 
 		if noMoreRetries {
-			glog.V(2).Infof("hit maximum retries %d with error %v", i, err)
+			glog.Infof("hit maximum retries %d with error %v", i, err)
 			return done, err
 		}
 	}


### PR DESCRIPTION
We want to be sure the retry loop is working, and we want to know when
we're incurring retry failures (if something is expected to fail).