### PR TITLE
modify default kube-proxy resource request

### DIFF
--- a/pkg/model/components/kubeproxy.go
+++ b/pkg/model/components/kubeproxy.go
@@ -44,7 +44,11 @@ func (b *KubeProxyOptionsBuilder) BuildOptions(o interface{}) error {
 	// Any change here should be accompanied by a proportional change in CPU
 	// requests of other per-node add-ons (e.g. fluentd).
 	if config.CPURequest == "" {
-		config.CPURequest = "100m"
+		config.CPURequest = "50m"
+	}
+
+	if config.MemoryRequest == "" {
+		config.MemoryRequest = "32Mi"
 	}
 
 	image, err := Image("kube-proxy", clusterSpec, b.Context.AssetBuilder)

--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
@@ -194,10 +194,11 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
     master: 127.0.0.1:8080
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
+    cpuRequest: 50m
     hostnameOverride: '@aws'
     image: gcr.io/google_containers/kube-proxy:v1.4.12
     logLevel: 2
+    memoryRequest: 32Mi
   kubeScheduler:
     image: gcr.io/google_containers/kube-scheduler:v1.4.12
     leaderElection:
@@ -428,10 +429,11 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
     version: 1.11.2
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
+    cpuRequest: 50m
     hostnameOverride: '@aws'
     image: gcr.io/google_containers/kube-proxy:v1.4.12
     logLevel: 2
+    memoryRequest: 32Mi
   kubelet:
     allowPrivileged: true
     apiServers: https://api.internal.additionalcidr.example.com

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -203,10 +203,11 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
     master: 127.0.0.1:8080
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
+    cpuRequest: 50m
     hostnameOverride: '@aws'
     image: gcr.io/google_containers/kube-proxy:v1.4.12
     logLevel: 2
+    memoryRequest: 32Mi
   kubeScheduler:
     image: gcr.io/google_containers/kube-scheduler:v1.4.12
     leaderElection:
@@ -457,10 +458,11 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
     version: 1.11.2
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
+    cpuRequest: 50m
     hostnameOverride: '@aws'
     image: gcr.io/google_containers/kube-proxy:v1.4.12
     logLevel: 2
+    memoryRequest: 32Mi
   kubelet:
     allowPrivileged: true
     apiServers: https://api.internal.additionaluserdata.example.com

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -194,10 +194,11 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     master: 127.0.0.1:8080
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
+    cpuRequest: 50m
     hostnameOverride: '@aws'
     image: gcr.io/google_containers/kube-proxy:v1.4.12
     logLevel: 2
+    memoryRequest: 32Mi
   kubeScheduler:
     image: gcr.io/google_containers/kube-scheduler:v1.4.12
     leaderElection:
@@ -428,10 +429,11 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
     version: 1.11.2
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
+    cpuRequest: 50m
     hostnameOverride: '@aws'
     image: gcr.io/google_containers/kube-proxy:v1.4.12
     logLevel: 2
+    memoryRequest: 32Mi
   kubelet:
     allowPrivileged: true
     apiServers: https://api.internal.minimal.example.com

--- a/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_master-us-west-2a.masters.k8s-iam.us-west-2.td.priv_user_data
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_master-us-west-2a.masters.k8s-iam.us-west-2.td.priv_user_data
@@ -210,11 +210,12 @@ kubeControllerManager:
   useServiceAccountCredentials: true
 kubeProxy:
   clusterCIDR: 100.96.0.0/11
-  cpuRequest: 100m
+  cpuRequest: 50m
   featureGates: null
   hostnameOverride: '@aws'
   image: gcr.io/google_containers/kube-proxy:v1.8.4
   logLevel: 2
+  memoryRequest: 32Mi
 kubeScheduler:
   image: gcr.io/google_containers/kube-scheduler:v1.8.4
   leaderElection:

--- a/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_nodes.k8s-iam.us-west-2.td.priv_user_data
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_nodes.k8s-iam.us-west-2.td.priv_user_data
@@ -153,11 +153,12 @@ docker:
   version: 1.13.1
 kubeProxy:
   clusterCIDR: 100.96.0.0/11
-  cpuRequest: 100m
+  cpuRequest: 50m
   featureGates: null
   hostnameOverride: '@aws'
   image: gcr.io/google_containers/kube-proxy:v1.8.4
   logLevel: 2
+  memoryRequest: 32Mi
 kubelet:
   allowPrivileged: true
   cgroupRoot: /

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -214,10 +214,11 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
     useServiceAccountCredentials: true
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
+    cpuRequest: 50m
     hostnameOverride: '@aws'
     image: gcr.io/google_containers/kube-proxy:v1.8.0
     logLevel: 2
+    memoryRequest: 32Mi
   kubeScheduler:
     image: gcr.io/google_containers/kube-scheduler:v1.8.0
     leaderElection:
@@ -452,10 +453,11 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
     version: 1.13.1
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
+    cpuRequest: 50m
     hostnameOverride: '@aws'
     image: gcr.io/google_containers/kube-proxy:v1.8.0
     logLevel: 2
+    memoryRequest: 32Mi
   kubelet:
     allowPrivileged: true
     cgroupRoot: /

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -194,10 +194,11 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     master: 127.0.0.1:8080
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
+    cpuRequest: 50m
     hostnameOverride: '@aws'
     image: gcr.io/google_containers/kube-proxy:v1.4.12
     logLevel: 2
+    memoryRequest: 32Mi
   kubeScheduler:
     image: gcr.io/google_containers/kube-scheduler:v1.4.12
     leaderElection:
@@ -428,10 +429,11 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
     version: 1.11.2
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
+    cpuRequest: 50m
     hostnameOverride: '@aws'
     image: gcr.io/google_containers/kube-proxy:v1.4.12
     logLevel: 2
+    memoryRequest: 32Mi
   kubelet:
     allowPrivileged: true
     apiServers: https://api.internal.minimal.example.com


### PR DESCRIPTION
I'm running production kops cluster in aws with t3.large, m5.large and m5.xlarge nodes and monitor them with prometheus.

In my case, it was very rare to see kube-proxy uses more than `50m` of cpu(`10m` ~ `20m` in most cases) and `30Mi` of memory(never exceeded `30Mi` in my cluster), so I think `50m` of cpu and `32Mi` of memory are sufficient for default resource requests.