### PR TITLE
bash script: don't assume nodeup filename

### DIFF
--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -62,19 +62,15 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
-# Retry a download until we get it. Takes a hash and a set of URLs.
-#
-# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-# $2+ are the URLs to download.
+# Retry a download until we get it. args: name, sha, url1, url2...
 download-or-bust() {
-  local -r hash="$1"
-  shift 1
+  local -r file="$1"
+  local -r hash="$2"
+  shift 2
 
   urls=( $* )
   while true; do
     for url in "${urls[@]}"; do
-      local file="${url##*/}"
-
       if [[ -e "${file}" ]]; then
         echo "== File exists for ${url} =="
 
@@ -132,18 +128,17 @@ function try-download-release() {
   # optimization.
 
   local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-  local -r nodeup_filename="${nodeup_urls[0]##*/}"
   if [[ -n "${NODEUP_HASH:-}" ]]; then
     local -r nodeup_hash="${NODEUP_HASH}"
   else
   # TODO: Remove?
     echo "Downloading sha1 (not found in env)"
-    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+    download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+    local -r nodeup_hash=$(cat nodeup.sha1)
   fi
 
   echo "Downloading nodeup (${nodeup_urls[@]})"
-  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+  download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
   chmod +x nodeup
 }

--- a/pkg/model/tests/data/bootstrapscript_0.txt
+++ b/pkg/model/tests/data/bootstrapscript_0.txt
@@ -51,19 +51,15 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
-# Retry a download until we get it. Takes a hash and a set of URLs.
-#
-# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-# $2+ are the URLs to download.
+# Retry a download until we get it. args: name, sha, url1, url2...
 download-or-bust() {
-  local -r hash="$1"
-  shift 1
+  local -r file="$1"
+  local -r hash="$2"
+  shift 2
 
   urls=( $* )
   while true; do
     for url in "${urls[@]}"; do
-      local file="${url##*/}"
-
       if [[ -e "${file}" ]]; then
         echo "== File exists for ${url} =="
 
@@ -121,18 +117,17 @@ function try-download-release() {
   # optimization.
 
   local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-  local -r nodeup_filename="${nodeup_urls[0]##*/}"
   if [[ -n "${NODEUP_HASH:-}" ]]; then
     local -r nodeup_hash="${NODEUP_HASH}"
   else
   # TODO: Remove?
     echo "Downloading sha1 (not found in env)"
-    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+    download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+    local -r nodeup_hash=$(cat nodeup.sha1)
   fi
 
   echo "Downloading nodeup (${nodeup_urls[@]})"
-  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+  download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
   chmod +x nodeup
 }

--- a/pkg/model/tests/data/bootstrapscript_1.txt
+++ b/pkg/model/tests/data/bootstrapscript_1.txt
@@ -51,19 +51,15 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
-# Retry a download until we get it. Takes a hash and a set of URLs.
-#
-# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-# $2+ are the URLs to download.
+# Retry a download until we get it. args: name, sha, url1, url2...
 download-or-bust() {
-  local -r hash="$1"
-  shift 1
+  local -r file="$1"
+  local -r hash="$2"
+  shift 2
 
   urls=( $* )
   while true; do
     for url in "${urls[@]}"; do
-      local file="${url##*/}"
-
       if [[ -e "${file}" ]]; then
         echo "== File exists for ${url} =="
 
@@ -121,18 +117,17 @@ function try-download-release() {
   # optimization.
 
   local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-  local -r nodeup_filename="${nodeup_urls[0]##*/}"
   if [[ -n "${NODEUP_HASH:-}" ]]; then
     local -r nodeup_hash="${NODEUP_HASH}"
   else
   # TODO: Remove?
     echo "Downloading sha1 (not found in env)"
-    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+    download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+    local -r nodeup_hash=$(cat nodeup.sha1)
   fi
 
   echo "Downloading nodeup (${nodeup_urls[@]})"
-  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+  download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
   chmod +x nodeup
 }

--- a/pkg/model/tests/data/bootstrapscript_2.txt
+++ b/pkg/model/tests/data/bootstrapscript_2.txt
@@ -51,19 +51,15 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
-# Retry a download until we get it. Takes a hash and a set of URLs.
-#
-# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-# $2+ are the URLs to download.
+# Retry a download until we get it. args: name, sha, url1, url2...
 download-or-bust() {
-  local -r hash="$1"
-  shift 1
+  local -r file="$1"
+  local -r hash="$2"
+  shift 2
 
   urls=( $* )
   while true; do
     for url in "${urls[@]}"; do
-      local file="${url##*/}"
-
       if [[ -e "${file}" ]]; then
         echo "== File exists for ${url} =="
 
@@ -121,18 +117,17 @@ function try-download-release() {
   # optimization.
 
   local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-  local -r nodeup_filename="${nodeup_urls[0]##*/}"
   if [[ -n "${NODEUP_HASH:-}" ]]; then
     local -r nodeup_hash="${NODEUP_HASH}"
   else
   # TODO: Remove?
     echo "Downloading sha1 (not found in env)"
-    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+    download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+    local -r nodeup_hash=$(cat nodeup.sha1)
   fi
 
   echo "Downloading nodeup (${nodeup_urls[@]})"
-  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+  download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
   chmod +x nodeup
 }

--- a/pkg/model/tests/data/bootstrapscript_3.txt
+++ b/pkg/model/tests/data/bootstrapscript_3.txt
@@ -51,19 +51,15 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
-# Retry a download until we get it. Takes a hash and a set of URLs.
-#
-# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-# $2+ are the URLs to download.
+# Retry a download until we get it. args: name, sha, url1, url2...
 download-or-bust() {
-  local -r hash="$1"
-  shift 1
+  local -r file="$1"
+  local -r hash="$2"
+  shift 2
 
   urls=( $* )
   while true; do
     for url in "${urls[@]}"; do
-      local file="${url##*/}"
-
       if [[ -e "${file}" ]]; then
         echo "== File exists for ${url} =="
 
@@ -121,18 +117,17 @@ function try-download-release() {
   # optimization.
 
   local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-  local -r nodeup_filename="${nodeup_urls[0]##*/}"
   if [[ -n "${NODEUP_HASH:-}" ]]; then
     local -r nodeup_hash="${NODEUP_HASH}"
   else
   # TODO: Remove?
     echo "Downloading sha1 (not found in env)"
-    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+    download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+    local -r nodeup_hash=$(cat nodeup.sha1)
   fi
 
   echo "Downloading nodeup (${nodeup_urls[@]})"
-  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+  download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
   chmod +x nodeup
 }

--- a/pkg/model/tests/data/bootstrapscript_4.txt
+++ b/pkg/model/tests/data/bootstrapscript_4.txt
@@ -51,19 +51,15 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
-# Retry a download until we get it. Takes a hash and a set of URLs.
-#
-# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-# $2+ are the URLs to download.
+# Retry a download until we get it. args: name, sha, url1, url2...
 download-or-bust() {
-  local -r hash="$1"
-  shift 1
+  local -r file="$1"
+  local -r hash="$2"
+  shift 2
 
   urls=( $* )
   while true; do
     for url in "${urls[@]}"; do
-      local file="${url##*/}"
-
       if [[ -e "${file}" ]]; then
         echo "== File exists for ${url} =="
 
@@ -121,18 +117,17 @@ function try-download-release() {
   # optimization.
 
   local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-  local -r nodeup_filename="${nodeup_urls[0]##*/}"
   if [[ -n "${NODEUP_HASH:-}" ]]; then
     local -r nodeup_hash="${NODEUP_HASH}"
   else
   # TODO: Remove?
     echo "Downloading sha1 (not found in env)"
-    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+    download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+    local -r nodeup_hash=$(cat nodeup.sha1)
   fi
 
   echo "Downloading nodeup (${nodeup_urls[@]})"
-  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+  download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
   chmod +x nodeup
 }

--- a/pkg/model/tests/data/bootstrapscript_5.txt
+++ b/pkg/model/tests/data/bootstrapscript_5.txt
@@ -51,19 +51,15 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
-# Retry a download until we get it. Takes a hash and a set of URLs.
-#
-# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-# $2+ are the URLs to download.
+# Retry a download until we get it. args: name, sha, url1, url2...
 download-or-bust() {
-  local -r hash="$1"
-  shift 1
+  local -r file="$1"
+  local -r hash="$2"
+  shift 2
 
   urls=( $* )
   while true; do
     for url in "${urls[@]}"; do
-      local file="${url##*/}"
-
       if [[ -e "${file}" ]]; then
         echo "== File exists for ${url} =="
 
@@ -121,18 +117,17 @@ function try-download-release() {
   # optimization.
 
   local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-  local -r nodeup_filename="${nodeup_urls[0]##*/}"
   if [[ -n "${NODEUP_HASH:-}" ]]; then
     local -r nodeup_hash="${NODEUP_HASH}"
   else
   # TODO: Remove?
     echo "Downloading sha1 (not found in env)"
-    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+    download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+    local -r nodeup_hash=$(cat nodeup.sha1)
   fi
 
   echo "Downloading nodeup (${nodeup_urls[@]})"
-  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+  download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
   chmod +x nodeup
 }

--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
@@ -36,19 +36,15 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -106,18 +102,17 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }
@@ -315,19 +310,15 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -385,18 +376,17 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -45,19 +45,15 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -115,18 +111,17 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }
@@ -344,19 +339,15 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -414,18 +405,17 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -36,19 +36,15 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -106,18 +102,17 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }
@@ -315,19 +310,15 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -385,18 +376,17 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -36,19 +36,15 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -106,18 +102,17 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }
@@ -335,19 +330,15 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -405,18 +396,17 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -36,19 +36,15 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -106,18 +102,17 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }
@@ -315,19 +310,15 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -385,18 +376,17 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
@@ -36,19 +36,15 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -106,18 +102,17 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }
@@ -336,19 +331,15 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -406,18 +397,17 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }
@@ -636,19 +626,15 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -706,18 +692,17 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }
@@ -936,19 +921,15 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -1006,18 +987,17 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
@@ -36,19 +36,15 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -106,18 +102,17 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }
@@ -336,19 +331,15 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -406,18 +397,17 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }
@@ -636,19 +626,15 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -706,18 +692,17 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }
@@ -936,19 +921,15 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
     cd ${INSTALL_DIR}
   }
 
