### PR TITLE
Call klog.InitFlags in dns-controller

### DIFF
--- a/dns-controller/cmd/dns-controller/main.go
+++ b/dns-controller/cmd/dns-controller/main.go
@@ -60,6 +60,7 @@ func main() {
 	var updateInterval int
 
 	// Be sure to get the glog flags
+	klog.InitFlags(nil)
 	klog.Flush()
 
 	flag.StringVar(&dnsServer, "dns-server", "", "DNS Server")


### PR DESCRIPTION
Otherwise the logging flags don't get registered.