### PR TITLE
1.12.0-beta.1 bug - use dynamic s3 prefix in addAmazonVPCCNIPermissions func

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -185,7 +185,7 @@ func (b *PolicyBuilder) BuildAWSPolicyMaster() (*Policy, error) {
 	}
 
 	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.AmazonVPC != nil {
-		addAmazonVPCCNIPermissions(p, resource, b.Cluster.Spec.IAM.Legacy, b.Cluster.GetName())
+		addAmazonVPCCNIPermissions(p, resource, b.Cluster.Spec.IAM.Legacy, b.Cluster.GetName(), b.IAMPrefix())
 	}
 
 	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.LyftVPC != nil {
@@ -222,7 +222,7 @@ func (b *PolicyBuilder) BuildAWSPolicyNode() (*Policy, error) {
 	}
 
 	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.AmazonVPC != nil {
-		addAmazonVPCCNIPermissions(p, resource, b.Cluster.Spec.IAM.Legacy, b.Cluster.GetName())
+		addAmazonVPCCNIPermissions(p, resource, b.Cluster.Spec.IAM.Legacy, b.Cluster.GetName(), b.IAMPrefix())
 	}
 
 	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.LyftVPC != nil {
@@ -855,7 +855,7 @@ func addLyftVPCPermissions(p *Policy, resource stringorslice.StringOrSlice, lega
 	)
 }
 
-func addAmazonVPCCNIPermissions(p *Policy, resource stringorslice.StringOrSlice, legacyIAM bool, clusterName string) {
+func addAmazonVPCCNIPermissions(p *Policy, resource stringorslice.StringOrSlice, legacyIAM bool, clusterName string, iamPrefix string) {
 	if legacyIAM {
 		// Legacy IAM provides ec2:*, so no additional permissions required
 		return
@@ -882,8 +882,9 @@ func addAmazonVPCCNIPermissions(p *Policy, resource stringorslice.StringOrSlice,
 			Action: stringorslice.Slice([]string{
 				"ec2:CreateTags",
 			}),
-			Resource: stringorslice.Slice([]string{"arn:aws:ec2:*:*:network-interface/*"}),
-		},
+			Resource: stringorslice.Slice([]string{
+				strings.Join([]string{iamPrefix, ":ec2:*:*:network-interface/*"}, ""),
+			})},
 	)
 }
 


### PR DESCRIPTION
This PR is for https://github.com/kubernetes/kops/issues/6754 (more info in that issue), which is currently a problem in the 1.12.0-beta.1 release. https://github.com/kubernetes/kops/pull/6389 introduced a bug that only applies IAM policies correctly for AWS environments, and doesn't take into account AWS China and AWS Gov.

This change utilizes the `IAMPrefix` function to account for those environments.

**Before**
```
  IAMRolePolicy/nodes.xxx.k8s.local
  	PolicyDocument      
  	                    	...
  	                    	          "*"
  	                    	        ]
  	                    	+     },
  	                    	+     {
  	                    	+       "Effect": "Allow",
  	                    	+       "Action": [
  	                    	+         "ec2:CreateTags"
  	                    	+       ],
  	                    	+       "Resource": [
  	                    	+         "arn:aws:ec2:*:*:network-interface/*"
  	                    	+       ]
  	                    	      }
  	                    	    ]
  	                    	...
```

**After**
```
  IAMRolePolicy/nodes.xxx.k8s.local
  	PolicyDocument      
  	                    	...
  	                    	          "*"
  	                    	        ]
  	                    	+     },
  	                    	+     {
  	                    	+       "Effect": "Allow",
  	                    	+       "Action": [
  	                    	+         "ec2:CreateTags"
  	                    	+       ],
  	                    	+       "Resource": [
  	                    	+         "arn:aws-cn:ec2:*:*:network-interface/*"
  	                    	+       ]
  	                    	      }
  	                    	    ]
  	                    	...
```