### PR TITLE
Allow NodeAuthorizer to speak via HTTP Proxy if configured

### DIFF
--- a/upup/models/cloudup/resources/addons/node-authorizer.addons.k8s.io/k8s-1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-authorizer.addons.k8s.io/k8s-1.10.yaml.template
@@ -1,3 +1,4 @@
+{{- $proxy := .EgressProxy }}
 {{- $na := .NodeAuthorization.NodeAuthorizer }}
 {{- $name := "node-authorizer" }}
 {{- $namespace := "kube-system" }}
@@ -165,6 +166,15 @@ spec:
             - --tls-client-ca=/config/ca.pem
             - --tls-private-key=/config/tls-key.pem
             - --token-ttl={{ $na.TokenTTL.Duration }}
+          {{- if $proxy }}
+          env:
+            - name: http_proxy
+              value: {{ $proxy.HTTPProxy.Host }}:{{ $proxy.HTTPProxy.Port }}
+            {{- if $proxy.ProxyExcludes }}
+            - name: no_proxy
+              value: {{ $proxy.ProxyExcludes }}
+            {{- end }}
+          {{- end }}
           resources:
             limits:
               cpu: 100m

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -150,7 +150,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 	if b.cluster.Spec.NodeAuthorization != nil {
 		{
 			key := "node-authorizer.addons.k8s.io"
-			version := "v0.0.4"
+			version := "v0.0.4-kops.1"
 
 			{
 				location := key + "/k8s-1.10.yaml"


### PR DESCRIPTION
If the Kops Cluster is configured with a HTTP Proxy (no direct internet access), the Node Authorizer (if enabled) is unable to talk to the AWS API. This change passes the http proxy environment variables into the Node Authorizer spec, if it has been defined in the Kops ClusterSpec.