### PR TITLE
Add event ttl flag

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -918,6 +918,9 @@ spec:
                   items:
                     type: string
                   type: array
+                eventTTL:
+                  description: Amount of time to retain Kubernetes events
+                  type: string
                 experimentalEncryptionProviderConfig:
                   description: ExperimentalEncryptionProviderConfig enables encryption
                     at rest for secrets.

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -450,6 +450,9 @@ type KubeAPIServerConfig struct {
 
 	// CPURequest, cpu request compute resource for api server. Defaults to "150m"
 	CPURequest string `json:"cpuRequest,omitempty"`
+
+	// Amount of time to retain Kubernetes events
+	EventTTL *metav1.Duration `json:"eventTTL,omitempty" flag:"event-ttl"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -450,6 +450,9 @@ type KubeAPIServerConfig struct {
 
 	// CPURequest, cpu request compute resource for api server. Defaults to "150m"
 	CPURequest string `json:"cpuRequest,omitempty"`
+
+	// Amount of time to retain Kubernetes events
+	EventTTL *metav1.Duration `json:"eventTTL,omitempty" flag:"event-ttl"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -3089,6 +3089,7 @@ func autoConvert_v1alpha1_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.ServiceAccountIssuer = in.ServiceAccountIssuer
 	out.APIAudiences = in.APIAudiences
 	out.CPURequest = in.CPURequest
+	out.EventTTL = in.EventTTL
 	return nil
 }
 
@@ -3186,6 +3187,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha1_KubeAPIServerConfig(in *ko
 	out.ServiceAccountIssuer = in.ServiceAccountIssuer
 	out.APIAudiences = in.APIAudiences
 	out.CPURequest = in.CPURequest
+	out.EventTTL = in.EventTTL
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -1917,6 +1917,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.EventTTL != nil {
+		in, out := &in.EventTTL, &out.EventTTL
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -450,6 +450,9 @@ type KubeAPIServerConfig struct {
 
 	// CPURequest, cpu request compute resource for api server. Defaults to "150m"
 	CPURequest string `json:"cpuRequest,omitempty"`
+
+	// Amount of time to retain Kubernetes events
+	EventTTL *metav1.Duration `json:"eventTTL,omitempty" flag:"event-ttl"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3359,6 +3359,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.ServiceAccountIssuer = in.ServiceAccountIssuer
 	out.APIAudiences = in.APIAudiences
 	out.CPURequest = in.CPURequest
+	out.EventTTL = in.EventTTL
 	return nil
 }
 
@@ -3456,6 +3457,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.ServiceAccountIssuer = in.ServiceAccountIssuer
 	out.APIAudiences = in.APIAudiences
 	out.CPURequest = in.CPURequest
+	out.EventTTL = in.EventTTL
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1988,6 +1988,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.EventTTL != nil {
+		in, out := &in.EventTTL, &out.EventTTL
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2170,6 +2170,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.EventTTL != nil {
+		in, out := &in.EventTTL, &out.EventTTL
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/flagbuilder/buildflags_test.go
+++ b/pkg/flagbuilder/buildflags_test.go
@@ -220,6 +220,12 @@ func TestBuildAPIServerFlags(t *testing.T) {
 			},
 			Expected: "--authorization-webhook-cache-unauthorized-ttl=10s --insecure-port=0 --secure-port=0",
 		},
+		{
+			Config: &kops.KubeAPIServerConfig{
+				EventTTL: &metav1.Duration{Duration: 3 * time.Hour},
+			},
+			Expected: "--event-ttl=3h0m0s --insecure-port=0 --secure-port=0",
+		},
 	}
 
 	for _, test := range grid {


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
Add support for kops to declare `event-ttl` flag from `kube-apiserver`  

**Which issue(s) this PR fixes**:
Fixes #7484 

**Special notes for your reviewer**:
Should I remove `pkg/apis/kops/types.generated.go` from this PR?
This file made this PR longer than it should be :disappointed: 
I ran this commented command [here](https://github.com/kubernetes/kops/blob/a9574284465216a26929d8ef5e5fa5ee8e69e92f/Makefile#L666)

**Does this PR introduce a user-facing change?**:
```release-note
Add "event-ttl" flag from kube-apiserver
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
kind: Cluster
spec:
    kubeAPIServer:
        eventTTL: 03h0m0s
```