### PR TITLE
Support mirrors with restricted characters

### DIFF
--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -176,20 +176,20 @@ func (t *ProtokubeBuilder) ProtokubeImageName() string {
 
 // ProtokubeImagePullCommand returns the command to pull the image
 func (t *ProtokubeBuilder) ProtokubeImagePullCommand() string {
-	source := ""
+	var sources []string
 	if t.NodeupConfig.ProtokubeImage != nil {
-		source = t.NodeupConfig.ProtokubeImage.Source
+		sources = t.NodeupConfig.ProtokubeImage.Sources
 	}
-	if source == "" {
+	if len(sources) == 0 {
 		// Nothing to pull; return dummy value
 		return "/bin/true"
 	}
-	if strings.HasPrefix(source, "http:") || strings.HasPrefix(source, "https:") || strings.HasPrefix(source, "s3:") {
+	if strings.HasPrefix(sources[0], "http:") || strings.HasPrefix(sources[0], "https:") || strings.HasPrefix(sources[0], "s3:") {
 		// We preloaded the image; return a dummy value
 		return "/bin/true"
 	}
 
-	return "/usr/bin/docker pull " + t.NodeupConfig.ProtokubeImage.Source
+	return "/usr/bin/docker pull " + sources[0]
 }
 
 // ProtokubeFlags are the flags for protokube

--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -46,8 +46,8 @@ type Config struct {
 type Image struct {
 	// This is the name we would pass to "docker run", whereas source could be a URL from which we would download an image.
 	Name string `json:"name,omitempty"`
-	// Source is the URL from which we should download the image
-	Source string `json:"source,omitempty"`
+	// Sources is a list of URLs from which we should download the image
+	Sources []string `json:"sources,omitempty"`
 	// Hash is the hash of the file, to verify image integrity (even over http)
 	Hash string `json:"hash,omitempty"`
 }

--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
@@ -257,7 +257,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
   - c4871c7315817ee114f5c554a58da8ebc54f08c3@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubelet
   - d9fdb6b37597d371ef853cde76170f38a553aa78@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubectl
   - 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux/amd64/utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: additionalcidr.example.com
   ConfigBase: memfs://clusters.example.com/additionalcidr.example.com
   InstanceGroupName: master-us-test-1b
@@ -270,7 +270,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
     sources:
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
     - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
@@ -467,7 +467,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
   - c4871c7315817ee114f5c554a58da8ebc54f08c3@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubelet
   - d9fdb6b37597d371ef853cde76170f38a553aa78@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubectl
   - 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux/amd64/utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: additionalcidr.example.com
   ConfigBase: memfs://clusters.example.com/additionalcidr.example.com
   InstanceGroupName: nodes
@@ -480,7 +480,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
     sources:
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
     - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV

--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
@@ -269,7 +269,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
   protokubeImage:
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
-    source: https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    sources:
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -477,7 +479,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
   protokubeImage:
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
-    source: https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    sources:
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -278,7 +278,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
   protokubeImage:
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
-    source: https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    sources:
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -506,7 +508,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
   protokubeImage:
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
-    source: https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    sources:
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -266,7 +266,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
   - c4871c7315817ee114f5c554a58da8ebc54f08c3@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubelet
   - d9fdb6b37597d371ef853cde76170f38a553aa78@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubectl
   - 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux/amd64/utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: additionaluserdata.example.com
   ConfigBase: memfs://clusters.example.com/additionaluserdata.example.com
   InstanceGroupName: master-us-test-1a
@@ -279,7 +279,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
     sources:
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
     - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
@@ -496,7 +496,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
   - c4871c7315817ee114f5c554a58da8ebc54f08c3@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubelet
   - d9fdb6b37597d371ef853cde76170f38a553aa78@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubectl
   - 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux/amd64/utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: additionaluserdata.example.com
   ConfigBase: memfs://clusters.example.com/additionaluserdata.example.com
   InstanceGroupName: nodes
@@ -509,7 +509,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
     sources:
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
     - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -269,7 +269,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   protokubeImage:
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
-    source: https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    sources:
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -477,7 +479,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   protokubeImage:
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
-    source: https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    sources:
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -257,7 +257,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   - c4871c7315817ee114f5c554a58da8ebc54f08c3@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubelet
   - d9fdb6b37597d371ef853cde76170f38a553aa78@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubectl
   - 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux/amd64/utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: minimal.example.com
   ConfigBase: memfs://clusters.example.com/minimal.example.com
   InstanceGroupName: master-us-test-1a
@@ -270,7 +270,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
     sources:
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
     - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
@@ -467,7 +467,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   - c4871c7315817ee114f5c554a58da8ebc54f08c3@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubelet
   - d9fdb6b37597d371ef853cde76170f38a553aa78@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubectl
   - 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux/amd64/utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: minimal.example.com
   ConfigBase: memfs://clusters.example.com/minimal.example.com
   InstanceGroupName: nodes
@@ -480,7 +480,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
     sources:
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
     - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -277,7 +277,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
   - 4c7b8aafe652ae107c9131754a2ad4e9641a025b@https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubelet
   - 006fd43085e6ba2dc6b35b89af4d68cee3f689c9@https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl
   - 1d9788b0f5420e1a219aad2cb8681823fc515e7c@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux/amd64/utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: externallb.example.com
   ConfigBase: memfs://clusters.example.com/externallb.example.com
   InstanceGroupName: master-us-test-1a
@@ -290,7 +290,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
     sources:
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
     - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
@@ -492,7 +492,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
   - 4c7b8aafe652ae107c9131754a2ad4e9641a025b@https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubelet
   - 006fd43085e6ba2dc6b35b89af4d68cee3f689c9@https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl
   - 1d9788b0f5420e1a219aad2cb8681823fc515e7c@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux/amd64/utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: externallb.example.com
   ConfigBase: memfs://clusters.example.com/externallb.example.com
   InstanceGroupName: nodes
@@ -505,7 +505,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
     sources:
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
     - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -289,7 +289,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
   protokubeImage:
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
-    source: https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    sources:
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -502,7 +504,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
   protokubeImage:
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
-    source: https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    sources:
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -269,7 +269,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   protokubeImage:
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
-    source: https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    sources:
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -477,7 +479,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   protokubeImage:
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
-    source: https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    sources:
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -257,7 +257,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   - c4871c7315817ee114f5c554a58da8ebc54f08c3@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubelet
   - d9fdb6b37597d371ef853cde76170f38a553aa78@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubectl
   - 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux/amd64/utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: minimal.example.com
   ConfigBase: memfs://clusters.example.com/minimal.example.com
   InstanceGroupName: master-us-test-1a
@@ -270,7 +270,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
     sources:
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
     - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
@@ -467,7 +467,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   - c4871c7315817ee114f5c554a58da8ebc54f08c3@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubelet
   - d9fdb6b37597d371ef853cde76170f38a553aa78@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubectl
   - 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux/amd64/utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: minimal.example.com
   ConfigBase: memfs://clusters.example.com/minimal.example.com
   InstanceGroupName: nodes
@@ -480,7 +480,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
     sources:
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
     - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
 
   __EOF_KUBE_ENV

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1308,23 +1308,25 @@ func (c *ApplyClusterCmd) BuildNodeUpConfig(assetBuilder *assets.AssetBuilder, i
 			}
 
 			image := &nodeup.Image{
-				Source: u.String(),
-				Hash:   hash.Hex(),
+				Sources: []string{u.String()},
+				Hash:    hash.Hex(),
 			}
 			images = append(images, image)
 		}
 	}
 
 	{
-		location, hash, err := ProtokubeImageSource(assetBuilder)
+		u, hash, err := ProtokubeImageSource(assetBuilder)
 		if err != nil {
 			return nil, err
 		}
 
+		asset := BuildMirroredAsset(u, hash)
+
 		config.ProtokubeImage = &nodeup.Image{
-			Name:   kopsbase.DefaultProtokubeImageName(),
-			Source: location.String(),
-			Hash:   hash.Hex(),
+			Name:    kopsbase.DefaultProtokubeImageName(),
+			Sources: asset.Locations,
+			Hash:    asset.Hash.Hex(),
 		}
 	}
 

--- a/upup/pkg/fi/cloudup/urls.go
+++ b/upup/pkg/fi/cloudup/urls.go
@@ -35,6 +35,7 @@ const defaultKopsBaseUrl = "https://kubeupv2.s3.amazonaws.com/kops/%s/"
 const defaultKopsMirrorBase = "https://kubeupv2.s3.amazonaws.com/kops/"
 
 // defaultKopsMirrors is a list of our well-known mirrors
+// Note that we download in order
 var defaultKopsMirrors = []string{
 	"https://github.com/kubernetes/kops/releases/download/",
 	// We do need to include defaultKopsMirrorBase - the list replaces the base url

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -293,14 +293,14 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 
 	for i, image := range c.config.Images {
 		taskMap["LoadImage."+strconv.Itoa(i)] = &nodetasks.LoadImageTask{
-			Source: image.Source,
-			Hash:   image.Hash,
+			Sources: image.Sources,
+			Hash:    image.Hash,
 		}
 	}
 	if c.config.ProtokubeImage != nil {
 		taskMap["LoadImage.protokube"] = &nodetasks.LoadImageTask{
-			Source: c.config.ProtokubeImage.Source,
-			Hash:   c.config.ProtokubeImage.Hash,
+			Sources: c.config.ProtokubeImage.Sources,
+			Hash:    c.config.ProtokubeImage.Hash,
 		}
 	}
 


### PR DESCRIPTION
Github doesn't allow us to have slashes in our release artifact names; we
therefore support a configurable per-mirror set of substitutions. We use
that to map `/` to `-` for github.