### PR TITLE
Openstack support for rolling-update status

### DIFF
--- a/pkg/client/simple/vfsclientset/BUILD.bazel
+++ b/pkg/client/simple/vfsclientset/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/secrets:go_default_library",
         "//util/pkg/vfs:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/simple/vfsclientset/cluster.go
+++ b/pkg/client/simple/vfsclientset/cluster.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -138,6 +139,10 @@ func (r *ClusterVFS) Update(c *api.Cluster, status *api.ClusterStatus) (*api.Clu
 
 	if err := validation.ValidateClusterUpdate(c, status, old).ToAggregate(); err != nil {
 		return nil, err
+	}
+
+	if !apiequality.Semantic.DeepEqual(old.Spec, c.Spec) {
+		c.SetGeneration(old.GetGeneration() + 1)
 	}
 
 	if err := r.writeConfig(c, r.basePath.Join(clusterName, registry.PathCluster), c, vfs.WriteOptionOnlyIfExists); err != nil {

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -60,6 +60,8 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 	}
 	igMeta["k8s"] = b.ClusterName()
 	igMeta["KopsInstanceGroup"] = ig.Name
+	igMeta[openstack.INSTANCE_GROUP_GENERATION] = fmt.Sprintf("%d", ig.GetGeneration())
+	igMeta[openstack.CLUSTER_GENERATION] = fmt.Sprintf("%d", b.Cluster.GetGeneration())
 
 	startupScript, err := b.BootstrapScript.ResourceNodeUp(ig, b.Cluster)
 	if err != nil {

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -528,7 +528,7 @@ func (c *openstackCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []
 			}
 			continue
 		}
-		groups[instancegroup.ObjectMeta.Name], err = c.osBuildCloudInstanceGroup(instancegroup, &grp, nodeMap)
+		groups[instancegroup.ObjectMeta.Name], err = c.osBuildCloudInstanceGroup(cluster, instancegroup, &grp, nodeMap)
 		if err != nil {
 			return nil, fmt.Errorf("error getting cloud instance group %q: %v", instancegroup.ObjectMeta.Name, err)
 		}

--- a/upup/pkg/fi/cloudup/openstack/instance.go
+++ b/upup/pkg/fi/cloudup/openstack/instance.go
@@ -26,6 +26,11 @@ import (
 	"k8s.io/kops/util/pkg/vfs"
 )
 
+const (
+	INSTANCE_GROUP_GENERATION = "ig_generation"
+	CLUSTER_GENERATION        = "cluster_generation"
+)
+
 func (c *openstackCloud) CreateInstance(opt servers.CreateOptsBuilder) (*servers.Server, error) {
 	var server *servers.Server
 


### PR DESCRIPTION
/sig openstack

I have incremented generation when an instance group or cluster resource has been modified.  Both these generation values are stored on the metadata of openstack instances.  When a rolling update is performed it compares the generation of the cluster and instance group in swift with those on the instance.

One issue with this is that a new generation does not necessarily mean that a rolling update needs to be performed, such as min and max number of nodes.

```
~ $ kops --name derek.k8s.local rolling-update cluster
NAME			STATUS	NEEDUPDATE	READY	MIN	MAX	NODES
bastions		Ready	0		1	1	1	0
master-cloud-rtp-1-a	Ready	0		1	1	1	1
master-cloud-rtp-1-b	Ready	0		1	1	1	1
master-cloud-rtp-1-c	Ready	0		1	1	1	1
nodes			Ready	0		9	9	9	8

No rolling-update required.
~ $ kops --name derek.k8s.local edit ig nodes
~ $ kops --name derek.k8s.local rolling-update cluster
NAME			STATUS		NEEDUPDATE	READY	MIN	MAX	NODES
bastions		Ready		0		1	1	1	0
master-cloud-rtp-1-a	Ready		0		1	1	1	1
master-cloud-rtp-1-b	Ready		0		1	1	1	1
master-cloud-rtp-1-c	Ready		0		1	1	1	1
nodes			NeedsUpdate	9		0	5	5	8

Must specify --yes to rolling-update.
```

This PR is intended to resolve https://github.com/kubernetes/kops/issues/7056