### PR TITLE
Upload protokube to github as part of release

### DIFF
--- a/.shipbot.yaml
+++ b/.shipbot.yaml
@@ -13,3 +13,7 @@ assets:
     githubName: kops-windows-amd64
   - source: .build/dist/windows/amd64/kops.exe.sha1
     githubName: kops-windows-amd64-sha1
+  - source: .build/dist/images/protokube.tar.gz
+    githubName: images-protokube.tar.gz
+  - source: .build/dist/images/protokube.tar.gz.sha1
+    githubName: images-protokube.tar.gz.sha1


### PR DESCRIPTION
This will enable us to use github as one of our mirrors.