### PR TITLE
Add manage security groups for loadbalancers

### DIFF
--- a/nodeup/pkg/model/cloudconfig.go
+++ b/nodeup/pkg/model/cloudconfig.go
@@ -137,6 +137,7 @@ func (b *CloudConfigBuilder) Build(c *fi.ModelBuilderContext) error {
 				fmt.Sprintf("lb-method=%s", fi.StringValue(lb.Method)),
 				fmt.Sprintf("lb-provider=%s", fi.StringValue(lb.Provider)),
 				fmt.Sprintf("use-octavia=%t", fi.BoolValue(lb.UseOctavia)),
+				fmt.Sprintf("manage-security-groups=%t", fi.BoolValue(lb.ManageSecGroups)),
 				"",
 			)
 

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -538,6 +538,7 @@ type OpenstackLoadbalancerConfig struct {
 	FloatingNetworkID *string `json:"floatingNetworkID,omitempty"`
 	FloatingSubnet    *string `json:"floatingSubnet,omitempty"`
 	SubnetID          *string `json:"subnetID,omitempty"`
+	ManageSecGroups   *bool   `json:"manageSecurityGroups,omitempty"`
 }
 
 type OpenstackBlockStorageConfig struct {

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -538,6 +538,7 @@ type OpenstackLoadbalancerConfig struct {
 	FloatingNetworkID *string `json:"floatingNetworkID,omitempty"`
 	FloatingSubnet    *string `json:"floatingSubnet,omitempty"`
 	SubnetID          *string `json:"subnetID,omitempty"`
+	ManageSecGroups   *bool   `json:"manageSecurityGroups,omitempty"`
 }
 
 type OpenstackBlockStorageConfig struct {

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -4076,6 +4076,7 @@ func autoConvert_v1alpha1_OpenstackLoadbalancerConfig_To_kops_OpenstackLoadbalan
 	out.FloatingNetworkID = in.FloatingNetworkID
 	out.FloatingSubnet = in.FloatingSubnet
 	out.SubnetID = in.SubnetID
+	out.ManageSecGroups = in.ManageSecGroups
 	return nil
 }
 
@@ -4092,6 +4093,7 @@ func autoConvert_kops_OpenstackLoadbalancerConfig_To_v1alpha1_OpenstackLoadbalan
 	out.FloatingNetworkID = in.FloatingNetworkID
 	out.FloatingSubnet = in.FloatingSubnet
 	out.SubnetID = in.SubnetID
+	out.ManageSecGroups = in.ManageSecGroups
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2694,6 +2694,11 @@ func (in *OpenstackLoadbalancerConfig) DeepCopyInto(out *OpenstackLoadbalancerCo
 		*out = new(string)
 		**out = **in
 	}
+	if in.ManageSecGroups != nil {
+		in, out := &in.ManageSecGroups, &out.ManageSecGroups
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -538,6 +538,7 @@ type OpenstackLoadbalancerConfig struct {
 	FloatingNetworkID *string `json:"floatingNetworkID,omitempty"`
 	FloatingSubnet    *string `json:"floatingSubnet,omitempty"`
 	SubnetID          *string `json:"subnetID,omitempty"`
+	ManageSecGroups   *bool   `json:"manageSecurityGroups,omitempty"`
 }
 
 type OpenstackBlockStorageConfig struct {

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4346,6 +4346,7 @@ func autoConvert_v1alpha2_OpenstackLoadbalancerConfig_To_kops_OpenstackLoadbalan
 	out.FloatingNetworkID = in.FloatingNetworkID
 	out.FloatingSubnet = in.FloatingSubnet
 	out.SubnetID = in.SubnetID
+	out.ManageSecGroups = in.ManageSecGroups
 	return nil
 }
 
@@ -4362,6 +4363,7 @@ func autoConvert_kops_OpenstackLoadbalancerConfig_To_v1alpha2_OpenstackLoadbalan
 	out.FloatingNetworkID = in.FloatingNetworkID
 	out.FloatingSubnet = in.FloatingSubnet
 	out.SubnetID = in.SubnetID
+	out.ManageSecGroups = in.ManageSecGroups
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2765,6 +2765,11 @@ func (in *OpenstackLoadbalancerConfig) DeepCopyInto(out *OpenstackLoadbalancerCo
 		*out = new(string)
 		**out = **in
 	}
+	if in.ManageSecGroups != nil {
+		in, out := &in.ManageSecGroups, &out.ManageSecGroups
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2979,6 +2979,11 @@ func (in *OpenstackLoadbalancerConfig) DeepCopyInto(out *OpenstackLoadbalancerCo
 		*out = new(string)
 		**out = **in
 	}
+	if in.ManageSecGroups != nil {
+		in, out := &in.ManageSecGroups, &out.ManageSecGroups
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Implements possibility to configure manage-security-groups to openstack cloudprovider

this is part of issue #6631 but does not fix it completely (yet)
/sig openstack
/cc @drekle 