### PR TITLE
bumped k8s 1.11 versions to 1.11.10 in stable channel

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -46,7 +46,7 @@ spec:
     recommendedVersion: 1.12.7
     requiredVersion: 1.12.0
   - range: ">=1.11.0"
-    recommendedVersion: 1.11.9
+    recommendedVersion: 1.11.10
     requiredVersion: 1.11.0
   - range: ">=1.10.0"
     recommendedVersion: 1.10.13
@@ -85,7 +85,7 @@ spec:
   - range: ">=1.11.0-alpha.1"
     #recommendedVersion: "1.11.0"
     #requiredVersion: 1.11.0
-    kubernetesVersion: 1.11.9
+    kubernetesVersion: 1.11.10
   - range: ">=1.10.0-alpha.1"
     recommendedVersion: "1.10.0"
     #requiredVersion: 1.10.0


### PR DESCRIPTION
~/hold~

we might wait for 1 - 2 weeks after https://github.com/kubernetes/kops/pull/6969