### PR TITLE
Update rules_docker with python2 workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GCS_URL=$(GCS_LOCATION:gs://%=https://storage.googleapis.com/%)
 LATEST_FILE?=latest-ci.txt
 GOPATH_1ST:=$(shell go env | grep GOPATH | cut -f 2 -d \")
 UNIQUE:=$(shell date +%s)
-GOVERSION=1.12.5
+GOVERSION=1.12.9
 BUILD=$(GOPATH_1ST)/src/k8s.io/kops/.build
 LOCAL=$(BUILD)/local
 BINDATA_TARGETS=upup/models/bindata.go

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ go_register_toolchains(
     go_version = "1.12.9",
 )
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 gazelle_dependencies()
 
@@ -40,7 +40,7 @@ gazelle_dependencies()
 git_repository(
     name = "io_bazel_rules_docker",
     remote = "https://github.com/bazelbuild/rules_docker.git",
-    tag = "v0.7.0",
+    tag = "v0.9.0",
 )
 
 load(
@@ -129,4 +129,11 @@ git_repository(
     commit = "f85734f673056977d8ba04b0386394b684ca2acb",
     remote = "https://github.com/kubernetes/repo-infra.git",
     shallow_since = "1563324513 -0800",
+)
+
+go_repository(
+    name = "com_github_google_go_containerregistry",
+    importpath = "github.com/google/go-containerregistry",
+    sum = "h1:PTrxTL8TNRbZts4KqdJMsqRlrdjoiKFDq6MVitj8mPk=",
+    version = "v0.0.0-20190829181151-21b2e01cec04",
 )

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -10,4 +10,9 @@ build --stamp
 build --workspace_status_command=./tools/get_workspace_status.sh
 build --verbose_failures
 
+# Workaround for rules_docker python compatibility
+# See https://github.com/bazelbuild/rules_docker/issues/842
+# and https://github.com/bazelbuild/rules_docker/issues/580
+build --host_force_python=PY2
+
 test --test_output=errors


### PR DESCRIPTION
The [kops-postsubmit jobs](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/kops-postsubmit/1168617128891256836/) are currently failing with a python interpreter issue. See https://github.com/bazelbuild/rules_docker/issues/842 for more info and https://github.com/bazelbuild/rules_docker/issues/580 for tracking the long term fix.

Also updating the docker builds to use the same go version as https://github.com/kubernetes/kops/pull/7499

/assign @justinsb