### PR TITLE
Docs: Drop last DrainAndValidateRollingUpdate note

### DIFF
--- a/docs/changing_configuration.md
+++ b/docs/changing_configuration.md
@@ -12,7 +12,3 @@
 
 * Apply the rolling-update `kops rolling-update cluster ${NAME} --yes`
 
-NOTE: rolling-update does not yet perform a real rolling update - it just shuts down machines in sequence with a delay;
- there will be downtime [Issue #37](https://github.com/kubernetes/kops/issues/37)
-We have implemented a new feature that does drain and validate nodes.  This feature is experimental, and you can use the new feature by setting `export KOPS_FEATURE_FLAGS="+DrainAndValidateRollingUpdate"`.
-


### PR DESCRIPTION
The flag is enabled by default now.

As [mentioned in an earlier PR](https://github.com/kubernetes/kops/pull/4282#issuecomment-438275350) by @mbaeuerle.
