### PR TITLE
fix hostnames in kops openstack

### DIFF
--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -80,14 +80,9 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 			return fmt.Errorf("Failed to create UUID for instance: %v", err)
 		}
 		// FIXME: Must ensure 63 or less characters
-		instanceName := fi.String(
-			strings.ToLower(
-				fmt.Sprintf("%s-%d.%s", ig.Name, i+1, b.ClusterName()),
-			),
-		)
-
 		// replace all dots with -, this is needed to get external cloudprovider working
-		instanceName = strings.Replace(instanceName, ".", "-", -1)
+		iName := strings.ToLower(fmt.Sprintf("%s-%d.%s", ig.Name, i+1, b.ClusterName()))
+		instanceName := fi.String(strings.Replace(iName, ".", "-", -1))
 
 		securityGroupName := b.SecurityGroupName(ig.Spec.Role)
 		securityGroup := b.LinkToSecurityGroup(securityGroupName)

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -85,6 +85,10 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 				fmt.Sprintf("%s-%d.%s", ig.Name, i+1, b.ClusterName()),
 			),
 		)
+
+		// replace all dots with -, this is needed to get external cloudprovider working
+		instanceName = strings.Replace(instanceName, ".", "-", -1)
+
 		securityGroupName := b.SecurityGroupName(ig.Spec.Role)
 		securityGroup := b.LinkToSecurityGroup(securityGroupName)
 

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -58,6 +58,7 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 
 		igMeta[openstack.TagClusterName] = b.ClusterName()
 	}
+	igMeta["k8s"] = b.ClusterName()
 
 	startupScript, err := b.BootstrapScript.ResourceNodeUp(ig, b.Cluster)
 	if err != nil {
@@ -81,7 +82,7 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 		// FIXME: Must ensure 63 or less characters
 		instanceName := fi.String(
 			strings.ToLower(
-				fmt.Sprintf("%s-%d", *sg.Name, i+1),
+				fmt.Sprintf("%s-%d.%s", ig.Name, i+1, b.ClusterName()),
 			),
 		)
 		securityGroupName := b.SecurityGroupName(ig.Spec.Role)

--- a/pkg/resources/openstack/ports.go
+++ b/pkg/resources/openstack/ports.go
@@ -38,7 +38,8 @@ func (os *clusterDiscoveryOS) ListPorts() ([]*resources.Resource, error) {
 	}
 
 	for _, port := range ports {
-		if strings.Contains(port.Name, os.clusterName) {
+		clusteReplaced := strings.Replace(os.clusterName, ".", "-", -1)
+		if strings.HasSuffix(port.Name, clusteReplaced) {
 			resourceTracker := &resources.Resource{
 				Name: port.Name,
 				ID:   port.ID,


### PR DESCRIPTION
fixes #6441 

```
% openstack server list
+--------------------------------------+-------------------------------+--------+-----------------------------------------+--------+----------+
| ID                                   | Name                          | Status | Networks                                | Image  | Flavor   |
+--------------------------------------+-------------------------------+--------+-----------------------------------------+--------+----------+
| 83df9825-22cd-49c0-8f0e-ff90a7372832 | bastions-1.oma.k8s.local      | ACTIVE | oma.k8s.local=10.1.1.196, 192.168.1.206 | ubuntu | ds1G     |
| a83c3663-a07e-4cca-a8d2-53e4905d1259 | nodes-1.oma.k8s.local         | ACTIVE | oma.k8s.local=10.1.1.156                | ubuntu | m1.small |
| e3845789-1c6c-40ac-bd51-dbfd29df9051 | master-nova-2-1.oma.k8s.local | ACTIVE | oma.k8s.local=10.1.2.218                | ubuntu | m1.small |
| 0ca71cd0-b0fb-41fc-8628-296f3007e5b8 | master-nova-1-1.oma.k8s.local | ACTIVE | oma.k8s.local=10.1.1.12                 | ubuntu | m1.small |
| d4fed7f6-21aa-484a-8e1b-733eadb14060 | master-nova-3-1.oma.k8s.local | ACTIVE | oma.k8s.local=10.1.1.225                | ubuntu | m1.small |
+--------------------------------------+-------------------------------+--------+-----------------------------------------+--------+----------+
```

Kubernetes: (these will be fixed if openstack cloudprovider will start parsing hostnames correctly)
```
% kubectl get nodes
NAME                            STATUS     ROLES     AGE       VERSION
master-nova-1-1.oma.k8s.local   Ready      master    48s       v1.11.6
master-nova-2-1.oma.k8s.local   Ready      master    27s       v1.11.6
master-nova-3-1.oma.k8s.local   Ready      master    45s       v1.11.6
nodes-1.oma.k8s.local           NotReady   node      2s        v1.11.6
```

and hostnames are now in machines like `bastions-1`, `nodes-1`, `master-nova-2-1` and so on.

