### PR TITLE
WIP: Kubelet node labels

### DIFF
--- a/docs/apireference/build/documents/_generated_instancegroup_v1alpha2_kops_concept.md
+++ b/docs/apireference/build/documents/_generated_instancegroup_v1alpha2_kops_concept.md
@@ -24,7 +24,7 @@ spec:
     team: me
     project: ion
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   rootVolumeSize: 200
   rootVolumeOptimization: true

--- a/docs/apireference/build/index.html
+++ b/docs/apireference/build/index.html
@@ -411,7 +411,7 @@ Appears In:
 <span class="hljs-attr">    team:</span> <span class="hljs-string">me</span>
 <span class="hljs-attr">    project:</span> <span class="hljs-string">ion</span>
 <span class="hljs-attr">  nodeLabels:</span>
-    <span class="hljs-string">kops.k8s.io/instancegroup:</span> <span class="hljs-string">nodes</span>
+    <span class="hljs-string">node.kubernetes.io/instancegroup:</span> <span class="hljs-string">nodes</span>
 <span class="hljs-attr">  role:</span> <span class="hljs-string">Node</span>
 <span class="hljs-attr">  rootVolumeSize:</span> <span class="hljs-number">200</span>
 <span class="hljs-attr">  rootVolumeOptimization:</span> <span class="hljs-literal">true</span>

--- a/docs/apireference/examples/instancegroup/instancegroup.yaml
+++ b/docs/apireference/examples/instancegroup/instancegroup.yaml
@@ -16,7 +16,7 @@ sample: |
       team: me
       project: ion
     nodeLabels:
-      kops.k8s.io/instancegroup: nodes
+      node.kubernetes.io/instancegroup: nodes
     role: Node
     rootVolumeSize: 200
     rootVolumeOptimization: true

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -27,8 +27,8 @@ const (
 	// LabelClusterName is a cluster label cloud tag
 	LabelClusterName = "kops.k8s.io/cluster"
 	// NodeLabelInstanceGroup is a node label set to the name of the instance group
-	NodeLabelInstanceGroup = "kops.k8s.io/instancegroup"
-	// Deprecated - use the new labels & taints node-role.kubernetes.io/master and node-role.kubernetes.io/node
+	NodeLabelInstanceGroup = "node.kubernetes.io/instancegroup"
+	// Deprecated - use the new labels & taints node.kubernetes.io/master and node.kubernetes.io/node
 	TaintNoScheduleMaster15 = "dedicated=master:NoSchedule"
 )
 

