### PR TITLE
[jjo] Update Weave Net to version 2.5.1

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -163,7 +163,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.5.0'
+          image: 'weaveworks/weave-kube:2.5.1'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -201,7 +201,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.5.0'
+          image: 'weaveworks/weave-npc:2.5.1'
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -155,7 +155,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.5.0'
+          image: 'weaveworks/weave-kube:2.5.1'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -193,7 +193,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.5.0'
+          image: 'weaveworks/weave-npc:2.5.1'
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -159,7 +159,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.5.0'
+          image: 'weaveworks/weave-kube:2.5.1'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -197,7 +197,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.5.0'
+          image: 'weaveworks/weave-npc:2.5.1'
           resources:
             requests:
               cpu: 50m

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -672,9 +672,9 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		versions := map[string]string{
 			"pre-k8s-1.6": "2.3.0-kops.2",
 			"k8s-1.6":     "2.3.0-kops.2",
-			"k8s-1.7":     "2.5.0-kops.1",
-			"k8s-1.8":     "2.5.0-kops.1",
-			"k8s-1.12":    "2.5.0-kops.1",
+			"k8s-1.7":     "2.5.1-kops.1",
+			"k8s-1.8":     "2.5.1-kops.1",
+			"k8s-1.12":    "2.5.1-kops.1",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -104,18 +104,18 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.0-kops.1
+    version: 2.5.1-kops.1
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.0-kops.1
+    version: 2.5.1-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.0-kops.1
+    version: 2.5.1-kops.1


### PR DESCRIPTION
This release fixes #6369 syslog flooding as reported at
weaveworks/weave#3449.

Release notes
https://github.com/weaveworks/weave/releases/tag/v2.5.1

Signed-off-by: JuanJo Ciarlante <juanjosec@gmail.com>