### PR TITLE
Update weave to 2.5.2

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -164,7 +164,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.5.1'
+          image: 'weaveworks/weave-kube:2.5.2'
           ports:
             - name: metrics
               containerPort: 6782
@@ -204,7 +204,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.5.1'
+          image: 'weaveworks/weave-npc:2.5.2'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -156,7 +156,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.5.1'
+          image: 'weaveworks/weave-kube:2.5.2'
           ports:
             - name: metrics
               containerPort: 6782
@@ -196,7 +196,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.5.1'
+          image: 'weaveworks/weave-npc:2.5.2'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -160,7 +160,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.5.1'
+          image: 'weaveworks/weave-kube:2.5.2'
           ports:
             - name: metrics
               containerPort: 6782
@@ -200,7 +200,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.5.1'
+          image: 'weaveworks/weave-npc:2.5.2'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -673,9 +673,9 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		versions := map[string]string{
 			"pre-k8s-1.6": "2.3.0-kops.3",
 			"k8s-1.6":     "2.3.0-kops.3",
-			"k8s-1.7":     "2.5.1-kops.2",
-			"k8s-1.8":     "2.5.1-kops.2",
-			"k8s-1.12":    "2.5.1-kops.2",
+			"k8s-1.7":     "2.5.2-kops.2",
+			"k8s-1.8":     "2.5.2-kops.2",
+			"k8s-1.12":    "2.5.2-kops.2",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -123,7 +123,7 @@ spec:
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0 <1.8.0'
     manifest: networking.weave/k8s-1.7.yaml
-    manifestHash: e017ce8498a9c4b0569bf2e4d7f49f9f4201ef52
+    manifestHash: 258ad76c3ef165f216980c96367df13a8bffb1d8
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
@@ -131,7 +131,7 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: 390e23353f5370d294663065a3ca7e0fb1d63737
+    manifestHash: 748a1526515a719058b99c203cd943a740675e21
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
@@ -139,7 +139,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: c784dfaae5188e0b1e4dbfea0373abe8d1a01b48
+    manifestHash: 11e566a259bbb5f066cf2b06cd8832e74072a900
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -127,7 +127,7 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.1-kops.2
+    version: 2.5.2-kops.2
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
@@ -135,7 +135,7 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.1-kops.2
+    version: 2.5.2-kops.2
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
@@ -143,4 +143,4 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.1-kops.2
+    version: 2.5.2-kops.2


### PR DESCRIPTION
This PR updates weave to 2.5.2 to alleviate the following issues:

- In Kubernetes cluster, when a pod is deleted and at the same time if weave-net pod is restarting or in rare occasion like when weave-kube container is hung then IP address assigned to the pod is not freed and never released, potentially running out of IP's to allocate to the pod's on the node #3587, #3638

- In Kubernetes cluster a reclaim daemon runs as part of kube-utils that automates weave forget for deleted nodes. Fixes panic that occurs in reclaim daemon resulting in weave to attempt to connect to dead nodes #3613, #3623

This can be seen here - https://github.com/weaveworks/weave/releases/tag/v2.5.2