--- a/pkg/apis/kops/util/labels.go
+++ b/pkg/apis/kops/util/labels.go
@@ -22,15 +22,22 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+// GetNodeRole returns a string value of the Role for a given Node
 func GetNodeRole(node *v1.Node) string {
 	role := ""
-	// Newer labels
+
+	// New label
+	if v, ok := node.Labels["node.kubernetes.io/role"]; ok {
+		return v
+	}
+
+	// Older labels
 	for k := range node.Labels {
 		if strings.HasPrefix(k, "node-role.kubernetes.io/") {
 			role = strings.TrimPrefix(k, "node-role.kubernetes.io/")
 		}
 	}
-	// Older label
+
 	if role == "" {
 		role = node.Labels["kubernetes.io/role"]
 	}

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -63,7 +63,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -83,7 +83,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
@@ -71,7 +71,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   zones:
   - us-test-1a
@@ -91,7 +91,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1b
+    node.kubernetes.io/instancegroup: master-us-test-1b
   role: Master
   zones:
   - us-test-1b
@@ -111,7 +111,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1c
+    node.kubernetes.io/instancegroup: master-us-test-1c
   role: Master
   zones:
   - us-test-1c
@@ -131,7 +131,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   zones:
   - us-test-1a

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -79,7 +79,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -99,7 +99,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1b
+    node.kubernetes.io/instancegroup: master-us-test-1b
   role: Master
   subnets:
   - us-test-1b
@@ -119,7 +119,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1c
+    node.kubernetes.io/instancegroup: master-us-test-1c
   role: Master
   subnets:
   - us-test-1c
@@ -139,7 +139,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha1.yaml
@@ -77,7 +77,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   zones:
   - us-test-1a
@@ -97,7 +97,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1b
+    node.kubernetes.io/instancegroup: master-us-test-1b
   role: Master
   zones:
   - us-test-1b
@@ -117,7 +117,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1c
+    node.kubernetes.io/instancegroup: master-us-test-1c
   role: Master
   zones:
   - us-test-1c
@@ -137,7 +137,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   zones:
   - us-test-1a

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -85,7 +85,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -105,7 +105,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1b
+    node.kubernetes.io/instancegroup: master-us-test-1b
   role: Master
   subnets:
   - us-test-1b
@@ -125,7 +125,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1c
+    node.kubernetes.io/instancegroup: master-us-test-1c
   role: Master
   subnets:
   - us-test-1c
@@ -145,7 +145,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -70,7 +70,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test1-a
+    node.kubernetes.io/instancegroup: master-us-test1-a
   role: Master
   subnets:
   - us-test1
@@ -92,7 +92,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test1-b
+    node.kubernetes.io/instancegroup: master-us-test1-b
   role: Master
   subnets:
   - us-test1
@@ -114,7 +114,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test1-c
+    node.kubernetes.io/instancegroup: master-us-test1-c
   role: Master
   subnets:
   - us-test1
@@ -136,7 +136,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -83,7 +83,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a-1
+    node.kubernetes.io/instancegroup: master-us-test-1a-1
   role: Master
   subnets:
   - us-test-1a
@@ -103,7 +103,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a-2
+    node.kubernetes.io/instancegroup: master-us-test-1a-2
   role: Master
   subnets:
   - us-test-1a
@@ -123,7 +123,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a-3
+    node.kubernetes.io/instancegroup: master-us-test-1a-3
   role: Master
   subnets:
   - us-test-1a
@@ -143,7 +143,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1b-1
+    node.kubernetes.io/instancegroup: master-us-test-1b-1
   role: Master
   subnets:
   - us-test-1b
@@ -163,7 +163,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1b-2
+    node.kubernetes.io/instancegroup: master-us-test-1b-2
   role: Master
   subnets:
   - us-test-1b
@@ -183,7 +183,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha1.yaml
@@ -65,7 +65,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: bastions
+    node.kubernetes.io/instancegroup: bastions
   role: Bastion
   zones:
   - utility-us-test-1a
@@ -85,7 +85,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   zones:
   - us-test-1a
@@ -105,7 +105,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   zones:
   - us-test-1a

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -71,7 +71,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: bastions
+    node.kubernetes.io/instancegroup: bastions
   role: Bastion
   subnets:
   - utility-us-test-1a
@@ -91,7 +91,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -111,7 +111,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha1.yaml
@@ -61,7 +61,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   zones:
   - us-test-1a
@@ -81,7 +81,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   zones:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
@@ -65,7 +65,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -85,7 +85,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha1.yaml
@@ -65,7 +65,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: bastions
+    node.kubernetes.io/instancegroup: bastions
   role: Bastion
   zones:
   - utility-us-test-1a
@@ -85,7 +85,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   zones:
   - us-test-1a
@@ -105,7 +105,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   zones:
   - us-test-1a

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -71,7 +71,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: bastions
+    node.kubernetes.io/instancegroup: bastions
   role: Bastion
   subnets:
   - utility-us-test-1a
@@ -91,7 +91,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -111,7 +111,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -66,7 +66,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -86,7 +86,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/private/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha1.yaml
@@ -68,7 +68,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: bastions
+    node.kubernetes.io/instancegroup: bastions
   role: Bastion
   zones:
   - utility-us-test-1a
@@ -91,7 +91,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   zones:
   - us-test-1a
@@ -114,7 +114,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   zones:
   - us-test-1a

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -74,7 +74,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: bastions
+    node.kubernetes.io/instancegroup: bastions
   role: Bastion
   subnets:
   - utility-us-test-1a
@@ -97,7 +97,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -120,7 +120,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -71,7 +71,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -91,7 +91,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha1.yaml
@@ -61,7 +61,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   zones:
   - us-test-1a
@@ -81,7 +81,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   zones:
   - us-test-1a

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
@@ -65,7 +65,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -85,7 +85,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha1.yaml
@@ -61,7 +61,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   zones:
   - us-test-1a
@@ -81,7 +81,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   zones:
   - us-test-1a

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
@@ -65,7 +65,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -85,7 +85,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha1.yaml
@@ -60,7 +60,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   zones:
   - us-test-1a
@@ -80,7 +80,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   zones:
   - us-test-1a

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -64,7 +64,7 @@ spec:
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
+    node.kubernetes.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -84,7 +84,7 @@ spec:
   maxSize: 2
   minSize: 2
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    node.kubernetes.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_master-us-west-2a.masters.k8s-iam.us-west-2.td.priv_user_data
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_master-us-west-2a.masters.k8s-iam.us-west-2.td.priv_user_data
@@ -261,7 +261,7 @@ __EOF_CLUSTER_SPEC
 cat > ig_spec.yaml << '__EOF_IG_SPEC'
 kubelet: null
 nodeLabels:
-  kops.k8s.io/instancegroup: master-us-west-2a
+  node.kubernetes.io/instancegroup: master-us-west-2a
 taints: null
 
 __EOF_IG_SPEC

--- a/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_nodes.k8s-iam.us-west-2.td.priv_user_data
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_nodes.k8s-iam.us-west-2.td.priv_user_data
@@ -181,7 +181,7 @@ __EOF_CLUSTER_SPEC
 cat > ig_spec.yaml << '__EOF_IG_SPEC'
 kubelet: null
 nodeLabels:
-  kops.k8s.io/instancegroup: nodes
+  node.kubernetes.io/instancegroup: nodes
 taints: null
 
 __EOF_IG_SPEC

--- a/tests/integration/update_cluster/existing_iam_cloudformation/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/kubernetes.tf
@@ -80,7 +80,7 @@ resource "aws_autoscaling_group" "master-us-west-2a-masters-k8s-iam-us-west-2-td
   }
 
   tag = {
-    key                 = "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/instancegroup"
     value               = "master-us-west-2a"
     propagate_at_launch = true
   }
