### PR TITLE
Put 1.13 and 1.14 into channels

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -34,7 +34,7 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.14.0"
-    recommendedVersion: 1.14.0
+    recommendedVersion: 1.14.1
     requiredVersion: 1.14.0
   - range: ">=1.13.0"
     recommendedVersion: 1.13.5
@@ -67,6 +67,14 @@ spec:
     recommendedVersion: 1.4.12
     requiredVersion: 1.4.2
   kopsVersions:
+  - range: ">=1.14.0-alpha.1"
+    #recommendedVersion: "1.14.0"
+    #requiredVersion: 1.14.0
+    kubernetesVersion: 1.14.1
+  - range: ">=1.13.0-alpha.1"
+    #recommendedVersion: "1.13.0"
+    #requiredVersion: 1.13.0
+    kubernetesVersion: 1.13.5
   - range: ">=1.12.0-alpha.1"
     #recommendedVersion: "1.12.0"
     #requiredVersion: 1.12.0

--- a/channels/stable
+++ b/channels/stable
@@ -33,6 +33,12 @@ spec:
     networking:
       kubenet: {}
   kubernetesVersions:
+  - range: ">=1.14.0"
+    recommendedVersion: 1.14.1
+    requiredVersion: 1.14.0
+  - range: ">=1.13.0"
+    recommendedVersion: 1.13.5
+    requiredVersion: 1.13.0
   - range: ">=1.12.0"
     recommendedVersion: 1.12.7
     requiredVersion: 1.12.0
@@ -61,6 +67,14 @@ spec:
     recommendedVersion: 1.4.12
     requiredVersion: 1.4.2
   kopsVersions:
+  - range: ">=1.14.0-alpha.1"
+    #recommendedVersion: "1.14.0"
+    #requiredVersion: 1.14.0
+    kubernetesVersion: 1.14.1
+  - range: ">=1.13.0-alpha.1"
+    #recommendedVersion: "1.13.0"
+    #requiredVersion: 1.13.0
+    kubernetesVersion: 1.13.5
   - range: ">=1.12.0-alpha.1"
     #recommendedVersion: "1.12.0"
     #requiredVersion: 1.12.0


### PR DESCRIPTION
Because they are both pre-release (for kops), we can put them into
stable & alpha channels immediately.