### PR TITLE
Kubelet configuration: Maximum pods flag is miscalculated when using Amazon VPC CNI

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -504,7 +504,18 @@ func (b *KubeletBuilder) buildKubeletConfigSpec() (*kops.KubeletConfigSpec, erro
 	}
 
 	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.AmazonVPC != nil {
-		instanceType, err := awsup.GetMachineTypeInfo(strings.Split(b.InstanceGroup.Spec.MachineType, ",")[0])
+		sess := session.Must(session.NewSession())
+		metadata := ec2metadata.New(sess)
+
+		// Get the actual instance type by querying the EC2 instance metadata service.
+		instanceTypeName, err := metadata.GetMetadata("instance-type")
+		if err != nil {
+			// Otherwise, fall back to the Instance Group spec.
+			instanceTypeName = strings.Split(b.InstanceGroup.Spec.MachineType, ",")[0]
+		}
+
+		// Get the instance type's detailed information.
+		instanceType, err := awsup.GetMachineTypeInfo(instanceTypeName)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Nodeup takes into account the first instance type from the Instance Group spec when the `max-pods` is calculated. This leads to a miscalculated value when using multiple instance types.

This PR fixes the issue by querying the EC2 instance metadata service to find out the actual instance type and maintains backward compatibility by falling back to the Instance Group spec.