### PR TITLE
fix error when updating/creating lb in openstack

### DIFF
--- a/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
@@ -56,10 +56,8 @@ func (e *FloatingIP) FindIPAddress(context *fi.Context) (*string, error) {
 		if err != nil {
 			return nil, err
 		}
-		if len(fips) == 1 {
-			if fips[0].PortID == fi.StringValue(e.LB.PortID) {
-				return &fips[0].FloatingIP, nil
-			}
+		if len(fips) == 1 && fips[0].PortID == fi.StringValue(e.LB.PortID) {
+			return &fips[0].FloatingIP, nil
 		}
 		// not found
 		return nil, nil

--- a/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
@@ -48,6 +48,22 @@ func (e *FloatingIP) FindIPAddress(context *fi.Context) (*string, error) {
 	}
 
 	cloud := context.Cloud.(openstack.OpenstackCloud)
+	// try to find using portid, the floatingips always attached to port
+	if e.ID == nil && e.LB != nil && e.LB.PortID != nil {
+		fips, err := cloud.ListL3FloatingIPs(l3floatingip.ListOpts{
+			PortID: fi.StringValue(e.LB.PortID),
+		})
+		if err != nil {
+			return nil, err
+		}
+		if len(fips) == 1 {
+			if fips[0].PortID == fi.StringValue(e.LB.PortID) {
+				return &fips[0].FloatingIP, nil
+			}
+		}
+		// not found
+		return nil, nil
+	}
 
 	fip, err := cloud.GetFloatingIP(fi.StringValue(e.ID))
 	if err != nil {


### PR DESCRIPTION
before:
```
% ~/go/bin/kops update cluster --name sre.k8s.local
I0201 15:19:36.050171   35045 apply_cluster.go:558] Gossip DNS: skipping DNS validation
I0201 15:19:36.127396   35045 executor.go:103] Tasks: 0 done / 89 total; 41 can run
I0201 15:19:37.793851   35045 executor.go:103] Tasks: 41 done / 89 total; 21 can run
I0201 15:19:38.834867   35045 executor.go:103] Tasks: 62 done / 89 total; 12 can run
I0201 15:19:39.658100   35045 executor.go:103] Tasks: 74 done / 89 total; 6 can run
I0201 15:19:40.227216   35045 executor.go:103] Tasks: 80 done / 89 total; 1 can run
I0201 15:19:40.607063   35045 executor.go:103] Tasks: 81 done / 89 total; 4 can run
I0201 15:19:45.773743   35045 context.go:231] hit maximum retries 4 with error GetFloatingIP: fetching floating IP failed: Resource not found
W0201 15:19:45.774159   35045 executor.go:130] error running task "Keypair/master" (9m54s remaining to succeed): error finding address for *openstacktasks.FloatingIP {"Name":"fip-api.sre.k8s.local","ID":"29883b66-733b-4c0a-8ce1-9e1ae13cc2f8","Server":null,"LB":{"ID":"2753cab4-4d02-4422-849e-0c1139cd4e6e","Name":"api.sre.k8s.local","Subnet":"zone-1.sre.k8s.local","VipSubnet":null,"Lifecycle":"Sync","PortID":"5d1d3d2a-9fd6-4d0e-81b2-5610b7e3d9d7"},"Lifecycle":"Sync"}: GetFloatingIP: fetching floating IP failed: Resource not found
I0201 15:19:45.774206   35045 executor.go:103] Tasks: 84 done / 89 total; 5 can run
I0201 15:19:47.352172   35045 executor.go:103] Tasks: 89 done / 89 total; 0 can run
```

after:
```
% ~/go/bin/kops update cluster --name sre.k8s.local
I0201 15:21:13.892666   35247 apply_cluster.go:558] Gossip DNS: skipping DNS validation
I0201 15:21:13.959864   35247 executor.go:103] Tasks: 0 done / 89 total; 41 can run
I0201 15:21:15.910621   35247 executor.go:103] Tasks: 41 done / 89 total; 21 can run
I0201 15:21:17.205824   35247 executor.go:103] Tasks: 62 done / 89 total; 12 can run
I0201 15:21:18.090179   35247 executor.go:103] Tasks: 74 done / 89 total; 6 can run
I0201 15:21:18.921335   35247 executor.go:103] Tasks: 80 done / 89 total; 1 can run
I0201 15:21:19.200064   35247 executor.go:103] Tasks: 81 done / 89 total; 4 can run
I0201 15:21:19.695067   35247 executor.go:103] Tasks: 85 done / 89 total; 4 can run
I0201 15:21:20.882301   35247 executor.go:103] Tasks: 89 done / 89 total; 0 can run
```

/sig openstack

@drekle could you test this? I do not have possibility to recreate lbaas currently. So I was thinking to run tests like 1) create new kops cluster (is lbaas working correctly?) 2) update something in cluster (like scale and run update --yes) 3) delete cluster. I have only executed commands without `--yes`