### PR TITLE
Update 1.12 addon manifests to use apps/v1, rbac v1

### DIFF
--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  namespace: kube-system
+  name: aws-iam-authenticator
+  labels:
+    k8s-app: aws-iam-authenticator
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        k8s-app: aws-iam-authenticator
+    spec:
+      # run on the host network (don't depend on CNI)
+      hostNetwork: true
+
+      # run on each master node
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - key: CriticalAddonsOnly
+        operator: Exists
+
+      # run `aws-iam-authenticator server` with three volumes
+      # - config (mounted from the ConfigMap at /etc/aws-iam-authenticator/config.yaml)
+      # - state (persisted TLS certificate and keys, mounted from the host)
+      # - output (output kubeconfig to plug into your apiserver configuration, mounted from the host)
+      containers:
+      - name: aws-iam-authenticator
+        image: gcr.io/heptio-images/authenticator:v0.3.0
+        args:
+        - server
+        - --config=/etc/aws-iam-authenticator/config.yaml
+        - --state-dir=/var/aws-iam-authenticator
+        - --kubeconfig-pregenerated=true
+
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 10m
+          limits:
+            memory: 20Mi
+            cpu: 100m
+
+        volumeMounts:
+        - name: config
+          mountPath: /etc/aws-iam-authenticator/
+        - name: state
+          mountPath: /var/aws-iam-authenticator/
+        - name: output
+          mountPath: /etc/kubernetes/aws-iam-authenticator/
+
+      volumes:
+      - name: config
+        configMap:
+          name: aws-iam-authenticator
+      - name: output
+        hostPath:
+          path: /srv/kubernetes/aws-iam-authenticator/
+      - name: state
+        hostPath:
+          path: /srv/kubernetes/aws-iam-authenticator/

--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   namespace: kube-system
@@ -9,6 +9,9 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      k8s-app: aws-iam-authenticator
   template:
     metadata:
       annotations:

