### PR TITLE
[Issue-7148] Legacyetcd support for Digital Ocean

### DIFF
--- a/docs/tutorial/digitalocean.md
+++ b/docs/tutorial/digitalocean.md
@@ -24,8 +24,9 @@ export S3_ENDPOINT=nyc3.digitaloceanspaces.com # this can also be ams3.digitaloc
 export S3_ACCESS_KEY_ID=<access-key-id>  # where <access-key-id> is the Spaces API Access Key for your bucket
 export S3_SECRET_ACCESS_KEY=<secret-key>  # where <secret-key> is the Spaces API Secret Key for your bucket
 
-# this is required since DigitalOcean support is currently in alpha so it is feature gated
-export KOPS_FEATURE_FLAGS="AlphaAllowDO"
+# this is required since DigitalOcean support is currently in alpha so it is feature gated, also need Override flag to use legacy etcd.
+# we will eventually support etcdmanager, but until then, we need to specify this flag.
+export KOPS_FEATURE_FLAGS="AlphaAllowDO,+SpecOverrideFlag"
 ```
 
 ## Creating a Cluster
@@ -35,15 +36,15 @@ Note that you kops will only be able to successfully provision clusters in regio
 
 ```bash
 # coreos (the default) + flannel overlay cluster in tor1
-kops create cluster --cloud=digitalocean --name=my-cluster.example.com --networking=flannel --zones=tor1 --ssh-public-key=~/.ssh/id_rsa.pub
+kops create cluster --cloud=digitalocean --name=my-cluster.example.com --networking=flannel --zones=tor1 --ssh-public-key=~/.ssh/id_rsa.pub --override cluster.spec.etcdClusters[*].provider=Legacy
 kops update cluster my-cluster.example.com --yes
 
 # ubuntu + weave overlay cluster in nyc1 using larger droplets
-kops create cluster --cloud=digitalocean --name=my-cluster.example.com --image=ubuntu-16-04-x64 --networking=weave --zones=nyc1 --ssh-public-key=~/.ssh/id_rsa.pub --node-size=s-8vcpu-32gb
+kops create cluster --cloud=digitalocean --name=my-cluster.example.com --image=ubuntu-16-04-x64 --networking=weave --zones=nyc1 --ssh-public-key=~/.ssh/id_rsa.pub --node-size=s-8vcpu-32gb --override cluster.spec.etcdClusters[*].provider=Legacy
 kops update cluster my-cluster.example.com --yes
 
 # debian + flannel overlay cluster in ams3 using optimized droplets
-kops create cluster --cloud=digitalocean --name=my-cluster.example.com --image=debian-9-x64 --networking=flannel --zones=ams3 --ssh-public-key=~/.ssh/id_rsa.pub --node-size=c-4
+kops create cluster --cloud=digitalocean --name=my-cluster.example.com --image=debian-9-x64 --networking=flannel --zones=ams3 --ssh-public-key=~/.ssh/id_rsa.pub --node-size=c-4 --override cluster.spec.etcdClusters[*].provider=Legacy
 kops update cluster my-cluster.example.com --yes
 
 # to delete a cluster

--- a/pkg/model/components/etcdmanager/BUILD.bazel
+++ b/pkg/model/components/etcdmanager/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/urls:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
+        "//upup/pkg/fi/cloudup/do:go_default_library",
         "//upup/pkg/fi/cloudup/gce:go_default_library",
         "//upup/pkg/fi/fitasks:go_default_library",
         "//upup/pkg/fi/loader:go_default_library",

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/kops/pkg/model"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"k8s.io/kops/upup/pkg/fi/cloudup/do"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/fitasks"
 	"k8s.io/kops/util/pkg/exec"
@@ -379,6 +380,16 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster *kops.EtcdClusterSpec) (*v1.Po
 				gce.GceLabelNameRolePrefix + "master=master",
 			}
 			config.VolumeNameTag = gce.GceLabelNameEtcdClusterPrefix + etcdCluster.Name
+
+		case kops.CloudProviderDO:
+			config.VolumeProvider = "do"
+
+			config.VolumeTag = []string{
+				fmt.Sprintf("kubernetes.io/cluster/%s=owned", b.Cluster.Name),
+				do.TagNameEtcdClusterPrefix + etcdCluster.Name,
+				do.TagNameRolePrefix + "master=1",
+			}
+			config.VolumeNameTag = do.TagNameEtcdClusterPrefix + etcdCluster.Name
 
 		default:
 			return nil, fmt.Errorf("CloudProvider %q not supported with etcd-manager", b.Cluster.Spec.CloudProvider)

--- a/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
@@ -47,11 +47,10 @@ spec:
           operator: Exists
           tolerationSeconds: 300
       containers:
-      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.7
+      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.15
         name: digitalocean-cloud-controller-manager
         command:
           - "/bin/digitalocean-cloud-controller-manager"
-          - "--cloud-provider=digitalocean"
           - "--leader-elect=true"
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/dns.go
+++ b/upup/pkg/fi/cloudup/dns.go
@@ -38,6 +38,8 @@ const (
 	// https://en.wikipedia.org/wiki/Reserved_IP_addresses
 	PlaceholderIP  = "203.0.113.123"
 	PlaceholderTTL = 10
+	// DigitalOcean's DNS servers require a certain minimum TTL (it's 30), keeping 60 here.
+	PlaceholderTTLDigitialOcean = 60
 )
 
 func findZone(cluster *kops.Cluster, cloud fi.Cloud) (dnsprovider.Zone, error) {
@@ -228,7 +230,12 @@ func precreateDNS(cluster *kops.Cluster, cloud fi.Cloud) error {
 
 		klog.V(2).Infof("Pre-creating DNS record %s => %s", dnsHostname, PlaceholderIP)
 
-		changeset.Add(rrs.New(dnsHostname, []string{PlaceholderIP}, PlaceholderTTL, rrstype.A))
+		if cloud.ProviderID() == kops.CloudProviderDO {
+			changeset.Add(rrs.New(dnsHostname, []string{PlaceholderIP}, PlaceholderTTLDigitialOcean, rrstype.A))
+		} else {
+			changeset.Add(rrs.New(dnsHostname, []string{PlaceholderIP}, PlaceholderTTL, rrstype.A))
+		}
+
 		created = append(created, dnsHostname)
 	}
 

--- a/upup/pkg/fi/cloudup/do/cloud.go
+++ b/upup/pkg/fi/cloudup/do/cloud.go
@@ -21,6 +21,9 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 )
 
+const TagNameEtcdClusterPrefix = "k8s.io/etcd/"
+const TagNameRolePrefix = "k8s.io/role/"
+
 func NewDOCloud(region string) (fi.Cloud, error) {
 	return digitalocean.NewCloud(region)
 }


### PR DESCRIPTION
Couple of updates to get digitial ocean cloud provider working with the latest master.

- Updated the digital ocean cloud manager to an updated version - 0.1.15

- Update KOPS_FEATURE_FLAGS to also include an override flag, this is temporary, I'll be adding the next set of changes to include support for etcd-manager, but until then we can use legacy support.

- Update etcd manager for DO cloud provider, so we don't get a not supported error. will be adding another PR for more changes to the etcdmanager repo to support DO.

Note: I have tested this change and it seems to work on release-1.12, release-1.13 and release-1.14 branches. I believe there is some issue with the latest master, I didn't see any logs generated in the master linux server once I SSH to it. If this gets approved, I would like to cherry pick this into release-1.13 or release-1.14 based on your suggestion.