### PR TITLE
Launch Template Feature Flag

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -77,7 +77,6 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		default:
 			tsk.LaunchConfiguration = task.(*awstasks.LaunchConfiguration)
 		}
-
 		c.AddTask(tsk)
 
 		// @step: add any external load balancer attachments

--- a/pkg/model/awsmodel/context.go
+++ b/pkg/model/awsmodel/context.go
@@ -33,7 +33,8 @@ func UseLaunchTemplate(ig *kops.InstanceGroup) bool {
 		return true
 	}
 	// @note: this mixed instance polices was added before the feature flag, to keep the
-	// same behviour we also check this
+	// same behviour we also check this. But since the feature hasn't been cut into a tagged
+	// release it possible to use just the feature flag??
 	if ig.Spec.MixedInstancesPolicy != nil {
 		return true
 	}

--- a/pkg/model/awsmodel/context.go
+++ b/pkg/model/awsmodel/context.go
@@ -18,6 +18,7 @@ package awsmodel
 
 import (
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/model"
 )
 
@@ -28,5 +29,14 @@ type AWSModelContext struct {
 
 // UseLaunchTemplate checks if we need to use a launch template rather than configuration
 func UseLaunchTemplate(ig *kops.InstanceGroup) bool {
-	return ig.Spec.MixedInstancesPolicy != nil
+	if featureflag.EnableLaunchTemplates.Enabled() {
+		return true
+	}
+	// @note: this mixed instance polices was added before the feature flag, to keep the
+	// same behviour we also check this
+	if ig.Spec.MixedInstancesPolicy != nil {
+		return true
+	}
+
+	return false
 }

--- a/pkg/model/gcemodel/storageacl.go
+++ b/pkg/model/gcemodel/storageacl.go
@@ -46,7 +46,7 @@ func (b *StorageAclBuilder) Build(c *fi.ModelBuilderContext) error {
 		return fmt.Errorf("error fetching ServiceAccount: %v", err)
 	}
 
-	if featureflag.GoogleCloudBucketAcl.Enabled() {
+	if featureflag.GoogleCloudBucketACL.Enabled() {
 		clusterPath := b.Cluster.Spec.ConfigBase
 		p, err := vfs.Context.BuildVfsPath(clusterPath)
 		if err != nil {

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -266,7 +266,6 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 		if e.UseMixedInstancesPolicy() {
 			// we can zero this out for now and use the mixed instance policy for definition
 			request.LaunchTemplate = nil
-			// add the mixed instance policy
 			request.MixedInstancesPolicy = &autoscaling.MixedInstancesPolicy{
 				InstancesDistribution: &autoscaling.InstancesDistribution{
 					OnDemandPercentageAboveBaseCapacity: e.MixedOnDemandAboveBase,
@@ -475,12 +474,21 @@ func (e *AutoscalingGroup) UseMixedInstancesPolicy() bool {
 	if e.LaunchTemplate == nil {
 		return false
 	}
-	items := []interface{}{e.MixedOnDemandAboveBase, e.MixedOnDemandBase, e.MixedSpotAllocationStrategy, e.MixedSpotInstancePools}
-
-	for _, x := range items {
-		if x != nil {
-			return true
-		}
+	// @check if any of the mixed instance policies settings are toggled
+	if e.MixedOnDemandAboveBase != nil {
+		return true
+	}
+	if e.MixedOnDemandBase != nil {
+		return true
+	}
+	if e.MixedSpotAllocationStrategy != nil {
+		return true
+	}
+	if e.MixedSpotInstancePools != nil {
+		return true
+	}
+	if len(e.MixedInstanceOverrides) > 0 {
+		return true
 	}
 
 	return false

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -252,10 +252,21 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 			VPCZoneIdentifier:    fi.String(strings.Join(e.AutoscalingGroupSubnets(), ",")),
 		}
 
+		// @check are we using a launchconfiguation
 		if e.LaunchConfiguration != nil {
 			request.LaunchConfigurationName = e.LaunchConfiguration.ID
 		}
+		// @check are we using launch template
+		if e.LaunchTemplate != nil {
+			request.LaunchTemplate = &autoscaling.LaunchTemplateSpecification{
+				LaunchTemplateName: e.LaunchTemplate.ID,
+			}
+		}
+		// @check if we are using mixed instance policies
 		if e.UseMixedInstancesPolicy() {
+			// we can zero this out for now and use the mixed instance policy for definition
+			request.LaunchTemplate = nil
+			// add the mixed instance policy
 			request.MixedInstancesPolicy = &autoscaling.MixedInstancesPolicy{
 				InstancesDistribution: &autoscaling.InstancesDistribution{
 					OnDemandPercentageAboveBaseCapacity: e.MixedOnDemandAboveBase,


### PR DESCRIPTION
The current implementation only enables launch templates for AWS when mixed instance policies are enabled for the instancegroup. This PR adds a feature flag that allows users to enable for all instancegroups (master, bastion etc). The option is, as the tittle suggests, gated behind a feature flag. Once this in place we potentially open up the door for launch templates options _(credits, purchase options etc) _

- adding a feature flags to allow users to switch over to launch templates completely
- fixing up the logic of how we select the launchtemplate vs launchconfiguration in the ASG render
- fixing up the checking of the mixed instance policy attribute as it was a interface to a thing
- cleaned up the feature flags a little along the way