### PR TITLE
move OpenStack from alpha to beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We like to think of it as `kubectl` for clusters.
 
 `kops` helps you create, destroy, upgrade and maintain production-grade, highly
 available, Kubernetes clusters from the command line. AWS (Amazon Web Services)
-is currently officially supported, with GCE in beta support , and VMware vSphere
+is currently officially supported, with GCE and OpenStack in beta support, and VMware vSphere
 in alpha, and other platforms planned.
 
 
@@ -30,7 +30,7 @@ in alpha, and other platforms planned.
 </p>
 
 
-## Launching a Kubernetes cluster hosted on AWS, GCE or DigitalOcean
+## Launching a Kubernetes cluster hosted on AWS, GCE, DigitalOcean or OpenStack
 
 To replicate the above demo, check out our [tutorial](/docs/aws.md) for
 launching a Kubernetes cluster hosted on AWS.
@@ -38,6 +38,8 @@ launching a Kubernetes cluster hosted on AWS.
 To install a Kubernetes cluster on GCE please follow this [guide](/docs/tutorial/gce.md).
 
 To install a Kubernetes cluster on DigitalOcean, follow this [guide](/docs/tutorial/digitalocean.md).
+
+To install a Kubernetes cluster on OpenStack, follow this [guide](/docs/tutorial/openstack.md).
 
 **For anything beyond experimental clusters it is highly encouraged to [version control the cluster manifest files](/docs/manifests_and_customizing_via_api.md) and [run kops in a CI environment](/docs/continuous_integration.md).**
 

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -382,15 +382,13 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 		cmd.Flags().StringVar(&options.SpotinstOrientation, "spotinst-orientation", options.SpotinstOrientation, "Set the prediction strategy (valid values: balanced, cost, equal-distribution and availability)")
 	}
 
-	if cloudup.AlphaAllowOpenstack.Enabled() {
-		// Openstack flags
-		cmd.Flags().StringVar(&options.OpenstackExternalNet, "os-ext-net", options.OpenstackExternalNet, "The name of the external network to use with the openstack router")
-		cmd.Flags().StringVar(&options.OpenstackExternalSubnet, "os-ext-subnet", options.OpenstackExternalSubnet, "The name of the external floating subnet to use with the openstack router")
-		cmd.Flags().StringVar(&options.OpenstackLbSubnet, "os-lb-floating-subnet", options.OpenstackLbSubnet, "The name of the external subnet to use with the kubernetes api")
-		cmd.Flags().BoolVar(&options.OpenstackStorageIgnoreAZ, "os-kubelet-ignore-az", options.OpenstackStorageIgnoreAZ, "If true kubernetes may attach volumes across availability zones")
-		cmd.Flags().BoolVar(&options.OpenstackLBOctavia, "os-octavia", options.OpenstackLBOctavia, "If true octavia loadbalancer api will be used")
-		cmd.Flags().StringVar(&options.OpenstackDNSServers, "os-dns-servers", options.OpenstackDNSServers, "comma separated list of DNS Servers which is used in network")
-	}
+	// Openstack flags
+	cmd.Flags().StringVar(&options.OpenstackExternalNet, "os-ext-net", options.OpenstackExternalNet, "The name of the external network to use with the openstack router")
+	cmd.Flags().StringVar(&options.OpenstackExternalSubnet, "os-ext-subnet", options.OpenstackExternalSubnet, "The name of the external floating subnet to use with the openstack router")
+	cmd.Flags().StringVar(&options.OpenstackLbSubnet, "os-lb-floating-subnet", options.OpenstackLbSubnet, "The name of the external subnet to use with the kubernetes api")
+	cmd.Flags().BoolVar(&options.OpenstackStorageIgnoreAZ, "os-kubelet-ignore-az", options.OpenstackStorageIgnoreAZ, "If true kubernetes may attach volumes across availability zones")
+	cmd.Flags().BoolVar(&options.OpenstackLBOctavia, "os-octavia", options.OpenstackLBOctavia, "If true octavia loadbalancer api will be used")
+	cmd.Flags().StringVar(&options.OpenstackDNSServers, "os-dns-servers", options.OpenstackDNSServers, "comma separated list of DNS Servers which is used in network")
 
 	return cmd
 }
@@ -908,7 +906,7 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 			}
 		}
 
