### PR TITLE
Ability to scale down instancegroup in openstack

### DIFF
--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -153,9 +153,12 @@ func (b *ServerGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	for _, ig := range b.InstanceGroups {
 		glog.V(2).Infof("Found instance group with name %s and role %v.", ig.Name, ig.Spec.Role)
 		sgTask := &openstacktasks.ServerGroup{
-			Name:      s(fmt.Sprintf("%s-%s", clusterName, ig.Name)),
-			Policies:  []string{"anti-affinity"},
-			Lifecycle: b.Lifecycle,
+			Name:        s(fmt.Sprintf("%s-%s", clusterName, ig.Name)),
+			ClusterName: s(clusterName),
+			IGName:      s(ig.Name),
+			Policies:    []string{"anti-affinity"},
+			Lifecycle:   b.Lifecycle,
+			MaxSize:     ig.Spec.MaxSize,
 		}
 		c.AddTask(sgTask)
 

--- a/upup/pkg/fi/cloudup/openstacktasks/servergroup.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/servergroup.go
@@ -18,20 +18,25 @@ package openstacktasks
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 )
 
 //go:generate fitask -type=ServerGroup
 type ServerGroup struct {
-	ID        *string
-	Name      *string
-	Members   []string
-	Policies  []string
-	Lifecycle *fi.Lifecycle
+	ID          *string
+	Name        *string
+	ClusterName *string
+	IGName      *string
+	Members     []string
+	Policies    []string
+	MaxSize     *int32
+	Lifecycle   *fi.Lifecycle
 }
 
 var _ fi.CompareWithID = &ServerGroup{}
@@ -62,17 +67,26 @@ func (s *ServerGroup) Find(context *fi.Context) (*ServerGroup, error) {
 				return nil, fmt.Errorf("Found multiple server groups with name %s", fi.StringValue(s.Name))
 			}
 			actual = &ServerGroup{
-				Name:      fi.String(serverGroup.Name),
-				ID:        fi.String(serverGroup.ID),
-				Members:   serverGroup.Members,
-				Lifecycle: s.Lifecycle,
-				Policies:  serverGroup.Policies,
+				Name:        fi.String(serverGroup.Name),
+				ClusterName: s.ClusterName,
+				IGName:      s.IGName,
+				ID:          fi.String(serverGroup.ID),
+				Members:     serverGroup.Members,
+				Lifecycle:   s.Lifecycle,
+				Policies:    serverGroup.Policies,
+				MaxSize:     fi.Int32(int32(len(serverGroup.Members))),
 			}
 		}
 	}
 	if actual == nil {
 		return nil, nil
 	}
+
+	// ignore if IG is scaled up, this is handled in instancetasks
+	if fi.Int32Value(actual.MaxSize) < fi.Int32Value(s.MaxSize) {
+		s.MaxSize = actual.MaxSize
+	}
+
 	s.ID = actual.ID
 	s.Members = actual.Members
 	return actual, nil
@@ -113,6 +127,31 @@ func (_ *ServerGroup) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, cha
 		}
 		e.ID = fi.String(g.ID)
 		return nil
+	} else if changes.MaxSize != nil && fi.Int32Value(a.MaxSize) > fi.Int32Value(changes.MaxSize) {
+		currentLastIndex := fi.Int32Value(a.MaxSize)
+
+		for currentLastIndex > fi.Int32Value(changes.MaxSize) {
+			iName := strings.ToLower(fmt.Sprintf("%s-%d.%s", fi.StringValue(a.IGName), currentLastIndex, fi.StringValue(a.ClusterName)))
+			instanceName := strings.Replace(iName, ".", "-", -1)
+			opts := servers.ListOpts{
+				Name: fmt.Sprintf("^%s$", instanceName),
+			}
+			instances, err := t.Cloud.ListInstances(opts)
+			if err != nil {
+				return fmt.Errorf("error fetching instance list: %v", err)
+			}
+
+			if len(instances) == 1 {
+				glog.V(2).Infof("Openstack task ServerGroup scaling down instance %s", instanceName)
+				err := t.Cloud.DeleteInstanceWithID(instances[0].ID)
+				if err != nil {
+					return fmt.Errorf("Could not delete instance %s: %v", instanceName, err)
+				}
+			} else {
+				return fmt.Errorf("found %d instances with name: %s", len(instances), instanceName)
+			}
+			currentLastIndex -= 1
+		}
 	}
 
 	glog.V(2).Infof("Openstack task ServerGroup::RenderOpenstack did nothing")


### PR DESCRIPTION
Fixes issue #6417 

Example how it works:
```
% openstack server list|grep sre.k8s.local-nodes
| d61764c9-8945-4e3c-b2f5-a52854bdb0bb | sre.k8s.local-nodes-5         | ACTIVE | sre.k8s.local=10.1.8.20                | debian-9-openstack-amd64 | m1.medium |
| e23678d0-3ce9-4896-97d9-e1dc46dae915 | sre.k8s.local-nodes-4         | ACTIVE | sre.k8s.local=10.1.8.21                | debian-9-openstack-amd64 | m1.medium |
| 2efe0513-07df-46a7-b317-62713e377f6c | sre.k8s.local-nodes-3         | ACTIVE | sre.k8s.local=10.1.8.12                | debian-9-openstack-amd64 | m1.medium |
| 51875385-7989-4d78-aeec-478fd94d7fff | sre.k8s.local-nodes-2         | ACTIVE | sre.k8s.local=10.1.8.19                | debian-9-openstack-amd64 | m1.medium |
| 716eabf8-0526-431b-805a-7eb1218a622e | sre.k8s.local-nodes-1         | ACTIVE | sre.k8s.local=10.1.8.9                 | debian-9-openstack-amd64 | m1.medium |
```

Set ig maxsize from 5 -> 3 using `kops edit ig --name sre.k8s.local nodes`

```
% kops update cluster --name sre.k8s.local
...
  ServerGroup/sre.k8s.local-nodes
  	MaxSize             	 5 -> 3
...
```

Execute changes
```
% kops update cluster --name sre.k8s.local --yes
```

Verify that it did change
```
% openstack server list|grep sre.k8s.local-nodes
| 2efe0513-07df-46a7-b317-62713e377f6c | sre.k8s.local-nodes-3         | ACTIVE | sre.k8s.local=10.1.8.12                | debian-9-openstack-amd64 | m1.medium |
| 51875385-7989-4d78-aeec-478fd94d7fff | sre.k8s.local-nodes-2         | ACTIVE | sre.k8s.local=10.1.8.19                | debian-9-openstack-amd64 | m1.medium |
| 716eabf8-0526-431b-805a-7eb1218a622e | sre.k8s.local-nodes-1         | ACTIVE | sre.k8s.local=10.1.8.9                 | debian-9-openstack-amd64 | m1.medium |
```

This needs #6385 to be merged first, tests will fail before that

/hold
/sig openstack
