### PR TITLE
Remove calico open port

### DIFF
--- a/pkg/model/firewall.go
+++ b/pkg/model/firewall.go
@@ -245,10 +245,6 @@ func (b *FirewallModelBuilder) applyNodeToMasterBlockSpecificPorts(c *fi.ModelBu
 	protocols := []Protocol{}
 
 	if b.Cluster.Spec.Networking.Calico != nil {
-		// Calico needs to access etcd
-		// TODO: Remove, replace with etcd in calico manifest
-		klog.Warningf("Opening etcd port on masters for access from the nodes, for calico.  This is unsafe in untrusted environments.")
-		tcpBlocked[4001] = false
 		protocols = append(protocols, ProtocolIPIP)
 	}
 


### PR DESCRIPTION
* Calico no longer needs this port open
* Since master should now be 1.16, kops 1.16 should only be used with 1.13 and up and therefor calico migration will have been required already. (May want to add logic here but I figured I would open this for comments in the meantime). See https://github.com/kubernetes/kops/pull/6358 for details.

/hold