### PR TITLE
Openstack loadbalancers erronous modification requests

### DIFF
--- a/upup/pkg/fi/cloudup/openstacktasks/lblistener.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lblistener.go
@@ -63,7 +63,7 @@ func NewLBListenerTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Li
 	}
 
 	for _, pool := range lb.Pools {
-		poolTask, err := NewLBPoolTaskFromCloud(cloud, lifecycle, &pool, nil)
+		poolTask, err := NewLBPoolTaskFromCloud(cloud, lifecycle, &pool, find.Pool)
 		if err != nil {
 			return nil, fmt.Errorf("NewLBListenerTaskFromCloud: Failed to create new LBListener task for pool %s: %v", pool.Name, err)
 		}
@@ -72,7 +72,10 @@ func NewLBListenerTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Li
 		break
 	}
 	if find != nil {
+		// Update all search terms
 		find.ID = listenerTask.ID
+		find.Name = listenerTask.Name
+		find.Pool = listenerTask.Pool
 	}
 	return listenerTask, nil
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/lbpool.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lbpool.go
@@ -74,7 +74,9 @@ func NewLBPoolTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecy
 		a.Loadbalancer = loadbalancerTask
 	}
 	if find != nil {
+		// Update all search terms
 		find.ID = a.ID
+		find.Name = a.Name
 	}
 	return a, nil
 }


### PR DESCRIPTION
After running update after deploying a cluster I would see that there are changes needed:
```
I0128 15:47:00.139526   74377 executor.go:103] Tasks: 85 done / 90 total; 5 can run
I0128 15:47:05.417116   74377 executor.go:103] Tasks: 90 done / 90 total; 0 can run
Will modify resources:
  LBListener/api.sre.k8s.local
  	Pool                	 <nil> -> name:api.sre.k8s.local-https id:35c1c056-8a50-4fa3-9cff-0362327ab778
```

As a result of this PR I will see the following:
```
I0128 15:44:31.896008   74024 executor.go:103] Tasks: 85 done / 90 total; 5 can run
I0128 15:44:36.783791   74024 executor.go:103] Tasks: 90 done / 90 total; 0 can run
No changes need to be applied
```

@zetaab ptal