--- a/upup/models/cloudup/resources/addons/authentication.kope.io/k8s-1.12.yaml
+++ b/upup/models/cloudup/resources/addons/authentication.kope.io/k8s-1.12.yaml
@@ -1,0 +1,185 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kopeio-auth
+  labels:
+    k8s-addon: authentication.kope.io
+    role.kubernetes.io/authentication: "1"
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-api
+  namespace: kopeio-auth
+  labels:
+    k8s-addon: authentication.kope.io
+    role.kubernetes.io/authentication: "1"
+spec:
+  selector:
+    app: auth-api
+  ports:
+  - port: 443
+    targetPort: 9002
+
+---
+
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: auth-api
+  namespace: kopeio-auth
+  labels:
+    k8s-addon: authentication.kope.io
+    role.kubernetes.io/authentication: "1"
+spec:
+  template:
+    metadata:
+      labels:
+        app: auth-api
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      serviceAccountName: auth-api
+      hostNetwork: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      containers:
+      - name: auth-api
+        image: kopeio/auth-api:1.0.20171125
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9001
+        command:
+        - /auth-api
+        - --listen=127.0.0.1:9001
+        - --secure-port=9002
+        - --etcd-servers=http://127.0.0.1:4001
+        - --v=8
+        - --storage-backend=etcd2
+
+---
+
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1alpha1.auth.kope.io
+  labels:
+    k8s-addon: authentication.kope.io
+    role.kubernetes.io/authentication: "1"
+spec:
+  insecureSkipTLSVerify: true
+  group: auth.kope.io
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: auth-api
+    namespace: kopeio-auth
+  version: v1alpha1
+
+---
+
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1alpha1.config.auth.kope.io
+  labels:
+    k8s-addon: authentication.kope.io
+    role.kubernetes.io/authentication: "1"
+spec:
+  insecureSkipTLSVerify: true
+  group: config.auth.kope.io
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: auth-api
+    namespace: kopeio-auth
+  version: v1alpha1
+
+---
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: auth-api
+  namespace: kopeio-auth
+  labels:
+    k8s-addon: authentication.kope.io
+    role.kubernetes.io/authentication: "1"
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kopeio-auth:auth-api:auth-reader
+  namespace: kube-system
+  labels:
+    k8s-addon: authentication.kope.io
+    role.kubernetes.io/authentication: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: auth-api
+  namespace: kopeio-auth
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kopeio-auth:system:auth-delegator
+  labels:
+    k8s-addon: authentication.kope.io
+    role.kubernetes.io/authentication: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: auth-api
+  namespace: kopeio-auth
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: auth-api
+  namespace: kopeio-auth
+  labels:
+    k8s-addon: authentication.kope.io
+    role.kubernetes.io/authentication: "1"
+rules:
+- apiGroups: ["auth.kope.io"]
+  resources: ["users"]
+  verbs: ["get", "list", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: auth-api
+  namespace: kopeio-auth
+  labels:
+    k8s-addon: authentication.kope.io
+    role.kubernetes.io/authentication: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: auth-api
+subjects:
+- kind: ServiceAccount
+  name: auth-api
+  namespace: kopeio-auth

--- a/upup/models/cloudup/resources/addons/authentication.kope.io/k8s-1.12.yaml
+++ b/upup/models/cloudup/resources/addons/authentication.kope.io/k8s-1.12.yaml
@@ -25,7 +25,7 @@ spec:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: auth-api
@@ -34,6 +34,9 @@ metadata:
     k8s-addon: authentication.kope.io
     role.kubernetes.io/authentication: "1"
 spec:
+  selector:
+    matchLabels:
+      app: auth-api
   template:
     metadata:
       labels:
@@ -66,7 +69,7 @@ spec:
 
 ---
 
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1alpha1.auth.kope.io
@@ -85,7 +88,7 @@ spec:
 
 ---
 
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1alpha1.config.auth.kope.io

--- a/upup/models/cloudup/resources/addons/core.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/core.addons.k8s.io/k8s-1.12.yaml.template
@@ -1,0 +1,153 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:cloud-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+
+---
+
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: cloud-controller-manager
+  name: cloud-controller-manager
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cloud-controller-manager
+  template:
+    metadata:
+      labels:
+        k8s-app: cloud-controller-manager
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      serviceAccountName: cloud-controller-manager
+      containers:
+      - name: cloud-controller-manager
+        # for in-tree providers we use k8s.gcr.io/cloud-controller-manager
+        # this can be replaced with any other image for out-of-tree providers
+        image: k8s.gcr.io/cloud-controller-manager:v{{ .KubernetesVersion }}  # Reviewers: Will this work?
+        command:
+        - /usr/local/bin/cloud-controller-manager
+        - --cloud-provider={{ .CloudProvider }}
+        - --leader-elect=true
+        - --use-service-account-credentials
+        # these flags will vary for every cloud provider
+        - --allocate-node-cidrs=true
+        - --configure-cloud-routes=true
+        - --cluster-cidr={{ .KubeControllerManager.ClusterCIDR }}
+        volumeMounts:
+        - name: ca-certificates
+          mountPath: /etc/ssl/certs
+      hostNetwork: true
+      dnsPolicy: Default
+      volumes:
+      - name: ca-certificates
+        hostPath:
+          path: /etc/ssl/certs
+      tolerations:
+      # this is required so CCM can bootstrap itself
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      # this is to have the daemonset runnable on master nodes
+      # the taint may vary depending on your cluster setup
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      # this is to restrict CCM to only run on master nodes
+      # the node selector may vary depending on your cluster setup
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+

--- a/upup/models/cloudup/resources/addons/core.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/core.addons.k8s.io/k8s-1.12.yaml.template
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
@@ -81,7 +81,7 @@ metadata:
 ---
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: system:cloud-controller-manager
 roleRef:
@@ -95,7 +95,7 @@ subjects:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -1,0 +1,190 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+      kubernetes.io/cluster-service: "true"
+      k8s-addon: coredns.addons.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    k8s-addon: coredns.addons.k8s.io
+  name: system:coredns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    k8s-addon: coredns.addons.k8s.io
+  name: system:coredns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:coredns
+subjects:
+- kind: ServiceAccount
+  name: coredns
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+      addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health
+        kubernetes {{ KubeDNS.Domain }}. in-addr.arpa ip6.arpa {
+          pods insecure
+          upstream
+          fallthrough in-addr.arpa ip6.arpa
+        }
+        prometheus :9153
+        forward . /etc/resolv.conf
+        loop
+        cache 30
+        loadbalance
+        reload
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    k8s-addon: coredns.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+    spec:
+      priorityClassName: system-cluster-critical
+      serviceAccountName: coredns
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+      nodeSelector:
+          beta.kubernetes.io/os: linux
+      containers:
+      - name: coredns
+        image: k8s.gcr.io/coredns:1.3.1
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        args: [ "-conf", "/etc/coredns/Corefile" ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+          readOnly: true
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9153
+          name: metrics
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+      dnsPolicy: Default
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns
+            items:
+            - key: Corefile
+              path: Corefile
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  annotations:
+    prometheus.io/port: "9153"
+    prometheus.io/scrape: "true"
+  labels:
+    k8s-addon: coredns.addons.k8s.io
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+spec:
+  selector:
+    k8s-app: kube-dns
+  clusterIP: {{ KubeDNS.ServerIP }}
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+  - name: metrics
+    port: 9153
+    protocol: TCP

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -1,0 +1,116 @@
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: dns-controller
+  namespace: kube-system
+  labels:
+    k8s-addon: dns-controller.addons.k8s.io
+    k8s-app: dns-controller
+    version: v1.12.0-alpha.1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: dns-controller
+  template:
+    metadata:
+      labels:
+        k8s-addon: dns-controller.addons.k8s.io
+        k8s-app: dns-controller
+        version: v1.12.0-alpha.1
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        # For 1.6, we keep the old tolerations in case of a downgrade to 1.5
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key": "dedicated", "value": "master"}]'
+    spec:
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        effect: NoSchedule
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      dnsPolicy: Default  # Don't use cluster DNS (we are likely running before kube-dns)
+      hostNetwork: true
+      serviceAccount: dns-controller
+      containers:
+      - name: dns-controller
+        image: kope/dns-controller:1.12.0-alpha.1
+        command:
+{{ range $arg := DnsControllerArgv }}
+        - "{{ $arg }}"
+{{ end }}
+{{- if .EgressProxy }}
+        env:
+{{ range $name, $value := ProxyEnv }}
+        - name: {{ $name }}
+          value: {{ $value }}
+{{ end }}
+{{- end }}
+{{- if eq .CloudProvider "digitalocean" }}
+        env:
+        - name: DIGITALOCEAN_ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: digitalocean
+              key: access-token
+{{- end }}
+        resources:
+          requests:
+            cpu: 50m
+            memory: 50Mi
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dns-controller
+  namespace: kube-system
+  labels:
+    k8s-addon: dns-controller.addons.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-addon: dns-controller.addons.k8s.io
+  name: kops:dns-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - ingress
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "extensions"
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-addon: dns-controller.addons.k8s.io
+  name: kops:dns-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kops:dns-controller
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:serviceaccount:kube-system:dns-controller

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: dns-controller
   namespace: kube-system
@@ -20,8 +20,6 @@ spec:
         version: v1.12.0-alpha.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        # For 1.6, we keep the old tolerations in case of a downgrade to 1.5
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key": "dedicated", "value": "master"}]'
     spec:
       tolerations:
       - key: "node-role.kubernetes.io/master"
@@ -70,7 +68,7 @@ metadata:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -100,7 +98,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.12.yaml.template
@@ -1,0 +1,92 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: external-dns
+  namespace: kube-system
+  labels:
+    k8s-addon: external-dns.addons.k8s.io
+    k8s-app: external-dns
+    version: v0.4.4
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: external-dns
+  template:
+    metadata:
+      labels:
+        k8s-addon: external-dns.addons.k8s.io
+        k8s-app: external-dns
+        version: v0.4.4
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        # For 1.6, we keep the old tolerations in case of a downgrade to 1.5
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key": "dedicated", "value": "master"}]'
+    spec:
+      serviceAccount: external-dns
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        effect: NoSchedule
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      dnsPolicy: Default  # Don't use cluster DNS (we are likely running before kube-dns)
+      hostNetwork: true
+      containers:
+      - name: external-dns
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.4
+        args:
+{{ range $arg := ExternalDnsArgv }}
+        - "{{ $arg }}"
+{{ end }}
+        resources:
+          requests:
+            cpu: 50m
+            memory: 50Mi
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  namespace: kube-system
+  labels:
+    k8s-addon: external-dns.addons.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-addon: external-dns.addons.k8s.io
+  name: kops:external-dns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - list
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-addon: external-dns.addons.k8s.io
+  name: kops:external-dns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kops:external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: kube-system

--- a/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.12.yaml.template
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: external-dns
@@ -20,8 +20,6 @@ spec:
         version: v0.4.4
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        # For 1.6, we keep the old tolerations in case of a downgrade to 1.5
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key": "dedicated", "value": "master"}]'
     spec:
       serviceAccount: external-dns
       tolerations:
@@ -54,7 +52,7 @@ metadata:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -76,7 +74,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
@@ -1,0 +1,311 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if or (.KubeDNS.UpstreamNameservers) (.KubeDNS.StubDomains) }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-dns
+  namespace: kube-system
+data:
+  {{- if .KubeDNS.UpstreamNameservers }}
+  upstreamNameservers: |
+    {{ ToJSON .KubeDNS.UpstreamNameservers }}
+  {{- end }}
+  {{- if .KubeDNS.StubDomains }}
+  stubDomains: |
+    {{ ToJSON .KubeDNS.StubDomains }}
+  {{- end }}
+{{- end }}
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-dns-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: kube-dns.addons.k8s.io
+    k8s-app: kube-dns-autoscaler
+    kubernetes.io/cluster-service: "true"
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns-autoscaler
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        # For 1.6, we keep the old tolerations in case of a downgrade to 1.5
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+    spec:
+      containers:
+      - name: autoscaler
+        image: k8s.gcr.io/cluster-proportional-autoscaler-{{Arch}}:1.1.2-r2
+        resources:
+            requests:
+                cpu: "20m"
+                memory: "10Mi"
+        command:
+          - /cluster-proportional-autoscaler
+          - --namespace=kube-system
+          - --configmap=kube-dns-autoscaler
+          # Should keep target in sync with cluster/addons/dns/kubedns-controller.yaml.base
+          - --target=Deployment/kube-dns
+          # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
+          # If using small nodes, "nodesPerReplica" should dominate.
+          - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
+          - --logtostderr=true
+          - --v=2
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      serviceAccountName: kube-dns-autoscaler
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-addon: kube-dns.addons.k8s.io
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+spec:
+  # replicas: not specified here:
+  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
+  # 2. Default is 1.
+  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+  strategy:
+    rollingUpdate:
+      maxSurge: 10%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        # For 1.6, we keep the old tolerations in case of a downgrade to 1.5
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '10055'
+    spec:
+      dnsPolicy: Default  # Don't use cluster DNS.
+      serviceAccountName: kube-dns
+      volumes:
+      - name: kube-dns-config
+        configMap:
+          name: kube-dns
+          optional: true
+
+      containers:
+      - name: kubedns
+        image: k8s.gcr.io/k8s-dns-kube-dns-{{Arch}}:1.14.10
+        resources:
+          # TODO: Set memory limits when we've profiled the container for large
+          # clusters, then set request = limit to keep this container in
+          # guaranteed class. Currently, this container falls into the
+          # "burstable" category so the kubelet doesn't backoff from restarting it.
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        livenessProbe:
+          httpGet:
+            path: /healthcheck/kubedns
+            port: 10054
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 8081
+            scheme: HTTP
+          # we poll on pod startup for the Kubernetes master service and
+          # only setup the /readiness HTTP server once that's available.
+          initialDelaySeconds: 3
+          timeoutSeconds: 5
+        args:
+        - --config-dir=/kube-dns-config
+        - --dns-port=10053
+        - --domain={{ KubeDNS.Domain }}.
+        - --v=2
+        env:
+        - name: PROMETHEUS_PORT
+          value: "10055"
+        ports:
+        - containerPort: 10053
+          name: dns-local
+          protocol: UDP
+        - containerPort: 10053
+          name: dns-tcp-local
+          protocol: TCP
+        - containerPort: 10055
+          name: metrics
+          protocol: TCP
+        volumeMounts:
+        - name: kube-dns-config
+          mountPath: /kube-dns-config
+
+      - name: dnsmasq
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-{{Arch}}:1.14.10
+        livenessProbe:
+          httpGet:
+            path: /healthcheck/dnsmasq
+            port: 10054
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        args:
+        - -v=2
+        - -logtostderr
+        - -configDir=/etc/k8s/dns/dnsmasq-nanny
+        - -restartDnsmasq=true
+        - --
+        - -k
+        - --cache-size={{ KubeDNS.CacheMaxSize }}
+        - --dns-forward-max={{ KubeDNS.CacheMaxConcurrent }}
+        - --no-negcache
+        - --log-facility=-
+        - --server=/{{ KubeDNS.Domain }}/127.0.0.1#10053
+        - --server=/in-addr.arpa/127.0.0.1#10053
+        - --server=/in6.arpa/127.0.0.1#10053
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
+        resources:
+          requests:
+            cpu: 150m
+            memory: 20Mi
+        volumeMounts:
+        - name: kube-dns-config
+          mountPath: /etc/k8s/dns/dnsmasq-nanny
+
+      - name: sidecar
+        image: k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 10054
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        args:
+        - --v=2
+        - --logtostderr
+        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.{{ KubeDNS.Domain }},5,A
+        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.{{ KubeDNS.Domain }},5,A
+        ports:
+        - containerPort: 10054
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 10m
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-addon: kube-dns.addons.k8s.io
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "KubeDNS"
+spec:
+  selector:
+    k8s-app: kube-dns
+  clusterIP: {{ KubeDNS.ServerIP }}
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-dns-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: kube-dns.addons.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-addon: kube-dns.addons.k8s.io
+  name: kube-dns-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
+  - apiGroups: [""]
+    resources: ["replicationcontrollers/scale"]
+    verbs: ["get", "update"]
+  - apiGroups: ["extensions"]
+    resources: ["deployments/scale", "replicasets/scale"]
+    verbs: ["get", "update"]
+# Remove the configmaps rule once below issue is fixed:
+# kubernetes-incubator/cluster-proportional-autoscaler#16
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-addon: kube-dns.addons.k8s.io
+  name: kube-dns-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-dns-autoscaler
+subjects:
+- kind: ServiceAccount
+  name: kube-dns-autoscaler
+  namespace: kube-system

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
@@ -32,7 +32,7 @@ data:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-dns-autoscaler
@@ -42,18 +42,19 @@ metadata:
     k8s-app: kube-dns-autoscaler
     kubernetes.io/cluster-service: "true"
 spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-dns-autoscaler
   template:
     metadata:
       labels:
         k8s-app: kube-dns-autoscaler
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        # For 1.6, we keep the old tolerations in case of a downgrade to 1.5
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-{{Arch}}:1.1.2-r2
+        image: k8s.gcr.io/cluster-proportional-autoscaler-{{Arch}}:1.3.0
         resources:
             requests:
                 cpu: "20m"
@@ -76,7 +77,7 @@ spec:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-dns
@@ -103,8 +104,6 @@ spec:
         k8s-app: kube-dns
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        # For 1.6, we keep the old tolerations in case of a downgrade to 1.5
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
         prometheus.io/scrape: 'true'
         prometheus.io/port: '10055'
     spec:
@@ -271,7 +270,7 @@ metadata:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -295,7 +294,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
@@ -54,7 +54,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-{{Arch}}:1.3.0
+        image: k8s.gcr.io/cluster-proportional-autoscaler-{{Arch}}:1.4.0
         resources:
             requests:
                 cpu: "20m"
@@ -283,7 +283,7 @@ rules:
   - apiGroups: [""]
     resources: ["replicationcontrollers/scale"]
     verbs: ["get", "update"]
-  - apiGroups: ["extensions"]
+  - apiGroups: ["extensions", "apps"]
     resources: ["deployments/scale", "replicasets/scale"]
     verbs: ["get", "update"]
 # Remove the configmaps rule once below issue is fixed:

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.12.yaml.template
@@ -1,0 +1,126 @@
+# Vendored from https://github.com/aws/amazon-vpc-cni-k8s/blob/v1.3.0/config/v1.3/aws-k8s-cni.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aws-node
+rules:
+- apiGroups:
+  - crd.k8s.amazonaws.com
+  resources:
+  - "*"
+  - namespaces
+  verbs:
+  - "*"
+- apiGroups: [""]
+  resources:
+  - pods
+  - nodes
+  - namespaces
+  verbs: ["list", "watch", "get"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  verbs: ["list", "watch"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-node
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aws-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+- kind: ServiceAccount
+  name: aws-node
+  namespace: kube-system
+---
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: aws-node
+  namespace: kube-system
+  labels:
+    k8s-app: aws-node
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      k8s-app: aws-node
+  template:
+    metadata:
+      labels:
+        k8s-app: aws-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      serviceAccountName: aws-node
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+      containers:
+      - image: "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.3.0" }}"
+        ports:
+        - containerPort: 61678
+          name: metrics
+        name: aws-node
+        env:
+          - name: AWS_VPC_K8S_CNI_LOGLEVEL
+            value: DEBUG
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: WATCH_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        resources:
+          requests:
+            cpu: 10m
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /host/etc/cni/net.d
+          name: cni-net-dir
+        - mountPath: /host/var/log
+          name: log-dir
+        - mountPath: /var/run/docker.sock
+          name: dockersock
+      volumes:
+      - name: cni-bin-dir
+        hostPath:
+          path: /opt/cni/bin
+      - name: cni-net-dir
+        hostPath:
+          path: /etc/cni/net.d
+      - name: log-dir
+        hostPath:
+          path: /var/log
+      - name: dockersock
+        hostPath:
+          path: /var/run/docker.sock
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: eniconfigs.crd.k8s.amazonaws.com
+spec:
+  scope: Cluster
+  group: crd.k8s.amazonaws.com
+  version: v1alpha1
+  names:
+    scope: Cluster
+    plural: eniconfigs
+    singular: eniconfig
+    kind: ENIConfig

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.12.yaml.template
@@ -43,7 +43,7 @@ subjects:
   namespace: kube-system
 ---
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: aws-node
   namespace: kube-system

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -1,0 +1,465 @@
+{{- $etcd_scheme := EtcdScheme }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  etcd-config: |-
+    ---
+    endpoints: [{{ $cluster := index .EtcdClusters 0 -}}
+                      {{- range $j, $member := $cluster.Members -}}
+                          {{- if $j }},{{ end -}}
+                          "{{ $etcd_scheme }}://etcd-{{ $member.Name }}.internal.{{ ClusterName }}:4001"
+                      {{- end }}]
+    {{- if eq $etcd_scheme "https" }}
+    ca-file: '/var/lib/etcd-secrets/ca.pem'
+    key-file: '/var/lib/etcd-secrets/calico-client-key.pem'
+    cert-file: '/var/lib/etcd-secrets/calico-client.pem'
+    {{- end }}
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+  sidecar-http-proxy: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: >-
+          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+    spec:
+      serviceAccountName: cilium
+{{ with .Networking.Cilium }}
+      containers:
+      - image: "cilium/cilium:{{ .Version }}"
+        imagePullPolicy: Always
+        name: cilium-agent
+        command: [ "cilium-agent" ]
+        args:
+{{ if .Debug }}
+          - "--debug=true"
+{{ end }}
+{{ if .DebugVerbose}}
+  {{ range $j, $group:= .DebugVerbose}}
+          - "--debug-verbose"
+          - "{{ $group}}"
+  {{ end }}
+{{ end }}
+{{ if ne .AccessLog "" }}
+          - "--access-log"
+          - "{{ .AccessLog}}"
+{{ end }}
+{{ if .AgentLabels }}
+  {{ range $j, $label := .AgentLabels }}
+          - "--agent-labels"
+          - "{{ $label }}"
+  {{ end }}
+{{ end }}
+{{ if ne .AllowLocalhost "" }}
+          - "--allow-localhost"
+          - "{{ .AllowLocalhost}}"
+{{ end }}
+{{ if .AutoIpv6NodeRoutes }}
+          - "--auto-ipv6-node-routes"
+{{ end }}
+{{ if ne .BPFRoot "" }}
+          - "--bpf-root"
+          - "{{ .BPFRoot }}"
+{{ end }}
+{{ if .ContainerRuntime }}
+  {{ range $j, $runtime:= .ContainerRuntime }}
+          - "--container-runtime"
+          - "{{ $runtime}}"
+  {{ end }}
+{{ end }}
+{{ if .ContainerRuntimeEndpoint }}
+  {{ range $runtime, $endpoint:= .ContainerRuntimeEndpoint }}
+          - "--container-runtime-endpoint={{ $runtime }}={{ $endpoint }}"
+  {{ end }}
+{{ end }}
+{{ if ne .Device "" }}
+          - "--device"
+          - "{{ .Device }}"
+{{ end }}
+{{ if .DisableConntrack }}
+          - "--disable-conntrack"
+{{ end }}
+{{ if .DisableIpv4 }}
+          - "--disable-ipv4"
+{{ end }}
+{{ if .DisableK8sServices }}
+          - "--disable-k8s-services"
+{{ end }}
+{{ if ne .EnablePolicy "" }}
+          - "--enable-policy"
+          - "{{ .EnablePolicy }}"
+{{ end }}
+{{ if .EnableTracing }}
+          - "--enable-tracing"
+{{ end }}
+{{ if ne .EnvoyLog "" }}
+          - "--envoy-log"
+          - "{{ .EnvoyLog }}"
+{{ end }}
+{{ if ne .Ipv4ClusterCIDRMaskSize 0 }}
+          - "--ipv4-cluster-cidr-mask-size"
+          - "{{ .Ipv4ClusterCIDRMaskSize }}"
+{{ end }}
+{{ if ne .Ipv4Node "" }}
+          - "--ipv4-node"
+          - "{{ .Ipv4Node }}"
+{{ end }}
+{{ if ne .Ipv4Range "" }}
+          - "--ipv4-range"
+          - "{{ .Ipv4Range }}"
+{{ end }}
+{{ if ne .Ipv4ServiceRange "" }}
+          - "--ipv4-service-range"
+          - "{{ .Ipv4ServiceRange }}"
+{{ end }}
+{{ if ne .Ipv6ClusterAllocCidr "" }}
+          - "--ipv6-cluster-alloc-cidr"
+          - "{{ .Ipv6ClusterAllocCidr }}"
+{{ end }}
+{{ if ne .Ipv6Node "" }}
+          - "--ipv6-node"
+          - "{{ .Ipv6Node }}"
+{{ end }}
+{{ if ne .Ipv6Range "" }}
+          - "--ipv6-range"
+          - "{{ .Ipv6Range }}"
+{{ end }}
+{{ if ne .Ipv6ServiceRange "" }}
+          - "--ipv6-service-range"
+          - "{{ .Ipv6ServiceRange }}"
+{{ end }}
+{{ if ne .K8sAPIServer "" }}
+          - "--k8s-api-server"
+          - "{{ .K8sAPIServer }}"
+{{ end }}
+{{ if ne .K8sKubeconfigPath "" }}
+          - "--k8s-kubeconfig-path"
+          - "{{ .K8sKubeconfigPath }}"
+{{ end }}
+{{ if .KeepBPFTemplates }}
+          - "--keep-bpf-templates"
+{{ end }}
+{{ if .KeepConfig }}
+          - "--keep-config"
+{{ end }}
+{{ if ne .LabelPrefixFile "" }}
+          - "--label-prefix-file"
+          - "{{ .LabelPrefixFile }}"
+{{ end }}
+{{ if .Labels }}
+  {{ range $j, $label := .Labels }}
+          - "--labels"
+          - "{{ $label }}"
+  {{ end }}
+{{ end }}
+{{ if ne .LB "" }}
+          - "--lb"
+          - "{{ .LB }}"
+{{ end }}
+{{ if ne .LibDir "" }}
+          - "--lib-dir"
+          - "{{ .LibDir }}"
+{{ end }}
+{{ if .LogDrivers }}
+  {{ range $j, $driver := .LogDrivers }}
+          - "--log-driver"
+          - "{{ $driver}}"
+  {{ end }}
+{{ end }}
+{{ if .LogOpt }}
+  {{ range $option, $value := .LogOpt }}
+          - "--log-opt={{ $option }}={{ $value }}"
+  {{ end }}
+{{ end }}
+{{ if .Logstash }}
+          - "--logstash"
+{{ end }}
+{{ if ne .LogstashAgent "" }}
+          - "--logstash-agent"
+          - "{{ .LogstashAgent }}"
+{{ end }}
+{{ if ne .LogstashProbeTimer 0 }}
+          - "--logstash-probe-timer"
+          - "{{ .LogstashProbeTimer }}"
+{{ end }}
+{{ if eq .DisableMasquerade true }}
+          - "--masquerade"
+          - "false"
+{{ end }}
+{{ if ne .Nat46Range "" }}
+          - "--nat46-range"
+          - "{{ .Nat46Range }}"
+{{ end }}
+{{ if .Pprof}}
+          - "--pprof"
+{{ end }}
+{{ if ne .PrefilterDevice "" }}
+          - "--prefilter-device"
+          - "{{ .PrefilterDevice }}"
+{{ end }}
+{{ if ne .PrometheusServeAddr "" }}
+          - "--prometheus-serve-addr"
+          - "{{ .PrometheusServeAddr }}"
+{{ end }}
+{{ if .Restore}}
+          - "--restore"
+{{ end }}
+{{ if .SingleClusterRoute}}
+          - "--single-cluster-route"
+{{ end }}
+{{ if ne .SocketPath "" }}
+          - "--socket-path"
+          - "{{ .SocketPath }}"
+{{ end }}
+{{ if ne .StateDir "" }}
+          - "--state-dir"
+          - "{{ .StateDir }}"
+{{ end }}
+{{ if ne .TracePayloadLen 0 }}
+          - "--trace-payloadlen"
+          - "{{ .TracePayloadLen}}"
+{{ end }}
+{{ if ne .Tunnel "" }}
+          - "--tunnel"
+          - "{{ .Tunnel }}"
+{{ end }}
+# end of `with .Networking.Cilium`
+{{ end }}
+          - "--kvstore"
+          - "etcd"
+          - "--kvstore-opt"
+          - "etcd.config=/var/lib/etcd-config/etcd.config"
+        ports:
+          - name: prometheus
+            containerPort: 9090
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - "/cni-install.sh"
+          preStop:
+            exec:
+              command:
+                - "/cni-uninstall.sh"
+        env:
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+          - name: "DISABLE_IPV4"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: disable-ipv4
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+          - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-metrics-config
+                optional: true
+                key: prometheus-serve-addr
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          failureThreshold: 10
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+          - name: cni-path
+            mountPath: /host/opt/cni/bin
+          - name: etc-cni-netd
+            mountPath: /host/etc/cni/net.d
+          - name: docker-socket
+            mountPath: /var/run/docker.sock
+            readOnly: true
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+        {{- if eq $etcd_scheme "https" }}
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+        {{- end }}
+        securityContext:
+          capabilities:
+            add:
+              - "NET_ADMIN"
+          privileged: true
+      hostNetwork: true
+      volumes:
+          # To keep state between restarts / upgrades
+        - name: cilium-run
+          hostPath:
+            path: /var/run/cilium
+          # To keep state between restarts / upgrades
+        - name: bpf-maps
+          hostPath:
+            path: /sys/fs/bpf
+          # To read docker events from the node
+        - name: docker-socket
+          hostPath:
+            path: /var/run/docker.sock
+          # To install cilium cni plugin in the host
+        - name: cni-path
+          hostPath:
+            path: /opt/cni/bin
+          # To install cilium cni configuration in the host
+        - name: etc-cni-netd
+          hostPath:
+              path: /etc/cni/net.d
+          # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+            - key: etcd-config
+              path: etcd.config
+        {{- if eq $etcd_scheme "https" }}
+        - name: etcd-secrets
+          hostPath:
+            path: /srv/kubernetes/calico
+        {{- end }}
+      tolerations:
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+      # Mark cilium's pod as critical for rescheduling
+      - key: CriticalAddonsOnly
+        operator: "Exists"
+      - effect: NoExecute
+        operator: Exists
+      # Allow the pod to run on all nodes.  This is required
+      # for cluster communication
+      - effect: NoSchedule
+        operator: Exists
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumendpoints
+  verbs:
+  - "*"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -31,27 +31,16 @@ metadata:
   name: cilium
   namespace: kube-system
 ---
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: cilium
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium
-subjects:
-- kind: ServiceAccount
-  name: cilium
-  namespace: kube-system
-- kind: Group
-  name: system:nodes
----
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cilium
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium
+      kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:
@@ -401,7 +390,7 @@ spec:
         operator: Exists
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cilium
 rules:
@@ -463,3 +452,18 @@ rules:
   - ciliumendpoints
   verbs:
   - "*"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes

--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.12.yaml.template
@@ -1,0 +1,149 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+  labels:
+    role.kubernetes.io/networking: "1"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+  labels:
+    role.kubernetes.io/networking: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flannel
+subjects:
+- kind: ServiceAccount
+  name: flannel
+  namespace: kube-system
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: flannel
+  namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kube-flannel-cfg
+  namespace: kube-system
+  labels:
+    k8s-app: flannel
+    role.kubernetes.io/networking: "1"
+data:
+  cni-conf.json: |
+    {
+      "name": "cbr0",
+      "type": "flannel",
+      "delegate": {
+        "forceAddress": true,
+        "isDefaultGateway": true,
+        "hairpinMode": true
+      }
+    }
+  net-conf.json: |
+    {
+      "Network": "{{ .NonMasqueradeCIDR }}",
+      "Backend": {
+        "Type": "{{ FlannelBackendType }}"
+      }
+    }
+---
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: kube-flannel-ds
+  namespace: kube-system
+  labels:
+    k8s-app: flannel
+    role.kubernetes.io/networking: "1"
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: flannel
+        role.kubernetes.io/networking: "1"
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+      serviceAccountName: flannel
+      tolerations:
+      - operator: Exists
+      initContainers:
+      - name: install-cni
+        image: quay.io/coreos/flannel:v0.10.0-amd64
+        command:
+        - cp
+        args:
+        - -f
+        - /etc/kube-flannel/cni-conf.json
+        - /etc/cni/net.d/10-flannel.conf
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      containers:
+      - name: kube-flannel
+        image: quay.io/coreos/flannel:v0.10.0-amd64
+        command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
+        securityContext:
+          privileged: true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          limits:
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - name: run
+          mountPath: /run
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      volumes:
+        - name: run
+          hostPath:
+            path: /run
+        - name: cni
+          hostPath:
+            path: /etc/cni/net.d
+        - name: flannel-cfg
+          configMap:
+            name: kube-flannel-cfg

--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.12.yaml.template
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
   labels:
@@ -26,7 +26,7 @@ rules:
       - patch
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
   labels:
@@ -76,7 +76,7 @@ data:
     }
 ---
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: kube-flannel-ds
   namespace: kube-system
@@ -84,6 +84,11 @@ metadata:
     k8s-app: flannel
     role.kubernetes.io/networking: "1"
 spec:
+  selector:
+    matchLabels:
+      tier: node
+      app: flannel
+      role.kubernetes.io/networking: "1"
   template:
     metadata:
       labels:

--- a/upup/models/cloudup/resources/addons/networking.kope.io/k8s-1.12.yaml
+++ b/upup/models/cloudup/resources/addons/networking.kope.io/k8s-1.12.yaml
@@ -1,0 +1,104 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kopeio-networking-agent
+  namespace: kube-system
+  labels:
+    k8s-addon: networking.kope.io
+    role.kubernetes.io/networking: "1"
+spec:
+  template:
+    metadata:
+      labels:
+        name: kopeio-networking-agent
+        role.kubernetes.io/networking: "1"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+    spec:
+      hostPID: true
+      hostIPC: true
+      hostNetwork: true
+      containers:
+        - resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              memory: 100Mi
+          securityContext:
+            privileged: true
+          image: kopeio/networking-agent:1.0.20181028
+          name: networking-agent
+          volumeMounts:
+            - name: lib-modules
+              mountPath: /lib/modules
+              readOnly: true
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+      serviceAccountName: kopeio-networking-agent
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      volumes:
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kopeio-networking-agent
+  namespace: kube-system
+  labels:
+    k8s-addon: networking.kope.io
+    role.kubernetes.io/networking: "1"
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-addon: networking.kope.io
+  name: kopeio:networking-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-addon: networking.kope.io
+  name: kopeio:networking-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kopeio:networking-agent
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:serviceaccount:kube-system:kopeio-networking-agent

--- a/upup/models/cloudup/resources/addons/networking.kope.io/k8s-1.12.yaml
+++ b/upup/models/cloudup/resources/addons/networking.kope.io/k8s-1.12.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kopeio-networking-agent
@@ -7,6 +7,10 @@ metadata:
     k8s-addon: networking.kope.io
     role.kubernetes.io/networking: "1"
 spec:
+  selector:
+    matchLabels:
+      name: kopeio-networking-agent
+      role.kubernetes.io/networking: "1"
   template:
     metadata:
       labels:

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -1,0 +1,163 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-router-cfg
+  namespace: kube-system
+  labels:
+    tier: node
+    k8s-app: kube-router
+data:
+  cni-conf.json: |
+    {
+      "name":"kubernetes",
+      "type":"bridge",
+      "bridge":"kube-bridge",
+      "isDefaultGateway":true,
+      "ipam": {
+        "type":"host-local"
+      }
+    }
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: kube-router
+    tier: node
+  name: kube-router
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-router
+        tier: node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      containers:
+      - name: kube-router
+        image: cloudnativelabs/kube-router:v0.1.0
+        args:
+        - --run-router=true
+        - --run-firewall=true
+        - --run-service-proxy=true
+        - --metrics-port=12013
+        - --kubeconfig=/var/lib/kube-router/kubeconfig
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 250Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kubeconfig
+          mountPath: /var/lib/kube-router/kubeconfig
+          readOnly: true
+      initContainers:
+      - name: install-cni
+        image: busybox
+        command:
+        - /bin/sh
+        - -c
+        - set -e -x;
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+            TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
+            cp /etc/kube-router/cni-conf.json ${TMP};
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+          fi
+        volumeMounts:
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kube-router-cfg
+          mountPath: /etc/kube-router
+      hostNetwork: true
+      serviceAccountName: kube-router
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /lib/modules
+        name: lib-modules
+      - hostPath:
+          path: /etc/cni/net.d
+        name: cni-conf-dir
+      - name: kubeconfig
+        hostPath:
+          path: /var/lib/kube-router/kubeconfig
+      - name: kube-router-cfg
+        configMap:
+          name: kube-router-cfg
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-router
+  namespace: kube-system
+---
+# Kube-router roles
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-router
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - pods
+      - services
+      - nodes
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["extensions"]
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-router
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-router
+subjects:
+- kind: ServiceAccount
+  name: kube-router
+  namespace: kube-system
+- kind: User
+  name: system:kube-router

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -18,7 +18,7 @@ data:
       }
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
@@ -27,6 +27,10 @@ metadata:
   name: kube-router
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-router
+      tier: node
   template:
     metadata:
       labels:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -1,0 +1,749 @@
