### PR TITLE
Automated cherry pick of #7211: Use NodeAuthorizer config options instead of soely

### DIFF
--- a/nodeup/pkg/model/node_authorizer.go
+++ b/nodeup/pkg/model/node_authorizer.go
@@ -89,7 +89,13 @@ func (b *NodeAuthorizationBuilder) Build(c *fi.ModelBuilderContext) error {
 		man.Set("Service", "ExecStartPre", "/bin/bash -c 'while [ ! -f "+clientCert+" ]; do sleep 5; done; sleep 5'")
 
 		interval := 10 * time.Second
+		if na.Interval != nil {
+			interval = na.Interval.Duration
+		}
 		timeout := 5 * time.Minute
+		if na.Timeout != nil {
+			timeout = na.Timeout.Duration
+		}
 
 		// @node: using a string array just to make it easier to read
 		dockerCmd := []string{

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -189,6 +189,8 @@ type NodeAuthorizerSpec struct {
 	NodeURL string `json:"nodeURL,omitempty"`
 	// Port is the port the service is running on the master
 	Port int `json:"port,omitempty"`
+	// Interval the time between retires for authorization request
+	Interval *metav1.Duration `json:"interval,omitempty"`
 	// Timeout the max time for authorization request
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 	// TokenTTL is the max ttl for an issued token

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -188,6 +188,8 @@ type NodeAuthorizerSpec struct {
 	NodeURL string `json:"nodeURL,omitempty"`
 	// Port is the port the service is running on the master
 	Port int `json:"port,omitempty"`
+	// Interval the time between retires for authorization request
+	Interval *metav1.Duration `json:"interval,omitempty"`
 	// Timeout the max time for authorization request
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 	// TokenTTL is the max ttl for an issued token

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -3974,6 +3974,7 @@ func autoConvert_v1alpha1_NodeAuthorizerSpec_To_kops_NodeAuthorizerSpec(in *Node
 	out.Image = in.Image
 	out.NodeURL = in.NodeURL
 	out.Port = in.Port
+	out.Interval = in.Interval
 	out.Timeout = in.Timeout
 	out.TokenTTL = in.TokenTTL
 	return nil
@@ -3990,6 +3991,7 @@ func autoConvert_kops_NodeAuthorizerSpec_To_v1alpha1_NodeAuthorizerSpec(in *kops
 	out.Image = in.Image
 	out.NodeURL = in.NodeURL
 	out.Port = in.Port
+	out.Interval = in.Interval
 	out.Timeout = in.Timeout
 	out.TokenTTL = in.TokenTTL
 	return nil

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2661,6 +2661,11 @@ func (in *NodeAuthorizerSpec) DeepCopyInto(out *NodeAuthorizerSpec) {
 			copy(*out, *in)
 		}
 	}
+	if in.Interval != nil {
+		in, out := &in.Interval, &out.Interval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
 		*out = new(v1.Duration)

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -189,6 +189,8 @@ type NodeAuthorizerSpec struct {
 	NodeURL string `json:"nodeURL,omitempty"`
 	// Port is the port the service is running on the master
 	Port int `json:"port,omitempty"`
+	// Interval the time between retires for authorization request
+	Interval *metav1.Duration `json:"interval,omitempty"`
 	// Timeout the max time for authorization request
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 	// TokenTTL is the max ttl for an issued token

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4244,6 +4244,7 @@ func autoConvert_v1alpha2_NodeAuthorizerSpec_To_kops_NodeAuthorizerSpec(in *Node
 	out.Image = in.Image
 	out.NodeURL = in.NodeURL
 	out.Port = in.Port
+	out.Interval = in.Interval
 	out.Timeout = in.Timeout
 	out.TokenTTL = in.TokenTTL
 	return nil
@@ -4260,6 +4261,7 @@ func autoConvert_kops_NodeAuthorizerSpec_To_v1alpha2_NodeAuthorizerSpec(in *kops
 	out.Image = in.Image
 	out.NodeURL = in.NodeURL
 	out.Port = in.Port
+	out.Interval = in.Interval
 	out.Timeout = in.Timeout
 	out.TokenTTL = in.TokenTTL
 	return nil

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2732,6 +2732,11 @@ func (in *NodeAuthorizerSpec) DeepCopyInto(out *NodeAuthorizerSpec) {
 			copy(*out, *in)
 		}
 	}
+	if in.Interval != nil {
+		in, out := &in.Interval, &out.Interval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
 		*out = new(v1.Duration)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2930,6 +2930,11 @@ func (in *NodeAuthorizerSpec) DeepCopyInto(out *NodeAuthorizerSpec) {
 			copy(*out, *in)
 		}
 	}
+	if in.Interval != nil {
+		in, out := &in.Interval, &out.Interval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
 		*out = new(v1.Duration)


### PR DESCRIPTION
Cherry pick of #7211 on release-1.13.

#7211: Use NodeAuthorizer config options instead of soely