### PR TITLE
package task: cleaner behaviour when package is installed

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -894,9 +894,6 @@ func (b *DockerBuilder) Build(c *fi.ModelBuilderContext) error {
 					Source:  s(dv.Source),
 					Hash:    s(dv.Hash),
 					Deps:    extraPkgs,
-
-					// TODO: PreventStart is now unused?
-					PreventStart: fi.Bool(true),
 				}
 				c.AddTask(packageTask)
 			}

--- a/nodeup/pkg/model/tests/dockerbuilder/docker_1.12.1/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/docker_1.12.1/tasks.yaml
@@ -215,7 +215,6 @@ Name: bridge-utils
 ---
 Name: docker-engine
 hash: 30f7840704361673db2b62f25b6038628184b056
-preventStart: true
 source: http://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_1.12.1-0~xenial_amd64.deb
 version: 1.12.1-0~xenial
 ---

--- a/nodeup/pkg/model/tests/dockerbuilder/logflags/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/logflags/tasks.yaml
@@ -215,7 +215,6 @@ Name: bridge-utils
 ---
 Name: docker-engine
 hash: b758fc88346a1e5eebf7408b0d0c99f4f134166c
-preventStart: true
 source: http://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_1.12.3-0~xenial_amd64.deb
 version: 1.12.3-0~xenial
 ---

--- a/nodeup/pkg/model/tests/dockerbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/simple/tasks.yaml
@@ -215,7 +215,6 @@ Name: bridge-utils
 ---
 Name: docker-engine
 hash: b758fc88346a1e5eebf7408b0d0c99f4f134166c
-preventStart: true
 source: http://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_1.12.3-0~xenial_amd64.deb
 version: 1.12.3-0~xenial
 ---

--- a/upup/pkg/fi/nodeup/nodetasks/package.go
+++ b/upup/pkg/fi/nodeup/nodetasks/package.go
@@ -37,10 +37,9 @@ import (
 type Package struct {
 	Name string
 
-	Version      *string `json:"version,omitempty"`
-	Source       *string `json:"source,omitempty"`
-	Hash         *string `json:"hash,omitempty"`
-	PreventStart *bool   `json:"preventStart,omitempty"`
+	Version *string `json:"version,omitempty"`
+	Source  *string `json:"source,omitempty"`
+	Hash    *string `json:"hash,omitempty"`
 
 	// Healthy is true if the package installation did not fail
 	Healthy *bool `json:"healthy,omitempty"`
@@ -240,6 +239,7 @@ func (e *Package) findYum(c *fi.Context) (*Package, error) {
 		return nil, nil
 	}
 
+	// Prevent spurious changes
 	return &Package{
 		Name:    e.Name,
 		Version: fi.String(installedVersion),
@@ -346,6 +346,10 @@ func (_ *Package) RenderLocal(t *local.LocalTarget, a, e, changes *Package) erro
 				return fmt.Errorf("unsupported package system")
 			}
 		}
+
+		// Make out fields we can't read / can't do anything about
+		changes.Source = nil
+		changes.Hash = nil
 
 		if !reflect.DeepEqual(changes, &Package{}) {
 			klog.Warningf("cannot apply package changes for %q: %v", e.Name, changes)


### PR DESCRIPTION
Ignore fields that help us locate the source package, also remove the
unused PreventStart field.