### PR TITLE
Deep-copy proto state to prevent concurrent modification

### DIFF
--- a/protokube/pkg/gossip/mesh/state.go
+++ b/protokube/pkg/gossip/mesh/state.go
@@ -159,10 +159,19 @@ func (s *state) merge(message *KVState, changes *KVState) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
-	changed := mergeKVState(&s.data, message, changes)
+	var c KVState
+	if s.data.Records != nil {
+		c.Records = make(map[string]*KVStateRecord)
+		for k, v := range s.data.Records {
+			c.Records[k] = v
+		}
+	}
+
+	changed := mergeKVState(&c, message, changes)
 
 	if changed {
 		s.version++
+		s.data = c
 	}
 }
 


### PR DESCRIPTION
Backport of #6707 to the 1.11.x series; as this impacts 1.11.x and 1.12.x (which has the fix) requires some potentially non-trivial changes to upgrade. IMO this should be merged and a new bugfix release cut. On my clusters protokube (per master) is hitting this every ~3 minutes -- which is causing a lot of excessive churn and cloud-provider calls.

Fix #6635