### PR TITLE
stop kubelet to prevent orphan containers

### DIFF
--- a/hooks/nvidia-device-plugin/image/files/02-nvidia-docker.sh
+++ b/hooks/nvidia-device-plugin/image/files/02-nvidia-docker.sh
@@ -66,6 +66,11 @@ EOF
 # Note that the nvidia-docker version must match the docker-ce version
 # --force-confold prevents prompt for replacement of daemon.json
 apt-get -y update
+# Stop protokube to ensure not bring kubelet up again
+systemctl stop protokube
+# Stop kubelet to ensure not bring stopped containers up again and leak
+# them as orphan containers
+systemctl stop kubelet
 # pin versions https://github.com/NVIDIA/nvidia-docker/wiki/Frequently-Asked-Questions#how-do-i-install-20-if-im-not-using-the-latest-docker-version
 apt-get install -y --allow-downgrades -o Dpkg::Options::="--force-confold" \
   nvidia-docker2=2.0.3+docker18.09.4-1 \
@@ -79,3 +84,6 @@ apt-get install -y --allow-downgrades -o Dpkg::Options::="--force-confold" \
 #  Permanently disable these systemd units via masking.
 systemctl mask cloud-init.service
 systemctl mask kops-configuration.service
+
+# Restore protokube and protokube will bring up kubelet
+systemctl start protokube


### PR DESCRIPTION
xref #6728

When install the nvidia docker runtime, kubelet will try to restart stopped containers via old docker. This will leak those containers as orphan containers.