### PR TITLE
Put 1.12 into stable channel, for users of kops 1.12-alphas

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -33,6 +33,9 @@ spec:
     networking:
       kubenet: {}
   kubernetesVersions:
+  - range: ">=1.12.0"
+    recommendedVersion: 1.12.7
+    requiredVersion: 1.12.0
   - range: ">=1.11.0"
     recommendedVersion: 1.11.7
     requiredVersion: 1.11.0
@@ -58,6 +61,10 @@ spec:
     recommendedVersion: 1.4.12
     requiredVersion: 1.4.2
   kopsVersions:
+  - range: ">=1.12.0-alpha.1"
+    #recommendedVersion: "1.12.0"
+    #requiredVersion: 1.12.0
+    kubernetesVersion: 1.12.7
   - range: ">=1.11.0-alpha.1"
     #recommendedVersion: "1.11.0"
     #requiredVersion: 1.11.0


### PR DESCRIPTION
This ensures that users that use kops 1.12 (alpha) get k8s 1.12 by
default.  We go straight to the latest k8s 1.12 release - there's no
reason to recommend an earlier one.