### PR TITLE
Fixed "NeedsUpdate" status of nodes in mixedinstancegroups after rolling update

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -596,7 +596,12 @@ func findAutoscalingGroupLaunchConfiguration(c AWSCloud, g *autoscaling.Group) (
 				request := &ec2.DescribeLaunchTemplateVersionsInput{
 					LaunchTemplateName: &name,
 				}
-				versions, _ := c.EC2().DescribeLaunchTemplateVersions(request)
+
+				versions, err := c.EC2().DescribeLaunchTemplateVersions(request)
+				if err != nil {
+					return "", fmt.Errorf("error finding versions for launch template: %v", err)
+				}
+
 				var version string
 				for _, v := range versions.LaunchTemplateVersions {
 					if *v.DefaultVersion {

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -18,6 +18,7 @@ package awsup
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -570,7 +571,7 @@ func matchesAsgTags(tags map[string]string, actual []*autoscaling.TagDescription
 }
 
 // findAutoscalingGroupLaunchConfiguration is responsible for finding the launch - which could be a launchconfiguration, a template or a mixed instance policy template
-func findAutoscalingGroupLaunchConfiguration(g *autoscaling.Group) (string, error) {
+func findAutoscalingGroupLaunchConfiguration(c AWSCloud, g *autoscaling.Group) (string, error) {
 	name := aws.StringValue(g.LaunchConfigurationName)
 	if name != "" {
 		return name, nil
@@ -592,7 +593,18 @@ func findAutoscalingGroupLaunchConfiguration(g *autoscaling.Group) (string, erro
 			if g.MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification != nil {
 				// honestly!!
 				name = aws.StringValue(g.MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.LaunchTemplateName)
-				version := aws.StringValue(g.MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.Version)
+				request := &ec2.DescribeLaunchTemplateVersionsInput{
+					LaunchTemplateName: &name,
+				}
+				versions, _ := c.EC2().DescribeLaunchTemplateVersions(request)
+				var version string
+				for _, v := range versions.LaunchTemplateVersions {
+					if *v.DefaultVersion {
+						version = strconv.FormatInt(*v.VersionNumber, 10)
+						break
+					}
+				}
+
 				if name != "" {
 					launchTemplate := name + ":" + version
 					return launchTemplate, nil
@@ -625,7 +637,7 @@ func findInstanceLaunchConfiguration(i *autoscaling.Instance) string {
 }
 
 func awsBuildCloudInstanceGroup(c AWSCloud, ig *kops.InstanceGroup, g *autoscaling.Group, nodeMap map[string]*v1.Node) (*cloudinstances.CloudInstanceGroup, error) {
-	newConfigName, err := findAutoscalingGroupLaunchConfiguration(g)
+	newConfigName, err := findAutoscalingGroupLaunchConfiguration(c, g)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR fixed issue #6796,  that "NeedsUpdate" status of nodes in mixedinstancegroups after rolling update.