### PR TITLE
allow tcp/udp/icmp traffic from node to master on GCE

### DIFF
--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -101,7 +101,7 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		c.AddTask(t)
 	}
 
-	// Allow limited traffic from nodes -> masters
+	// Allow full traffic from nodes -> masters
 	{
 		t := &gcetasks.FirewallRule{
 			Name:       s(b.SafeObjectName("node-to-master")),
@@ -109,7 +109,7 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Network:    b.LinkToNetwork(),
 			SourceTags: []string{b.GCETagForRole(kops.InstanceGroupRoleNode)},
 			TargetTags: []string{b.GCETagForRole(kops.InstanceGroupRoleMaster)},
-			Allowed:    []string{"tcp:443", "tcp:4194"},
+			Allowed:    []string{"tcp", "udp", "icmp"},
 		}
 		c.AddTask(t)
 	}
@@ -123,7 +123,7 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Network:      b.LinkToNetwork(),
 			SourceRanges: []string{b.Cluster.Spec.NonMasqueradeCIDR},
 			TargetTags:   []string{b.GCETagForRole(kops.InstanceGroupRoleMaster)},
-			Allowed:      []string{"tcp:443", "tcp:4194"},
+			Allowed:      []string{"tcp", "udp", "icmp"},
 		}
 		c.AddTask(t)
 	}

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -105,12 +105,14 @@ resource "google_compute_firewall" "cidr-to-master-ha-gce-example-com" {
 
   allow = {
     protocol = "tcp"
-    ports    = ["443"]
   }
 
   allow = {
-    protocol = "tcp"
-    ports    = ["4194"]
+    protocol = "udp"
+  }
+
+  allow = {
+    protocol = "icmp"
   }
 
   source_ranges = ["100.64.0.0/10"]
@@ -232,12 +234,14 @@ resource "google_compute_firewall" "node-to-master-ha-gce-example-com" {
 
   allow = {
     protocol = "tcp"
-    ports    = ["443"]
   }
 
   allow = {
-    protocol = "tcp"
-    ports    = ["4194"]
+    protocol = "udp"
+  }
+
+  allow = {
+    protocol = "icmp"
   }
 
   source_tags = ["ha-gce-example-com-k8s-io-role-node"]


### PR DESCRIPTION
fixes #7157

In the modern world, we often want to monitor processes or actions on master nodes with the help of prometheus and on the nodes a large number of exporters live, prometheus most often does not live on the master and therefore needs network access to the master node up to the pods that live in the hostnetwork and pod cidr network.

As far as I can see, these rules have been applied for a very long time and it is not very clear why exactly such ones are.

This PR expands access to master nodes over a normal and overlay network with cluster nodes.