### PR TITLE
add OWNERS file to openstack spesific folders

### DIFF
--- a/pkg/model/openstackmodel/OWNERS
+++ b/pkg/model/openstackmodel/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- dims # just for bootstrapping the provider
+- zetaab
+reviewers:
+- dims # just for bootstrapping the provider
+- zetaab

--- a/pkg/model/openstackmodel/OWNERS
+++ b/pkg/model/openstackmodel/OWNERS
@@ -2,5 +2,5 @@ approvers:
 - dims # just for bootstrapping the provider
 - zetaab
 reviewers:
-- dims # just for bootstrapping the provider
+- drekle
 - zetaab

--- a/pkg/resources/openstack/OWNERS
+++ b/pkg/resources/openstack/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- dims # just for bootstrapping the provider
+- zetaab
+reviewers:
+- dims # just for bootstrapping the provider
+- zetaab

--- a/pkg/resources/openstack/OWNERS
+++ b/pkg/resources/openstack/OWNERS
@@ -2,5 +2,5 @@ approvers:
 - dims # just for bootstrapping the provider
 - zetaab
 reviewers:
-- dims # just for bootstrapping the provider
+- drekle
 - zetaab

--- a/upup/pkg/fi/cloudup/openstack/OWNERS
+++ b/upup/pkg/fi/cloudup/openstack/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- dims # just for bootstrapping the provider
+- zetaab
+reviewers:
+- dims # just for bootstrapping the provider
+- zetaab

--- a/upup/pkg/fi/cloudup/openstack/OWNERS
+++ b/upup/pkg/fi/cloudup/openstack/OWNERS
@@ -2,5 +2,5 @@ approvers:
 - dims # just for bootstrapping the provider
 - zetaab
 reviewers:
-- dims # just for bootstrapping the provider
+- drekle
 - zetaab

--- a/upup/pkg/fi/cloudup/openstacktasks/OWNERS
+++ b/upup/pkg/fi/cloudup/openstacktasks/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- dims # just for bootstrapping the provider
+- zetaab
+reviewers:
+- dims # just for bootstrapping the provider
+- zetaab

--- a/upup/pkg/fi/cloudup/openstacktasks/OWNERS
+++ b/upup/pkg/fi/cloudup/openstacktasks/OWNERS
@@ -2,5 +2,5 @@ approvers:
 - dims # just for bootstrapping the provider
 - zetaab
 reviewers:
-- dims # just for bootstrapping the provider
+- drekle
 - zetaab


### PR DESCRIPTION
We are currently heavily doing contributions to openstack kops code. We would like to decrease time of development lifecycle. That is why we propose that we add OWNERS file to openstack part of the code - so we can approve/review things ourselves. 

These files contains now only two approvers (me and dims) but we will add more contributors when they will have kube org membership. They are working towards that.

/sig openstack