### PR TITLE
Allow customizing Resource Request & Limits for CoreDNS

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -345,13 +345,19 @@ type KubeDNSConfig struct {
 	// Replicas is the number of pod replicas - @deprecated as this is now in the addon and controlled by autoscaler
 	Replicas int `json:"replicas,omitempty"`
 	// Provider indicates whether CoreDNS or kube-dns will be the default service discovery.
-	Provider string `json:"provider,omitempty"`
+	v string `json:"provider,omitempty"`
 	// ServerIP is the server ip
 	ServerIP string `json:"serverIP,omitempty"`
 	// StubDomains redirects a domains to another DNS service
 	StubDomains map[string][]string `json:"stubDomains,omitempty"`
 	// UpstreamNameservers sets the upstream nameservers for queries not on the cluster domain
 	UpstreamNameservers []string `json:"upstreamNameservers,omitempty"`
+	// MemoryRequest specifies the memory requests of each dns container in the cluster. Default 70m.
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest specifies the cpu requests of each dns container in the cluster. Defualt 100m.
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// MemoryLimit specifies the memory limit of each dns container in the cluster. Default 170m.
+	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 }
 
 // ExternalDNSConfig are options of the dns-controller

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -354,7 +354,7 @@ type KubeDNSConfig struct {
 	UpstreamNameservers []string `json:"upstreamNameservers,omitempty"`
 	// MemoryRequest specifies the memory requests of each dns container in the cluster. Default 70m.
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
-	// CPURequest specifies the cpu requests of each dns container in the cluster. Defualt 100m.
+	// CPURequest specifies the cpu requests of each dns container in the cluster. Default 100m.
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// MemoryLimit specifies the memory limit of each dns container in the cluster. Default 170m.
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -345,7 +345,7 @@ type KubeDNSConfig struct {
 	// Replicas is the number of pod replicas - @deprecated as this is now in the addon and controlled by autoscaler
 	Replicas int `json:"replicas,omitempty"`
 	// Provider indicates whether CoreDNS or kube-dns will be the default service discovery.
-	v string `json:"provider,omitempty"`
+	Provider string `json:"provider,omitempty"`
 	// ServerIP is the server ip
 	ServerIP string `json:"serverIP,omitempty"`
 	// StubDomains redirects a domains to another DNS service

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -351,6 +351,12 @@ type KubeDNSConfig struct {
 	StubDomains map[string][]string `json:"stubDomains,omitempty"`
 	// UpstreamNameservers sets the upstream nameservers for queries not on the cluster domain
 	UpstreamNameservers []string `json:"upstreamNameservers,omitempty"`
+	// MemoryRequest specifies the memory requests of each dns container in the cluster. Default 70m.
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest specifies the cpu requests of each dns container in the cluster. Defualt 100m.
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// MemoryLimit specifies the memory limit of each dns container in the cluster. Default 170m.
+	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 }
 
 // ExternalDNSConfig are options of the dns-controller

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -353,7 +353,7 @@ type KubeDNSConfig struct {
 	UpstreamNameservers []string `json:"upstreamNameservers,omitempty"`
 	// MemoryRequest specifies the memory requests of each dns container in the cluster. Default 70m.
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
-	// CPURequest specifies the cpu requests of each dns container in the cluster. Defualt 100m.
+	// CPURequest specifies the cpu requests of each dns container in the cluster. Default 100m.
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// MemoryLimit specifies the memory limit of each dns container in the cluster. Default 170m.
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -3182,6 +3182,9 @@ func autoConvert_v1alpha1_KubeDNSConfig_To_kops_KubeDNSConfig(in *KubeDNSConfig,
 	out.ServerIP = in.ServerIP
 	out.StubDomains = in.StubDomains
 	out.UpstreamNameservers = in.UpstreamNameservers
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
+	out.MemoryLimit = in.MemoryLimit
 	return nil
 }
 
@@ -3200,6 +3203,9 @@ func autoConvert_kops_KubeDNSConfig_To_v1alpha1_KubeDNSConfig(in *kops.KubeDNSCo
 	out.ServerIP = in.ServerIP
 	out.StubDomains = in.StubDomains
 	out.UpstreamNameservers = in.UpstreamNameservers
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
+	out.MemoryLimit = in.MemoryLimit
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -1975,6 +1975,21 @@ func (in *KubeDNSConfig) DeepCopyInto(out *KubeDNSConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -352,6 +352,12 @@ type KubeDNSConfig struct {
 	StubDomains map[string][]string `json:"stubDomains,omitempty"`
 	// UpstreamNameservers sets the upstream nameservers for queries not on the cluster domain
 	UpstreamNameservers []string `json:"upstreamNameservers,omitempty"`
+	// MemoryRequest specifies the memory requests of each dns container in the cluster. Default 70m.
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest specifies the cpu requests of each dns container in the cluster. Defualt 100m.
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// MemoryLimit specifies the memory limit of each dns container in the cluster. Default 170m.
+	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 }
 
 // ExternalDNSConfig are options of the dns-controller

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -354,7 +354,7 @@ type KubeDNSConfig struct {
 	UpstreamNameservers []string `json:"upstreamNameservers,omitempty"`
 	// MemoryRequest specifies the memory requests of each dns container in the cluster. Default 70m.
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
-	// CPURequest specifies the cpu requests of each dns container in the cluster. Defualt 100m.
+	// CPURequest specifies the cpu requests of each dns container in the cluster. Default 100m.
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// MemoryLimit specifies the memory limit of each dns container in the cluster. Default 170m.
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3452,6 +3452,9 @@ func autoConvert_v1alpha2_KubeDNSConfig_To_kops_KubeDNSConfig(in *KubeDNSConfig,
 	out.ServerIP = in.ServerIP
 	out.StubDomains = in.StubDomains
 	out.UpstreamNameservers = in.UpstreamNameservers
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
+	out.MemoryLimit = in.MemoryLimit
 	return nil
 }
 
@@ -3470,6 +3473,9 @@ func autoConvert_kops_KubeDNSConfig_To_v1alpha2_KubeDNSConfig(in *kops.KubeDNSCo
 	out.ServerIP = in.ServerIP
 	out.StubDomains = in.StubDomains
 	out.UpstreamNameservers = in.UpstreamNameservers
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
+	out.MemoryLimit = in.MemoryLimit
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2046,6 +2046,21 @@ func (in *KubeDNSConfig) DeepCopyInto(out *KubeDNSConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2228,6 +2228,21 @@ func (in *KubeDNSConfig) DeepCopyInto(out *KubeDNSConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/model/components/BUILD.bazel
+++ b/pkg/model/components/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -57,6 +57,36 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 	if clusterSpec.KubeDNS.Domain == "" {
 		clusterSpec.KubeDNS.Domain = clusterSpec.ClusterDNSDomain
 	}
+	
+	if clusterSpec.KubeDNS.MemoryRequest != "" {
+		MemoryRequest, err := resource.ParseQuantity(clusterSpec.KubeDNS.MemoryRequest)
+		if err != nil {
+			return fmt.Errorf("Error parsing MemoryRequest=%q", clusterSpec.KubeDNS.MemoryRequest)
+		}
+		resourceLimits["cpu"] = MemoryRequest
+	}else{
+		clusterSpec.KubeDNS.MemoryRequest="70m"
+	}
+	
+	if clusterSpec.KubeDNS.CPURequest != "" {
+		CPURequest, err := resource.ParseQuantity(clusterSpec.KubeDNS.CPURequest)
+		if err != nil {
+			return fmt.Errorf("Error parsing CPURequest=%q", clusterSpec.KubeDNS.CPURequest)
+		}
+		resourceLimits["cpu"] = CPURequest
+	}else{
+		clusterSpec.KubeDNS.CPURequest="100m"
+	}
+	
+	if clusterSpec.KubeDNS.MemoryLimit != "" {
+		MemoryLimit, err := resource.ParseQuantity(clusterSpec.KubeDNS.MemoryLimit)
+		if err != nil {
+			return fmt.Errorf("Error parsing MemoryLimit=%q", clusterSpec.KubeDNS.MemoryLimit)
+		}
+		resourceLimits["cpu"] = MemoryLimit
+	}else{
+		clusterSpec.KubeDNS.MemoryLimit="170m"
+	}
 
 	return nil
 }

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -59,22 +59,19 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.KubeDNS.Domain = clusterSpec.ClusterDNSDomain
 	}
 
-	if !clusterSpec.KubeDNS.MemoryRequest.IsZero() {
-		clusterSpec.KubeDNS.MemoryRequest = clusterSpec.KubeDNS.MemoryRequest
-	} else {
-		clusterSpec.KubeDNS.MemoryRequest = resource.MustParse("70m")
+	if clusterSpec.KubeDNS.MemoryRequest.IsZero() {
+		defualtMemoryRequest := resource.MustParse("70m")
+		clusterSpec.KubeDNS.MemoryRequest = &defualtMemoryRequest
 	}
 
-	if !clusterSpec.KubeDNS.CPURequest.IsZero() {
-		clusterSpec.KubeDNS.CPURequest = clusterSpec.KubeDNS.CPURequest
-	} else {
-		clusterSpec.KubeDNS.CPURequest = resource.MustParse("100m")
+	if clusterSpec.KubeDNS.CPURequest.IsZero() {
+		defaultCPURequest := resource.MustParse("100m")
+		clusterSpec.KubeDNS.CPURequest = &defaultCPURequest
 	}
 
-	if !clusterSpec.KubeDNS.MemoryLimit.IsZero() {
-		clusterSpec.KubeDNS.MemoryLimit = clusterSpec.KubeDNS.MemoryLimit
-	} else {
-		clusterSpec.KubeDNS.MemoryLimit = resource.MustParse("170m")
+	if clusterSpec.KubeDNS.MemoryLimit.IsZero() {
+		defaultMemoryLimit := resource.MustParse("170m")
+		clusterSpec.KubeDNS.MemoryLimit = &defaultMemoryLimit
 	}
 
 	return nil

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -59,18 +59,18 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.KubeDNS.Domain = clusterSpec.ClusterDNSDomain
 	}
 
-	if clusterSpec.KubeDNS.MemoryRequest.IsZero() {
-		defualtMemoryRequest := resource.MustParse("70m")
+	if clusterSpec.KubeDNS.MemoryRequest == nil || clusterSpec.KubeDNS.MemoryRequest.IsZero() {
+		defualtMemoryRequest := resource.MustParse("70Mi")
 		clusterSpec.KubeDNS.MemoryRequest = &defualtMemoryRequest
 	}
 
-	if clusterSpec.KubeDNS.CPURequest.IsZero() {
+	if clusterSpec.KubeDNS.CPURequest == nil || clusterSpec.KubeDNS.CPURequest.IsZero() {
 		defaultCPURequest := resource.MustParse("100m")
 		clusterSpec.KubeDNS.CPURequest = &defaultCPURequest
 	}
 
-	if clusterSpec.KubeDNS.MemoryLimit.IsZero() {
-		defaultMemoryLimit := resource.MustParse("170m")
+	if clusterSpec.KubeDNS.MemoryLimit == nil || clusterSpec.KubeDNS.MemoryLimit.IsZero() {
+		defaultMemoryLimit := resource.MustParse("170Mi")
 		clusterSpec.KubeDNS.MemoryLimit = &defaultMemoryLimit
 	}
 

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -60,8 +60,8 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if clusterSpec.KubeDNS.MemoryRequest == nil || clusterSpec.KubeDNS.MemoryRequest.IsZero() {
-		defualtMemoryRequest := resource.MustParse("70Mi")
-		clusterSpec.KubeDNS.MemoryRequest = &defualtMemoryRequest
+		defaultMemoryRequest := resource.MustParse("70Mi")
+		clusterSpec.KubeDNS.MemoryRequest = &defaultMemoryRequest
 	}
 
 	if clusterSpec.KubeDNS.CPURequest == nil || clusterSpec.KubeDNS.CPURequest.IsZero() {

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -17,6 +17,7 @@ limitations under the License.
 package components
 
 import (
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi/loader"
 )
@@ -57,35 +58,23 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 	if clusterSpec.KubeDNS.Domain == "" {
 		clusterSpec.KubeDNS.Domain = clusterSpec.ClusterDNSDomain
 	}
-	
-	if clusterSpec.KubeDNS.MemoryRequest != "" {
-		MemoryRequest, err := resource.ParseQuantity(clusterSpec.KubeDNS.MemoryRequest)
-		if err != nil {
-			return fmt.Errorf("Error parsing MemoryRequest=%q", clusterSpec.KubeDNS.MemoryRequest)
-		}
-		resourceLimits["cpu"] = MemoryRequest
-	}else{
-		clusterSpec.KubeDNS.MemoryRequest="70m"
+
+	if !clusterSpec.KubeDNS.MemoryRequest.IsZero() {
+		clusterSpec.KubeDNS.MemoryRequest = clusterSpec.KubeDNS.MemoryRequest
+	} else {
+		clusterSpec.KubeDNS.MemoryRequest = resource.MustParse("70m")
 	}
-	
-	if clusterSpec.KubeDNS.CPURequest != "" {
-		CPURequest, err := resource.ParseQuantity(clusterSpec.KubeDNS.CPURequest)
-		if err != nil {
-			return fmt.Errorf("Error parsing CPURequest=%q", clusterSpec.KubeDNS.CPURequest)
-		}
-		resourceLimits["cpu"] = CPURequest
-	}else{
-		clusterSpec.KubeDNS.CPURequest="100m"
+
+	if !clusterSpec.KubeDNS.CPURequest.IsZero() {
+		clusterSpec.KubeDNS.CPURequest = clusterSpec.KubeDNS.CPURequest
+	} else {
+		clusterSpec.KubeDNS.CPURequest = resource.MustParse("100m")
 	}
-	
-	if clusterSpec.KubeDNS.MemoryLimit != "" {
-		MemoryLimit, err := resource.ParseQuantity(clusterSpec.KubeDNS.MemoryLimit)
-		if err != nil {
-			return fmt.Errorf("Error parsing MemoryLimit=%q", clusterSpec.KubeDNS.MemoryLimit)
-		}
-		resourceLimits["cpu"] = MemoryLimit
-	}else{
-		clusterSpec.KubeDNS.MemoryLimit="170m"
+
+	if !clusterSpec.KubeDNS.MemoryLimit.IsZero() {
+		clusterSpec.KubeDNS.MemoryLimit = clusterSpec.KubeDNS.MemoryLimit
+	} else {
+		clusterSpec.KubeDNS.MemoryLimit = resource.MustParse("170m")
 	}
 
 	return nil

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -111,10 +111,10 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            memory: 170Mi
+            memory: {{ KubeDNS.MemoryLimit }}
           requests:
-            cpu: 100m
-            memory: 70Mi
+            cpu: {{ KubeDNS.CPURequest }}
+            memory: {{ KubeDNS.MemoryRequest }}
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
         - name: config-volume

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
@@ -111,10 +111,10 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-          memory: {{ KubeDNS.MemoryLimit }}
-        requests:
-          cpu: {{ KubeDNS.CPURequest }}
-          memory: {{ KubeDNS.MemoryRequest }}
+            memory: {{ KubeDNS.MemoryLimit }}
+          requests:
+            cpu: {{ KubeDNS.CPURequest }}
+            memory: {{ KubeDNS.MemoryRequest }}
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
         - name: config-volume

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
@@ -111,10 +111,10 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            memory: 170Mi
-          requests:
-            cpu: 100m
-            memory: 70Mi
+          memory: {{ KubeDNS.MemoryLimit }}
+        requests:
+          cpu: {{ KubeDNS.CPURequest }}
+          memory: {{ KubeDNS.MemoryRequest }}
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
         - name: config-volume

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -256,7 +256,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 	if kubeDNS.Provider == "CoreDNS" {
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.3.1-kops.2"
+			version := "1.3.1-kops.3"
 
 			{
 				location := key + "/k8s-1.6.yaml"
@@ -276,7 +276,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.3.0-kops.1"
+			version := "1.3.0-kops.2"
 
 			{
 				location := key + "/k8s-1.12.yaml"


### PR DESCRIPTION
We have needed to adjust the default request/limits for coredns. This allows you to customize these settings as part of the cluster config. 
