### PR TITLE
Allow custom CNI to use IPIP protocol

### DIFF
--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -51,7 +51,8 @@ type ExternalNetworkingSpec struct {
 // Networking is not managed by kops - we can create options here that directly configure e.g. weave
 // but this is useful for arbitrary network modes or for modes that don't need additional configuration.
 type CNINetworkingSpec struct {
-	UsesSecondaryIP bool `json:"usesSecondaryIP,omitempty"`
+	UsesSecondaryIP   bool `json:"usesSecondaryIP,omitempty"`
+	AllowProtocolIPIP bool `json:"allowProtocolIPIP,omitempty"`
 }
 
 // KopeioNetworkingSpec declares that we want Kopeio networking

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -51,7 +51,8 @@ type ExternalNetworkingSpec struct {
 // Networking is not managed by kops - we can create options here that directly configure e.g. weave
 // but this is useful for arbitrary network modes or for modes that don't need additional configuration.
 type CNINetworkingSpec struct {
-	UsesSecondaryIP bool `json:"usesSecondaryIP,omitempty"`
+	UsesSecondaryIP   bool `json:"usesSecondaryIP,omitempty"`
+	AllowProtocolIPIP bool `json:"allowProtocolIPIP,omitempty"`
 }
 
 // KopeioNetworkingSpec declares that we want Kopeio networking

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1072,6 +1072,7 @@ func Convert_kops_AwsAuthenticationSpec_To_v1alpha1_AwsAuthenticationSpec(in *ko
 
 func autoConvert_v1alpha1_CNINetworkingSpec_To_kops_CNINetworkingSpec(in *CNINetworkingSpec, out *kops.CNINetworkingSpec, s conversion.Scope) error {
 	out.UsesSecondaryIP = in.UsesSecondaryIP
+	out.AllowProtocolIPIP = in.AllowProtocolIPIP
 	return nil
 }
 
@@ -1082,6 +1083,7 @@ func Convert_v1alpha1_CNINetworkingSpec_To_kops_CNINetworkingSpec(in *CNINetwork
 
 func autoConvert_kops_CNINetworkingSpec_To_v1alpha1_CNINetworkingSpec(in *kops.CNINetworkingSpec, out *CNINetworkingSpec, s conversion.Scope) error {
 	out.UsesSecondaryIP = in.UsesSecondaryIP
+	out.AllowProtocolIPIP = in.AllowProtocolIPIP
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -51,7 +51,8 @@ type ExternalNetworkingSpec struct {
 // Networking is not managed by kops - we can create options here that directly configure e.g. weave
 // but this is useful for arbitrary network modes or for modes that don't need additional configuration.
 type CNINetworkingSpec struct {
-	UsesSecondaryIP bool `json:"usesSecondaryIP,omitempty"`
+	UsesSecondaryIP   bool `json:"usesSecondaryIP,omitempty"`
+	AllowProtocolIPIP bool `json:"allowProtocolIPIP,omitempty"`
 }
 
 // KopeioNetworkingSpec declares that we want Kopeio networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1114,6 +1114,7 @@ func Convert_kops_BastionSpec_To_v1alpha2_BastionSpec(in *kops.BastionSpec, out 
 
 func autoConvert_v1alpha2_CNINetworkingSpec_To_kops_CNINetworkingSpec(in *CNINetworkingSpec, out *kops.CNINetworkingSpec, s conversion.Scope) error {
 	out.UsesSecondaryIP = in.UsesSecondaryIP
+	out.AllowProtocolIPIP = in.AllowProtocolIPIP
 	return nil
 }
 
@@ -1124,6 +1125,7 @@ func Convert_v1alpha2_CNINetworkingSpec_To_kops_CNINetworkingSpec(in *CNINetwork
 
 func autoConvert_kops_CNINetworkingSpec_To_v1alpha2_CNINetworkingSpec(in *kops.CNINetworkingSpec, out *CNINetworkingSpec, s conversion.Scope) error {
 	out.UsesSecondaryIP = in.UsesSecondaryIP
+	out.AllowProtocolIPIP = in.AllowProtocolIPIP
 	return nil
 }
 

--- a/pkg/model/firewall.go
+++ b/pkg/model/firewall.go
@@ -175,6 +175,11 @@ func (b *FirewallModelBuilder) applyNodeToMasterAllowSpecificPorts(c *fi.ModelBu
 		if b.Cluster.Spec.Networking.Kuberouter != nil {
 			protocols = append(protocols, ProtocolIPIP)
 		}
+
+		if b.Cluster.Spec.Networking.CNI != nil && b.Cluster.Spec.Networking.CNI.AllowProtocolIPIP == true {
+			glog.V(4).Infof("Allow ProtocolIPIP for CNI as AllowProtocolIPIP == true.")
+			protocols = append(protocols, ProtocolIPIP)
+		}
 	}
 
 	for _, udpPort := range udpPorts {
@@ -267,6 +272,11 @@ func (b *FirewallModelBuilder) applyNodeToMasterBlockSpecificPorts(c *fi.ModelBu
 	}
 
 	if b.Cluster.Spec.Networking.Kuberouter != nil {
+		protocols = append(protocols, ProtocolIPIP)
+	}
+
+	if b.Cluster.Spec.Networking.CNI != nil && b.Cluster.Spec.Networking.CNI.AllowProtocolIPIP == true {
+		glog.V(4).Infof("Allow ProtocolIPIP for CNI as AllowProtocolIPIP == true.")
 		protocols = append(protocols, ProtocolIPIP)
 	}
 


### PR DESCRIPTION
As discussed here: https://kubernetes.slack.com/archives/C8MKE2G5P/p1553370687156900

Allows custom CNI networking (such as custom configuration of calico) to enable IPIP protocol between nodes and masters.
