### PR TITLE
Remove unused ClientGetter from Drain code

### DIFF
--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -398,7 +398,6 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 		Force:             options.Force,
 		Cloud:             cloud,
 		K8sClient:         k8sClient,
-		ClientGetter:      clientGetter,
 		FailOnDrainError:  options.FailOnDrainError,
 		FailOnValidate:    options.FailOnValidate,
 		CloudOnly:         options.CloudOnly,

--- a/pkg/instancegroups/BUILD.bazel
+++ b/pkg/instancegroups/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 	api "k8s.io/kops/pkg/apis/kops"
@@ -44,8 +43,9 @@ type RollingUpdateCluster struct {
 
 	Force bool
 
-	K8sClient        kubernetes.Interface
-	ClientGetter     genericclioptions.RESTClientGetter
+	// K8sClient is the kubernetes client, used for draining etc
+	K8sClient kubernetes.Interface
+
 	FailOnDrainError bool
 	FailOnValidate   bool
 	CloudOnly        bool


### PR DESCRIPTION
This is no longer needed now we are using the k8s drain code.