### PR TITLE
Add shortNames and columns to InstanceGroup CRD

### DIFF
--- a/k8s/crds/kops_v1alpha2_instancegroup.yaml
+++ b/k8s/crds/kops_v1alpha2_instancegroup.yaml
@@ -6,10 +6,33 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: instancegroups.kops.k8s.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.role
+    description: Role
+    name: role
+    type: string
+  - JSONPath: .spec.machineType
+    description: Machine Type
+    name: machineType
+    type: string
+  - JSONPath: .spec.minSize
+    description: Min
+    name: min
+    type: integer
+  - JSONPath: .spec.maxSize
+    description: Max
+    name: max
+    type: integer
+  - JSONPath: .spec.zones
+    description: Zones
+    name: zones
+    type: string
   group: kops.k8s.io
   names:
     kind: InstanceGroup
     plural: instancegroups
+    shortNames:
+    - ig
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -22,7 +22,12 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
+// +kubebuilder:printcolumn:name="role",type="string",JSONPath=".spec.role",description="Role",priority=0
+// +kubebuilder:printcolumn:name="machineType",type="string",JSONPath=".spec.machineType",description="Machine Type",priority=0
+// +kubebuilder:printcolumn:name="min",type="integer",JSONPath=".spec.minSize",description="Min",priority=0
+// +kubebuilder:printcolumn:name="max",type="integer",JSONPath=".spec.maxSize",description="Max",priority=0
+// +kubebuilder:printcolumn:name="zones",type="string",JSONPath=".spec.zones",description="Zones",priority=0
+// +kubebuilder:resource:shortName=ig
 // InstanceGroup represents a group of instances (either nodes or masters) with the same configuration
 type InstanceGroup struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
This makes the appearance in `kubectl get ig` very similar to the
`kops get ig` format.