### PR TITLE
Update channel recommended versions for kops versions

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -85,23 +85,23 @@ spec:
   - range: ">=1.16.0-alpha.1"
     #recommendedVersion: "1.16.0"
     #requiredVersion: 1.16.0
-    kubernetesVersion: 1.16.0-alpha.1
+    kubernetesVersion: 1.16.0-alpha.3
   - range: ">=1.15.0-alpha.1"
     #recommendedVersion: "1.15.0"
     #requiredVersion: 1.15.0
-    kubernetesVersion: 1.15.0-alpha.1
+    kubernetesVersion: 1.15.3
   - range: ">=1.14.0-alpha.1"
     #recommendedVersion: "1.14.0"
     #requiredVersion: 1.14.0
-    kubernetesVersion: 1.14.4
+    kubernetesVersion: 1.14.6
   - range: ">=1.13.0-alpha.1"
     #recommendedVersion: "1.13.0"
     #requiredVersion: 1.13.0
-    kubernetesVersion: 1.13.8
+    kubernetesVersion: 1.13.10
   - range: ">=1.12.0-alpha.1"
     recommendedVersion: "1.12.1"
     #requiredVersion: 1.12.0
-    kubernetesVersion: 1.12.9
+    kubernetesVersion: 1.12.10
   - range: ">=1.11.0-alpha.1"
     #recommendedVersion: "1.11.0"
     #requiredVersion: 1.11.0

--- a/channels/stable
+++ b/channels/stable
@@ -73,18 +73,22 @@ spec:
     recommendedVersion: 1.4.12
     requiredVersion: 1.4.2
   kopsVersions:
+  - range: ">=1.15.0-alpha.1"
+    #recommendedVersion: "1.14.0"
+    #requiredVersion: 1.14.0
+    kubernetesVersion: 1.15.3
   - range: ">=1.14.0-alpha.1"
     #recommendedVersion: "1.14.0"
     #requiredVersion: 1.14.0
-    kubernetesVersion: 1.14.1
+    kubernetesVersion: 1.14.6
   - range: ">=1.13.0-alpha.1"
     #recommendedVersion: "1.13.0"
     #requiredVersion: 1.13.0
-    kubernetesVersion: 1.13.5
+    kubernetesVersion: 1.13.10
   - range: ">=1.12.0-alpha.1"
     recommendedVersion: "1.12.1"
     #requiredVersion: 1.12.0
-    kubernetesVersion: 1.12.8
+    kubernetesVersion: 1.12.10
   - range: ">=1.11.0-alpha.1"
     #recommendedVersion: "1.11.0"
     #requiredVersion: 1.11.0


### PR DESCRIPTION
The kubernetesVersion in the kopsVersions block is used for new
clusters.  I had forgotten to update it, so new clusters were being
created with versions that then immediately recommended an update.