### PR TITLE
fix openstack lb pool member logic

### DIFF
--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -194,6 +194,8 @@ type OpenstackCloud interface {
 
 	CreatePool(opts v2pools.CreateOpts) (*v2pools.Pool, error)
 
+	GetPool(poolID string, memberID string) (*v2pools.Member, error)
+
 	ListPools(v2pools.ListOpts) ([]v2pools.Pool, error)
 
 	ListListeners(opts listeners.ListOpts) ([]listeners.Listener, error)


### PR DESCRIPTION
without this PR the kops will always show in `kops update` that there is need for add new loadbalancer members. After this PR it will not do that if not really needed

/sig openstack