### PR TITLE
Openstack environment escaping

### DIFF
--- a/nodeup/pkg/bootstrap/install.go
+++ b/nodeup/pkg/bootstrap/install.go
@@ -151,11 +151,11 @@ func (i *Installation) buildSystemdJob() *nodetasks.Service {
 			"OS_AUTH_URL",
 			"OS_REGION_NAME",
 		} {
-			buffer.WriteString("\"")
+			buffer.WriteString("'")
 			buffer.WriteString(envVar)
 			buffer.WriteString("=")
 			buffer.WriteString(os.Getenv(envVar))
-			buffer.WriteString("\" ")
+			buffer.WriteString("' ")
 		}
 	}
 

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -83,7 +83,7 @@ func (b *BootstrapScript) buildEnvironmentVariables(cluster *kops.Cluster) (map[
 			"OS_AUTH_URL",
 			"OS_REGION_NAME",
 		} {
-			env[envVar] = os.Getenv(envVar)
+			env[envVar] = fmt.Sprintf("'%s'", os.Getenv(envVar))
 		}
 	}
 


### PR DESCRIPTION
Openstack allows special characters in its password fields.  To support this I have changed the mapping on the user_data as well as nodeup to use single quotes.  Protokube had already supported this.

Fixes:
#6658
/sig openstack