### PR TITLE
Ability to Configure Etcdv2 Datastore for Calico V3

### DIFF
--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -77,6 +77,8 @@ type FlannelNetworkingSpec struct {
 // CalicoNetworkingSpec declares that we want Calico networking
 type CalicoNetworkingSpec struct {
 	CrossSubnet bool `json:"crossSubnet,omitempty"` // Enables Calico's cross-subnet mode when set to true
+	// Configure Etcdv2 as Datastore for calico v3
+	DataStoreType string `json:"dataStoreType,omitempty"`
 	// LogSeverityScreen lets us set the desired log level. (Default: info)
 	LogSeverityScreen string `json:"logSeverityScreen,omitempty"`
 	// MTU to be set in the cni-network-config for calico.

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -77,6 +77,8 @@ type FlannelNetworkingSpec struct {
 // CalicoNetworkingSpec declares that we want Calico networking
 type CalicoNetworkingSpec struct {
 	CrossSubnet bool `json:"crossSubnet,omitempty"` // Enables Calico's cross-subnet mode when set to true
+	// Configure Etcdv2 as Datastore for calico v3
+	DataStoreType string `json:"dataStoreType,omitempty"`
 	// LogSeverityScreen lets us set the desired log level. (Default: info)
 	LogSeverityScreen string `json:"logSeverityScreen,omitempty"`
 	// MTU to be set in the cni-network-config for calico.

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1110,6 +1110,7 @@ func Convert_kops_CNINetworkingSpec_To_v1alpha1_CNINetworkingSpec(in *kops.CNINe
 
 func autoConvert_v1alpha1_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *CalicoNetworkingSpec, out *kops.CalicoNetworkingSpec, s conversion.Scope) error {
 	out.CrossSubnet = in.CrossSubnet
+	out.DataStoreType = in.DataStoreType
 	out.LogSeverityScreen = in.LogSeverityScreen
 	out.MTU = in.MTU
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
@@ -1127,6 +1128,7 @@ func Convert_v1alpha1_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *Cali
 
 func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha1_CalicoNetworkingSpec(in *kops.CalicoNetworkingSpec, out *CalicoNetworkingSpec, s conversion.Scope) error {
 	out.CrossSubnet = in.CrossSubnet
+	out.DataStoreType = in.DataStoreType
 	out.LogSeverityScreen = in.LogSeverityScreen
 	out.MTU = in.MTU
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -77,6 +77,8 @@ type FlannelNetworkingSpec struct {
 // CalicoNetworkingSpec declares that we want Calico networking
 type CalicoNetworkingSpec struct {
 	CrossSubnet bool `json:"crossSubnet,omitempty"` // Enables Calico's cross-subnet mode when set to true
+	// Configure Etcdv2 as Datastore for calico v3
+	DataStoreType string `json:"dataStoreType,omitempty"`
 	// LogSeverityScreen lets us set the desired log level. (Default: info)
 	LogSeverityScreen string `json:"logSeverityScreen,omitempty"`
 	// MTU to be set in the cni-network-config for calico.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1152,6 +1152,7 @@ func Convert_kops_CNINetworkingSpec_To_v1alpha2_CNINetworkingSpec(in *kops.CNINe
 
 func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *CalicoNetworkingSpec, out *kops.CalicoNetworkingSpec, s conversion.Scope) error {
 	out.CrossSubnet = in.CrossSubnet
+	out.DataStoreType = in.DataStoreType
 	out.LogSeverityScreen = in.LogSeverityScreen
 	out.MTU = in.MTU
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
@@ -1169,6 +1170,7 @@ func Convert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *Cali
 
 func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *kops.CalicoNetworkingSpec, out *CalicoNetworkingSpec, s conversion.Scope) error {
 	out.CrossSubnet = in.CrossSubnet
+	out.DataStoreType = in.DataStoreType
 	out.LogSeverityScreen = in.LogSeverityScreen
 	out.MTU = in.MTU
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -802,23 +802,9 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.12":    "3.7.4-kops.1",
 		}
 
-		{
-			id := "k8s-1.12"
-			location := key + "/" + id + ".yaml"
-
-			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
-				Name:              fi.String(key),
-				Version:           fi.String(versions[id]),
-				Selector:          networkingSelector,
-				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.12.0",
-				Id:                id,
-			})
-		}
-
-		if b.cluster.Spec.Networking.Calico.MajorVersion == "v3" {
+		if b.cluster.Spec.Networking.Calico.DataStoreType != "etcdv2" {
 			{
-				id := "k8s-1.7-v3"
+				id := "k8s-1.12"
 				location := key + "/" + id + ".yaml"
 
 				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
@@ -826,7 +812,27 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 					Version:           fi.String(versions[id]),
 					Selector:          networkingSelector,
 					Manifest:          fi.String(location),
-					KubernetesVersion: ">=1.7.0 <1.12.0",
+					KubernetesVersion: ">=1.12.0",
+					Id:                id,
+				})
+			}
+		}
+
+		if b.cluster.Spec.Networking.Calico.MajorVersion == "v3" {
+			{
+				id := "k8s-1.7-v3"
+				kversion := ">=1.7.0 <1.12.0"
+				location := key + "/" + id + ".yaml"
+				if b.cluster.Spec.Networking.Calico.DataStoreType == "etcdv2" {
+					kversion = ">=1.7.0"
+				}
+
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(versions[id]),
+					Selector:          networkingSelector,
+					Manifest:          fi.String(location),
+					KubernetesVersion: kversion,
 					Id:                id,
 				})
 			}


### PR DESCRIPTION
Enables setting the Datastore to Etcdv2 for Calico V3

Example:
```
networking:
  calico:
    DataStoreType: etcdv2
```

Testing:
Created cluster on AWS with networking set to calico, and DataStoreType set to `etcdv2` this will use  `k8s-1.7-v3` template
Created cluster DataStoreType not set, which will default to current behavior to using `k8s-1.12` template

Closes #7303