### PR TITLE
add support to set cluster spec.kubelet

### DIFF
--- a/pkg/commands/BUILD.bazel
+++ b/pkg/commands/BUILD.bazel
@@ -35,5 +35,8 @@ go_test(
     name = "go_default_test",
     srcs = ["set_cluster_test.go"],
     embed = [":go_default_library"],
-    deps = ["//pkg/apis/kops:go_default_library"],
+    deps = [
+        "//pkg/apis/kops:go_default_library",
+        "//upup/pkg/fi:go_default_library",
+    ],
 )

--- a/pkg/commands/set_cluster.go
+++ b/pkg/commands/set_cluster.go
@@ -81,6 +81,14 @@ func SetClusterFields(fields []string, cluster *api.Cluster, instanceGroups []*a
 
 		// For now we have hard-code the values we want to support; we'll get test coverage and then do this properly...
 		switch kv[0] {
+		case "spec.kubelet.authorizationMode":
+			cluster.Spec.Kubelet.AuthorizationMode = kv[1]
+		case "spec.kubelet.authenticationTokenWebhook":
+			v, err := strconv.ParseBool(kv[1])
+			if err != nil {
+				return fmt.Errorf("unknown boolean value: %q", kv[1])
+			}
+			cluster.Spec.Kubelet.AuthenticationTokenWebhook = &v
 		case "cluster.spec.nodePortAccess":
 			cluster.Spec.NodePortAccess = append(cluster.Spec.NodePortAccess, kv[1])
 		case "spec.kubernetesVersion":

--- a/pkg/commands/set_cluster_test.go
+++ b/pkg/commands/set_cluster_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/upup/pkg/fi"
 )
 
 func TestSetClusterFields(t *testing.T) {
@@ -32,9 +33,22 @@ func TestSetClusterFields(t *testing.T) {
 		{
 			Fields: []string{
 				"spec.kubernetesVersion=1.8.2",
+				"spec.kubelet.authorizationMode=Webhook",
+				"spec.kubelet.authenticationTokenWebhook=true",
+			},
+			Input: kops.Cluster{
+				Spec: kops.ClusterSpec{
+					Kubelet: &kops.KubeletConfigSpec{},
+				},
 			},
 			Output: kops.Cluster{
-				Spec: kops.ClusterSpec{KubernetesVersion: "1.8.2"},
+				Spec: kops.ClusterSpec{
+					KubernetesVersion: "1.8.2",
+					Kubelet: &kops.KubeletConfigSpec{
+						AuthorizationMode:          "Webhook",
+						AuthenticationTokenWebhook: fi.Bool(true),
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Really basic use case:

```
$  kops set cluster --name=kubernetes.example.com spec.kubelet.anonymousAuth=false

unhandled field: "spec.kubelet.anonymousAuth=false"
````
```
$  kops set cluster --name=kubernetes.example.com spec.kubelet.authorizationMode=Webhook

unhandled field: "spec.kubelet.authorizationMode=Webhook"
````

This PR adds support for those two fields
* spec.kubelet.authorizationMode
* spec.kubelet.authenticationTokenWebhook

`metrics-server` also needs this to [work properly](https://github.com/kubernetes-incubator/metrics-server/issues/212#issuecomment-459321884).