### PR TITLE
Choose docker version 18.06.2 for k8s >= 1.12

### DIFF
--- a/pkg/model/components/docker.go
+++ b/pkg/model/components/docker.go
@@ -53,7 +53,9 @@ func (b *DockerOptionsBuilder) BuildOptions(o interface{}) error {
 		}
 
 		dockerVersion := ""
-		if sv.Major == 1 && sv.Minor >= 9 {
+		if sv.Major == 1 && sv.Minor >= 12 {
+			dockerVersion = "18.06.2"
+		} else if sv.Major == 1 && sv.Minor >= 9 {
 			dockerVersion = "17.03.2"
 		} else if sv.Major == 1 && sv.Minor >= 8 {
 			dockerVersion = "1.13.1"


### PR DESCRIPTION
Helps us avoid the recent CVE