### PR TITLE
Allow configuring the MTU (Calico)

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -191,6 +191,18 @@ When you enable cross-subnet mode in kops, an addon controller ([k8s-ec2-srcdst]
 will be deployed as a Pod (which will be scheduled on one of the masters) to facilitate the disabling of said source/destination address checks.
 Only the masters have the IAM policy (`ec2:*`) to allow k8s-ec2-srcdst to execute `ec2:ModifyInstanceAttribute`.
 
+### Configuring Calico MTU
+
+The Calico MTU is configurable by editing the cluster and setting `mtu` option in the calico configuration.
+AWS VPCs support jumbo frames, so on cluster creation kops sets the calico MTU to 8912 bytes (9001 minus overhead).
+
+```
+spec:
+  networking:
+    calico:
+      mtu: 8912
+```
+
 #### More information about Calico
 
 For Calico specific documentation please visit the [Calico Docs](http://docs.projectcalico.org/latest/getting-started/kubernetes/).

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -242,7 +242,7 @@ data:
 
   # TODO: Do we want to configure this?
   # Configure the MTU to use
-  veth_mtu: "1440"
+  veth_mtu: "{{- or .Networking.Calico.MTU "1440" }}"
 
   # Configure the Calico backend to use.
   calico_backend: "bird"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -240,7 +240,6 @@ data:
   # essential.
   typha_service_name: "none"
 
-  # TODO: Do we want to configure this?
   # Configure the MTU to use
   veth_mtu: "{{- or .Networking.Calico.MTU "1440" }}"
 

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7-v3.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7-v3.yaml.template
@@ -32,6 +32,9 @@ data:
           "etcd_scheme": "https",
           {{- end }}
           "log_level": "info",
+          {{- if .Networking.Calico.MTU }}
+          "mtu": {{- or .Networking.Calico.MTU }},
+          {{- end }}
           "ipam": {
             "type": "calico-ipam"
           },
@@ -259,6 +262,10 @@ spec:
               value: "autodetect"
             - name: FELIX_HEALTHENABLED
               value: "true"
+            {{- if .Networking.Calico.MTU }}
+            - name: FELIX_IPINIPMTU
+              value: "{{- or .Networking.Calico.MTU }}"
+            {{- end}}
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
Fixes: #7086
Fixes: #6407  
- Allow configuring the MTU on both `k8s-1.7-v3` and `k8s-1.12` templates

Related docs: https://docs.projectcalico.org/v3.7/networking/mtu#selecting-mtu-size