### PR TITLE
[jjo] add docker-ce 18.06.2 for CVE-2019-5736

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -525,50 +525,50 @@ var dockerVersions = []dockerVersion{
 
 	// 18.03.1 - Bionic
 	{
-		DockerVersion: "18.03.1",
+		DockerVersion: "18.06.2",
 		Name:          "docker-ce",
 		Distros:       []distros.Distribution{distros.DistributionBionic},
 		Architectures: []Architecture{ArchitectureAmd64},
-		Version:       "18.03.1~ce~3-0~ubuntu",
-		Source:        "https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce_18.03.1~ce~3-0~ubuntu_amd64.deb",
-		Hash:          "b55b32bd0e9176dd32b1e6128ad9fda10a65cc8b",
+		Version:       "18.06.2~ce~3-0~ubuntu",
+		Source:        "https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce_18.06.2~ce~3-0~ubuntu_amd64.deb",
+		Hash:          "9607c67644e3e1ad9661267c99499004f2e84e05",
 		Dependencies:  []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
 		//Depends: iptables, init-system-helpers, lsb-base, libapparmor1, libc6, libdevmapper1.02.1, libltdl7, libeseccomp2, libsystemd0
 		//Recommends: aufs-tools, ca-certificates, cgroupfs-mount | cgroup-lite, git, xz-utils, apparmor
 	},
 
-	// 18.06.1 - Debian Stretch
+	// 18.06.2 - Debian Stretch
 	{
 
-		DockerVersion: "18.06.1",
+		DockerVersion: "18.06.2",
 		Name:          "docker-ce",
 		Distros:       []distros.Distribution{distros.DistributionDebian9},
 		Architectures: []Architecture{ArchitectureAmd64},
-		Version:       "18.06.1~ce-0~debian",
-		Source:        "https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_18.06.1~ce~3-0~debian_amd64.deb",
-		Hash:          "18473b80e61b6d4eb8b52d87313abd71261287e5",
+		Version:       "18.06.2~ce-0~debian",
+		Source:        "https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_18.06.2~ce~3-0~debian_amd64.deb",
+		Hash:          "aad1efd2c90725034e996c6a368ccc2bf41ca5b8",
 		Dependencies:  []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 	},
 
-	// 18.06.1 - CentOS / Rhel7 (two packages)
+	// 18.06.2 - CentOS / Rhel7 (two packages)
 	{
-		DockerVersion: "18.06.1",
+		DockerVersion: "18.06.2",
 		Name:          "container-selinux-2",
 		Distros:       []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
 		Architectures: []Architecture{ArchitectureAmd64},
-		Version:       "18.06.1.ce",
+		Version:       "18.06.2.ce",
 		Source:        "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
 		Hash:          "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
 		Dependencies:  []string{"policycoreutils-python"},
 	},
 	{
-		DockerVersion: "18.06.1",
+		DockerVersion: "18.06.2",
 		Name:          "docker-ce",
 		Distros:       []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
 		Architectures: []Architecture{ArchitectureAmd64},
-		Version:       "18.06.1.ce",
-		Source:        "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-18.06.1.ce-3.el7.x86_64.rpm",
-		Hash:          "0a1325e570c5e54111a79623c9fd0c0c714d3a11",
+		Version:       "18.06.2.ce",
+		Source:        "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-18.06.2.ce-3.el7.x86_64.rpm",
+		Hash:          "456eb7c5bfb37fac342e9ade21b602c076c5b367",
 		Dependencies:  []string{"libtool-ltdl", "libseccomp", "libcgroup"},
 	},
 }

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -501,6 +501,20 @@ var dockerVersions = []dockerVersion{
 		//Recommends: aufs-tools, ca-certificates, cgroupfs-mount | cgroup-lite, git, xz-utils, apparmor
 	},
 
