### PR TITLE
Nodeup should skip managing docker on amazon linux 2

### DIFF
--- a/nodeup/pkg/distros/distribution.go
+++ b/nodeup/pkg/distros/distribution.go
@@ -24,18 +24,19 @@ import (
 type Distribution string
 
 var (
-	DistributionJessie      Distribution = "jessie"
-	DistributionDebian9     Distribution = "debian9"
-	DistributionDebian10    Distribution = "buster"
-	DistributionXenial      Distribution = "xenial"
-	DistributionBionic      Distribution = "bionic"
-	DistributionRhel7       Distribution = "rhel7"
-	DistributionCentos7     Distribution = "centos7"
-	DistributionRhel8       Distribution = "rhel8"
-	DistributionCentos8     Distribution = "centos8"
-	DistributionCoreOS      Distribution = "coreos"
-	DistributionFlatcar     Distribution = "flatcar"
-	DistributionContainerOS Distribution = "containeros"
+	DistributionJessie       Distribution = "jessie"
+	DistributionDebian9      Distribution = "debian9"
+	DistributionDebian10     Distribution = "buster"
+	DistributionXenial       Distribution = "xenial"
+	DistributionBionic       Distribution = "bionic"
+	DistributionRhel7        Distribution = "rhel7"
+	DistributionCentos7      Distribution = "centos7"
+	DistributionRhel8        Distribution = "rhel8"
+	DistributionCentos8      Distribution = "centos8"
+	DistributionCoreOS       Distribution = "coreos"
+	DistributionFlatcar      Distribution = "flatcar"
+	DistributionContainerOS  Distribution = "containeros"
+	DistributionAmazonLinux2 Distribution = "amazonlinux2"
 )
 
 func (d Distribution) BuildTags() []string {
@@ -64,6 +65,8 @@ func (d Distribution) BuildTags() []string {
 		t = []string{"_flatcar"}
 	case DistributionContainerOS:
 		t = []string{"_containeros"}
+	case DistributionAmazonLinux2:
+		t = []string{"_amazonlinux2"}
 	default:
 		klog.Fatalf("unknown distribution: %s", d)
 		return nil
@@ -88,7 +91,7 @@ func (d Distribution) IsDebianFamily() bool {
 		return true
 	case DistributionXenial, DistributionBionic:
 		return true
-	case DistributionCentos7, DistributionRhel7:
+	case DistributionCentos7, DistributionRhel7, DistributionAmazonLinux2:
 		return false
 	case DistributionCoreOS, DistributionContainerOS:
 		return false
@@ -104,7 +107,7 @@ func (d Distribution) IsUbuntu() bool {
 		return false
 	case DistributionXenial, DistributionBionic:
 		return true
-	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8:
+	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8, DistributionAmazonLinux2:
 		return false
 	case DistributionCoreOS, DistributionFlatcar, DistributionContainerOS:
 		return false
@@ -116,7 +119,7 @@ func (d Distribution) IsUbuntu() bool {
 
 func (d Distribution) IsRHELFamily() bool {
 	switch d {
-	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8:
+	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8, DistributionAmazonLinux2:
 		return true
 	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9, DistributionDebian10:
 		return false
@@ -132,7 +135,7 @@ func (d Distribution) IsSystemd() bool {
 	switch d {
 	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9, DistributionDebian10:
 		return true
-	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8:
+	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8, DistributionAmazonLinux2:
 		return true
 	case DistributionCoreOS, DistributionFlatcar:
 		return true

--- a/nodeup/pkg/distros/identify.go
+++ b/nodeup/pkg/distros/identify.go
@@ -113,7 +113,7 @@ func FindDistribution(rootfs string) (Distribution, error) {
 				return DistributionContainerOS, nil
 			}
 			if strings.HasPrefix(line, "PRETTY_NAME=\"Amazon Linux 2") {
-				return DistributionCentos7, nil
+				return DistributionAmazonLinux2, nil
 			}
 		}
 		klog.Warningf("unhandled /etc/os-release info %q", string(osRelease))

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -849,6 +849,13 @@ func (b *DockerBuilder) Build(c *fi.ModelBuilderContext) error {
 			return err
 		}
 		return nil
+
+	case distros.DistributionAmazonLinux2:
+		klog.Infof("Detected DistributionAmazonLinux2; won't install Docker")
+		if err := b.buildContainerOSConfigurationDropIn(c); err != nil {
+			return err
+		}
+		return nil
 	}
 
 	// Add Apache2 license


### PR DESCRIPTION
I tried amazon linux 2 with kops 1.12.3/kube 1.12.10 and my host is not making much progress, it is stuck on nodeup:

```
Aug 30 03:58:11 ip-10-43-202-247.us-west-2.compute.internal nodeup[4925]: I0830 03:58:11.582065    4925 executor.go:103] Tasks: 40 done / 48 total; 1 can run
Aug 30 03:58:11 ip-10-43-202-247.us-west-2.compute.internal nodeup[4925]: I0830 03:58:11.582105    4925 executor.go:178] Executing task "Package/docker-ce": Package: docker-ce
Aug 30 03:58:11 ip-10-43-202-247.us-west-2.compute.internal nodeup[4925]: I0830 03:58:11.582145    4925 package.go:206] Listing installed packages: /usr/bin/rpm -q docker-ce --queryformat %{NAME} %{VERSION}
Aug 30 03:58:11 ip-10-43-202-247.us-west-2.compute.internal nodeup[4925]: I0830 03:58:11.607332    4925 package.go:267] Installing package "docker-ce" (dependencies: [Package: container-selinux])
Aug 30 03:58:11 ip-10-43-202-247.us-west-2.compute.internal nodeup[4925]: I0830 03:58:11.661015    4925 files.go:100] Hash matched for "/var/cache/nodeup/packages/docker-ce": sha1:0a1325e570c5e54111a79623c9fd0c0c714d3a11
Aug 30 03:58:11 ip-10-43-202-247.us-west-2.compute.internal nodeup[4925]: I0830 03:58:11.661107    4925 files.go:100] Hash matched for "/var/cache/nodeup/packages/container-selinux": sha1:d9f87f7f4f2e8e611f556d873a17b8c0c580fec0
Aug 30 03:58:11 ip-10-43-202-247.us-west-2.compute.internal nodeup[4925]: I0830 03:58:11.661117    4925 package.go:304] running command [/usr/bin/rpm -i /var/cache/nodeup/packages/docker-ce /var/cache/nodeup/packages/container-selinux]
Aug 30 03:58:11 ip-10-43-202-247.us-west-2.compute.internal nodeup[4925]: W0830 03:58:11.709197    4925 executor.go:130] error running task "Package/docker-ce" (7m27s remaining to succeed): error installing package "docker-ce": exit status 2: warning: /var/cache/nodeup/packages/docker-ce: Header V4 RSA/SHA512 Signature, key ID 621e9f35: NOKEY
Aug 30 03:58:11 ip-10-43-202-247.us-west-2.compute.internal nodeup[4925]: warning: /var/cache/nodeup/packages/container-selinux: Header V3 RSA/SHA256 Signature, key ID f4a80eb5: NOKEY
Aug 30 03:58:11 ip-10-43-202-247.us-west-2.compute.internal nodeup[4925]: error: Failed dependencies:
Aug 30 03:58:11 ip-10-43-202-247.us-west-2.compute.internal nodeup[4925]: docker conflicts with docker-ce-18.06.1.ce-3.el7.x86_64
Aug 30 03:58:11 ip-10-43-202-247.us-west-2.compute.internal nodeup[4925]: docker-io conflicts with docker-ce-18.06.1.ce-3.el7.x86_64
Aug 30 03:58:11 ip-10-43-202-247.us-west-2.compute.internal nodeup[4925]: I0830 03:58:11.709218    4925 executor.go:145] No progress made, sleeping before retrying 1 failed task(s)
```

this code short circuits installing docker from centos repos and goes with whatever the AMI provides.

Amazon will be tracking stable versions of docker, see here: https://aws.amazon.com/amazon-linux-2/release-notes/ and look for this bit:

```
The package for Docker is only available through extras and is enabled by default. When new versions of Docker are released, support will be provided only for the most current stable packages.
```

so kops doesn't need to do anything for docker.