+{{- $etcd_scheme := EtcdScheme }}
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  # The calico-etcd PetSet service IP:port
+  etcd_endpoints: "{{ $cluster := index .EtcdClusters 0 -}}
+                      {{- range $j, $member := $cluster.Members -}}
+                          {{- if $j }},{{ end -}}
+                          {{ $etcd_scheme }}://etcd-{{ $member.Name }}.internal.{{ ClusterName }}:4001
+                      {{- end }}"
+
+  # Configure the Calico backend to use.
+  calico_backend: "bird"
+
+  # The CNI network configuration to install on each node.
+  cni_network_config: |-
+    {
+      "name": "k8s-pod-network",
+      "cniVersion": "0.3.0",
+      "plugins": [
+        {
+          "type": "calico",
+          "etcd_endpoints": "__ETCD_ENDPOINTS__",
+          {{- if eq $etcd_scheme "https" }}
+          "etcd_ca_cert_file": "/srv/kubernetes/calico/ca.pem",
+          "etcd_cert_file": "/srv/kubernetes/calico/calico-client.pem",
+          "etcd_key_file": "/srv/kubernetes/calico/calico-client-key.pem",
+          "etcd_scheme": "https",
+          {{- end }}
+          "log_level": "info",
+          "ipam": {
+            "type": "calico-ipam"
+          },
+          "policy": {
+            "type": "k8s"
+          },
+          "kubernetes": {
+            "kubeconfig": "/etc/cni/net.d/__KUBECONFIG_FILENAME__"
+          }
+        },
+        {
+          "type": "portmap",
+          "snat": true,
+          "capabilities": {"portMappings": true}
+        }
+      ]
+    }
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-node
+  labels:
+    role.kubernetes.io/networking: "1"
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs:
+      - get
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-node
+  labels:
+    role.kubernetes.io/networking: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+- kind: ServiceAccount
+  name: calico-node
+  namespace: kube-system
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-kube-controllers
+  labels:
+    role.kubernetes.io/networking: "1"
+rules:
+  - apiGroups:
+    - ""
+    - extensions
+    resources:
+      - pods
+      - namespaces
+      - networkpolicies
+      - nodes
+    verbs:
+      - watch
+      - list
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-kube-controllers
+  labels:
+    role.kubernetes.io/networking: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-kube-controllers
+subjects:
+- kind: ServiceAccount
+  name: calico-kube-controllers
+  namespace: kube-system
+
+---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+    role.kubernetes.io/networking: "1"
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+        role.kubernetes.io/networking: "1"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      tolerations:
+        # Make sure calico/node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      serviceAccountName: calico-node
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 0
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: quay.io/calico/node:v3.4.0
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            {{- if eq $etcd_scheme "https" }}
+            - name: ETCD_CERT_FILE
+              value: /certs/calico-client.pem
+            - name: ETCD_KEY_FILE
+              value: /certs/calico-client-key.pem
+            - name: ETCD_CA_CERT_FILE
+              value: /certs/ca.pem
+            {{- end }}
+            # Choose the backend to use.
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+            # Cluster type to identify the deployment type
+            - name: CLUSTER_TYPE
+              value: "kops,bgp"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set noderef for node controller.
+            - name: CALICO_K8S_NODE_REF
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
+            # chosen from this range. Changing this value after installation will have
+            # no effect. This should fall within `--cluster-cidr`.
+            # Configure the IP Pool from which Pod IPs will be chosen.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "{{ .KubeControllerManager.ClusterCIDR }}"
+            - name: CALICO_IPV4POOL_IPIP
+              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}cross-subnet{{- else -}}always{{- end -}}"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Set Felix logging to the desired level
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "{{- or .Networking.Calico.LogSeverityScreen "info" }}"
+            # Set to enable the experimental Prometheus metrics server
+            - name: FELIX_PROMETHEUSMETRICSENABLED
+              value: "{{- or .Networking.Calico.PrometheusMetricsEnabled "false" }}"
+            # TCP port that the Prometheus metrics server should bind to
+            - name: FELIX_PROMETHEUSMETRICSPORT
+              value: "{{- or .Networking.Calico.PrometheusMetricsPort "9091" }}"
+            # Enable Prometheus Go runtime metrics collection
+            - name: FELIX_PROMETHEUSGOMETRICSENABLED
+              value: "{{- or .Networking.Calico.PrometheusGoMetricsEnabled "true" }}"
+            # Enable Prometheus process metrics collection
+            - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
+              value: "{{- or .Networking.Calico.PrometheusProcessMetricsEnabled "true" }}"
+            # Auto-detect the BGP IP address.
+            - name: IP
+              value: "autodetect"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 10m
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 9099
+              host: localhost
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+              - /bin/calico-node
+              - -bird-ready
+              - -felix-ready
+            periodSeconds: 10
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            # Necessary for gossip based DNS
+            - mountPath: /etc/hosts
+              name: etc-hosts
+              readOnly: true
+            {{- if eq $etcd_scheme "https" }}
+            - mountPath: /certs
+              name: calico
+              readOnly: true
+            {{- end }}
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: quay.io/calico/cni:v3.4.0
+          command: ["/install-cni.sh"]
+          env:
+            # Name of the CNI config file to create.
+            - name: CNI_CONF_NAME
+              value: "10-calico.conflist"
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+            # Necessary for gossip based DNS
+            - mountPath: /etc/hosts
+              name: etc-hosts
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+      initContainers:
+        - name: migrate
+          image: calico/upgrade:v1.0.5
+          command: ['/bin/sh', '-c', '/node-init-container.sh']
+          env:
+            - name: CALICO_ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            - name: CALICO_APIV1_DATASTORE_TYPE
+              value: "etcdv2"
+            - name: CALICO_APIV1_ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+          {{- if eq $etcd_scheme "https" }}
+            - name: CALICO_ETCD_CERT_FILE
+              value: /certs/calico-client.pem
+            - name: CALICO_ETCD_KEY_FILE
+              value: /certs/calico-client-key.pem
+            - name: CALICO_ETCD_CA_CERT_FILE
+              value: /certs/ca.pem
+            - name: CALICO_APIV1_ETCD_CERT_FILE
+              value: /certs/calico-client.pem
+            - name: CALICO_APIV1_ETCD_KEY_FILE
+              value: /certs/calico-client-key.pem
+            - name: CALICO_APIV1_ETCD_CA_CERT_FILE
+              value: /certs/ca.pem
+          {{- end }}
+          volumeMounts:
+            # Necessary for gossip based DNS
+            - mountPath: /etc/hosts
+              name: etc-hosts
+              readOnly: true
+          {{- if eq $etcd_scheme "https" }}
+            - mountPath: /certs
+              name: calico
+              readOnly: true
+          {{- end }}
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        - name: var-lib-calico
+          hostPath:
+            path: /var/lib/calico
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+        # Necessary for gossip based DNS
+        - name: etc-hosts
+          hostPath:
+            path: /etc/hosts
+        {{- if eq $etcd_scheme "https" }}
+        - name: calico
+          hostPath:
+            path: /srv/kubernetes/calico
+        {{- end }}
+
+---
+
+# This manifest deploys the Calico Kubernetes controllers.
+# See https://github.com/projectcalico/kube-controllers
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+  labels:
+    k8s-app: calico-kube-controllers
+    role.kubernetes.io/networking: "1"
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+spec:
+  # The controllers can only have a single active instance.
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+      labels:
+        k8s-app: calico-kube-controllers
+        role.kubernetes.io/networking: "1"
+    spec:
+      # The controllers must run in the host network namespace so that
+      # it isn't governed by policy that would prevent it from working.
+      hostNetwork: true
+      tolerations:
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      serviceAccountName: calico-kube-controllers
+      containers:
+        - name: calico-kube-controllers
+          image: quay.io/calico/kube-controllers:v3.4.0
+          resources:
+            requests:
+              cpu: 10m
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # Choose which controllers to run.
+            - name: ENABLED_CONTROLLERS
+              value: policy,profile,workloadendpoint,node
+            {{- if eq $etcd_scheme "https" }}
+            - name: ETCD_CERT_FILE
+              value: /certs/calico-client.pem
+            - name: ETCD_KEY_FILE
+              value: /certs/calico-client-key.pem
+            - name: ETCD_CA_CERT_FILE
+              value: /certs/ca.pem
+          volumeMounts:
+            - mountPath: /certs
+              name: calico
+              readOnly: true
+            {{- end }}
+          readinessProbe:
+            exec:
+              command:
+              - /usr/bin/check-status
+              - -r
+      initContainers:
+        - name: migrate
+          image: calico/upgrade:v1.0.5
+          command: ['/bin/sh', '-c', '/controller-init.sh']
+          env:
+            - name: CALICO_ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            - name: CALICO_APIV1_DATASTORE_TYPE
+              value: "etcdv2"
+            - name: CALICO_APIV1_ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+          {{- if eq $etcd_scheme "https" }}
+            - name: CALICO_ETCD_CERT_FILE
+              value: /certs/calico-client.pem
+            - name: CALICO_ETCD_KEY_FILE
+              value: /certs/calico-client-key.pem
+            - name: CALICO_ETCD_CA_CERT_FILE
+              value: /certs/ca.pem
+            - name: CALICO_APIV1_ETCD_CERT_FILE
+              value: /certs/calico-client.pem
+            - name: CALICO_APIV1_ETCD_KEY_FILE
+              value: /certs/calico-client-key.pem
+            - name: CALICO_APIV1_ETCD_CA_CERT_FILE
+              value: /certs/ca.pem
+          {{- end }}
+          volumeMounts:
+            # Necessary for gossip based DNS
+            - mountPath: /etc/hosts
+              name: etc-hosts
+              readOnly: true
+          {{- if eq $etcd_scheme "https" }}
+            - mountPath: /certs
+              name: calico
+              readOnly: true
+          {{- end }}
+      volumes:
+        # Necessary for gossip based DNS
+        - name: etc-hosts
+          hostPath:
+            path: /etc/hosts
+        {{- if eq $etcd_scheme "https" }}
+        - name: calico
+          hostPath:
+            path: /srv/kubernetes/calico
+        {{- end }}
+
+# This manifest runs the Migration complete container that monitors for the
+# completion of the calico-node Daemonset rollout and when it finishes
+# successfully rolling out it will mark the migration complete and allow pods
+# to be created again.
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-upgrade-job
+  namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-upgrade-job
+  labels:
+    role.kubernetes.io/networking: "1"
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+      - daemonsets/status
+    verbs:
+      - get
+      - list
+      - watch
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-upgrade-job
+  labels:
+    role.kubernetes.io/networking: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-upgrade-job
+subjects:
+- kind: ServiceAccount
+  name: calico-upgrade-job
+  namespace: kube-system
+---
+# If anything in this job is changed then the name of the job
+# should be changed because Jobs cannot be updated, so changing
+# the name would run a different Job if the previous version had been
+# created before and it does not hurt to rerun this job.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: calico-complete-upgrade-v331
+  namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
+spec:
+  template:
+    metadata:
+      labels:
+        role.kubernetes.io/networking: "1"
+    spec:
+      hostNetwork: true
+      serviceAccountName: calico-upgrade-job
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate-completion
+          image: calico/upgrade:v1.0.5
+          command: ['/bin/sh', '-c', '/completion-job.sh']
+          env:
+            - name: EXPECTED_NODE_IMAGE
+              value: quay.io/calico/node:v3.4.0
+            # The location of the Calico etcd cluster.
+            - name: CALICO_ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            - name: CALICO_APIV1_DATASTORE_TYPE
+              value: "etcdv2"
+            - name: CALICO_APIV1_ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+          {{- if eq $etcd_scheme "https" }}
+            - name: CALICO_ETCD_CERT_FILE
+              value: /certs/calico-client.pem
+            - name: CALICO_ETCD_KEY_FILE
+              value: /certs/calico-client-key.pem
+            - name: CALICO_ETCD_CA_CERT_FILE
+              value: /certs/ca.pem
+            - name: CALICO_APIV1_ETCD_CERT_FILE
+              value: /certs/calico-client.pem
+            - name: CALICO_APIV1_ETCD_KEY_FILE
+              value: /certs/calico-client-key.pem
+            - name: CALICO_APIV1_ETCD_CA_CERT_FILE
+              value: /certs/ca.pem
+          {{- end }}
+          volumeMounts:
+            # Necessary for gossip based DNS
+            - mountPath: /etc/hosts
+              name: etc-hosts
+              readOnly: true
+          {{- if eq $etcd_scheme "https" }}
+            - mountPath: /certs
+              name: calico
+              readOnly: true
+          {{- end }}
+      volumes:
+        - name: etc-hosts
+          hostPath:
+            path: /etc/hosts
+        {{- if eq $etcd_scheme "https" }}
+        - name: calico
+          hostPath:
+            path: /srv/kubernetes/calico
+        {{- end }}
+
+{{ if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}
+# This manifest installs the k8s-ec2-srcdst container, which disables
+# src/dst ip checks to allow BGP to function for calico for hosts within subnets
+# This only applies for AWS environments.
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: k8s-ec2-srcdst
+  labels:
+    role.kubernetes.io/networking: "1"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-ec2-srcdst
+  namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: k8s-ec2-srcdst
+  labels:
+    role.kubernetes.io/networking: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-ec2-srcdst
+subjects:
+- kind: ServiceAccount
+  name: k8s-ec2-srcdst
+  namespace: kube-system
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: k8s-ec2-srcdst
+  namespace: kube-system
+  labels:
+    k8s-app: k8s-ec2-srcdst
+    role.kubernetes.io/networking: "1"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: k8s-ec2-srcdst
+  template:
+    metadata:
+      labels:
+        k8s-app: k8s-ec2-srcdst
+        role.kubernetes.io/networking: "1"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+      serviceAccountName: k8s-ec2-srcdst
+      containers:
+        - image: ottoyiu/k8s-ec2-srcdst:v0.2.1
+          name: k8s-ec2-srcdst
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          env:
+            - name: AWS_REGION
+              value: {{ Region }}
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: "/etc/ssl/certs/ca-certificates.crt"
+              readOnly: true
+          imagePullPolicy: "Always"
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: "/etc/ssl/certs/ca-certificates.crt"
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+{{- end -}}

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -53,7 +53,7 @@ data:
 ---
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-node
   labels:
@@ -78,7 +78,7 @@ metadata:
 ---
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-node
   labels:
@@ -103,7 +103,7 @@ metadata:
 ---
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-kube-controllers
   labels:
@@ -130,7 +130,7 @@ rules:
 ---
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-kube-controllers
   labels:
@@ -150,7 +150,7 @@ subjects:
 # as the Calico CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: calico-node
   namespace: kube-system
@@ -404,7 +404,7 @@ spec:
 
 # This manifest deploys the Calico Kubernetes controllers.
 # See https://github.com/projectcalico/kube-controllers
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-kube-controllers
@@ -419,6 +419,10 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      k8s-app: calico-kube-controllers
+      role.kubernetes.io/networking: "1"
   template:
     metadata:
       name: calico-kube-controllers
@@ -538,7 +542,7 @@ metadata:
 ---
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-upgrade-job
   labels:
@@ -555,7 +559,7 @@ rules:
       - watch
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: calico-upgrade-job
@@ -652,7 +656,7 @@ spec:
 ---
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: k8s-ec2-srcdst
   labels:
@@ -681,7 +685,7 @@ metadata:
 ---
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: k8s-ec2-srcdst
   labels:
@@ -697,7 +701,7 @@ subjects:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: k8s-ec2-srcdst

--- a/upup/models/cloudup/resources/addons/networking.romana/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.romana/k8s-1.12.yaml.template
@@ -1,0 +1,350 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: romana-listener
+rules:
+- apiGroups:
+  - "*"
+  resources:
+  - pods
+  - namespaces
+  - nodes
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "*"
+  resources:
+  - services
+  verbs:
+  - update
+  - list
+  - watch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: romana-listener
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: romana-listener
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: romana-listener
+subjects:
+- kind: ServiceAccount
+  name: romana-listener
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: romana-agent
+rules:
+- apiGroups:
+  - "*"
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: romana-agent
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: romana-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: romana-agent
+subjects:
+- kind: ServiceAccount
+  name: romana-agent
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: romana-etcd
+  namespace: kube-system
+spec:
+  clusterIP: {{ .Networking.Romana.EtcdServiceIP }}
+  ports:
+  - name: etcd
+    port: 12379
+    protocol: TCP
+    targetPort: 4001
+  selector:
+    k8s-app: etcd-server
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: romana
+  namespace: kube-system
+spec:
+  clusterIP: {{ .Networking.Romana.DaemonServiceIP }}
+  ports:
+  - name: daemon
+    port: 9600
+    protocol: TCP
+    targetPort: 9600
+  selector:
+    romana-app: daemon
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: romana-daemon
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        romana-app: daemon
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: romana-daemon
+        image: quay.io/romana/daemon:v2.0.2
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            memory: 64Mi
+        args:
+        - --cloud=aws
+        - --network-cidr-overrides=romana-network={{ .KubeControllerManager.ClusterCIDR }}
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: romana-listener
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        romana-app: listener
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      hostNetwork: true
+      serviceAccountName: romana-listener
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: romana-listener
+        image: quay.io/romana/listener:v2.0.2
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            memory: 64Mi
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: romana-agent
+  namespace: kube-system
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        romana-app: agent
+    spec:
+      hostNetwork: true
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
+      serviceAccountName: romana-agent
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      containers:
+      - name: romana-agent
+        image: quay.io/romana/agent:v2.0.2
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 25m
+            memory: 128Mi
+          limits:
+            memory: 128Mi
+        env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        args:
+        - --service-cluster-ip-range={{ .ServiceClusterIPRange }}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: host-usr-local-bin
+          mountPath: /host/usr/local/bin
+        - name: host-etc-romana
+          mountPath: /host/etc/romana
+        - name: host-cni-bin
+          mountPath: /host/opt/cni/bin
+        - name: host-cni-net-d
+          mountPath: /host/etc/cni/net.d
+        - name: run-path
+          mountPath: /var/run/romana
+      volumes:
+      - name: host-usr-local-bin
+        hostPath:
+          path: /usr/local/bin
+      - name: host-etc-romana
+        hostPath:
+          path: /etc/romana
+      - name: host-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-cni-net-d
+        hostPath:
+          path: /etc/cni/net.d
+      - name: run-path
+        hostPath:
+          path: /var/run/romana
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: romana-aws
+rules:
+- apiGroups:
+  - "*"
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: romana-aws
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: romana-aws
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: romana-aws
+subjects:
+- kind: ServiceAccount
+  name: romana-aws
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: romana-aws
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        romana-app: aws
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      hostNetwork: true
+      serviceAccountName: romana-aws
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: romana-aws
+        image: quay.io/romana/aws:v2.0.2
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            memory: 64Mi
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: romana-vpcrouter
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        romana-app: vpcrouter
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: romana-vpcrouter
+        image: quay.io/romana/vpcrouter-romana-plugin:1.1.17
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 45m
+            memory: 128Mi
+          limits:
+            memory: 128Mi
+        args:
+        - --etcd_use_v2
+        - --etcd_addr={{ .Networking.Romana.EtcdServiceIP }}
+        - --etcd_port=12379

--- a/upup/models/cloudup/resources/addons/networking.romana/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.romana/k8s-1.12.yaml.template
@@ -1,6 +1,6 @@
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: romana-listener
 rules:
@@ -39,7 +39,7 @@ metadata:
   namespace: kube-system
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: romana-listener
 roleRef:
@@ -52,7 +52,7 @@ subjects:
   namespace: kube-system
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: romana-agent
 rules:
@@ -71,7 +71,7 @@ metadata:
   namespace: kube-system
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: romana-agent
 roleRef:
@@ -117,13 +117,18 @@ spec:
   sessionAffinity: None
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: romana-daemon
   namespace: kube-system
+  labels:
+    romana-app: daemon
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      romana-app: daemon
   template:
     metadata:
       labels:
@@ -149,13 +154,16 @@ spec:
         - --cloud=aws
         - --network-cidr-overrides=romana-network={{ .KubeControllerManager.ClusterCIDR }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: romana-listener
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      romana-app: listener
   template:
     metadata:
       labels:
@@ -179,14 +187,19 @@ spec:
           limits:
             memory: 64Mi
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: romana-agent
   namespace: kube-system
+  labels:
+    romana-app: agent
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      romana-app: agent
   template:
     metadata:
       labels:
@@ -254,7 +267,7 @@ spec:
           path: /var/run/romana
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: romana-aws
 rules:
@@ -274,7 +287,7 @@ metadata:
   namespace: kube-system
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: romana-aws
 roleRef:
@@ -286,13 +299,18 @@ subjects:
   name: romana-aws
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: romana-aws
   namespace: kube-system
+  labels:
+    romana-app: aws
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      romana-app: aws
   template:
     metadata:
       labels:
@@ -316,13 +334,18 @@ spec:
           limits:
             memory: 64Mi
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: romana-vpcrouter
   namespace: kube-system
+  labels:
+    romana-app: vpcrouter
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      romana-app: vpcrouter
   template:
     metadata:
       labels:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -1,0 +1,247 @@
+{{- if WeaveSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: weave-net
+  namespace: kube-system
+stringData:
+  network-password: {{ WeaveSecret }}
+---
+{{- end }}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: weave-net
+  namespace: kube-system
+  labels:
+    name: weave-net
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: weave-net
+  namespace: kube-system
+  labels:
+    name: weave-net
+    role.kubernetes.io/networking: "1"
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - namespaces
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - 'networking.k8s.io'
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: weave-net
+  namespace: kube-system
+  labels:
+    name: weave-net
+    role.kubernetes.io/networking: "1"
+roleRef:
+  kind: ClusterRole
+  name: weave-net
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: weave-net
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: weave-net
+  namespace: kube-system
+  labels:
+    name: weave-net
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    resourceNames:
+      - weave-net
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: weave-net
+  namespace: kube-system
+  labels:
+    name: weave-net
+roleRef:
+  kind: Role
+  name: weave-net
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: weave-net
+    namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: weave-net
+  namespace: kube-system
+  labels:
+    name: weave-net
+    role.kubernetes.io/networking: "1"
+spec:
+  # Wait 5 seconds to let pod connect before rolling next pod
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        name: weave-net
+        role.kubernetes.io/networking: "1"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      containers:
+        - name: weave
+          command:
+            - /home/weave/launch.sh
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: IPALLOC_RANGE
+              value: {{ .KubeControllerManager.ClusterCIDR }}
+            {{- if .Networking.Weave.MTU }}
+            - name: WEAVE_MTU
+              value: "{{ .Networking.Weave.MTU }}"
+            {{- end }}
+            {{- if .Networking.Weave.NoMasqLocal }}
+            - name: NO_MASQ_LOCAL
+              value: "{{ .Networking.Weave.NoMasqLocal }}"
+            {{- end }}
+            {{- if .Networking.Weave.ConnLimit }}
+            - name: CONN_LIMIT
+              value: "{{ .Networking.Weave.ConnLimit }}"
+            {{- end }}
+            {{- if WeaveSecret }}
+            - name: WEAVE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: weave-net
+                  key: network-password
+            {{- end }}
+          image: 'weaveworks/weave-kube:2.5.0'
+          livenessProbe:
+            httpGet:
+              host: 127.0.0.1
+              path: /status
+              port: 6784
+            initialDelaySeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 200Mi
+            limits:
+              memory: 200Mi
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: weavedb
+              mountPath: /weavedb
+            - name: cni-bin
+              mountPath: /host/opt
+            - name: cni-bin2
+              mountPath: /host/home
+            - name: cni-conf
+              mountPath: /host/etc
+            - name: dbus
+              mountPath: /host/var/lib/dbus
+            - name: lib-modules
+              mountPath: /lib/modules
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+        - name: weave-npc
+          args: []
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          image: 'weaveworks/weave-npc:2.5.0'
+          resources:
+            requests:
+              cpu: 50m
+              memory: 200Mi
+            limits:
+              memory: 200Mi
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+      hostNetwork: true
+      hostPID: true
+      restartPolicy: Always
+      securityContext:
+        seLinuxOptions: {}
+      serviceAccountName: weave-net
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
+      volumes:
+        - name: weavedb
+          hostPath:
+            path: /var/lib/weave
+        - name: cni-bin
+          hostPath:
+            path: /opt
+        - name: cni-bin2
+          hostPath:
+            path: /home
+        - name: cni-conf
+          hostPath:
+            path: /etc
+        - name: dbus
+          hostPath:
+            path: /var/lib/dbus
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
+  updateStrategy:
+    type: RollingUpdate

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -17,7 +17,7 @@ metadata:
   labels:
     name: weave-net
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: weave-net
@@ -52,7 +52,7 @@ rules:
       - patch
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: weave-net
@@ -69,7 +69,7 @@ subjects:
     name: weave-net
     namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: weave-net
@@ -93,7 +93,7 @@ rules:
     verbs:
       - create
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: weave-net
@@ -109,7 +109,7 @@ subjects:
     name: weave-net
     namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: weave-net
@@ -120,6 +120,10 @@ metadata:
 spec:
   # Wait 5 seconds to let pod connect before rolling next pod
   minReadySeconds: 5
+  selector:
+    matchLabels:
+      name: weave-net
+      role.kubernetes.io/networking: "1"
   template:
     metadata:
       labels:

--- a/upup/models/cloudup/resources/addons/node-authorizer.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-authorizer.addons.k8s.io/k8s-1.12.yaml.template
@@ -1,0 +1,188 @@
+{{- $proxy := .EgressProxy }}
+{{- $na := .NodeAuthorization.NodeAuthorizer }}
+{{- $name := "node-authorizer" }}
+{{- $namespace := "kube-system" }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  namespace: {{ $namespace }}
+  labels:
+    k8s-app: {{ $name }}
+    k8s-addon: {{ $name }}.addons.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kops:{{ $name }}:nodes-viewer
+  labels:
+    k8s-app: {{ $name }}
+    k8s-addon: {{ $name }}.addons.k8s.io
+rules:
+- apiGroups:
+  - "*"
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+---
+# permits the node access to create a CSR
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kops:{{ $name }}:system:bootstrappers
+  labels:
+    k8s-app: {{ $name }}
+    k8s-addon: {{ $name }}.addons.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:node-bootstrapper
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: Group
+  name: system:bootstrappers
+  apiGroup: rbac.authorization.k8s.io
+---
+# indicates to the controller to auto-sign the CSR for this group
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kops:{{ $name }}:approval
+  labels:
+    k8s-app: {{ $name }}
+    k8s-addon: {{ $name }}.addons.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:certificates.k8s.io:certificatesigningrequests:nodeclient
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: Group
+  name: system:bootstrappers
+  apiGroup: rbac.authorization.k8s.io
+---
+# the service permission requires to create the bootstrap tokens
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: kops:{{ $namespace }}:{{ $name }}
+  namespace: {{ $namespace }}
+  labels:
+    k8s-app: {{ $name }}
+    k8s-addon: {{ $name }}.addons.k8s.io
+rules:
+- apiGroups:
+  - "*"
+  resources:
+  - secrets
+  verbs:
+  - create
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: kops:{{ $namespace }}:{{ $name }}
+  namespace: {{ $namespace }}
+  labels:
+    k8s-app: {{ $name }}
+    k8s-addon: {{ $name }}.addons.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kops:{{ $namespace }}:{{ $name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $name }}
+  namespace: {{ $namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kops:{{ $name }}:nodes-viewer
+  labels:
+    k8s-app: {{ $name }}
+    k8s-addon: {{ $name }}.addons.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kops:{{ $name }}:nodes-viewer
+subjects:
+- kind: ServiceAccount
+  name: {{ $name }}
+  namespace: {{ $namespace }}
+---
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ $name }}
+  namespace: {{ $namespace }}
+  labels:
+    k8s-app: {{ $name }}
+    k8s-addon: {{ $name }}.addons.k8s.io
+spec:
+  selector:
+    matchLabels:
+      k8s-app: {{ $name }}
+  template:
+    metadata:
+      labels:
+        k8s-app: {{ $name }}
+      annotations:
+        dns.alpha.kubernetes.io/internal: {{ $name }}-internal.{{ ClusterName }}
+        prometheus.io/port: "{{ $na.Port }}"
+        prometheus.io/scheme: "https"
+        prometheus.io/scrape: "true"
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/role: master
+      serviceAccount: {{ $name }}
+      securityContext:
+        fsGroup: 1000
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+      volumes:
+        - name: config
+          hostPath:
+            path: /srv/kubernetes/node-authorizer
+            type: DirectoryOrCreate
+      containers:
+        - name: {{ $name }}
+          image: {{ $na.Image }}
+          args:
+            - server
+            - --authorization-timeout={{ $na.Timeout.Duration }}
+            - --authorizer={{ $na.Authorizer }}
+            - --cluster-name={{ ClusterName }}
+            {{- range $na.Features }}
+            - --feature={{ . }}
+            {{- end }}
+            - --listen=0.0.0.0:{{ $na.Port }}
+            - --tls-cert=/config/tls.pem
+            - --tls-client-ca=/config/ca.pem
+            - --tls-private-key=/config/tls-key.pem
+            - --token-ttl={{ $na.TokenTTL.Duration }}
+          {{- if $proxy }}
+          env:
+            - name: http_proxy
+              value: {{ $proxy.HTTPProxy.Host }}:{{ $proxy.HTTPProxy.Port }}
+            {{- if $proxy.ProxyExcludes }}
+            - name: no_proxy
+              value: {{ $proxy.ProxyExcludes }}
+            {{- end }}
+          {{- end }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 64Mi
+            requests:
+              cpu: 10m
+              memory: 10Mi
+          volumeMounts:
+            - mountPath: /config
+              readOnly: true
+              name: config

--- a/upup/models/cloudup/resources/addons/node-authorizer.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-authorizer.addons.k8s.io/k8s-1.12.yaml.template
@@ -13,7 +13,7 @@ metadata:
     k8s-addon: {{ $name }}.addons.k8s.io
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kops:{{ $name }}:nodes-viewer
   labels:
@@ -63,7 +63,7 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 ---
 # the service permission requires to create the bootstrap tokens
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kops:{{ $namespace }}:{{ $name }}
@@ -80,7 +80,7 @@ rules:
   - create
   - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kops:{{ $namespace }}:{{ $name }}
@@ -114,7 +114,7 @@ subjects:
   namespace: {{ $namespace }}
 ---
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ $name }}
   namespace: {{ $namespace }}

--- a/upup/models/cloudup/resources/addons/podsecuritypolicy.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/podsecuritypolicy.addons.k8s.io/k8s-1.12.yaml.template
@@ -1,0 +1,82 @@
+---
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    k8s-addon: podsecuritypolicy.addons.k8s.io
+  name: kube-system
+spec:
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostPID: true
+  hostIPC: true
+  hostNetwork: true
+  hostPorts:
+  - min: 1
+    max: 65536
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  annotations:
+    k8s-addon: podsecuritypolicy.addons.k8s.io
+  name: kops:kube-system:psp
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - kube-system
+  verbs:
+  - use
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kops:kube-system:psp
+roleRef:
+  kind: ClusterRole
+  name: kops:kube-system:psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: Group
+  name: system:masters
+  apiGroup: rbac.authorization.k8s.io
+# permit the kubelets to access this policy (used for manifests)
+- kind: User
+  name: kubelet
+  apiGroup: rbac.authorization.k8s.io
+{{- if UseBootstrapTokens }}
+- kind: Group
+  name: system:nodes
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  annotations:
+    k8s-addon: podsecuritypolicy.addons.k8s.io
+  name: kops:kube-system:psp
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: kops:kube-system:psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+# permit the cluster wise admin to use this policy
+- kind: Group
+  name: system:serviceaccounts:kube-system
+  apiGroup: rbac.authorization.k8s.io

--- a/upup/models/cloudup/resources/addons/podsecuritypolicy.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/podsecuritypolicy.addons.k8s.io/k8s-1.12.yaml.template
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   annotations:
@@ -26,7 +26,7 @@ spec:
   volumes:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
@@ -43,7 +43,7 @@ rules:
   - use
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kops:kube-system:psp
 roleRef:
@@ -65,7 +65,7 @@ subjects:
 {{- end }}
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   annotations:
     k8s-addon: podsecuritypolicy.addons.k8s.io

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -140,7 +140,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 				Version:           fi.String(version),
 				Selector:          map[string]string{"k8s-addon": key},
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.10.0",
+				KubernetesVersion: ">=1.10.0 <1.12.0",
+				Id:                id,
+			})
+			manifests[key+"-"+id] = "addons/" + location
+		}
+
+		{
+			location := key + "/k8s-1.12.yaml"
+			id := "k8s-1.12"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(version),
+				Selector:          map[string]string{"k8s-addon": key},
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.12.0",
 				Id:                id,
 			})
 			manifests[key+"-"+id] = "addons/" + location