@@ -118,7 +118,7 @@ resource "aws_autoscaling_group" "nodes-k8s-iam-us-west-2-td-priv" {
   }
 
   tag = {
-    key                 = "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/instancegroup"
     value               = "nodes"
     propagate_at_launch = true
   }

--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
@@ -21,13 +21,25 @@ spec:
     spec:
       # run on the host network (don't depend on CNI)
       hostNetwork: true
-
-      # run on each master node
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            - matchExpressions:
+              - key: node.kubernetes.io/role
+                operator: In
+                values:
+                - master
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.kubernetes.io/role
+        operator: Equal
+        value: master
       - key: CriticalAddonsOnly
         operator: Exists
 

--- a/upup/models/cloudup/resources/addons/authentication.kope.io/k8s-1.12.yaml
+++ b/upup/models/cloudup/resources/addons/authentication.kope.io/k8s-1.12.yaml
@@ -46,13 +46,27 @@ spec:
     spec:
       serviceAccountName: auth-api
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            - matchExpressions:
+              - key: node.kubernetes.io/role
+                operator: In
+                values:
+                - master
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
-      - key: "CriticalAddonsOnly"
-        operator: "Exists"
+      - effect: NoSchedule
+        key: node.kubernetes.io/role
+        operator: Equal
+        value: master
+      - key: CriticalAddonsOnly
+        operator: Exists
       containers:
       - name: auth-api
         image: kopeio/auth-api:1.0.20171125

--- a/upup/models/cloudup/resources/addons/core.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/core.addons.k8s.io/k8s-1.12.yaml.template
@@ -111,8 +111,18 @@ spec:
       labels:
         k8s-app: cloud-controller-manager
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            - matchExpressions:
+              - key: node.kubernetes.io/role
+                operator: In
+                values:
+                - master
       serviceAccountName: cloud-controller-manager
       containers:
       - name: cloud-controller-manager
