### PR TITLE
specify dns servers to openstack subnet

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -151,6 +151,7 @@ type CreateClusterOptions struct {
 	// OpenstackExternalNet is the name of the external network for the openstack router
 	OpenstackExternalNet     string
 	OpenstackStorageIgnoreAZ bool
+	OpenstackDNSServers      string
 
 	// OpenstackLBOctavia is boolean value should we use octavia or old loadbalancer api
 	OpenstackLBOctavia bool
@@ -383,6 +384,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 		cmd.Flags().StringVar(&options.OpenstackExternalNet, "os-ext-net", options.OpenstackExternalNet, "The name of the external network to use with the openstack router")
 		cmd.Flags().BoolVar(&options.OpenstackStorageIgnoreAZ, "os-kubelet-ignore-az", options.OpenstackStorageIgnoreAZ, "If true kubernetes may attach volumes across availability zones")
 		cmd.Flags().BoolVar(&options.OpenstackLBOctavia, "os-octavia", options.OpenstackLBOctavia, "If true octavia loadbalancer api will be used")
+		cmd.Flags().StringVar(&options.OpenstackDNSServers, "os-dns-servers", options.OpenstackDNSServers, "comma separated list of DNS Servers which is used in network")
 	}
 
 	return cmd
@@ -914,6 +916,9 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 					Timeout:    fi.String("30s"),
 					MaxRetries: fi.Int(3),
 				},
+			}
+			if c.OpenstackDNSServers != "" {
+				cluster.Spec.CloudConfig.Openstack.Router.DNSServers = fi.String(c.OpenstackDNSServers)
 			}
 		}
 	}

--- a/docs/tutorial/openstack.md
+++ b/docs/tutorial/openstack.md
@@ -63,4 +63,5 @@ kops delete cluster my-cluster.k8s.local --yes
 #### Optional flags
 * `--os-kubelet-ignore-az=true` Nova and Cinder have different availability zones, more information [Kubernetes docs](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#block-storage)
 * `--os-octavia=true` If Octavia Loadbalancer api should be used instead of old lbaas v2 api.
+* `--os-dns-servers=8.8.8.8,8.8.4.4` You can define dns servers to be used in your cluster if your openstack setup does not have working dnssetup by default
 

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -528,6 +528,7 @@ type OpenstackMonitor struct {
 // OpenstackRouter defines the config for a router
 type OpenstackRouter struct {
 	ExternalNetwork *string `json:"externalNetwork,omitempty"`
+	DNSServers      *string `json:"dnsServers,omitempty"`
 }
 
 // OpenstackConfiguration defines cloud config elements for the openstack cloud provider

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -528,6 +528,7 @@ type OpenstackMonitor struct {
 // OpenstackRouter defines the config for a router
 type OpenstackRouter struct {
 	ExternalNetwork *string `json:"externalNetwork,omitempty"`
+	DNSServers      *string `json:"dnsServers,omitempty"`
 }
 
 // OpenstackConfiguration defines cloud config elements for the openstack cloud provider

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -4096,6 +4096,7 @@ func Convert_kops_OpenstackMonitor_To_v1alpha1_OpenstackMonitor(in *kops.Opensta
 
 func autoConvert_v1alpha1_OpenstackRouter_To_kops_OpenstackRouter(in *OpenstackRouter, out *kops.OpenstackRouter, s conversion.Scope) error {
 	out.ExternalNetwork = in.ExternalNetwork
+	out.DNSServers = in.DNSServers
 	return nil
 }
 
@@ -4106,6 +4107,7 @@ func Convert_v1alpha1_OpenstackRouter_To_kops_OpenstackRouter(in *OpenstackRoute
 
 func autoConvert_kops_OpenstackRouter_To_v1alpha1_OpenstackRouter(in *kops.OpenstackRouter, out *OpenstackRouter, s conversion.Scope) error {
 	out.ExternalNetwork = in.ExternalNetwork
+	out.DNSServers = in.DNSServers
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2696,6 +2696,11 @@ func (in *OpenstackRouter) DeepCopyInto(out *OpenstackRouter) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DNSServers != nil {
+		in, out := &in.DNSServers, &out.DNSServers
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -528,6 +528,7 @@ type OpenstackMonitor struct {
 // OpenstackRouter defines the config for a router
 type OpenstackRouter struct {
 	ExternalNetwork *string `json:"externalNetwork,omitempty"`
+	DNSServers      *string `json:"dnsServers,omitempty"`
 }
 
 // OpenstackConfiguration defines cloud config elements for the openstack cloud provider

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4366,6 +4366,7 @@ func Convert_kops_OpenstackMonitor_To_v1alpha2_OpenstackMonitor(in *kops.Opensta
 
 func autoConvert_v1alpha2_OpenstackRouter_To_kops_OpenstackRouter(in *OpenstackRouter, out *kops.OpenstackRouter, s conversion.Scope) error {
 	out.ExternalNetwork = in.ExternalNetwork
+	out.DNSServers = in.DNSServers
 	return nil
 }
 
@@ -4376,6 +4377,7 @@ func Convert_v1alpha2_OpenstackRouter_To_kops_OpenstackRouter(in *OpenstackRoute
 
 func autoConvert_kops_OpenstackRouter_To_v1alpha2_OpenstackRouter(in *kops.OpenstackRouter, out *OpenstackRouter, s conversion.Scope) error {
 	out.ExternalNetwork = in.ExternalNetwork
+	out.DNSServers = in.DNSServers
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2767,6 +2767,11 @@ func (in *OpenstackRouter) DeepCopyInto(out *OpenstackRouter) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DNSServers != nil {
+		in, out := &in.DNSServers, &out.DNSServers
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2981,6 +2981,11 @@ func (in *OpenstackRouter) DeepCopyInto(out *OpenstackRouter) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DNSServers != nil {
+		in, out := &in.DNSServers, &out.DNSServers
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/model/openstackmodel/network.go
+++ b/pkg/model/openstackmodel/network.go
@@ -62,6 +62,14 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			CIDR:      s(sp.CIDR),
 			Lifecycle: b.Lifecycle,
 		}
+		if b.Cluster.Spec.CloudConfig.Openstack.Router.DNSServers != nil {
+			dnsSplitted := strings.Split(fi.StringValue(b.Cluster.Spec.CloudConfig.Openstack.Router.DNSServers), ",")
+			dnsNameSrv := make([]*string, len(dnsSplitted))
+			for i, ns := range dnsSplitted {
+				dnsNameSrv[i] = fi.String(ns)
+			}
+			t.DNSServers = dnsNameSrv
+		}
 		c.AddTask(t)
 
 		t1 := &openstacktasks.RouterInterface{


### PR DESCRIPTION
Like discussed in https://github.com/kubernetes/kops/issues/6520#issuecomment-467075620 (most of the openstacks?) does not have working dnsservers by default in instances. Like I do have 4 openstacks and none of them have working dnsserver by default. This means that when I create instance, the nslookup for instance does not just work. If I define dnsservers to subnet, then it will pass those dnsservers to instance resolv.conf and dns works.

/cc @drekle 
/sig openstack