### PR TITLE
Add Debian 10 (buster) support

### DIFF
--- a/nodeup/pkg/distros/distribution.go
+++ b/nodeup/pkg/distros/distribution.go
@@ -26,6 +26,7 @@ type Distribution string
 var (
 	DistributionJessie      Distribution = "jessie"
 	DistributionDebian9     Distribution = "debian9"
+	DistributionDebian10    Distribution = "buster"
 	DistributionXenial      Distribution = "xenial"
 	DistributionBionic      Distribution = "bionic"
 	DistributionRhel7       Distribution = "rhel7"
@@ -40,7 +41,7 @@ func (d Distribution) BuildTags() []string {
 	switch d {
 	case DistributionJessie:
 		t = []string{"_jessie"}
-	case DistributionDebian9:
+	case DistributionDebian9, DistributionDebian10:
 		t = []string{} // trying to move away from tags
 	case DistributionXenial:
 		t = []string{"_xenial"}
@@ -74,7 +75,7 @@ func (d Distribution) BuildTags() []string {
 
 func (d Distribution) IsDebianFamily() bool {
 	switch d {
-	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9:
+	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9, DistributionDebian10:
 		return true
 	case DistributionCentos7, DistributionRhel7:
 		return false
@@ -90,7 +91,7 @@ func (d Distribution) IsRHELFamily() bool {
 	switch d {
 	case DistributionCentos7, DistributionRhel7:
 		return true
-	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9:
+	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9, DistributionDebian10:
 		return false
 	case DistributionCoreOS, DistributionContainerOS:
 		return false
@@ -102,7 +103,7 @@ func (d Distribution) IsRHELFamily() bool {
 
 func (d Distribution) IsSystemd() bool {
 	switch d {
-	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9:
+	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9, DistributionDebian10:
 		return true
 	case DistributionCentos7, DistributionRhel7:
 		return true

--- a/nodeup/pkg/distros/identify.go
+++ b/nodeup/pkg/distros/identify.go
@@ -54,6 +54,8 @@ func FindDistribution(rootfs string) (Distribution, error) {
 			return DistributionJessie, nil
 		} else if strings.HasPrefix(debianVersion, "9.") {
 			return DistributionDebian9, nil
+		} else if strings.HasPrefix(debianVersion, "10.") {
+			return DistributionDebian10, nil
 		} else {
 			return "", fmt.Errorf("unhandled debian version %q", debianVersion)
 		}

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -617,6 +617,19 @@ var dockerVersions = []dockerVersion{
 		Dependencies:  []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 	},
 
+	// 18.06.3 - Debian Buster
+	{
+
+		DockerVersion: "18.06.3",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionDebian10},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "18.06.3~ce~3-0~debian",
+		Source:        "https://download.docker.com/linux/debian/dists/buster/pool/stable/amd64/docker-ce_18.06.3~ce~3-0~debian_amd64.deb",
+		Hash:          "05c9b098437bcf1b489c2a3a9764c3b779af7bc4",
+		Dependencies:  []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
+	},
+
 	// 18.06.2 - Jessie
 	{
 		DockerVersion: "18.06.2",

--- a/nodeup/pkg/model/kubectl.go
+++ b/nodeup/pkg/model/kubectl.go
@@ -104,7 +104,7 @@ func (b *KubectlBuilder) Build(c *fi.ModelBuilderContext) error {
 func (b *KubectlBuilder) findKubeconfigUser() (*fi.User, *fi.Group, error) {
 	var users []string
 	switch b.Distribution {
-	case distros.DistributionJessie, distros.DistributionDebian9:
+	case distros.DistributionJessie, distros.DistributionDebian9, distros.DistributionDebian10:
 		users = []string{"admin", "root"}
 	case distros.DistributionCentos7:
 		users = []string{"centos"}


### PR DESCRIPTION
```
root@master-zone-1-2-1-localtest-k8s-local:/home/debian# kubectl get nodes -o wide
NAME                                    STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                       KERNEL-VERSION         CONTAINER-RUNTIME
master-zone-1-1-1-localtest-k8s-local   Ready    master   73s   v1.14.2   10.1.32.7     <none>        Debian GNU/Linux 10 (buster)   4.19.0-5-cloud-amd64   docker://18.6.3
master-zone-1-2-1-localtest-k8s-local   Ready    master   76s   v1.14.2   10.1.32.4     <none>        Debian GNU/Linux 10 (buster)   4.19.0-5-cloud-amd64   docker://18.6.3
master-zone-1-3-1-localtest-k8s-local   Ready    master   72s   v1.14.2   10.1.32.6     <none>        Debian GNU/Linux 10 (buster)   4.19.0-5-cloud-amd64   docker://18.6.3
nodes-1-localtest-k8s-local             Ready    node     32s   v1.14.2   10.1.32.16    <none>        Debian GNU/Linux 10 (buster)   4.19.0-5-cloud-amd64   docker://18.6.3
nodes-2-localtest-k8s-local             Ready    node     23s   v1.14.2   10.1.32.13    <none>        Debian GNU/Linux 10 (buster)   4.19.0-5-cloud-amd64   docker://18.6.3
```

debian buster is already in release freeze mode and is going to be released soon. That is why we need get support for kops as well