### PR TITLE
util/pkg/vfs: Fix swallowed errors

### DIFF
--- a/util/pkg/vfs/sshfs.go
+++ b/util/pkg/vfs/sshfs.go
@@ -190,7 +190,8 @@ func (p *SSHPath) WriteFile(data io.ReadSeeker, acl ACL) error {
 	}
 
 	if err == nil {
-		session, err := p.client.NewSession()
+		var session *ssh.Session
+		session, err = p.client.NewSession()
 		if err != nil {
 			err = fmt.Errorf("error creating session for rename: %v", err)
 		} else {


### PR DESCRIPTION
Creating a new SSH session inside of an if-block also declared a new `err` variable with scope that never made it out to the return.