### PR TITLE
[DO-7442] Digital Ocean add consistent volume and droplet tags for multi master feature

### DIFF
--- a/pkg/model/BUILD.bazel
+++ b/pkg/model/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//upup/pkg/fi/cloudup/aliup:go_default_library",
         "//upup/pkg/fi/cloudup/awstasks:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
+        "//upup/pkg/fi/cloudup/do:go_default_library",
         "//upup/pkg/fi/cloudup/dotasks:go_default_library",
         "//upup/pkg/fi/cloudup/gce:go_default_library",
         "//upup/pkg/fi/cloudup/gcetasks:go_default_library",

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -394,7 +394,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster *kops.EtcdClusterSpec) (*v1.Po
 			config.VolumeProvider = "do"
 
 			// DO does not support . in tags / names
-			safeClusterName := do.SafeDOClusterName(b.Cluster.Name)
+			safeClusterName := do.SafeClusterName(b.Cluster.Name)
 
 			config.VolumeTag = []string{
 				fmt.Sprintf("%s=%s", do.TagKubernetesClusterNamePrefix, safeClusterName),

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -393,10 +393,12 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster *kops.EtcdClusterSpec) (*v1.Po
 		case kops.CloudProviderDO:
 			config.VolumeProvider = "do"
 
+			// DO does not support . in tags / names
+			safeClusterName := strings.Replace(b.Cluster.Name, ".", "-", -1)
+
 			config.VolumeTag = []string{
-				fmt.Sprintf("kubernetes.io/cluster=%s", b.Cluster.Name),
-				do.TagNameEtcdClusterPrefix + etcdCluster.Name,
-				do.TagNameRolePrefix + "master=1",
+				fmt.Sprintf("%s=%s", do.TagKubernetesClusterNamePrefix, safeClusterName),
+				do.TagKubernetesClusterIndex,
 			}
 			config.VolumeNameTag = do.TagNameEtcdClusterPrefix + etcdCluster.Name
 

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -394,7 +394,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster *kops.EtcdClusterSpec) (*v1.Po
 			config.VolumeProvider = "do"
 
 			// DO does not support . in tags / names
-			safeClusterName := strings.Replace(b.Cluster.Name, ".", "-", -1)
+			safeClusterName := do.SafeDOClusterName(b.Cluster.Name)
 
 			config.VolumeTag = []string{
 				fmt.Sprintf("%s=%s", do.TagKubernetesClusterNamePrefix, safeClusterName),

--- a/pkg/model/domodel/BUILD.bazel
+++ b/pkg/model/domodel/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/model:go_default_library",
         "//upup/pkg/fi:go_default_library",
+        "//upup/pkg/fi/cloudup/do:go_default_library",
         "//upup/pkg/fi/cloudup/dotasks:go_default_library",
     ],
 )

--- a/pkg/model/domodel/droplets.go
+++ b/pkg/model/domodel/droplets.go
@@ -17,11 +17,12 @@ limitations under the License.
 package domodel
 
 import (
-	"strings"
-	"strconv"
 	"k8s.io/kops/pkg/model"
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/do"
 	"k8s.io/kops/upup/pkg/fi/cloudup/dotasks"
+	"strconv"
+	"strings"
 )
 
 // DropletBuilder configures droplets for the cluster
@@ -44,8 +45,8 @@ func (d *DropletBuilder) Build(c *fi.ModelBuilderContext) error {
 	sshKeyFingerPrint := splitSSHKeyName[len(splitSSHKeyName)-1]
 
 	// replace "." with "-" since DO API does not accept "."
-	clusterTag := "KubernetesCluster:" + strings.Replace(d.ClusterName(), ".", "-", -1)
-	
+	clusterTag := do.TagKubernetesClusterNamePrefix + ":" + strings.Replace(d.ClusterName(), ".", "-", -1)
+
 	indexCount := 0
 	// In the future, DigitalOcean will use Machine API to manage groups,
 	// for now create d.InstanceGroups.Spec.MinSize amount of droplets
@@ -65,12 +66,12 @@ func (d *DropletBuilder) Build(c *fi.ModelBuilderContext) error {
 
 		if ig.IsMaster() {
 			indexCount++
-			clusterTagIndex := "K8S-INDEX:" + strconv.Itoa(indexCount)
-			droplet.Tags = []string{clusterTag, clusterTagIndex} 
+			clusterTagIndex := do.TagKubernetesClusterIndex + ":" + strconv.Itoa(indexCount)
+			droplet.Tags = []string{clusterTag, clusterTagIndex}
 		} else {
 			droplet.Tags = []string{clusterTag}
 		}
-		
+
 		userData, err := d.BootstrapScript.ResourceNodeUp(ig, d.Cluster)
 		if err != nil {
 			return err

--- a/pkg/model/domodel/droplets.go
+++ b/pkg/model/domodel/droplets.go
@@ -47,7 +47,7 @@ func (d *DropletBuilder) Build(c *fi.ModelBuilderContext) error {
 	// replace "." with "-" since DO API does not accept "."
 	clusterTag := do.TagKubernetesClusterNamePrefix + ":" + strings.Replace(d.ClusterName(), ".", "-", -1)
 
-	indexCount := 0
+	masterIndexCount := 0
 	// In the future, DigitalOcean will use Machine API to manage groups,
 	// for now create d.InstanceGroups.Spec.MinSize amount of droplets
 	for _, ig := range d.InstanceGroups {
@@ -64,12 +64,12 @@ func (d *DropletBuilder) Build(c *fi.ModelBuilderContext) error {
 		droplet.Image = fi.String(ig.Spec.Image)
 		droplet.SSHKey = fi.String(sshKeyFingerPrint)
 
+		droplet.Tags = []string{clusterTag}
+
 		if ig.IsMaster() {
-			indexCount++
-			clusterTagIndex := do.TagKubernetesClusterIndex + ":" + strconv.Itoa(indexCount)
-			droplet.Tags = []string{clusterTag, clusterTagIndex}
-		} else {
-			droplet.Tags = []string{clusterTag}
+			masterIndexCount++
+			clusterTagIndex := do.TagKubernetesClusterIndex + ":" + strconv.Itoa(masterIndexCount)
+			droplet.Tags = append(droplet.Tags, clusterTagIndex)
 		}
 
 		userData, err := d.BootstrapScript.ResourceNodeUp(ig, d.Cluster)

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -178,7 +178,7 @@ func (b *MasterVolumeBuilder) addAWSVolume(c *fi.ModelBuilderContext, name strin
 
 func (b *MasterVolumeBuilder) addDOVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) {
 	// required that names start with a lower case and only contains letters, numbers and hyphens
-	name = "kops-" + strings.Replace(name, ".", "-", -1)
+	name = "kops-" + do.SafeDOClusterName(name)
 
 	// DO has a 64 character limit for volume names
 	if len(name) >= 64 {
@@ -186,11 +186,11 @@ func (b *MasterVolumeBuilder) addDOVolume(c *fi.ModelBuilderContext, name string
 	}
 
 	tags := make(map[string]string)
-	tags[do.TagNameEtcdClusterPrefix+etcd.Name] = gce.SafeClusterName(m.Name)
-	tags[do.TagKubernetesClusterIndex] = gce.SafeClusterName(m.Name)
+	tags[do.TagNameEtcdClusterPrefix+etcd.Name] = do.SafeDOClusterName(m.Name)
+	tags[do.TagKubernetesClusterIndex] = do.SafeDOClusterName(m.Name)
 
 	// We always add an owned tags (these can't be shared)
-	tags[do.TagKubernetesClusterNamePrefix] = gce.SafeClusterName(b.Cluster.ObjectMeta.Name)
+	tags[do.TagKubernetesClusterNamePrefix] = do.SafeDOClusterName(b.Cluster.ObjectMeta.Name)
 
 	t := &dotasks.Volume{
 		Name:      s(name),

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/dotasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
+	"k8s.io/kops/upup/pkg/fi/cloudup/do"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gcetasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstacktasks"
@@ -184,11 +185,19 @@ func (b *MasterVolumeBuilder) addDOVolume(c *fi.ModelBuilderContext, name string
 		name = name[:64]
 	}
 
+	tags := make(map[string]string)
+	tags[do.TagNameEtcdClusterPrefix+etcd.Name] = gce.SafeClusterName(m.Name)
+
+	// We always add an owned tags (these can't be shared)
+	tags[do.TagKubernetesClusterNamePrefix] = gce.SafeClusterName(b.Cluster.ObjectMeta.Name)
+	
+	
 	t := &dotasks.Volume{
 		Name:      s(name),
 		Lifecycle: b.Lifecycle,
 		SizeGB:    fi.Int64(int64(volumeSize)),
 		Region:    s(zone),
+		Tags: tags,
 	}
 
 	c.AddTask(t)

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -29,9 +29,9 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/aliup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"k8s.io/kops/upup/pkg/fi/cloudup/do"
 	"k8s.io/kops/upup/pkg/fi/cloudup/dotasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
-	"k8s.io/kops/upup/pkg/fi/cloudup/do"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gcetasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstacktasks"
@@ -187,17 +187,17 @@ func (b *MasterVolumeBuilder) addDOVolume(c *fi.ModelBuilderContext, name string
 
 	tags := make(map[string]string)
 	tags[do.TagNameEtcdClusterPrefix+etcd.Name] = gce.SafeClusterName(m.Name)
+	tags[do.TagKubernetesClusterIndex] = gce.SafeClusterName(m.Name)
 
 	// We always add an owned tags (these can't be shared)
 	tags[do.TagKubernetesClusterNamePrefix] = gce.SafeClusterName(b.Cluster.ObjectMeta.Name)
-	
-	
+
 	t := &dotasks.Volume{
 		Name:      s(name),
 		Lifecycle: b.Lifecycle,
 		SizeGB:    fi.Int64(int64(volumeSize)),
 		Region:    s(zone),
-		Tags: tags,
+		Tags:      tags,
 	}
 
 	c.AddTask(t)

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -178,7 +178,7 @@ func (b *MasterVolumeBuilder) addAWSVolume(c *fi.ModelBuilderContext, name strin
 
 func (b *MasterVolumeBuilder) addDOVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) {
 	// required that names start with a lower case and only contains letters, numbers and hyphens
-	name = "kops-" + do.SafeDOClusterName(name)
+	name = "kops-" + do.SafeClusterName(name)
 
 	// DO has a 64 character limit for volume names
 	if len(name) >= 64 {
@@ -186,11 +186,11 @@ func (b *MasterVolumeBuilder) addDOVolume(c *fi.ModelBuilderContext, name string
 	}
 
 	tags := make(map[string]string)
-	tags[do.TagNameEtcdClusterPrefix+etcd.Name] = do.SafeDOClusterName(m.Name)
-	tags[do.TagKubernetesClusterIndex] = do.SafeDOClusterName(m.Name)
+	tags[do.TagNameEtcdClusterPrefix+etcd.Name] = do.SafeClusterName(m.Name)
+	tags[do.TagKubernetesClusterIndex] = do.SafeClusterName(m.Name)
 
 	// We always add an owned tags (these can't be shared)
-	tags[do.TagKubernetesClusterNamePrefix] = do.SafeDOClusterName(b.Cluster.ObjectMeta.Name)
+	tags[do.TagKubernetesClusterNamePrefix] = do.SafeClusterName(b.Cluster.ObjectMeta.Name)
 
 	t := &dotasks.Volume{
 		Name:      s(name),

--- a/upup/pkg/fi/cloudup/do/cloud.go
+++ b/upup/pkg/fi/cloudup/do/cloud.go
@@ -27,9 +27,9 @@ const TagNameEtcdClusterPrefix = "etcdCluster-"
 const TagNameRolePrefix = "k8s.io/role/"
 const TagKubernetesClusterNamePrefix = "KubernetesCluster"
 
-func SafeDOClusterName(clusterName string) string {
-	// GCE does not support . in tags / names
-	safeClusterName := strings.ReplaceAll(clusterName, ".", "-")
+func SafeClusterName(clusterName string) string {
+	// DO does not support . in tags / names
+	safeClusterName := strings.Replace(clusterName, ".", "-", -1)
 	return safeClusterName
 }
 

--- a/upup/pkg/fi/cloudup/do/cloud.go
+++ b/upup/pkg/fi/cloudup/do/cloud.go
@@ -19,12 +19,19 @@ package do
 import (
 	"k8s.io/kops/pkg/resources/digitalocean"
 	"k8s.io/kops/upup/pkg/fi"
+	"strings"
 )
 
 const TagKubernetesClusterIndex = "k8s-index"
 const TagNameEtcdClusterPrefix = "etcdCluster-"
 const TagNameRolePrefix = "k8s.io/role/"
 const TagKubernetesClusterNamePrefix = "KubernetesCluster"
+
+func SafeDOClusterName(clusterName string) string {
+	// GCE does not support . in tags / names
+	safeClusterName := strings.ReplaceAll(clusterName, ".", "-")
+	return safeClusterName
+}
 
 func NewDOCloud(region string) (fi.Cloud, error) {
 	return digitalocean.NewCloud(region)

--- a/upup/pkg/fi/cloudup/do/cloud.go
+++ b/upup/pkg/fi/cloudup/do/cloud.go
@@ -21,8 +21,9 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 )
 
-const TagNameEtcdClusterPrefix = "k8s.io/etcd/"
+const TagNameEtcdClusterPrefix = "etcdCluster-"
 const TagNameRolePrefix = "k8s.io/role/"
+const TagKubernetesClusterNamePrefix = "KubernetesCluster"
 
 func NewDOCloud(region string) (fi.Cloud, error) {
 	return digitalocean.NewCloud(region)

--- a/upup/pkg/fi/cloudup/do/cloud.go
+++ b/upup/pkg/fi/cloudup/do/cloud.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 )
 
+const TagKubernetesClusterIndex = "k8s-index"
 const TagNameEtcdClusterPrefix = "etcdCluster-"
 const TagNameRolePrefix = "k8s.io/role/"
 const TagKubernetesClusterNamePrefix = "KubernetesCluster"

--- a/upup/pkg/fi/cloudup/dotasks/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/dotasks/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//upup/pkg/fi/cloudup/do:go_default_library",
         "//upup/pkg/fi/cloudup/terraform:go_default_library",
         "//vendor/github.com/digitalocean/godo:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -19,7 +19,6 @@ package dotasks
 import (
 	"context"
 	"errors"
-	//"strconv"
 	"github.com/digitalocean/godo"
 
 	"k8s.io/klog"

--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -143,13 +143,7 @@ func (_ *Droplet) RenderDO(t *do.DOAPITarget, a, e, changes *Droplet) error {
 		newDropletCount = expectedCount - actualCount
 	}
 
-	// var dropletTags []string
-	// indexCount := 0
 	for i := 0; i < newDropletCount; i++ {
-		// indexCount++
-		// clusterTagIndex := "k8s-index:" + strconv.Itoa(indexCount)
-		// dropletTags = append(e.Tags, clusterTagIndex)
-
 		_, _, err = t.Cloud.Droplets().Create(context.TODO(), &godo.DropletCreateRequest{
 			Name:              fi.StringValue(e.Name),
 			Region:            fi.StringValue(e.Region),
@@ -162,7 +156,7 @@ func (_ *Droplet) RenderDO(t *do.DOAPITarget, a, e, changes *Droplet) error {
 		})
 
 		if err != nil {
-			klog.Errorf("Error creating droplet with Name=%s",  fi.StringValue(e.Name))
+			klog.Errorf("Error creating droplet with Name=%s", fi.StringValue(e.Name))
 			return err
 		}
 	}

--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -19,9 +19,10 @@ package dotasks
 import (
 	"context"
 	"errors"
-
+	//"strconv"
 	"github.com/digitalocean/godo"
 
+	"k8s.io/klog"
 	"k8s.io/kops/pkg/resources/digitalocean"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/do"
@@ -142,21 +143,30 @@ func (_ *Droplet) RenderDO(t *do.DOAPITarget, a, e, changes *Droplet) error {
 		newDropletCount = expectedCount - actualCount
 	}
 
-	var dropletNames []string
+	// var dropletTags []string
+	// indexCount := 0
 	for i := 0; i < newDropletCount; i++ {
-		dropletNames = append(dropletNames, fi.StringValue(e.Name))
+		// indexCount++
+		// clusterTagIndex := "k8s-index:" + strconv.Itoa(indexCount)
+		// dropletTags = append(e.Tags, clusterTagIndex)
+
+		_, _, err = t.Cloud.Droplets().Create(context.TODO(), &godo.DropletCreateRequest{
+			Name:              fi.StringValue(e.Name),
+			Region:            fi.StringValue(e.Region),
+			Size:              fi.StringValue(e.Size),
+			Image:             godo.DropletCreateImage{Slug: fi.StringValue(e.Image)},
+			PrivateNetworking: true,
+			Tags:              e.Tags,
+			UserData:          userData,
+			SSHKeys:           []godo.DropletCreateSSHKey{{Fingerprint: fi.StringValue(e.SSHKey)}},
+		})
+
+		if err != nil {
+			klog.Errorf("Error creating droplet with Name=%s",  fi.StringValue(e.Name))
+			return err
+		}
 	}
 
-	_, _, err = t.Cloud.Droplets().CreateMultiple(context.TODO(), &godo.DropletMultiCreateRequest{
-		Names:             dropletNames,
-		Region:            fi.StringValue(e.Region),
-		Size:              fi.StringValue(e.Size),
-		Image:             godo.DropletCreateImage{Slug: fi.StringValue(e.Image)},
-		PrivateNetworking: true,
-		Tags:              e.Tags,
-		UserData:          userData,
-		SSHKeys:           []godo.DropletCreateSSHKey{{Fingerprint: fi.StringValue(e.SSHKey)}},
-	})
 	return err
 }
 

--- a/upup/pkg/fi/cloudup/dotasks/volume.go
+++ b/upup/pkg/fi/cloudup/dotasks/volume.go
@@ -18,8 +18,8 @@ package dotasks
 
 import (
 	"context"
+	"fmt"
 	"github.com/digitalocean/godo"
-	"strings"
 
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/resources/digitalocean"
@@ -112,14 +112,10 @@ func (_ *Volume) RenderDO(t *do.DOAPITarget, a, e, changes *Volume) error {
 
 	tagArray := []string{}
 
-	klog.V(2).Info("Looping DO tag arrays")
 	for k, v := range e.Tags {
-		s := []string{k, v}
-
 		// DO tags don't accept =. Separate the key and value with an ":"
-		strJoin := strings.Join(s, ":")
-		klog.V(2).Infof("DO - Join the volume tag - %s", strJoin)
-		tagArray = append(tagArray, strJoin)
+		klog.V(10).Infof("DO - Join the volume tag - %s", fmt.Sprintf("%s:%s", k, v))
+		tagArray = append(tagArray, fmt.Sprintf("%s:%s", k, v))
 	}
 
 	volService := t.Cloud.Volumes()

--- a/upup/pkg/fi/cloudup/dotasks/volume.go
+++ b/upup/pkg/fi/cloudup/dotasks/volume.go
@@ -18,8 +18,8 @@ package dotasks
 
 import (
 	"context"
-	"strings"
 	"github.com/digitalocean/godo"
+	"strings"
 
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/resources/digitalocean"
@@ -111,16 +111,16 @@ func (_ *Volume) RenderDO(t *do.DOAPITarget, a, e, changes *Volume) error {
 	}
 
 	tagArray := []string{}
-	   
+
 	klog.V(2).Info("Looping DO tag arrays")
 	for k, v := range e.Tags {
-		 s := []string{k, v};
+		s := []string{k, v}
 
-		 // DO tags don't accept =. Separate the key and value with an ":"
-		 strJoin := strings.Join(s, ":")
-		 klog.V(2).Infof("DO - Join the volume tag - %s", strJoin)
-		 tagArray = append(tagArray, strJoin)            
-    }
+		// DO tags don't accept =. Separate the key and value with an ":"
+		strJoin := strings.Join(s, ":")
+		klog.V(2).Infof("DO - Join the volume tag - %s", strJoin)
+		tagArray = append(tagArray, strJoin)
+	}
 
 	volService := t.Cloud.Volumes()
 	_, _, err := volService.CreateVolume(context.TODO(), &godo.VolumeCreateRequest{

--- a/upup/pkg/fi/cloudup/dotasks/volume.go
+++ b/upup/pkg/fi/cloudup/dotasks/volume.go
@@ -18,9 +18,10 @@ package dotasks
 
 import (
 	"context"
-
+	"strings"
 	"github.com/digitalocean/godo"
 
+	"k8s.io/klog"
 	"k8s.io/kops/pkg/resources/digitalocean"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/do"
@@ -35,6 +36,7 @@ type Volume struct {
 
 	SizeGB *int64
 	Region *string
+	Tags   map[string]string
 }
 
 var _ fi.CompareWithID = &Volume{}
@@ -108,12 +110,26 @@ func (_ *Volume) RenderDO(t *do.DOAPITarget, a, e, changes *Volume) error {
 		return nil
 	}
 
+	tagArray := []string{}
+	   
+	klog.V(2).Info("Looping DO tag arrays")
+	for k, v := range e.Tags {
+		 s := []string{k, v};
+
+		 // DO tags don't accept =. Separate the key and value with an ":"
+		 strJoin := strings.Join(s, ":")
+		 klog.V(2).Infof("DO - Join the volume tag - %s", strJoin)
+		 tagArray = append(tagArray, strJoin)            
+    }
+
 	volService := t.Cloud.Volumes()
 	_, _, err := volService.CreateVolume(context.TODO(), &godo.VolumeCreateRequest{
 		Name:          fi.StringValue(e.Name),
 		Region:        fi.StringValue(e.Region),
 		SizeGigaBytes: fi.Int64Value(e.SizeGB),
+		Tags:          tagArray,
 	})
+
 	return err
 }
 


### PR DESCRIPTION
Digital Ocean doesn't support Multi master yet. This PR introduces tags that helps in associating a specific droplet to a volume. 
I have tested with by making the needed changes in etcd-manager and they are getting linked up properly. I'll be sending a PR for etcd-manager repo separately once this is merged.

I'll also be adding a new PR to add DO support for protokube's gossip cluster to add peers as part of the next step.