### PR TITLE
Make an actual deep-copy of the state

### DIFF
--- a/protokube/pkg/gossip/mesh/state.go
+++ b/protokube/pkg/gossip/mesh/state.go
@@ -150,8 +150,10 @@ func (s *state) updateValues(removeKeys []string, putEntries map[string]string) 
 func (s *state) getData() *KVState {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
-	d := &KVState{}
-	*d = s.data
+
+	// make a deep-copy. To avoid a bunch of reflection etc. this simply marshals and unmarshals
+	b, _ := proto.Marshal(&s.data)
+	d, _ := DecodeKVState(b)
 	return d
 }
 


### PR DESCRIPTION
Before this patch this was creating a shallow copy, as the KVState was
copied but the underlying map (Records) wasn't.

Fixes #7134


Go playground showing the issue with the previous copy mechanism: https://play.golang.org/p/0-NAWVpbR7s