### PR TITLE
Enable scraping of weave metrics

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -130,6 +130,7 @@ spec:
         name: weave-net
         role.kubernetes.io/networking: "1"
       annotations:
+        prometheus.io/scrape: "true"
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
@@ -164,6 +165,9 @@ spec:
                   key: network-password
             {{- end }}
           image: 'weaveworks/weave-kube:2.5.1'
+          ports:
+            - name: metrics
+              containerPort: 6782
           readinessProbe:
             httpGet:
               host: 127.0.0.1
@@ -201,6 +205,9 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
           image: 'weaveworks/weave-npc:2.5.1'
+          ports:
+            - name: metrics
+              containerPort: 6781
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
@@ -116,6 +116,7 @@ spec:
         name: weave-net
         role.kubernetes.io/networking: "1"
       annotations:
+        prometheus.io/scrape: "true"
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
@@ -146,6 +147,9 @@ spec:
                   key: network-password
             {{- end }}
           image: 'weaveworks/weave-kube:2.3.0'
+          ports:
+            - name: metrics
+              containerPort: 6782
           readinessProbe:
             httpGet:
               host: 127.0.0.1
@@ -182,6 +186,9 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
           image: 'weaveworks/weave-npc:2.3.0'
+          ports:
+            - name: metrics
+              containerPort: 6781
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -126,6 +126,7 @@ spec:
         name: weave-net
         role.kubernetes.io/networking: "1"
       annotations:
+        prometheus.io/scrape: "true"
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
@@ -156,6 +157,9 @@ spec:
                   key: network-password
             {{- end }}
           image: 'weaveworks/weave-kube:2.5.1'
+          ports:
+            - name: metrics
+              containerPort: 6782
           readinessProbe:
             httpGet:
               host: 127.0.0.1
@@ -193,6 +197,9 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
           image: 'weaveworks/weave-npc:2.5.1'
+          ports:
+            - name: metrics
+              containerPort: 6781
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -126,6 +126,7 @@ spec:
         name: weave-net
         role.kubernetes.io/networking: "1"
       annotations:
+        prometheus.io/scrape: "true"
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
@@ -160,6 +161,9 @@ spec:
                   key: network-password
             {{- end }}
           image: 'weaveworks/weave-kube:2.5.1'
+          ports:
+            - name: metrics
+              containerPort: 6782
           readinessProbe:
             httpGet:
               host: 127.0.0.1
@@ -197,6 +201,9 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
           image: 'weaveworks/weave-npc:2.5.1'
+          ports:
+            - name: metrics
+              containerPort: 6781
           resources:
             requests:
               cpu: 50m

--- a/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        prometheus.io/scrape: "true"
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: >-
           [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"},{"key":"CriticalAddonsOnly", "operator":"Exists"}]
@@ -47,6 +48,9 @@ spec:
               value: "{{ .Networking.Weave.ConnLimit }}"
             {{- end }}
           image: 'weaveworks/weave-kube:2.3.0'
+          ports:
+            - name: metrics
+              containerPort: 6782
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -84,6 +88,9 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
           image: 'weaveworks/weave-npc:2.3.0'
+          ports:
+            - name: metrics
+              containerPort: 6781
           resources:
             requests:
               cpu: 50m

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -671,11 +671,11 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 	if b.cluster.Spec.Networking.Weave != nil {
 		key := "networking.weave"
 		versions := map[string]string{
-			"pre-k8s-1.6": "2.3.0-kops.2",
-			"k8s-1.6":     "2.3.0-kops.2",
-			"k8s-1.7":     "2.5.1-kops.1",
-			"k8s-1.8":     "2.5.1-kops.1",
-			"k8s-1.12":    "2.5.1-kops.1",
+			"pre-k8s-1.6": "2.3.0-kops.3",
+			"k8s-1.6":     "2.3.0-kops.3",
+			"k8s-1.7":     "2.5.1-kops.2",
+			"k8s-1.8":     "2.5.1-kops.2",
+			"k8s-1.12":    "2.5.1-kops.2",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -107,40 +107,40 @@ spec:
   - id: pre-k8s-1.6
     kubernetesVersion: <1.6.0
     manifest: networking.weave/pre-k8s-1.6.yaml
-    manifestHash: 68a216203c07e9c94f933e59b0bb128cda67ea84
+    manifestHash: 564f5bea5d9eee61af636dba48c4092a0bedef7f
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.3.0-kops.2
+    version: 2.3.0-kops.3
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.7.0'
     manifest: networking.weave/k8s-1.6.yaml
-    manifestHash: c507056ef3fafc4a761e13e3ea929ee5913fc147
+    manifestHash: 6897c214a84d8ba960f7c92e237e1f9d8edea394
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.3.0-kops.2
+    version: 2.3.0-kops.3
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0 <1.8.0'
     manifest: networking.weave/k8s-1.7.yaml
-    manifestHash: 65de8dd63d2fc63c71bb8c72be8511cdf5565b5e
+    manifestHash: e017ce8498a9c4b0569bf2e4d7f49f9f4201ef52
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.1-kops.1
+    version: 2.5.1-kops.2
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: bbe1619bb252db86f0c79a1c633cb2bd4423e8e7
+    manifestHash: 390e23353f5370d294663065a3ca7e0fb1d63737
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.1-kops.1
+    version: 2.5.1-kops.2
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: a41cbe09f1d3331a1566167dd75470645b7d2fb7
+    manifestHash: c784dfaae5188e0b1e4dbfea0373abe8d1a01b48
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.1-kops.1
+    version: 2.5.1-kops.2


### PR DESCRIPTION
Weave has some [useful metrics](https://github.com/weaveworks/weave/blob/master/site/tasks/manage/metrics.md) that it exposes on two ports:
* `6782` - Weave router
* `6781` - Weave network policy controller

This change annotates the weave pod, making it a target for scraping by prometheus. 

It also adds two container ports, one for each container, which prometheus will probe for `/metrics` endpoints. This gets around the limitation that you can only have one `prometheus.io/port` annotation per pod. I've also given the ports the name "metrics" so that if necessary, users can adjust their prometheus configuration to [target them more directly](https://stackoverflow.com/a/46825817).