### PR TITLE
include docker 18.06.1 missed dependency

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -501,7 +501,7 @@ var dockerVersions = []dockerVersion{
 		//Recommends: aufs-tools, ca-certificates, cgroupfs-mount | cgroup-lite, git, xz-utils, apparmor
 	},
 
-	// 17.09.0 - Centos / Rhel7
+	// 17.09.0 - Centos / Rhel7 (two packages)
 	{
 		DockerVersion: "17.09.0",
 		Name:          "container-selinux-2",

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -504,6 +504,16 @@ var dockerVersions = []dockerVersion{
 	// 17.09.0 - Centos / Rhel7
 	{
 		DockerVersion: "17.09.0",
+		Name:          "container-selinux-2",
+		Distros:       []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "17.09.0.ce",
+		Source:        "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
+		Hash:          "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
+		Dependencies:  []string{"policycoreutils-python"},
+	},
+	{
+		DockerVersion: "17.09.0",
 		Name:          "docker-ce",
 		Distros:       []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
 		Architectures: []Architecture{ArchitectureAmd64},

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -540,7 +540,17 @@ var dockerVersions = []dockerVersion{
 		Dependencies:  []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 	},
 
-	// 18.06.1 - CentOS / Rhel7
+	// 18.06.1 - CentOS / Rhel7 (two packages)
+	{
+		DockerVersion: "18.06.1",
+		Name:          "container-selinux-2",
+		Distros:       []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "18.06.1.ce",
+		Source:        "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
+		Hash:          "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
+		Dependencies:  []string{"policycoreutils-python"},
+	},
 	{
 		DockerVersion: "18.06.1",
 		Name:          "docker-ce",


### PR DESCRIPTION
Fixes #6225 

Thanks to @[xrl](https://github.com/xrl) for doing the actual work.

**Testing Completed with docker v17.09.0**
Created a cluster on Rhel7 with Calico and deleted

**Testing Completed with docker v18.06.1-ce**
Created a cluster on Rhel7 with Calico and deleted
Created a cluster on AWS Linux 2 with Amazon VPC CNI and deleted