### PR TITLE
Add some permissions to cluster-autoscaler clusterrole

### DIFF
--- a/addons/cluster-autoscaler/v1.10.0.yaml
+++ b/addons/cluster-autoscaler/v1.10.0.yaml
@@ -42,10 +42,13 @@ rules:
   resources: ["poddisruptionbudgets"]
   verbs: ["watch","list"]
 - apiGroups: ["apps"]
-  resources: ["statefulsets"]
+  resources: ["statefulsets","replicasets","daemonsets"]
   verbs: ["watch","list","get"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
+  verbs: ["watch","list","get"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
   verbs: ["watch","list","get"]
 
 ---


### PR DESCRIPTION
I had the following errors in the log:

E0715 06:51:45.385758       1 reflector.go:125] k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes/listers.go:312: Failed to list *v1.DaemonSet: daemonsets.apps is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler" cannot list daemonsets.apps at the cluster scope
E0715 06:51:45.399557       1 reflector.go:125] k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes/listers.go:339: Failed to list *v1.ReplicaSet: replicasets.apps is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler" cannot list replicasets.apps at the cluster scope
E0715 06:51:45.894870       1 reflector.go:125] k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes/listers.go:330: Failed to list *v1.Job: jobs.batch is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler" cannot list jobs.batch at the cluster scope

These changes fix them.