### PR TITLE
Speed up rolling-update - longer timeout on validation, less scheduled holds

### DIFF
--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -151,14 +151,13 @@ func (o *RollingUpdateOptions) InitDefaults() {
 	o.FailOnDrainError = false
 	o.FailOnValidate = true
 
-	o.MasterInterval = 5 * time.Minute
-	o.NodeInterval = 4 * time.Minute
-	o.BastionInterval = 5 * time.Minute
+	o.MasterInterval = 15 * time.Second
+	o.NodeInterval = 15 * time.Second
+	o.BastionInterval = 15 * time.Second
 	o.Interactive = false
 
-	o.PostDrainDelay = 90 * time.Second
-	o.ValidationTimeout = 5 * time.Minute
-
+	o.PostDrainDelay = 5 * time.Second
+	o.ValidationTimeout = 15 * time.Minute
 }
 
 func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -67,7 +67,7 @@ kops rolling-update cluster [flags]
 ### Options
 
 ```
-      --bastion-interval duration      Time to wait between restarting bastions (default 5m0s)
+      --bastion-interval duration      Time to wait between restarting bastions (default 15s)
       --cloudonly                      Perform rolling update without confirming progress with k8s
       --fail-on-drain-error            The rolling-update will fail if draining a node fails. (default true)
       --fail-on-validate-error         The rolling-update will fail if the cluster fails to validate. (default true)
@@ -76,10 +76,10 @@ kops rolling-update cluster [flags]
       --instance-group strings         List of instance groups to update (defaults to all if not specified)
       --instance-group-roles strings   If specified, only instance groups of the specified role will be updated (e.g. Master,Node,Bastion)
   -i, --interactive                    Prompt to continue after each instance is updated
-      --master-interval duration       Time to wait between restarting masters (default 5m0s)
-      --node-interval duration         Time to wait between restarting nodes (default 4m0s)
-      --post-drain-delay duration      Time to wait after draining each node (default 1m30s)
-      --validation-timeout duration    Maximum time to wait for a cluster to validate (default 5m0s)
+      --master-interval duration       Time to wait between restarting masters (default 15s)
+      --node-interval duration         Time to wait between restarting nodes (default 15s)
+      --post-drain-delay duration      Time to wait after draining each node (default 5s)
+      --validation-timeout duration    Maximum time to wait for a cluster to validate (default 15m0s)
   -y, --yes                            Perform rolling update immediately, without --yes rolling-update executes a dry-run
 ```
 

--- a/docs/releases/1.15-NOTES.md
+++ b/docs/releases/1.15-NOTES.md
@@ -1,0 +1,26 @@
+## Release notes for kops 1.15 series
+
+(The kops 1.15 release has not been released yet, this is a document to gather the notes prior to the release).
+
+# Significant changes
+
+* kops now supports running with objects as CRDs, stored in a kubernetes apiserver.
+* The apiGroup for kops objects has changed from `kops` to `kops.k8s.io`, to
+  support CRDs.  You can continue to provide either apiGroup as input (but you
+  should ideally move to `kops.k8s.io`), but the output will always be of the
+  `kops.k8s.io` form.
+* Rolling updates are much faster by default.  A lot of the time-padding that
+  was in previous versions has been replaced with reliance on validation.  The
+  `--cloudonly` case is much faster than previously, which we believe to be
+  correct because we expect this is normally for disaster-recovery scenarios,
+  but you may want to specify longer timings via flags if you are relying on
+  time-based delays.
+
+# Required Actions
+
+* If checking the output as a string (yaml or json), please note that the
+  apiGroup will now be kops.k8s.io, not kops.  If performing strict string
+  comparison you will need to update your expected values.
+
+# Full change list since 1.14.0 release
+


### PR DESCRIPTION
We reduce the amount of time we wait on a purely scheduled basis
during a rolling-update, and instead increase the timeout on the
validation.

This will be a behavioural change - particularly for `--cloudonly`
mode, but that mode seems more useful when things are going wrong
anyway, when people will likely set _even lower_ timeouts.