### PR TITLE
ignore openstack managed volume tags

### DIFF
--- a/upup/pkg/fi/cloudup/openstacktasks/volume.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/volume.go
@@ -68,6 +68,14 @@ func (c *Volume) Find(context *fi.Context) (*Volume, error) {
 		Tags:             v.Metadata,
 		Lifecycle:        c.Lifecycle,
 	}
+	// remove tags "readonly" and "attached_mode", openstack are adding these and if not removed
+	// kops will always try to update volumes
+	if _, ok := actual.Tags["readonly"]; ok {
+		delete(actual.Tags, "readonly");
+	}
+	if _, ok := actual.Tags["attached_mode"]; ok {
+		delete(actual.Tags, "attached_mode");
+	}
 	c.ID = actual.ID
 	c.AvailabilityZone = actual.AvailabilityZone
 	return actual, nil

--- a/upup/pkg/fi/cloudup/openstacktasks/volume.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/volume.go
@@ -71,10 +71,10 @@ func (c *Volume) Find(context *fi.Context) (*Volume, error) {
 	// remove tags "readonly" and "attached_mode", openstack are adding these and if not removed
 	// kops will always try to update volumes
 	if _, ok := actual.Tags["readonly"]; ok {
-		delete(actual.Tags, "readonly");
+		delete(actual.Tags, "readonly")
 	}
 	if _, ok := actual.Tags["attached_mode"]; ok {
-		delete(actual.Tags, "attached_mode");
+		delete(actual.Tags, "attached_mode")
 	}
 	c.ID = actual.ID
 	c.AvailabilityZone = actual.AvailabilityZone


### PR DESCRIPTION
openstack is managing readonly and attached_mode tags in volumes. Without ignoring these labels, the kops will always try to update volume tags. After this PR those are ignored and kops will not try to update volumes if those two tags are changed.

/sig openstack