### PR TITLE
VPC cleanup: recognize the error code for concurrent VPC deletion

### DIFF
--- a/pkg/resources/aws/vpc.go
+++ b/pkg/resources/aws/vpc.go
@@ -39,6 +39,11 @@ func DeleteVPC(cloud fi.Cloud, r *resources.Resource) error {
 	}
 	_, err := c.EC2().DeleteVpc(request)
 	if err != nil {
+		if awsup.AWSErrorCode(err) == "InvalidVpcID.NotFound" {
+			// Concurrently deleted
+			return nil
+		}
+
 		if IsDependencyViolation(err) {
 			return err
 		}


### PR DESCRIPTION
Hit this when I was cleaning up my VPCs manually.