### PR TITLE
Allow uneven etcd zones

### DIFF
--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -157,10 +157,11 @@ func (c *populateClusterSpec) run(clientset simple.Clientset) error {
 					//if clusterSubnets[zone] == nil {
 					//	return fmt.Errorf("EtcdMembers for %q is configured in zone %q, but that is not configured at the k8s-cluster level", etcd.Name, m.Zone)
 					//}
+					etcdNames[m.Name] = m
 					etcdInstanceGroups[instanceGroupName] = m
 				}
 
-				if (len(etcdInstanceGroups) % 2) == 0 {
+				if (len(etcdNames) % 2) == 0 {
 					// Not technically a requirement, but doesn't really make sense to allow
 					return fmt.Errorf("there should be an odd number of master-zones, for etcd's quorum.  Hint: Use --zones and --master-zones to declare node zones and master zones separately")
 				}


### PR DESCRIPTION
Previously trying to use multiple etcd members on two AZs would result in the "there should be an odd number of master-zones" error, even if there was an odd number of etcd members.

This change fixes the etcdNames check by actually storing the values in the map, and uses that to check that the number of etcd members is an odd number, even if the zones are reused (there is an existing warning for that).