### PR TITLE
Upate Lyft CNI to v0.5.1

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -502,9 +502,9 @@ for Kubernetes specific CNI challenges.
 
 #### Lyft CNI
 
-The [lyft cni-ipvlan-vpc-k8s](https://github.com/lyft/cni-ipvlan-vpc-k8s) plugin uses Amazon Elastic Network Interfaces (ENI) to assing AWS-managed IPs to Pods using the Linux kernel's IPvlan driver in L2 mode.
+The [lyft cni-ipvlan-vpc-k8s](https://github.com/lyft/cni-ipvlan-vpc-k8s) plugin uses Amazon Elastic Network Interfaces (ENI) to assign AWS-managed IPs to Pods using the Linux kernel's IPvlan driver in L2 mode.
 
-Read the [prerequisites](https://github.com/lyft/cni-ipvlan-vpc-k8s#prerequisites) before starting.
+Read the [prerequisites](https://github.com/lyft/cni-ipvlan-vpc-k8s#prerequisites) before starting. In addition to that, you need to specify the VPC ID as `spec.networkID` in the cluster spec file.
 
 To use the Lyft CNI plugin you specify
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -527,7 +527,7 @@ $ kops create cluster \
   --name myclustername.mydns.io
 ```
 
-You can specify which subnets to use for allocating Pod IPs by specifing
+You can specify which subnets to use for allocating Pod IPs by specifying
 
 ```
   networking:

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -43,6 +43,7 @@ Several different CNI providers are currently built into kops:
 * [weave](https://github.com/weaveworks/weave)
 * [amazon-vpc-routed-eni](./networking.md#amazon-vpc-backend)
 * [Cilium](http://docs.cilium.io)
+* [Lyft cni-ipvlan-vpc-k8s](https://github.com/lyft/cni-ipvlan-vpc-k8s)
 
 The manifests for the providers are included with kops, and you simply use `--networking provider-name`.
 Replace the provider name with the names listed above with you `kops cluster create`.  For instance
@@ -498,6 +499,75 @@ Here are some steps items that will confirm a good CNI install:
 
 The sig-networking and sig-cluster-lifecycle channels on K8s slack are always good starting places
 for Kubernetes specific CNI challenges.
+
+#### Lyft CNI
+
+The [lyft cni-ipvlan-vpc-k8s](https://github.com/lyft/cni-ipvlan-vpc-k8s) plugin uses Amazon Elastic Network Interfaces (ENI) to assing AWS-managed IPs to Pods using the Linux kernel's IPvlan driver in L2 mode.
+
+Read the [prerequisites](https://github.com/lyft/cni-ipvlan-vpc-k8s#prerequisites) before starting.
+
+To use the Lyft CNI plugin you specify
+
+```
+  networking:
+    lyftvpc: {}
+```
+
+in the cluster spec file or pass the `--networking lyftvpc` option on the command line to kops:
+
+```console
+$ export ZONES=mylistofzones
+$ kops create cluster \
+  --zones $ZONES \
+  --master-zones $ZONES \
+  --master-size m4.large \
+  --node-size m4.large \
+  --networking lyftvpc \
+  --yes \
+  --name myclustername.mydns.io
+```
+
+You can specify which subnets to use for allocating Pod IPs by specifing
+
+```
+  networking:
+    lyftvpc:
+      subnetTags:
+        kubernetes_kubelet: true
+```
+
+In this example, new interfaces will be attached to subnets tagged with `kubernetes_kubelet = true`.
+
+**Note:** The following permissions are added to all nodes by kops to run the provider:
+
+```json
+  {
+    "Sid": "kopsK8sEC2NodeAmazonVPCPerms",
+    "Effect": "Allow",
+    "Action": [
+      "ec2:CreateNetworkInterface",
+      "ec2:AttachNetworkInterface",
+      "ec2:DeleteNetworkInterface",
+      "ec2:DetachNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DescribeInstances",
+      "ec2:ModifyNetworkInterfaceAttribute",
+      "ec2:AssignPrivateIpAddresses",
+      "ec2:UnassignPrivateIpAddresses",
+      "tag:TagResources"
+    ],
+    "Resource": [
+      "*"
+    ]
+  },
+  {
+    "Effect": "Allow",
+    "Action": "ec2:CreateTags",
+    "Resource": "arn:aws:ec2:*:*:network-interface/*"
+  }
+```
+
+In case of any issues the directory `/var/log/aws-routed-eni` contains the log files of the CNI plugin. This directory is located in all the nodes in the cluster.
 
 ## Switching between networking providers
 

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -855,6 +855,7 @@ func addLyftVPCPermissions(p *Policy, resource stringorslice.StringOrSlice, lega
 				"ec2:DetachNetworkInterface",
 				"ec2:DeleteNetworkInterface",
 				"ec2:ModifyNetworkInterfaceAttribute",
+				"ec2:DescribeVpcs",
 			}),
 			Resource: resource,
 		},

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1153,8 +1153,8 @@ func (c *ApplyClusterCmd) AddFileAssets(assetBuilder *assets.AssetBuilder) error
 
 		urlString := os.Getenv("LYFT_VPC_DOWNLOAD_URL")
 		if urlString == "" {
-			urlString = "https://github.com/lyft/cni-ipvlan-vpc-k8s/releases/download/v0.5.0/cni-ipvlan-vpc-k8s-v0.5.0.tar.gz"
-			hash, err = hashing.FromString("0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5")
+			urlString = "https://github.com/lyft/cni-ipvlan-vpc-k8s/releases/download/v0.5.1/cni-ipvlan-vpc-k8s-v0.5.1.tar.gz"
+			hash, err = hashing.FromString("6e8308bc3205a9f88998df5ba5f0d3845a84ec8ff207a698277dd51eb7e3fb52")
 			if err != nil {
 				// Should be impossible
 				return fmt.Errorf("invalid hard-coded hash for lyft url")

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1153,8 +1153,8 @@ func (c *ApplyClusterCmd) AddFileAssets(assetBuilder *assets.AssetBuilder) error
 
 		urlString := os.Getenv("LYFT_VPC_DOWNLOAD_URL")
 		if urlString == "" {
-			urlString = "https://github.com/lyft/cni-ipvlan-vpc-k8s/releases/download/v0.4.2/cni-ipvlan-vpc-k8s-v0.4.2.tar.gz"
-			hash, err = hashing.FromString("bfdc65028a3bf8ffe14388fca28ede3600e7e2dee4e781908b6a23f9e79f86ad")
+			urlString = "https://github.com/lyft/cni-ipvlan-vpc-k8s/releases/download/v0.5.0/cni-ipvlan-vpc-k8s-v0.5.0.tar.gz"
+			hash, err = hashing.FromString("0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5")
 			if err != nil {
 				// Should be impossible
 				return fmt.Errorf("invalid hard-coded hash for lyft url")


### PR DESCRIPTION
This PR:
- Update the Lyft CNI to v0.5.1
- Add a new IAM policy because `ec2:DescribeVpcs is required for m5 and c5 instances because the AWS metadata server does not return the secondary CIDR block on these instance types.`
- Add the Lyft CNI to the documentation

~Marked as WIP because I still need to test this build by spinning up a new cluster, but I'm happy to get any feedback if you something that doesn't look right.~
Tested by creating a new cluster and upgrading an existing one.