### PR TITLE
Spotinst: New hybrid integration mode

### DIFF
--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -76,6 +76,8 @@ var (
 	Spotinst = New("Spotinst", Bool(false))
 	// SpotinstOcean toggles the use of Spotinst Ocean instance group implementation.
 	SpotinstOcean = New("SpotinstOcean", Bool(false))
+	// SpotinstHybrid toggles between hybrid and full instance group implementations.
+	SpotinstHybrid = New("SpotinstHybrid", Bool(false))
 	// SpotinstController toggles the installation of the Spotinst controller addon.
 	SpotinstController = New("SpotinstController", Bool(true))
 	// VPCSkipEnableDNSSupport if set will make that a VPC does not need DNSSupport enabled.

--- a/pkg/model/awsmodel/BUILD.bazel
+++ b/pkg/model/awsmodel/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/featureflag:go_default_library",
         "//pkg/model:go_default_library",
         "//pkg/model/defaults:go_default_library",
+        "//pkg/model/spotinstmodel:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awstasks:go_default_library",
         "//upup/pkg/fi/fitasks:go_default_library",

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -20,9 +20,12 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/klog"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/model"
 	"k8s.io/kops/pkg/model/defaults"
+	"k8s.io/kops/pkg/model/spotinstmodel"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
 
@@ -53,6 +56,13 @@ var _ fi.ModelBuilder = &AutoscalingGroupModelBuilder{}
 func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	for _, ig := range b.InstanceGroups {
 		name := b.AutoscalingGroupName(ig)
+
+		if featureflag.SpotinstHybrid.Enabled() {
+			if spotinstmodel.ManageInstanceGroup(ig) {
+				klog.V(2).Infof("Skipping instance group: %q", name)
+				continue
+			}
+		}
 
 		// @check if his instancegroup is backed by a fleet and override with a launch template
 		task, err := func() (fi.Task, error) {

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -58,7 +58,7 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		name := b.AutoscalingGroupName(ig)
 
 		if featureflag.SpotinstHybrid.Enabled() {
-			if spotinstmodel.ManageInstanceGroup(ig) {
+			if spotinstmodel.HybridInstanceGroup(ig) {
 				klog.V(2).Infof("Skipping instance group: %q", name)
 				continue
 			}

--- a/pkg/model/spotinstmodel/BUILD.bazel
+++ b/pkg/model/spotinstmodel/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//pkg/apis/kops:go_default_library",
         "//pkg/featureflag:go_default_library",
         "//pkg/model:go_default_library",
-        "//pkg/model/awsmodel:go_default_library",
         "//pkg/model/defaults:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awstasks:go_default_library",

--- a/pkg/model/spotinstmodel/instance_group.go
+++ b/pkg/model/spotinstmodel/instance_group.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/model"
-	"k8s.io/kops/pkg/model/awsmodel"
 	"k8s.io/kops/pkg/model/defaults"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
@@ -34,6 +33,10 @@ import (
 )
 
 const (
+	// InstanceGroupLabelManaged is the metadata label used on the instance
+	// group to specify that the Spotinst provider should be used to upon creation.
+	InstanceGroupLabelManaged = "spotinst.io/managed"
+
 	// InstanceGroupLabelSpotPercentage is the metadata label used on the
 	// instance group to specify the percentage of Spot instances that
 	// should spin up from the target capacity.
@@ -101,7 +104,7 @@ const (
 
 // InstanceGroupModelBuilder configures InstanceGroup objects
 type InstanceGroupModelBuilder struct {
-	*awsmodel.AWSModelContext
+	*model.KopsModelContext
 
 	BootstrapScript   *model.BootstrapScript
 	Lifecycle         *fi.Lifecycle
@@ -115,8 +118,16 @@ func (b *InstanceGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	var err error
 
 	for _, ig := range b.InstanceGroups {
-		klog.V(2).Infof("Building instance group: %q", b.AutoscalingGroupName(ig))
+		name := b.AutoscalingGroupName(ig)
 
+		if featureflag.SpotinstHybrid.Enabled() {
+			if !ManageInstanceGroup(ig) {
+				klog.V(2).Infof("Skipping instance group: %q", name)
+				continue
+			}
+		}
+
+		klog.V(2).Infof("Building instance group: %q", name)
 		switch ig.Spec.Role {
 
 		// Create both Master and Bastion instance groups as Elastigroups.
@@ -642,7 +653,7 @@ func (b *InstanceGroupModelBuilder) buildRootVolumeOpts(ig *kops.InstanceGroup) 
 	{
 		typ := fi.StringValue(ig.Spec.RootVolumeType)
 		if typ == "" {
-			typ = awsmodel.DefaultVolumeType
+			typ = "gp2"
 		}
 		opts.Type = fi.String(typ)
 	}
@@ -912,4 +923,12 @@ func defaultSpotPercentage(ig *kops.InstanceGroup) *float64 {
 	}
 
 	return &percentage
+}
+
+// ManageInstanceGroup indicates whether the instance group labeled with
+// a metadata label `spotinst.io/managed` which means the Spotinst provider
+// should be used to upon creation if the `SpotinstHybrid` feature flag is on.
+func ManageInstanceGroup(ig *kops.InstanceGroup) bool {
+	managed, _ := strconv.ParseBool(ig.ObjectMeta.Labels[InstanceGroupLabelManaged])
+	return managed
 }

--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -61,6 +61,7 @@ func ListResourcesAWS(cloud awsup.AWSCloud, clusterName string) (map[string]*res
 		//ListCloudFormationStacks,
 
 		// EC2
+		ListAutoScalingGroups,
 		ListInstances,
 		ListKeypairs,
 		ListSecurityGroups,
@@ -86,9 +87,6 @@ func ListResourcesAWS(cloud awsup.AWSCloud, clusterName string) (map[string]*res
 	if featureflag.Spotinst.Enabled() {
 		// Spotinst resources
 		listFunctions = append(listFunctions, ListSpotinstResources)
-	} else {
-		// AutoScaling Groups
-		listFunctions = append(listFunctions, ListAutoScalingGroups)
 	}
 
 	for _, fn := range listFunctions {


### PR DESCRIPTION
### Description

This PR allows users to gradually integrate with Spotinst.

When the Spotinst feature flag is toggled on (`export KOPS_FEATURE_FLAGS="+Spotinst"`), kops manages all instance groups through the Spotinst API using both Spotinst Elastigroup and Spotinst Ocean.

The new hybrid integration mode allows users to continue managing their instance groups through AWS Auto Scaling Groups, except for specific instance groups labeled with a predefined metadata label.

### Usage

1. Toggle on the hybrid integration feature flag:
```sh
export KOPS_FEATURE_FLAGS="+Spotinst,SpotinstHybrid"
```

2. Create a new instance group or update an existing one:
```yaml
apiVersion: kops/v1alpha2
kind: InstanceGroup
metadata:
  labels:
    ...
    spotinst.io/hybrid: "true"
    ...
spec:
  ...
```
