### PR TITLE
Add nodeup to shipbot targets for release upload

### DIFF
--- a/.shipbot.yaml
+++ b/.shipbot.yaml
@@ -21,3 +21,7 @@ assets:
     githubName: linux-amd64-utils.tar.gz
   - source: .build/dist/linux/amd64/utils.tar.gz.sha1
     githubName: linux-amd64-utils.tar.gz.sha1
+  - source: .build/dist/nodeup
+    githubName: linux-amd64-nodeup
+  - source: .build/dist/nodeup.sha1
+    githubName: linux-amd64-nodeup.sha1

--- a/Makefile
+++ b/Makefile
@@ -783,6 +783,7 @@ bazel-version-dist: bazel-crossbuild-nodeup bazel-crossbuild-kops bazel-protokub
 	(${SHASUMCMD} ${BAZELUPLOAD}/kops/${VERSION}/windows/amd64/kops.exe | cut -d' ' -f1) > ${BAZELUPLOAD}/kops/${VERSION}/windows/amd64/kops.exe.sha1
 	cp bazel-bin/images/utils-builder/utils.tar.gz ${BAZELUPLOAD}/kops/${VERSION}/linux/amd64/utils.tar.gz
 	(${SHASUMCMD} ${BAZELUPLOAD}/kops/${VERSION}/linux/amd64/utils.tar.gz | cut -d' ' -f1) > ${BAZELUPLOAD}/kops/${VERSION}/linux/amd64/utils.tar.gz.sha1
+	cp -fr ${BAZELUPLOAD}/kops/${VERSION}/* ${BAZELDIST}/
 
 .PHONY: bazel-upload
 bazel-upload: bazel-version-dist # Upload kops to S3

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -42,6 +42,7 @@ See [1.5.0-alpha4 commit](https://github.com/kubernetes/kops/commit/a60d7982e04c
 ## Check builds OK
 
 ```
+rm -rf .build/ .bazelbuild/
 make ci
 ```
 


### PR DESCRIPTION
I had omitted it previously, so it wasn't getting copied to mirrors.