### PR TITLE
Warn/prevent if the version of etcd is unsupported with etcd-manager

### DIFF
--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -82,6 +82,8 @@ var (
 	VPCSkipEnableDNSSupport = New("VPCSkipEnableDNSSupport", Bool(false))
 	// VSphereCloudProvider enables the vsphere cloud provider
 	VSphereCloudProvider = New("VSphereCloudProvider", Bool(false))
+	// SkipEtcdVersionCheck will bypass the check that etcd-manager is using a supported etcd version
+	SkipEtcdVersionCheck = New("SkipEtcdVersionCheck", Bool(false))
 )
 
 // FeatureFlag defines a feature flag

--- a/pkg/model/components/etcdmanager/BUILD.bazel
+++ b/pkg/model/components/etcdmanager/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/apis/kops:go_default_library",
         "//pkg/assets:go_default_library",
         "//pkg/dns:go_default_library",
+        "//pkg/featureflag:go_default_library",
         "//pkg/flagbuilder:go_default_library",
         "//pkg/k8scodecs:go_default_library",
         "//pkg/kubemanifest:go_default_library",


### PR DESCRIPTION
Should prevent the scenario where etcd-manager can't come up because of a different version.

Can be bypassed with the SkipEtcdVersionCheck feature flag.