@@ -146,8 +156,11 @@ spec:
       # the taint may vary depending on your cluster setup
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      - key: node.kubernetes.io/role
+        effect: NoSchedule
+        operator: Equal
+        value: master
       # this is to restrict CCM to only run on master nodes
       # the node selector may vary depending on your cluster setup
       - key: "CriticalAddonsOnly"
         operator: "Exists"
-

--- a/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.13.yaml.template
+++ b/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.13.yaml.template
@@ -1,0 +1,174 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: digitalocean
+  namespace: kube-system
+stringData:
+  # insert your DO access token here
+  access-token: {{ DO_TOKEN }}
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: digitalocean-cloud-controller-manager
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: digitalocean-cloud-controller-manager
+  template:
+    metadata:
+      labels:
+        k8s-app: digitalocean-cloud-controller-manager
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            - matchExpressions:
+              - key: node.kubernetes.io/role
+                operator: In
+                values:
+                - master
+      serviceAccountName: cloud-controller-manager
+      dnsPolicy: Default
+      hostNetwork: true
+      tolerations:
+        - key: "node.cloudprovider.kubernetes.io/uninitialized"
+          value: "true"
+          effect: "NoSchedule"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+        - key: node.kubernetes.io/role
+          effect: NoSchedule
+          operator: Equal
+          value: master
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 300
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 300
+      containers:
+      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.7
+        name: digitalocean-cloud-controller-manager
+        command:
+          - "/bin/digitalocean-cloud-controller-manager"
+          - "--cloud-provider=digitalocean"
+          - "--leader-elect=true"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        env:
+          - name: KUBERNETES_SERVICE_HOST
+            value: "127.0.0.1"
+          - name: KUBERNETES_SERVICE_PORT
+            value: "443"
+          - name: DO_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: digitalocean
+                key: access-token
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: system:cloud-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -21,11 +21,25 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            - matchExpressions:
+              - key: node.kubernetes.io/role
+                operator: In
+                values:
+                - master
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        effect: NoSchedule
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.kubernetes.io/role
+        operator: Equal
+        value: master
       dnsPolicy: Default  # Don't use cluster DNS (we are likely running before kube-dns)
       hostNetwork: true
       serviceAccount: dns-controller

--- a/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.12.yaml.template
@@ -22,11 +22,25 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       serviceAccount: external-dns
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            - matchExpressions:
+              - key: node.kubernetes.io/role
+                operator: In
+                values:
+                - master
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        effect: NoSchedule
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.kubernetes.io/role
+        operator: Equal
+        value: master
       dnsPolicy: Default  # Don't use cluster DNS (we are likely running before kube-dns)
       hostNetwork: true
       containers:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -780,9 +780,25 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostNetwork: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            - matchExpressions:
+              - key: node.kubernetes.io/role
+                operator: In
+                values:
+                - master
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.kubernetes.io/role
+        operator: Equal
+        value: master
       - key: CriticalAddonsOnly
         operator: Exists
       serviceAccountName: k8s-ec2-srcdst
@@ -805,7 +821,4 @@ spec:
         - name: ssl-certs
           hostPath:
             path: "/etc/ssl/certs/ca-certificates.crt"
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
 {{- end -}}
-

--- a/upup/models/cloudup/resources/addons/networking.romana/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.romana/k8s-1.12.yaml.template
@@ -134,12 +134,26 @@ spec:
       labels:
         romana-app: daemon
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
-      hostNetwork: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            - matchExpressions:
+              - key: node.kubernetes.io/role
+                operator: In
+                values:
+                - master
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.kubernetes.io/role
+        operator: Equal
+        value: master
+      hostNetwork: true
       containers:
       - name: romana-daemon
         image: quay.io/romana/daemon:v2.0.2
@@ -169,13 +183,27 @@ spec:
       labels:
         romana-app: listener
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            - matchExpressions:
+              - key: node.kubernetes.io/role
+                operator: In
+                values:
+                - master
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.kubernetes.io/role
+        operator: Equal
+        value: master
       hostNetwork: true
       serviceAccountName: romana-listener
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
       containers:
       - name: romana-listener
         image: quay.io/romana/listener:v2.0.2
