### PR TITLE
Normalize etcd cluster provider names

### DIFF
--- a/pkg/commands/set_cluster.go
+++ b/pkg/commands/set_cluster.go
@@ -109,8 +109,12 @@ func SetClusterFields(fields []string, cluster *api.Cluster, instanceGroups []*a
 				c.Version = kv[1]
 			}
 		case "cluster.spec.etcdClusters[*].provider":
+			p, err := toEtcdProviderType(kv[1])
+			if err != nil {
+				return err
+			}
 			for _, etcd := range cluster.Spec.EtcdClusters {
-				etcd.Provider = api.EtcdProviderType(kv[1])
+				etcd.Provider = p
 			}
 		case "cluster.spec.etcdClusters[*].manager.image":
 			for _, etcd := range cluster.Spec.EtcdClusters {
@@ -124,4 +128,16 @@ func SetClusterFields(fields []string, cluster *api.Cluster, instanceGroups []*a
 		}
 	}
 	return nil
+}
+
+func toEtcdProviderType(in string) (api.EtcdProviderType, error) {
+	s := strings.ToLower(in)
+	switch s {
+	case "legacy":
+		return api.EtcdProviderTypeLegacy, nil
+	case "manager":
+		return api.EtcdProviderTypeManager, nil
+	default:
+		return api.EtcdProviderTypeManager, fmt.Errorf("unknown etcd provider type %q", in)
+	}
 }


### PR DESCRIPTION
Instead of just casting a string, we validate and normalize.