### PR TITLE
WIP: Support custom rootCAs in OpenStack

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -471,6 +471,25 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster *kops.EtcdClusterSpec) (*v1.Po
 		}
 	}
 
+	// mount root CAs from instance if we have custom CA cert
+	if os.Getenv("OS_CACERT") != "" {
+		container.VolumeMounts = append(container.VolumeMounts, v1.VolumeMount{
+			Name:      "ca-certs",
+			MountPath: "/etc/ssl/certs",
+			ReadOnly:  true,
+		})
+		hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate
+		pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+			Name: "ca-certs",
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
+					Path: "/etc/ssl/certs",
+					Type: &hostPathDirectoryOrCreate,
+				},
+			},
+		})
+	}
+
 	kubemanifest.MarkPodAsCritical(pod)
 	kubemanifest.MarkPodAsClusterCritical(pod)
 

--- a/upup/pkg/fi/cloudup/openstack/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/openstack/BUILD.bazel
@@ -59,7 +59,9 @@ go_library(
         "//vendor/github.com/gophercloud/gophercloud/pagination:go_default_library",
         "//vendor/github.com/mitchellh/mapstructure:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/util/cert:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )


### PR DESCRIPTION
in OpenStack there is huge problem that quite many people uses self-signed certificates in OpenStack API. As I see it, supporting custom CA certificates is better than just running things in insecure mode.

For instance, k8s OpenStack cloudprovider is mounting always `/etc/ssl/certs` hostpath to inside containers `/etc/ssl/certs`. This is needed in case of etcd-manager and kops-controller.

@justinsb However, I am missing one thing: how to upload custom ca certificate to instance enough early (before first cloudprovider api call is done by nodeup) AND how to add that certificate to rootCAs? Can I use something existing or do we need new model for this? 

Basically I could use instancegroup additionaldata to make shellscript which will copy root ca there, but the problem is that how to regenerate rootCAs, like in case of debian/ubuntu I need run `update-ca-certificates`. I cannot hardcode that thing to code in kops cli side because its distro dependent