### PR TITLE
fix(addons/coredns.addons.k8s.io) Workaound to stop coredns crashing on 1.3.1 version

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -171,6 +171,7 @@ spec:
             memory: {{ KubeDNS.MemoryRequest }}
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
+        # Workaround for 1.3.1 bug, can be removed after bumping to 1.4+. See: https://github.com/coredns/coredns/pull/2529
         - name: tmp
           mountPath: /tmp
         - name: config-volume
@@ -210,6 +211,7 @@ spec:
             scheme: HTTP
       dnsPolicy: Default
       volumes:
+        # Workaround for 1.3.1 bug, can be removed after bumping to 1.4+. See: https://github.com/coredns/coredns/pull/2529
         - name: tmp
           emptyDir: {}
         - name: config-volume

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -171,6 +171,8 @@ spec:
             memory: {{ KubeDNS.MemoryRequest }}
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         - name: config-volume
           mountPath: /etc/coredns
           readOnly: true
@@ -208,6 +210,8 @@ spec:
             scheme: HTTP
       dnsPolicy: Default
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: config-volume
           configMap:
             name: coredns

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -283,7 +283,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.3.0-kops.2"
+			version := "1.3.1"
 
 			{
 				location := key + "/k8s-1.12.yaml"


### PR DESCRIPTION
[There is a known bug on `CoreOS` `1.3.1`](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#known-issues) wherein if the Kubernetes API shuts down while CoreDNS is connected, CoreDNS will crash. 

The workaround is to create a `/tmp` volume [See here](https://github.com/coredns/deployment/pull/138/files)

## Logs:
```
E0827 00:44:53.344864       1 reflector.go:134] github.com/coredns/coredns/plugin/kubernetes/controller.go:322: Failed to list *v1.Namespace: Get https://172.20.0.1:443/api/v1/namespaces?limit=500&resourceVersion=0: dial tcp 172.20.0.1:443: connect: connection refused
E0827 00:44:53.344864       1 reflector.go:134] github.com/coredns/coredns/plugin/kubernetes/controller.go:322: Failed to list *v1.Namespace: Get https://172.20.0.1:443/api/v1/namespaces?limit=500&resourceVersion=0: dial tcp 172.20.0.1:443: connect: connection refused
log: exiting because of error: log: cannot create log: open /tmp/coredns.coredns-57f8cc697b-dnpkj.unknownuser.log.ERROR.20190827-004453.1: no such file or directory
```

After this patch, CoreDNS stopped crashing.

## References
https://github.com/kubernetes/kubernetes/issues/75414
https://github.com/coredns/coredns/issues/2629 
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#known-issues
https://github.com/coredns/deployment/pull/138 
