### PR TITLE
Promote alpha to stable and update alpha

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -34,7 +34,7 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.12.0"
-    recommendedVersion: 1.12.6
+    recommendedVersion: 1.12.7
     requiredVersion: 1.12.0
   - range: ">=1.11.0"
     recommendedVersion: 1.11.8
@@ -64,7 +64,7 @@ spec:
   - range: ">=1.12.0-alpha.1"
     #recommendedVersion: "1.12.0"
     #requiredVersion: 1.12.0
-    kubernetesVersion: 1.12.6
+    kubernetesVersion: 1.12.7
   - range: ">=1.11.0-alpha.1"
     #recommendedVersion: "1.11.0"
     #requiredVersion: 1.11.0

--- a/channels/stable
+++ b/channels/stable
@@ -34,10 +34,10 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.11.0"
-    recommendedVersion: 1.11.7
+    recommendedVersion: 1.11.8
     requiredVersion: 1.11.0
   - range: ">=1.10.0"
-    recommendedVersion: 1.10.12
+    recommendedVersion: 1.10.13
     requiredVersion: 1.10.0
   - range: ">=1.9.0"
     recommendedVersion: 1.9.11
@@ -61,11 +61,11 @@ spec:
   - range: ">=1.11.0-alpha.1"
     #recommendedVersion: "1.11.0"
     #requiredVersion: 1.11.0
-    kubernetesVersion: 1.11.7
+    kubernetesVersion: 1.11.8
   - range: ">=1.10.0-alpha.1"
     recommendedVersion: "1.10.0"
     #requiredVersion: 1.10.0
-    kubernetesVersion: 1.10.12
+    kubernetesVersion: 1.10.13
   - range: ">=1.9.0-alpha.1"
     recommendedVersion: 1.9.2
     #requiredVersion: 1.9.0


### PR DESCRIPTION
We've been running 1.11.8 in prod for awhile. Also promoting 1.10.13 and updating alpha.

Fixes #6662 
