### PR TITLE
Fix typo in aws-iam-authenticator image field name

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -277,7 +277,7 @@ type KopeioAuthenticationSpec struct {
 
 type AwsAuthenticationSpec struct {
 	// Image is the AWS IAM Authenticator docker image to use
-	Image string `json:"imagew,omitempty"`
+	Image string `json:"image,omitempty"`
 }
 
 type AuthorizationSpec struct {


### PR DESCRIPTION
Introduced here: https://github.com/kubernetes/kops/pull/6730/files#diff-843e01eb04cf09979da2bd7a655b3526R280

This typo hasn't been in any stable Kops releases, so backwards compatibility shouldn't be necessary.

This will need to be backported to release-1.14 and release-1.13