### PR TITLE
Promote Kubernetes 1.11.7 to stable

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -34,7 +34,7 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.11.0"
-    recommendedVersion: 1.11.6
+    recommendedVersion: 1.11.7
     requiredVersion: 1.11.0
   - range: ">=1.10.0"
     recommendedVersion: 1.10.12
@@ -61,7 +61,7 @@ spec:
   - range: ">=1.11.0-alpha.1"
     #recommendedVersion: "1.11.0"
     #requiredVersion: 1.11.0
-    kubernetesVersion: 1.11.6
+    kubernetesVersion: 1.11.7
   - range: ">=1.10.0-alpha.1"
     recommendedVersion: "1.10.0"
     #requiredVersion: 1.10.0


### PR DESCRIPTION
We have been using this version in several production clusters for a while and is confident this can go into the stable channel