### PR TITLE
Make docker 18.06.3 the default for k8s >= 1.12

### DIFF
--- a/pkg/model/components/docker.go
+++ b/pkg/model/components/docker.go
@@ -54,7 +54,7 @@ func (b *DockerOptionsBuilder) BuildOptions(o interface{}) error {
 
 		dockerVersion := ""
 		if sv.Major == 1 && sv.Minor >= 12 {
-			dockerVersion = "18.06.2"
+			dockerVersion = "18.06.3"
 		} else if sv.Major == 1 && sv.Minor >= 9 {
 			dockerVersion = "17.03.2"
 		} else if sv.Major == 1 && sv.Minor >= 8 {


### PR DESCRIPTION
Includes the fix for CVE-2019-5736