@@ -161,7 +176,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 					Version:           fi.String(version),
 					Selector:          map[string]string{"k8s-addon": key},
 					Manifest:          fi.String(location),
-					KubernetesVersion: ">=1.10.0",
+					KubernetesVersion: ">=1.10.0 <1.12.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
+
+			{
+				location := key + "/k8s-1.12.yaml"
+				id := "k8s-1.12.yaml"
+
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(version),
+					Selector:          map[string]string{"k8s-addon": key},
+					Manifest:          fi.String(location),
+					KubernetesVersion: ">=1.12.0",
 					Id:                id,
 				})
 				manifests[key+"-"+id] = "addons/" + location
@@ -200,7 +230,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 					Version:           fi.String(version),
 					Selector:          map[string]string{"k8s-addon": key},
 					Manifest:          fi.String(location),
-					KubernetesVersion: ">=1.6.0",
+					KubernetesVersion: ">=1.6.0 <1.12.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
+
+			{
+				location := key + "/k8s-1.12.yaml"
+				id := "k8s-1.12"
+
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(version),
+					Selector:          map[string]string{"k8s-addon": key},
+					Manifest:          fi.String(location),
+					KubernetesVersion: ">=1.12.0",
 					Id:                id,
 				})
 				manifests[key+"-"+id] = "addons/" + location
