### PR TITLE
Try using chattr to mark docker-runc as immutable

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -55,6 +55,9 @@ type dockerVersion struct {
 
 	// PlainBinary indicates that the Source is not an OS, but a "bare" tar.gz
 	PlainBinary bool
+
+	// MarkImmutable is a list of files on which we should perform a `chattr +i <file>`
+	MarkImmutable []string
 }
 
 // DefaultDockerVersion is the (legacy) docker version we use if one is not specified in the manifest.
@@ -379,6 +382,7 @@ var dockerVersions = []dockerVersion{
 		Source:        "http://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_17.03.2~ce-0~debian-stretch_amd64.deb",
 		Hash:          "36773361cf44817371770cb4e6e6823590d10297",
 		Dependencies:  []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
+		MarkImmutable: []string{"/usr/bin/docker-runc"},
 	},
 
 	// 17.03.2 - Jessie
@@ -391,6 +395,7 @@ var dockerVersions = []dockerVersion{
 		Source:        "http://download.docker.com/linux/debian/dists/jessie/pool/stable/amd64/docker-ce_17.03.2~ce-0~debian-jessie_amd64.deb",
 		Hash:          "a7ac54aaa7d33122ca5f7a2df817cbefb5cdbfc7",
 		Dependencies:  []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
+		MarkImmutable: []string{"/usr/bin/docker-runc"},
 	},
 
 	// 17.03.2 - Jessie on ARM
@@ -403,6 +408,7 @@ var dockerVersions = []dockerVersion{
 		Source:        "http://download.docker.com/linux/debian/dists/jessie/pool/stable/armhf/docker-ce_17.03.2~ce-0~debian-jessie_armhf.deb",
 		Hash:          "71e425b83ce0ef49d6298d61e61c4efbc76b9c65",
 		Dependencies:  []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
+		MarkImmutable: []string{"/usr/bin/docker-runc"},
 	},
 
 	// 17.03.2 - Xenial
@@ -415,6 +421,7 @@ var dockerVersions = []dockerVersion{
 		Source:        "http://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_17.03.2~ce-0~ubuntu-xenial_amd64.deb",
 		Hash:          "4dcee1a05ec592e8a76e53e5b464ea43085a2849",
 		Dependencies:  []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		MarkImmutable: []string{"/usr/bin/docker-runc"},
 	},
 
 	// 17.03.2 - Ubuntu Bionic via binary download (no packages available)
@@ -426,6 +433,7 @@ var dockerVersions = []dockerVersion{
 		Source:        "http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz",
 		Hash:          "141716ae046016a1792ce232a0f4c8eed7fe37d1",
 		Dependencies:  []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		MarkImmutable: []string{"/usr/bin/docker-runc"},
 	},
 
 	// 17.03.2 - Centos / Rhel7 (two packages)
