### PR TITLE
Update AMIs in alpha channels

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -23,12 +23,18 @@ spec:
       providerID: aws
       kubernetesVersion: ">=1.10.0 <1.11.0"
     # Stretch is the default for 1.11 (for nvme)
-    - name: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2018-08-17
+    - name: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2019-08-16
       providerID: aws
       kubernetesVersion: ">=1.11.0 <1.12.0"
-    - name: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21
+    - name: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-08-16
       providerID: aws
-      kubernetesVersion: ">=1.12.0"
+      kubernetesVersion: ">=1.12.0 <1.13.0"
+    - name: kope.io/k8s-1.13-debian-stretch-amd64-hvm-ebs-2019-08-16
+      providerID: aws
+      kubernetesVersion: ">=1.13.0 <1.14.0"
+    - name: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
+      providerID: aws
+      kubernetesVersion: ">=1.14.0"
     - providerID: gce
       name: "cos-cloud/cos-stable-65-10323-99-0"
   cluster:


### PR DESCRIPTION
Add 1.13 and 1.14 images, bump 1.11 and 1.12 images.