### PR TITLE
Complete support for Flatcar

### DIFF
--- a/nodeup/pkg/distros/distribution.go
+++ b/nodeup/pkg/distros/distribution.go
@@ -90,7 +90,7 @@ func (d Distribution) IsDebianFamily() bool {
 		return true
 	case DistributionCentos7, DistributionRhel7:
 		return false
-	case DistributionCoreOS, DistributionContainerOS:
+	case DistributionCoreOS, DistributionFlatcar, DistributionContainerOS:
 		return false
 	default:
 		klog.Fatalf("unknown distribution: %s", d)

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -166,6 +166,10 @@ func (b *KubeControllerManagerBuilder) buildPod() (*v1.Pod, error) {
 			// The /usr directory is read-only for CoreOS
 			volumePluginDir = "/var/lib/kubelet/volumeplugins/"
 
+		case distros.DistributionFlatcar:
+			// The /usr directory is read-only for CoreOS
+			volumePluginDir = "/var/lib/kubelet/volumeplugins/"
+
 		default:
 			volumePluginDir = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
 		}

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -167,7 +167,7 @@ func (b *KubeControllerManagerBuilder) buildPod() (*v1.Pod, error) {
 			volumePluginDir = "/var/lib/kubelet/volumeplugins/"
 
 		case distros.DistributionFlatcar:
-			// The /usr directory is read-only for CoreOS
+			// The /usr directory is read-only for Flatcar
 			volumePluginDir = "/var/lib/kubelet/volumeplugins/"
 
 		default:

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -580,6 +580,10 @@ func (b *KubeletBuilder) buildKubeletConfigSpec() (*kops.KubeletConfigSpec, erro
 			// The /usr directory is read-only for CoreOS
 			c.VolumePluginDirectory = "/var/lib/kubelet/volumeplugins/"
 
+		case distros.DistributionFlatcar:
+			// The /usr directory is read-only for Flatcar
+			c.VolumePluginDirectory = "/var/lib/kubelet/volumeplugins/"
+
 		default:
 			c.VolumePluginDirectory = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
 		}

--- a/nodeup/pkg/model/miscutils.go
+++ b/nodeup/pkg/model/miscutils.go
@@ -40,6 +40,9 @@ func (b *MiscUtilsBuilder) Build(c *fi.ModelBuilderContext) error {
 	case distros.DistributionCoreOS:
 		klog.V(2).Infof("Detected CoreOS; won't install misc. utils")
 		return nil
+	case distros.DistributionFlatcar:
+		klog.V(2).Infof("Detected Flatcar; won't install misc. utils")
+		return nil
 	}
 
 	// TODO: These packages have been auto-installed for a long time, and likely we don't need all of them any longer

--- a/nodeup/pkg/model/ntp.go
+++ b/nodeup/pkg/model/ntp.go
@@ -42,7 +42,7 @@ func (b *NTPBuilder) Build(c *fi.ModelBuilderContext) error {
 		klog.Infof("Detected CoreOS; won't install ntp")
 		return nil
 	case distros.DistributionFlatcar:
-		klog.Infof("Detected CoreOS; won't install ntp")
+		klog.Infof("Detected Flatcar; won't install ntp")
 		return nil
 	}
 

--- a/nodeup/pkg/model/ntp.go
+++ b/nodeup/pkg/model/ntp.go
@@ -41,6 +41,9 @@ func (b *NTPBuilder) Build(c *fi.ModelBuilderContext) error {
 	case distros.DistributionCoreOS:
 		klog.Infof("Detected CoreOS; won't install ntp")
 		return nil
+	case distros.DistributionFlatcar:
+		klog.Infof("Detected CoreOS; won't install ntp")
+		return nil
 	}
 
 	if b.Distribution.IsDebianFamily() {


### PR DESCRIPTION
Signed-off-by: Salvatore Mazzarino <dev@mazzarino.cz>

Another tiny change that fixes the support for Flatcar (still broken, unfortunately) 

As tested in the release **1.15.1-alpha.1**

```txt
core@ip-172-20-65-153 ~ $ sudo journalctl -u coreos-cloudinit-350015389.service
-- Logs begin at Mon 2019-09-09 20:19:38 UTC, end at Mon 2019-09-09 20:26:45 UTC. --
Sep 09 20:19:59 ip-172-20-65-153.ec2.internal systemd[1]: Started Unit generated and executed by coreos-cloudinit on behalf of user.
Sep 09 20:19:59 ip-172-20-65-153.ec2.internal bash[1454]: == nodeup node config starting ==
Sep 09 20:19:59 ip-172-20-65-153.ec2.internal bash[1454]: Downloading nodeup (https://github.com/kubernetes/kops/releases/download/1.15.0-alpha.1/linux-am>
Sep 09 20:19:59 ip-172-20-65-153.ec2.internal bash[1454]:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
Sep 09 20:19:59 ip-172-20-65-153.ec2.internal bash[1454]:                                  Dload  Upload   Total   Spent    Left  Speed
Sep 09 20:19:59 ip-172-20-65-153.ec2.internal bash[1454]: [158B blob data]
Sep 09 20:20:00 ip-172-20-65-153.ec2.internal bash[1454]: [158B blob data]
Sep 09 20:20:00 ip-172-20-65-153.ec2.internal bash[1454]: == Downloaded https://github.com/kubernetes/kops/releases/download/1.15.0-alpha.1/linux-amd64-no>
Sep 09 20:20:00 ip-172-20-65-153.ec2.internal bash[1454]: Running nodeup
Sep 09 20:20:00 ip-172-20-65-153.ec2.internal bash[1454]: nodeup version 1.15.0-alpha.1 (git-7c84c4848)
Sep 09 20:20:00 ip-172-20-65-153.ec2.internal bash[1454]: F0909 20:20:00.545365    1481 distribution.go:96] unknown distribution: flatcar
Sep 09 20:20:00 ip-172-20-65-153.ec2.internal systemd[1]: coreos-cloudinit-350015389.service: Main process exited, code=exited, status=1/FAILURE
Sep 09 20:20:00 ip-172-20-65-153.ec2.internal systemd[1]: coreos-cloudinit-350015389.service: Failed with result 'exit-code'.
```