### PR TITLE
Add min-port=1024 to dnsmasq in kube-dns

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
@@ -193,6 +193,7 @@ spec:
         - --server=/{{ KubeDNS.Domain }}/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053
         - --server=/in6.arpa/127.0.0.1#10053
+        - --min-port=1024
         ports:
         - containerPort: 53
           name: dns

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -194,6 +194,7 @@ spec:
         - --server=/{{ KubeDNS.Domain }}/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053
         - --server=/in6.arpa/127.0.0.1#10053
+        - --min-port=1024
         ports:
         - containerPort: 53
           name: dns

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
@@ -147,6 +147,7 @@ spec:
         - --no-resolv
         - --server=127.0.0.1#10053
         - --log-facility=-
+        - --min-port=1024
         ports:
         - containerPort: 53
           name: dns


### PR DESCRIPTION
Do not use ports less than that given as source for outbound DNS queries. Dnsmasq picks random ports as source for outbound queries: when this option is given, the ports used will always to larger than that specified. Useful for systems behind firewalls

More information: Kubernetes kube-dns uses dnsmasq version 2.78 (http://www.thekelleys.org.uk/dnsmasq/dnsmasq-2.78.tar.xz), which doesn't set the default min_port to 1024 (probably a bug). Later versions of dnsmasq have fixed this issue and don't need explicit min-port command-line argument.
