### PR TITLE
Fix elb tagging

### DIFF
--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -119,6 +119,13 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 			glog.V(1).Infof("WARNING: You are overwriting the Load Balancers, Security Group. When this is done you are responsible for ensure the correct rules!")
 		}
 
+		tags := b.CloudTags(loadBalancerName, false)
+		for k, v := range b.Cluster.Spec.CloudLabels {
+			tags[k] = v
+		}
+		// Override the returned name to be the expected ELB name
+		tags["Name"] = "api." + b.ClusterName()
+
 		elb = &awstasks.LoadBalancer{
 			Name:      fi.String("api." + b.ClusterName()),
 			Lifecycle: b.Lifecycle,
@@ -143,7 +150,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 				IdleTimeout: fi.Int64(int64(idleTimeout.Seconds())),
 			},
 
-			Tags: b.Cluster.Spec.CloudLabels,
+			Tags: tags,
 		}
 
 		switch lbSpec.Type {

--- a/pkg/model/bastion.go
+++ b/pkg/model/bastion.go
@@ -208,6 +208,13 @@ func (b *BastionModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			idleTimeout = time.Second * time.Duration(*b.Cluster.Spec.Topology.Bastion.IdleTimeoutSeconds)
 		}
 
+		tags := b.CloudTags(loadBalancerName, false)
+		for k, v := range b.Cluster.Spec.CloudLabels {
+			tags[k] = v
+		}
+		// Override the returned name to be the expected ELB name
+		tags["Name"] = "bastion." + b.ClusterName()
+
 		elb = &awstasks.LoadBalancer{
 			Name:      s("bastion." + b.ClusterName()),
 			Lifecycle: b.Lifecycle,
@@ -232,6 +239,8 @@ func (b *BastionModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			ConnectionSettings: &awstasks.LoadBalancerConnectionSettings{
 				IdleTimeout: i64(int64(idleTimeout.Seconds())),
 			},
+
+			Tags: tags,
 		}
 
 		c.AddTask(elb)

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -271,8 +271,9 @@ resource "aws_elb" "api-bastionuserdata-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "bastionuserdata.example.com"
-    Name              = "api.bastionuserdata.example.com"
+    KubernetesCluster                                   = "bastionuserdata.example.com"
+    Name                                                = "api.bastionuserdata.example.com"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
   }
 }
 
@@ -300,8 +301,9 @@ resource "aws_elb" "bastion-bastionuserdata-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "bastionuserdata.example.com"
-    Name              = "bastion.bastionuserdata.example.com"
+    KubernetesCluster                                   = "bastionuserdata.example.com"
+    Name                                                = "bastion.bastionuserdata.example.com"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -226,10 +226,11 @@ resource "aws_elb" "api-complex-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "complex.example.com"
-    Name              = "api.complex.example.com"
-    Owner             = "John Doe"
-    "foo/bar"         = "fib+baz"
+    KubernetesCluster                           = "complex.example.com"
+    Name                                        = "api.complex.example.com"
+    Owner                                       = "John Doe"
+    "foo/bar"                                   = "fib+baz"
+    "kubernetes.io/cluster/complex.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -335,8 +335,9 @@ resource "aws_elb" "api-existingsg-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "existingsg.example.com"
-    Name              = "api.existingsg.example.com"
+    KubernetesCluster                              = "existingsg.example.com"
+    Name                                           = "api.existingsg.example.com"
+    "kubernetes.io/cluster/existingsg.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/lifecycle_phases/loadbalancer-kubernetes.tf
+++ b/tests/integration/update_cluster/lifecycle_phases/loadbalancer-kubernetes.tf
@@ -133,8 +133,9 @@ resource "aws_elb" "bastion-lifecyclephases-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "lifecyclephases.example.com"
-    Name              = "bastion.lifecyclephases.example.com"
+    KubernetesCluster                                   = "lifecyclephases.example.com"
+    Name                                                = "bastion.lifecyclephases.example.com"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -251,8 +251,9 @@ resource "aws_elb" "api-private-shared-subnet-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "private-shared-subnet.example.com"
-    Name              = "api.private-shared-subnet.example.com"
+    KubernetesCluster                                         = "private-shared-subnet.example.com"
+    Name                                                      = "api.private-shared-subnet.example.com"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
   }
 }
 
@@ -280,8 +281,9 @@ resource "aws_elb" "bastion-private-shared-subnet-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "private-shared-subnet.example.com"
-    Name              = "bastion.private-shared-subnet.example.com"
+    KubernetesCluster                                         = "private-shared-subnet.example.com"
+    Name                                                      = "bastion.private-shared-subnet.example.com"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -271,8 +271,9 @@ resource "aws_elb" "api-privatecalico-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "privatecalico.example.com"
-    Name              = "api.privatecalico.example.com"
+    KubernetesCluster                                 = "privatecalico.example.com"
+    Name                                              = "api.privatecalico.example.com"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
   }
 }
 
@@ -300,8 +301,9 @@ resource "aws_elb" "bastion-privatecalico-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "privatecalico.example.com"
-    Name              = "bastion.privatecalico.example.com"
+    KubernetesCluster                                 = "privatecalico.example.com"
+    Name                                              = "bastion.privatecalico.example.com"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -271,8 +271,9 @@ resource "aws_elb" "api-privatecanal-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "privatecanal.example.com"
-    Name              = "api.privatecanal.example.com"
+    KubernetesCluster                                = "privatecanal.example.com"
+    Name                                             = "api.privatecanal.example.com"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
   }
 }
 
