### PR TITLE
Spotinst: Ocean's Strategy object is optional

### DIFF
--- a/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
@@ -139,9 +139,11 @@ func (o *Ocean) Find(c *fi.Context) (*Ocean, error) {
 
 	// Strategy.
 	{
-		actual.SpotPercentage = ocean.Strategy.SpotPercentage
-		actual.FallbackToOnDemand = ocean.Strategy.FallbackToOnDemand
-		actual.UtilizeReservedInstances = ocean.Strategy.UtilizeReservedInstances
+		if strategy := ocean.Strategy; strategy != nil {
+			actual.SpotPercentage = strategy.SpotPercentage
+			actual.FallbackToOnDemand = strategy.FallbackToOnDemand
+			actual.UtilizeReservedInstances = strategy.UtilizeReservedInstances
+		}
 	}
 
 	// Compute.


### PR DESCRIPTION
Spotinst does not require a `Strategy` object to be set from now on. So, this field is nullable now. This PR fixes the relevant task to avoid `runtime error: invalid memory address or nil pointer dereference`. 