### PR TITLE
Add extra privilege to prometheus-k8s ClusterRole

### DIFF
--- a/addons/prometheus-operator/v0.19.0.yaml
+++ b/addons/prometheus-operator/v0.19.0.yaml
@@ -12943,8 +12943,12 @@ rules:
   - ""
   resources:
   - nodes/metrics
+  - pods
+  - endpoints
+  - services
   verbs:
   - get
+  - list
 - nonResourceURLs:
   - /metrics
   verbs:


### PR DESCRIPTION
**The Problem**:

I was not able to monitor my nginx ingress controller metrics after deploying the prometheus operator addons. 

This is my service monitor yaml.

```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  labels:
    app: nginx-dev
    k8s-app: nginx-dev
  name: nginx-dev
  namespace: monitoring
spec:
  jobLabel: component
  selector:
    matchLabels:
      app: nginx-ingress
      component: controller
  namespaceSelector:
    matchNames:
      - dev
  endpoints:
  - port: metrics
    interval: 5s
    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
```

After applying it, I got  the following errors:

```txt
Failed to list *v1.Pod: pods is forbidden: User \"system:serviceaccount:monitoring:prometheus-k8s\" cannot list pods in the namespace \"dev\""
```

```txt
Failed to list *v1.Service: services is forbidden: User \"system:serviceaccount:monitoring:prometheus-k8s\" cannot list services in the namespace \"dev\""
```

```txt
Failed to list *v1.Endpoints: endpoints is forbidden: User \"system:serviceaccount:monitoring:prometheus-k8s\" cannot list endpoints in the namespace \"dev\"
```

**Fixing the Problem**

I had to modify the ClusterRole by adding extra privileges (see diff) to resolve the permission errors.


