### PR TITLE
Fix prow-postsubmit by copying prebuilt archive in bazel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -465,6 +465,10 @@ utils-dist:
 	mkdir -p ${DIST}/linux/amd64/
 	docker run -v `pwd`/.build/dist/linux/amd64/:/dist utils-builder /extract.sh
 
+.PHONY: bazel-utils-dist
+bazel-utils-dist:
+	bazel build //images/utils-builder:utils
+
 # --------------------------------------------------
 # development targets
 
@@ -756,7 +760,7 @@ bazel-protokube-export:
 	(${SHASUMCMD} ${BAZELIMAGES}/protokube.tar.gz | cut -d' ' -f1) > ${BAZELIMAGES}/protokube.tar.gz.sha1
 
 .PHONY: bazel-version-dist
-bazel-version-dist: bazel-crossbuild-nodeup bazel-crossbuild-kops bazel-protokube-export utils-dist
+bazel-version-dist: bazel-crossbuild-nodeup bazel-crossbuild-kops bazel-protokube-export bazel-utils-dist
 	rm -rf ${BAZELUPLOAD}
 	mkdir -p ${BAZELUPLOAD}/kops/${VERSION}/linux/amd64/
 	mkdir -p ${BAZELUPLOAD}/kops/${VERSION}/darwin/amd64/
@@ -773,8 +777,8 @@ bazel-version-dist: bazel-crossbuild-nodeup bazel-crossbuild-kops bazel-protokub
 	(${SHASUMCMD} ${BAZELUPLOAD}/kops/${VERSION}/darwin/amd64/kops | cut -d' ' -f1) > ${BAZELUPLOAD}/kops/${VERSION}/darwin/amd64/kops.sha1
 	cp bazel-bin/cmd/kops/windows_amd64_pure_stripped/kops.exe ${BAZELUPLOAD}/kops/${VERSION}/windows/amd64/kops.exe
 	(${SHASUMCMD} ${BAZELUPLOAD}/kops/${VERSION}/windows/amd64/kops.exe | cut -d' ' -f1) > ${BAZELUPLOAD}/kops/${VERSION}/windows/amd64/kops.exe.sha1
-	cp ${DIST}/linux/amd64/utils.tar.gz ${BAZELUPLOAD}/kops/${VERSION}/linux/amd64/utils.tar.gz
-	cp ${DIST}/linux/amd64/utils.tar.gz.sha1 ${BAZELUPLOAD}/kops/${VERSION}/linux/amd64/utils.tar.gz.sha1
+	cp bazel-bin/images/utils-builder/utils.tar.gz ${BAZELUPLOAD}/kops/${VERSION}/linux/amd64/utils.tar.gz
+	(${SHASUMCMD} ${BAZELUPLOAD}/kops/${VERSION}/linux/amd64/utils.tar.gz | cut -d' ' -f1) > ${BAZELUPLOAD}/kops/${VERSION}/linux/amd64/utils.tar.gz.sha1
 
 .PHONY: bazel-upload
 bazel-upload: bazel-version-dist # Upload kops to S3

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -100,3 +100,12 @@ dpkg_list(
         "@debian_stretch//file:Packages.json",
     ],
 )
+
+# We use the prebuilt utils.tar.gz containing socat & conntrack, building it in bazel is really painful
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+http_file(
+    name = "utils_tar_gz",
+    urls = ["https://kubeupv2.s3.amazonaws.com/kops/1.11.0-alpha.1/linux/amd64/utils.tar.gz"],
+    sha256 = "74ff5d81ba62f7a153da1138ae0890594867816bcc9fc40cfe1c96fe06110d43",
+)

--- a/images/utils-builder/BUILD.bazel
+++ b/images/utils-builder/BUILD.bazel
@@ -1,0 +1,38 @@
+# Download and build socat from source
+# Relies on system C++ compiler etc, so this is really only good for building from prow
+# Note: not yet used
+#genrule(
+#    name = "build-socat",
+#    srcs = ["build-socat.sh"],
+#    outs = ["socat"],
+#    cmd = "./$(location build-socat.sh) $@",
+#)
+
+genrule(
+    name = "extract_socat",
+    srcs = ["@utils_tar_gz//file"],
+    outs = ["socat"],
+    cmd = "tar -x -z --no-same-owner -f ./$(location @utils_tar_gz//file) utils/socat && mv utils/socat \"$@\"",
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "extract_conntrack",
+    srcs = ["@utils_tar_gz//file"],
+    outs = ["conntrack"],
+    cmd = "tar -x -z --no-same-owner -f ./$(location @utils_tar_gz//file) utils/conntrack && mv utils/conntrack \"$@\"",
+    visibility = ["//visibility:public"],
+)
+
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+pkg_tar(
+    name = "utils",
+    extension = "tar.gz",
+    package_dir = "utils",
+    srcs = [
+        "socat",
+        "conntrack",
+    ],
+    mode = "0755",
+)


### PR DESCRIPTION
It's roughly possible to build socat, but conntrack looks much harder
to build in bazel.  For compatability we just reuse the prebuilt
utils.tar.gz (these are utilities that rarely change).