### PR TITLE
[DO-7148] Digital Ocean support for etcd-manager

### DIFF
--- a/docs/tutorial/digitalocean.md
+++ b/docs/tutorial/digitalocean.md
@@ -24,9 +24,8 @@ export S3_ENDPOINT=nyc3.digitaloceanspaces.com # this can also be ams3.digitaloc
 export S3_ACCESS_KEY_ID=<access-key-id>  # where <access-key-id> is the Spaces API Access Key for your bucket
 export S3_SECRET_ACCESS_KEY=<secret-key>  # where <secret-key> is the Spaces API Secret Key for your bucket
 
-# this is required since DigitalOcean support is currently in alpha so it is feature gated, also need Override flag to use legacy etcd.
-# we will eventually support etcdmanager, but until then, we need to specify this flag.
-export KOPS_FEATURE_FLAGS="AlphaAllowDO,+SpecOverrideFlag"
+# this is required since DigitalOcean support is currently in alpha so it is feature gated
+export KOPS_FEATURE_FLAGS="AlphaAllowDO"
 ```
 
 ## Creating a Cluster
@@ -36,15 +35,15 @@ Note that you kops will only be able to successfully provision clusters in regio
 
 ```bash
 # coreos (the default) + flannel overlay cluster in tor1
-kops create cluster --cloud=digitalocean --name=my-cluster.example.com --networking=flannel --zones=tor1 --ssh-public-key=~/.ssh/id_rsa.pub --override cluster.spec.etcdClusters[*].provider=Legacy
+kops create cluster --cloud=digitalocean --name=my-cluster.example.com --networking=flannel --zones=tor1 --ssh-public-key=~/.ssh/id_rsa.pub
 kops update cluster my-cluster.example.com --yes
 
 # ubuntu + weave overlay cluster in nyc1 using larger droplets
-kops create cluster --cloud=digitalocean --name=my-cluster.example.com --image=ubuntu-16-04-x64 --networking=weave --zones=nyc1 --ssh-public-key=~/.ssh/id_rsa.pub --node-size=s-8vcpu-32gb --override cluster.spec.etcdClusters[*].provider=Legacy
+kops create cluster --cloud=digitalocean --name=my-cluster.example.com --image=ubuntu-16-04-x64 --networking=weave --zones=nyc1 --ssh-public-key=~/.ssh/id_rsa.pub --node-size=s-8vcpu-32gb
 kops update cluster my-cluster.example.com --yes
 
 # debian + flannel overlay cluster in ams3 using optimized droplets
-kops create cluster --cloud=digitalocean --name=my-cluster.example.com --image=debian-9-x64 --networking=flannel --zones=ams3 --ssh-public-key=~/.ssh/id_rsa.pub --node-size=c-4 --override cluster.spec.etcdClusters[*].provider=Legacy
+kops create cluster --cloud=digitalocean --name=my-cluster.example.com --image=debian-9-x64 --networking=flannel --zones=ams3 --ssh-public-key=~/.ssh/id_rsa.pub --node-size=c-4
 kops update cluster my-cluster.example.com --yes
 
 # to delete a cluster

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -181,7 +181,7 @@ func parseManifest(data []byte) ([]runtime.Object, error) {
 	return objects, nil
 }
 
-// Until we introduce the bundle, we hard-code the manifest (3.0.20190516)
+// Until we introduce the bundle, we hard-code the manifest
 var defaultManifest = `
 apiVersion: v1
 kind: Pod

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -535,4 +535,3 @@ type config struct {
 	VolumeNameTag        string   `flag:"volume-name-tag"`
 	DNSSuffix            string   `flag:"dns-suffix"`
 }
-

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -478,15 +478,9 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster *kops.EtcdClusterSpec) (*v1.Po
 	container.Env = appendEnvVariableIfExist("OS_AUTH_URL", container.Env)
 	container.Env = appendEnvVariableIfExist("OS_REGION_NAME", container.Env)
 
-	if kops.CloudProviderID(b.Cluster.Spec.CloudProvider) == kops.CloudProviderDO && os.Getenv("DIGITALOCEAN_ACCESS_TOKEN") != "" {
-		container.Env = append(container.Env, []v1.EnvVar{
-					{Name: "DIGITALOCEAN_ACCESS_TOKEN", Value: os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")},
-					{Name: "S3_ENDPOINT", Value: os.Getenv("S3_ENDPOINT")},
-					{Name:"S3_ACCESS_KEY_ID", Value: os.Getenv("S3_ACCESS_KEY_ID")},
-					{Name: "S3_SECRET_ACCESS_KEY", Value: os.Getenv("S3_SECRET_ACCESS_KEY")},
-				}...)
-		}
-	
+	// Digital Ocean related values.
+	container.Env = appendEnvVariableIfExist("DIGITALOCEAN_ACCESS_TOKEN", container.Env)
+
 	{
 		foundPKI := false
 		for i := range pod.Spec.Volumes {

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -190,7 +190,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - image: kopeio/etcd-manager:3.0.20190516
+  - image: kopeio/etcd-manager:3.0.20190816
     name: etcd-manager
     resources:
       requests:
@@ -394,7 +394,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster *kops.EtcdClusterSpec) (*v1.Po
 			config.VolumeProvider = "do"
 
 			config.VolumeTag = []string{
-				fmt.Sprintf("kubernetes.io/cluster/%s=owned", b.Cluster.Name),
+				fmt.Sprintf("kubernetes.io/cluster=%s", b.Cluster.Name),
 				do.TagNameEtcdClusterPrefix + etcdCluster.Name,
 				do.TagNameRolePrefix + "master=1",
 			}


### PR DESCRIPTION
This PR incorporates changes to use etcd-manager, instead of the legacy mode.
Able to see the cluster coming up Ok with this change.

Please refer to the etcdmanager PR that is merged (https://github.com/kopeio/etcd-manager/pull/243) to incorporate DigitialOcean related changes.