@@ -438,6 +446,7 @@ var dockerVersions = []dockerVersion{
 		Source:        "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-17.03.2.ce-1.el7.centos.x86_64.rpm",
 		Hash:          "494ca888f5b1553f93b9d9a5dad4a67f76cf9eb5",
 		Dependencies:  []string{"libtool-ltdl", "libseccomp", "libcgroup"},
+		MarkImmutable: []string{"/usr/bin/docker-runc"},
 	},
 	{
 		DockerVersion: "17.03.2",
@@ -730,19 +739,21 @@ func (b *DockerBuilder) Build(c *fi.ModelBuilderContext) error {
 
 			count++
 
+			var packageTask fi.Task
 			if dv.PlainBinary {
-				c.AddTask(&nodetasks.Archive{
+				packageTask = &nodetasks.Archive{
 					Name:            "docker",
 					Source:          dv.Source,
 					Hash:            dv.Hash,
 					TargetDir:       "/usr/bin/",
 					StripComponents: 1,
-				})
+				}
+				c.AddTask(packageTask)
 
 				c.AddTask(b.buildDockerGroup())
 				c.AddTask(b.buildSystemdSocket())
 			} else {
-				c.AddTask(&nodetasks.Package{
+				packageTask = &nodetasks.Package{
 					Name:    dv.Name,
 					Version: s(dv.Version),
 					Source:  s(dv.Source),
@@ -750,6 +761,16 @@ func (b *DockerBuilder) Build(c *fi.ModelBuilderContext) error {
 
 					// TODO: PreventStart is now unused?
 					PreventStart: fi.Bool(true),
+				}
+				c.AddTask(packageTask)
+			}
+
+			// As a mitigation for CVE-2019-5736 (possibly a fix, definitely defense-in-depth) we chattr docker-runc to be immutable
+			for _, f := range dv.MarkImmutable {
+				c.AddTask(&nodetasks.Chattr{
+					File: f,
+					Mode: "+i",
+					Deps: []fi.Task{packageTask},
 				})
 			}
 

--- a/upup/pkg/fi/nodeup/nodetasks/BUILD.bazel
+++ b/upup/pkg/fi/nodeup/nodetasks/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "archive.go",
         "asset.go",
         "bindmount.go",
+        "chattr.go",
         "createsdir.go",
         "file.go",
         "group.go",

--- a/upup/pkg/fi/nodeup/nodetasks/chattr.go
+++ b/upup/pkg/fi/nodeup/nodetasks/chattr.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodetasks
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/nodeup/cloudinit"
+	"k8s.io/kops/upup/pkg/fi/nodeup/local"
+)
+
+// Chattr performs a chattr command, in particular to set a file as immutable
+type Chattr struct {
+	File string `json:"file"`
+	Mode string `json:"mode"`
+
+	Deps []fi.Task `json:"-"`
+}
+
+var _ fi.Task = &Chattr{}
+
+func (s *Chattr) String() string {
+	return fmt.Sprintf("Chattr: chattr %s %s", s.Mode, s.File)
+}
+
+var _ fi.HasName = &Archive{}
+
+func (e *Chattr) GetName() *string {
+	return fi.String("Chattr-" + e.File)
+}
+
+func (e *Chattr) SetName(name string) {
+	glog.Fatalf("SetName not supported for Chattr task")
+}
+
+var _ fi.HasDependencies = &Chattr{}
+
+// GetDependencies implements HasDependencies::GetDependencies
+func (e *Chattr) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+	return e.Deps
+}
+
+func (e *Chattr) Find(c *fi.Context) (*Chattr, error) {
+	// We always re-run the chattr command
+	return nil, nil
+}
+
+func (e *Chattr) Run(c *fi.Context) error {
+	return fi.DefaultDeltaRunMethod(e, c)
+}
+
+func (s *Chattr) CheckChanges(a, e, changes *Chattr) error {
+	return nil
+}
+
+func (_ *Chattr) RenderLocal(t *local.LocalTarget, a, e, changes *Chattr) error {
+	return e.execute(t)
+}
+
+func (e *Chattr) execute(t Executor) error {
+	chattrCommand := []string{"chattr", e.Mode, e.File}
+
+	glog.Infof("running chattr command chattr %s", chattrCommand)
+	if output, err := t.CombinedOutput(chattrCommand); err != nil {
+		return fmt.Errorf("error doing %q: %v: %s", strings.Join(chattrCommand, " "), err, string(output))
+	}
+
+	return nil
+}
+
+func (_ *Chattr) RenderCloudInit(t *cloudinit.CloudInitTarget, a, e, changes *Chattr) error {
+	return fmt.Errorf("Chattr::RenderCloudInit not implemented")
+}

--- a/upup/pkg/fi/nodeup/nodetasks/service.go
+++ b/upup/pkg/fi/nodeup/nodetasks/service.go
@@ -69,7 +69,7 @@ func (p *Service) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 		// launching a custom Kubernetes build), they all depend on
 		// the "docker.service" Service task.
 		switch v.(type) {
-		case *File, *Package, *UpdatePackages, *UserTask, *GroupTask, *MountDiskTask:
+		case *File, *Package, *UpdatePackages, *UserTask, *GroupTask, *MountDiskTask, *Chattr:
 			deps = append(deps, v)
 		case *Service, *LoadImageTask:
 			// ignore


### PR DESCRIPTION
May be a workaround for CVE-2019-5736, is defense in depth in any case.