### PR TITLE
Quick Clean

### DIFF
--- a/pkg/model/awsmodel/context.go
+++ b/pkg/model/awsmodel/context.go
@@ -27,17 +27,16 @@ type AWSModelContext struct {
 	*model.KopsModelContext
 }
 
+// UseMixedInstancePolicies indicates if we are using mixed instance policies
+func UseMixedInstancePolicies(ig *kops.InstanceGroup) bool {
+	return ig.Spec.MixedInstancesPolicy != nil
+}
+
 // UseLaunchTemplate checks if we need to use a launch template rather than configuration
 func UseLaunchTemplate(ig *kops.InstanceGroup) bool {
 	if featureflag.EnableLaunchTemplates.Enabled() {
 		return true
 	}
-	// @note: this mixed instance polices was added before the feature flag, to keep the
-	// same behviour we also check this. But since the feature hasn't been cut into a tagged
-	// release it possible to use just the feature flag??
-	if ig.Spec.MixedInstancesPolicy != nil {
-		return true
-	}
 
-	return false
+	return UseMixedInstancePolicies(ig)
 }


### PR DESCRIPTION
- cleaning up the UseLaunchTemplate(); we need the check for the LT and mixed policies to be separate as you can have a mixed instance policy without going full LT 