### PR TITLE
Fix template clusterName behavior

### DIFF
--- a/cmd/kops/toolbox_template.go
+++ b/cmd/kops/toolbox_template.go
@@ -111,7 +111,14 @@ func runToolBoxTemplate(f *util.Factory, out io.Writer, options *toolboxTemplate
 	if err != nil {
 		return err
 	}
-	context["clusterName"] = options.clusterName
+
+	// @step: set clusterName from template's values or cli flag
+	value, ok := context["clusterName"].(string)
+	if ok {
+		options.clusterName = value
+	} else {
+		context["clusterName"] = options.clusterName
+	}
 
 	// @check if we are just rendering the config value
 	if options.configValue != "" {


### PR DESCRIPTION
This commit will allow you to define clusterName from the template's values file.
Before that our clusterName value would be overriden by the cli flag ( whether defined or not ).

Now we have an approach where if the value is defined, it will have priority over the cli flag.
This commit will also align with the official documentation under https://github.com/kubernetes/kops/blob/master/docs/cluster_template.md