### PR TITLE
Improved release process docs

### DIFF
--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -65,8 +65,8 @@ Make sure you are on the release branch `git checkout release-1.X`
 
 ```
 make release-tag
-git push
-git push --tags
+git push git@github.com:kubernetes/kops
+git push --tags git@github.com:kubernetes/kops
 ```
 
 ## Update release branch


### PR DESCRIPTION
Even if we didn't pull over SSH (for example if we're running in CI),
we need to push the branch with over ssh.