### PR TITLE
fix(upup/models/cloudup/resources/addons/coredns.addons.k8s.io) missing resourceVersion

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -228,6 +228,9 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
+  # Without this resourceVersion value, an update of the Service between versions will yield:
+  #   Service "kube-dns" is invalid: metadata.resourceVersion: Invalid value: "": must be specified for an update
+  resourceVersion: "0"
 spec:
   selector:
     k8s-app: kube-dns


### PR DESCRIPTION
This PR fixes a protokube error while applying the `coredns` addon.  [We can see the same behavior (already fixed) on kubeadm using kube-dns](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/phases/addons/dns/manifests.go#L194-L196)

## Error logs

```
I0826 22:05:34.677310   14969 addon.go:130] Applying update from "s3://BUCKET-STATE-STORE/CLUSTER-NAME/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
I0826 22:05:34.677339   14969 s3fs.go:220] Reading file "s3://BUCKET-STATE-STORE/CLUSTER-NAME/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
I0826 22:05:34.693912   14969 apply.go:67] Running command: kubectl apply -f /tmp/channel974681140/manifest.yaml
I0826 22:05:34.853468   14969 apply.go:70] error running kubectl apply -f /tmp/channel974681140/manifest.yaml
The Service "coredns" is invalid: metadata.resourceVersion: Invalid value: "": must be specified for an update
Error: error updating "coredns.addons.k8s.io": error applying update from "coredns.addons.k8s.io/k8s-1.12.yaml": error running kubectl
Usage:
  channels apply channel [flags]

Flags:
  -f, --filename strings   Apply from a local file
  -h, --help               help for channel
      --yes                Apply update

Global Flags:
      --alsologtostderr                  log to standard error as well as files
      --config string                    config file (default is $HOME/.channels.yaml)
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --log_file string                  If non-empty, use this log file
      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --logtostderr                      log to standard error instead of files (default true)
      --skip_headers                     If true, avoid header prefixes in the log messages
      --skip_log_headers                 If true, avoid headers when openning log files
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          number for the log level verbosity (default 0)
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging


error updating "coredns.addons.k8s.io": error applying update from "coredns.addons.k8s.io/k8s-1.12.yaml": error running kubectl
W0826 22:05:34.854816    2243 kube_boot.go:157] error applying channel "s3://BUCKET-STATE-STORE/CLUSTER-NAME/addons/bootstrap-channel.yaml": error running channels: exit status 1
```

## After fix:
```
I0826 22:18:38.134799   29343 s3fs.go:220] Reading file "s3://BUCKET-STATE-STORE/CLUSTER-NAME/addons/bootstrap-channel.yaml"
I0826 22:18:38.165114   29343 addons.go:113] Skipping version range "<1.6.0" that does not match current version 1.13.10
I0826 22:18:38.165140   29343 addons.go:113] Skipping version range ">=1.6.0 <1.12.0" that does not match current version 1.13.10
I0826 22:18:38.165149   29343 addons.go:113] Skipping version range "<1.6.0" that does not match current version 1.13.10
I0826 22:18:38.165155   29343 addons.go:113] Skipping version range ">=1.6.0 <1.12.0" that does not match current version 1.13.10
I0826 22:18:38.165161   29343 addons.go:113] Skipping version range "<1.7.0" that does not match current version 1.13.10
I0826 22:18:38.165167   29343 addons.go:113] Skipping version range ">=1.7.0 <1.12.0" that does not match current version 1.13.10
No update required
```

Thanks @deadc ❤️ 
