### PR TITLE
Spotinst: Rolling update always reports NeedsUpdate

### DIFF
--- a/pkg/resources/spotinst/resources.go
+++ b/pkg/resources/spotinst/resources.go
@@ -337,6 +337,25 @@ func buildCloudInstanceGroupFromLaunchSpec(cloud Cloud, ig *kops.InstanceGroup, 
 func registerCloudInstanceGroupMembers(instanceGroup *cloudinstances.CloudInstanceGroup, nodeMap map[string]*v1.Node,
 	instances []Instance, currentInstanceGroupName string, instanceGroupUpdatedAt time.Time) error {
 
+	// The instance registration below registers all active instances with
+	// their instance group. In addition, it looks for outdated instances by
+	// comparing each instance creation timestamp against the modification
+	// timestamp of its instance group.
+	//
+	// In a rolling-update operation, one or more detach operations are
+	// performed to replace existing instances. This is done by updating the
+	// instance group and results in updating the modification timestamp to the
+	// current time.
+	//
+	// The update of the modification timestamp occurs only after the detach
+	// operation is completed, meaning that new instances have already been
+	// created, so our comparison may be incorrect.
+	//
+	// In order to work around this issue, we assume that the detach operation
+	// will take up to two minutes, and therefore we subtract this duration from
+	// the modification timestamp of the instance group before the comparison.
+	instanceGroupUpdatedAt = instanceGroupUpdatedAt.Add(-2 * time.Minute)
+
 	for _, instance := range instances {
 		if instance.Id() == "" {
 			klog.Warningf("Ignoring instance with no ID: %v", instance)


### PR DESCRIPTION
The instance registration registers all active instances with their instance group. In addition, it looks for outdated instances by comparing each instance creation timestamp against the modification timestamp of its instance group. 

In a rolling-update operation, one or more detach operations are performed to replace existing instances. This is done by updating the instance group and results in updating the modification timestamp to the current time. The update of the modification timestamp occurs only after the detach operation is completed, meaning that new instances have already been created, so our comparison may be incorrect. 

In order to work around this issue, we assume that the detach operation will take up to two minutes, and therefore we subtract this duration from the modification timestamp of the instance group before the comparison.