### PR TITLE
Fix amazon-vpc-routed-eni yaml template

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.10.yaml.template
@@ -120,7 +120,6 @@ spec:
   group: crd.k8s.amazonaws.com
   version: v1alpha1
   names:
-    scope: Cluster
     plural: eniconfigs
     singular: eniconfig
     kind: ENIConfig


### PR DESCRIPTION
Current yaml structure is invalid.
Crosschecked with https://github.com/aws/amazon-vpc-cni-k8s/blob/master/config/v1.3/aws-k8s-cni.yaml

Fixes #6499.