### PR TITLE
Adding affinity and PDB to dns.

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -98,6 +98,18 @@ spec:
       labels:
         k8s-app: kube-dns
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: k8s-app
+                      operator: In
+                      values:
+                        - kube-dns
+                topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
       serviceAccountName: coredns
       tolerations:
@@ -188,3 +200,16 @@ spec:
   - name: metrics
     port: 9153
     protocol: TCP
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kube-dns
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  minAvailable: 1
+

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
@@ -107,6 +107,18 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '10055'
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: k8s-app
+                      operator: In
+                      values:
+                        - kube-dns
+                topologyKey: kubernetes.io/hostname
       dnsPolicy: Default  # Don't use cluster DNS.
       serviceAccountName: kube-dns
       volumes:
@@ -308,3 +320,15 @@ subjects:
 - kind: ServiceAccount
   name: kube-dns-autoscaler
   namespace: kube-system
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kube-dns
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  minAvailable: 1


### PR DESCRIPTION
Adds affinity and PDB to dns.

Several times had situation where kube-dns pods were scheduled on the same worker (including empheral instances) and during ie. rolling-updates / node termination / node drain events DNS was unresponsible for few seconds.