### PR TITLE
Add permission for CreateTag on ENI to amazon-vpc-cni-k8s

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -363,6 +363,11 @@ $ kops create cluster \
     "Resource": [
       "*"
     ]
+  },
+  {
+    "Effect": "Allow",
+    "Action": "ec2:CreateTags",
+    "Resource": "arn:aws:ec2:*:*:network-interface/*"
   }
 ```
 

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -877,6 +877,13 @@ func addAmazonVPCCNIPermissions(p *Policy, resource stringorslice.StringOrSlice,
 			}),
 			Resource: resource,
 		},
+		&Statement{
+			Effect: StatementEffectAllow,
+			Action: stringorslice.Slice([]string{
+				"ec2:CreateTags",
+			}),
+			Resource: stringorslice.Slice([]string{"arn:aws:ec2:*:*:network-interface/*"}),
+		},
 	)
 }
 


### PR DESCRIPTION
Although amazon-vpc-cni-k8s adds tag to ENI, kops does not add the
permission. Hence it does not work by default.

This patch adds the permission for CreateTag on ENI to
amazon-vpc-cni-k8s's nodes policy.

Currently cluster gets following error by default. (And this error could be solved by adding permission.)
```
2019-01-24T07:39:08Z [WARN] Failed to tag the newly created eni eni-08dda1a05fb50d64b:  UnauthorizedOperation: You are not authorized to perform this operation. .. snip ..
```