### PR TITLE
Update stretch dependencies and kubeup

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -81,8 +81,8 @@ dpkg_src(
     name = "debian_stretch",
     arch = "amd64",
     distro = "stretch",
-    sha256 = "4b981bd2445d85cf1d93ea9f2d2dc235d20543ecdadd0d8065a10793b94eab9b",
-    snapshot = "20190131T155411Z",
+    sha256 = "da378b113f0b1edcf5b1f2c3074fd5476c7fd6e6df3752f824aad22e7547e699",
+    snapshot = "20190520T104418Z",
     url = "http://snapshot.debian.org/archive",
 )
 
@@ -114,8 +114,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 http_file(
     name = "utils_tar_gz",
-    urls = ["https://kubeupv2.s3.amazonaws.com/kops/1.11.1/linux/amd64/utils.tar.gz"],
-    sha256 = "0e685eb751a32f782705311049b2592c4724add6f19ffdad1e7ce4f55816d7d8",
+    urls = ["https://kubeupv2.s3.amazonaws.com/kops/1.12.1/linux/amd64/utils.tar.gz"],
+    sha256 = "5c956247241dd94300ba13c6dd9cb5843382d4255125a7a6639d2aad68b9050c",
 )
 
 git_repository(


### PR DESCRIPTION
These are a bit out of date so it'd be good to have master more up to date when testing clusters.  This probably doesn't need to be cherry picked.