### PR TITLE
Make gofmt fails find usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -504,7 +504,7 @@ dep-ensure: dep-prereqs
 
 .PHONY: gofmt
 gofmt:
-	find -name "*.go" | grep -v vendor | xargs bazel run //:gofmt -- -w -s
+	find $(MAKEDIR) -name "*.go" | grep -v vendor | xargs bazel run //:gofmt -- -w -s
 
 .PHONY: goimports
 goimports:


### PR DESCRIPTION
Find on mac requires path, where as in linux it does not appear to.

Mac:
```
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
```

Linux:
```
Usage: find [-H] [-L] [-P] [-Olevel] [-D help|tree|search|stat|rates|opt|exec|time] [path...] [expression]
```

Added the path as this should work with both systems.