### PR TITLE
Don't try to delete ElasticIPs of NatGateway is shared

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -1339,7 +1339,13 @@ func FindNatGateways(cloud fi.Cloud, routeTables map[string]*resources.Resource,
 			natGatewayId := aws.StringValue(ngw.NatGatewayId)
 
 			forceShared := !ownedNatGatewayIds.Has(natGatewayId)
-			resourceTrackers = append(resourceTrackers, buildNatGatewayResource(ngw, forceShared, clusterName))
+			ngwResource := buildNatGatewayResource(ngw, forceShared, clusterName)
+			resourceTrackers = append(resourceTrackers, ngwResource)
+
+			// Dont try to remove ElasticIPs if NatGateway is shared
+			if ngwResource.Shared {
+				continue
+			}
 
 			// If we're deleting the NatGateway, we should delete the ElasticIP also
 			for _, address := range ngw.NatGatewayAddresses {


### PR DESCRIPTION
Right now, if a NatGateway is shared, kops will still try to remove ElasticIPs associated to the NatGateway when trying to delete a cluster. These ElasticIPs don't have any ownership tags.

This will never work, as kops is not deleting the NatGateway, and it shouldn't anyway, since kops doesn't own the ElasticIP.

Fixed this by not checking for ElasticIPs when trying to delete a shared NatGateway.
Tested that with an owned NatGateway, the associated Elastic IP is still deleted.