### PR TITLE
Automated cherry pick of #6840: Fix typo in aws-iam-authenticator image field name

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -277,7 +277,7 @@ type KopeioAuthenticationSpec struct {
 
 type AwsAuthenticationSpec struct {
 	// Image is the AWS IAM Authenticator docker image to use
-	Image string `json:"imagew,omitempty"`
+	Image string `json:"image,omitempty"`
 }
 
 type AuthorizationSpec struct {


### PR DESCRIPTION
Cherry pick of #6840 on release-1.14.

#6840: Fix typo in aws-iam-authenticator image field name