### PR TITLE
Mark ENI 0 as delete_on_termination for LaunchTemplates

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation.go
@@ -156,7 +156,8 @@ func (t *LaunchTemplate) RenderCloudformation(target *cloudformation.Cloudformat
 			ImageID:      image,
 			InstanceType: e.InstanceType,
 			NetworkInterfaces: []*cloudformationLaunchTemplateNetworkInterfaces{
-				{AssociatePublicIPAddress: e.AssociatePublicIP},
+				{AssociatePublicIPAddress: e.AssociatePublicIP,
+					DeleteOnTermination: fi.Bool(true)},
 			},
 		},
 	}

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation_test.go
@@ -63,7 +63,8 @@ func TestLaunchTemplateCloudformationRender(t *testing.T) {
           "KeyName": "mykey",
           "NetworkInterfaces": [
             {
-              "AssociatePublicIpAddress": true
+              "AssociatePublicIpAddress": true,
+              "DeleteOnTermination": true
             }
           ],
           "Placement": [
@@ -144,7 +145,8 @@ func TestLaunchTemplateCloudformationRender(t *testing.T) {
           "KeyName": "mykey",
           "NetworkInterfaces": [
             {
-              "AssociatePublicIpAddress": true
+              "AssociatePublicIpAddress": true,
+              "DeleteOnTermination": true
             }
           ],
           "Placement": [

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -162,7 +162,8 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 		InstanceType: e.InstanceType,
 		Lifecycle:    &terraform.Lifecycle{CreateBeforeDestroy: fi.Bool(true)},
 		NetworkInterfaces: []*terraformLaunchTemplateNetworkInterfaces{
-			{AssociatePublicIPAddress: e.AssociatePublicIP},
+			{AssociatePublicIPAddress: e.AssociatePublicIP,
+				DeleteOnTermination: fi.Bool(true)},
 		},
 	}
 

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
@@ -78,6 +78,7 @@ resource "aws_launch_template" "test" {
 
   network_interfaces = {
     associate_public_ip_address = true
+    delete_on_termination       = true
     security_groups             = ["${aws_security_group.nodes-1.id}", "${aws_security_group.nodes-2.id}"]
   }
 
@@ -155,6 +156,7 @@ resource "aws_launch_template" "test" {
 
   network_interfaces = {
     associate_public_ip_address = true
+    delete_on_termination       = true
     security_groups             = ["${aws_security_group.nodes-1.id}", "${aws_security_group.nodes-2.id}"]
   }
 


### PR DESCRIPTION
We are not setting the primary eni has delete_on_termination when using LaunchTemplates, which is leaving behind ENIs