### PR TITLE
Add ability to specify cpuRequest for API Server

### DIFF
--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -385,8 +385,13 @@ func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 	} else if kubeAPIServer.SecurePort != 0 {
 		probeAction.Port = intstr.FromInt(int(kubeAPIServer.SecurePort))
 		probeAction.Scheme = v1.URISchemeHTTPS
+	} 
+	
+	requestCPU := resource.MustParse("150m")
+	if b.Cluster.Spec.KubeAPIServer.CPURequest != nil {
+		requestCPU = resource.MustParse(b.Cluster.Spec.KubeAPIServer.CPURequest)
 	}
-
+	
 	container := &v1.Container{
 		Name:  "kube-apiserver",
 		Image: b.Cluster.Spec.KubeAPIServer.Image,
@@ -416,7 +421,7 @@ func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 		},
 		Resources: v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				v1.ResourceCPU: resource.MustParse(b.Cluster.Spec.KubeAPIServer.CPURequest),
+				v1.ResourceCPU: requestCPU
 			},
 		},
 	}

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -385,13 +385,13 @@ func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 	} else if kubeAPIServer.SecurePort != 0 {
 		probeAction.Port = intstr.FromInt(int(kubeAPIServer.SecurePort))
 		probeAction.Scheme = v1.URISchemeHTTPS
-	} 
-	
+	}
+
 	requestCPU := resource.MustParse("150m")
 	if b.Cluster.Spec.KubeAPIServer.CPURequest != nil {
 		requestCPU = resource.MustParse(b.Cluster.Spec.KubeAPIServer.CPURequest)
 	}
-	
+
 	container := &v1.Container{
 		Name:  "kube-apiserver",
 		Image: b.Cluster.Spec.KubeAPIServer.Image,
@@ -421,7 +421,7 @@ func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 		},
 		Resources: v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				v1.ResourceCPU: requestCPU
+				v1.ResourceCPU: requestCPU,
 			},
 		},
 	}

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -388,7 +388,7 @@ func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 	}
 
 	requestCPU := resource.MustParse("150m")
-	if b.Cluster.Spec.KubeAPIServer.CPURequest != nil {
+	if b.Cluster.Spec.KubeAPIServer.CPURequest != "" {
 		requestCPU = resource.MustParse(b.Cluster.Spec.KubeAPIServer.CPURequest)
 	}
 

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -416,7 +416,7 @@ func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 		},
 		Resources: v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				v1.ResourceCPU: resource.MustParse("150m"),
+				v1.ResourceCPU: resource.MustParse(b.Cluster.Spec.KubeAPIServer.CPURequest),
 			},
 		},
 	}

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -413,6 +413,7 @@ type KubeAPIServerConfig struct {
 	// The specified file can contain multiple keys, and the flag can be specified multiple times with different files.
 	// If unspecified, --tls-private-key-file is used.
 	ServiceAccountKeyFile []string `json:"serviceAccountKeyFile,omitempty" flag:"service-account-key-file"`
+
 	// CPURequest, cpu request compute resource for kube proxy e.g. "20m"
 	CPURequest string `json:"cpuRequest,omitempty"`
 }

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -414,7 +414,7 @@ type KubeAPIServerConfig struct {
 	// If unspecified, --tls-private-key-file is used.
 	ServiceAccountKeyFile []string `json:"serviceAccountKeyFile,omitempty" flag:"service-account-key-file"`
 
-	// CPURequest, cpu request compute resource for kube proxy e.g. "20m"
+	// CPURequest, cpu request compute resource for api server. Defaults to "150m"
 	CPURequest string `json:"cpuRequest,omitempty"`
 }
 

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -411,6 +411,8 @@ type KubeAPIServerConfig struct {
 	// The specified file can contain multiple keys, and the flag can be specified multiple times with different files.
 	// If unspecified, --tls-private-key-file is used.
 	ServiceAccountKeyFile []string `json:"serviceAccountKeyFile,omitempty" flag:"service-account-key-file"`
+	// CPURequest, cpu request compute resource for kube proxy e.g. "20m"
+	CPURequest string `json:"cpuRequest,omitempty"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -413,6 +413,9 @@ type KubeAPIServerConfig struct {
 	// The specified file can contain multiple keys, and the flag can be specified multiple times with different files.
 	// If unspecified, --tls-private-key-file is used.
 	ServiceAccountKeyFile []string `json:"serviceAccountKeyFile,omitempty" flag:"service-account-key-file"`
+
+	// CPURequest, cpu request compute resource for kube proxy e.g. "20m"
+	CPURequest string `json:"cpuRequest,omitempty"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -414,7 +414,7 @@ type KubeAPIServerConfig struct {
 	// If unspecified, --tls-private-key-file is used.
 	ServiceAccountKeyFile []string `json:"serviceAccountKeyFile,omitempty" flag:"service-account-key-file"`
 
-	// CPURequest, cpu request compute resource for kube proxy e.g. "20m"
+	// CPURequest, cpu request compute resource for api server. Defaults to "150m"
 	CPURequest string `json:"cpuRequest,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -2985,6 +2985,7 @@ func autoConvert_v1alpha1_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.TargetRamMb = in.TargetRamMb
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
+	out.CPURequest = in.CPURequest
 	return nil
 }
 
@@ -3072,6 +3073,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha1_KubeAPIServerConfig(in *ko
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.TargetRamMb = in.TargetRamMb
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
+	out.CPURequest = in.CPURequest
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -413,6 +413,9 @@ type KubeAPIServerConfig struct {
 	// The specified file can contain multiple keys, and the flag can be specified multiple times with different files.
 	// If unspecified, --tls-private-key-file is used.
 	ServiceAccountKeyFile []string `json:"serviceAccountKeyFile,omitempty" flag:"service-account-key-file"`
+
+	// CPURequest, cpu request compute resource for kube proxy e.g. "20m"
+	CPURequest string `json:"cpuRequest,omitempty"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -414,7 +414,7 @@ type KubeAPIServerConfig struct {
 	// If unspecified, --tls-private-key-file is used.
 	ServiceAccountKeyFile []string `json:"serviceAccountKeyFile,omitempty" flag:"service-account-key-file"`
 
-	// CPURequest, cpu request compute resource for kube proxy e.g. "20m"
+	// CPURequest, cpu request compute resource for api server. Defaults to "150m"
 	CPURequest string `json:"cpuRequest,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3255,6 +3255,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.TargetRamMb = in.TargetRamMb
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
+	out.CPURequest = in.CPURequest
 	return nil
 }
 
@@ -3342,6 +3343,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.TargetRamMb = in.TargetRamMb
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
+	out.CPURequest = in.CPURequest
 	return nil
 }
 


### PR DESCRIPTION
Adds ability to specify cupRequest for the API Server

```
spec:
  kubeAPIServer:
    cpuRequest: 300m
```