### PR TITLE
Honor documentation regarding state : enable file state store #6463

### DIFF
--- a/util/pkg/vfs/vfs.go
+++ b/util/pkg/vfs/vfs.go
@@ -112,7 +112,7 @@ func IsClusterReadable(p Path) bool {
 		return false
 
 	case *FSPath:
-		return false
+		return true
 
 	case *MemFSPath:
 		return false


### PR DESCRIPTION
As the doc mention file state are supported : https://github.com/kubernetes/kops/blob/master/docs/state.md

Unfortunately this false boolean in the vfs.go file won't allow this. Simply changing this value seems to make it work

Test made 

```
TEMP_DIR=$(mktemp -d)
cd $TEMP_DIR
# $KOPS_BUILD_PATH is the path for building kops. (ending with  .build/local)
# Build is made by running "make kops" at the root of this repo , go version go1.12.7 linux/amd64
# I have nothing in us-east-1a it was jsut to launch the command line
$KOPS_BUILD_PATH/kops create cluster --name test.k8s.local --state=$TEMP_DIR/state --zones us-east-1a
# I interrupt the process when it is trying to contact AWS API 
# Message like : No progress made, sleeping before retrying 2 failed task(s)

$KOPS_BUILD_PATH/kops create secret dockerconfig -f ~/.docker/config.json --name test.k8s.local --state=$TEMP_DIR/state
$KOPS_BUILD_PATH/kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub --name test.k8s.local --state=$TEMP_DIR/state

ls -l $TEMP_DIR/state/test.k8s.local 
total 24
-rw------- 1 user user 5103 Jul 22 15:47 cluster.spec
-rw------- 1 user user 1068 Jul 22 15:47 config
drwxr-xr-x 2 user user 4096 Jul 22 15:47 instancegroup
drwxr-xr-x 3 user user 4096 Jul 22 15:47 pki
drwxr-xr-x 2 user user 4096 Jul 22 15:47 secrets

cd /tmp
rm -rf $TEMP_DIR
```

The state is written into the expected directory as shown.

Let me know if you need anything else to validate this but that look like a very trivial fix.
