### PR TITLE
Add usesNAT flag to control nonMasqueradeCIDR check for custom CNI networking

### DIFF
--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -52,6 +52,7 @@ type ExternalNetworkingSpec struct {
 // but this is useful for arbitrary network modes or for modes that don't need additional configuration.
 type CNINetworkingSpec struct {
 	UsesSecondaryIP bool `json:"usesSecondaryIP,omitempty"`
+	UsesNAT         bool `json:"usesNAT,omitempty"`
 }
 
 // KopeioNetworkingSpec declares that we want Kopeio networking

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -196,7 +196,11 @@ func ValidateCluster(c *kops.Cluster, strict bool) *field.Error {
 			return field.Invalid(fieldSpec.Child("NonMasqueradeCIDR"), nonMasqueradeCIDRString, "Cluster had an invalid NonMasqueradeCIDR")
 		}
 
-		if networkCIDR != nil && subnet.Overlap(nonMasqueradeCIDR, networkCIDR) && c.Spec.Networking != nil && c.Spec.Networking.AmazonVPC == nil && c.Spec.Networking.LyftVPC == nil {
+		if networkCIDR != nil && subnet.Overlap(nonMasqueradeCIDR, networkCIDR) &&
+			c.Spec.Networking != nil &&
+			(c.Spec.Networking.CNI == nil || c.Spec.Networking.CNI.UsesNAT) &&
+			c.Spec.Networking.AmazonVPC == nil &&
+			c.Spec.Networking.LyftVPC == nil {
 
 			return field.Invalid(fieldSpec.Child("NonMasqueradeCIDR"), nonMasqueradeCIDRString, fmt.Sprintf("NonMasqueradeCIDR %q cannot overlap with NetworkCIDR %q", nonMasqueradeCIDRString, c.Spec.NetworkCIDR))
 		}


### PR DESCRIPTION
Add usesNAT flag to control nonMasqueradeCIDR check for custom CNI networking.

Previously, only the kops-controlled amazonvpc or lyftvpc addons were allowed to overlap the nonMasqueradeCIDR with the network CIDR. This allows overlap with a custom CNI plugin, unless the user declares that the plugin uses NAT (and therefore the CIDRs should not overlap).

/cc @grosser 