@@ -222,7 +267,27 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 					Version:           fi.String(version),
 					Selector:          map[string]string{"k8s-addon": key},
 					Manifest:          fi.String(location),
-					KubernetesVersion: ">=1.6.0",
+					KubernetesVersion: ">=1.6.0 <1.12.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
+		}
+
+		{
+			key := "coredns.addons.k8s.io"
+			version := "1.3.0-kops.1"
+
+			{
+				location := key + "/k8s-1.12.yaml"
+				id := "k8s-1.12"
+
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(version),
+					Selector:          map[string]string{"k8s-addon": key},
+					Manifest:          fi.String(location),
+					KubernetesVersion: ">=1.12.0",
 					Id:                id,
 				})
 				manifests[key+"-"+id] = "addons/" + location
@@ -333,7 +398,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 					Version:           fi.String(version),
 					Selector:          map[string]string{"k8s-addon": key},
 					Manifest:          fi.String(location),
-					KubernetesVersion: ">=1.6.0",
+					KubernetesVersion: ">=1.6.0 <1.12.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
+
+			{
+				location := key + "/k8s-1.12.yaml"
+				id := "k8s-1.12"
+
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(version),
+					Selector:          map[string]string{"k8s-addon": key},
+					Manifest:          fi.String(location),
+					KubernetesVersion: ">=1.12.0",
 					Id:                id,
 				})
 				manifests[key+"-"+id] = "addons/" + location
