### PR TITLE
Sync data-types for webhook config with upstream

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -348,17 +348,17 @@ type KubeAPIServerConfig struct {
 	// AuditWebhookBatchMaxSize is The maximum size of a batch. Only used in batch mode. (default 400)
 	AuditWebhookBatchMaxSize *int32 `json:"auditWebhookBatchMaxSize,omitempty" flag:"audit-webhook-batch-max-size"`
 	// AuditWebhookBatchMaxWait is The amount of time to wait before force writing the batch that hadn't reached the max size. Only used in batch mode. (default 30s)
-	AuditWebhookBatchMaxWait string `json:"auditWebhookBatchMaxWait,omitempty" flag:"audit-webhook-batch-max-wait"`
+	AuditWebhookBatchMaxWait *metav1.Duration `json:"auditWebhookBatchMaxWait,omitempty" flag:"audit-webhook-batch-max-wait"`
 	// AuditWebhookBatchThrottleBurst is Maximum number of requests sent at the same moment if ThrottleQPS was not utilized before. Only used in batch mode. (default 15)
 	AuditWebhookBatchThrottleBurst *int32 `json:"auditWebhookBatchThrottleBurst,omitempty" flag:"audit-webhook-batch-throttle-burst"`
 	// AuditWebhookBatchThrottleEnable is Whether batching throttling is enabled. Only used in batch mode. (default true)
-	AuditWebhookBatchThrottleEnable string `json:"auditWebhookBatchThrottleEnable,omitempty" flag:"audit-webhook-batch-throttle-enable"`
+	AuditWebhookBatchThrottleEnable *bool `json:"auditWebhookBatchThrottleEnable,omitempty" flag:"audit-webhook-batch-throttle-enable"`
 	// AuditWebhookBatchThrottleQps is Maximum average number of batches per second. Only used in batch mode. (default 10)
-	AuditWebhookBatchThrottleQps *float64 `json:"auditWebhookBatchThrottleQps,omitempty" flag:"audit-webhook-batch-throttle-qps"`
+	AuditWebhookBatchThrottleQps *float32 `json:"auditWebhookBatchThrottleQps,omitempty" flag:"audit-webhook-batch-throttle-qps"`
 	// AuditWebhookConfigFile is Path to a kubeconfig formatted file that defines the audit webhook configuration. Requires the 'AdvancedAuditing' feature gate.
 	AuditWebhookConfigFile string `json:"auditWebhookConfigFile,omitempty" flag:"audit-webhook-config-file"`
 	// AuditWebhookInitialBackoff is The amount of time to wait before retrying the first failed request. (default 10s)
-	AuditWebhookInitialBackoff string `json:"auditWebhookInitialBackoff,omitempty" flag:"audit-webhook-initial-backoff"`
+	AuditWebhookInitialBackoff *metav1.Duration `json:"auditWebhookInitialBackoff,omitempty" flag:"audit-webhook-initial-backoff"`
 	// AuditWebhookMode is Strategy for sending audit events. Blocking indicates sending events should block server responses. Batch causes the backend to buffer and write events asynchronously. Known modes are batch,blocking. (default "batch")
 	AuditWebhookMode string `json:"auditWebhookMode,omitempty" flag:"audit-webhook-mode"`
 	// File with webhook configuration for token authentication in kubeconfig format. The API server will query the remote service to determine authentication for bearer tokens.

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -348,17 +348,17 @@ type KubeAPIServerConfig struct {
 	// AuditWebhookBatchMaxSize is The maximum size of a batch. Only used in batch mode. (default 400)
 	AuditWebhookBatchMaxSize *int32 `json:"auditWebhookBatchMaxSize,omitempty" flag:"audit-webhook-batch-max-size"`
 	// AuditWebhookBatchMaxWait is The amount of time to wait before force writing the batch that hadn't reached the max size. Only used in batch mode. (default 30s)
-	AuditWebhookBatchMaxWait string `json:"auditWebhookBatchMaxWait,omitempty" flag:"audit-webhook-batch-max-wait"`
+	AuditWebhookBatchMaxWait *metav1.Duration `json:"auditWebhookBatchMaxWait,omitempty" flag:"audit-webhook-batch-max-wait"`
 	// AuditWebhookBatchThrottleBurst is Maximum number of requests sent at the same moment if ThrottleQPS was not utilized before. Only used in batch mode. (default 15)
 	AuditWebhookBatchThrottleBurst *int32 `json:"auditWebhookBatchThrottleBurst,omitempty" flag:"audit-webhook-batch-throttle-burst"`
 	// AuditWebhookBatchThrottleEnable is Whether batching throttling is enabled. Only used in batch mode. (default true)
-	AuditWebhookBatchThrottleEnable string `json:"auditWebhookBatchThrottleEnable,omitempty" flag:"audit-webhook-batch-throttle-enable"`
+	AuditWebhookBatchThrottleEnable *bool `json:"auditWebhookBatchThrottleEnable,omitempty" flag:"audit-webhook-batch-throttle-enable"`
 	// AuditWebhookBatchThrottleQps is Maximum average number of batches per second. Only used in batch mode. (default 10)
-	AuditWebhookBatchThrottleQps *float64 `json:"auditWebhookBatchThrottleQps,omitempty" flag:"audit-webhook-batch-throttle-qps"`
+	AuditWebhookBatchThrottleQps *float32 `json:"auditWebhookBatchThrottleQps,omitempty" flag:"audit-webhook-batch-throttle-qps"`
 	// AuditWebhookConfigFile is Path to a kubeconfig formatted file that defines the audit webhook configuration. Requires the 'AdvancedAuditing' feature gate.
 	AuditWebhookConfigFile string `json:"auditWebhookConfigFile,omitempty" flag:"audit-webhook-config-file"`
 	// AuditWebhookInitialBackoff is The amount of time to wait before retrying the first failed request. (default 10s)
-	AuditWebhookInitialBackoff string `json:"auditWebhookInitialBackoff,omitempty" flag:"audit-webhook-initial-backoff"`
+	AuditWebhookInitialBackoff *metav1.Duration `json:"auditWebhookInitialBackoff,omitempty" flag:"audit-webhook-initial-backoff"`
 	// AuditWebhookMode is Strategy for sending audit events. Blocking indicates sending events should block server responses. Batch causes the backend to buffer and write events asynchronously. Known modes are batch,blocking. (default "batch")
 	AuditWebhookMode string `json:"auditWebhookMode,omitempty" flag:"audit-webhook-mode"`
 	// File with webhook configuration for token authentication in kubeconfig format. The API server will query the remote service to determine authentication for bearer tokens.

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -1719,14 +1719,29 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.AuditWebhookBatchMaxWait != nil {
+		in, out := &in.AuditWebhookBatchMaxWait, &out.AuditWebhookBatchMaxWait
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.AuditWebhookBatchThrottleBurst != nil {
 		in, out := &in.AuditWebhookBatchThrottleBurst, &out.AuditWebhookBatchThrottleBurst
 		*out = new(int32)
 		**out = **in
 	}
+	if in.AuditWebhookBatchThrottleEnable != nil {
+		in, out := &in.AuditWebhookBatchThrottleEnable, &out.AuditWebhookBatchThrottleEnable
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AuditWebhookBatchThrottleQps != nil {
 		in, out := &in.AuditWebhookBatchThrottleQps, &out.AuditWebhookBatchThrottleQps
-		*out = new(float64)
+		*out = new(float32)
+		**out = **in
+	}
+	if in.AuditWebhookInitialBackoff != nil {
+		in, out := &in.AuditWebhookInitialBackoff, &out.AuditWebhookInitialBackoff
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.AuthenticationTokenWebhookConfigFile != nil {

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -348,17 +348,17 @@ type KubeAPIServerConfig struct {
 	// AuditWebhookBatchMaxSize is The maximum size of a batch. Only used in batch mode. (default 400)
 	AuditWebhookBatchMaxSize *int32 `json:"auditWebhookBatchMaxSize,omitempty" flag:"audit-webhook-batch-max-size"`
 	// AuditWebhookBatchMaxWait is The amount of time to wait before force writing the batch that hadn't reached the max size. Only used in batch mode. (default 30s)
-	AuditWebhookBatchMaxWait string `json:"auditWebhookBatchMaxWait,omitempty" flag:"audit-webhook-batch-max-wait"`
+	AuditWebhookBatchMaxWait *metav1.Duration `json:"auditWebhookBatchMaxWait,omitempty" flag:"audit-webhook-batch-max-wait"`
 	// AuditWebhookBatchThrottleBurst is Maximum number of requests sent at the same moment if ThrottleQPS was not utilized before. Only used in batch mode. (default 15)
 	AuditWebhookBatchThrottleBurst *int32 `json:"auditWebhookBatchThrottleBurst,omitempty" flag:"audit-webhook-batch-throttle-burst"`
 	// AuditWebhookBatchThrottleEnable is Whether batching throttling is enabled. Only used in batch mode. (default true)
-	AuditWebhookBatchThrottleEnable string `json:"auditWebhookBatchThrottleEnable,omitempty" flag:"audit-webhook-batch-throttle-enable"`
+	AuditWebhookBatchThrottleEnable *bool `json:"auditWebhookBatchThrottleEnable,omitempty" flag:"audit-webhook-batch-throttle-enable"`
 	// AuditWebhookBatchThrottleQps is Maximum average number of batches per second. Only used in batch mode. (default 10)
-	AuditWebhookBatchThrottleQps *float64 `json:"auditWebhookBatchThrottleQps,omitempty" flag:"audit-webhook-batch-throttle-qps"`
+	AuditWebhookBatchThrottleQps *float32 `json:"auditWebhookBatchThrottleQps,omitempty" flag:"audit-webhook-batch-throttle-qps"`
 	// AuditWebhookConfigFile is Path to a kubeconfig formatted file that defines the audit webhook configuration. Requires the 'AdvancedAuditing' feature gate.
 	AuditWebhookConfigFile string `json:"auditWebhookConfigFile,omitempty" flag:"audit-webhook-config-file"`
 	// AuditWebhookInitialBackoff is The amount of time to wait before retrying the first failed request. (default 10s)
-	AuditWebhookInitialBackoff string `json:"auditWebhookInitialBackoff,omitempty" flag:"audit-webhook-initial-backoff"`
+	AuditWebhookInitialBackoff *metav1.Duration `json:"auditWebhookInitialBackoff,omitempty" flag:"audit-webhook-initial-backoff"`
 	// AuditWebhookMode is Strategy for sending audit events. Blocking indicates sending events should block server responses. Batch causes the backend to buffer and write events asynchronously. Known modes are batch,blocking. (default "batch")
 	AuditWebhookMode string `json:"auditWebhookMode,omitempty" flag:"audit-webhook-mode"`
 	// File with webhook configuration for token authentication in kubeconfig format. The API server will query the remote service to determine authentication for bearer tokens.

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1790,14 +1790,29 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.AuditWebhookBatchMaxWait != nil {
+		in, out := &in.AuditWebhookBatchMaxWait, &out.AuditWebhookBatchMaxWait
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.AuditWebhookBatchThrottleBurst != nil {
 		in, out := &in.AuditWebhookBatchThrottleBurst, &out.AuditWebhookBatchThrottleBurst
 		*out = new(int32)
 		**out = **in
 	}
+	if in.AuditWebhookBatchThrottleEnable != nil {
+		in, out := &in.AuditWebhookBatchThrottleEnable, &out.AuditWebhookBatchThrottleEnable
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AuditWebhookBatchThrottleQps != nil {
 		in, out := &in.AuditWebhookBatchThrottleQps, &out.AuditWebhookBatchThrottleQps
-		*out = new(float64)
+		*out = new(float32)
+		**out = **in
+	}
+	if in.AuditWebhookInitialBackoff != nil {
+		in, out := &in.AuditWebhookInitialBackoff, &out.AuditWebhookInitialBackoff
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.AuthenticationTokenWebhookConfigFile != nil {

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -1972,14 +1972,29 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.AuditWebhookBatchMaxWait != nil {
+		in, out := &in.AuditWebhookBatchMaxWait, &out.AuditWebhookBatchMaxWait
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.AuditWebhookBatchThrottleBurst != nil {
 		in, out := &in.AuditWebhookBatchThrottleBurst, &out.AuditWebhookBatchThrottleBurst
 		*out = new(int32)
 		**out = **in
 	}
+	if in.AuditWebhookBatchThrottleEnable != nil {
+		in, out := &in.AuditWebhookBatchThrottleEnable, &out.AuditWebhookBatchThrottleEnable
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AuditWebhookBatchThrottleQps != nil {
 		in, out := &in.AuditWebhookBatchThrottleQps, &out.AuditWebhookBatchThrottleQps
-		*out = new(float64)
+		*out = new(float32)
+		**out = **in
+	}
+	if in.AuditWebhookInitialBackoff != nil {
+		in, out := &in.AuditWebhookInitialBackoff, &out.AuditWebhookInitialBackoff
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.AuthenticationTokenWebhookConfigFile != nil {

--- a/upup/pkg/fi/values.go
+++ b/upup/pkg/fi/values.go
@@ -42,7 +42,21 @@ func String(s string) *string {
 	return &s
 }
 
-// Float64 returns a point to a flot64
+// Float32 returns a point to a float32
+func Float32(v float32) *float32 {
+	return &v
+}
+
+// Float32Value returns the value of the float
+func Float32Value(v *float32) float32 {
+	if v == nil {
+		return 0.0
+	}
+
+	return *v
+}
+
+// Float64 returns a point to a float64
 func Float64(v float64) *float64 {
 	return &v
 }


### PR DESCRIPTION
This is going to be in componentconfig soon, so it would be nice to
have the same types.

These flags were recently mapped in #6361 and have not yet been in a
release - it's now or never!  (Though technically it is only the
AuditWebhookBatchThrottleEnable that won't parse identically)

Also added tests!