### PR TITLE
Support for WARM_IP_TARGET config on aws-vpc-cni

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.12.yaml.template
@@ -88,6 +88,10 @@ spec:
         env:
           - name: AWS_VPC_K8S_CNI_LOGLEVEL
             value: DEBUG
+          {{- if .Networking.AmazonVPC.WarmIpTarget }}
+          - name: WARM_IP_TARGET
+            value: "{{ .Networking.AmazonVPC.WarmIpTarget }}"
+          {{- end }}
           - name: MY_NODE_NAME
             valueFrom:
               fieldRef:


### PR DESCRIPTION
This change is related to #7122 without the ability to set the WARM_IP_TARGETS one cannot easily make use of the aws cni feature to release IPs back to the subnet pool. See release notes for [amazon-vpc-cni-k8s/v1.5.0](https://github.com/aws/amazon-vpc-cni-k8s/releases/tag/v1.5.0)