### PR TITLE
expose DryRunTarget changes and deletions

### DIFF
--- a/upup/pkg/fi/dryrun_target.go
+++ b/upup/pkg/fi/dryrun_target.go
@@ -403,6 +403,17 @@ func (t *DryRunTarget) Finish(taskMap map[string]Task) error {
 	return t.PrintReport(taskMap, t.out)
 }
 
+// Changes returns all changed tasks
+func (t *DryRunTarget) Changes() []Task {
+	var tasks []Task
+	for _, r := range t.changes {
+		if r.aIsNil {
+			tasks = append(tasks, r.changes)
+		}
+	}
+	return tasks
+}
+
 // HasChanges returns true iff any changes would have been made
 func (t *DryRunTarget) HasChanges() bool {
 	return len(t.changes)+len(t.deletions) != 0

--- a/upup/pkg/fi/dryrun_target.go
+++ b/upup/pkg/fi/dryrun_target.go
@@ -412,15 +412,18 @@ func (t *DryRunTarget) Deletions() []string {
 	return deletions
 }
 
-// Changes returns all changed task names
-func (t *DryRunTarget) Changes() []string {
-	var changes []string
+// Changes returns tasks which is going to be created or updated
+func (t *DryRunTarget) Changes() (map[string]Task, map[string]Task) {
+	creates := make(map[string]Task)
+	updates := make(map[string]Task)
 	for _, r := range t.changes {
 		if r.aIsNil {
-			changes = append(changes, getTaskName(r.changes))
+			creates[getTaskName(r.changes)] = r.changes
+		} else {
+			updates[getTaskName(r.changes)] = r.changes
 		}
 	}
-	return changes
+	return creates, updates
 }
 
 // HasChanges returns true iff any changes would have been made

--- a/upup/pkg/fi/dryrun_target.go
+++ b/upup/pkg/fi/dryrun_target.go
@@ -403,15 +403,24 @@ func (t *DryRunTarget) Finish(taskMap map[string]Task) error {
 	return t.PrintReport(taskMap, t.out)
 }
 
-// Changes returns all changed tasks
-func (t *DryRunTarget) Changes() []Task {
-	var tasks []Task
+// Deletions returns all task names which is going to be deleted
+func (t *DryRunTarget) Deletions() []string {
+	var deletions []string
+	for _, d := range t.deletions {
+		deletions = append(deletions, d.TaskName())
+	}
+	return deletions
+}
+
+// Changes returns all changed task names
+func (t *DryRunTarget) Changes() []string {
+	var changes []string
 	for _, r := range t.changes {
 		if r.aIsNil {
-			tasks = append(tasks, r.changes)
+			changes = append(changes, getTaskName(r.changes))
 		}
 	}
-	return tasks
+	return changes
 }
 
 // HasChanges returns true iff any changes would have been made


### PR DESCRIPTION
Currently it is (almost) impossible to read dryrun changes using machines. DryRunTarget changes is exposed only with function `PrintReport`. However, that is quite difficult to read with machine, so that is why I would like to ask expose the changed tasks. Is there reason why this `changes` field is private?

