### PR TITLE
find sshkey resource when updating cluster

### DIFF
--- a/pkg/resources/openstack/compute.go
+++ b/pkg/resources/openstack/compute.go
@@ -99,7 +99,7 @@ func listServerGroups(cloud openstack.OpenstackCloud, clusterName string) ([]*re
 func listKeypairs(cloud openstack.OpenstackCloud, clusterName string) ([]*resources.Resource, error) {
 	var resourceTrackers []*resources.Resource
 
-	kp, err := cloud.ListKeypair(clusterName)
+	kp, err := cloud.GetKeypair(clusterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get keypair: %s", err)
 	}

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -150,8 +150,8 @@ type OpenstackCloud interface {
 	//CreateSubnet will create a new Neutron subnet
 	CreateSubnet(opt subnets.CreateOptsBuilder) (*subnets.Subnet, error)
 
-	// ListKeypair will return the Nova keypairs
-	ListKeypair(name string) (*keypairs.KeyPair, error)
+	// GetKeypair will return the Nova keypair
+	GetKeypair(name string) (*keypairs.KeyPair, error)
 
 	// CreateKeypair will create a new Nova Keypair
 	CreateKeypair(opt keypairs.CreateOptsBuilder) (*keypairs.KeyPair, error)

--- a/upup/pkg/fi/cloudup/openstack/keypair.go
+++ b/upup/pkg/fi/cloudup/openstack/keypair.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/kops/util/pkg/vfs"
 )
 
-func (c *openstackCloud) ListKeypair(name string) (*keypairs.KeyPair, error) {
+func (c *openstackCloud) GetKeypair(name string) (*keypairs.KeyPair, error) {
 	var k *keypairs.KeyPair
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
 		rs, err := keypairs.Get(c.novaClient, name).Extract()

--- a/upup/pkg/fi/cloudup/openstacktasks/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/openstacktasks/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
     importpath = "k8s.io/kops/upup/pkg/fi/cloudup/openstacktasks",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/pki:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/openstack:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/upup/pkg/fi/cloudup/openstacktasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/sshkey.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 
+	"k8s.io/kops/pkg/pki"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 )
@@ -45,7 +46,7 @@ func (e *SSHKey) CompareWithID() *string {
 
 func (e *SSHKey) Find(c *fi.Context) (*SSHKey, error) {
 	cloud := c.Cloud.(openstack.OpenstackCloud)
-	rs, err := cloud.ListKeypair(openstackKeyPairName(fi.StringValue(e.Name)))
+	rs, err := cloud.GetKeypair(openstackKeyPairName(fi.StringValue(e.Name)))
 	if err != nil {
 		return nil, err
 	}
@@ -69,6 +70,19 @@ func (e *SSHKey) Find(c *fi.Context) (*SSHKey, error) {
 }
 
 func (e *SSHKey) Run(c *fi.Context) error {
+	if e.KeyFingerprint == nil && e.PublicKey != nil {
+		publicKey, err := e.PublicKey.AsString()
+		if err != nil {
+			return fmt.Errorf("error reading SSH public key: %v", err)
+		}
+
+		keyFingerprint, err := pki.ComputeOpenSSHKeyFingerprint(publicKey)
+		if err != nil {
+			return fmt.Errorf("error computing key fingerprint for SSH key: %v", err)
+		}
+		glog.V(2).Infof("Computed SSH key fingerprint as %q", keyFingerprint)
+		e.KeyFingerprint = &keyFingerprint
+	}
 	return fi.DefaultDeltaRunMethod(e, c)
 }
 


### PR DESCRIPTION
this pr is needed that kops will find existing keypair when updating cluster. Without this it does not find it and tries always to recreate sshkey

/sig openstack