### PR TITLE
implement ig deletegroup for openstack

### DIFF
--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -456,7 +456,7 @@ func (c *openstackCloud) DeleteGroup(g *cloudinstances.CloudInstanceGroup) error
 		}
 	}
 
-	err := c.DeleteServerGroup(grp.ID)
+	err = c.DeleteServerGroup(grp.ID)
 	if err != nil {
 		return fmt.Errorf("Could not server group %q: %v", grp.ID, err)
 	}


### PR DESCRIPTION
implements possibility to delete instancegroup in openstack. This PR needs #6385 to be merged first, before it is merged this PR tests will fail.

/sig openstack