### PR TITLE
Fixed kubernetes dashboard yaml link

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -83,7 +83,7 @@ The [dashboard project](https://github.com/kubernetes/dashboard) provides a nice
 
 Install using:
 ```
-kubectl create -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/kubernetes-dashboard/v1.10.0.yaml
+kubectl create -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/kubernetes-dashboard/v1.10.1.yaml
 ```
 
 And then navigate to `https://api.<clustername>/ui`


### PR DESCRIPTION
Was pointing to https://raw.githubusercontent.com/kubernetes/kops/master/addons/kubernetes-dashboard/v1.10.0.yaml

Fixed it to point to https://raw.githubusercontent.com/kubernetes/kops/master/addons/kubernetes-dashboard/v1.10.1.yaml