@@ -370,7 +450,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 					Version:           fi.String(version),
 					Selector:          map[string]string{"k8s-addon": key},
 					Manifest:          fi.String(location),
-					KubernetesVersion: ">=1.6.0",
+					KubernetesVersion: ">=1.6.0 <1.12.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
+
+			{
+				location := key + "/k8s-1.12.yaml"
+				id := "k8s-1.12"
+
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(version),
+					Selector:          map[string]string{"k8s-addon": key},
+					Manifest:          fi.String(location),
+					KubernetesVersion: ">=1.12.0",
 					Id:                id,
 				})
 				manifests[key+"-"+id] = "addons/" + location
@@ -550,7 +645,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 				Version:           fi.String(version),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.6.0",
+				KubernetesVersion: ">=1.6.0 <1.12.0",
+				Id:                id,
+			})
+			manifests[key+"-"+id] = "addons/" + location
+		}
+
+		{
+			location := key + "/k8s-1.12.yaml"
+			id := "k8s-1.12"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(version),
+				Selector:          networkingSelector,
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.12.0",
 				Id:                id,
 			})
 			manifests[key+"-"+id] = "addons/" + location
@@ -564,6 +674,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 			"k8s-1.6":     "2.3.0-kops.2",
 			"k8s-1.7":     "2.5.0-kops.1",
 			"k8s-1.8":     "2.5.0-kops.1",
