### PR TITLE
Mount FlexVolume directory in kube-controller-manager pod

### DIFF
--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -151,6 +151,16 @@ func (b *KubeControllerManagerBuilder) buildPod() (*v1.Pod, error) {
 		},
 	}
 
+	volumePluginDir := b.Cluster.Spec.Kubelet.VolumePluginDirectory
+
+	// Ensure the Volume Plugin dir is mounted on the same path as the host machine so DaemonSet deployment is possible
+	if volumePluginDir == "" {
+		volumePluginDir = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec"
+	} else {
+		// If volume-plugin-dir flag is set in kubelet, match dir in kube-controller
+		flags = append(flags, "--flex-volume-plugin-dir="+volumePluginDir)
+	}
+
 	container := &v1.Container{
 		Name:  "kube-controller-manager",
 		Image: b.Cluster.Spec.KubeControllerManager.Image,
@@ -194,6 +204,8 @@ func (b *KubeControllerManagerBuilder) buildPod() (*v1.Pod, error) {
 
 	addHostPathMapping(pod, container, "logfile", "/var/log/kube-controller-manager.log").ReadOnly = false
 	addHostPathMapping(pod, container, "varlibkcm", "/var/lib/kube-controller-manager")
+
+	addHostPathMapping(pod, container, "volplugins", volumePluginDir).ReadOnly = false
 
 	pod.Spec.Containers = append(pod.Spec.Containers, *container)
 


### PR DESCRIPTION
Mounts the FlexVolume directory so that FlexVolumes with attach capability can run on KOPs clusters