### PR TITLE
Promote 1.12 image from alpha to stable

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -26,7 +26,7 @@ spec:
     - name: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2018-08-17
       providerID: aws
       kubernetesVersion: ">=1.11.0 <1.12.0"
-    - name: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-13
+    - name: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21
       providerID: aws
       kubernetesVersion: ">=1.12.0"
     - providerID: gce


### PR DESCRIPTION
includes fixes for "TCP SACK PANIC" CVE

xref: https://github.com/kubernetes/kops/pull/7176

/cc @justinsb @KashifSaadat