### PR TITLE
Add maxPersistentVolumes to support the KUBE_MAX_PD_VOLS scheduler setting

### DIFF
--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"fmt"
+	"strconv"
 
 	"k8s.io/kops/pkg/flagbuilder"
 	"k8s.io/kops/pkg/k8scodecs"
@@ -162,6 +163,14 @@ func (b *KubeSchedulerBuilder) buildPod() (*v1.Pod, error) {
 			"/usr/local/bin/kube-scheduler",
 			sortedStrings(flags),
 			"/var/log/kube-scheduler.log")
+	}
+
+	if c.MaxPersistentVolumes != nil {
+		maxPDV := v1.EnvVar{
+			Name:  "KUBE_MAX_PD_VOLS", // https://kubernetes.io/docs/concepts/storage/storage-limits/
+			Value: strconv.Itoa(int(*c.MaxPersistentVolumes)),
+		}
+		container.Env = append(container.Env, maxPDV)
 	}
 
 	pod.Spec.Containers = append(pod.Spec.Containers, *container)

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -553,6 +553,11 @@ type KubeSchedulerConfig struct {
 	UsePolicyConfigMap *bool `json:"usePolicyConfigMap,omitempty"`
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
+	// MaxPersistentVolumes changes the maximum number of persistent volumes the scheduler will scheduler onto the same
+	// node. Only takes into affect if value is positive. This corresponds to the KUBE_MAX_PD_VOLS environment variable,
+	// which has been supported as far back as Kubernetes 1.7. The default depends on the version and the cloud provider
+	// as outlined: https://kubernetes.io/docs/concepts/storage/storage-limits/
+	MaxPersistentVolumes *int32 `json:"maxPersistentVolumes,omitempty"`
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -553,6 +553,11 @@ type KubeSchedulerConfig struct {
 	UsePolicyConfigMap *bool `json:"usePolicyConfigMap,omitempty"`
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
+	// MaxPersistentVolumes changes the maximum number of persistent volumes the scheduler will scheduler onto the same
+	// node. Only takes into affect if value is positive. This corresponds to the KUBE_MAX_PD_VOLS environment variable,
+	// which has been supported as far back as Kubernetes 1.7. The default depends on the version and the cloud provider
+	// as outlined: https://kubernetes.io/docs/concepts/storage/storage-limits/
+	MaxPersistentVolumes *int32 `json:"maxPersistentVolumes,omitempty"`
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -3345,6 +3345,7 @@ func autoConvert_v1alpha1_KubeSchedulerConfig_To_kops_KubeSchedulerConfig(in *Ku
 	}
 	out.UsePolicyConfigMap = in.UsePolicyConfigMap
 	out.FeatureGates = in.FeatureGates
+	out.MaxPersistentVolumes = in.MaxPersistentVolumes
 	return nil
 }
 
@@ -3368,6 +3369,7 @@ func autoConvert_kops_KubeSchedulerConfig_To_v1alpha1_KubeSchedulerConfig(in *ko
 	}
 	out.UsePolicyConfigMap = in.UsePolicyConfigMap
 	out.FeatureGates = in.FeatureGates
+	out.MaxPersistentVolumes = in.MaxPersistentVolumes
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2152,6 +2152,11 @@ func (in *KubeSchedulerConfig) DeepCopyInto(out *KubeSchedulerConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.MaxPersistentVolumes != nil {
+		in, out := &in.MaxPersistentVolumes, &out.MaxPersistentVolumes
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -553,6 +553,11 @@ type KubeSchedulerConfig struct {
 	UsePolicyConfigMap *bool `json:"usePolicyConfigMap,omitempty"`
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
+	// MaxPersistentVolumes changes the maximum number of persistent volumes the scheduler will scheduler onto the same
+	// node. Only takes into affect if value is positive. This corresponds to the KUBE_MAX_PD_VOLS environment variable,
+	// which has been supported as far back as Kubernetes 1.7. The default depends on the version and the cloud provider
+	// as outlined: https://kubernetes.io/docs/concepts/storage/storage-limits/
+	MaxPersistentVolumes *int32 `json:"maxPersistentVolumes,omitempty"`
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3615,6 +3615,7 @@ func autoConvert_v1alpha2_KubeSchedulerConfig_To_kops_KubeSchedulerConfig(in *Ku
 	}
 	out.UsePolicyConfigMap = in.UsePolicyConfigMap
 	out.FeatureGates = in.FeatureGates
+	out.MaxPersistentVolumes = in.MaxPersistentVolumes
 	return nil
 }
 
@@ -3638,6 +3639,7 @@ func autoConvert_kops_KubeSchedulerConfig_To_v1alpha2_KubeSchedulerConfig(in *ko
 	}
 	out.UsePolicyConfigMap = in.UsePolicyConfigMap
 	out.FeatureGates = in.FeatureGates
+	out.MaxPersistentVolumes = in.MaxPersistentVolumes
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2223,6 +2223,11 @@ func (in *KubeSchedulerConfig) DeepCopyInto(out *KubeSchedulerConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.MaxPersistentVolumes != nil {
+		in, out := &in.MaxPersistentVolumes, &out.MaxPersistentVolumes
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2405,6 +2405,11 @@ func (in *KubeSchedulerConfig) DeepCopyInto(out *KubeSchedulerConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.MaxPersistentVolumes != nil {
+		in, out := &in.MaxPersistentVolumes, &out.MaxPersistentVolumes
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
This PR adds `maxPersistentVolumes` to the `KubeSchedulerConfig` struct, which allows the cluster operator to set the `KUBE_MAX_PD_VOLS` environment variable on the kube-scheduler static pod manifest to set a [custom node-specific volume limit](https://kubernetes.io/docs/concepts/storage/storage-limits/#custom-limits).

This env-var has been supported as far back as the [Kubernetes 1.7 scheduler](https://github.com/kubernetes/kubernetes/blob/release-1.7/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go#L49), which is older than the kops compatibility matrix. As such, I didn't add a Kubernetes version guard check; I also didn't bother going further back.

*Background:* We unfortunately need this, because even dynamic volume limits (supported in k8s 1.15) is still not conservative enough. Pods needing a PV (AWS EBS in our case) end up getting scheduled on instances that do not support additional volumes. Specifically, we use [amazon-vpc-cni](https://github.com/aws/amazon-vpc-cni-k8s/), which assigns each pod a first-class VPC IP address; each AWS ENI counts as an attachment which lowers the maximum number of supported volumes.