### PR TITLE
Fix kubelet api admin

### DIFF
--- a/upup/models/cloudup/resources/addons/rbac.addons.k8s.io/kubelet-api-admin.yaml
+++ b/upup/models/cloudup/resources/addons/rbac.addons.k8s.io/kubelet-api-admin.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kops:system:kubelet-api-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kubelet-api-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: kubelet-api

--- a/upup/models/cloudup/resources/addons/rbac.addons.k8s.io/kubelet-api-admin.yaml
+++ b/upup/models/cloudup/resources/addons/rbac.addons.k8s.io/kubelet-api-admin.yaml
@@ -8,6 +8,7 @@ roleRef:
   kind: ClusterRole
   name: system:kubelet-api-admin
 subjects:
+# TODO: perhaps change the client cerificate, place into a group and using a group selector instead?
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: kubelet-api

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -281,7 +281,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 				Version:           fi.String(version),
 				Selector:          map[string]string{"k8s-addon": key},
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.8.0",
+				KubernetesVersion: ">=1.9.0",
 				Id:                id,
 			})
 			manifests[key+"-"+id] = "addons/" + location

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -266,38 +266,25 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 	}
 
 	{
-		// @check if kubelet web authorization is enabled - by default the  is not bound
+		// Adding the kubelet-api-admin binding: this is required when switching to webhook authorization on the kubelet
 		// docs: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#other-component-roles
 		// issue: https://github.com/kubernetes/kops/issues/5176
-		var enabled bool
+		key := "rbac.addons.k8s.io"
+		version := "v0.0.1"
 
-		// @TODO: now technically kubelet config can come form instancegroup, master kubelet or cluster, though i'm not
-		// sure how to check the instancegroups here
-		if b.cluster.Spec.Kubelet != nil && fi.BoolValue(b.cluster.Spec.Kubelet.AuthenticationTokenWebhook) {
-			enabled = true
-		}
-		if b.cluster.Spec.MasterKubelet != nil && fi.BoolValue(b.cluster.Spec.MasterKubelet.AuthenticationTokenWebhook) {
-			enabled = true
-		}
+		{
+			id := "kubelet-api-admin"
+			location := key + "/kubelet-api-admin.yaml"
 
-		if enabled {
-			key := "rbac.addons.k8s.io"
-			version := "v0.0.1"
-
-			{
-				id := "kubelet-api-admin"
-				location := key + "/kubelet-api-admin.yaml"
-
-				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
-					Name:              fi.String(key),
-					Version:           fi.String(version),
-					Selector:          map[string]string{"k8s-addon": key},
-					Manifest:          fi.String(location),
-					KubernetesVersion: ">=1.8.0",
-					Id:                id,
-				})
-				manifests[key+"-"+id] = "addons/" + location
-			}
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(version),
+				Selector:          map[string]string{"k8s-addon": key},
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.8.0",
+				Id:                id,
+			})
+			manifests[key+"-"+id] = "addons/" + location
 		}
 	}
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -30,6 +30,13 @@ spec:
     selector:
       k8s-addon: rbac.addons.k8s.io
     version: 1.8.0
+  - id: kubelet-api-admin
+    kubernetesVersion: '>=1.9.0'
+    manifest: rbac.addons.k8s.io/kubelet-api-admin.yaml
+    name: rbac.addons.k8s.io
+    selector:
+      k8s-addon: rbac.addons.k8s.io
+    version: v0.0.1
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
     name: limit-range.addons.k8s.io
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
@@ -30,6 +30,13 @@ spec:
     selector:
       k8s-addon: rbac.addons.k8s.io
     version: 1.8.0
+  - id: kubelet-api-admin
+    kubernetesVersion: '>=1.9.0'
+    manifest: rbac.addons.k8s.io/kubelet-api-admin.yaml
+    name: rbac.addons.k8s.io
+    selector:
+      k8s-addon: rbac.addons.k8s.io
+    version: v0.0.1
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
     name: limit-range.addons.k8s.io
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -30,6 +30,13 @@ spec:
     selector:
       k8s-addon: rbac.addons.k8s.io
     version: 1.8.0
+  - id: kubelet-api-admin
+    kubernetesVersion: '>=1.9.0'
+    manifest: rbac.addons.k8s.io/kubelet-api-admin.yaml
+    name: rbac.addons.k8s.io
+    selector:
+      k8s-addon: rbac.addons.k8s.io
+    version: v0.0.1
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
     name: limit-range.addons.k8s.io
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -30,6 +30,13 @@ spec:
     selector:
       k8s-addon: rbac.addons.k8s.io
     version: 1.8.0
+  - id: kubelet-api-admin
+    kubernetesVersion: '>=1.9.0'
+    manifest: rbac.addons.k8s.io/kubelet-api-admin.yaml
+    name: rbac.addons.k8s.io
+    selector:
+      k8s-addon: rbac.addons.k8s.io
+    version: v0.0.1
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
     name: limit-range.addons.k8s.io
     selector:


### PR DESCRIPTION
When switching in kubelet webhook mode to for authorization, the current kube-apiserver user configured via the `--kubelet-client-certificate` and `--kubelet-client-key` uses a [cn=kubelet-api](https://github.com/kubernetes/kops/blob/master/pkg/model/pki.go#L74-L81) which doesn't have the perms to perform it's tasks. The `system:kubelet-api-admin` is created by [default](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#other-component-roles) but is not bound by default to any users/groups