### PR TITLE
Use the forward plugin instead of proxy plugin in CoreDNS

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
@@ -68,7 +68,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        proxy . /etc/resolv.conf
+        forward . /etc/resolv.conf
         loop
         cache 30
         loadbalance

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -211,7 +211,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 	if kubeDNS.Provider == "CoreDNS" {
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.3.0-kops.1"
+			version := "1.3.0-kops.2"
 
 			{
 				location := key + "/k8s-1.6.yaml"


### PR DESCRIPTION
Modify the CoreDNS configuration to use the forward plugin instead of the existing proxy plugin.
Refer: https://github.com/kubernetes/kubernetes/issues/73254