### PR TITLE
Update Loadbalancer Pools

### DIFF
--- a/upup/pkg/fi/cloudup/openstacktasks/lb.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lb.go
@@ -72,11 +72,13 @@ func NewLBTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecycle,
 		Lifecycle: lifecycle,
 		PortID:    fi.String(lb.VipPortID),
 		Subnet:    fi.String(sub.Name),
+		VipSubnet: fi.String(lb.VipSubnetID),
 	}
 
 	if find != nil {
 		find.ID = actual.ID
-		find.PortID = fi.String(lb.VipPortID)
+		find.PortID = actual.PortID
+		find.VipSubnet = actual.VipSubnet
 	}
 	return actual, nil
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/servergroup.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/servergroup.go
@@ -64,7 +64,7 @@ func (s *ServerGroup) Find(context *fi.Context) (*ServerGroup, error) {
 			actual = &ServerGroup{
 				Name:      fi.String(serverGroup.Name),
 				ID:        fi.String(serverGroup.ID),
-				Members:   nil, // TODO implement logic how servergrp members are updated
+				Members:   serverGroup.Members,
 				Lifecycle: s.Lifecycle,
 				Policies:  serverGroup.Policies,
 			}
@@ -74,6 +74,7 @@ func (s *ServerGroup) Find(context *fi.Context) (*ServerGroup, error) {
 		return nil, nil
 	}
 	s.ID = actual.ID
+	s.Members = actual.Members
 	return actual, nil
 }
 


### PR DESCRIPTION
/sig openstack

An issue exists in pool association during an update where the members of a server group are not iterated over as they are nil, additionally this will fail if the server group exists prior to the cluster being deployed.

@zetaab ptal