### PR TITLE
Support for using hostPort when using flannel

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.12.yaml.template
@@ -60,12 +60,22 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
-      "type": "flannel",
-      "delegate": {
-        "forceAddress": true,
-        "isDefaultGateway": true,
-        "hairpinMode": true
-      }
+      "plugins": [
+        {
+          "type": "flannel",
+          "delegate": {
+            "forceAddress": true,
+            "isDefaultGateway": true,
+            "hairpinMode": true
+          }
+        },
+        {
+          "type": "portmap",
+          "capabilities": {
+            "portMappings": true
+          }
+        }
+      ]
     }
   net-conf.json: |
     {
@@ -110,7 +120,7 @@ spec:
         args:
         - -f
         - /etc/kube-flannel/cni-conf.json
-        - /etc/cni/net.d/10-flannel.conf
+        - /etc/cni/net.d/10-flannel.conflist
         volumeMounts:
         - name: cni
           mountPath: /etc/cni/net.d

--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.6.yaml.template
@@ -60,12 +60,22 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
-      "type": "flannel",
-      "delegate": {
-        "forceAddress": true,
-        "isDefaultGateway": true,
-        "hairpinMode": true
-      }
+      "plugins": [
+        {
+          "type": "flannel",
+          "delegate": {
+            "forceAddress": true,
+            "isDefaultGateway": true,
+            "hairpinMode": true
+          }
+        },
+        {
+          "type": "portmap",
+          "capabilities": {
+            "portMappings": true
+          }
+        }
+      ]
     }
   net-conf.json: |
     {
@@ -105,7 +115,7 @@ spec:
         args:
         - -f
         - /etc/kube-flannel/cni-conf.json
-        - /etc/cni/net.d/10-flannel.conf
+        - /etc/cni/net.d/10-flannel.conflist
         volumeMounts:
         - name: cni
           mountPath: /etc/cni/net.d

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -751,7 +751,11 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 	if b.cluster.Spec.Networking.Flannel != nil {
 		key := "networking.flannel"
-		version := "0.11.0-kops.1"
+		versions := map[string]string{
+			"pre-k8s-1.6": "0.11.0-kops.1",
+			"k8s-1.6":     "0.11.0-kops.2",
+			"k8s-1.12":    "0.11.0-kops.2",
+		}
 
 		{
 			location := key + "/pre-k8s-1.6.yaml"
@@ -759,7 +763,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
-				Version:           fi.String(version),
+				Version:           fi.String(versions[id]),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
 				KubernetesVersion: "<1.6.0",
@@ -773,7 +777,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
-				Version:           fi.String(version),
+				Version:           fi.String(versions[id]),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
 				KubernetesVersion: ">=1.6.0 <1.12.0",
@@ -787,7 +791,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
-				Version:           fi.String(version),
+				Version:           fi.String(versions[id]),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
 				KubernetesVersion: ">=1.12.0",


### PR DESCRIPTION
Similar to #3206 but for `flannel`, related to #3132

In this PR I updated the flannel's `cni` config file to enable `portmap` plugin and changed its extension from `.conf` to `.conflist` in order to support multiple plugins.

P.S.
I haven't changed pre 1.6 manifests, to avoid breaking old clusters that doesn't ship `portmap` plugin