### PR TITLE
Allow local filesystem state stores (to aid CI pull-request workflows)

### DIFF
--- a/util/pkg/vfs/vfs.go
+++ b/util/pkg/vfs/vfs.go
@@ -102,16 +102,13 @@ func IsClusterReadable(p Path) bool {
 	}
 
 	switch p.(type) {
-	case *S3Path, *GSPath, *SwiftPath, *OSSPath:
+	case *S3Path, *GSPath, *SwiftPath, *OSSPath, *FSPath:
 		return true
 
 	case *KubernetesPath:
 		return true
 
 	case *SSHPath:
-		return false
-
-	case *FSPath:
 		return false
 
 	case *MemFSPath:


### PR DESCRIPTION
Allows the usage of state storage based on the local filesystem, based on the `file://` prefix/protocol, as [documented](https://github.com/kubernetes/kops/blob/master/docs/state.md).

Fixes [#6463](https://github.com/kubernetes/kops/issues/6463).