@@ -316,13 +344,27 @@ spec:
       labels:
         romana-app: aws
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            - matchExpressions:
+              - key: node.kubernetes.io/role
+                operator: In
+                values:
+                - master
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.kubernetes.io/role
+        operator: Equal
+        value: master
       hostNetwork: true
       serviceAccountName: romana-aws
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
       containers:
       - name: romana-aws
         image: quay.io/romana/aws:v2.0.2
@@ -351,12 +393,26 @@ spec:
       labels:
         romana-app: vpcrouter
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
-      hostNetwork: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            - matchExpressions:
+              - key: node.kubernetes.io/role
+                operator: In
+                values:
+                - master
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.kubernetes.io/role
+        operator: Equal
+        value: master
+      hostNetwork: true
       containers:
       - name: romana-vpcrouter
         image: quay.io/romana/vpcrouter-romana-plugin:1.1.17

--- a/upup/models/cloudup/resources/addons/node-authorizer.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-authorizer.addons.k8s.io/k8s-1.12.yaml.template
@@ -136,15 +136,29 @@ spec:
         prometheus.io/scrape: "true"
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            - matchExpressions:
+              - key: node.kubernetes.io/role
+                operator: In
+                values:
+                - master
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.kubernetes.io/role
+        operator: Equal
+        value: master
       hostNetwork: true
-      nodeSelector:
-        kubernetes.io/role: master
       serviceAccount: {{ $name }}
       securityContext:
         fsGroup: 1000
-      tolerations:
-        - key: "node-role.kubernetes.io/master"
-          effect: NoSchedule
       volumes:
         - name: config
           hostPath:

--- a/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.11.yaml.template
@@ -189,16 +189,26 @@ spec:
       # run on the host network (don't depend on CNI)
       hostNetwork: true
       # run on each master node
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
-      securityContext:
-        runAsUser: 1001
-      serviceAccountName: cloud-controller-manager
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            - matchExpressions:
+              - key: node.kubernetes.io/role
+                operator: In
+                values:
+                - master
       tolerations:
       - effect: NoSchedule
         operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
+      securityContext:
+        runAsUser: 1001
+      serviceAccountName: cloud-controller-manager
       containers:
       - name: openstack-cloud-controller-manager
         image: "{{- .ExternalCloudControllerManager.Image }}"

