### PR TITLE
Bump etcd-manager version to 3.0.20190224

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -168,7 +168,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - image: kopeio/etcd-manager:3.0.20190125
+  - image: kopeio/etcd-manager:3.0.20190224
     name: etcd-manager
     resources:
       requests:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -62,7 +62,7 @@ Contents:
           --v=8 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
           --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
           > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20190125
+        image: kopeio/etcd-manager:3.0.20190224
         name: etcd-manager
         resources:
           requests:
@@ -132,7 +132,7 @@ Contents:
           --v=8 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
           --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
           > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20190125
+        image: kopeio/etcd-manager:3.0.20190224
         name: etcd-manager
         resources:
           requests:


### PR DESCRIPTION
Includes https://github.com/kopeio/etcd-manager/pull/190, fix for
symlinks as seen on GCE.