### PR TITLE
Stop setting deprecated --allow-privileged Kubelet flag in 1.14

### DIFF
--- a/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_master-us-west-2a.masters.k8s-iam.us-west-2.td.priv_user_data
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_master-us-west-2a.masters.k8s-iam.us-west-2.td.priv_user_data
@@ -221,7 +221,6 @@ kubeScheduler:
     leaderElect: true
   logLevel: 2
 kubelet:
-  allowPrivileged: true
   cgroupRoot: /
   cloudProvider: aws
   clusterDNS: 100.64.0.10
@@ -239,7 +238,6 @@ kubelet:
   podManifestPath: /etc/kubernetes/manifests
   requireKubeconfig: true
 masterKubelet:
-  allowPrivileged: true
   cgroupRoot: /
   cloudProvider: aws
   clusterDNS: 100.64.0.10

--- a/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_nodes.k8s-iam.us-west-2.td.priv_user_data
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_nodes.k8s-iam.us-west-2.td.priv_user_data
@@ -159,7 +159,6 @@ kubeProxy:
   image: gcr.io/google_containers/kube-proxy:v1.8.4
   logLevel: 2
 kubelet:
-  allowPrivileged: true
   cgroupRoot: /
   cloudProvider: aws
   clusterDNS: 100.64.0.10


### PR DESCRIPTION
This is required for https://github.com/kubernetes/kubernetes/pull/71835 to pass tests.

@justinsb is this the right place to make this change, and am I correct in assuming that setting the field to nil will prevent it from being set on the command line?

/assign @justinsb