### PR TITLE
Remove confusing comma in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ release number.  kops version 1.8.0 has a minor version of 8. The numbering
 follows the semantic versioning specification, MAJOR.MINOR.PATCH.
 
 For example, kops 1.8.0 does not support Kubernetes 1.9.2, but kops 1.9.0
-supports Kubernetes 1.9.2 and previous Kubernetes versions. Only when kops minor
-version matches, the Kubernetes minor version does kops officially support the
+supports Kubernetes 1.9.2 and previous Kubernetes versions. Only when the kops minor
+version matches the Kubernetes minor version does kops officially support the
 Kubernetes release.  kops does not stop a user from installing mismatching
 versions of K8s, but Kubernetes releases always require kops to install specific
 versions of components like docker, that tested against the particular


### PR DESCRIPTION
I think this sentence is clearer without the comma, as it better
clarifies the relationship between k8s and kops.