### PR TITLE
add masterPublicName support in kops set cluster

### DIFF
--- a/pkg/commands/set_cluster.go
+++ b/pkg/commands/set_cluster.go
@@ -94,7 +94,7 @@ func SetClusterFields(fields []string, cluster *api.Cluster, instanceGroups []*a
 		case "spec.kubernetesVersion":
 			cluster.Spec.KubernetesVersion = kv[1]
 		case "spec.masterPublicName":
-			cluster.Spec.masterPublicName = kv[1]
+			cluster.Spec.MasterPublicName = kv[1]
 		case "cluster.spec.etcdClusters[*].enableEtcdTLS":
 			v, err := strconv.ParseBool(kv[1])
 			if err != nil {

--- a/pkg/commands/set_cluster.go
+++ b/pkg/commands/set_cluster.go
@@ -93,7 +93,8 @@ func SetClusterFields(fields []string, cluster *api.Cluster, instanceGroups []*a
 			cluster.Spec.NodePortAccess = append(cluster.Spec.NodePortAccess, kv[1])
 		case "spec.kubernetesVersion":
 			cluster.Spec.KubernetesVersion = kv[1]
-
+		case "spec.masterPublicName":
+			cluster.Spec.masterPublicName = kv[1]
 		case "cluster.spec.etcdClusters[*].enableEtcdTLS":
 			v, err := strconv.ParseBool(kv[1])
 			if err != nil {
@@ -102,7 +103,6 @@ func SetClusterFields(fields []string, cluster *api.Cluster, instanceGroups []*a
 			for _, c := range cluster.Spec.EtcdClusters {
 				c.EnableEtcdTLS = v
 			}
-
 		case "cluster.spec.etcdClusters[*].enableTLSAuth":
 			v, err := strconv.ParseBool(kv[1])
 			if err != nil {
@@ -111,7 +111,6 @@ func SetClusterFields(fields []string, cluster *api.Cluster, instanceGroups []*a
 			for _, c := range cluster.Spec.EtcdClusters {
 				c.EnableTLSAuth = v
 			}
-
 		case "cluster.spec.etcdClusters[*].version":
 			for _, c := range cluster.Spec.EtcdClusters {
 				c.Version = kv[1]


### PR DESCRIPTION
currently returns `unhandled field: "spec.masterPublicName=..."`