### PR TITLE
Calico -> 3.7.4 for older versions

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7-v3.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7-v3.yaml.template
@@ -192,7 +192,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.7.2
+          image: quay.io/calico/node:v3.7.4
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -301,7 +301,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v3.7.2
+          image: quay.io/calico/cni:v3.7.4
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -439,7 +439,7 @@ spec:
       serviceAccountName: calico-kube-controllers
       containers:
         - name: calico-kube-controllers
-          image: quay.io/calico/kube-controllers:v3.7.2
+          image: quay.io/calico/kube-controllers:v3.7.4
           resources:
             requests:
               cpu: 10m
@@ -597,7 +597,7 @@ spec:
           command: ['/bin/sh', '-c', '/completion-job.sh']
           env:
             - name: EXPECTED_NODE_IMAGE
-              value: quay.io/calico/node:v3.7.2
+              value: quay.io/calico/node:v3.7.4
             # The location of the Calico etcd cluster.
             - name: CALICO_ETCD_ENDPOINTS
               valueFrom:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -824,8 +824,8 @@ func (b *BootstrapChannelBuilder) buildManifest() (*channelsapi.Addons, map[stri
 			"pre-k8s-1.6": "2.4.2-kops.1",
 			"k8s-1.6":     "2.6.9-kops.1",
 			"k8s-1.7":     "2.6.12-kops.1",
-			"k8s-1.7-v3":  "3.7.2-kops.3",
-			"k8s-1.12":    "3.7.2-kops.4",
+			"k8s-1.7-v3":  "3.7.4-kops.1",
+			"k8s-1.12":    "3.7.4-kops.1",
 		}
 
 		{


### PR DESCRIPTION
Both in bootstrapchannelbuilder (follow-up to #7249), but also in
older versions, because it is a security fix for TTA-2019-002.