### PR TITLE
Openstack Floating IP Deletion

### DIFF
--- a/pkg/resources/openstack/floatingip.go
+++ b/pkg/resources/openstack/floatingip.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	l3floatingip "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
+	"k8s.io/kops/pkg/resources"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
+)
+
+const (
+	typeFloatingIP = "FloatingIP"
+)
+
+func DeleteFloatingIP(cloud fi.Cloud, r *resources.Resource) error {
+	return cloud.(openstack.OpenstackCloud).DeleteFloatingIP(r.ID)
+}
+
+func DeleteL3FloatingIP(cloud fi.Cloud, r *resources.Resource) error {
+	return cloud.(openstack.OpenstackCloud).DeleteL3FloatingIP(r.ID)
+}
+
+func (os *clusterDiscoveryOS) listL3FloatingIPs(routerID string) ([]*resources.Resource, error) {
+	var resourceTrackers []*resources.Resource
+	l3floatingIPs, err := os.osCloud.ListL3FloatingIPs(l3floatingip.ListOpts{})
+	if err != nil {
+		return resourceTrackers, err
+	}
+	for _, floatingIP := range l3floatingIPs {
+		if floatingIP.RouterID == routerID {
+			resourceTracker := &resources.Resource{
+				Name:    floatingIP.FloatingIP,
+				ID:      floatingIP.ID,
+				Type:    typeFloatingIP,
+				Deleter: DeleteL3FloatingIP,
+			}
+			resourceTrackers = append(resourceTrackers, resourceTracker)
+		}
+	}
+	return resourceTrackers, nil
+}
+
+func (os *clusterDiscoveryOS) listFloatingIPs(instanceID string) ([]*resources.Resource, error) {
+	var resourceTrackers []*resources.Resource
+	floatingIPs, err := os.osCloud.ListFloatingIPs()
+	if err != nil {
+		return resourceTrackers, err
+	}
+	for _, floatingIP := range floatingIPs {
+		if floatingIP.InstanceID == instanceID {
+			resourceTracker := &resources.Resource{
+				Name:    floatingIP.IP,
+				ID:      floatingIP.ID,
+				Type:    typeFloatingIP,
+				Deleter: DeleteFloatingIP,
+			}
+			resourceTrackers = append(resourceTrackers, resourceTracker)
+		}
+	}
+	return resourceTrackers, nil
+}

--- a/pkg/resources/openstack/instances.go
+++ b/pkg/resources/openstack/instances.go
@@ -38,6 +38,14 @@ func (os *clusterDiscoveryOS) ListInstances() ([]*resources.Resource, error) {
 	}
 
 	for _, instance := range instances {
+
+		// Clean up any bound floating IP's
+		floatingIPs, err := os.listFloatingIPs(instance.ID)
+		if err != nil {
+			return resourceTrackers, err
+		}
+		resourceTrackers = append(resourceTrackers, floatingIPs...)
+
 		resourceTracker := &resources.Resource{
 			Name: instance.Name,
 			ID:   instance.ID,

--- a/pkg/resources/openstack/network.go
+++ b/pkg/resources/openstack/network.go
@@ -55,6 +55,14 @@ func (os *clusterDiscoveryOS) ListNetwork() ([]*resources.Resource, error) {
 			return resourceTrackers, err
 		}
 		for _, router := range routers {
+
+			// Get the floating IP's associated to this router
+			floatingIPs, err := os.listL3FloatingIPs(router.ID)
+			if err != nil {
+				return resourceTrackers, err
+			}
+			resourceTrackers = append(resourceTrackers, floatingIPs...)
+
 			resourceTracker := &resources.Resource{
 				Name: router.Name,
 				ID:   router.ID,

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -252,10 +252,13 @@ type OpenstackCloud interface {
 	GetFloatingIP(id string) (fip *floatingips.FloatingIP, err error)
 
 	AssociateFloatingIPToInstance(serverID string, opts floatingips.AssociateOpts) (err error)
+
 	ListFloatingIPs() (fips []floatingips.FloatingIP, err error)
 	ListL3FloatingIPs(opts l3floatingip.ListOpts) (fips []l3floatingip.FloatingIP, err error)
 	CreateFloatingIP(opts floatingips.CreateOpts) (*floatingips.FloatingIP, error)
 	CreateL3FloatingIP(opts l3floatingip.CreateOpts) (fip *l3floatingip.FloatingIP, err error)
+	DeleteFloatingIP(id string) error
+	DeleteL3FloatingIP(id string) error
 }
 
 type openstackCloud struct {

--- a/upup/pkg/fi/cloudup/openstack/floatingip.go
+++ b/upup/pkg/fi/cloudup/openstack/floatingip.go
@@ -97,7 +97,7 @@ func (c *openstackCloud) CreateL3FloatingIP(opts l3floatingip.CreateOpts) (fip *
 func (c *openstackCloud) ListFloatingIPs() (fips []floatingips.FloatingIP, err error) {
 
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		pages, err := floatingips.List(c.novaClient).AllPages()
+		pages, err := floatingips.List(c.ComputeClient()).AllPages()
 		if err != nil {
 			return false, fmt.Errorf("Failed to list floating ip: %v", err)
 		}
@@ -136,4 +136,40 @@ func (c *openstackCloud) ListL3FloatingIPs(opts l3floatingip.ListOpts) (fips []l
 		return fips, err
 	}
 	return fips, nil
+}
+
+func (c *openstackCloud) DeleteFloatingIP(id string) (err error) {
+
+	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
+		err = l3floatingip.Delete(c.ComputeClient(), id).ExtractErr()
+		if err != nil {
+			return false, fmt.Errorf("Failed to delete floating ip %s: %v", id, err)
+		}
+		return true, nil
+	})
+	if !done {
+		if err == nil {
+			err = wait.ErrWaitTimeout
+		}
+		return err
+	}
+	return err
+}
+
+func (c *openstackCloud) DeleteL3FloatingIP(id string) (err error) {
+
+	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
+		err = l3floatingip.Delete(c.NetworkingClient(), id).ExtractErr()
+		if err != nil {
+			return false, fmt.Errorf("Failed to delete L3 floating ip %s: %v", id, err)
+		}
+		return true, nil
+	})
+	if !done {
+		if err == nil {
+			err = wait.ErrWaitTimeout
+		}
+		return err
+	}
+	return err
 }


### PR DESCRIPTION
Adding the addition of floating IP resources for deletion.

Here are the pertinent elements of the cluster delete log:
```

TYPE		NAME										ID
FloatingIP	<FLOATING_IP_1>									2294df09-0f91-41f4-bf6f-b249c51f810f
FloatingIP	<FLOATING_IP_2>									d68cfc48-f9a1-4f1c-871a-1a4526d24c55

```
one of these is a bastion, and one is a loadbalancer.

```
FloatingIP:2294df09-0f91-41f4-bf6f-b249c51f810f	ok
FloatingIP:d68cfc48-f9a1-4f1c-871a-1a4526d24c55	ok
```

And of course...
```
Deleted cluster: "derek.k8s.local"
```

/sig openstack