### PR TITLE
fix(addons/networking.projectcalico.org) calico kube-controllers is needed in CRD mode

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -442,9 +442,6 @@ subjects:
   namespace: kube-system
 ---
 
-# This manifest scales the Calico Kubernetes controllers down to size 0.
-# They are not needed in CRD mode.
-# See https://github.com/projectcalico/kube-controllers
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -458,7 +455,7 @@ spec:
     matchLabels:
       k8s-app: calico-kube-controllers
   # The controllers can only have a single active instance.
-  replicas: 0
+  replicas: 1
   strategy:
     type: Recreate
   template:
@@ -469,12 +466,17 @@ spec:
         k8s-app: calico-kube-controllers
         role.kubernetes.io/networking: "1"
     spec:
+      hostNetwork: true
+      serviceAccount: calico-node
+      serviceAccountName: calico-node
       containers:
         - name: calico-kube-controllers
           image: calico/kube-controllers:v3.8.0
-      initContainers:
-        - name: migrate
-          image: calico/upgrade:v1.0.5
+          env:
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            - name: ENABLED_CONTROLLERS
+              value: policy,namespace,serviceaccount,workloadendpoint,node
 
 ---
 


### PR DESCRIPTION
The code comment says that Calico Kube Controllers isn't need in CRD mode, but we can see [docs of calico saying how to configure for datastore mode](https://docs.projectcalico.org/v3.8/reference/kube-controllers/configuration) and we started having problems using calico without this.

## Problem description
 - We start seeing logs like this in `calico-node`:
```
2019-09-03 14:50:41.821 [INFO][24] ipam.go 311: Looking up existing affinities for host handle="ipip-tunnel-addr-ip-10-164-41-80.ec2.internal" host="ip-10-164-41-80.ec2.internal"
2019-09-03 14:50:41.966 [INFO][24] ipam.go 369: Ran out of existing affine blocks for host handle="ipip-tunnel-addr-ip-10-164-41-80.ec2.internal" host="ip-10-164-41-80.ec2.internal"
2019-09-03 14:50:41.971 [INFO][24] ipam.go 434: No more affine blocks, but need to allocate 1 more addresses - allocate another block handle="ipip-tunnel-addr-ip-10-164-41-80.ec2.internal" host="ip-10-164-41-80.ec2.internal"
2019-09-03 14:50:41.971 [INFO][24] ipam.go 438: Looking for an unclaimed block handle="ipip-tunnel-addr-ip-10-164-41-80.ec2.internal" host="ip-10-164-41-80.ec2.internal"
```
- New nodes stopped to be up and Estabilished in `calicoctl node status`
- We can see a lot of unused `ipamblocks` and `blockaffinities` resources on K8S with a very different number when compared to our nodes running:
```
kubectl get ipamblocks | wc -l && kubectl get blockaffinities | wc -l && kubectl get nodes | wc -l
512
512
76
```
- After applying the deployment of `calico-kube-controller`, everything started working again and the numbers are now correct:
```
kubectl get ipamblocks | wc -l && kubectl get blockaffinities | wc -l && kubectl get nodes | wc -l
76
76
76
```

- We can see calico-kube-controllers logs doing what was expected here:
```
2019-09-04 13:16:09.681 [INFO][1] ipam.go 1166: Releasing all IPs with handle 'ipip-tunnel-addr-ip-10-164-76-215.ec2.internal'
2019-09-04 13:16:13.677 [INFO][1] kdd.go 154: Cleaning up IPAM resources for deleted node node="ip-10-164-41-56.ec2.internal"
```