### PR TITLE
Add required action to read ACM certificates

### DIFF
--- a/addons/kube-ingress-aws-controller/README.md
+++ b/addons/kube-ingress-aws-controller/README.md
@@ -88,6 +88,7 @@ kube-ingress-aws-controller, which we will use:
   "Action": [
     "acm:ListCertificates",
     "acm:DescribeCertificate",
+    "acm:GetCertificate",
     "autoscaling:DescribeAutoScalingGroups",
     "autoscaling:DescribeLoadBalancerTargetGroups",
     "autoscaling:AttachLoadBalancers",

--- a/addons/kube-ingress-aws-controller/README.md
+++ b/addons/kube-ingress-aws-controller/README.md
@@ -129,6 +129,7 @@ and add this to your node policy:
           "Action": [
             "acm:ListCertificates",
             "acm:DescribeCertificate",
+            "acm:GetCertificate",
             "autoscaling:DescribeAutoScalingGroups",
             "autoscaling:DescribeLoadBalancerTargetGroups",
             "autoscaling:AttachLoadBalancers",


### PR DESCRIPTION
Additional actions were required to be able to read ACM certificates on worker nodes.