### PR TITLE
Make weave memory resources configurable

### DIFF
--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -61,9 +61,10 @@ type KopeioNetworkingSpec struct {
 
 // WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU         *int32 `json:"mtu,omitempty"`
-	ConnLimit   *int32 `json:"connLimit,omitempty"`
-	NoMasqLocal *int32 `json:"noMasqLocal,omitempty"`
+	MTU             *int32  `json:"mtu,omitempty"`
+	ConnLimit       *int32  `json:"connLimit,omitempty"`
+	MemoryResources *string `json:"memoryResources,omitempty"`
+	NoMasqLocal     *int32  `json:"noMasqLocal,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -61,9 +61,10 @@ type KopeioNetworkingSpec struct {
 
 // WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU         *int32 `json:"mtu,omitempty"`
-	ConnLimit   *int32 `json:"connLimit,omitempty"`
-	NoMasqLocal *int32 `json:"noMasqLocal,omitempty"`
+	MTU             *int32  `json:"mtu,omitempty"`
+	ConnLimit       *int32  `json:"connLimit,omitempty"`
+	MemoryResources *string `json:"memoryResources,omitempty"`
+	NoMasqLocal     *int32  `json:"noMasqLocal,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -4523,6 +4523,7 @@ func Convert_kops_VolumeSpec_To_v1alpha1_VolumeSpec(in *kops.VolumeSpec, out *Vo
 func autoConvert_v1alpha1_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveNetworkingSpec, out *kops.WeaveNetworkingSpec, s conversion.Scope) error {
 	out.MTU = in.MTU
 	out.ConnLimit = in.ConnLimit
+	out.MemoryResources = in.MemoryResources
 	out.NoMasqLocal = in.NoMasqLocal
 	return nil
 }