-  # Retry a download until we get it. Takes a hash and a set of URLs.
-  #
-  # $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
-  # $2+ are the URLs to download.
+  # Retry a download until we get it. args: name, sha, url1, url2...
   download-or-bust() {
-    local -r hash="$1"
-    shift 1
+    local -r file="$1"
+    local -r hash="$2"
+    shift 2
 
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        local file="${url##*/}"
-
         if [[ -e "${file}" ]]; then
           echo "== File exists for ${url} =="
 
@@ -1006,18 +987,17 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
     # optimization.
 
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
-    local -r nodeup_filename="${nodeup_urls[0]##*/}"
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
     else
     # TODO: Remove?
       echo "Downloading sha1 (not found in env)"
-      download-or-bust "" "${nodeup_urls[@]/%/.sha1}"
-      local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")
+      download-or-bust nodeup.sha1 "" "${nodeup_urls[@]/%/.sha1}"
+      local -r nodeup_hash=$(cat nodeup.sha1)
     fi
 
     echo "Downloading nodeup (${nodeup_urls[@]})"
-    download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"
+    download-or-bust nodeup "${nodeup_hash}" "${nodeup_urls[@]}"
 
     chmod +x nodeup
   }


### PR DESCRIPTION
We were previously assuming that the name of the URL matched the name
we wanted to download to, but also assuming that the name of the file
was nodeup.  Change to download to a known file location, whatever the
mirror url.