### PR TITLE
Use EnsureTask for create static pod directory

### DIFF
--- a/docs/boot-sequence.md
+++ b/docs/boot-sequence.md
@@ -50,6 +50,10 @@ On nodes:
 
 * kube-proxy (which configures iptables so that the k8s-network will work)
 
+It is possible to add custom static pods by using `fileAssets` in the
+cluster spec. This might be useful for any custom bootstraping that
+doesn't fit into `additionalUserData` or `hooks`.
+
 ## kubelet start
 
 Kubelet starts up, starts (and restarts) all the containers in /etc/kubernetes/manifests.

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -95,7 +95,7 @@ func (b *KubeletBuilder) Build(c *fi.ModelBuilderContext) error {
 			if err != nil {
 				return err
 			}
-			c.AddTask(t)
+			c.EnsureTask(t)
 		}
 	}
 	{


### PR DESCRIPTION
A `nodetasks.File` task is created to create the kubelet static pod directory.

This is currently created with `AddTask` which will fail if there is a duplicate task.

I am using a `fileAsset` to deploy a static pod for some custom bootstraping that I need to do (etcd certificate rotation as we are using an external etcd cluster no the one in kops). It looks like this:
```
spec
  ...
 fileAssets:
  ...
  - name: certificate-rotator.manifest
    path: /etc/kubernetes/manifests/certificate-rotator.manifest
    roles:
    - Master
    content: |
      {{ include "certificate-rotator.manifest" . | indent 6 }}
...
```
This will also create a `nodetasks.File` for the directory. This uses `EnsureTask` but unfortunately the `kubelet.go` runs after so raises an error with duplicate tasks.

This simple solution unblocks this. Plus it is pretty cool so I documented it in the only section I could find about static pods :)