### PR TITLE
Manifest hashing: move trimming out of hash function

### DIFF
--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -18,6 +18,7 @@ package cloudup
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/klog"
 	channelsapi "k8s.io/kops/channels/pkg/api"
@@ -68,13 +69,16 @@ func (b *BootstrapChannelBuilder) Build(c *fi.ModelBuilderContext) error {
 			return fmt.Errorf("error remapping manifest %s: %v", manifestPath, err)
 		}
 
+		// Trim whitespace
+		manifestBytes = []byte(strings.TrimSpace(string(manifestBytes)))
+
 		rawManifest := string(manifestBytes)
 		klog.V(4).Infof("Manifest %v", rawManifest)
 
-		manifestHash, err := utils.HashString(&rawManifest)
+		manifestHash, err := utils.HashString(rawManifest)
 		klog.V(4).Infof("hash %s", manifestHash)
 		if err != nil {
-			manifestHash = ""
+			return fmt.Errorf("error hashing manifest: %v", err)
 		}
 		a.ManifestHash = manifestHash
 

--- a/upup/pkg/fi/utils/hash.go
+++ b/upup/pkg/fi/utils/hash.go
@@ -19,14 +19,12 @@ package utils
 import (
 	"crypto/sha1"
 	"encoding/hex"
-	"strings"
 )
 
 // HashString Takes String and returns a sha1 hash represented as a string
-func HashString(s *string) (string, error) {
+func HashString(s string) (string, error) {
 	h := sha1.New()
-	ts := strings.TrimSpace(*s)
-	_, err := h.Write([]byte(ts))
+	_, err := h.Write([]byte(s))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
It's a little confusing to have a hash function which auto-trims.  But
trimming the manifests does make sense.  We also want to be sure that
the hash matches the raw hash of the manifest, which it didn't when we
transformed the manifest "inside the hash".