### PR TITLE
Default etcd-version to 3.3.10 for >= 1.14

### DIFF
--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -40,6 +40,8 @@ const (
 	DefaultEtcd3Version_1_11 = "3.2.24"
 
 	DefaultEtcd3Version_1_13 = "3.2.24"
+
+	DefaultEtcd3Version_1_14 = "3.3.10"
 )
 
 // BuildOptions is responsible for filling in the defaults for the etcd cluster model
@@ -60,7 +62,9 @@ func (b *EtcdOptionsBuilder) BuildOptions(o interface{}) error {
 		// Ensure the version is set
 		if c.Version == "" && c.Provider == kops.EtcdProviderTypeLegacy {
 			// Even if in legacy mode, etcd version 2 is unsupported as of k8s 1.13
-			if b.IsKubernetesGTE("1.13") {
+			if b.IsKubernetesGTE("1.14") {
+				c.Version = DefaultEtcd3Version_1_14
+			} else if b.IsKubernetesGTE("1.13") {
 				c.Version = DefaultEtcd3Version_1_13
 			} else {
 				c.Version = DefaultEtcd2Version
@@ -69,7 +73,11 @@ func (b *EtcdOptionsBuilder) BuildOptions(o interface{}) error {
 
 		if c.Version == "" && c.Provider == kops.EtcdProviderTypeManager {
 			// From 1.11, we run the k8s-recommended versions of etcd when using the manager
-			if b.IsKubernetesGTE("1.11") {
+			if b.IsKubernetesGTE("1.14") {
+				c.Version = DefaultEtcd3Version_1_14
+			} else if b.IsKubernetesGTE("1.13") {
+				c.Version = DefaultEtcd3Version_1_13
+			} else if b.IsKubernetesGTE("1.11") {
 				c.Version = DefaultEtcd3Version_1_11
 			} else {
 				c.Version = DefaultEtcd2Version


### PR DESCRIPTION
This is the current recommended etcd version for 1.14 / 1.15