### PR TITLE
travis: Remove go-vet and boilerplate checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -566,8 +566,10 @@ ci: govet verify-gofmt verify-boilerplate verify-bazel verify-misspelling nodeup
 # we skip tasks that rely on bazel and are covered by other jobs
 #  verify-gofmt: uses bazel, covered by pull-kops-verify-gofmt
 #  verify-bazel: uses bazel, covered by pull-kops-verify-bazel
+#  govet: covered by pull-kops-verify-govet
+#  verify-boilerplate: covered by pull-kops-verify-boilerplate
 .PHONY: travis-ci
-travis-ci: govet verify-boilerplate verify-misspelling nodeup examples test | verify-gendocs verify-packages verify-apimachinery
+travis-ci: verify-misspelling nodeup examples test | verify-gendocs verify-packages verify-apimachinery
 	echo "Done!"
 
 .PHONY: pr


### PR DESCRIPTION
These are covered by prow jobs now.