+	// 18.06.2 - Xenial
+	{
+		DockerVersion: "18.06.2",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionXenial},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "18.06.2~ce~3-0~ubuntu",
+		Source:        "https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_18.06.2~ce~3-0~ubuntu_amd64.deb",
+		Hash:          "03e5eaae9c84b144e1140d9b418e43fce0311892",
+		Dependencies:  []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		//Depends: iptables, init-system-helpers, lsb-base, libapparmor1, libc6, libdevmapper1.02.1, libltdl7, libeseccomp2, libsystemd0
+		//Recommends: aufs-tools, ca-certificates, cgroupfs-mount | cgroup-lite, git, xz-utils, apparmor
+	},
+
 	// 17.09.0 - Centos / Rhel7 (two packages)
 	{
 		DockerVersion: "17.09.0",
@@ -571,7 +585,7 @@ var dockerVersions = []dockerVersion{
 		Name:          "docker-ce",
 		Distros:       []distros.Distribution{distros.DistributionDebian9},
 		Architectures: []Architecture{ArchitectureAmd64},
-		Version:       "18.06.2~ce-0~debian",
+		Version:       "18.06.2~ce~3-0~debian",
 		Source:        "https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_18.06.2~ce~3-0~debian_amd64.deb",
 		Hash:          "aad1efd2c90725034e996c6a368ccc2bf41ca5b8",
 		Dependencies:  []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -525,6 +525,20 @@ var dockerVersions = []dockerVersion{
 
 	// 18.03.1 - Bionic
 	{
+		DockerVersion: "18.03.1",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionBionic},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "18.03.1~ce~3-0~ubuntu",
+		Source:        "https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce_18.03.1~ce~3-0~ubuntu_amd64.deb",
+		Hash:          "b55b32bd0e9176dd32b1e6128ad9fda10a65cc8b",
+		Dependencies:  []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		//Depends: iptables, init-system-helpers, lsb-base, libapparmor1, libc6, libdevmapper1.02.1, libltdl7, libeseccomp2, libsystemd0
+		//Recommends: aufs-tools, ca-certificates, cgroupfs-mount | cgroup-lite, git, xz-utils, apparmor
+	},
+
+	// 18.06.2 - Bionic
+	{
 		DockerVersion: "18.06.2",
 		Name:          "docker-ce",
 		Distros:       []distros.Distribution{distros.DistributionBionic},
@@ -535,6 +549,19 @@ var dockerVersions = []dockerVersion{
 		Dependencies:  []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
 		//Depends: iptables, init-system-helpers, lsb-base, libapparmor1, libc6, libdevmapper1.02.1, libltdl7, libeseccomp2, libsystemd0
 		//Recommends: aufs-tools, ca-certificates, cgroupfs-mount | cgroup-lite, git, xz-utils, apparmor
+	},
+
+	// 18.06.1 - Debian Stretch
+	{
+
+		DockerVersion: "18.06.1",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionDebian9},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "18.06.1~ce-0~debian",
+		Source:        "https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_18.06.1~ce~3-0~debian_amd64.deb",
+		Hash:          "18473b80e61b6d4eb8b52d87313abd71261287e5",
+		Dependencies:  []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 	},
 
 	// 18.06.2 - Debian Stretch
@@ -548,6 +575,28 @@ var dockerVersions = []dockerVersion{
 		Source:        "https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_18.06.2~ce~3-0~debian_amd64.deb",
 		Hash:          "aad1efd2c90725034e996c6a368ccc2bf41ca5b8",
 		Dependencies:  []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
+	},
+
+	// 18.06.1 - CentOS / Rhel7 (two packages)
+	{
+		DockerVersion: "18.06.1",
+		Name:          "container-selinux-2",
+		Distros:       []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "18.06.1.ce",
+		Source:        "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
+		Hash:          "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
+		Dependencies:  []string{"policycoreutils-python"},
+	},
+	{
+		DockerVersion: "18.06.1",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "18.06.1.ce",
+		Source:        "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-18.06.1.ce-3.el7.x86_64.rpm",
+		Hash:          "0a1325e570c5e54111a79623c9fd0c0c714d3a11",
+		Dependencies:  []string{"libtool-ltdl", "libseccomp", "libcgroup"},
 	},
 
 	// 18.06.2 - CentOS / Rhel7 (two packages)


### PR DESCRIPTION
Fixes #6459.

* Update CentOS, Debian Stretch and Ubuntu Bionic
  docker-ce packages to 18.06.2