### PR TITLE
Automated cherry pick of #7444: upgrade weave to 2.5.2 to address the issues in

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -164,7 +164,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.5.1'
+          image: 'weaveworks/weave-kube:2.5.2'
           ports:
             - name: metrics
               containerPort: 6782
@@ -204,7 +204,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.5.1'
+          image: 'weaveworks/weave-npc:2.5.2'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -156,7 +156,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.5.1'
+          image: 'weaveworks/weave-kube:2.5.2'
           ports:
             - name: metrics
               containerPort: 6782
@@ -196,7 +196,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.5.1'
+          image: 'weaveworks/weave-npc:2.5.2'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -160,7 +160,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.5.1'
+          image: 'weaveworks/weave-kube:2.5.2'
           ports:
             - name: metrics
               containerPort: 6782
@@ -200,7 +200,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.5.1'
+          image: 'weaveworks/weave-npc:2.5.2'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -674,9 +674,9 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		versions := map[string]string{
 			"pre-k8s-1.6": "2.3.0-kops.3",
 			"k8s-1.6":     "2.3.0-kops.3",
-			"k8s-1.7":     "2.5.1-kops.2",
-			"k8s-1.8":     "2.5.1-kops.2",
-			"k8s-1.12":    "2.5.1-kops.2",
+			"k8s-1.7":     "2.5.2-kops.2",
+			"k8s-1.8":     "2.5.2-kops.2",
+			"k8s-1.12":    "2.5.2-kops.2",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -119,7 +119,7 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.1-kops.2
+    version: 2.5.2-kops.2
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
@@ -127,7 +127,7 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.1-kops.2
+    version: 2.5.2-kops.2
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
@@ -135,4 +135,4 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.1-kops.2
+    version: 2.5.2-kops.2

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -115,7 +115,7 @@ spec:
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0 <1.8.0'
     manifest: networking.weave/k8s-1.7.yaml
-    manifestHash: e017ce8498a9c4b0569bf2e4d7f49f9f4201ef52
+    manifestHash: 258ad76c3ef165f216980c96367df13a8bffb1d8
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
@@ -123,7 +123,7 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: 390e23353f5370d294663065a3ca7e0fb1d63737
+    manifestHash: 748a1526515a719058b99c203cd943a740675e21
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
@@ -131,7 +131,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: c784dfaae5188e0b1e4dbfea0373abe8d1a01b48
+    manifestHash: 11e566a259bbb5f066cf2b06cd8832e74072a900
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
Cherry pick of #7444 on release-1.14.

#7444: upgrade weave to 2.5.2 to address the issues in