### PR TITLE
Add arg min-port=1024 to dnsmasq container in kube-dns

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
@@ -204,6 +204,7 @@ spec:
         - --server=/{{ KubeDNS.Domain }}/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053
         - --server=/in6.arpa/127.0.0.1#10053
+        - --min-port=1024
         ports:
         - containerPort: 53
           name: dns

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -194,6 +194,7 @@ spec:
         - --server=/{{ KubeDNS.Domain }}/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053
         - --server=/in6.arpa/127.0.0.1#10053
+        - --min-port=1024
         ports:
         - containerPort: 53
           name: dns

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/pre-k8s-1.6.yaml.template
@@ -147,6 +147,7 @@ spec:
         - --no-resolv
         - --server=127.0.0.1#10053
         - --log-facility=-
+        - --min-port=1024
         ports:
         - containerPort: 53
           name: dns

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -13,7 +13,7 @@ spec:
   - id: pre-k8s-1.6
     kubernetesVersion: <1.6.0
     manifest: kube-dns.addons.k8s.io/pre-k8s-1.6.yaml
-    manifestHash: bda4d8eb6a2f2470ab1ddd8b3e7cb29029348804
+    manifestHash: 90f1e4bedea6da183eb4c6788879f7297119ff3e
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -21,7 +21,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 430dbc54269c26f0226835ff501457fa38d2cec8
+    manifestHash: 14ae2e8c90c7641ea15e871c77516db1d3aed6da
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -29,7 +29,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 3b31109025d81ac10fbfcc6acf1d1b32170cd2c8
+    manifestHash: 339b8060032db51e34335f03524619bc876f1548
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
@@ -13,7 +13,7 @@ spec:
   - id: pre-k8s-1.6
     kubernetesVersion: <1.6.0
     manifest: kube-dns.addons.k8s.io/pre-k8s-1.6.yaml
-    manifestHash: bda4d8eb6a2f2470ab1ddd8b3e7cb29029348804
+    manifestHash: 90f1e4bedea6da183eb4c6788879f7297119ff3e
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -21,7 +21,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 430dbc54269c26f0226835ff501457fa38d2cec8
+    manifestHash: 14ae2e8c90c7641ea15e871c77516db1d3aed6da
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -29,7 +29,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 3b31109025d81ac10fbfcc6acf1d1b32170cd2c8
+    manifestHash: 339b8060032db51e34335f03524619bc876f1548
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -13,7 +13,7 @@ spec:
   - id: pre-k8s-1.6
     kubernetesVersion: <1.6.0
     manifest: kube-dns.addons.k8s.io/pre-k8s-1.6.yaml
-    manifestHash: bda4d8eb6a2f2470ab1ddd8b3e7cb29029348804
+    manifestHash: 90f1e4bedea6da183eb4c6788879f7297119ff3e
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -21,7 +21,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 430dbc54269c26f0226835ff501457fa38d2cec8
+    manifestHash: 14ae2e8c90c7641ea15e871c77516db1d3aed6da
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -29,7 +29,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 3b31109025d81ac10fbfcc6acf1d1b32170cd2c8
+    manifestHash: 339b8060032db51e34335f03524619bc876f1548
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -13,7 +13,7 @@ spec:
   - id: pre-k8s-1.6
     kubernetesVersion: <1.6.0
     manifest: kube-dns.addons.k8s.io/pre-k8s-1.6.yaml
-    manifestHash: bda4d8eb6a2f2470ab1ddd8b3e7cb29029348804
+    manifestHash: 90f1e4bedea6da183eb4c6788879f7297119ff3e
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -21,7 +21,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 430dbc54269c26f0226835ff501457fa38d2cec8
+    manifestHash: 14ae2e8c90c7641ea15e871c77516db1d3aed6da
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -29,7 +29,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 3b31109025d81ac10fbfcc6acf1d1b32170cd2c8
+    manifestHash: 339b8060032db51e34335f03524619bc876f1548
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io


### PR DESCRIPTION
Do not use ports less than that given as source for outbound DNS queries. Dnsmasq picks random ports as source for outbound queries: when this option is given, the ports used will always to larger than that specified. Useful for systems behind firewalls.

More information: Kubernetes kube-dns uses dnsmasq version 2.78 (http://www.thekelleys.org.uk/dnsmasq/dnsmasq-2.78.tar.xz), which doesn't set the default min_port to 1024 (probably a bug). Later versions of dnsmasq have fixed this issue and don't need explicit min-port command-line argument.