### PR TITLE
upgrade calico to 2.6.12 to fix TTA-2018-001

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7.yaml.template
@@ -155,7 +155,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v2.6.9
+          image: quay.io/calico/node:v2.6.12
           resources:
             requests:
               cpu: 10m
@@ -244,7 +244,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v1.11.5
+          image: quay.io/calico/cni:v1.11.8
           resources:
             requests:
               cpu: 10m
@@ -337,7 +337,7 @@ spec:
         operator: Exists
       containers:
         - name: calico-kube-controllers
-          image: quay.io/calico/kube-controllers:v1.0.4
+          image: quay.io/calico/kube-controllers:v1.0.5
           resources:
             requests:
               cpu: 10m

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -667,7 +667,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		versions := map[string]string{
 			"pre-k8s-1.6": "2.4.2-kops.1",
 			"k8s-1.6":     "2.6.9-kops.1",
-			"k8s-1.7":     "2.6.9-kops.1",
+			"k8s-1.7":     "2.6.12-kops.1",
 			"k8s-1.7-v3":  "3.4.0-kops.3",
 		}
 


### PR DESCRIPTION
https://www.projectcalico.org/security-bulletins/#TTA-2018-001