### PR TITLE
Add support for netExtraArgs

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -110,6 +110,20 @@ spec:
       mtu: 8912
 ```
 
+### Configuring Weave Net EXTRA_ARGS
+
+Weave allows you to pass command line arguments to weave by adding those arguments to the EXTRA_ARGS environmental variable.
+This can be used for debugging or for customizing the logging level of weave net. 
+
+```
+spec:
+  networking:
+    weave:
+      netExtraArgs: "--log-level=info"
+```
+
+Note that it is possible to break the cluster networking if flags are improperly used and as such this option should be used with caution.
+
 ### Configuring Weave network encryption
 
 The Weave network encryption is configurable by creating a weave network secret password.

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -61,9 +61,10 @@ type KopeioNetworkingSpec struct {
 
 // WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU         *int32 `json:"mtu,omitempty"`
-	ConnLimit   *int32 `json:"connLimit,omitempty"`
-	NoMasqLocal *int32 `json:"noMasqLocal,omitempty"`
+	MTU          *int32 `json:"mtu,omitempty"`
+	ConnLimit    *int32 `json:"connLimit,omitempty"`
+	NoMasqLocal  *int32 `json:"noMasqLocal,omitempty"`
+	NetExtraArgs string `json:"netExtraArgs,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -61,9 +61,10 @@ type KopeioNetworkingSpec struct {
 
 // WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU         *int32 `json:"mtu,omitempty"`
-	ConnLimit   *int32 `json:"connLimit,omitempty"`
-	NoMasqLocal *int32 `json:"noMasqLocal,omitempty"`
+	MTU          *int32 `json:"mtu,omitempty"`
+	ConnLimit    *int32 `json:"connLimit,omitempty"`
+	NoMasqLocal  *int32 `json:"noMasqLocal,omitempty"`
+	NetExtraArgs string `json:"netExtraArgs,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -4534,6 +4534,7 @@ func autoConvert_v1alpha1_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *We
 	out.MTU = in.MTU
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
+	out.NetExtraArgs = in.NetExtraArgs
 	return nil
 }
 
@@ -4546,6 +4547,7 @@ func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha1_WeaveNetworkingSpec(in *ko
 	out.MTU = in.MTU
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
+	out.NetExtraArgs = in.NetExtraArgs
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -61,9 +61,10 @@ type KopeioNetworkingSpec struct {
 
 // WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU         *int32 `json:"mtu,omitempty"`
-	ConnLimit   *int32 `json:"connLimit,omitempty"`
-	NoMasqLocal *int32 `json:"noMasqLocal,omitempty"`
+	MTU          *int32 `json:"mtu,omitempty"`
+	ConnLimit    *int32 `json:"connLimit,omitempty"`
+	NoMasqLocal  *int32 `json:"noMasqLocal,omitempty"`
+	NetExtraArgs string `json:"netExtraArgs,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4862,6 +4862,7 @@ func autoConvert_v1alpha2_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *We
 	out.MTU = in.MTU
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
+	out.NetExtraArgs = in.NetExtraArgs
 	return nil
 }
 
@@ -4874,6 +4875,7 @@ func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha2_WeaveNetworkingSpec(in *ko
 	out.MTU = in.MTU
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
+	out.NetExtraArgs = in.NetExtraArgs
 	return nil
 }
 

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -157,6 +157,10 @@ spec:
             - name: CONN_LIMIT
               value: "{{ .Networking.Weave.ConnLimit }}"
             {{- end }}
+            {{- if .Networking.Weave.NetExtraArgs }}
+            - name: EXTRA_ARGS
+              value: "{{ .Networking.Weave.NetExtraArgs }}"
+            {{- end }}
             {{- if WeaveSecret }}
             - name: WEAVE_PASSWORD
               valueFrom:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
@@ -139,6 +139,10 @@ spec:
             - name: CONN_LIMIT
               value: "{{ .Networking.Weave.ConnLimit }}"
             {{- end }}
+            {{- if .Networking.Weave.NetExtraArgs }}
+            - name: EXTRA_ARGS
+              value: "{{ .Networking.Weave.NetExtraArgs }}"
+            {{- end }}
             {{- if WeaveSecret }}
             - name: WEAVE_PASSWORD
               valueFrom:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -149,6 +149,10 @@ spec:
             - name: CONN_LIMIT
               value: "{{ .Networking.Weave.ConnLimit }}"
             {{- end }}
+            {{- if .Networking.Weave.NetExtraArgs }}
+            - name: EXTRA_ARGS
+              value: "{{ .Networking.Weave.NetExtraArgs }}"
+            {{- end }}
             {{- if WeaveSecret }}
             - name: WEAVE_PASSWORD
               valueFrom:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -153,6 +153,10 @@ spec:
             - name: CONN_LIMIT
               value: "{{ .Networking.Weave.ConnLimit }}"
             {{- end }}
+            {{- if .Networking.Weave.NetExtraArgs }}
+            - name: EXTRA_ARGS
+              value: "{{ .Networking.Weave.NetExtraArgs }}"
+            {{- end }}
             {{- if WeaveSecret }}
             - name: WEAVE_PASSWORD
               valueFrom:


### PR DESCRIPTION
(First part of #7390)

This adds `netExtraArgs` to the Weave spec and allows for adding extra command line parameters to weave net (well, technically weave-kube).

This has been tested by applying it to one of our clusters.