### PR TITLE
Add min-resync-period for Controller Manager

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -489,6 +489,9 @@ type KubeControllerManagerConfig struct {
 	TLSCipherSuites []string `json:"tlsCipherSuites,omitempty" flag:"tls-cipher-suites"`
 	// TLSMinVersion indicates the minimum TLS version allowed
 	TLSMinVersion string `json:"tlsMinVersion,omitempty" flag:"tls-min-version"`
+	// MinResyncPeriod indicates the resync period in reflectors.
+	// The resync period will be random between MinResyncPeriod and 2*MinResyncPeriod. (default 12h0m0s)
+	MinResyncPeriod string `json:"minResyncPeriod,omitempty" flag:"min-resync-period"`
 }
 
 // CloudControllerManagerConfig is the configuration of the cloud controller

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -489,6 +489,9 @@ type KubeControllerManagerConfig struct {
 	TLSCipherSuites []string `json:"tlsCipherSuites,omitempty" flag:"tls-cipher-suites"`
 	// TLSMinVersion indicates the minimum TLS version allowed
 	TLSMinVersion string `json:"tlsMinVersion,omitempty" flag:"tls-min-version"`
+	// MinResyncPeriod indicates the resync period in reflectors.
+	// The resync period will be random between MinResyncPeriod and 2*MinResyncPeriod. (default 12h0m0s)
+	MinResyncPeriod string `json:"minResyncPeriod,omitempty" flag:"min-resync-period"`
 }
 
 // CloudControllerManagerConfig is the configuration of the cloud controller

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -3118,6 +3118,7 @@ func autoConvert_v1alpha1_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.FeatureGates = in.FeatureGates
 	out.TLSCipherSuites = in.TLSCipherSuites
 	out.TLSMinVersion = in.TLSMinVersion
+	out.MinResyncPeriod = in.MinResyncPeriod
 	return nil
 }
 
@@ -3164,6 +3165,7 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha1_KubeControllerMana
 	out.FeatureGates = in.FeatureGates
 	out.TLSCipherSuites = in.TLSCipherSuites
 	out.TLSMinVersion = in.TLSMinVersion
+	out.MinResyncPeriod = in.MinResyncPeriod
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -489,6 +489,9 @@ type KubeControllerManagerConfig struct {
 	TLSCipherSuites []string `json:"tlsCipherSuites,omitempty" flag:"tls-cipher-suites"`
 	// TLSMinVersion indicates the minimum TLS version allowed
 	TLSMinVersion string `json:"tlsMinVersion,omitempty" flag:"tls-min-version"`
+	// MinResyncPeriod indicates the resync period in reflectors.
+	// The resync period will be random between MinResyncPeriod and 2*MinResyncPeriod. (default 12h0m0s)
+	MinResyncPeriod string `json:"minResyncPeriod,omitempty" flag:"min-resync-period"`
 }
 
 // CloudControllerManagerConfig is the configuration of the cloud controller

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3388,6 +3388,7 @@ func autoConvert_v1alpha2_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.FeatureGates = in.FeatureGates
 	out.TLSCipherSuites = in.TLSCipherSuites
 	out.TLSMinVersion = in.TLSMinVersion
+	out.MinResyncPeriod = in.MinResyncPeriod
 	return nil
 }
 
@@ -3434,6 +3435,7 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha2_KubeControllerMana
 	out.FeatureGates = in.FeatureGates
 	out.TLSCipherSuites = in.TLSCipherSuites
 	out.TLSMinVersion = in.TLSMinVersion
+	out.MinResyncPeriod = in.MinResyncPeriod
 	return nil
 }
 


### PR DESCRIPTION
Adds ability to specify minResyncPeriod for the Controller Manager

```
spec:
  kubeControllerManager:
    minResyncPeriod: 6h
```