### PR TITLE
Enable etcd-manager / etcd3 / etcd-tls in kops 1.12

### DIFF
--- a/docs/etcd/manager.md
+++ b/docs/etcd/manager.md
@@ -10,10 +10,6 @@ built into kops, but it addresses some limitations also:
 * allows etcd2 -> etcd3 upgrade (along with minor upgrades)
 * allows cluster resizing (e.g. going from 1 to 3 nodes)
 
-etcd-manager is currently in early alpha - it is undergoing testing. However, if
-you have a test cluster where you don't mind if it erases all your data, please
-do try it out and provide feedback.
-
 If using kubernetes >= 1.12 (which will not formally be supported until kops 1.12), note that etcd-manager will be used by default.  You can override this with the `cluster.spec.etcdClusters[*].provider=Legacy` override.  This can be specified:
 
 * as an argument to `kops create cluster`: `--overrides cluster.spec.etcdClusters[*].provider=Legacy`
@@ -24,8 +20,8 @@ If using kubernetes >= 1.12 (which will not formally be supported until kops 1.1
 
 ## How to use etcd-manager
 
-Reminder: etcd-manager is alpha, and may cause you to lose the data in your
-kubernetes cluster.
+Reminder: etcd-manager is alpha, and we encourage you to back up the data in
+your kubernetes cluster.
 
 To create a test cluster:
 ```bash
@@ -67,7 +63,7 @@ kops delete cluster example.k8s.local --yes
 ```
 
 You can also do this for existing clusters. though remember that this is still
-an early alpha, so don't use for clusters with important data.  You just run the
+young software, so please back up important cluster data first.  You just run the
 two `kops set cluster` commands.  Note that `kops set cluster` is just an easy
 command line way to set some fields in the cluster spec - if you're using a
 GitOps approach you can change the manifest files directly. You can also `kops

--- a/docs/releases/1.12-NOTES.md
+++ b/docs/releases/1.12-NOTES.md
@@ -1,0 +1,25 @@
+## Release notes for kops 1.12 series
+
+# Significant changes
+
+* kops 1.12 enables etcd-manager by default.  For kubernetes 1.12 (and later) we
+  default to etcd3.  We also enable TLS for etcd communications when using
+  etcd-manager.  More information is in the [etcd migration
+  documentation](https://github.com/kubernetes/kops/blob/master/docs/etcd3-migration.md)
+* Components are no longer allowed to interact with etcd directly.  Calico will
+  be switched to use CRDs instead of directly with etcd.  This is a disruptive
+  upgrade, please read the calico notes in the [etcd migration
+  documentation](https://github.com/kubernetes/kops/blob/master/docs/etcd3-migration.md)
+
+# Required Actions
+
+* Please back-up important data before upgrading, as the [etcd2 to etcd3
+  migration](https://github.com/kubernetes/kops/blob/master/docs/etcd3-migration.md)
+  is higher risk than most upgrades.
+* Note that the upgrade for Calico users is disruptive, because it requires
+  switching from direct-etcd-storage to CRD backed storage.
+
+# Full change list since 1.11.0 release
+
+(will be included with 1.12.0 beta releases)
+

--- a/nodeup/pkg/model/BUILD.bazel
+++ b/nodeup/pkg/model/BUILD.bazel
@@ -67,6 +67,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authentication/user:go_default_library",
+        "//vendor/k8s.io/client-go/util/cert:go_default_library",
         "//vendor/k8s.io/kubernetes/pkg/util/mount:go_default_library",
     ],
 )

--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -287,6 +287,17 @@ func (c *NodeupModelContext) IsKubernetesGTE(version string) bool {
 	return util.IsKubernetesGTE(version, c.kubernetesVersion)
 }
 
+// UseEtcdManager checks if the etcd cluster has etcd-manager enabled
+func (c *NodeupModelContext) UseEtcdManager() bool {
+	for _, x := range c.Cluster.Spec.EtcdClusters {
+		if x.Provider == kops.EtcdProviderTypeManager {
+			return true
+		}
+	}
+
+	return false
+}
+
 // UseEtcdTLS checks if the etcd cluster has TLS enabled bool
 func (c *NodeupModelContext) UseEtcdTLS() bool {
 	// @note: because we enforce that 'both' have to be enabled for TLS we only need to check one here.

--- a/nodeup/pkg/model/convenience.go
+++ b/nodeup/pkg/model/convenience.go
@@ -119,6 +119,23 @@ func addHostPathMapping(pod *v1.Pod, container *v1.Container, name, path string)
 	return &container.VolumeMounts[len(container.VolumeMounts)-1]
 }
 
+// addHostPathVolume is shorthand for mapping a host path into a container
+func addHostPathVolume(pod *v1.Pod, container *v1.Container, hostPath v1.HostPathVolumeSource, volumeMount v1.VolumeMount) {
+	vol := v1.Volume{
+		Name: volumeMount.Name,
+		VolumeSource: v1.VolumeSource{
+			HostPath: &hostPath,
+		},
+	}
+
+	if volumeMount.MountPath == "" {
+		volumeMount.MountPath = hostPath.Path
+	}
+
+	pod.Spec.Volumes = append(pod.Spec.Volumes, vol)
+	container.VolumeMounts = append(container.VolumeMounts, volumeMount)
+}
+
 // convEtcdSettingsToMs converts etcd settings to a string rep of int milliseconds
 func convEtcdSettingsToMs(dur *metav1.Duration) string {
 	return strconv.FormatInt(dur.Nanoseconds()/1000000, 10)

--- a/nodeup/pkg/model/etcd_manager_tls.go
+++ b/nodeup/pkg/model/etcd_manager_tls.go
@@ -17,7 +17,15 @@ limitations under the License.
 package model
 
 import (
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	"github.com/golang/glog"
+	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/kops/upup/pkg/fi"
 )
 
@@ -39,6 +47,9 @@ func (b *EtcdManagerTLSBuilder) Build(ctx *fi.ModelBuilderContext) error {
 
 		keys := make(map[string]string)
 		keys["etcd-manager-ca"] = "etcd-manager-ca-" + k
+		keys["etcd-peers-ca"] = "etcd-peers-ca-" + k
+		// Because API server can only have a single client-cert, we need to share a client CA
+		keys["etcd-clients-ca"] = "etcd-clients-ca"
 
 		for fileName, keystoreName := range keys {
 			cert, err := b.KeyStore.FindCert(keystoreName)
@@ -56,6 +67,88 @@ func (b *EtcdManagerTLSBuilder) Build(ctx *fi.ModelBuilderContext) error {
 			if err := b.BuildPrivateKeyTask(ctx, keystoreName, d+"/"+fileName+".key"); err != nil {
 				return err
 			}
+		}
+	}
+
+	// We also dynamically generate the client keypair for apiserver
+	if err := b.buildKubeAPIServerKeypair(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *EtcdManagerTLSBuilder) buildKubeAPIServerKeypair() error {
+	etcdClientsCACertificate, err := b.KeyStore.FindCert("etcd-clients-ca")
+	if err != nil {
+		return err
+	}
+
+	etcdClientsCAPrivateKey, err := b.KeyStore.FindPrivateKey("etcd-clients-ca")
+	if err != nil {
+		return err
+	}
+
+	if etcdClientsCACertificate == nil {
+		glog.Errorf("unable to find etcd-clients-ca certificate, won't build key for apiserver")
+		return nil
+	}
+	if etcdClientsCAPrivateKey == nil {
+		glog.Errorf("unable to find etcd-clients-ca private key, won't build key for apiserver")
+		return nil
+	}
+
+	dir := "/etc/kubernetes/pki/kube-apiserver"
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("error creating directories %q: %v", dir, err)
+	}
+
+	{
+		p := filepath.Join(dir, "etcd-ca.crt")
+		certBytes := certutil.EncodeCertPEM(etcdClientsCACertificate.Certificate)
+		if err := ioutil.WriteFile(p, certBytes, 0644); err != nil {
+			return fmt.Errorf("error writing certificate key file %q: %v", p, err)
+		}
+	}
+
+	name := "etcd-client"
+
+	humanName := dir + "/" + name
+	privateKey, err := certutil.NewPrivateKey()
+	if err != nil {
+		return fmt.Errorf("unable to create private key %q: %v", humanName, err)
+	}
+	privateKeyBytes := certutil.EncodePrivateKeyPEM(privateKey)
+
+	certConfig := certutil.Config{
+		CommonName: "kube-apiserver",
+		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	signingKey, ok := etcdClientsCAPrivateKey.Key.(*rsa.PrivateKey)
+	if !ok {
+		return fmt.Errorf("etcd-clients-ca private key had unexpected type %T", etcdClientsCAPrivateKey.Key)
+	}
+
+	glog.Infof("signing certificate for %q", humanName)
+	cert, err := certutil.NewSignedCert(certConfig, privateKey, etcdClientsCACertificate.Certificate, signingKey)
+	if err != nil {
+		return fmt.Errorf("error signing certificate for %q: %v", humanName, err)
+	}
+
+	certBytes := certutil.EncodeCertPEM(cert)
+
+	{
+		p := filepath.Join(dir, name+".crt")
+		if err := ioutil.WriteFile(p, certBytes, 0644); err != nil {
+			return fmt.Errorf("error writing certificate key file %q: %v", p, err)
+		}
+	}
+
+	{
+		p := filepath.Join(dir, name+".key")
+		if err := ioutil.WriteFile(p, privateKeyBytes, 0600); err != nil {
+			return fmt.Errorf("error writing private key file %q: %v", p, err)
 		}
 	}
 

--- a/nodeup/pkg/model/etcd_manager_tls.go
+++ b/nodeup/pkg/model/etcd_manager_tls.go
@@ -138,17 +138,16 @@ func (b *EtcdManagerTLSBuilder) buildKubeAPIServerKeypair() error {
 
 	certBytes := certutil.EncodeCertPEM(cert)
 
+	p := filepath.Join(dir, name)
 	{
-		p := filepath.Join(dir, name+".crt")
-		if err := ioutil.WriteFile(p, certBytes, 0644); err != nil {
-			return fmt.Errorf("error writing certificate key file %q: %v", p, err)
+		if err := ioutil.WriteFile(p+".crt", certBytes, 0644); err != nil {
+			return fmt.Errorf("error writing certificate key file %q: %v", p+".crt", err)
 		}
 	}
 
 	{
-		p := filepath.Join(dir, name+".key")
-		if err := ioutil.WriteFile(p, privateKeyBytes, 0600); err != nil {
-			return fmt.Errorf("error writing private key file %q: %v", p, err)
+		if err := ioutil.WriteFile(p+".key", privateKeyBytes, 0600); err != nil {
+			return fmt.Errorf("error writing private key file %q: %v", p+".key", err)
 		}
 	}
 

--- a/nodeup/pkg/model/etcd_tls.go
+++ b/nodeup/pkg/model/etcd_tls.go
@@ -32,7 +32,7 @@ var _ fi.ModelBuilder = &EtcdTLSBuilder{}
 // Build is responsible for performing setup for CNIs that need etcd TLS support
 func (b *EtcdTLSBuilder) Build(c *fi.ModelBuilderContext) error {
 	// @check if tls is enabled and if so, we need to download the client certificates
-	if b.UseEtcdTLS() {
+	if !b.UseEtcdManager() && b.UseEtcdTLS() {
 		name := "calico-client"
 		dirname := "calico"
 		ca := filepath.Join(dirname, "ca.pem")

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -1,4 +1,13 @@
 Lifecycle: null
+Name: etcd-clients-ca
+Signer: null
+alternateNameTasks: null
+alternateNames: null
+format: v1alpha2
+subject: cn=etcd-clients-ca
+type: ca
+---
+Lifecycle: null
 Name: etcd-manager-ca-events
 Signer: null
 alternateNameTasks: null
@@ -14,6 +23,24 @@ alternateNameTasks: null
 alternateNames: null
 format: v1alpha2
 subject: cn=etcd-manager-ca-main
+type: ca
+---
+Lifecycle: null
+Name: etcd-peers-ca-events
+Signer: null
+alternateNameTasks: null
+alternateNames: null
+format: v1alpha2
+subject: cn=etcd-peers-ca-events
+type: ca
+---
+Lifecycle: null
+Name: etcd-peers-ca-main
+Signer: null
+alternateNameTasks: null
+alternateNames: null
+format: v1alpha2
+subject: cn=etcd-peers-ca-main
 type: ca
 ---
 Contents:
@@ -56,10 +83,10 @@ Contents:
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
           --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events
-          --client-urls=http://__name__:4002 --cluster-name=etcd-events --containerized=true
+          --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
           --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3997
-          --insecure=false --peer-urls=http://__name__:2381 --quarantine-client-urls=http://__name__:3995
-          --v=8 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
+          --insecure=false --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
+          --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
           --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
           > /tmp/pipe 2>&1
         image: kopeio/etcd-manager:3.0.20190224
@@ -126,10 +153,10 @@ Contents:
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
           --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main
-          --client-urls=http://__name__:4001 --cluster-name=etcd --containerized=true
+          --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
           --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3996
-          --insecure=false --peer-urls=http://__name__:2380 --quarantine-client-urls=http://__name__:3994
-          --v=8 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
+          --insecure=false --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
+          --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
           --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
           > /tmp/pipe 2>&1
         image: kopeio/etcd-manager:3.0.20190224

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -326,6 +326,17 @@ func (m *KopsModelContext) UsePrivateDNS() bool {
 	return false
 }
 
+// UseEtcdManager checks to see if etcd manager is enabled
+func (c *KopsModelContext) UseEtcdManager() bool {
+	for _, x := range c.Cluster.Spec.EtcdClusters {
+		if x.Provider == kops.EtcdProviderTypeManager {
+			return true
+		}
+	}
+
+	return false
+}
+
 // UseEtcdTLS checks to see if etcd tls is enabled
 func (m *KopsModelContext) UseEtcdTLS() bool {
 	for _, x := range m.Cluster.Spec.EtcdClusters {

--- a/protokube/cmd/protokube/BUILD.bazel
+++ b/protokube/cmd/protokube/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = [
+        "dns_cleanup.go",
+        "main.go",
+    ],
     importpath = "k8s.io/kops/protokube/cmd/protokube",
     visibility = ["//visibility:private"],
     deps = [

--- a/protokube/cmd/protokube/dns_cleanup.go
+++ b/protokube/cmd/protokube/dns_cleanup.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/kops/dns-controller/pkg/dns"
+	"k8s.io/kops/protokube/pkg/protokube"
+)
+
+// removeDNSRecords removes the specified DNS records
+func removeDNSRecords(nameList string, dnsProvider protokube.DNSProvider) {
+	for {
+		var removeRecords []dns.Record
+		for _, s := range strings.Split(nameList, ",") {
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+
+			removeRecords = append(removeRecords, dns.Record{
+				FQDN:       s,
+				RecordType: dns.RecordTypeA,
+			})
+		}
+
+		if len(removeRecords) == 0 {
+			return
+		}
+
+		if err := dnsProvider.RemoveRecordsImmediate(removeRecords); err != nil {
+			glog.Warningf("error removing records %q, will retry: %v", nameList, err)
+		} else {
+			glog.Infof("removed DNS records %q", nameList)
+			return
+		}
+		time.Sleep(5 * time.Second)
+	}
+}

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -96,6 +96,9 @@ func run() error {
 	manageEtcd := false
 	flag.BoolVar(&manageEtcd, "manage-etcd", manageEtcd, "Set to manage etcd (deprecated in favor of etcd-manager)")
 
+	var removeDNSNames string
+	flag.StringVar(&removeDNSNames, "remove-dns-names", removeDNSNames, "If set, will remove the DNS records specified")
+
 	// Trick to avoid 'logging before flag.Parse' warning
 	flag.CommandLine.Parse([]string{})
 
@@ -341,6 +344,11 @@ func run() error {
 			DNSController: dnsController,
 		}
 	}
+
+	go func() {
+		removeDNSRecords(removeDNSNames, dnsProvider)
+	}()
+
 	modelDir := "model/etcd"
 
 	var channels []string

--- a/protokube/pkg/protokube/gossipdns.go
+++ b/protokube/pkg/protokube/gossipdns.go
@@ -17,6 +17,7 @@ limitations under the License.
 package protokube
 
 import (
+	k8sdns "k8s.io/kops/dns-controller/pkg/dns"
 	"k8s.io/kops/protokube/pkg/gossip/dns"
 )
 
@@ -36,6 +37,18 @@ func (p *GossipDnsProvider) Replace(fqdn string, values []string) error {
 		record.Rrdatas = append(record.Rrdatas, value)
 	}
 	return p.DNSView.ApplyChangeset(p.Zone, nil, []*dns.DNSRecord{record})
+}
+
+func (p *GossipDnsProvider) RemoveRecordsImmediate(records []k8sdns.Record) error {
+	var removeRecords []*dns.DNSRecord
+	for _, r := range records {
+		removeRecords = append(removeRecords, &dns.DNSRecord{
+			Name:    r.FQDN,
+			RrsType: string(r.RecordType),
+		})
+	}
+
+	return p.DNSView.ApplyChangeset(p.Zone, removeRecords, nil)
 }
 
 func (p *GossipDnsProvider) Run() {

--- a/protokube/pkg/protokube/kube_dns.go
+++ b/protokube/pkg/protokube/kube_dns.go
@@ -27,6 +27,10 @@ const defaultTTL = time.Minute
 
 type DNSProvider interface {
 	Replace(fqdn string, values []string) error
+
+	// RemoveRecordsImmediate deletes the specified DNS records, without batching etc
+	RemoveRecordsImmediate(records []dns.Record) error
+
 	Run()
 }
 
@@ -49,6 +53,10 @@ type KopsDnsProvider struct {
 }
 
 var _ DNSProvider = &KopsDnsProvider{}
+
+func (p *KopsDnsProvider) RemoveRecordsImmediate(records []dns.Record) error {
+	return p.DNSController.RemoveRecordsImmediate(records)
+}
 
 func (p *KopsDnsProvider) Replace(fqdn string, values []string) error {
 	ttl := defaultTTL


### PR DESCRIPTION
In 1.12 (kops & kubenetes):

* We default etcd-manager on
* We default to etcd3
* We default to full TLS for etcd (client and peer)
* We stop allowing external access to etcd