### PR TITLE
Bootstrap: protokube labels its own node with node-role label

### DIFF
--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -227,6 +227,14 @@ type ProtokubeFlags struct {
 	// RemoveDNSNames allows us to remove dns records, so that they can be managed elsewhere
 	// We use it e.g. for the switch to etcd-manager
 	RemoveDNSNames string `json:"removeDNSNames,omitempty" flag:"remove-dns-names"`
+
+	// BootstrapMasterNodeLabels applies the critical node-role labels to our node,
+	// which lets us bring up the controllers that can only run on masters, which are then
+	// responsible for node labels.  The node is specified by NodeName
+	BootstrapMasterNodeLabels bool `json:"bootstrapMasterNodeLabels,omitempty" flag:"bootstrap-master-node-labels"`
+
+	// NodeName is the name of the node as will be created in kubernetes.  Primarily used by BootstrapMasterNodeLabels.
+	NodeName string `json:"nodeName,omitempty" flag:"node-name"`
 }
 
 // ProtokubeFlags is responsible for building the command line flags for protokube
@@ -367,6 +375,16 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) (*Protokube
 
 	if k8sVersion.Major == 1 && k8sVersion.Minor <= 5 {
 		f.ApplyTaints = fi.Bool(true)
+	}
+
+	if k8sVersion.Major == 1 && k8sVersion.Minor >= 16 {
+		f.BootstrapMasterNodeLabels = true
+
+		nodeName, err := t.NodeName()
+		if err != nil {
+			return nil, fmt.Errorf("error getting NodeName: %v", err)
+		}
+		f.NodeName = nodeName
 	}
 
 	// Remove DNS names if we're using etcd-manager

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -98,6 +98,12 @@ func run() error {
 	manageEtcd := false
 	flag.BoolVar(&manageEtcd, "manage-etcd", manageEtcd, "Set to manage etcd (deprecated in favor of etcd-manager)")
 
+	bootstrapMasterNodeLabels := false
+	flag.BoolVar(&bootstrapMasterNodeLabels, "bootstrap-master-node-labels", bootstrapMasterNodeLabels, "Bootstrap the labels for master nodes (required in k8s 1.16)")
+
+	nodeName := ""
+	flag.StringVar(&nodeName, "node-name", nodeName, "name of the node as will be created in kubernetes; used with bootstrap-master-node-labels")
+
 	var removeDNSNames string
 	flag.StringVar(&removeDNSNames, "remove-dns-names", removeDNSNames, "If set, will remove the DNS records specified")
 
@@ -387,28 +393,30 @@ func run() error {
 	}
 
 	k := &protokube.KubeBoot{
-		ApplyTaints:           applyTaints,
-		Channels:              channels,
-		DNS:                   dnsProvider,
-		ManageEtcd:            manageEtcd,
-		EtcdBackupImage:       etcdBackupImage,
-		EtcdBackupStore:       etcdBackupStore,
-		EtcdImageSource:       etcdImageSource,
-		EtcdElectionTimeout:   etcdElectionTimeout,
-		EtcdHeartbeatInterval: etcdHeartbeatInterval,
-		InitializeRBAC:        initializeRBAC,
-		InternalDNSSuffix:     dnsInternalSuffix,
-		InternalIP:            internalIP,
-		Kubernetes:            protokube.NewKubernetesContext(),
-		Master:                master,
-		ModelDir:              modelDir,
-		PeerCA:                peerCA,
-		PeerCert:              peerCert,
-		PeerKey:               peerKey,
-		TLSAuth:               tlsAuth,
-		TLSCA:                 tlsCA,
-		TLSCert:               tlsCert,
-		TLSKey:                tlsKey,
+		ApplyTaints:               applyTaints,
+		BootstrapMasterNodeLabels: bootstrapMasterNodeLabels,
+		NodeName:                  nodeName,
+		Channels:                  channels,
+		DNS:                       dnsProvider,
+		ManageEtcd:                manageEtcd,
+		EtcdBackupImage:           etcdBackupImage,
+		EtcdBackupStore:           etcdBackupStore,
+		EtcdImageSource:           etcdImageSource,
+		EtcdElectionTimeout:       etcdElectionTimeout,
+		EtcdHeartbeatInterval:     etcdHeartbeatInterval,
+		InitializeRBAC:            initializeRBAC,
+		InternalDNSSuffix:         dnsInternalSuffix,
+		InternalIP:                internalIP,
+		Kubernetes:                protokube.NewKubernetesContext(),
+		Master:                    master,
+		ModelDir:                  modelDir,
+		PeerCA:                    peerCA,
+		PeerCert:                  peerCert,
+		PeerKey:                   peerKey,
+		TLSAuth:                   tlsAuth,
+		TLSCA:                     tlsCA,
+		TLSCert:                   tlsCert,
+		TLSKey:                    tlsKey,
 	}
 
 	k.Init(volumes)

--- a/protokube/pkg/protokube/BUILD.bazel
+++ b/protokube/pkg/protokube/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "kube_boot_task.go",
         "kube_context.go",
         "kube_dns.go",
+        "labeler.go",
         "models.go",
         "nsenter_exec.go",
         "openstack_volume.go",

--- a/protokube/pkg/protokube/kube_boot.go
+++ b/protokube/pkg/protokube/kube_boot.go
@@ -82,6 +82,14 @@ type KubeBoot struct {
 	// PeerKey is the path to a peer private key for etcd
 	PeerKey string
 
+	// BootstrapMasterNodeLabels controls the initial application of node labels to our node
+	// The node is found by matching NodeName
+	BootstrapMasterNodeLabels bool
+
+	// NodeName is the name of our node as it will be registered in k8s.
+	// Used by BootstrapMasterNodeLabels
+	NodeName string
+
 	volumeMounter   *VolumeMountController
 	etcdControllers map[string]*EtcdController
 }
@@ -142,6 +150,11 @@ func (k *KubeBoot) syncOnce() error {
 	}
 
 	if k.Master {
+		if k.BootstrapMasterNodeLabels {
+			if err := bootstrapMasterNodeLabels(k.Kubernetes, k.NodeName); err != nil {
+				klog.Warningf("error bootstrapping master node labels: %v", err)
+			}
+		}
 		if k.ApplyTaints {
 			if err := applyMasterTaints(k.Kubernetes); err != nil {
 				klog.Warningf("error updating master taints: %v", err)

--- a/protokube/pkg/protokube/labeler.go
+++ b/protokube/pkg/protokube/labeler.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protokube
+
+import (
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"k8s.io/klog"
+)
+
+// bootstrapMasterNodeLabels applies labels to the current node so that it acts as a master
+func bootstrapMasterNodeLabels(kubeContext *KubernetesContext, nodeName string) error {
+	client, err := kubeContext.KubernetesClient()
+	if err != nil {
+		return err
+	}
+
+	klog.V(2).Infof("Querying k8s for node %q", nodeName)
+	node, err := client.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error querying node %q: %v", nodeName, err)
+	}
+
+	labels := map[string]string{
+		"node-role.kubernetes.io/master": "",
+	}
+
+	shouldPatch := false
+	for k, v := range labels {
+		actual, found := node.Labels[k]
+		if !found || actual != v {
+			shouldPatch = true
+		}
+	}
+
+	if !shouldPatch {
+		return nil
+	}
+
+	klog.V(2).Infof("patching node %q to add labels %v", nodeName, labels)
+
+	nodePatchMetadata := &nodePatchMetadata{
+		Labels: labels,
+	}
+	nodePatch := &nodePatch{
+		Metadata: nodePatchMetadata,
+	}
+
+	nodePatchJson, err := json.Marshal(nodePatch)
+	if err != nil {
+		return fmt.Errorf("error building node patch: %v", err)
+	}
+
+	klog.V(2).Infof("sending patch for node %q: %q", node.Name, string(nodePatchJson))
+	_, err = client.CoreV1().Nodes().Patch(node.Name, types.StrategicMergePatchType, nodePatchJson)
+	if err != nil {
+		return fmt.Errorf("error applying patch to node: %v", err)
+	}
+
+	return nil
+}

--- a/protokube/pkg/protokube/tainter.go
+++ b/protokube/pkg/protokube/tainter.go
@@ -35,6 +35,7 @@ type nodePatch struct {
 
 type nodePatchMetadata struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 }
 
 type nodePatchSpec struct {


### PR DESCRIPTION
As of k8s 1.16, the node-role label is protected for security reasons.
We will introduce a controller to set those labels generically.
However, we need these labels to run the controller (only) on master
nodes.

To solve this bootstrapping problem, we use protokube to apply the
master role node labels to the master node only.  This isn't a
security problem because we assume that protokube on the master is
highly trusted - we are still administering labels centrally.

Then kops-controller can use this label to target the master nodes,
and run a central label controller.