### PR TITLE
Included type in SSL certificate documentation

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -52,6 +52,7 @@ You can use a valid SSL Certificate for your API Server Load Balancer. Currently
 spec:
   api:
     loadBalancer:
+      type: Public
       sslCertificate: arn:aws:acm:<region>:<accountId>:certificate/<uuid>
 ```
 


### PR DESCRIPTION
If you specify `spec.api.loadBalancer.sslCertificate`, but not `spec.api.loadBalancer.type`, the configuration will be invalid.