### PR TITLE
Replace use of cmdutil IsFilenameSliceEmpty

### DIFF
--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -88,7 +88,7 @@ func NewCmdCreate(f *util.Factory, out io.Writer) *cobra.Command {
 		Long:    createLong,
 		Example: createExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			if cmdutil.IsFilenameSliceEmpty(options.Filenames) {
+			if len(options.Filenames) == 0 {
 				cmd.Help()
 				return
 			}

--- a/cmd/kops/delete.go
+++ b/cmd/kops/delete.go
@@ -75,7 +75,7 @@ func NewCmdDelete(f *util.Factory, out io.Writer) *cobra.Command {
 		Example:    deleteExample,
 		SuggestFor: []string{"rm"},
 		Run: func(cmd *cobra.Command, args []string) {
-			if cmdutil.IsFilenameSliceEmpty(options.Filenames) {
+			if len(options.Filenames) == 0 {
 				cmd.Help()
 				return
 			}

--- a/cmd/kops/replace.go
+++ b/cmd/kops/replace.go
@@ -72,7 +72,7 @@ func NewCmdReplace(f *util.Factory, out io.Writer) *cobra.Command {
 		Long:    replaceLong,
 		Example: replaceExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			if cmdutil.IsFilenameSliceEmpty(options.Filenames) {
+			if len(options.Filenames) == 0 {
 				cmd.Help()
 				return
 			}


### PR DESCRIPTION
The function was trivial, and it is changed in a later k8s version.