### PR TITLE
remove using deviceowner when filtering existing routerinterfaces

### DIFF
--- a/upup/pkg/fi/cloudup/openstacktasks/routerinterface.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/routerinterface.go
@@ -58,9 +58,9 @@ func (i *RouterInterface) CompareWithID() *string {
 func (i *RouterInterface) Find(context *fi.Context) (*RouterInterface, error) {
 	cloud := context.Cloud.(openstack.OpenstackCloud)
 	opt := ports.ListOpts{
-		NetworkID:   fi.StringValue(i.Subnet.Network.ID),
-		DeviceID:    fi.StringValue(i.Router.ID),
-		ID:          fi.StringValue(i.ID),
+		NetworkID: fi.StringValue(i.Subnet.Network.ID),
+		DeviceID:  fi.StringValue(i.Router.ID),
+		ID:        fi.StringValue(i.ID),
 	}
 	ps, err := cloud.ListPorts(opt)
 	if err != nil {

--- a/upup/pkg/fi/cloudup/openstacktasks/routerinterface.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/routerinterface.go
@@ -59,7 +59,6 @@ func (i *RouterInterface) Find(context *fi.Context) (*RouterInterface, error) {
 	cloud := context.Cloud.(openstack.OpenstackCloud)
 	opt := ports.ListOpts{
 		NetworkID:   fi.StringValue(i.Subnet.Network.ID),
-		DeviceOwner: "network:router_interface",
 		DeviceID:    fi.StringValue(i.Router.ID),
 		ID:          fi.StringValue(i.ID),
 	}


### PR DESCRIPTION
the deviceowner name seems to be different depending on which openstack people are using. That is why I will suggest removing that as filter parameter.

in our case the deviceowner name in openstack is `ha_router_replicated_interface` which means that kops will never found routerinterface and tries recreate it again (and fails)

/sig openstack