@@ -300,8 +301,9 @@ resource "aws_elb" "bastion-privatecanal-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "privatecanal.example.com"
-    Name              = "bastion.privatecanal.example.com"
+    KubernetesCluster                                = "privatecanal.example.com"
+    Name                                             = "bastion.privatecanal.example.com"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -271,8 +271,9 @@ resource "aws_elb" "api-privatedns1-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "privatedns1.example.com"
-    Name              = "api.privatedns1.example.com"
+    KubernetesCluster                               = "privatedns1.example.com"
+    Name                                            = "api.privatedns1.example.com"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
 
@@ -300,8 +301,9 @@ resource "aws_elb" "bastion-privatedns1-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "privatedns1.example.com"
-    Name              = "bastion.privatedns1.example.com"
+    KubernetesCluster                               = "privatedns1.example.com"
+    Name                                            = "bastion.privatedns1.example.com"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -266,8 +266,9 @@ resource "aws_elb" "api-privatedns2-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "privatedns2.example.com"
-    Name              = "api.privatedns2.example.com"
+    KubernetesCluster                               = "privatedns2.example.com"
+    Name                                            = "api.privatedns2.example.com"
+    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
   }
 }
 
@@ -295,8 +296,9 @@ resource "aws_elb" "bastion-privatedns2-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "privatedns2.example.com"
-    Name              = "bastion.privatedns2.example.com"
+    KubernetesCluster                               = "privatedns2.example.com"
+    Name                                            = "bastion.privatedns2.example.com"
+    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -271,8 +271,9 @@ resource "aws_elb" "api-privateflannel-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "privateflannel.example.com"
-    Name              = "api.privateflannel.example.com"
+    KubernetesCluster                                  = "privateflannel.example.com"
+    Name                                               = "api.privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
   }
 }
 
@@ -300,8 +301,9 @@ resource "aws_elb" "bastion-privateflannel-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "privateflannel.example.com"
-    Name              = "bastion.privateflannel.example.com"
+    KubernetesCluster                                  = "privateflannel.example.com"
+    Name                                               = "bastion.privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -276,8 +276,9 @@ resource "aws_elb" "api-privatekopeio-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "privatekopeio.example.com"
-    Name              = "api.privatekopeio.example.com"
+    KubernetesCluster                                 = "privatekopeio.example.com"
+    Name                                              = "api.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
   }
 }
 
@@ -305,8 +306,9 @@ resource "aws_elb" "bastion-privatekopeio-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "privatekopeio.example.com"
-    Name              = "bastion.privatekopeio.example.com"
+    KubernetesCluster                                 = "privatekopeio.example.com"
+    Name                                              = "bastion.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -271,8 +271,9 @@ resource "aws_elb" "api-privateweave-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "privateweave.example.com"
-    Name              = "api.privateweave.example.com"
+    KubernetesCluster                                = "privateweave.example.com"
+    Name                                             = "api.privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
   }
 }
 
@@ -300,8 +301,9 @@ resource "aws_elb" "bastion-privateweave-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "privateweave.example.com"
-    Name              = "bastion.privateweave.example.com"
+    KubernetesCluster                                = "privateweave.example.com"
+    Name                                             = "bastion.privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
   }
 }
 

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -256,8 +256,9 @@ resource "aws_elb" "api-unmanaged-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "unmanaged.example.com"
-    Name              = "api.unmanaged.example.com"
+    KubernetesCluster                             = "unmanaged.example.com"
+    Name                                          = "api.unmanaged.example.com"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
   }
 }
 
@@ -285,8 +286,9 @@ resource "aws_elb" "bastion-unmanaged-example-com" {
   idle_timeout = 300
 
   tags = {
-    KubernetesCluster = "unmanaged.example.com"
-    Name              = "bastion.unmanaged.example.com"
+    KubernetesCluster                             = "unmanaged.example.com"
+    Name                                          = "bastion.unmanaged.example.com"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
   }
 }
 

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -162,6 +162,10 @@ func (c *MockAWSCloud) CreateELBTags(loadBalancerName string, tags map[string]st
 	return createELBTags(c, loadBalancerName, tags)
 }
 
+func (c *MockAWSCloud) RemoveELBTags(loadBalancerName string, tags map[string]string) error {
+	return removeELBTags(c, loadBalancerName, tags)
+}
+
 func (c *MockAWSCloud) GetELBV2Tags(ResourceArn string) (map[string]string, error) {
 	return getELBV2Tags(c, ResourceArn)
 }


### PR DESCRIPTION
Turns out we weren't tagging quite right, also needed to add a removal function.

To note, this also adds a new tag to existing elbs since we're now using `b.Cluster.Spec.CloudLabels` to generate the elb tags:
```
"kubernetes.io/cluster/clustername.example.com" = "owned"
```
I don't believe this should have any negative effects.

Fixes: #6646, #2048 

Since this was included in 1.12 and has some weird effects, I think we should cherry-pick it in.
