### PR TITLE
WIP: Update CoreDNS to v1.4.0

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.14.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.14.yaml.template
@@ -69,10 +69,10 @@ data:
         }
         prometheus :9153
         forward . /etc/resolv.conf
-        loop
         cache 30
-        loadbalance
+        loop
         reload
+        loadbalance
     }
 ---
 apiVersion: apps/v1
@@ -84,6 +84,7 @@ metadata:
     k8s-app: kube-dns
     k8s-addon: coredns.addons.k8s.io
     kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
 spec:
   replicas: 2
   strategy:
@@ -104,10 +105,10 @@ spec:
         - key: "CriticalAddonsOnly"
           operator: "Exists"
       nodeSelector:
-          beta.kubernetes.io/os: linux
+        beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.3.1
+        image: coredns/coredns:1.4.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -267,7 +267,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 					Version:           fi.String(version),
 					Selector:          map[string]string{"k8s-addon": key},
 					Manifest:          fi.String(location),
-					KubernetesVersion: ">=1.6.0 <1.12.0",
+					KubernetesVersion: ">=1.6.0 <1.14.0",
 					Id:                id,
 				})
 				manifests[key+"-"+id] = "addons/" + location
@@ -276,18 +276,18 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.3.0-kops.1"
+			version := "1.4.0"
 
 			{
-				location := key + "/k8s-1.12.yaml"
-				id := "k8s-1.12"
+				location := key + "/k8s-1.14.yaml"
+				id := "k8s-1.14"
 
 				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 					Name:              fi.String(key),
 					Version:           fi.String(version),
 					Selector:          map[string]string{"k8s-addon": key},
 					Manifest:          fi.String(location),
-					KubernetesVersion: ">=1.12.0",
+					KubernetesVersion: ">=1.14.0",
 					Id:                id,
 				})
 				manifests[key+"-"+id] = "addons/" + location


### PR DESCRIPTION
- Updated CoreDNS to v1.4.0 - Related Kubernetes v1.14 release notes:
```
There is a known issue coredns/coredns#2629 in CoreDNS 1.3.1, wherein if the Kubernetes API shuts down while CoreDNS is connected, CoreDNS will crash. The issue is fixed in CoreDNS 1.4.0 in coredns/coredns#2529.
```