### PR TITLE
Use EnsureTask for internal api route53 record

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -56,6 +56,17 @@ spec:
       sslCertificate: arn:aws:acm:<region>:<accountId>:certificate/<uuid>
 ```
 
+It is possible to use the load balancer internally by setting the `useForInternalApi: true`.
+This will point both `masterPublicName` and `masterInternalName` to the load balancer. You can therefore set both of these to the same value in this configuration.
+
+```yaml
+spec:
+  api:
+    loadBalancer:
+      type: Internal
+      useForInternalApi: true
+```
+
 ### etcdClusters v3 & tls
 
 Although kops doesn't presently default to etcd3, it is possible to turn on both v3 and TLS authentication for communication amongst cluster members. These options may be enabled via the cluster spec (manifests only i.e. no command line options as yet). An upfront warning; at present no upgrade path exists for migrating from v2 to v3 so **DO NOT** try to enable this on a v2 running cluster as it must be done on cluster creation. The below example snippet assumes a HA cluster of three masters.

--- a/pkg/model/dns.go
+++ b/pkg/model/dns.go
@@ -127,7 +127,8 @@ func (b *DNSModelBuilder) Build(c *fi.ModelBuilderContext) error {
 				ResourceType:       s("A"),
 				TargetLoadBalancer: b.LinkToELB("api"),
 			}
-			c.AddTask(internalApiDnsName)
+			// Using EnsureTask as MasterInternalName and MasterPublicName could be the same
+			c.EnsureTask(internalApiDnsName)
 		}
 	}
 


### PR DESCRIPTION
When using `useForInternalApi: true` it makes sense to have `masterPublicName` and `masterInternalName` set to the same value as they will both point to the same load balancer.

This currently isn't possible as a duplicate task is detected and an error is thrown.

Similar to #6616 so a simple `EnsureTask` is needed for the error not to be raised. I have also added to the documentation as there was no mention of `useForInternalApi`.