### PR TITLE
Set and mount the correct volume plugin dir based on OS

### DIFF
--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -19,13 +19,13 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/spf13/viper"
 	"io"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -409,6 +409,21 @@ spec:
     amazonvpc: {}
 ```
 
+#### Configure a Flex Volume plugin directory
+An optional flag can be provided within the KubeletSpec to set a volume plugin directory (must be accessible for read/write operations), which is additionally provided to the Controller Manager and mounted in accordingly.
+
+Kops will set this for you based off the Operating System in use:
+- ContainerOS: `/home/kubernetes/flexvolume/`
+- CoreOS: `/var/lib/kubelet/volumeplugins/`
+- Default (in-line with upstream k8s): `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`
+
+If you wish to override this value, it can be done so with the following addition to the kubelet spec:
+```yaml
+spec:
+  kubelet:
+    volumePluginDirectory: /provide/a/writable/path/here
+```
+
 ### kubeScheduler
 
 This block contains configurations for `kube-scheduler`.  See https://kubernetes.io/docs/admin/kube-scheduler/
@@ -443,7 +458,7 @@ Specifying KubeDNS will install kube-dns as the default service discovery.
 
 This will install [CoreDNS](https://coredns.io/) instead of kube-dns.
 
-**Note:** If you are upgrading to CoreDNS, kube-dns will be left in place and must be removed manually (you can scale the kube-dns and kube-dns-autoscaler deployments in the `kube-system` namespace to 0 as a starting point). The `kube-dns` Service itself should be left in place, as this retains the ClusterIP and eliminates the possibility of DNS outages in your cluster. If you would like to continue autoscaling, update the `kube-dns-autoscaler` Deployment container command for `--target=Deployment/kube-dns` to be `--target=Deployment/coredns`. 
+**Note:** If you are upgrading to CoreDNS, kube-dns will be left in place and must be removed manually (you can scale the kube-dns and kube-dns-autoscaler deployments in the `kube-system` namespace to 0 as a starting point). The `kube-dns` Service itself should be left in place, as this retains the ClusterIP and eliminates the possibility of DNS outages in your cluster. If you would like to continue autoscaling, update the `kube-dns-autoscaler` Deployment container command for `--target=Deployment/kube-dns` to be `--target=Deployment/coredns`.
 
 ### kubeControllerManager
 This block contains configurations for the `controller-manager`.

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -160,15 +160,19 @@ func (b *KubeControllerManagerBuilder) buildPod() (*v1.Pod, error) {
 		switch b.Distribution {
 		case distros.DistributionContainerOS:
 			// Default is different on ContainerOS, see https://github.com/kubernetes/kubernetes/pull/58171
-			volumePluginDir = "/home/kubernetes/flexvolume"
+			volumePluginDir = "/home/kubernetes/flexvolume/"
+
+		case distros.DistributionCoreOS:
+			// The /usr directory is read-only for CoreOS
+			volumePluginDir = "/var/lib/kubelet/volumeplugins/"
 
 		default:
-			volumePluginDir = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec"
+			volumePluginDir = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
 		}
-	} else {
-		// If volume-plugin-dir flag is set in kubelet, match dir in kube-controller
-		flags = append(flags, "--flex-volume-plugin-dir="+volumePluginDir)
 	}
+
+	// Add the volumePluginDir flag if provided in the kubelet spec, or set above based on the OS
+	flags = append(flags, "--flex-volume-plugin-dir="+volumePluginDir)
 
 	container := &v1.Container{
 		Name:  "kube-controller-manager",

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -591,6 +591,21 @@ func (b *KubeletBuilder) buildKubeletConfigSpec() (*kops.KubeletConfigSpec, erro
 		// For 1.5 and earlier, protokube will taint the master
 	}
 
+	if c.VolumePluginDirectory == "" {
+		switch b.Distribution {
+		case distros.DistributionContainerOS:
+			// Default is different on ContainerOS, see https://github.com/kubernetes/kubernetes/pull/58171
+			c.VolumePluginDirectory = "/home/kubernetes/flexvolume/"
+
+		case distros.DistributionCoreOS:
+			// The /usr directory is read-only for CoreOS
+			c.VolumePluginDirectory = "/var/lib/kubelet/volumeplugins/"
+
+		default:
+			c.VolumePluginDirectory = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
+		}
+	}
+
 	return c, nil
 }
 

--- a/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
@@ -3,7 +3,7 @@ path: /etc/kubernetes/manifests
 type: directory
 ---
 contents: |
-  DAEMON_ARGS="--feature-gates=AllowExtTrafficLocalEndpoints=false,ExperimentalCriticalPodAnnotation=true --node-labels=kubernetes.io/role=node,node-role.kubernetes.io/node= --pod-manifest-path=/etc/kubernetes/manifests --cni-bin-dir=/opt/cni/bin/ --cni-conf-dir=/etc/cni/net.d/ --network-plugin-dir=/opt/cni/bin/"
+  DAEMON_ARGS="--feature-gates=AllowExtTrafficLocalEndpoints=false,ExperimentalCriticalPodAnnotation=true --node-labels=kubernetes.io/role=node,node-role.kubernetes.io/node= --pod-manifest-path=/etc/kubernetes/manifests --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cni-bin-dir=/opt/cni/bin/ --cni-conf-dir=/etc/cni/net.d/ --network-plugin-dir=/opt/cni/bin/"
   HOME="/root"
 path: /etc/sysconfig/kubelet
 type: file

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -146,7 +146,7 @@ type KubeletConfigSpec struct {
 	EvictionMaxPodGracePeriod int32 `json:"evictionMaxPodGracePeriod,omitempty" flag:"eviction-max-pod-grace-period" flag-empty:"0"`
 	// Comma-delimited list of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.
 	EvictionMinimumReclaim string `json:"evictionMinimumReclaim,omitempty" flag:"eviction-minimum-reclaim"`
-	// The full path of the directory in which to search for additional third party volume plugins
+	// The full path of the directory in which to search for additional third party volume plugins (this path must be writeable, dependant on your choice of OS)
 	VolumePluginDirectory string `json:"volumePluginDirectory,omitempty" flag:"volume-plugin-dir"`
 	// Taints to add when registering a node in the cluster
 	Taints []string `json:"taints,omitempty" flag:"register-with-taints"`

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -146,7 +146,7 @@ type KubeletConfigSpec struct {
 	EvictionMaxPodGracePeriod int32 `json:"evictionMaxPodGracePeriod,omitempty" flag:"eviction-max-pod-grace-period" flag-empty:"0"`
 	// Comma-delimited list of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.
 	EvictionMinimumReclaim string `json:"evictionMinimumReclaim,omitempty" flag:"eviction-minimum-reclaim"`
-	// The full path of the directory in which to search for additional third party volume plugins
+	// The full path of the directory in which to search for additional third party volume plugins (this path must be writeable, dependant on your choice of OS)
 	VolumePluginDirectory string `json:"volumePluginDirectory,omitempty" flag:"volume-plugin-dir"`
 	// Taints to add when registering a node in the cluster
 	Taints []string `json:"taints,omitempty" flag:"register-with-taints"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -146,7 +146,7 @@ type KubeletConfigSpec struct {
 	EvictionMaxPodGracePeriod int32 `json:"evictionMaxPodGracePeriod,omitempty" flag:"eviction-max-pod-grace-period" flag-empty:"0"`
 	// Comma-delimited list of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.
 	EvictionMinimumReclaim string `json:"evictionMinimumReclaim,omitempty" flag:"eviction-minimum-reclaim"`
-	// The full path of the directory in which to search for additional third party volume plugins
+	// The full path of the directory in which to search for additional third party volume plugins (this path must be writeable, dependant on your choice of OS)
 	VolumePluginDirectory string `json:"volumePluginDirectory,omitempty" flag:"volume-plugin-dir"`
 	// Taints to add when registering a node in the cluster
 	Taints []string `json:"taints,omitempty" flag:"register-with-taints"`


### PR DESCRIPTION
Following the introduction of PR #6874 we had the following occur:
- A flex volume plugin directory was mounted on the kube controller manager even when no flag was specified
- The default flex volume plugin directory is not writeable for certain Operating Systems (e.g. CoreOS)

This PR will set the volume plugin dir according to OS (both for kubelet and controller manager) and always provides the flag to the controller manager.