### PR TITLE
Add exec-opts options to dockerconfig

### DIFF
--- a/pkg/apis/kops/dockerconfig.go
+++ b/pkg/apis/kops/dockerconfig.go
@@ -28,6 +28,8 @@ type DockerConfig struct {
 	DataRoot *string `json:"dataRoot,omitempty" flag:"data-root"`
 	// DefaultUlimit is the ulimits for containers
 	DefaultUlimit []string `json:"defaultUlimit,omitempty" flag:"default-ulimit,repeat"`
+	// ExecOpt is a series of options passed to the runtime
+	ExecOpt []string `json:"execOpt,omitempty" flag:"exec-opt,repeat"`
 	// ExecRoot is the root directory for execution state files (default "/var/run/docker")
 	ExecRoot *string `json:"execRoot,omitempty" flag:"exec-root"`
 	// Experimental features permits enabling new features such as dockerd metrics

--- a/pkg/apis/kops/v1alpha1/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha1/dockerconfig.go
@@ -28,6 +28,8 @@ type DockerConfig struct {
 	DataRoot *string `json:"dataRoot,omitempty" flag:"data-root"`
 	// DefaultUlimit is the ulimits for containers
 	DefaultUlimit []string `json:"defaultUlimit,omitempty" flag:"default-ulimit,repeat"`
+	// ExecOpt is a series of options passed to the runtime
+	ExecOpt []string `json:"execOpt,omitempty" flag:"exec-opt,repeat"`
 	// ExecRoot is the root directory for execution state files (default "/var/run/docker")
 	ExecRoot *string `json:"execRoot,omitempty" flag:"exec-root"`
 	// Experimental features permits enabling new features such as dockerd metrics

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -2079,6 +2079,7 @@ func autoConvert_v1alpha1_DockerConfig_To_kops_DockerConfig(in *DockerConfig, ou
 	out.BridgeIP = in.BridgeIP
 	out.DataRoot = in.DataRoot
 	out.DefaultUlimit = in.DefaultUlimit
+	out.ExecOpt = in.ExecOpt
 	out.ExecRoot = in.ExecRoot
 	out.Experimental = in.Experimental
 	out.Hosts = in.Hosts
@@ -2111,6 +2112,7 @@ func autoConvert_kops_DockerConfig_To_v1alpha1_DockerConfig(in *kops.DockerConfi
 	out.BridgeIP = in.BridgeIP
 	out.DataRoot = in.DataRoot
 	out.DefaultUlimit = in.DefaultUlimit
+	out.ExecOpt = in.ExecOpt
 	out.ExecRoot = in.ExecRoot
 	out.Experimental = in.Experimental
 	out.Hosts = in.Hosts

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -877,6 +877,11 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ExecOpt != nil {
+		in, out := &in.ExecOpt, &out.ExecOpt
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ExecRoot != nil {
 		in, out := &in.ExecRoot, &out.ExecRoot
 		*out = new(string)

--- a/pkg/apis/kops/v1alpha2/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha2/dockerconfig.go
@@ -28,6 +28,8 @@ type DockerConfig struct {
 	DataRoot *string `json:"dataRoot,omitempty" flag:"data-root"`
 	// DefaultUlimit is the ulimits for containers
 	DefaultUlimit []string `json:"defaultUlimit,omitempty" flag:"default-ulimit,repeat"`
+	// ExecOpt is a series of options passed to the runtime
+	ExecOpt []string `json:"execOpt,omitempty" flag:"exec-opt,repeat"`
 	// ExecRoot is the root directory for execution state files (default "/var/run/docker")
 	ExecRoot *string `json:"execRoot,omitempty" flag:"exec-root"`
 	// Experimental features permits enabling new features such as dockerd metrics

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2186,6 +2186,7 @@ func autoConvert_v1alpha2_DockerConfig_To_kops_DockerConfig(in *DockerConfig, ou
 	out.BridgeIP = in.BridgeIP
 	out.DataRoot = in.DataRoot
 	out.DefaultUlimit = in.DefaultUlimit
+	out.ExecOpt = in.ExecOpt
 	out.ExecRoot = in.ExecRoot
 	out.Experimental = in.Experimental
 	out.Hosts = in.Hosts
@@ -2218,6 +2219,7 @@ func autoConvert_kops_DockerConfig_To_v1alpha2_DockerConfig(in *kops.DockerConfi
 	out.BridgeIP = in.BridgeIP
 	out.DataRoot = in.DataRoot
 	out.DefaultUlimit = in.DefaultUlimit
+	out.ExecOpt = in.ExecOpt
 	out.ExecRoot = in.ExecRoot
 	out.Experimental = in.Experimental
 	out.Hosts = in.Hosts

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -850,6 +850,11 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ExecOpt != nil {
+		in, out := &in.ExecOpt, &out.ExecOpt
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ExecRoot != nil {
 		in, out := &in.ExecRoot, &out.ExecRoot
 		*out = new(string)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -973,6 +973,11 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ExecOpt != nil {
+		in, out := &in.ExecOpt, &out.ExecOpt
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ExecRoot != nil {
 		in, out := &in.ExecRoot, &out.ExecRoot
 		*out = new(string)


### PR DESCRIPTION
Add exec options so it is possible to support `native.cgroupdriver=systemd` as recommended in k8s production documentation [0].

[0] https://kubernetes.io/docs/setup/production-environment/container-runtimes/

