### PR TITLE
promote k8s versions

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -46,13 +46,13 @@ spec:
     recommendedVersion: 1.16.0-alpha.3
     requiredVersion: 1.16.0-alpha.1
   - range: ">=1.15.0"
-    recommendedVersion: 1.15.2
+    recommendedVersion: 1.15.3
     requiredVersion: 1.15.0
   - range: ">=1.14.0"
-    recommendedVersion: 1.14.5
+    recommendedVersion: 1.14.6
     requiredVersion: 1.14.0
   - range: ">=1.13.0"
-    recommendedVersion: 1.13.9
+    recommendedVersion: 1.13.10
     requiredVersion: 1.13.0
   - range: ">=1.12.0"
     recommendedVersion: 1.12.10

--- a/channels/stable
+++ b/channels/stable
@@ -37,13 +37,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.15.0"
-    recommendedVersion: 1.15.2
+    recommendedVersion: 1.15.3
     requiredVersion: 1.15.0
   - range: ">=1.14.0"
-    recommendedVersion: 1.14.5
+    recommendedVersion: 1.14.6
     requiredVersion: 1.14.0
   - range: ">=1.13.0"
-    recommendedVersion: 1.13.9
+    recommendedVersion: 1.13.10
     requiredVersion: 1.13.0
   - range: ">=1.12.0"
     recommendedVersion: 1.12.10


### PR DESCRIPTION
https://discuss.kubernetes.io/t/security-release-of-kubernetes-v1-15-3-v1-14-6-v1-13-10-cve-2019-9512-and-cve-2019-9514/7596