### PR TITLE
Allow the AWS IAM Authenticator image name to be overridden

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -276,6 +276,8 @@ type KopeioAuthenticationSpec struct {
 }
 
 type AwsAuthenticationSpec struct {
+	// Image is the AWS IAM Authenticator docker image to use
+	Image string `json:"imagew,omitempty"`
 }
 
 type AuthorizationSpec struct {

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -275,6 +275,8 @@ type KopeioAuthenticationSpec struct {
 }
 
 type AwsAuthenticationSpec struct {
+	// Image is the AWS IAM Authenticator docker image to use
+	Image string `json:"image,omitempty"`
 }
 
 type AuthorizationSpec struct {

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1051,6 +1051,7 @@ func Convert_kops_AuthorizationSpec_To_v1alpha1_AuthorizationSpec(in *kops.Autho
 }
 
 func autoConvert_v1alpha1_AwsAuthenticationSpec_To_kops_AwsAuthenticationSpec(in *AwsAuthenticationSpec, out *kops.AwsAuthenticationSpec, s conversion.Scope) error {
+	out.Image = in.Image
 	return nil
 }
 
@@ -1060,6 +1061,7 @@ func Convert_v1alpha1_AwsAuthenticationSpec_To_kops_AwsAuthenticationSpec(in *Aw
 }
 
 func autoConvert_kops_AwsAuthenticationSpec_To_v1alpha1_AwsAuthenticationSpec(in *kops.AwsAuthenticationSpec, out *AwsAuthenticationSpec, s conversion.Scope) error {
+	out.Image = in.Image
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -276,6 +276,8 @@ type KopeioAuthenticationSpec struct {
 }
 
 type AwsAuthenticationSpec struct {
+	// Image is the AWS IAM Authenticator docker image to uses
+	Image string `json:"image,omitempty"`
 }
 
 type AuthorizationSpec struct {

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1071,6 +1071,7 @@ func Convert_kops_AuthorizationSpec_To_v1alpha2_AuthorizationSpec(in *kops.Autho
 }
 
 func autoConvert_v1alpha2_AwsAuthenticationSpec_To_kops_AwsAuthenticationSpec(in *AwsAuthenticationSpec, out *kops.AwsAuthenticationSpec, s conversion.Scope) error {
+	out.Image = in.Image
 	return nil
 }
 
@@ -1080,6 +1081,7 @@ func Convert_v1alpha2_AwsAuthenticationSpec_To_kops_AwsAuthenticationSpec(in *Aw
 }
 
 func autoConvert_kops_AwsAuthenticationSpec_To_v1alpha2_AwsAuthenticationSpec(in *kops.AwsAuthenticationSpec, out *AwsAuthenticationSpec, s conversion.Scope) error {
+	out.Image = in.Image
 	return nil
 }
 

--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.10.yaml.template
@@ -34,7 +34,7 @@ spec:
       # - output (output kubeconfig to plug into your apiserver configuration, mounted from the host)
       containers:
       - name: aws-iam-authenticator
-        image: gcr.io/heptio-images/authenticator:v0.3.0
+        image: {{ or .Authentication.Aws.Image "gcr.io/heptio-images/authenticator:v0.3.0" }}
         args:
         - server
         - --config=/etc/aws-iam-authenticator/config.yaml

--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
@@ -37,7 +37,7 @@ spec:
       # - output (output kubeconfig to plug into your apiserver configuration, mounted from the host)
       containers:
       - name: aws-iam-authenticator
-        image: gcr.io/heptio-images/authenticator:v0.3.0
+        image: {{ or .Authentication.Aws.Image "gcr.io/heptio-images/authenticator:v0.3.0" }}
         args:
         - server
         - --config=/etc/aws-iam-authenticator/config.yaml

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -1184,7 +1184,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		}
 		if b.cluster.Spec.Authentication.Aws != nil {
 			key := "authentication.aws"
-			version := "0.3.0"
+			version := "0.3.0-kops.1"
 
 			{
 				location := key + "/k8s-1.10.yaml"


### PR DESCRIPTION
This allows us to upgrade to more recent versions without waiting on a Kops release.

I'm not sure where we can add a test for this functionality but I'm happy to add one if pointed in the right direction. Otherwise, it will look like something like this:

```yaml
...
spec:
  authentication:
    aws:
      image: 894847497797.dkr.ecr.us-west-2.amazonaws.com/aws-iam-authenticator:0.4.0-alpha.1-debian
...
```


```
  ManagedFile/mycluster-addons-authentication.aws-k8s-1.10
  	Contents
  	                    	...
  	                    	          - --state-dir=/var/aws-iam-authenticator
  	                    	          - --kubeconfig-pregenerated=true
  	                    	+         image: 894847497797.dkr.ecr.us-west-2.amazonaws.com/aws-iam-authenticator:0.4.0-alpha.1-debian
  	                    	-         image: gcr.io/heptio-images/authenticator:v0.3.0
  	                    	          name: aws-iam-authenticator
  	                    	          resources:

```

/area addon-manager
/area aws