### PR TITLE
Cache ASGs, LCs, and AMIs

### DIFF
--- a/cloudmock/aws/mockautoscaling/group.go
+++ b/cloudmock/aws/mockautoscaling/group.go
@@ -139,6 +139,8 @@ func (m *MockAutoscaling) DescribeAutoScalingGroups(input *autoscaling.DescribeA
 					match = true
 				}
 			}
+		} else {
+			match = true
 		}
 
 		if match {
@@ -179,9 +181,6 @@ func (m *MockAutoscaling) DescribeAutoScalingGroupsRequest(*autoscaling.Describe
 }
 
 func (m *MockAutoscaling) DescribeAutoScalingGroupsPages(request *autoscaling.DescribeAutoScalingGroupsInput, callback func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool) error {
-	if request.MaxRecords != nil {
-		klog.Fatalf("MaxRecords not implemented")
-	}
 	if request.NextToken != nil {
 		klog.Fatalf("NextToken not implemented")
 	}

--- a/cloudmock/aws/mockautoscaling/launchconfigurations.go
+++ b/cloudmock/aws/mockautoscaling/launchconfigurations.go
@@ -46,9 +46,6 @@ func (m *MockAutoscaling) DescribeLaunchConfigurationsPages(request *autoscaling
 	if request.LaunchConfigurationNames != nil {
 		klog.Fatalf("LaunchConfigurationNames not implemented")
 	}
-	if request.MaxRecords != nil {
-		klog.Fatalf("MaxRecords not implemented")
-	}
 	if request.NextToken != nil {
 		klog.Fatalf("NextToken not implemented")
 	}


### PR DESCRIPTION
A proposal for #7111

The core problem is that to fetch a single ASG / LC, we must fetch all of them in pages of 50. This quickly results in backoffs from aws. For a ~230 ASG cluster, this PR reduces the time for `kops update cluster` from ~30 min to ~15 seconds.

There are two current issues with this PR:
1. All changes to items are in the W side of an RWMutex, forcing them to be serial now instead of parallel
2. When fetching ASGs / LCs, there is a race condition that can occur if a modification happens between warming the cache and R locking for using the cache

I have never touched the kops codebase before, so am looking for input on if there are other approaches to doing this and if there are other ideas on how to be more thread-safe.

cc: @mikesplain 