### PR TITLE
Promote alpha kubernetes versions to stable

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -72,7 +72,7 @@ spec:
   - range: ">=1.10.0-alpha.1"
     recommendedVersion: "1.10.0"
     #requiredVersion: 1.10.0
-    kubernetesVersion: 1.10.11
+    kubernetesVersion: 1.10.12
   - range: ">=1.9.0-alpha.1"
     recommendedVersion: 1.9.2
     #requiredVersion: 1.9.0

--- a/channels/stable
+++ b/channels/stable
@@ -37,10 +37,10 @@ spec:
     recommendedVersion: 1.11.6
     requiredVersion: 1.11.0
   - range: ">=1.10.0"
-    recommendedVersion: 1.10.11
+    recommendedVersion: 1.10.12
     requiredVersion: 1.10.0
   - range: ">=1.9.0"
-    recommendedVersion: 1.9.10
+    recommendedVersion: 1.9.11
     requiredVersion: 1.9.0
   - range: ">=1.8.0"
     recommendedVersion: 1.8.15
@@ -59,17 +59,17 @@ spec:
     requiredVersion: 1.4.2
   kopsVersions:
   - range: ">=1.11.0-alpha.1"
-    #recommendedVersion: "1.10.0"
-    #requiredVersion: 1.10.0
+    #recommendedVersion: "1.11.0"
+    #requiredVersion: 1.11.0
     kubernetesVersion: 1.11.6
   - range: ">=1.10.0-alpha.1"
     recommendedVersion: "1.10.0"
     #requiredVersion: 1.10.0
-    kubernetesVersion: 1.10.11
+    kubernetesVersion: 1.10.12
   - range: ">=1.9.0-alpha.1"
     recommendedVersion: 1.9.2
     #requiredVersion: 1.9.0
-    kubernetesVersion: 1.9.10
+    kubernetesVersion: 1.9.11
   - range: ">=1.8.0-alpha.1"
     recommendedVersion: 1.8.1
     requiredVersion: 1.7.1


### PR DESCRIPTION
* 1.10.12
* 1.9.11

Also fix the recommended versions to prevent an immediately upgrade
prompt.