### PR TITLE
Use readinessProbe for weave-net instead of livenessProbe

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -164,12 +164,11 @@ spec:
                   key: network-password
             {{- end }}
           image: 'weaveworks/weave-kube:2.5.1'
-          livenessProbe:
+          readinessProbe:
             httpGet:
               host: 127.0.0.1
               path: /status
               port: 6784
-            initialDelaySeconds: 30
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
@@ -146,12 +146,11 @@ spec:
                   key: network-password
             {{- end }}
           image: 'weaveworks/weave-kube:2.3.0'
-          livenessProbe:
+          readinessProbe:
             httpGet:
               host: 127.0.0.1
               path: /status
               port: 6784
-            initialDelaySeconds: 30
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -156,12 +156,11 @@ spec:
                   key: network-password
             {{- end }}
           image: 'weaveworks/weave-kube:2.5.1'
-          livenessProbe:
+          readinessProbe:
             httpGet:
               host: 127.0.0.1
               path: /status
               port: 6784
-            initialDelaySeconds: 30
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -160,12 +160,11 @@ spec:
                   key: network-password
             {{- end }}
           image: 'weaveworks/weave-kube:2.5.1'
-          livenessProbe:
+          readinessProbe:
             httpGet:
               host: 127.0.0.1
               path: /status
               port: 6784
-            initialDelaySeconds: 30
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
Brings the kops templates in line with recent(ish) weave-net upstream changes. 

References:
weaveworks/weave#3421
weaveworks/weave#3417