### PR TITLE
Include aws-cloud-provider roles in 1.15

### DIFF
--- a/upup/models/cloudup/resources/addons/storage-aws.addons.k8s.io/v1.15.0.yaml
+++ b/upup/models/cloudup/resources/addons/storage-aws.addons.k8s.io/v1.15.0.yaml
@@ -1,0 +1,66 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: default
+  labels:
+    k8s-addon: storage-aws.addons.k8s.io
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+
+---
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp2
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    k8s-addon: storage-aws.addons.k8s.io
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-addon: storage-aws.addons.k8s.io
+  name: system:aws-cloud-provider
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-addon: storage-aws.addons.k8s.io
+  name: system:aws-cloud-provider
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:aws-cloud-provider
+subjects:
+- kind: ServiceAccount
+  name: aws-cloud-provider
+  namespace: kube-system

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -475,7 +475,22 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if kops.CloudProviderID(b.cluster.Spec.CloudProvider) == kops.CloudProviderAWS {
 		key := "storage-aws.addons.k8s.io"
-		version := "1.7.0"
+		version := "1.15.0"
+
+		{
+			id := "v1.15.0"
+			location := key + "/" + id + ".yaml"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(version),
+				Selector:          map[string]string{"k8s-addon": key},
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.15.0",
+				Id:                id,
+			})
+			manifests[key+"-"+id] = "addons/" + location
+		}
 
 		{
 			id := "v1.7.0"
@@ -486,7 +501,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 				Version:           fi.String(version),
 				Selector:          map[string]string{"k8s-addon": key},
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.7.0",
+				KubernetesVersion: ">=1.7.0 <1.15.0",
 				Id:                id,
 			})
 			manifests[key+"-"+id] = "addons/" + location

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -70,20 +70,27 @@ spec:
     selector:
       k8s-addon: dns-controller.addons.k8s.io
     version: 1.14.0-alpha.1
+  - id: v1.15.0
+    kubernetesVersion: '>=1.15.0'
+    manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
+    name: storage-aws.addons.k8s.io
+    selector:
+      k8s-addon: storage-aws.addons.k8s.io
+    version: 1.15.0
   - id: v1.7.0
-    kubernetesVersion: '>=1.7.0'
+    kubernetesVersion: '>=1.7.0 <1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.7.0.yaml
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
-    version: 1.7.0
+    version: 1.15.0
   - id: v1.6.0
     kubernetesVersion: <1.7.0
     manifest: storage-aws.addons.k8s.io/v1.6.0.yaml
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
-    version: 1.7.0
+    version: 1.15.0
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0 <1.12.0'
     manifest: networking.cilium.io/k8s-1.7.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
@@ -70,20 +70,27 @@ spec:
     selector:
       k8s-addon: dns-controller.addons.k8s.io
     version: 1.14.0-alpha.1
+  - id: v1.15.0
+    kubernetesVersion: '>=1.15.0'
+    manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
+    name: storage-aws.addons.k8s.io
+    selector:
+      k8s-addon: storage-aws.addons.k8s.io
+    version: 1.15.0
   - id: v1.7.0
-    kubernetesVersion: '>=1.7.0'
+    kubernetesVersion: '>=1.7.0 <1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.7.0.yaml
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
-    version: 1.7.0
+    version: 1.15.0
   - id: v1.6.0
     kubernetesVersion: <1.7.0
     manifest: storage-aws.addons.k8s.io/v1.6.0.yaml
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
-    version: 1.7.0
+    version: 1.15.0
   - id: pre-k8s-1.6
     kubernetesVersion: <1.6.0
     manifest: networking.kope.io/pre-k8s-1.6.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -70,17 +70,24 @@ spec:
     selector:
       k8s-addon: dns-controller.addons.k8s.io
     version: 1.14.0-alpha.1
+  - id: v1.15.0
+    kubernetesVersion: '>=1.15.0'
+    manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
+    name: storage-aws.addons.k8s.io
+    selector:
+      k8s-addon: storage-aws.addons.k8s.io
+    version: 1.15.0
   - id: v1.7.0
-    kubernetesVersion: '>=1.7.0'
+    kubernetesVersion: '>=1.7.0 <1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.7.0.yaml
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
-    version: 1.7.0
+    version: 1.15.0
   - id: v1.6.0
     kubernetesVersion: <1.7.0
     manifest: storage-aws.addons.k8s.io/v1.6.0.yaml
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
-    version: 1.7.0
+    version: 1.15.0

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -70,20 +70,27 @@ spec:
     selector:
       k8s-addon: dns-controller.addons.k8s.io
     version: 1.14.0-alpha.1
+  - id: v1.15.0
+    kubernetesVersion: '>=1.15.0'
+    manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
+    name: storage-aws.addons.k8s.io
+    selector:
+      k8s-addon: storage-aws.addons.k8s.io
+    version: 1.15.0
   - id: v1.7.0
-    kubernetesVersion: '>=1.7.0'
+    kubernetesVersion: '>=1.7.0 <1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.7.0.yaml
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
-    version: 1.7.0
+    version: 1.15.0
   - id: v1.6.0
     kubernetesVersion: <1.7.0
     manifest: storage-aws.addons.k8s.io/v1.6.0.yaml
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
-    version: 1.7.0
+    version: 1.15.0
   - id: pre-k8s-1.6
     kubernetesVersion: <1.6.0
     manifest: networking.weave/pre-k8s-1.6.yaml


### PR DESCRIPTION
We consider it part of the storage configuration for AWS now.

Upstream change: https://github.com/kubernetes/kubernetes/pull/66635