### PR TITLE
Subnet Update Consistency

### DIFF
--- a/pkg/model/openstackmodel/network.go
+++ b/pkg/model/openstackmodel/network.go
@@ -57,10 +57,11 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	for _, sp := range b.Cluster.Spec.Subnets {
 		subnetName := sp.Name + "." + b.ClusterName()
 		t := &openstacktasks.Subnet{
-			Name:      s(subnetName),
-			Network:   b.LinkToNetwork(),
-			CIDR:      s(sp.CIDR),
-			Lifecycle: b.Lifecycle,
+			Name:       s(subnetName),
+			Network:    b.LinkToNetwork(),
+			CIDR:       s(sp.CIDR),
+			DNSServers: make([]*string, 0),
+			Lifecycle:  b.Lifecycle,
 		}
 		if b.Cluster.Spec.CloudConfig.Openstack.Router.DNSServers != nil {
 			dnsSplitted := strings.Split(fi.StringValue(b.Cluster.Spec.CloudConfig.Openstack.Router.DNSServers), ",")

--- a/upup/pkg/fi/cloudup/openstacktasks/subnet.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/subnet.go
@@ -120,13 +120,13 @@ func (_ *Subnet) CheckChanges(a, e, changes *Subnet) error {
 		if changes.Name != nil {
 			return fi.CannotChangeField("Name")
 		}
-		if e.DNSServers != nil {
+		if changes.DNSServers != nil {
 			return fi.CannotChangeField("DNSServers")
 		}
-		if e.Network != nil {
+		if changes.Network != nil {
 			return fi.CannotChangeField("Network")
 		}
-		if e.CIDR != nil {
+		if changes.CIDR != nil {
 			return fi.CannotChangeField("CIDR")
 		}
 	}


### PR DESCRIPTION
The purpose of this PR is to resolve some errors which can be thrown after updating some already deployed subnet objects.  Because the expected struct is checked instead of the changes struct an update may fail after resources have already been deployed.

/sig openstack