### PR TITLE
Run coreDNS as DaemonSet on master nodes.

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -76,7 +76,7 @@ data:
     }
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: coredns
   namespace: kube-system
@@ -85,11 +85,6 @@ metadata:
     k8s-addon: coredns.addons.k8s.io
     kubernetes.io/cluster-service: "true"
 spec:
-  replicas: 2
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
   selector:
     matchLabels:
       k8s-app: kube-dns
@@ -101,10 +96,16 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: coredns
       tolerations:
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"
-      nodeSelector:
-          beta.kubernetes.io/os: linux
+      - operator: Exists
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/role
+                operator: In
+                values:
+                - master
       containers:
       - name: coredns
         image: k8s.gcr.io/coredns:1.3.1


### PR DESCRIPTION
As of now CoreDNS pods may be scheduled on same node compromising H.A. By running CoreDNS as DaemonSet on master nodes we allow scale to zero of nodes as well as H.A. of CoreDNS. 
I agree that it might eat up crucial master nodes resources but I like to think CoreDNS in the same league of scheduler/apiserver and other master control components. Hence it make sense to run it as well using same pattern. 
