### PR TITLE
Ignore empty hashfiles

### DIFF
--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -314,6 +314,10 @@ func (a *AssetBuilder) findHash(file *FileAsset) (*hashing.Hash, error) {
 
 			// Accept a hash string that is `<hash> <filename>`
 			fields := strings.Fields(hashString)
+			if len(fields) == 0 {
+				klog.Infof("hash file was empty %q", hashURL)
+				continue
+			}
 			return hashing.FromString(fields[0])
 		}
 	}


### PR DESCRIPTION
While developing sha256 support, I observed that an empty hash file
caused a panic.