### PR TITLE
Automated cherry pick of #6877: bazel: fix distroless imports for latest bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,11 +67,15 @@ git_repository(
 load(
     "@distroless//package_manager:package_manager.bzl",
     "package_manager_repositories",
-    "dpkg_src",
-    "dpkg_list",
 )
 
 package_manager_repositories()
+
+load(
+    "@distroless//package_manager:dpkg.bzl",
+    "dpkg_src",
+    "dpkg_list",
+)
 
 dpkg_src(
     name = "debian_stretch",


### PR DESCRIPTION
Cherry pick of #6877 on release-1.14.

#6877: bazel: fix distroless imports for latest bazel