+			"k8s-1.12":    "2.5.0-kops.1",
 		}
 
 		{
@@ -620,7 +731,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 				Version:           fi.String(versions[id]),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.8.0",
+				KubernetesVersion: ">=1.8.0 <1.12.0",
+				Id:                id,
+			})
+			manifests[key+"-"+id] = "addons/" + location
+		}
+
+		{
+			location := key + "/k8s-1.12.yaml"
+			id := "k8s-1.12"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(versions[id]),
+				Selector:          networkingSelector,
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.12.0",
 				Id:                id,
 			})
 			manifests[key+"-"+id] = "addons/" + location
@@ -655,7 +781,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 				Version:           fi.String(version),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.6.0",
+				KubernetesVersion: ">=1.6.0 <1.12.0",
+				Id:                id,
+			})
+			manifests[key+"-"+id] = "addons/" + location
+		}
+
+		{
+			location := key + "/k8s-1.12.yaml"
+			id := "k8s-1.12"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(version),
+				Selector:          networkingSelector,
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.12.0",
 				Id:                id,
 			})
 			manifests[key+"-"+id] = "addons/" + location
@@ -669,6 +810,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 			"k8s-1.6":     "2.6.9-kops.1",
 			"k8s-1.7":     "2.6.12-kops.1",
 			"k8s-1.7-v3":  "3.4.0-kops.3",
+			"k8s-1.12":    "3.4.0-kops.3",
 		}
 
 		if b.cluster.Spec.Networking.Calico.MajorVersion == "v3" {
@@ -681,7 +823,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 					Version:           fi.String(versions[id]),
 					Selector:          networkingSelector,
 					Manifest:          fi.String(location),
-					KubernetesVersion: ">=1.7.0",
+					KubernetesVersion: ">=1.7.0 <1.12.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
+
+			{
+				id := "k8s-1.12"
+				location := key + "/" + id + ".yaml"
+
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(versions[id]),
+					Selector:          networkingSelector,
+					Manifest:          fi.String(location),
+					KubernetesVersion: ">=1.12.0",
 					Id:                id,
 				})
 				manifests[key+"-"+id] = "addons/" + location
