### PR TITLE
Dont set ExperimentalCriticalPodAnnotation feature gate in k8s 1.16

### DIFF
--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -243,7 +243,7 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.Kubelet.FeatureGates = make(map[string]string)
 	}
 	if _, found := clusterSpec.Kubelet.FeatureGates["ExperimentalCriticalPodAnnotation"]; !found {
-		if b.Context.IsKubernetesGTE("1.5.2") {
+		if b.Context.IsKubernetesGTE("1.5.2") && b.Context.IsKubernetesLT("1.16") {
 			clusterSpec.Kubelet.FeatureGates["ExperimentalCriticalPodAnnotation"] = "true"
 		}
 	}


### PR DESCRIPTION
The E2E tests are [currently failing](https://testgrid.k8s.io/sig-cluster-lifecycle-kops#kops-aws-1.14) due to this [kubelet error](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-beta/1163216201782923264/artifacts/52.77.251.45/kubelet.log):

`F0818 22:43:57.642896    6424 server.go:179] unrecognized feature gate: ExperimentalCriticalPodAnnotation`

This feature gate [was removed in Kubernetes 1.16](https://github.com/kubernetes/kubernetes/pull/80342)