### PR TITLE
Fix Flatcar distro

### DIFF
--- a/upup/pkg/fi/nodeup/nodetasks/service.go
+++ b/upup/pkg/fi/nodeup/nodetasks/service.go
@@ -43,6 +43,8 @@ const (
 
 	coreosSystemdSystemPath = "/etc/systemd/system"
 
+	flatcarSystemdSystemPath = "/etc/systemd/system"
+
 	containerosSystemdSystemPath = "/etc/systemd/system"
 )
 
@@ -150,6 +152,8 @@ func (e *Service) systemdSystemPath(target tags.HasTags) (string, error) {
 		return centosSystemdSystemPath, nil
 	} else if target.HasTag("_coreos") {
 		return coreosSystemdSystemPath, nil
+	} else if target.HasTag("_flatcar") {
+		return flatcarSystemdSystemPath, nil
 	} else if target.HasTag("_containeros") {
 		return containerosSystemdSystemPath, nil
 	} else {


### PR DESCRIPTION
Signed-off-by: Salvatore Mazzarino <dev@mazzarino.cz>

This solves an issue for Flatcar distribution. kops can't bootstrap because the systemd dir is not found due to unmatched tag.

How can we test this safely? Do we have integration tests that could cover this? If not I don't mind to create them