### PR TITLE
Makefile: keep go vet simple

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,6 @@ BAZELUPLOAD=$(BAZELBUILD)/upload
 UID:=$(shell id -u)
 GID:=$(shell id -g)
 TESTABLE_PACKAGES:=$(shell egrep -v "k8s.io/kops/vendor" hack/.packages)
-# We need to ignore clientsets because of kubernetes/kubernetes#60584
-GOVETABLE_PACKAGES:=$(shell egrep -v "k8s.io/kops/vendor|clientset/fake" hack/.packages)
 BAZEL_OPTIONS?=
 API_OPTIONS?=
 GCFLAGS?=
@@ -516,7 +514,7 @@ verify-goimports:
 
 .PHONY: govet
 govet: ${BINDATA_TARGETS}
-	go vet ${GOVETABLE_PACKAGES}
+	go vet ./...
 
 # --------------------------------------------------
 # Continuous integration targets


### PR DESCRIPTION
We can now go vet all our packages, go vet excludes vendor since 1.9,
and the clientset is go-vet safe now.