### PR TITLE
Set priority for static pods

### DIFF
--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -481,6 +481,7 @@ func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 	pod.Spec.Containers = append(pod.Spec.Containers, *container)
 
 	kubemanifest.MarkPodAsCritical(pod)
+	kubemanifest.MarkPodAsClusterCritical(pod)
 
 	return pod, nil
 }

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -198,6 +198,7 @@ func (b *KubeControllerManagerBuilder) buildPod() (*v1.Pod, error) {
 	pod.Spec.Containers = append(pod.Spec.Containers, *container)
 
 	kubemanifest.MarkPodAsCritical(pod)
+	kubemanifest.MarkPodAsClusterCritical(pod)
 
 	return pod, nil
 }

--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -264,6 +264,10 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 	// involved in scheduling kube-proxy).
 	kubemanifest.MarkPodAsCritical(pod)
 
+	// Also set priority so that kube-proxy does not get evicted in clusters where
+	// PodPriority is enabled.
+	kubemanifest.MarkPodAsNodeCritical(pod)
+
 	return pod, nil
 }
 

--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -153,6 +153,7 @@ func (b *KubeSchedulerBuilder) buildPod() (*v1.Pod, error) {
 	pod.Spec.Containers = append(pod.Spec.Containers, *container)
 
 	kubemanifest.MarkPodAsCritical(pod)
+	kubemanifest.MarkPodAsClusterCritical(pod)
 
 	return pod, nil
 }

--- a/pkg/kubemanifest/BUILD.bazel
+++ b/pkg/kubemanifest/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "critical.go",
         "images.go",
         "manifest.go",
+        "priority.go",
         "visitor.go",
         "volumes.go",
     ],

--- a/pkg/kubemanifest/priority.go
+++ b/pkg/kubemanifest/priority.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubemanifest
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// MarkPodAsNodeCritical sets the pod priority to system-node-critical
+func MarkPodAsNodeCritical(pod *v1.Pod) {
+	pod.Spec.PriorityClassName = "system-node-critical"
+}
+
+// MarkPodAsClusterCritical sets the pod priority to system-cluster-critical
+func MarkPodAsClusterCritical(pod *v1.Pod) {
+	pod.Spec.PriorityClassName = "system-cluster-critical"
+}

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -445,6 +445,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster *kops.EtcdClusterSpec) (*v1.Po
 	}
 
 	kubemanifest.MarkPodAsCritical(pod)
+	kubemanifest.MarkPodAsClusterCritical(pod)
 
 	return pod, nil
 }

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -108,6 +108,7 @@ Contents:
           name: varlogetcd
       hostNetwork: true
       hostPID: true
+      priorityClassName: system-cluster-critical
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
@@ -178,6 +179,7 @@ Contents:
           name: varlogetcd
       hostNetwork: true
       hostPID: true
+      priorityClassName: system-cluster-critical
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/protokube/pkg/protokube/etcd_manifest.go
+++ b/protokube/pkg/protokube/etcd_manifest.go
@@ -165,6 +165,7 @@ func BuildEtcdManifest(c *EtcdCluster) *v1.Pod {
 	}
 
 	kubemanifest.MarkPodAsCritical(pod)
+	kubemanifest.MarkPodAsClusterCritical(pod)
 
 	return pod
 }

--- a/protokube/tests/integration/build_etcd_manifest/main/etcd_env_vars.yaml
+++ b/protokube/tests/integration/build_etcd_manifest/main/etcd_env_vars.yaml
@@ -93,6 +93,7 @@ spec:
       name: hosts
       readOnly: true
   hostNetwork: true
+  priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
     operator: Exists

--- a/protokube/tests/integration/build_etcd_manifest/main/non_tls.yaml
+++ b/protokube/tests/integration/build_etcd_manifest/main/non_tls.yaml
@@ -87,6 +87,7 @@ spec:
       name: hosts
       readOnly: true
   hostNetwork: true
+  priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
     operator: Exists

--- a/protokube/tests/integration/build_etcd_manifest/main/tls.yaml
+++ b/protokube/tests/integration/build_etcd_manifest/main/tls.yaml
@@ -106,6 +106,7 @@ spec:
       name: srvkubernetes
       readOnly: true
   hostNetwork: true
+  priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
     operator: Exists


### PR DESCRIPTION
Setting a high priority for kube-proxy is important in clusters that run with PodPriority enabled, otherwise it will get evicted from worker nodes whenever there are unschedulable pods. Also set priorities for the other static pods defined by kops, mainly for completeness.

This should be safe these days since the API always accepts PriorityClassName even if PodPriority isn't enabled.

Fixes #6615.