### PR TITLE
Configure calico MTU

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -240,9 +240,12 @@ data:
   # essential.
   typha_service_name: "none"
 
-  # TODO: Do we want to configure this?
   # Configure the MTU to use
+  {{- if .Networking.Calico.MTU }}
+  veth_mtu: "{{ .Networking.Calico.MTU }}"
+  {{- else }}
   veth_mtu: "{{- if eq .CloudProvider "openstack" -}}1430{{- else -}}1440{{- end -}}"
+  {{- end }}
 
   # Configure the Calico backend to use.
   calico_backend: "bird"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -242,7 +242,7 @@ data:
 
   # TODO: Do we want to configure this?
   # Configure the MTU to use
-  veth_mtu: "1440"
+  veth_mtu: "{{- if eq .CloudProvider "openstack" -}}1430{{- else -}}1440{{- end -}}"
 
   # Configure the Calico backend to use.
   calico_backend: "bird"


### PR DESCRIPTION
If I am using 1440 MTU in openstack, it is not working at all. After modifying it to 1430 calico works fine.

Like this doc says the correct value for openstack is 1430:

https://docs.projectcalico.org/v3.7/networking/mtu 