### PR TITLE
External out-of-tree CloudControllerManager support for openstack

### DIFF
--- a/docs/tutorial/openstack.md
+++ b/docs/tutorial/openstack.md
@@ -64,3 +64,32 @@ kops delete cluster my-cluster.k8s.local --yes
 * `--os-kubelet-ignore-az=true` Nova and Cinder have different availability zones, more information [Kubernetes docs](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#block-storage)
 * `--os-octavia=true` If Octavia Loadbalancer api should be used instead of old lbaas v2 api.
 
+
+# Using external cloud controller manager
+If you want use [External CCM](https://github.com/kubernetes/cloud-provider-openstack) in your installation, this section contains instructions what you should do to get it up and running.
+
+Enable featureflag:
+
+```
+export KOPS_FEATURE_FLAGS=AlphaAllowOpenstack,+EnableExternalCloudController
+```
+
+Create cluster without `--yes` flag (or modify existing cluster):
+
+```
+kops edit cluster <cluster>
+```
+
+Add following to clusterspec:
+
+```
+  cloudControllerManager:
+    image: jesseh/occm:latest <- you can use this or compile your own
+    logLevel: 2
+```
+
+Finally
+
+```
+kops update cluster --name <cluster> --yes
+```

--- a/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.11.yaml.template
@@ -1,0 +1,95 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+  labels:
+    k8s-addon: openstack.addons.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-addon: openstack.addons.k8s.io
+  name: system:openstack
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-addon: openstack.addons.k8s.io
+  name: system:openstack
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openstack
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: kube-system
+  name: openstack-cloud-provider
+  labels:
+    k8s-app: openstack-cloud-provider
+    k8s-addon: openstack.addons.k8s.io
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: openstack-cloud-provider
+  template:
+    metadata:
+      labels:
+        name: openstack-cloud-provider
+    spec:
+      # run on the host network (don't depend on CNI)
+      hostNetwork: true
+      # run on each master node
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsUser: 1001
+      serviceAccountName: cloud-controller-manager
+      tolerations:
+      # this is required so CCM can bootstrap itself
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      # this is to have the daemonset runnable on master nodes
+      # the taint may vary depending on your cluster setup
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      # this is to restrict CCM to only run on master nodes
+      # the node selector may vary depending on your cluster setup
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      containers:
+      - name: openstack-cloud-controller-manager
+        image: "{{- .ExternalCloudControllerManager.Image }}"
+        args:
+          - /bin/openstack-cloud-controller-manager
+          - --v={{ .ExternalCloudControllerManager.LogLevel }}
+          - --cloud-config=/etc/kubernetes/cloud.config
+          - --cloud-provider=openstack
+          - --master=http://localhost:8080
+        volumeMounts:
+        - mountPath: /etc/kubernetes/cloud.config
+          name: cloudconfig
+          readOnly: true
+      volumes:
+      - hostPath:
+          path: /etc/kubernetes/cloud.config
+        name: cloudconfig

--- a/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.11.yaml.template
@@ -8,33 +8,162 @@ metadata:
     k8s-addon: openstack.addons.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-node-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-node-controller
+subjects:
+- kind: ServiceAccount
+  name: cloud-node-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:pvl-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:pvl-controller
+subjects:
+- kind: ServiceAccount
+  name: pvl-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    k8s-addon: openstack.addons.k8s.io
-  name: system:openstack
+  name: system:cloud-controller-manager
 rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
 - apiGroups:
   - ""
   resources:
   - configmaps
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: ClusterRole
 metadata:
-  labels:
-    k8s-addon: openstack.addons.k8s.io
-  name: system:openstack
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:openstack
-subjects:
-- kind: ServiceAccount
-  name: cloud-controller-manager
-  namespace: kube-system
+  name: system:cloud-node-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:pvl-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -84,7 +213,8 @@ spec:
           - --v={{ .ExternalCloudControllerManager.LogLevel }}
           - --cloud-config=/etc/kubernetes/cloud.config
           - --cloud-provider=openstack
-          - --master=http://localhost:8080
+          - --use-service-account-credentials=true
+          - --address=127.0.0.1
         volumeMounts:
         - mountPath: /etc/kubernetes/cloud.config
           name: cloudconfig

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -1219,40 +1219,61 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 	}
 
 	if featureflag.EnableExternalCloudController.Enabled() && b.cluster.Spec.ExternalCloudControllerManager != nil {
-		{
-			key := "core.addons.k8s.io"
-			version := "1.7.0"
+		// cloudprovider specific out-of-tree controller
+		if kops.CloudProviderID(b.cluster.Spec.CloudProvider) == kops.CloudProviderOpenstack {
+			{
+				key := "openstack.addons.k8s.io"
+				version := "1.11.0"
 
-			location := key + "/k8s-1.7.yaml"
-			id := "k8s-1.7-ccm"
+				location := key + "/k8s-1.11.yaml"
+				id := "k8s-1.11-ccm"
 
-			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
-				Name:              fi.String(key),
-				Version:           fi.String(version),
-				Selector:          map[string]string{"k8s-addon": key},
-				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.7.0 <1.12.0",
-				Id:                id,
-			})
-			manifests[key+"-"+id] = "addons/" + location
-		}
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(version),
+					Manifest:          fi.String(location),
+					Selector:          map[string]string{"k8s-addon": key},
+					KubernetesVersion: ">=1.11.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
+		} else {
+			{
+				key := "core.addons.k8s.io"
+				version := "1.7.0"
 
-		{
-			key := "core.addons.k8s.io"
-			version := "1.12.0"
+				location := key + "/k8s-1.7.yaml"
+				id := "k8s-1.7-ccm"
 
-			location := key + "/k8s-1.12.yaml"
-			id := "k8s-1.12-ccm"
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(version),
+					Selector:          map[string]string{"k8s-addon": key},
+					Manifest:          fi.String(location),
+					KubernetesVersion: ">=1.7.0 <1.12.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
 
-			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
-				Name:              fi.String(key),
-				Version:           fi.String(version),
-				Selector:          map[string]string{"k8s-addon": key},
-				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.12.0",
-				Id:                id,
-			})
-			manifests[key+"-"+id] = "addons/" + location
+			{
+				key := "core.addons.k8s.io"
+				version := "1.12.0"
+
+				location := key + "/k8s-1.12.yaml"
+				id := "k8s-1.12-ccm"
+
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(version),
+					Selector:          map[string]string{"k8s-addon": key},
+					Manifest:          fi.String(location),
+					KubernetesVersion: ">=1.12.0",
+					Id:                id,
+				})
+				manifests[key+"-"+id] = "addons/" + location
+			}
 		}
 	}
 


### PR DESCRIPTION
fixes #6439 for openstack

This adds possibility to use kops with external CCM. In case of openstack that provider contains more features than in tree one. Also in-tree one is deprecated https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider and codes is going to be removed in some point.