### PR TITLE
Update kube-router to 0.3.1

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router:v0.1.0
+        image: cloudnativelabs/kube-router:v0.3.1
         args:
         - --run-router=true
         - --run-firewall=true

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router:v0.1.0
+        image: cloudnativelabs/kube-router:v0.3.1
         args:
         - --run-router=true
         - --run-firewall=true

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -955,7 +955,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 	if b.cluster.Spec.Networking.Kuberouter != nil {
 		key := "networking.kuberouter"
-		version := "0.1.1-kops.3"
+		version := "0.3.1-kops.1"
 
 		{
 			location := key + "/k8s-1.6.yaml"


### PR DESCRIPTION
Bump kube-router version to v 0.3.1. This version includes various security fixes and performance improvements.