### PR TITLE
Upgrading k8s-srcdst to v0.2.2

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -787,7 +787,7 @@ spec:
         operator: Exists
       serviceAccountName: k8s-ec2-srcdst
       containers:
-        - image: ottoyiu/k8s-ec2-srcdst:v0.2.1
+        - image: ottoyiu/k8s-ec2-srcdst:v0.2.2
           name: k8s-ec2-srcdst
           resources:
             requests:


### PR DESCRIPTION
Version upgrade:
* v0.2.2 - fix unexpected panic when a Node gets deleted