### PR TITLE
Mention version of Kops that introduced new features

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -56,7 +56,8 @@ spec:
       sslCertificate: arn:aws:acm:<region>:<accountId>:certificate/<uuid>
 ```
 
-It is possible to use the load balancer internally by setting the `useForInternalApi: true`.
+*Openstack only*
+As of Kops 1.12.0 it is possible to use the load balancer internally by setting the `useForInternalApi: true`.
 This will point both `masterPublicName` and `masterInternalName` to the load balancer. You can therefore set both of these to the same value in this configuration.
 
 ```yaml
@@ -99,7 +100,7 @@ etcdClusters:
 
 By default, the Volumes created for the etcd clusters are `gp2` and 20GB each. The volume size, type and Iops( for `io1`) can be configured via their parameters. Conversion between `gp2` and `io1` is not supported, nor are size changes.
 
-It is also possible to specify the requests for your etcd cluster members using the `cpuRequest` and `memoryRequest` parameters.
+As of Kops 1.12.0 it is also possible to specify the requests for your etcd cluster members using the `cpuRequest` and `memoryRequest` parameters.
 
 ```yaml
 etcdClusters:
@@ -170,7 +171,7 @@ spec:
     zone: us-east-1a
 ```
 
-In the case that you don't use NAT gateways or internet gateways, you can use the "External" flag for egress to force kops to ignore egress for the subnet. This can be useful when other tools are used to manage egress for the subnet such as virtual private gateways. Please note that your cluster may need to have access to the internet upon creation, so egress must be available upon initializing a cluster. This is intended for use when egress is managed external to kops, typically with an existing cluster.
+In the case that you don't use NAT gateways or internet gateways, Kops 1.12.0 introduced the "External" flag for egress to force kops to ignore egress for the subnet. This can be useful when other tools are used to manage egress for the subnet such as virtual private gateways. Please note that your cluster may need to have access to the internet upon creation, so egress must be available upon initializing a cluster. This is intended for use when egress is managed external to kops, typically with an existing cluster.
 
 ```
 spec:
@@ -355,7 +356,7 @@ spec:
 ```
 
 #### Setting kubelet CPU management policies
-To enable cpu management policies in kubernetes as per [cpu management doc](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies)
+Kops 1.12.0 added support for enabling cpu management policies in kubernetes as per [cpu management doc](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies)
 we have to set the flag `--cpu-manager-policy` to the appropriate value on all the kubelets. This must be specified in the `kubelet` spec in our cluster.yml.
 
 ```

--- a/docs/instance_groups.md
+++ b/docs/instance_groups.md
@@ -114,7 +114,7 @@ spec:
 
 ## Adding additional storage to the instance groups
 
-You can add additional storage _(note, presently confined to AWS)_ via the instancegroup specification.
+As of Kops 1.12.0 you can add additional storage _(note, presently confined to AWS)_ via the instancegroup specification.
 
 ```YAML
 ---
@@ -228,6 +228,8 @@ So the procedure is:
 ## Creating a instance group of mixed instances types (AWS Only)
 
 AWS permits the creation of EC2 Fleet Autoscaling Group using a [mixed instance policy](https://aws.amazon.com/blogs/aws/ec2-fleet-manage-thousands-of-on-demand-and-spot-instances-with-one-request/), allowing the users to build a target capacity and make up of on-demand and spot instances while offloading the allocation strategy to AWS. In order to create a mixed instance policy instancegroup.
+
+Support for mixed instance groups was added in Kops 1.12.0
 
 ```YAML
 ---

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -444,7 +444,7 @@ For support with Cilium Network Policies you can reach out on Slack or Github:
 
 #### Configuraing Flannel iptables resync period
 
-Flannel iptables resync option is configurable via editing a cluster and adding
+As of Kops 1.12.0, Flannel iptables resync option is configurable via editing a cluster and adding
 `iptablesResyncSeconds` option to spec:
 
 ```


### PR DESCRIPTION
I went through `git diff 1.11.1 -- docs/ 1.12.0 -- docs/` and included the Kops version that introduced any new features mentioned in the docs. I'm hoping this will cut down on the confusion when reading the master branch's docs and seeing features not included in the latest stable Kops release.

A stopgap until we can properly version our documentation.

/area documentation