@@ -726,7 +883,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 					Version:           fi.String(versions[id]),
 					Selector:          networkingSelector,
 					Manifest:          fi.String(location),
-					KubernetesVersion: ">=1.7.0",
+					KubernetesVersion: ">=1.7.0 <1.12.0",
 					Id:                id,
 				})
 				manifests[key+"-"+id] = "addons/" + location
@@ -831,7 +988,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 				Version:           fi.String(version),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.6.0",
+				KubernetesVersion: ">=1.6.0 <1.12.0",
+				Id:                id,
+			})
+			manifests[key+"-"+id] = "addons/" + location
+		}
+
+		{
+			location := key + "/k8s-1.12.yaml"
+			id := "k8s-1.12"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(version),
+				Selector:          networkingSelector,
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.12.0",
 				Id:                id,
 			})
 			manifests[key+"-"+id] = "addons/" + location
@@ -851,7 +1023,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 				Version:           fi.String(version),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.7.0",
+				KubernetesVersion: ">=1.7.0 <1.12.0",
+				Id:                id,
+			})
+			manifests[key+"-"+id] = "addons/" + location
+		}
+
+		{
+			location := key + "/k8s-1.12.yaml"
+			id := "k8s-1.12"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(version),
+				Selector:          networkingSelector,
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.12.0",
 				Id:                id,
 			})
 			manifests[key+"-"+id] = "addons/" + location
@@ -901,7 +1088,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 				Version:           fi.String(version),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.10.0",
+				KubernetesVersion: ">=1.10.0 <1.12.0",
+				Id:                id,
+			})
+			manifests[key+"-"+id] = "addons/" + location
+		}
+
+		{
+			id := "k8s-1.12"
+			location := key + "/" + id + ".yaml"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(version),
+				Selector:          networkingSelector,
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.12.0",
 				Id:                id,
 			})
 			manifests[key+"-"+id] = "addons/" + location
@@ -921,7 +1123,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 				Version:           fi.String(version),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.7.0",
+				KubernetesVersion: ">=1.7.0 <1.12.0",
+				Id:                id,
+			})
+			manifests[key+"-"+id] = "addons/" + location
+		}
+
+		{
+			id := "k8s-1.12"
+			location := key + "/" + id + ".yaml"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(version),
+				Selector:          networkingSelector,
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.12.0",
 				Id:                id,
 			})
 			manifests[key+"-"+id] = "addons/" + location
@@ -944,7 +1161,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 					Version:           fi.String(version),
 					Selector:          authenticationSelector,
 					Manifest:          fi.String(location),
-					KubernetesVersion: ">=1.8.0",
+					KubernetesVersion: ">=1.8.0 <1.12.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
+
+			{
+				location := key + "/k8s-1.12.yaml"
+				id := "k8s-1.12"
+
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(version),
+					Selector:          authenticationSelector,
+					Manifest:          fi.String(location),
+					KubernetesVersion: ">=1.12.0",
 					Id:                id,
 				})
 				manifests[key+"-"+id] = "addons/" + location
@@ -963,7 +1195,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 					Version:           fi.String(version),
 					Selector:          authenticationSelector,
 					Manifest:          fi.String(location),
-					KubernetesVersion: ">=1.10.0",
+					KubernetesVersion: ">=1.10.0 <1.12.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
+
+			{
+				location := key + "/k8s-1.12.yaml"
+				id := "k8s-1.12"
+
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(version),
+					Selector:          authenticationSelector,
+					Manifest:          fi.String(location),
+					KubernetesVersion: ">=1.12.0",
 					Id:                id,
 				})
 				manifests[key+"-"+id] = "addons/" + location
@@ -984,7 +1231,25 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 				Version:           fi.String(version),
 				Selector:          map[string]string{"k8s-addon": key},
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.7.0",
+				KubernetesVersion: ">=1.7.0 <1.12.0",
+				Id:                id,
+			})
+			manifests[key+"-"+id] = "addons/" + location
+		}
+
+		{
+			key := "core.addons.k8s.io"
+			version := "1.12.0"
+
+			location := key + "/k8s-1.12.yaml"
+			id := "k8s-1.12-ccm"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(version),
+				Selector:          map[string]string{"k8s-addon": key},
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.12.0",
 				Id:                id,
 			})
 			manifests[key+"-"+id] = "addons/" + location

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
@@ -18,6 +18,7 @@ package cloudup
 
 import (
 	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"testing"
@@ -128,7 +129,11 @@ func runChannelBuilderTest(t *testing.T, key string) {
 	if strings.TrimSpace(string(expectedManifest)) != strings.TrimSpace(actualManifest) {
 		diffString := diff.FormatDiff(string(expectedManifest), actualManifest)
 		t.Logf("diff:\n%s\n", diffString)
-
-		t.Fatalf("manifest differed from expected for test %q", key)
+		t.Errorf("manifest differed from expected for test %q", key)
+		if os.Getenv("UPDATE_CHANNEL_BUILDER_TEST_FIXTURES") == "true" {
+			ioutil.WriteFile(expectedManifestPath, []byte(actualManifest), 0755)
+		} else {
+			t.Logf("to update fixtures automatically, run with UPDATE_CHANNEL_BUILDER_TEST_FIXTURES=true")
+		}
 	}
 }

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -17,8 +17,15 @@ spec:
       k8s-addon: kube-dns.addons.k8s.io
     version: 1.14.10
   - id: k8s-1.6
-    kubernetesVersion: '>=1.6.0'
+    kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
+    name: kube-dns.addons.k8s.io
+    selector:
+      k8s-addon: kube-dns.addons.k8s.io
+    version: 1.14.10
+  - id: k8s-1.12
+    kubernetesVersion: '>=1.12.0'
+    manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -50,8 +57,15 @@ spec:
       k8s-addon: dns-controller.addons.k8s.io
     version: 1.12.0-alpha.1
   - id: k8s-1.6
-    kubernetesVersion: '>=1.6.0'
+    kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.6.yaml
+    name: dns-controller.addons.k8s.io
+    selector:
+      k8s-addon: dns-controller.addons.k8s.io
+    version: 1.12.0-alpha.1
+  - id: k8s-1.12
+    kubernetesVersion: '>=1.12.0'
+    manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -71,8 +85,15 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
     version: 1.7.0
   - id: k8s-1.7
-    kubernetesVersion: '>=1.7.0'
+    kubernetesVersion: '>=1.7.0 <1.12.0'
     manifest: networking.cilium.io/k8s-1.7.yaml
+    name: networking.cilium.io
+    selector:
+      role.kubernetes.io/networking: "1"
+    version: v1.0-kops.2
+  - id: k8s-1.12
+    kubernetesVersion: '>=1.12.0'
+    manifest: networking.cilium.io/k8s-1.12.yaml
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
@@ -17,8 +17,15 @@ spec:
       k8s-addon: kube-dns.addons.k8s.io
     version: 1.14.10
   - id: k8s-1.6
-    kubernetesVersion: '>=1.6.0'
+    kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
+    name: kube-dns.addons.k8s.io
+    selector:
+      k8s-addon: kube-dns.addons.k8s.io
+    version: 1.14.10
+  - id: k8s-1.12
+    kubernetesVersion: '>=1.12.0'
+    manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -50,8 +57,15 @@ spec:
       k8s-addon: dns-controller.addons.k8s.io
     version: 1.12.0-alpha.1
   - id: k8s-1.6
-    kubernetesVersion: '>=1.6.0'
+    kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.6.yaml
+    name: dns-controller.addons.k8s.io
+    selector:
+      k8s-addon: dns-controller.addons.k8s.io
+    version: 1.12.0-alpha.1
+  - id: k8s-1.12
+    kubernetesVersion: '>=1.12.0'
+    manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -78,8 +92,15 @@ spec:
       role.kubernetes.io/networking: "1"
     version: 1.0.20181028-kops.1
   - id: k8s-1.6
-    kubernetesVersion: '>=1.6.0'
+    kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: networking.kope.io/k8s-1.6.yaml
+    name: networking.kope.io
+    selector:
+      role.kubernetes.io/networking: "1"
+    version: 1.0.20181028-kops.1
+  - id: k8s-1.12
+    kubernetesVersion: '>=1.12.0'
+    manifest: networking.kope.io/k8s-1.12.yaml
     name: networking.kope.io
     selector:
       role.kubernetes.io/networking: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -17,8 +17,15 @@ spec:
       k8s-addon: kube-dns.addons.k8s.io
     version: 1.14.10
   - id: k8s-1.6
-    kubernetesVersion: '>=1.6.0'
+    kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
+    name: kube-dns.addons.k8s.io
+    selector:
+      k8s-addon: kube-dns.addons.k8s.io
+    version: 1.14.10
+  - id: k8s-1.12
+    kubernetesVersion: '>=1.12.0'
+    manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -50,8 +57,15 @@ spec:
       k8s-addon: dns-controller.addons.k8s.io
     version: 1.12.0-alpha.1
   - id: k8s-1.6
-    kubernetesVersion: '>=1.6.0'
+    kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.6.yaml
+    name: dns-controller.addons.k8s.io
+    selector:
+      k8s-addon: dns-controller.addons.k8s.io
+    version: 1.12.0-alpha.1
+  - id: k8s-1.12
+    kubernetesVersion: '>=1.12.0'
+    manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -17,8 +17,15 @@ spec:
       k8s-addon: kube-dns.addons.k8s.io
     version: 1.14.10
   - id: k8s-1.6
-    kubernetesVersion: '>=1.6.0'
+    kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
+    name: kube-dns.addons.k8s.io
+    selector:
+      k8s-addon: kube-dns.addons.k8s.io
+    version: 1.14.10
+  - id: k8s-1.12
+    kubernetesVersion: '>=1.12.0'
+    manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -50,8 +57,15 @@ spec:
       k8s-addon: dns-controller.addons.k8s.io
     version: 1.12.0-alpha.1
   - id: k8s-1.6
-    kubernetesVersion: '>=1.6.0'
+    kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.6.yaml
+    name: dns-controller.addons.k8s.io
+    selector:
+      k8s-addon: dns-controller.addons.k8s.io
+    version: 1.12.0-alpha.1
+  - id: k8s-1.12
+    kubernetesVersion: '>=1.12.0'
+    manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -92,8 +106,15 @@ spec:
       role.kubernetes.io/networking: "1"
     version: 2.5.0-kops.1
   - id: k8s-1.8
-    kubernetesVersion: '>=1.8.0'
+    kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
+    name: networking.weave
+    selector:
+      role.kubernetes.io/networking: "1"
+    version: 2.5.0-kops.1
+  - id: k8s-1.12
+    kubernetesVersion: '>=1.12.0'
+    manifest: networking.weave/k8s-1.12.yaml
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
xref #6273 

* the first commit is a straight copy of the latest manifest into a 1.12 manifest
* the second commit actually makes changes to the manifests
* the third commit updates the channel builder logic and test fixtures
* the fourth commit bumps cluster-proportional-autoscaler to 1.4.0 so it starts using apps/v1 APIs for scaling (xref https://github.com/kubernetes-incubator/cluster-proportional-autoscaler/pull/54)