### PR TITLE
Add mappings for Webhook authorization mode.

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -385,6 +385,12 @@ type KubeAPIServerConfig struct {
 	AuthenticationTokenWebhookCacheTTL *metav1.Duration `json:"authenticationTokenWebhookCacheTtl,omitempty" flag:"authentication-token-webhook-cache-ttl"`
 	// AuthorizationMode is the authorization mode the kubeapi is running in
 	AuthorizationMode *string `json:"authorizationMode,omitempty" flag:"authorization-mode"`
+	// File with webhook configuration for authorization in kubeconfig format. The API server will query the remote service to determine whether to authorize the request.
+	AuthorizationWebhookConfigFile *string `json:"authorizationWebhookConfigFile,omitempty" flag:"authorization-webhook-config-file"`
+	// The duration to cache authorized responses from the webhook token authorizer. Default is 5m. (default 5m0s)
+	AuthorizationWebhookCacheAuthorizedTTL *metav1.Duration `json:"authorizationWebhookCacheAuthorizedTtl,omitempty" flag:"authorization-webhook-cache-authorized-ttl"`
+	// The duration to cache authorized responses from the webhook token authorizer. Default is 30s. (default 30s)
+	AuthorizationWebhookCacheUnauthorizedTTL *metav1.Duration `json:"authorizationWebhookCacheUnauthorizedTtl,omitempty" flag:"authorization-webhook-cache-unauthorized-ttl"`
 	// AuthorizationRBACSuperUser is the name of the superuser for default rbac
 	AuthorizationRBACSuperUser *string `json:"authorizationRbacSuperUser,omitempty" flag:"authorization-rbac-super-user"`
 	// ExperimentalEncryptionProviderConfig enables encryption at rest for secrets.

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -385,6 +385,12 @@ type KubeAPIServerConfig struct {
 	AuthenticationTokenWebhookCacheTTL *metav1.Duration `json:"authenticationTokenWebhookCacheTtl,omitempty" flag:"authentication-token-webhook-cache-ttl"`
 	// AuthorizationMode is the authorization mode the kubeapi is running in
 	AuthorizationMode *string `json:"authorizationMode,omitempty" flag:"authorization-mode"`
+	// File with webhook configuration for authorization in kubeconfig format. The API server will query the remote service to determine whether to authorize the request.
+	AuthorizationWebhookConfigFile *string `json:"authorizationWebhookConfigFile,omitempty" flag:"authorization-webhook-config-file"`
+	// The duration to cache authorized responses from the webhook token authorizer. Default is 5m. (default 5m0s)
+	AuthorizationWebhookCacheAuthorizedTTL *metav1.Duration `json:"authorizationWebhookCacheAuthorizedTtl,omitempty" flag:"authorization-webhook-cache-authorized-ttl"`
+	// The duration to cache authorized responses from the webhook token authorizer. Default is 30s. (default 30s)
+	AuthorizationWebhookCacheUnauthorizedTTL *metav1.Duration `json:"authorizationWebhookCacheUnauthorizedTtl,omitempty" flag:"authorization-webhook-cache-unauthorized-ttl"`
 	// AuthorizationRBACSuperUser is the name of the superuser for default rbac
 	AuthorizationRBACSuperUser *string `json:"authorizationRbacSuperUser,omitempty" flag:"authorization-rbac-super-user"`
 	// ExperimentalEncryptionProviderConfig enables encryption at rest for secrets.

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -3017,6 +3017,9 @@ func autoConvert_v1alpha1_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.AuthenticationTokenWebhookConfigFile = in.AuthenticationTokenWebhookConfigFile
 	out.AuthenticationTokenWebhookCacheTTL = in.AuthenticationTokenWebhookCacheTTL
 	out.AuthorizationMode = in.AuthorizationMode
+	out.AuthorizationWebhookConfigFile = in.AuthorizationWebhookConfigFile
+	out.AuthorizationWebhookCacheAuthorizedTTL = in.AuthorizationWebhookCacheAuthorizedTTL
+	out.AuthorizationWebhookCacheUnauthorizedTTL = in.AuthorizationWebhookCacheUnauthorizedTTL
 	out.AuthorizationRBACSuperUser = in.AuthorizationRBACSuperUser
 	out.ExperimentalEncryptionProviderConfig = in.ExperimentalEncryptionProviderConfig
 	out.RequestheaderUsernameHeaders = in.RequestheaderUsernameHeaders
@@ -3108,6 +3111,9 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha1_KubeAPIServerConfig(in *ko
 	out.AuthenticationTokenWebhookConfigFile = in.AuthenticationTokenWebhookConfigFile
 	out.AuthenticationTokenWebhookCacheTTL = in.AuthenticationTokenWebhookCacheTTL
 	out.AuthorizationMode = in.AuthorizationMode
+	out.AuthorizationWebhookConfigFile = in.AuthorizationWebhookConfigFile
+	out.AuthorizationWebhookCacheAuthorizedTTL = in.AuthorizationWebhookCacheAuthorizedTTL
+	out.AuthorizationWebhookCacheUnauthorizedTTL = in.AuthorizationWebhookCacheUnauthorizedTTL
 	out.AuthorizationRBACSuperUser = in.AuthorizationRBACSuperUser
 	out.ExperimentalEncryptionProviderConfig = in.ExperimentalEncryptionProviderConfig
 	out.RequestheaderUsernameHeaders = in.RequestheaderUsernameHeaders

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -1822,30 +1822,18 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 	}
 	if in.AuthorizationWebhookConfigFile != nil {
 		in, out := &in.AuthorizationWebhookConfigFile, &out.AuthorizationWebhookConfigFile
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	if in.AuthorizationWebhookCacheAuthorizedTTL != nil {
 		in, out := &in.AuthorizationWebhookCacheAuthorizedTTL, &out.AuthorizationWebhookCacheAuthorizedTTL
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	if in.AuthorizationWebhookCacheUnauthorizedTTL != nil {
 		in, out := &in.AuthorizationWebhookCacheUnauthorizedTTL, &out.AuthorizationWebhookCacheUnauthorizedTTL
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	if in.AuthorizationRBACSuperUser != nil {
 		in, out := &in.AuthorizationRBACSuperUser, &out.AuthorizationRBACSuperUser

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -1820,6 +1820,33 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.AuthorizationWebhookConfigFile != nil {
+		in, out := &in.AuthorizationWebhookConfigFile, &out.AuthorizationWebhookConfigFile
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
+	if in.AuthorizationWebhookCacheAuthorizedTTL != nil {
+		in, out := &in.AuthorizationWebhookCacheAuthorizedTTL, &out.AuthorizationWebhookCacheAuthorizedTTL
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
+	if in.AuthorizationWebhookCacheUnauthorizedTTL != nil {
+		in, out := &in.AuthorizationWebhookCacheUnauthorizedTTL, &out.AuthorizationWebhookCacheUnauthorizedTTL
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
 	if in.AuthorizationRBACSuperUser != nil {
 		in, out := &in.AuthorizationRBACSuperUser, &out.AuthorizationRBACSuperUser
 		*out = new(string)

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -385,6 +385,12 @@ type KubeAPIServerConfig struct {
 	AuthenticationTokenWebhookCacheTTL *metav1.Duration `json:"authenticationTokenWebhookCacheTtl,omitempty" flag:"authentication-token-webhook-cache-ttl"`
 	// AuthorizationMode is the authorization mode the kubeapi is running in
 	AuthorizationMode *string `json:"authorizationMode,omitempty" flag:"authorization-mode"`
+	// File with webhook configuration for authorization in kubeconfig format. The API server will query the remote service to determine whether to authorize the request.
+	AuthorizationWebhookConfigFile *string `json:"authorizationWebhookConfigFile,omitempty" flag:"authorization-webhook-config-file"`
+	// The duration to cache authorized responses from the webhook token authorizer. Default is 5m. (default 5m0s)
+	AuthorizationWebhookCacheAuthorizedTTL *metav1.Duration `json:"authorizationWebhookCacheAuthorizedTtl,omitempty" flag:"authorization-webhook-cache-authorized-ttl"`
+	// The duration to cache authorized responses from the webhook token authorizer. Default is 30s. (default 30s)
+	AuthorizationWebhookCacheUnauthorizedTTL *metav1.Duration `json:"authorizationWebhookCacheUnauthorizedTtl,omitempty" flag:"authorization-webhook-cache-unauthorized-ttl"`
 	// AuthorizationRBACSuperUser is the name of the superuser for default rbac
 	AuthorizationRBACSuperUser *string `json:"authorizationRbacSuperUser,omitempty" flag:"authorization-rbac-super-user"`
 	// ExperimentalEncryptionProviderConfig enables encryption at rest for secrets.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3287,6 +3287,9 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.AuthenticationTokenWebhookConfigFile = in.AuthenticationTokenWebhookConfigFile
 	out.AuthenticationTokenWebhookCacheTTL = in.AuthenticationTokenWebhookCacheTTL
 	out.AuthorizationMode = in.AuthorizationMode
+	out.AuthorizationWebhookConfigFile = in.AuthorizationWebhookConfigFile
+	out.AuthorizationWebhookCacheAuthorizedTTL = in.AuthorizationWebhookCacheAuthorizedTTL
+	out.AuthorizationWebhookCacheUnauthorizedTTL = in.AuthorizationWebhookCacheUnauthorizedTTL
 	out.AuthorizationRBACSuperUser = in.AuthorizationRBACSuperUser
 	out.ExperimentalEncryptionProviderConfig = in.ExperimentalEncryptionProviderConfig
 	out.RequestheaderUsernameHeaders = in.RequestheaderUsernameHeaders
@@ -3378,6 +3381,9 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.AuthenticationTokenWebhookConfigFile = in.AuthenticationTokenWebhookConfigFile
 	out.AuthenticationTokenWebhookCacheTTL = in.AuthenticationTokenWebhookCacheTTL
 	out.AuthorizationMode = in.AuthorizationMode
+	out.AuthorizationWebhookConfigFile = in.AuthorizationWebhookConfigFile
+	out.AuthorizationWebhookCacheAuthorizedTTL = in.AuthorizationWebhookCacheAuthorizedTTL
+	out.AuthorizationWebhookCacheUnauthorizedTTL = in.AuthorizationWebhookCacheUnauthorizedTTL
 	out.AuthorizationRBACSuperUser = in.AuthorizationRBACSuperUser
 	out.ExperimentalEncryptionProviderConfig = in.ExperimentalEncryptionProviderConfig
 	out.RequestheaderUsernameHeaders = in.RequestheaderUsernameHeaders

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1891,6 +1891,33 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.AuthorizationWebhookConfigFile != nil {
+		in, out := &in.AuthorizationWebhookConfigFile, &out.AuthorizationWebhookConfigFile
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
+	if in.AuthorizationWebhookCacheAuthorizedTTL != nil {
+		in, out := &in.AuthorizationWebhookCacheAuthorizedTTL, &out.AuthorizationWebhookCacheAuthorizedTTL
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
+	if in.AuthorizationWebhookCacheUnauthorizedTTL != nil {
+		in, out := &in.AuthorizationWebhookCacheUnauthorizedTTL, &out.AuthorizationWebhookCacheUnauthorizedTTL
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
 	if in.AuthorizationRBACSuperUser != nil {
 		in, out := &in.AuthorizationRBACSuperUser, &out.AuthorizationRBACSuperUser
 		*out = new(string)

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1893,30 +1893,18 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 	}
 	if in.AuthorizationWebhookConfigFile != nil {
 		in, out := &in.AuthorizationWebhookConfigFile, &out.AuthorizationWebhookConfigFile
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	if in.AuthorizationWebhookCacheAuthorizedTTL != nil {
 		in, out := &in.AuthorizationWebhookCacheAuthorizedTTL, &out.AuthorizationWebhookCacheAuthorizedTTL
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	if in.AuthorizationWebhookCacheUnauthorizedTTL != nil {
 		in, out := &in.AuthorizationWebhookCacheUnauthorizedTTL, &out.AuthorizationWebhookCacheUnauthorizedTTL
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	if in.AuthorizationRBACSuperUser != nil {
 		in, out := &in.AuthorizationRBACSuperUser, &out.AuthorizationRBACSuperUser

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -266,6 +266,13 @@ func validateKubeAPIServer(v *kops.KubeAPIServerConfig, fldPath *field.Path) fie
 		}
 	}
 
+	if v.AuthorizationMode != nil && strings.Contains(*v.AuthorizationMode, "Webhook") {
+		if v.AuthorizationWebhookConfigFile == nil {
+			flds := [2]*string{v.AuthorizationMode, v.AuthorizationWebhookConfigFile}
+			allErrs = append(allErrs, field.Invalid(fldPath, flds, "Authorization mode Webhook requires AuthorizationWebhookConfigFile to be specified"))
+		}
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2075,30 +2075,18 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 	}
 	if in.AuthorizationWebhookConfigFile != nil {
 		in, out := &in.AuthorizationWebhookConfigFile, &out.AuthorizationWebhookConfigFile
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	if in.AuthorizationWebhookCacheAuthorizedTTL != nil {
 		in, out := &in.AuthorizationWebhookCacheAuthorizedTTL, &out.AuthorizationWebhookCacheAuthorizedTTL
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	if in.AuthorizationWebhookCacheUnauthorizedTTL != nil {
 		in, out := &in.AuthorizationWebhookCacheUnauthorizedTTL, &out.AuthorizationWebhookCacheUnauthorizedTTL
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	if in.AuthorizationRBACSuperUser != nil {
 		in, out := &in.AuthorizationRBACSuperUser, &out.AuthorizationRBACSuperUser

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2073,6 +2073,33 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.AuthorizationWebhookConfigFile != nil {
+		in, out := &in.AuthorizationWebhookConfigFile, &out.AuthorizationWebhookConfigFile
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
+	if in.AuthorizationWebhookCacheAuthorizedTTL != nil {
+		in, out := &in.AuthorizationWebhookCacheAuthorizedTTL, &out.AuthorizationWebhookCacheAuthorizedTTL
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
+	if in.AuthorizationWebhookCacheUnauthorizedTTL != nil {
+		in, out := &in.AuthorizationWebhookCacheUnauthorizedTTL, &out.AuthorizationWebhookCacheUnauthorizedTTL
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
 	if in.AuthorizationRBACSuperUser != nil {
 		in, out := &in.AuthorizationRBACSuperUser, &out.AuthorizationRBACSuperUser
 		*out = new(string)

--- a/pkg/flagbuilder/buildflags_test.go
+++ b/pkg/flagbuilder/buildflags_test.go
@@ -196,6 +196,24 @@ func TestBuildAPIServerFlags(t *testing.T) {
 			},
 			Expected: "--audit-webhook-batch-max-size=1000 --insecure-port=0 --secure-port=0",
 		},
+		{
+			Config: &kops.KubeAPIServerConfig{
+				AuthorizationWebhookConfigFile: fi.String("/authorization.yaml"),
+			},
+			Expected: "--authorization-webhook-config-file=/authorization.yaml --insecure-port=0 --secure-port=0",
+		},
+		{
+			Config: &kops.KubeAPIServerConfig{
+				AuthorizationWebhookCacheAuthorizedTTL: &metav1.Duration{Duration: 100 * time.Second},
+			},
+			Expected: "--authorization-webhook-cache-authorized-ttl=1m40s --insecure-port=0 --secure-port=0",
+		},
+		{
+			Config: &kops.KubeAPIServerConfig{
+				AuthorizationWebhookCacheUnauthorizedTTL: &metav1.Duration{Duration: 10 * time.Second},
+			},
+			Expected: "--authorization-webhook-cache-unauthorized-ttl=10s --insecure-port=0 --secure-port=0",
+		},
 	}
 
 	for _, test := range grid {


### PR DESCRIPTION
Adding the missing parameters I reported as an [issue](https://github.com/kubernetes/kops/issues/7321) the other day. First PR in a go repository so bear with me. Had a look at [previous similar addition](https://github.com/kubernetes/kops/commit/720174c678d934a4a2a28e10d39af7252fb81d56) an tried to figure it out from there. Added a few tests to verify and tested setting up a new cluster with the added parameters as well.