### PR TITLE
Added net.ipv4.tcp_keepalive_time to sysctls.go

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -105,6 +105,11 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"# Increase size of file handles and inode cache",
 			"fs.file-max = 2097152",
 			"",
+				 
+		        "# Decrease the keepalive timeout to solve connection timeout bug in case of IPVS",
+			"# https://success.docker.com/article/ipvs-connection-timeout-issue",	 
+			"net.ipv4.tcp_keepalive_time = 600",
+			"",
 
 			"# Max number of inotify instances and watches for a user",
 			"# Since dockerd runs as a single user, the default instances value of 128 per user is too low",


### PR DESCRIPTION
While using IPVS in kubeproxy, one occasionally gets 503 Connection timeout error. This error comes because IPVS timeout by default is 900 sec while TCP connection timeout is 7200 sec. To fix the issue, the tcp_keepalive_time has to be set to less than 900 secs.
Reference document : https://success.docker.com/article/ipvs-connection-timeout-issue