### PR TITLE
Allow configure ip to ip mode in calico

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -517,6 +517,7 @@ k8s.io/cloud-provider v0.0.0-20190819145148-d91c85d212d5 h1:WwHDS59SEe565zE0HkQe
 k8s.io/cloud-provider v0.0.0-20190819145148-d91c85d212d5/go.mod h1:QA5op/z7plbkib4HCBQiIgukeGT6nlgCm5eVxlp5Yw8=
 k8s.io/cluster-bootstrap v0.0.0-20190819145008-029dd04813af/go.mod h1:qLX6uJLmcJW//+paTJYkND4gjTK/v1CjUZCZfJJkaTQ=
 k8s.io/code-generator v0.0.0-20181117043124-c2090bec4d9b/go.mod h1:MYiN+ZJZ9HkETbgVZdWw2AsuAi9PZ4V80cwfuf2axe8=
+k8s.io/code-generator v0.0.0-20190612205613-18da4a14b22b h1:p+PRuwXWwk5e+UYvicGiavEupapqM5NOxUl3y1GkD6c=
 k8s.io/code-generator v0.0.0-20190612205613-18da4a14b22b/go.mod h1:G8bQwmHm2eafm5bgtX67XDZQ8CWKSGu9DekI+yN4Y5I=
 k8s.io/component-base v0.0.0-20190819141909-f0f7c184477d h1:4C6bgyEgzfGDQEkyq/swmBelfEIH494iHGdZPUF0KO8=
 k8s.io/component-base v0.0.0-20190819141909-f0f7c184477d/go.mod h1:DFWQCXgXVLiWtzFaS17KxHdlUeUymP7FLxZSkmL9/jU=
@@ -526,6 +527,7 @@ k8s.io/csi-api v0.0.0-20181011073329-55e69c84e236/go.mod h1:GH854hXKH+vaEO06X/DM
 k8s.io/csi-translation-lib v0.0.0-20190819145328-4831a4ced492 h1:Q59McQ11New10ymIUfQocTFJrQnEKUTU4kQtQNPekIs=
 k8s.io/csi-translation-lib v0.0.0-20190819145328-4831a4ced492/go.mod h1:8EWIx04nstfGUJ1PJyGegey8boDz9980RkmMqxPBuN0=
 k8s.io/gengo v0.0.0-20181106084056-51747d6e00da/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20190116091435-f8a0810f38af h1:SwjZbO0u5ZuaV6TRMWOGB40iaycX8sbdMQHtjNZ19dk=
 k8s.io/gengo v0.0.0-20190116091435-f8a0810f38af/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/heapster v1.2.0-beta.1/go.mod h1:h1uhptVXMwC8xtZBYsPXKVi8fpdlYkTs6k949KozGrM=
 k8s.io/helm v2.9.0+incompatible h1:3EFDJoqKSUe1BpC9qP+YaHi2Oua9hFT+C24/LhX2G1g=

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -93,6 +93,8 @@ type CalicoNetworkingSpec struct {
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 	// MajorVersion is the version of Calico to use
 	MajorVersion string `json:"majorVersion,omitempty"`
+	// IpPoolMode is mode for CALICO_IPV4POOL_IPIP
+	IpPoolMode string `json:"ipPoolMode,omitempty"`
 }
 
 // CanalNetworkingSpec declares that we want Canal networking

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -93,8 +93,8 @@ type CalicoNetworkingSpec struct {
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 	// MajorVersion is the version of Calico to use
 	MajorVersion string `json:"majorVersion,omitempty"`
-	// IpPoolMode is mode for CALICO_IPV4POOL_IPIP
-	IpPoolMode string `json:"ipPoolMode,omitempty"`
+	// IPIPMode is mode for CALICO_IPV4POOL_IPIP
+	IPIPMode string `json:"ipipMode,omitempty"`
 }
 
 // CanalNetworkingSpec declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -93,6 +93,8 @@ type CalicoNetworkingSpec struct {
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 	// MajorVersion is the version of Calico to use
 	MajorVersion string `json:"majorVersion,omitempty"`