@@ -4535,6 +4536,7 @@ func Convert_v1alpha1_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveN
 func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha1_WeaveNetworkingSpec(in *kops.WeaveNetworkingSpec, out *WeaveNetworkingSpec, s conversion.Scope) error {
 	out.MTU = in.MTU
 	out.ConnLimit = in.ConnLimit
+	out.MemoryResources = in.MemoryResources
 	out.NoMasqLocal = in.NoMasqLocal
 	return nil
 }

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -3178,6 +3178,11 @@ func (in *WeaveNetworkingSpec) DeepCopyInto(out *WeaveNetworkingSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MemoryResources != nil {
+		in, out := &in.MemoryResources, &out.MemoryResources
+		*out = new(string)
+		**out = **in
+	}
 	if in.NoMasqLocal != nil {
 		in, out := &in.NoMasqLocal, &out.NoMasqLocal
 		*out = new(int32)

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -61,9 +61,10 @@ type KopeioNetworkingSpec struct {
 
 // WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU         *int32 `json:"mtu,omitempty"`
-	ConnLimit   *int32 `json:"connLimit,omitempty"`
-	NoMasqLocal *int32 `json:"noMasqLocal,omitempty"`
+	MTU             *int32  `json:"mtu,omitempty"`
+	ConnLimit       *int32  `json:"connLimit,omitempty"`
+	MemoryResources *string `json:"memoryResources,omitempty"`
+	NoMasqLocal     *int32  `json:"noMasqLocal,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4851,6 +4851,7 @@ func Convert_kops_VolumeSpec_To_v1alpha2_VolumeSpec(in *kops.VolumeSpec, out *Vo
 func autoConvert_v1alpha2_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveNetworkingSpec, out *kops.WeaveNetworkingSpec, s conversion.Scope) error {
 	out.MTU = in.MTU
 	out.ConnLimit = in.ConnLimit
+	out.MemoryResources = in.MemoryResources
 	out.NoMasqLocal = in.NoMasqLocal
 	return nil
 }
@@ -4863,6 +4864,7 @@ func Convert_v1alpha2_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *WeaveN
 func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha2_WeaveNetworkingSpec(in *kops.WeaveNetworkingSpec, out *WeaveNetworkingSpec, s conversion.Scope) error {
 	out.MTU = in.MTU
 	out.ConnLimit = in.ConnLimit
+	out.MemoryResources = in.MemoryResources
 	out.NoMasqLocal = in.NoMasqLocal
 	return nil
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3249,6 +3249,11 @@ func (in *WeaveNetworkingSpec) DeepCopyInto(out *WeaveNetworkingSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MemoryResources != nil {
+		in, out := &in.MemoryResources, &out.MemoryResources
+		*out = new(string)
+		**out = **in
+	}
 	if in.NoMasqLocal != nil {
 		in, out := &in.NoMasqLocal, &out.NoMasqLocal
 		*out = new(int32)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3463,6 +3463,11 @@ func (in *WeaveNetworkingSpec) DeepCopyInto(out *WeaveNetworkingSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MemoryResources != nil {
+		in, out := &in.MemoryResources, &out.MemoryResources
+		*out = new(string)
+		**out = **in
+	}
 	if in.NoMasqLocal != nil {
 		in, out := &in.NoMasqLocal, &out.NoMasqLocal
 		*out = new(int32)

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -172,9 +172,9 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 200Mi
+              memory: {{- if .Networking.Weave.MemoryResources -}}{{ .Networking.Weave.MemoryResources }}{{- else -}}200Mi{{- end -}}
             limits:
-              memory: 200Mi
+              memory: {{- if .Networking.Weave.MemoryResources -}}{{ .Networking.Weave.MemoryResources }}{{- else -}}200Mi{{- end -}}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
@@ -154,9 +154,9 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 200Mi
+              memory: {{- if .Networking.Weave.MemoryResources -}}{{ .Networking.Weave.MemoryResources }}{{- else -}}200Mi{{- end -}}
             limits:
-              memory: 200Mi
+              memory: {{- if .Networking.Weave.MemoryResources -}}{{ .Networking.Weave.MemoryResources }}{{- else -}}200Mi{{- end -}}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -164,9 +164,9 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 200Mi
+              memory: {{- if .Networking.Weave.MemoryResources -}}{{ .Networking.Weave.MemoryResources }}{{- else -}}200Mi{{- end -}}
             limits:
-              memory: 200Mi
+              memory: {{- if .Networking.Weave.MemoryResources -}}{{ .Networking.Weave.MemoryResources }}{{- else -}}200Mi{{- end -}}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -168,9 +168,9 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 200Mi
+              memory: {{- if .Networking.Weave.MemoryResources -}}{{ .Networking.Weave.MemoryResources }}{{- else -}}200Mi{{- end -}}
             limits:
-              memory: 200Mi
+              memory: {{- if .Networking.Weave.MemoryResources -}}{{ .Networking.Weave.MemoryResources }}{{- else -}}200Mi{{- end -}}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
@@ -56,9 +56,9 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 200Mi
+              memory: {{- if .Networking.Weave.MemoryResources -}}{{ .Networking.Weave.MemoryResources }}{{- else -}}200Mi{{- end -}}
             limits:
-              memory: 200Mi
+              memory: {{- if .Networking.Weave.MemoryResources -}}{{ .Networking.Weave.MemoryResources }}{{- else -}}200Mi{{- end -}}
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
It's pretty clear that the 200MB doesn't suffice for large clusters (even when less than 100 node). Here's an example of my 7-day experience 👇

<img width="1346" alt="Screenshot 2019-07-23 at 16 01 56" src="https://user-images.githubusercontent.com/703786/61714400-633fbd80-ad63-11e9-8c88-59d01e4e350f.png">

We manually set it to `300MB` just to make sure our weave pods don't get OOM'd. We currently have `CONN_LIMIT` to the default of 100 but its worth noting increasing this limit means there'll be an increase in the memory consumption of the weave container in the weave pod.

~Will add auto-generated code after comments and feedback.~