### PR TITLE
 Don't default adding MIMEBOUNDARY headers when a mixed instances policy is set

### DIFF
--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -189,7 +189,7 @@ func AWSNodeUpTemplate(ig *kops.InstanceGroup) (string, error) {
 
 	userDataTemplate := NodeUpTemplate
 
-	if len(ig.Spec.AdditionalUserData) > 0 || ig.Spec.MixedInstancesPolicy != nil {
+	if len(ig.Spec.AdditionalUserData) > 0 {
 		/* Create a buffer to hold the user-data*/
 		buffer := bytes.NewBufferString("")
 		writer := bufio.NewWriter(buffer)

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
@@ -899,15 +899,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
   download-release
   echo "== nodeup node config done =="
 Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: |
-  Content-Type: multipart/mixed; boundary="MIMEBOUNDARY"
-  MIME-Version: 1.0
-
-  --MIMEBOUNDARY
-  Content-Disposition: attachment; filename="nodeup.sh"
-  Content-Transfer-Encoding: 7bit
-  Content-Type: text/x-shellscript
-  Mime-Version: 1.0
-
   #!/bin/bash
   # Copyright 2016 The Kubernetes Authors All rights reserved.
   #
@@ -1121,5 +1112,3 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
 
   download-release
   echo "== nodeup node config done =="
-
-  --MIMEBOUNDARY--

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
@@ -899,15 +899,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
   download-release
   echo "== nodeup node config done =="
 Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: |
-  Content-Type: multipart/mixed; boundary="MIMEBOUNDARY"
-  MIME-Version: 1.0
-
-  --MIMEBOUNDARY
-  Content-Disposition: attachment; filename="nodeup.sh"
-  Content-Transfer-Encoding: 7bit
-  Content-Type: text/x-shellscript
-  Mime-Version: 1.0
-
   #!/bin/bash
   # Copyright 2016 The Kubernetes Authors All rights reserved.
   #
@@ -1121,5 +1112,3 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
 
   download-release
   echo "== nodeup node config done =="
-
-  --MIMEBOUNDARY--


### PR DESCRIPTION
Currently the MIMEBOUNDARY header is added if one of the following cases is met:
- `AdditionalUserData` is set on an Instance Group
- `MixedInstancesPolicy` is set on an Instance Group

The latter being set on an IG for a CoreOS nodepool now breaks on provisioning the nodes, as CoreOS doesn't support MIME messages. It is still set as required when `AdditionalUserData` has been provided, but will need follow-up with further investigation to get additional user data scripts working when using CoreOS.

- Regressed in #6732 for CoreOS
- Fixes #7091
