### PR TITLE
Set GOPROXY in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ go:
 go_import_path: k8s.io/kops
 
 script:
-  - make travis-ci
+  - GOPROXY=https://proxy.golang.org make travis-ci


### PR DESCRIPTION
We were observing some flakes in the travis builds pulling from
github; by setting GOPROXY we should avoid those; we also gain some
security.