### PR TITLE
Add note regarding upgrading to CoreDNS

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -377,6 +377,8 @@ Specifying KubeDNS will install kube-dns as the default service discovery.
 
 This will install [CoreDNS](https://coredns.io/) instead of kube-dns.
 
+**Note:** If you are upgrading to CoreDNS, kube-dns will be left in place and must be removed manually. You can scale the kube-dns and kube-dns-autoscaler deployments in the `kube-system` namespace to 0 as a starting point
+
 ### kubeControllerManager
 This block contains configurations for the `controller-manager`.
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kops/issues/6318

When upgrading to `CoreDNS` from `kube-dns`, we should tell users that they need to cleanup kube-dns itself afterwards. Let me know if anyone feels this should be documented further elsewhere, with maybe a link to that doc here instead. 