### PR TITLE
possibility to specify floatingip subnet for resources in openstack

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -151,6 +151,7 @@ type CreateClusterOptions struct {
 
 	// OpenstackExternalNet is the name of the external network for the openstack router
 	OpenstackExternalNet     string
+	OpenstackExternalSubnet  string
 	OpenstackStorageIgnoreAZ bool
 	OpenstackDNSServers      string
 	OpenstackLbSubnet        string
@@ -384,6 +385,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	if cloudup.AlphaAllowOpenstack.Enabled() {
 		// Openstack flags
 		cmd.Flags().StringVar(&options.OpenstackExternalNet, "os-ext-net", options.OpenstackExternalNet, "The name of the external network to use with the openstack router")
+		cmd.Flags().StringVar(&options.OpenstackExternalSubnet, "os-ext-subnet", options.OpenstackExternalSubnet, "The name of the external floating subnet to use with the openstack router")
 		cmd.Flags().StringVar(&options.OpenstackLbSubnet, "os-lb-floating-subnet", options.OpenstackLbSubnet, "The name of the external subnet to use with the kubernetes api")
 		cmd.Flags().BoolVar(&options.OpenstackStorageIgnoreAZ, "os-kubelet-ignore-az", options.OpenstackStorageIgnoreAZ, "If true kubernetes may attach volumes across availability zones")
 		cmd.Flags().BoolVar(&options.OpenstackLBOctavia, "os-octavia", options.OpenstackLBOctavia, "If true octavia loadbalancer api will be used")
@@ -936,6 +938,9 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 			}
 			if c.OpenstackDNSServers != "" {
 				cluster.Spec.CloudConfig.Openstack.Router.DNSServers = fi.String(c.OpenstackDNSServers)
+			}
+			if c.OpenstackExternalSubnet != "" {
+				cluster.Spec.CloudConfig.Openstack.Router.ExternalSubnet = fi.String(c.OpenstackExternalSubnet)
 			}
 			if c.OpenstackLbSubnet != "" {
 				cluster.Spec.CloudConfig.Openstack.Loadbalancer.FloatingSubnet = fi.String(c.OpenstackLbSubnet)

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -153,6 +153,7 @@ type CreateClusterOptions struct {
 	OpenstackExternalNet     string
 	OpenstackStorageIgnoreAZ bool
 	OpenstackDNSServers      string
+	OpenstackLbSubnet        string
 
 	// OpenstackLBOctavia is boolean value should we use octavia or old loadbalancer api
 	OpenstackLBOctavia bool
@@ -383,6 +384,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	if cloudup.AlphaAllowOpenstack.Enabled() {
 		// Openstack flags
 		cmd.Flags().StringVar(&options.OpenstackExternalNet, "os-ext-net", options.OpenstackExternalNet, "The name of the external network to use with the openstack router")
+		cmd.Flags().StringVar(&options.OpenstackLbSubnet, "os-lb-floating-subnet", options.OpenstackLbSubnet, "The name of the external subnet to use with the kubernetes api")
 		cmd.Flags().BoolVar(&options.OpenstackStorageIgnoreAZ, "os-kubelet-ignore-az", options.OpenstackStorageIgnoreAZ, "If true kubernetes may attach volumes across availability zones")
 		cmd.Flags().BoolVar(&options.OpenstackLBOctavia, "os-octavia", options.OpenstackLBOctavia, "If true octavia loadbalancer api will be used")
 		cmd.Flags().StringVar(&options.OpenstackDNSServers, "os-dns-servers", options.OpenstackDNSServers, "comma separated list of DNS Servers which is used in network")
@@ -934,6 +936,9 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 			}
 			if c.OpenstackDNSServers != "" {
 				cluster.Spec.CloudConfig.Openstack.Router.DNSServers = fi.String(c.OpenstackDNSServers)
+			}
+			if c.OpenstackLbSubnet != "" {
+				cluster.Spec.CloudConfig.Openstack.Loadbalancer.FloatingSubnet = fi.String(c.OpenstackLbSubnet)
 			}
 		}
 	}

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -530,6 +530,7 @@ type OpenstackMonitor struct {
 type OpenstackRouter struct {
 	ExternalNetwork *string `json:"externalNetwork,omitempty"`
 	DNSServers      *string `json:"dnsServers,omitempty"`
+	ExternalSubnet  *string `json:"externalSubnet,omitempty"`
 }
 
 // OpenstackConfiguration defines cloud config elements for the openstack cloud provider

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -510,6 +510,7 @@ type OpenstackLoadbalancerConfig struct {
 	UseOctavia        *bool   `json:"useOctavia,omitempty"`
 	FloatingNetwork   *string `json:"floatingNetwork,omitempty"`
 	FloatingNetworkID *string `json:"floatingNetworkID,omitempty"`
+	FloatingSubnet    *string `json:"floatingSubnet,omitempty"`
 	SubnetID          *string `json:"subnetID,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -530,6 +530,7 @@ type OpenstackMonitor struct {
 type OpenstackRouter struct {
 	ExternalNetwork *string `json:"externalNetwork,omitempty"`
 	DNSServers      *string `json:"dnsServers,omitempty"`
+	ExternalSubnet  *string `json:"externalSubnet,omitempty"`
 }
 
 // OpenstackConfiguration defines cloud config elements for the openstack cloud provider

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -510,6 +510,7 @@ type OpenstackLoadbalancerConfig struct {
 	UseOctavia        *bool   `json:"useOctavia,omitempty"`
 	FloatingNetwork   *string `json:"floatingNetwork,omitempty"`
 	FloatingNetworkID *string `json:"floatingNetworkID,omitempty"`
+	FloatingSubnet    *string `json:"floatingSubnet,omitempty"`
 	SubnetID          *string `json:"subnetID,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -4103,6 +4103,7 @@ func Convert_kops_OpenstackMonitor_To_v1alpha1_OpenstackMonitor(in *kops.Opensta
 func autoConvert_v1alpha1_OpenstackRouter_To_kops_OpenstackRouter(in *OpenstackRouter, out *kops.OpenstackRouter, s conversion.Scope) error {
 	out.ExternalNetwork = in.ExternalNetwork
 	out.DNSServers = in.DNSServers
+	out.ExternalSubnet = in.ExternalSubnet
 	return nil
 }
 
@@ -4114,6 +4115,7 @@ func Convert_v1alpha1_OpenstackRouter_To_kops_OpenstackRouter(in *OpenstackRoute
 func autoConvert_kops_OpenstackRouter_To_v1alpha1_OpenstackRouter(in *kops.OpenstackRouter, out *OpenstackRouter, s conversion.Scope) error {
 	out.ExternalNetwork = in.ExternalNetwork
 	out.DNSServers = in.DNSServers
+	out.ExternalSubnet = in.ExternalSubnet
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -4050,6 +4050,7 @@ func autoConvert_v1alpha1_OpenstackLoadbalancerConfig_To_kops_OpenstackLoadbalan
 	out.UseOctavia = in.UseOctavia
 	out.FloatingNetwork = in.FloatingNetwork
 	out.FloatingNetworkID = in.FloatingNetworkID
+	out.FloatingSubnet = in.FloatingSubnet
 	out.SubnetID = in.SubnetID
 	return nil
 }
@@ -4065,6 +4066,7 @@ func autoConvert_kops_OpenstackLoadbalancerConfig_To_v1alpha1_OpenstackLoadbalan
 	out.UseOctavia = in.UseOctavia
 	out.FloatingNetwork = in.FloatingNetwork
 	out.FloatingNetworkID = in.FloatingNetworkID
+	out.FloatingSubnet = in.FloatingSubnet
 	out.SubnetID = in.SubnetID
 	return nil
 }

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2649,6 +2649,11 @@ func (in *OpenstackLoadbalancerConfig) DeepCopyInto(out *OpenstackLoadbalancerCo
 		*out = new(string)
 		**out = **in
 	}
+	if in.FloatingSubnet != nil {
+		in, out := &in.FloatingSubnet, &out.FloatingSubnet
+		*out = new(string)
+		**out = **in
+	}
 	if in.SubnetID != nil {
 		in, out := &in.SubnetID, &out.SubnetID
 		*out = new(string)

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2716,6 +2716,11 @@ func (in *OpenstackRouter) DeepCopyInto(out *OpenstackRouter) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ExternalSubnet != nil {
+		in, out := &in.ExternalSubnet, &out.ExternalSubnet
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -530,6 +530,7 @@ type OpenstackMonitor struct {
 type OpenstackRouter struct {
 	ExternalNetwork *string `json:"externalNetwork,omitempty"`
 	DNSServers      *string `json:"dnsServers,omitempty"`
+	ExternalSubnet  *string `json:"externalSubnet,omitempty"`
 }
 
 // OpenstackConfiguration defines cloud config elements for the openstack cloud provider

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -510,6 +510,7 @@ type OpenstackLoadbalancerConfig struct {
 	UseOctavia        *bool   `json:"useOctavia,omitempty"`
 	FloatingNetwork   *string `json:"floatingNetwork,omitempty"`
 	FloatingNetworkID *string `json:"floatingNetworkID,omitempty"`
+	FloatingSubnet    *string `json:"floatingSubnet,omitempty"`
 	SubnetID          *string `json:"subnetID,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4320,6 +4320,7 @@ func autoConvert_v1alpha2_OpenstackLoadbalancerConfig_To_kops_OpenstackLoadbalan
 	out.UseOctavia = in.UseOctavia
 	out.FloatingNetwork = in.FloatingNetwork
 	out.FloatingNetworkID = in.FloatingNetworkID
+	out.FloatingSubnet = in.FloatingSubnet
 	out.SubnetID = in.SubnetID
 	return nil
 }
@@ -4335,6 +4336,7 @@ func autoConvert_kops_OpenstackLoadbalancerConfig_To_v1alpha2_OpenstackLoadbalan
 	out.UseOctavia = in.UseOctavia
 	out.FloatingNetwork = in.FloatingNetwork
 	out.FloatingNetworkID = in.FloatingNetworkID
+	out.FloatingSubnet = in.FloatingSubnet
 	out.SubnetID = in.SubnetID
 	return nil
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4373,6 +4373,7 @@ func Convert_kops_OpenstackMonitor_To_v1alpha2_OpenstackMonitor(in *kops.Opensta
 func autoConvert_v1alpha2_OpenstackRouter_To_kops_OpenstackRouter(in *OpenstackRouter, out *kops.OpenstackRouter, s conversion.Scope) error {
 	out.ExternalNetwork = in.ExternalNetwork
 	out.DNSServers = in.DNSServers
+	out.ExternalSubnet = in.ExternalSubnet
 	return nil
 }
 
@@ -4384,6 +4385,7 @@ func Convert_v1alpha2_OpenstackRouter_To_kops_OpenstackRouter(in *OpenstackRoute
 func autoConvert_kops_OpenstackRouter_To_v1alpha2_OpenstackRouter(in *kops.OpenstackRouter, out *OpenstackRouter, s conversion.Scope) error {
 	out.ExternalNetwork = in.ExternalNetwork
 	out.DNSServers = in.DNSServers
+	out.ExternalSubnet = in.ExternalSubnet
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2787,6 +2787,11 @@ func (in *OpenstackRouter) DeepCopyInto(out *OpenstackRouter) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ExternalSubnet != nil {
+		in, out := &in.ExternalSubnet, &out.ExternalSubnet
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2720,6 +2720,11 @@ func (in *OpenstackLoadbalancerConfig) DeepCopyInto(out *OpenstackLoadbalancerCo
 		*out = new(string)
 		**out = **in
 	}
+	if in.FloatingSubnet != nil {
+		in, out := &in.FloatingSubnet, &out.FloatingSubnet
+		*out = new(string)
+		**out = **in
+	}
 	if in.SubnetID != nil {
 		in, out := &in.SubnetID, &out.SubnetID
 		*out = new(string)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2934,6 +2934,11 @@ func (in *OpenstackLoadbalancerConfig) DeepCopyInto(out *OpenstackLoadbalancerCo
 		*out = new(string)
 		**out = **in
 	}
+	if in.FloatingSubnet != nil {
+		in, out := &in.FloatingSubnet, &out.FloatingSubnet
+		*out = new(string)
+		**out = **in
+	}
 	if in.SubnetID != nil {
 		in, out := &in.SubnetID, &out.SubnetID
 		*out = new(string)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3001,6 +3001,11 @@ func (in *OpenstackRouter) DeepCopyInto(out *OpenstackRouter) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ExternalSubnet != nil {
+		in, out := &in.ExternalSubnet, &out.ExternalSubnet
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -147,6 +147,9 @@ type OpenstackCloud interface {
 	//ListExternalNetworks will return the Neutron networks with the router:external property
 	GetExternalNetwork() (*networks.Network, error)
 
+	// GetLBFloatingSubnet will return the subnet for floatingip which is used in lb
+	GetLBFloatingSubnet() (*subnets.Subnet, error)
+
 	//CreateNetwork will create a new Neutron network
 	CreateNetwork(opt networks.CreateOptsBuilder) (*networks.Network, error)
 
@@ -270,6 +273,7 @@ type openstackCloud struct {
 	dnsClient      *gophercloud.ServiceClient
 	lbClient       *gophercloud.ServiceClient
 	extNetworkName *string
+	floatingSubnet *string
 	tags           map[string]string
 	region         string
 	useOctavia     bool
@@ -386,6 +390,9 @@ func NewOpenstackCloud(tags map[string]string, spec *kops.ClusterSpec) (Openstac
 		}
 		if spec.CloudConfig.Openstack.Loadbalancer.UseOctavia != nil {
 			octavia = fi.BoolValue(spec.CloudConfig.Openstack.Loadbalancer.UseOctavia)
+		}
+		if spec.CloudConfig.Openstack.Loadbalancer.FloatingSubnet != nil {
+			c.floatingSubnet = spec.CloudConfig.Openstack.Loadbalancer.FloatingSubnet
 		}
 	}
 	c.useOctavia = octavia

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -147,6 +147,9 @@ type OpenstackCloud interface {
 	//ListExternalNetworks will return the Neutron networks with the router:external property
 	GetExternalNetwork() (*networks.Network, error)
 
+	// GetExternalSubnet will return the subnet for floatingip which is used in external router
+	GetExternalSubnet() (*subnets.Subnet, error)
+
 	// GetLBFloatingSubnet will return the subnet for floatingip which is used in lb
 	GetLBFloatingSubnet() (*subnets.Subnet, error)
 
@@ -273,6 +276,7 @@ type openstackCloud struct {
 	dnsClient      *gophercloud.ServiceClient
 	lbClient       *gophercloud.ServiceClient
 	extNetworkName *string
+	extSubnetName  *string
 	floatingSubnet *string
 	tags           map[string]string
 	region         string
@@ -376,6 +380,9 @@ func NewOpenstackCloud(tags map[string]string, spec *kops.ClusterSpec) (Openstac
 
 		c.extNetworkName = spec.CloudConfig.Openstack.Router.ExternalNetwork
 
+		if spec.CloudConfig.Openstack.Router.ExternalSubnet != nil {
+			c.extSubnetName = spec.CloudConfig.Openstack.Router.ExternalSubnet
+		}
 		if spec.CloudConfig.Openstack.Loadbalancer != nil &&
 			spec.CloudConfig.Openstack.Loadbalancer.FloatingNetworkID == nil &&
 			spec.CloudConfig.Openstack.Loadbalancer.FloatingNetwork != nil {

--- a/upup/pkg/fi/cloudup/openstack/subnet.go
+++ b/upup/pkg/fi/cloudup/openstack/subnet.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/util/pkg/vfs"
 )
 
@@ -84,4 +85,22 @@ func (c *openstackCloud) DeleteSubnet(subnetID string) error {
 	} else {
 		return wait.ErrWaitTimeout
 	}
+}
+
+func (c *openstackCloud) GetLBFloatingSubnet() (subnet *subnets.Subnet, err error) {
+	if c.floatingSubnet == nil {
+		return nil, nil
+	}
+
+	subnets, err := c.ListSubnets(subnets.ListOpts{
+		Name: fi.StringValue(c.floatingSubnet),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(subnets) == 1 {
+		return &subnets[0], nil
+	}
+	return nil, fmt.Errorf("did not find floatingsubnet for LB")
 }

--- a/upup/pkg/fi/cloudup/openstack/subnet.go
+++ b/upup/pkg/fi/cloudup/openstack/subnet.go
@@ -87,6 +87,24 @@ func (c *openstackCloud) DeleteSubnet(subnetID string) error {
 	}
 }
 
+func (c *openstackCloud) GetExternalSubnet() (subnet *subnets.Subnet, err error) {
+	if c.extSubnetName == nil {
+		return nil, nil
+	}
+
+	subnets, err := c.ListSubnets(subnets.ListOpts{
+		Name: fi.StringValue(c.extSubnetName),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(subnets) == 1 {
+		return &subnets[0], nil
+	}
+	return nil, fmt.Errorf("did not find floatingsubnet for external router")
+}
+
 func (c *openstackCloud) GetLBFloatingSubnet() (subnet *subnets.Subnet, err error) {
 	if c.floatingSubnet == nil {
 		return nil, nil

--- a/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
@@ -221,10 +221,19 @@ func (f *FloatingIP) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, chan
 
 		if e.LB != nil {
 			//Layer 3
-			fip, err := cloud.CreateL3FloatingIP(l3floatingip.CreateOpts{
+
+			opts := l3floatingip.CreateOpts{
 				FloatingNetworkID: external.ID,
 				PortID:            fi.StringValue(e.LB.PortID),
-			})
+			}
+			lbSubnet, err := cloud.GetLBFloatingSubnet()
+			if err != nil {
+				return fmt.Errorf("Failed to find floatingip subnet: %v", err)
+			}
+			if lbSubnet != nil {
+				opts.SubnetID = lbSubnet.ID
+			}
+			fip, err := cloud.CreateL3FloatingIP(opts)
 			if err != nil {
 				return fmt.Errorf("Failed to create floating IP: %v", err)
 			}

--- a/upup/pkg/fi/cloudup/openstacktasks/router.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/router.go
@@ -102,6 +102,18 @@ func (_ *Router) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes 
 			NetworkID: floatingNet.ID,
 		}
 
+		routerFloatingSubnet, err := t.Cloud.GetExternalSubnet()
+		if err != nil {
+			return fmt.Errorf("Failed to find floatingip subnet: %v", err)
+		}
+		if routerFloatingSubnet != nil {
+			opt.GatewayInfo.ExternalFixedIPs = []routers.ExternalFixedIP{
+				{
+					SubnetID: routerFloatingSubnet.ID,
+				},
+			}
+		}
+
 		v, err := t.Cloud.CreateRouter(opt)
 		if err != nil {
 			return fmt.Errorf("Error creating router: %v", err)


### PR DESCRIPTION
This is needed in openstack networks which do have more than one external floatingip subnet pool. Otherwise the openstack will always take the ip address from the first floatingip subnet pool, and if there is no ip addresses it will try the next one. This PR makes it possible to define the pool which should be used.

This needs #6478 to work

/sig openstack