### PR TITLE
Update static pod labels to use recommended keys

### DIFF
--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -368,7 +368,8 @@ func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 			Namespace:   "kube-system",
 			Annotations: b.buildAnnotations(),
 			Labels: map[string]string{
-				"k8s-app": "kube-apiserver",
+				"k8s-app":                "kube-apiserver",
+				"app.kubernetes.io/name": "kube-apiserver",
 			},
 		},
 		Spec: v1.PodSpec{

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -144,7 +144,8 @@ func (b *KubeControllerManagerBuilder) buildPod() (*v1.Pod, error) {
 			Name:      "kube-controller-manager",
 			Namespace: "kube-system",
 			Labels: map[string]string{
-				"k8s-app": "kube-controller-manager",
+				"k8s-app":                "kube-controller-manager",
+				"app.kubernetes.io/name": "kube-controller-manager",
 			},
 		},
 		Spec: v1.PodSpec{

--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -195,8 +195,9 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 			Name:      "kube-proxy",
 			Namespace: "kube-system",
 			Labels: map[string]string{
-				"k8s-app": "kube-proxy",
-				"tier":    "node",
+				"k8s-app":                "kube-proxy",
+				"app.kubernetes.io/name": "kube-proxy",
+				"tier":                   "node",
 			},
 		},
 		Spec: v1.PodSpec{

--- a/nodeup/pkg/model/kube_proxy_test.go
+++ b/nodeup/pkg/model/kube_proxy_test.go
@@ -73,8 +73,9 @@ func TestKubeProxyBuilder_buildPod(t *testing.T) {
 					Name:      "kube-proxy",
 					Namespace: "kube-system",
 					Labels: map[string]string{
-						"k8s-app": "kube-proxy",
-						"tier":    "node",
+						"k8s-app":                "kube-proxy",
+						"app.kubernetes.io/name": "kube-proxy",
+						"tier":                   "node",
 					},
 				},
 				Spec: v1.PodSpec{

--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -115,7 +115,8 @@ func (b *KubeSchedulerBuilder) buildPod() (*v1.Pod, error) {
 			Name:      "kube-scheduler",
 			Namespace: "kube-system",
 			Labels: map[string]string{
-				"k8s-app": "kube-scheduler",
+				"k8s-app":                "kube-scheduler",
+				"app.kubernetes.io/name": "kube-scheduler",
 			},
 		},
 		Spec: v1.PodSpec{

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -285,6 +285,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster *kops.EtcdClusterSpec) (*v1.Po
 		pod.Labels = make(map[string]string)
 	}
 	pod.Labels["k8s-app"] = pod.Name
+	pod.Labels["app.kubernetes.io/name"] = pod.Name
 
 	// TODO: Use a socket file for the quarantine port
 	quarantinedClientPort := 3994

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -73,6 +73,7 @@ Contents:
         scheduler.alpha.kubernetes.io/critical-pod: ""
       creationTimestamp: null
       labels:
+        app.kubernetes.io/name: etcd-manager-events
         k8s-app: etcd-manager-events
       name: etcd-manager-events
       namespace: kube-system
@@ -144,6 +145,7 @@ Contents:
         scheduler.alpha.kubernetes.io/critical-pod: ""
       creationTimestamp: null
       labels:
+        app.kubernetes.io/name: etcd-manager-main
         k8s-app: etcd-manager-main
       name: etcd-manager-main
       namespace: kube-system

--- a/protokube/pkg/protokube/etcd_manifest.go
+++ b/protokube/pkg/protokube/etcd_manifest.go
@@ -36,7 +36,10 @@ func BuildEtcdManifest(c *EtcdCluster) *v1.Pod {
 	pod.Kind = "Pod"
 	pod.Name = c.PodName
 	pod.Namespace = "kube-system"
-	pod.Labels = map[string]string{"k8s-app": c.PodName}
+	pod.Labels = map[string]string{
+		"k8s-app":                c.PodName,
+		"app.kubernetes.io/name": c.PodName,
+	}
 	pod.Spec.HostNetwork = true
 
 	// dereference our resource requests if they exist

--- a/protokube/tests/integration/build_etcd_manifest/main/etcd_env_vars.yaml
+++ b/protokube/tests/integration/build_etcd_manifest/main/etcd_env_vars.yaml
@@ -30,6 +30,7 @@ metadata:
     scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
+    app.kubernetes.io/name: etcd-server-main
     k8s-app: etcd-server-main
   name: etcd-server-main
   namespace: kube-system

--- a/protokube/tests/integration/build_etcd_manifest/main/non_tls.yaml
+++ b/protokube/tests/integration/build_etcd_manifest/main/non_tls.yaml
@@ -28,6 +28,7 @@ metadata:
     scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
+    app.kubernetes.io/name: etcd-server-main
     k8s-app: etcd-server-main
   name: etcd-server-main
   namespace: kube-system

--- a/protokube/tests/integration/build_etcd_manifest/main/tls.yaml
+++ b/protokube/tests/integration/build_etcd_manifest/main/tls.yaml
@@ -34,6 +34,7 @@ metadata:
     scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
+    app.kubernetes.io/name: etcd-server-main
     k8s-app: etcd-server-main
   name: etcd-server-main
   namespace: kube-system


### PR DESCRIPTION
See https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels

If we want to eventually get rid of the old k8s-app labels, we could announce their deprecation in the next release and then remove them in a few releases after that.

I'll have a followup PR for all the addon manifests