### PR TITLE
Update recommended kubernetes version

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -68,7 +68,7 @@ spec:
   - range: ">=1.11.0-alpha.1"
     #recommendedVersion: "1.11.0"
     #requiredVersion: 1.11.0
-    kubernetesVersion: 1.11.5
+    kubernetesVersion: 1.11.6
   - range: ">=1.10.0-alpha.1"
     recommendedVersion: "1.10.0"
     #requiredVersion: 1.10.0

--- a/channels/stable
+++ b/channels/stable
@@ -61,7 +61,7 @@ spec:
   - range: ">=1.11.0-alpha.1"
     #recommendedVersion: "1.10.0"
     #requiredVersion: 1.10.0
-    kubernetesVersion: 1.11.5
+    kubernetesVersion: 1.11.6
   - range: ">=1.10.0-alpha.1"
     recommendedVersion: "1.10.0"
     #requiredVersion: 1.10.0


### PR DESCRIPTION
Currently, the recommended version needs to be updated in multiple
places - once for new clusters and once for updates I believe. (We
probably could/should address this.)  But updating the two places to
1.11.6 for consistency.