### PR TITLE
Override volume zone name

### DIFF
--- a/docs/tutorial/openstack.md
+++ b/docs/tutorial/openstack.md
@@ -66,6 +66,49 @@ kops delete cluster my-cluster.k8s.local --yes
 * `--os-dns-servers=8.8.8.8,8.8.4.4` You can define dns servers to be used in your cluster if your openstack setup does not have working dnssetup by default
 
 
+# Compute and volume zone names does not match
+Some of the openstack users do not have compute zones named exactly the same than volume zones. Good example is that there are several compute zones for instance `zone-1`, `zone-2` and `zone-3`. Then there is only one volumezone which is usually called `nova`. By default this is problem in kops, because kops assumes that if you are deploying things to `zone-1` there should be compute and volume zone called `zone-1`.
+
+However, you can still get kops working in your openstack by doing following:
+
+**Create cluster using your compute zones**
+
+```
+kops create cluster \
+  ...
+  --zones zone-1,zone-2,zone-3 \
+  ...
+```
+
+**After you have initialized the configuration you need to edit configuration**
+
+```
+kops edit cluster my-cluster.k8s.local
+```
+
+Edit `ignore-volume-az` to `true` and `override-volume-az` according to your cinder az name.
+
+Example (volume zone is called `nova`):
+
+```
+spec:
+  ...
+  cloudConfig:
+    openstack:
+      blockStorage:
+        ignore-volume-az: true
+        override-volume-az: nova
+  ...
+```
+
+**Finally execute update cluster**
+
+```
+kops update cluster my-cluster.k8s.local --state ${KOPS_STATE_STORE} --yes
+```
+
+Kops should create instances to all three zones, but provision volumes from the same zone.
+
 # Using external cloud controller manager
 If you want use [External CCM](https://github.com/kubernetes/cloud-provider-openstack) in your installation, this section contains instructions what you should do to get it up and running.
 

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -542,8 +542,9 @@ type OpenstackLoadbalancerConfig struct {
 }
 
 type OpenstackBlockStorageConfig struct {
-	Version  *string `json:"bs-version,omitempty"`
-	IgnoreAZ *bool   `json:"ignore-volume-az,omitempty"`
+	Version    *string `json:"bs-version,omitempty"`
+	IgnoreAZ   *bool   `json:"ignore-volume-az,omitempty"`
+	OverrideAZ *string `json:"override-volume-az,omitempty"`
 }
 
 // OpenstackMonitor defines the config for a health monitor

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -542,8 +542,9 @@ type OpenstackLoadbalancerConfig struct {
 }
 
 type OpenstackBlockStorageConfig struct {
-	Version  *string `json:"bs-version,omitempty"`
-	IgnoreAZ *bool   `json:"ignore-volume-az,omitempty"`
+	Version    *string `json:"bs-version,omitempty"`
+	IgnoreAZ   *bool   `json:"ignore-volume-az,omitempty"`
+	OverrideAZ *string `json:"override-volume-az,omitempty"`
 }
 
 // OpenstackMonitor defines the config for a health monitor

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -3959,6 +3959,7 @@ func Convert_kops_NodeAuthorizerSpec_To_v1alpha1_NodeAuthorizerSpec(in *kops.Nod
 func autoConvert_v1alpha1_OpenstackBlockStorageConfig_To_kops_OpenstackBlockStorageConfig(in *OpenstackBlockStorageConfig, out *kops.OpenstackBlockStorageConfig, s conversion.Scope) error {
 	out.Version = in.Version
 	out.IgnoreAZ = in.IgnoreAZ
+	out.OverrideAZ = in.OverrideAZ
 	return nil
 }
 
@@ -3970,6 +3971,7 @@ func Convert_v1alpha1_OpenstackBlockStorageConfig_To_kops_OpenstackBlockStorageC
 func autoConvert_kops_OpenstackBlockStorageConfig_To_v1alpha1_OpenstackBlockStorageConfig(in *kops.OpenstackBlockStorageConfig, out *OpenstackBlockStorageConfig, s conversion.Scope) error {
 	out.Version = in.Version
 	out.IgnoreAZ = in.IgnoreAZ
+	out.OverrideAZ = in.OverrideAZ
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2622,6 +2622,11 @@ func (in *OpenstackBlockStorageConfig) DeepCopyInto(out *OpenstackBlockStorageCo
 		*out = new(bool)
 		**out = **in
 	}
+	if in.OverrideAZ != nil {
+		in, out := &in.OverrideAZ, &out.OverrideAZ
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -542,8 +542,9 @@ type OpenstackLoadbalancerConfig struct {
 }
 
 type OpenstackBlockStorageConfig struct {
-	Version  *string `json:"bs-version,omitempty"`
-	IgnoreAZ *bool   `json:"ignore-volume-az,omitempty"`
+	Version    *string `json:"bs-version,omitempty"`
+	IgnoreAZ   *bool   `json:"ignore-volume-az,omitempty"`
+	OverrideAZ *string `json:"override-volume-az,omitempty"`
 }
 
 // OpenstackMonitor defines the config for a health monitor

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4229,6 +4229,7 @@ func Convert_kops_NodeAuthorizerSpec_To_v1alpha2_NodeAuthorizerSpec(in *kops.Nod
 func autoConvert_v1alpha2_OpenstackBlockStorageConfig_To_kops_OpenstackBlockStorageConfig(in *OpenstackBlockStorageConfig, out *kops.OpenstackBlockStorageConfig, s conversion.Scope) error {
 	out.Version = in.Version
 	out.IgnoreAZ = in.IgnoreAZ
+	out.OverrideAZ = in.OverrideAZ
 	return nil
 }
 
@@ -4240,6 +4241,7 @@ func Convert_v1alpha2_OpenstackBlockStorageConfig_To_kops_OpenstackBlockStorageC
 func autoConvert_kops_OpenstackBlockStorageConfig_To_v1alpha2_OpenstackBlockStorageConfig(in *kops.OpenstackBlockStorageConfig, out *OpenstackBlockStorageConfig, s conversion.Scope) error {
 	out.Version = in.Version
 	out.IgnoreAZ = in.IgnoreAZ
+	out.OverrideAZ = in.OverrideAZ
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2693,6 +2693,11 @@ func (in *OpenstackBlockStorageConfig) DeepCopyInto(out *OpenstackBlockStorageCo
 		*out = new(bool)
 		**out = **in
 	}
+	if in.OverrideAZ != nil {
+		in, out := &in.OverrideAZ, &out.OverrideAZ
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2907,6 +2907,11 @@ func (in *OpenstackBlockStorageConfig) DeepCopyInto(out *OpenstackBlockStorageCo
 		*out = new(bool)
 		**out = **in
 	}
+	if in.OverrideAZ != nil {
+		in, out := &in.OverrideAZ, &out.OverrideAZ
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -262,6 +262,10 @@ func (b *MasterVolumeBuilder) addOpenstackVolume(c *fi.ModelBuilderContext, name
 	// This says "only mount on a master"
 	tags[openstack.TagNameRolePrefix+"master"] = "1"
 
+	// override zone
+	if b.Cluster.Spec.CloudConfig.Openstack.BlockStorage != nil && b.Cluster.Spec.CloudConfig.Openstack.BlockStorage.OverrideAZ != nil {
+		zone = fi.StringValue(b.Cluster.Spec.CloudConfig.Openstack.BlockStorage.OverrideAZ)
+	}
 	t := &openstacktasks.Volume{
 		Name:             s(name),
 		AvailabilityZone: s(zone),


### PR DESCRIPTION
We have currently problem that volume zone name does not match to compute zone names in openstack. This is pretty common in openstack installations and that is why there is similar feature in k8s cloudprovider https://github.com/kubernetes/cloud-provider-openstack/blob/master/pkg/cloudprovider/providers/openstack/openstack.go#L123 

This PR makes it possible to use single volume AZ and many compute zones. 

/sig openstack
