### PR TITLE
Don't precreate etcd DNS records if we're using etcd-manager

### DIFF
--- a/upup/pkg/fi/cloudup/dns.go
+++ b/upup/pkg/fi/cloudup/dns.go
@@ -262,6 +262,9 @@ func buildPrecreateDNSHostnames(cluster *kops.Cluster) []string {
 	}
 
 	for _, etcdCluster := range cluster.Spec.EtcdClusters {
+		if etcdCluster.Provider == kops.EtcdProviderTypeManager {
+			continue
+		}
 		etcClusterName := "etcd-" + etcdCluster.Name
 		if etcdCluster.Name == "main" {
 			// Special case


### PR DESCRIPTION
Fixes #7120

etcd-manager uses /etc/hosts and protokube actually deletes these etcd records (see [here](https://github.com/kubernetes/kops/blob/b2d90fd2c0e466a48ff5ebbfca472564f21b21a7/nodeup/pkg/model/protokube.go#L372-L393)), yet Kops is recreating the etcd records with this [placeholder IP](https://github.com/kubernetes/kops/blob/b2d90fd2c0e466a48ff5ebbfca472564f21b21a7/upup/pkg/fi/cloudup/dns.go#L39). This prevents that from happening.