### PR TITLE
Add selector back to calico 1.12 deployment

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -347,6 +347,9 @@ metadata:
     k8s-app: calico-kube-controllers
     role.kubernetes.io/networking: "1"
 spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-kube-controllers
   # The controllers can only have a single active instance.
   replicas: 0
   strategy:


### PR DESCRIPTION
I had mistakenly removed it previously, which meant the manifest it
didn't apply on an update.