-		if cloudup.AlphaAllowOpenstack.Enabled() && c.Cloud == "openstack" {
+		if c.Cloud == "openstack" {
 			if cluster.Spec.CloudConfig == nil {
 				cluster.Spec.CloudConfig = &api.CloudConfiguration{}
 			}

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -97,6 +97,12 @@ kops create cluster [flags]
       --node-size string                 Set instance size for nodes
       --node-tenancy string              The tenancy of the node group on AWS. Can be either default or dedicated.
       --node-volume-size int32           Set instance volume size (in GB) for nodes
+      --os-dns-servers string            comma separated list of DNS Servers which is used in network
+      --os-ext-net string                The name of the external network to use with the openstack router
+      --os-ext-subnet string             The name of the external floating subnet to use with the openstack router
+      --os-kubelet-ignore-az             If true kubernetes may attach volumes across availability zones
+      --os-lb-floating-subnet string     The name of the external subnet to use with the kubernetes api
+      --os-octavia                       If true octavia loadbalancer api will be used
       --out string                       Path to write any local output
   -o, --output string                    Output format. One of json|yaml. Used with the --dry-run flag.
       --project string                   Project to use (must be set on GCE)

--- a/docs/tutorial/openstack.md
+++ b/docs/tutorial/openstack.md
@@ -1,6 +1,6 @@
 # Getting Started with kops on OpenStack
 
-**WARNING**: OpenStack support on kops is currently **alpha** meaning it is in the early stages of development and subject to change, please use with caution.
+**WARNING**: OpenStack support on kops is currently **beta**, which means that OpenStack support is in good shape. However, always some small things might change before we can really say that it is production ready.
 
 The tutorial shown on this page works with `kops` v1.12 and above.
 
@@ -23,8 +23,6 @@ It is important to set the following environment variables:
 ```bash
 export KOPS_STATE_STORE=swift://<bucket-name> # where <bucket-name> is the name of the Swift container to use for kops state
 
-# this is required since OpenStack support is currently in alpha so it is feature gated
-export KOPS_FEATURE_FLAGS="AlphaAllowOpenstack"
 ```
 
 If your OpenStack does not have Swift you can use any other VFS store, such as S3.
@@ -117,7 +115,7 @@ If you want use [External CCM](https://github.com/kubernetes/cloud-provider-open
 Enable featureflag:
 
 ```
-export KOPS_FEATURE_FLAGS=AlphaAllowOpenstack,+EnableExternalCloudController
+export KOPS_FEATURE_FLAGS=+EnableExternalCloudController
 ```
 
 Create cluster without `--yes` flag (or modify existing cluster):

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -85,8 +85,6 @@ var (
 	AlphaAllowDO = featureflag.New("AlphaAllowDO", featureflag.Bool(false))
 	// AlphaAllowGCE is a feature flag that gates GCE support while it is alpha
 	AlphaAllowGCE = featureflag.New("AlphaAllowGCE", featureflag.Bool(false))
-	// AlphaAllowOpenstack is a feature flag that gates OpenStack support while it is alpha
-	AlphaAllowOpenstack = featureflag.New("AlphaAllowOpenstack", featureflag.Bool(false))
 	// AlphaAllowVsphere is a feature flag that gates vsphere support while it is alpha
 	AlphaAllowVsphere = featureflag.New("AlphaAllowVsphere", featureflag.Bool(false))
 	// AlphaAllowALI is a feature flag that gates aliyun support while it is alpha
@@ -517,9 +515,6 @@ func (c *ApplyClusterCmd) Run() error {
 
 	case kops.CloudProviderOpenstack:
 		{
-			if !AlphaAllowOpenstack.Enabled() {
-				return fmt.Errorf("Openstack support is currently alpha, and is feature-gated.  export KOPS_FEATURE_FLAGS=AlphaAllowOpenstack")
-			}
 
 			osCloud := cloud.(openstack.OpenstackCloud)
 			region = osCloud.Region()


### PR DESCRIPTION
We have contributed quite much to OpenStack part of kops. Our opinion is that OpenStack should not be anymore in alpha, because the things are in place what is needed to really run kops OpenStack heavily. Etcd manager support is there and so on.

What you think @justinsb? As I see it, this is not big change from code perspective. However, we could get more users by moving it out of alpha and receive feedback from our mistakes :)

We have been using kops OpenStack already like 6 months without huge issues. Thing that comes to my mind is that rolling-update is not working perfectly without external autoscaler pod (https://github.com/ElisaOyj/kops-autoscaler-openstack we deploy this to under kube-system and it will handle autoscaling instances back when we run rolling update to cluster).

/cc @drekle 