### PR TITLE
K8s 1.12.8 to stable 1.12.9 to alpha

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -43,7 +43,7 @@ spec:
     recommendedVersion: 1.13.6
     requiredVersion: 1.13.0
   - range: ">=1.12.0"
-    recommendedVersion: 1.12.8
+    recommendedVersion: 1.12.9
     requiredVersion: 1.12.0
   - range: ">=1.11.0"
     recommendedVersion: 1.11.10
@@ -81,7 +81,7 @@ spec:
   - range: ">=1.12.0-alpha.1"
     recommendedVersion: "1.12.1"
     #requiredVersion: 1.12.0
-    kubernetesVersion: 1.12.8
+    kubernetesVersion: 1.12.9
   - range: ">=1.11.0-alpha.1"
     #recommendedVersion: "1.11.0"
     #requiredVersion: 1.11.0

--- a/channels/stable
+++ b/channels/stable
@@ -43,7 +43,7 @@ spec:
     recommendedVersion: 1.13.5
     requiredVersion: 1.13.0
   - range: ">=1.12.0"
-    recommendedVersion: 1.12.7
+    recommendedVersion: 1.12.8
     requiredVersion: 1.12.0
   - range: ">=1.11.0"
     recommendedVersion: 1.11.9
@@ -81,7 +81,7 @@ spec:
   - range: ">=1.12.0-alpha.1"
     recommendedVersion: "1.12.1"
     #requiredVersion: 1.12.0
-    kubernetesVersion: 1.12.7
+    kubernetesVersion: 1.12.8
   - range: ">=1.11.0-alpha.1"
     #recommendedVersion: "1.11.0"
     #requiredVersion: 1.11.0


### PR DESCRIPTION
Mark 1.12.8 as recommendedVersion for stable channel and 1.12.9 as recommendedVersion for alpha channel