--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.9.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.9.0.yaml.template
@@ -135,4 +135,8 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      - key: node.kubernetes.io/role
+        effect: NoSchedule
+        operator: Equal
+        value: master
 ---

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -165,11 +165,11 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 	if b.cluster.Spec.NodeAuthorization != nil {
 		{
 			key := "node-authorizer.addons.k8s.io"
-			version := "v0.0.4-kops.1"
 
 			{
 				location := key + "/k8s-1.10.yaml"
 				id := "k8s-1.10.yaml"
+				version := "v0.0.4-kops.1"
 
 				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 					Name:              fi.String(key),
@@ -185,6 +185,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 			{
 				location := key + "/k8s-1.12.yaml"
 				id := "k8s-1.12.yaml"
+				version := "v0.0.4-kops.2"
 
 				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 					Name:              fi.String(key),
@@ -407,6 +408,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 			{
 				location := key + "/k8s-1.12.yaml"
 				id := "k8s-1.12"
+				version := "1.14.0-alpha.1-kops.1"
 
 				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 					Name:              fi.String(key),
@@ -459,6 +461,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 			{
 				location := key + "/k8s-1.12.yaml"
 				id := "k8s-1.12"
+				version := "0.4.4-kops.1"
 
 				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 					Name:              fi.String(key),
@@ -525,18 +528,34 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if kops.CloudProviderID(b.cluster.Spec.CloudProvider) == kops.CloudProviderDO {
 		key := "digitalocean-cloud-controller.addons.k8s.io"
-		version := "1.8"
 
 		{
 			id := "k8s-1.8"
 			location := key + "/" + id + ".yaml"
+			version := "1.8"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
 				Version:           fi.String(version),
 				Selector:          map[string]string{"k8s-addon": key},
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.8.0",
+				KubernetesVersion: ">=1.8.0 <1.13.0",
+				Id:                id,
+			})
+			manifests[key+"-"+id] = "addons/" + location
+		}
+
+		{
+			id := "k8s-1.13"
+			location := key + "/" + id + ".yaml"
+			version := "1.13"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(version),
+				Selector:          map[string]string{"k8s-addon": key},
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.13.0",
 				Id:                id,
 			})
 			manifests[key+"-"+id] = "addons/" + location
@@ -580,11 +599,11 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if featureflag.Spotinst.Enabled() {
 		key := "spotinst-kubernetes-cluster-controller.addons.k8s.io"
-		version := "1.0.39"
 
 		{
 			id := "v1.8.0"
 			location := key + "/" + id + ".yaml"
+			version := "1.0.39"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
@@ -600,6 +619,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		{
 			id := "v1.9.0"
 			location := key + "/" + id + ".yaml"
+			version := "1.0.39-kops.1"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
@@ -825,7 +845,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 			"k8s-1.6":     "2.6.9-kops.1",
 			"k8s-1.7":     "2.6.12-kops.1",
 			"k8s-1.7-v3":  "3.7.2-kops.3",
-			"k8s-1.12":    "3.7.2-kops.4",
+			"k8s-1.12":    "3.7.2-kops.5",
 		}
 
 		{
@@ -1026,11 +1046,11 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Networking.Romana != nil {
 		key := "networking.romana"
-		version := "v2.0.2-kops.2"
 
 		{
 			location := key + "/k8s-1.7.yaml"
 			id := "k8s-1.7"
+			version := "v2.0.2-kops.2"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
@@ -1046,6 +1066,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		{
 			location := key + "/k8s-1.12.yaml"
 			id := "k8s-1.12"
+			version := "v2.0.2-kops.3"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
@@ -1163,7 +1184,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 	if b.cluster.Spec.Authentication != nil {
 		if b.cluster.Spec.Authentication.Kopeio != nil {
-			key := "authentication.kope.io"
+			key := "authentication.kope.io-kops.1"
 			version := "1.0.20171125"
 
 			{
@@ -1198,7 +1219,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		}
 		if b.cluster.Spec.Authentication.Aws != nil {
 			key := "authentication.aws"
-			version := "0.4.0-kops.1"
+			version := "0.4.0-kops.2"
 
 			{
 				location := key + "/k8s-1.10.yaml"
@@ -1237,7 +1258,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 		if kops.CloudProviderID(b.cluster.Spec.CloudProvider) == kops.CloudProviderOpenstack {
 			{
 				key := "openstack.addons.k8s.io"
-				version := "1.11.0"
+				version := "1.11.0-kops.1"
 
 				location := key + "/k8s-1.11.yaml"
 				id := "k8s-1.11-ccm"
@@ -1273,7 +1294,7 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 
 			{
 				key := "core.addons.k8s.io"
-				version := "1.12.0"
+				version := "1.12.0-kops.1"
 
 				location := key + "/k8s-1.12.yaml"
 				id := "k8s-1.12-ccm"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -69,7 +69,7 @@ spec:
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.14.0-alpha.1
+    version: 1.14.0-alpha.1-kops.1
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
@@ -69,7 +69,7 @@ spec:
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.14.0-alpha.1
+    version: 1.14.0-alpha.1-kops.1
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -69,7 +69,7 @@ spec:
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.14.0-alpha.1
+    version: 1.14.0-alpha.1-kops.1
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -69,7 +69,7 @@ spec:
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.14.0-alpha.1
+    version: 1.14.0-alpha.1-kops.1
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml


### PR DESCRIPTION
From k8s v1.13 it is deprecated to use the kubelet `--node-labels` flag to set `kubernetes.io/` and `k8s.io/` prefixed labels other than a whitelisted set, and has been made into a fatal error which will be included in k8s v1.15/1.16.

This PR updates the related labels added by the kubelet (for k8s v1.13+) to conform to the whitelist, and updates the addons managed by kops where relevant.

The new labels are:
```
node.kubernetes.io/instancegroup: <name>
node.kubernetes.io/role: <master || node>
```

ALL user deployments making use of the following old labels will require updating:
```
kops.k8s.io/instancegroup: <name>
kubernetes.io/role: <master || node>
node-role.kubernetes.io/master: ""
node-role.kubernetes.io/node: ""
```