+	// IpPoolMode is mode for CALICO_IPV4POOL_IPIP
+	IpPoolMode string `json:"ipPoolMode,omitempty"`
 }
 
 // CanalNetworkingSpec declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -93,8 +93,8 @@ type CalicoNetworkingSpec struct {
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 	// MajorVersion is the version of Calico to use
 	MajorVersion string `json:"majorVersion,omitempty"`
-	// IpPoolMode is mode for CALICO_IPV4POOL_IPIP
-	IpPoolMode string `json:"ipPoolMode,omitempty"`
+	// IPIPMode is mode for CALICO_IPV4POOL_IPIP
+	IPIPMode string `json:"ipipMode,omitempty"`
 }
 
 // CanalNetworkingSpec declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1117,6 +1117,7 @@ func autoConvert_v1alpha1_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	out.MajorVersion = in.MajorVersion
+	out.IpPoolMode = in.IpPoolMode
 	return nil
 }
 
@@ -1134,6 +1135,7 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha1_CalicoNetworkingSpec(in *
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	out.MajorVersion = in.MajorVersion
+	out.IpPoolMode = in.IpPoolMode
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1117,7 +1117,7 @@ func autoConvert_v1alpha1_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	out.MajorVersion = in.MajorVersion
-	out.IpPoolMode = in.IpPoolMode
+	out.IPIPMode = in.IPIPMode
 	return nil
 }
 
@@ -1135,7 +1135,7 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha1_CalicoNetworkingSpec(in *
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	out.MajorVersion = in.MajorVersion
-	out.IpPoolMode = in.IpPoolMode
+	out.IPIPMode = in.IPIPMode
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -93,6 +93,8 @@ type CalicoNetworkingSpec struct {
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 	// MajorVersion is the version of Calico to use
 	MajorVersion string `json:"majorVersion,omitempty"`
+	// IpPoolMode is mode for CALICO_IPV4POOL_IPIP
+	IpPoolMode string `json:"ipPoolMode,omitempty"`
 }
 
 // CanalNetworkingSpec declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -93,8 +93,8 @@ type CalicoNetworkingSpec struct {
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 	// MajorVersion is the version of Calico to use
 	MajorVersion string `json:"majorVersion,omitempty"`
-	// IpPoolMode is mode for CALICO_IPV4POOL_IPIP
-	IpPoolMode string `json:"ipPoolMode,omitempty"`
+	// IPIPMode is mode for CALICO_IPV4POOL_IPIP
+	IPIPMode string `json:"ipipMode,omitempty"`
 }
 
 // CanalNetworkingSpec declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1159,6 +1159,7 @@ func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	out.MajorVersion = in.MajorVersion
+	out.IpPoolMode = in.IpPoolMode
 	return nil
 }
 
@@ -1176,6 +1177,7 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	out.MajorVersion = in.MajorVersion
+	out.IpPoolMode = in.IpPoolMode
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1159,7 +1159,7 @@ func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	out.MajorVersion = in.MajorVersion
-	out.IpPoolMode = in.IpPoolMode
+	out.IPIPMode = in.IPIPMode
 	return nil
 }
 
@@ -1177,7 +1177,7 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	out.MajorVersion = in.MajorVersion
-	out.IpPoolMode = in.IpPoolMode
+	out.IPIPMode = in.IPIPMode
 	return nil
 }
 

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -590,8 +590,7 @@ spec:
               value: "autodetect"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
-              # was value: "Always"
-              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}cross-subnet{{- else -}}always{{- end -}}"
+              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}cross-subnet{{- else -}} {{- or .Networking.Calico.IpPoolMode "always" -}} {{- end -}}"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -590,7 +590,7 @@ spec:
               value: "autodetect"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
-              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}cross-subnet{{- else -}} {{- or .Networking.Calico.IpPoolMode "always" -}} {{- end -}}"
+              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}cross-subnet{{- else -}} {{- or .Networking.Calico.IPIPMode "always" -}} {{- end -}}"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:


### PR DESCRIPTION
Currently ip to ip mode is hardcoded to be Always or CrossSubnet. However, ip to ip mode is taking quite big performance hit all the time. That is why we want to disable ip to ip mode in some services. We can see about ~10x increase in network performance if we use `never` option.

so the network config then is

```
  networking:
    calico:
      majorVersion: v3
      ipipMode: never
```

