### PR TITLE
Bump etcd-manager to 3.0.20190801

### DIFF
--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/loader"
 )
 
-const DefaultBackupImage = "kopeio/etcd-backup:3.0.20190516"
+const DefaultBackupImage = "kopeio/etcd-backup:3.0.20190801"
 
 // EtcdOptionsBuilder adds options for etcd to the model
 type EtcdOptionsBuilder struct {

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -189,7 +189,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - image: kopeio/etcd-manager:3.0.20190516
+  - image: kopeio/etcd-manager:3.0.20190801
     name: etcd-manager
     resources:
       requests:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -89,7 +89,7 @@ Contents:
           --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
           --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
           > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20190516
+        image: kopeio/etcd-manager:3.0.20190801
         name: etcd-manager
         resources:
           requests:
@@ -160,7 +160,7 @@ Contents:
           --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
           --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
           > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20190516
+        image: kopeio/etcd-manager:3.0.20190801
         name: etcd-manager
         resources:
           requests:


### PR DESCRIPTION
Relnotes are at https://github.com/kopeio/etcd-manager/blob/master/docs/relnotes/3.0.20190801.md

Highlights:

* etcd-manager-ctl is now available in the image, and for download from github
* etcd 3.3.13 is included
* etcd-manager will now run a compatible version of etcd if it is available (for example, etcd 3.3.13 instead of 3.3.11), to better import backups or support migration
* listen-metrics-urls can now be specified and will be passed through to etcd
* improved docs around internals