### PR TITLE
rolling-update features cordon/batch/detach

### DIFF
--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -68,7 +68,10 @@ kops rolling-update cluster [flags]
 
 ```
       --bastion-interval duration      Time to wait between restarting bastions (default 15s)
+      --batch-size int                 Number of nodes to roll at a time. (default 1)
       --cloudonly                      Perform rolling update without confirming progress with k8s
+      --cordon                         Cordon all nodes scheduled for replacement.
+      --detach                         Detaches the instance from the autoscale group. Useful to let the ASG trigger a new instance.
       --fail-on-drain-error            The rolling-update will fail if draining a node fails. (default true)
       --fail-on-validate-error         The rolling-update will fail if the cluster fails to validate. (default true)
       --force                          Force rolling update, even if no changes

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -51,6 +51,10 @@ var (
 	DNSPreCreate = New("DNSPreCreate", Bool(true))
 	// DrainAndValidateRollingUpdate if set will use new rolling update code that will drain and validate.
 	DrainAndValidateRollingUpdate = New("DrainAndValidateRollingUpdate", Bool(true))
+	// CordonAllWhenRollingUpdate if set will cordon all nodes scheduled for replacement.
+	CordonAllWhenRollingUpdate = New("CordonAllWhenRollingUpdate", Bool(true))
+	// BatchRollingUpdate set number of nodes to roll at a time
+	BatchRollingUpdate = New("BatchRollingUpdate", Bool(true))
 	// EnableLaunchTemplates indicates we wish to switch to using launch templates rather than launchconfigurations
 	EnableLaunchTemplates = New("EnableLaunchTemplates", Bool(false))
 	//EnableExternalCloudController toggles the use of cloud-controller-manager introduced in v1.7

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -95,6 +95,8 @@ func TestRollingUpdateAllNeedUpdate(t *testing.T) {
 		BastionInterval: 1 * time.Millisecond,
 		Force:           false,
 		K8sClient:       k8sClient,
+		BatchSize:       1,
+		Detach:          false,
 	}
 
 	cloud := c.Cloud.(awsup.AWSCloud)
@@ -239,6 +241,8 @@ func TestRollingUpdateNoneNeedUpdate(t *testing.T) {
 		BastionInterval: 1 * time.Millisecond,
 		Force:           false,
 		K8sClient:       k8sClient,
+		BatchSize:       1,
+		Detach:          true,
 	}
 
 	cloud := c.Cloud.(awsup.AWSCloud)
@@ -381,6 +385,8 @@ func TestRollingUpdateNoneNeedUpdateWithForce(t *testing.T) {
 		BastionInterval: 1 * time.Millisecond,
 		Force:           true,
 		K8sClient:       k8sClient,
+		BatchSize:       1,
+		Detach:          false,
 	}
 	cloud := c.Cloud.(awsup.AWSCloud)
 	setUpCloud(c)
@@ -490,6 +496,8 @@ func TestRollingUpdateEmptyGroup(t *testing.T) {
 		BastionInterval: 1 * time.Millisecond,
 		K8sClient:       k8sClient,
 		Force:           false,
+		BatchSize:       1,
+		Detach:          false,
 	}
 	cloud := c.Cloud.(awsup.AWSCloud)
 	setUpCloud(c)
@@ -555,6 +563,8 @@ func TestRollingUpdateUnknownRole(t *testing.T) {
 		BastionInterval: 1 * time.Millisecond,
 		Force:           false,
 		K8sClient:       k8sClient,
+		BatchSize:       1,
+		Detach:          false,
 	}
 	cloud := c.Cloud.(awsup.AWSCloud)
 	setUpCloud(c)

--- a/pkg/resources/digitalocean/cloud.go
+++ b/pkg/resources/digitalocean/cloud.go
@@ -126,3 +126,11 @@ func (c *Cloud) Droplets() godo.DropletsService {
 func (c *Cloud) FindVPCInfo(id string) (*fi.VPCInfo, error) {
 	return nil, errors.New("not implemented")
 }
+
+func (c Cloud) DetachInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return errors.New("DetachInstance not implemented on DigitalOcean")
+}
+
+func (c Cloud) DeleteDetachedInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return errors.New("DeleteDetachedInstance not implemented on DigitalOcean")
+}

--- a/upup/pkg/fi/cloud.go
+++ b/upup/pkg/fi/cloud.go
@@ -39,6 +39,12 @@ type Cloud interface {
 
 	// GetCloudGroups returns a map of cloud instances that back a kops cluster
 	GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error)
+
+	// DetachInstance detaches instance from ASG (aws implememtation only)
+	DetachInstance(instance *cloudinstances.CloudInstanceGroupMember) error
+
+	// DeleteDetachedInstance deletes a cloud instance
+	DeleteDetachedInstance(instance *cloudinstances.CloudInstanceGroupMember) error
 }
 
 type VPCInfo struct {

--- a/upup/pkg/fi/cloudup/aliup/ali_cloud.go
+++ b/upup/pkg/fi/cloudup/aliup/ali_cloud.go
@@ -146,6 +146,14 @@ func (c *aliCloudImplementation) DeleteInstance(i *cloudinstances.CloudInstanceG
 	return errors.New("DeleteInstance not implemented on aliCloud")
 }
 
+func (c aliCloudImplementation) DetachInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return errors.New("DetachInstance not implemented on aliCloud")
+}
+
+func (c aliCloudImplementation) DeleteDetachedInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return errors.New("DeleteDetachedInstance not implemented on aliCloud")
+}
+
 func (c *aliCloudImplementation) FindVPCInfo(id string) (*fi.VPCInfo, error) {
 	request := &ecs.DescribeVpcsArgs{
 		RegionId: common.Region(c.Region()),

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -90,6 +90,14 @@ func (c *MockAWSCloud) DeleteInstance(i *cloudinstances.CloudInstanceGroupMember
 	return deleteInstance(c, i)
 }
 
+func (c *MockAWSCloud) DeleteDetachedInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return deleteDetachedInstance(c, i)
+}
+
+func (c *MockAWSCloud) DetachInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return detachInstance(c, i)
+}
+
 func (c *MockAWSCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	return getCloudGroups(c, cluster, instancegroups, warnUnmatched, nodes)
 }

--- a/upup/pkg/fi/cloudup/baremetal/cloud.go
+++ b/upup/pkg/fi/cloudup/baremetal/cloud.go
@@ -17,6 +17,7 @@ limitations under the License.
 package baremetal
 
 import (
+	"errors"
 	"fmt"
 
 	"k8s.io/klog"
@@ -69,4 +70,12 @@ func (c *Cloud) DeleteGroup(g *cloudinstances.CloudInstanceGroup) error {
 func (c *Cloud) DeleteInstance(instance *cloudinstances.CloudInstanceGroupMember) error {
 	klog.V(8).Infof("baremetal cloud provider DeleteInstance not implemented yet")
 	return fmt.Errorf("baremetal cloud provider does not support deleting cloud instances at this time")
+}
+
+func (c Cloud) DetachInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return errors.New("DetachInstance not implemented on bareMetal")
+}
+
+func (c Cloud) DeleteDetachedInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return errors.New("DeleteDetachedInstance not implemented on bareMetal")
 }

--- a/upup/pkg/fi/cloudup/gce/instancegroups.go
+++ b/upup/pkg/fi/cloudup/gce/instancegroups.go
@@ -18,6 +18,7 @@ package gce
 
 import (
 	"encoding/base32"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"strings"
@@ -59,6 +60,22 @@ func (c *gceCloudImplementation) DeleteInstance(i *cloudinstances.CloudInstanceG
 // DeleteInstance deletes a GCE instance
 func (c *mockGCECloud) DeleteInstance(i *cloudinstances.CloudInstanceGroupMember) error {
 	return recreateCloudInstanceGroupMember(c, i)
+}
+
+func (c gceCloudImplementation) DetachInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return errors.New("DetachInstance not implemented on GCE")
+}
+
+func (c mockGCECloud) DetachInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return errors.New("DetachInstance not implemented on GCE")
+}
+
+func (c gceCloudImplementation) DeleteDetachedInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return errors.New("DeleteDetachedInstance not implemented on GCE")
+}
+
+func (c mockGCECloud) DeleteDetachedInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return errors.New("DeleteDetachedInstance not implemented on GCE")
 }
 
 // recreateCloudInstanceGroupMember recreates the specified instances, managed by an InstanceGroupManager

--- a/upup/pkg/fi/cloudup/openstack/instance.go
+++ b/upup/pkg/fi/cloudup/openstack/instance.go
@@ -17,6 +17,7 @@ limitations under the License.
 package openstack
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -104,6 +105,14 @@ func (c *openstackCloud) ListServerFloatingIPs(instanceID string) ([]*string, er
 func (c *openstackCloud) DeleteInstance(i *cloudinstances.CloudInstanceGroupMember) error {
 	klog.Warning("This does not work without running kops update cluster --yes in another terminal")
 	return c.DeleteInstanceWithID(i.ID)
+}
+
+func (c openstackCloud) DetachInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return errors.New("DetachInstance not implemented on OpenStack")
+}
+
+func (c openstackCloud) DeleteDetachedInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return errors.New("DeleteDetachedInstance not implemented on OpenStack")
 }
 
 func (c *openstackCloud) DeleteInstanceWithID(instanceID string) error {

--- a/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
+++ b/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
@@ -124,6 +124,14 @@ func (c *VSphereCloud) DeleteInstance(i *cloudinstances.CloudInstanceGroupMember
 	return fmt.Errorf("vSphere cloud provider does not support deleting cloud instances at this time.")
 }
 
+func (c VSphereCloud) DetachInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return errors.New("DetachInstance not implemented on VSphere")
+}
+
+func (c VSphereCloud) DeleteDetachedInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return errors.New("DeleteDetachedInstance not implemented on VSphere")
+}
+
 // DNS returns dnsprovider interface for this vSphere cloud.
 func (c *VSphereCloud) DNS() (dnsprovider.Interface, error) {
 	var provider dnsprovider.Interface


### PR DESCRIPTION
This addresses some of the issues in https://github.com/kubernetes/kops/issues/1718. I've written scripts outside of kops to do similar tasks, but as I kept adding functionality to my scripts, I decided it'd be better to contribute to the project. 

Simply put, I've added:
- batch rolling-update, 
- cordoning, 
- and ASG detachment.

I've added flags to rolling-update for the three different parts: 

```
kops rolling-update cluster --batch-size 5 --cordon --detach
```

Details of each:

`batch-size` - Effectively only works on nodes, not master. This will _detach_ or terminate `n` number of nodes at a time.  

`cordon` - When starting a rolling update, using the cordon flag will place a cordon on all the nodes that are scheduled to be updated. This is useful to prevent pods from getting deployed to nodes that will then get terminated again. 

`detach` - AWS ONLY for now. Instead of terminating a node and then letting the ASG create a new node, detach the node from the ASG instead. This keeps the node/pods healthy, allows time for the ASG to "heal", and the best part is we don't have to worry about min/max size of the ASG. Later in the rolling-update, these detached nodes get drained and terminated. 

Notes about time durations and intervals:

```
kops rolling-update cluster --batch-size 5 --cordon --detach --node-interval 60s --post-drain-delay 5s
```


- `node-interval` only run once per batch. Because of the nature of "batch", I figured it wouldn't make sense to wait after each node gets detached/terminated. I use this interval as the time to wait after a group of nodes have been acted on. 
- `post-drain-delay` still delays after each node that is drained. This still allows the user to decide how much time to give for pods to stabilize a little bit. 

I see some possible issues. 
1. If there's an error or the use stops the upgrade when nodes have been detached from the cloud autoscaling group, kops doesn't have control of the node anymore. 

This PR isn't technically a WIP,  but I will continue to add patches if I find them. 