### PR TITLE
WIP: Use existing subnets in OpenStack

### DIFF
--- a/cmd/kops/BUILD.bazel
+++ b/cmd/kops/BUILD.bazel
@@ -93,6 +93,7 @@ go_library(
         "//upup/pkg/fi/cloudup/aliup:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//upup/pkg/fi/cloudup/gce:go_default_library",
+        "//upup/pkg/fi/cloudup/openstack:go_default_library",
         "//upup/pkg/fi/utils:go_default_library",
         "//upup/pkg/kutil:go_default_library",
         "//util/pkg/tables:go_default_library",

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -155,7 +155,7 @@ type CreateClusterOptions struct {
 	OpenstackStorageIgnoreAZ bool
 	OpenstackDNSServers      string
 	OpenstackLbSubnet        string
-
+	OpenstackNetworkName     string
 	// OpenstackLBOctavia is boolean value should we use octavia or old loadbalancer api
 	OpenstackLBOctavia bool
 
@@ -389,6 +389,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVar(&options.OpenstackStorageIgnoreAZ, "os-kubelet-ignore-az", options.OpenstackStorageIgnoreAZ, "If true kubernetes may attach volumes across availability zones")
 	cmd.Flags().BoolVar(&options.OpenstackLBOctavia, "os-octavia", options.OpenstackLBOctavia, "If true octavia loadbalancer api will be used")
 	cmd.Flags().StringVar(&options.OpenstackDNSServers, "os-dns-servers", options.OpenstackDNSServers, "comma separated list of DNS Servers which is used in network")
+	cmd.Flags().StringVar(&options.OpenstackNetworkName, "os-network", options.OpenstackNetworkName, "The name of the existing OpenStack network to use")
 
 	return cmd
 }
@@ -923,6 +924,11 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 					Timeout:    fi.String("30s"),
 					MaxRetries: fi.Int(3),
 				},
+			}
+			if c.OpenstackNetworkName != "" {
+				cluster.Spec.CloudConfig.Openstack.NetworkName = fi.String(c.OpenstackNetworkName)
+			} else {
+				cluster.Spec.CloudConfig.Openstack.NetworkName = fi.String(c.ClusterName)
 			}
 			if c.OpenstackDNSServers != "" {
 				cluster.Spec.CloudConfig.Openstack.Router.DNSServers = fi.String(c.OpenstackDNSServers)

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -102,6 +102,7 @@ kops create cluster [flags]
       --os-ext-subnet string             The name of the external floating subnet to use with the openstack router
       --os-kubelet-ignore-az             If true kubernetes may attach volumes across availability zones
       --os-lb-floating-subnet string     The name of the external subnet to use with the kubernetes api
+      --os-network string                The name of the existing OpenStack network to use
       --os-octavia                       If true octavia loadbalancer api will be used
       --out string                       Path to write any local output
   -o, --output string                    Output format. One of json|yaml. Used with the --dry-run flag.

--- a/docs/tutorial/openstack.md
+++ b/docs/tutorial/openstack.md
@@ -150,6 +150,25 @@ kops create cluster \
 
 The biggest problem currently when installing without loadbalancer is that kubectl requests outside cluster is always going to first master. External loadbalancer is one option which can solve this issue.
 
+# Using existing OpenStack network
+**Warning!** This feature is **experimental** use only if you know what you are doing.
+
+By default KOPS will always create new network to your OpenStack project which name matches to your clustername. However, there is experimental feature to use existing network in OpenStack project. When you create new cluster you can specify flag `--os-network <netname>` and it will then use existing network.
+
+Using yaml this can be specified to yaml:
+
+```
+spec:
+  ...
+  cloudConfig:
+    openstack:
+      networkName: <netname>
+  ...
+```
+
+**Warning!** when deleting cluster, you need to be really careful that you do not break another dependencies under same network. Run `kops delete cluster` without `--yes` flag and go through the list. Otherwise you might see situation that you broke something else.
+
+
 # Using with self-signed certificates in OpenStack
 
 Kops can be configured to use insecure mode towards OpenStack. However, this is **NOT** recommended as OpenStack cloudprovider in kubernetes does not support it.

--- a/docs/tutorial/openstack.md
+++ b/docs/tutorial/openstack.md
@@ -168,6 +168,39 @@ spec:
 
 **Warning!** when deleting cluster, you need to be really careful that you do not break another dependencies under same network. Run `kops delete cluster` without `--yes` flag and go through the list. Otherwise you might see situation that you broke something else.
 
+# Using existing OpenStack subnets
+**Warning!** This feature is **experimental** use only if you know what you are doing.
+
+By default KOPS will always create new network and subnet to your OpenStack project. However, there is experimental feature to use existing network and subnets in OpenStack project. When you create new cluster you can specify flag `--subnets <commaseparated list of subnetids>` and it will then use existing subnet. There is similar flag for utility subnets `--utility-subnets <commaseparated list of subnetids>`.
+
+Example:
+
+```
+kops create cluster \
+  --cloud openstack \
+  --name sharedsub2.k8s.local \
+  --state ${KOPS_STATE_STORE} \
+  --zones zone-1 \
+  --network-cidr 10.1.0.0/16 \
+  --image debian-10-160819-devops \
+  --master-count=3 \
+  --node-count=2 \
+  --node-size m1.small \
+  --master-size m1.small \
+  --etcd-storage-type default \
+  --topology private \
+  --bastion \
+  --networking calico \
+  --api-loadbalancer-type public \
+  --os-kubelet-ignore-az=true \
+  --os-ext-net ext-net \
+  --subnets c7d20c0f-df3a-4e5b-842f-f633c182961f \
+  --utility-subnets 90871d21-b546-4c4a-a7c9-2337ddf5375f \
+  --os-octavia=true --yes
+```
+
+**Warning!** when deleting cluster, you need to be really careful that you do not break another dependencies under same network & subnet. Run `kops delete cluster` without `--yes` flag and go through the list. Otherwise you might see situation that you broke something else.
+
 
 # Using with self-signed certificates in OpenStack
 

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -618,6 +618,7 @@ type OpenstackConfiguration struct {
 	Router             *OpenstackRouter             `json:"router,omitempty"`
 	BlockStorage       *OpenstackBlockStorageConfig `json:"blockStorage,omitempty"`
 	InsecureSkipVerify *bool                        `json:"insecureSkipVerify,omitempty"`
+	NetworkName        *string                      `json:"networkName,omitempty"`
 }
 
 // CloudConfiguration defines the cloud provider configuration

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -618,6 +618,7 @@ type OpenstackConfiguration struct {
 	Router             *OpenstackRouter             `json:"router,omitempty"`
 	BlockStorage       *OpenstackBlockStorageConfig `json:"blockStorage,omitempty"`
 	InsecureSkipVerify *bool                        `json:"insecureSkipVerify,omitempty"`
+	NetworkName        *string                      `json:"networkName,omitempty"`
 }
 
 // CloudConfiguration defines the cloud provider configuration

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -4146,6 +4146,7 @@ func autoConvert_v1alpha1_OpenstackConfiguration_To_kops_OpenstackConfiguration(
 		out.BlockStorage = nil
 	}
 	out.InsecureSkipVerify = in.InsecureSkipVerify
+	out.NetworkName = in.NetworkName
 	return nil
 }
 
@@ -4192,6 +4193,7 @@ func autoConvert_kops_OpenstackConfiguration_To_v1alpha1_OpenstackConfiguration(
 		out.BlockStorage = nil
 	}
 	out.InsecureSkipVerify = in.InsecureSkipVerify
+	out.NetworkName = in.NetworkName
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2824,6 +2824,11 @@ func (in *OpenstackConfiguration) DeepCopyInto(out *OpenstackConfiguration) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.NetworkName != nil {
+		in, out := &in.NetworkName, &out.NetworkName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -618,6 +618,7 @@ type OpenstackConfiguration struct {
 	Router             *OpenstackRouter             `json:"router,omitempty"`
 	BlockStorage       *OpenstackBlockStorageConfig `json:"blockStorage,omitempty"`
 	InsecureSkipVerify *bool                        `json:"insecureSkipVerify,omitempty"`
+	NetworkName        *string                      `json:"networkName,omitempty"`
 }
 
 // CloudConfiguration defines the cloud provider configuration

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4416,6 +4416,7 @@ func autoConvert_v1alpha2_OpenstackConfiguration_To_kops_OpenstackConfiguration(
 		out.BlockStorage = nil
 	}
 	out.InsecureSkipVerify = in.InsecureSkipVerify
+	out.NetworkName = in.NetworkName
 	return nil
 }
 
@@ -4462,6 +4463,7 @@ func autoConvert_kops_OpenstackConfiguration_To_v1alpha2_OpenstackConfiguration(
 		out.BlockStorage = nil
 	}
 	out.InsecureSkipVerify = in.InsecureSkipVerify
+	out.NetworkName = in.NetworkName
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2895,6 +2895,11 @@ func (in *OpenstackConfiguration) DeepCopyInto(out *OpenstackConfiguration) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.NetworkName != nil {
+		in, out := &in.NetworkName, &out.NetworkName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3109,6 +3109,11 @@ func (in *OpenstackConfiguration) DeepCopyInto(out *OpenstackConfiguration) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.NetworkName != nil {
+		in, out := &in.NetworkName, &out.NetworkName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/model/openstackmodel/context.go
+++ b/pkg/model/openstackmodel/context.go
@@ -26,8 +26,16 @@ type OpenstackModelContext struct {
 	*model.KopsModelContext
 }
 
+func GetNetworkName(cluster string, network *string) string {
+	netName := cluster
+	if network != nil {
+		netName = fi.StringValue(network)
+	}
+	return netName
+}
+
 func (c *OpenstackModelContext) LinkToNetwork() *openstacktasks.Network {
-	return &openstacktasks.Network{Name: s(c.ClusterName())}
+	return &openstacktasks.Network{Name: s(GetNetworkName(c.ClusterName(), c.Cluster.Spec.CloudConfig.Openstack.NetworkName))}
 }
 
 func (c *OpenstackModelContext) LinkToRouter(name *string) *openstacktasks.Router {

--- a/pkg/model/openstackmodel/network.go
+++ b/pkg/model/openstackmodel/network.go
@@ -40,7 +40,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		t := &openstacktasks.Network{
 			Name:      s(netName),
 			ID:        s(b.Cluster.Spec.NetworkID),
-			AppendTag: s(clusterName),
+			Tag:       s(clusterName),
 			Lifecycle: b.Lifecycle,
 		}
 
@@ -64,7 +64,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			CIDR:       s(sp.CIDR),
 			DNSServers: make([]*string, 0),
 			Lifecycle:  b.Lifecycle,
-			AppendTag:  s(clusterName),
+			Tag:        s(clusterName),
 		}
 		if b.Cluster.Spec.CloudConfig.Openstack.Router.DNSServers != nil {
 			dnsSplitted := strings.Split(fi.StringValue(b.Cluster.Spec.CloudConfig.Openstack.Router.DNSServers), ",")

--- a/pkg/model/openstackmodel/network.go
+++ b/pkg/model/openstackmodel/network.go
@@ -33,7 +33,6 @@ var _ fi.ModelBuilder = &NetworkModelBuilder{}
 
 func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	clusterName := b.ClusterName()
-	routerName := strings.Replace(clusterName, ".", "-", -1)
 
 	netName := GetNetworkName(clusterName, b.Cluster.Spec.CloudConfig.Openstack.NetworkName)
 	{
@@ -47,17 +46,17 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		c.AddTask(t)
 	}
 
-	{
-		t := &openstacktasks.Router{
-			Name:      s(routerName),
-			Lifecycle: b.Lifecycle,
-		}
-
-		c.AddTask(t)
-	}
-
+	needRouter := true
+	routerName := strings.Replace(clusterName, ".", "-", -1)
 	for _, sp := range b.Cluster.Spec.Subnets {
-		subnetName := sp.Name + "." + b.ClusterName()
+		// assumes that we do not need to create routers if we use existing subnets
+		if sp.ProviderID != "" {
+			needRouter = false
+		}
+		subnetName, err := b.findSubnetNameByID(sp.ProviderID, sp.Name)
+		if err != nil {
+			return err
+		}
 		t := &openstacktasks.Subnet{
 			Name:       s(subnetName),
 			Network:    b.LinkToNetwork(),
@@ -76,14 +75,24 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		}
 		c.AddTask(t)
 
-		t1 := &openstacktasks.RouterInterface{
-			Name:      s("ri-" + sp.Name),
-			Subnet:    b.LinkToSubnet(s(subnetName)),
-			Router:    b.LinkToRouter(s(routerName)),
-			Lifecycle: b.Lifecycle,
+		if needRouter {
+			t1 := &openstacktasks.RouterInterface{
+				Name:      s("ri-" + sp.Name),
+				Subnet:    b.LinkToSubnet(s(subnetName)),
+				Router:    b.LinkToRouter(s(routerName)),
+				Lifecycle: b.Lifecycle,
+			}
+			c.AddTask(t1)
 		}
-		c.AddTask(t1)
 	}
 
+	if needRouter {
+		t := &openstacktasks.Router{
+			Name:      s(routerName),
+			Lifecycle: b.Lifecycle,
+		}
+
+		c.AddTask(t)
+	}
 	return nil
 }

--- a/pkg/model/openstackmodel/network.go
+++ b/pkg/model/openstackmodel/network.go
@@ -35,10 +35,12 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	clusterName := b.ClusterName()
 	routerName := strings.Replace(clusterName, ".", "-", -1)
 
+	netName := GetNetworkName(clusterName, b.Cluster.Spec.CloudConfig.Openstack.NetworkName)
 	{
 		t := &openstacktasks.Network{
-			Name:      s(clusterName),
+			Name:      s(netName),
 			ID:        s(b.Cluster.Spec.NetworkID),
+			AppendTag: s(clusterName),
 			Lifecycle: b.Lifecycle,
 		}
 
@@ -62,6 +64,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			CIDR:       s(sp.CIDR),
 			DNSServers: make([]*string, 0),
 			Lifecycle:  b.Lifecycle,
+			AppendTag:  s(clusterName),
 		}
 		if b.Cluster.Spec.CloudConfig.Openstack.Router.DNSServers != nil {
 			dnsSplitted := strings.Split(fi.StringValue(b.Cluster.Spec.CloudConfig.Openstack.Router.DNSServers), ",")

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -113,7 +113,7 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 		portTask := &openstacktasks.Port{
 			Name:           fi.String(fmt.Sprintf("%s-%s", "port", *instanceName)),
 			Network:        b.LinkToNetwork(),
-			AppendTag:      s(b.ClusterName()),
+			Tag:            s(b.ClusterName()),
 			SecurityGroups: securityGroups,
 			Subnets:        subnets,
 			Lifecycle:      b.Lifecycle,

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -59,7 +59,7 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 		igMeta[openstack.TagClusterName] = b.ClusterName()
 	}
 	igMeta["k8s"] = b.ClusterName()
-	igMeta["kopsNetwork"] = GetNetworkName(b.ClusterName(), b.Cluster.Spec.CloudConfig.Openstack.NetworkName)
+	igMeta[openstack.TagKopsNetwork] = GetNetworkName(b.ClusterName(), b.Cluster.Spec.CloudConfig.Openstack.NetworkName)
 	igMeta["KopsInstanceGroup"] = ig.Name
 	igMeta["KopsRole"] = fmt.Sprintf("%s", ig.Spec.Role)
 	igMeta[openstack.INSTANCE_GROUP_GENERATION] = fmt.Sprintf("%d", ig.GetGeneration())

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -59,6 +59,7 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 		igMeta[openstack.TagClusterName] = b.ClusterName()
 	}
 	igMeta["k8s"] = b.ClusterName()
+	igMeta["kopsNetwork"] = GetNetworkName(b.ClusterName(), b.Cluster.Spec.CloudConfig.Openstack.NetworkName)
 	igMeta["KopsInstanceGroup"] = ig.Name
 	igMeta["KopsRole"] = fmt.Sprintf("%s", ig.Spec.Role)
 	igMeta[openstack.INSTANCE_GROUP_GENERATION] = fmt.Sprintf("%d", ig.GetGeneration())
@@ -112,6 +113,7 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 		portTask := &openstacktasks.Port{
 			Name:           fi.String(fmt.Sprintf("%s-%s", "port", *instanceName)),
 			Network:        b.LinkToNetwork(),
+			AppendTag:      s(b.ClusterName()),
 			SecurityGroups: securityGroups,
 			Subnets:        subnets,
 			Lifecycle:      b.Lifecycle,
@@ -244,12 +246,13 @@ func (b *ServerGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		}
 		c.AddTask(listenerTask)
 
+		ifName := GetNetworkName(clusterName, b.Cluster.Spec.CloudConfig.Openstack.NetworkName)
 		for _, mastersg := range masters {
 			associateTask := &openstacktasks.PoolAssociation{
 				Name:          mastersg.Name,
 				Pool:          poolTask,
 				ServerGroup:   mastersg,
-				InterfaceName: fi.String(clusterName),
+				InterfaceName: fi.String(ifName),
 				ProtocolPort:  fi.Int(443),
 				Lifecycle:     b.Lifecycle,
 			}

--- a/pkg/resources/openstack/ports.go
+++ b/pkg/resources/openstack/ports.go
@@ -28,10 +28,10 @@ const (
 	typePort = "Port"
 )
 
-func (os *clusterDiscoveryOS) ListPorts(network networks.Network) ([]*resources.Resource, error) {
+func (os *clusterDiscoveryOS) ListPorts(network networks.Network, shared bool) ([]*resources.Resource, error) {
 	var resourceTrackers []*resources.Resource
 
-	ports, err := os.osCloud.ListPorts(ports.ListOpts{
+	projectPorts, err := os.osCloud.ListPorts(ports.ListOpts{
 		TenantID:  network.ProjectID,
 		NetworkID: network.ID,
 	})
@@ -39,7 +39,19 @@ func (os *clusterDiscoveryOS) ListPorts(network networks.Network) ([]*resources.
 		return nil, err
 	}
 
-	for _, port := range ports {
+	filteredPorts := []ports.Port{}
+	if shared {
+		// if we have sharednetwork, the port must have cluster tag
+		for _, singlePort := range projectPorts {
+			if fi.ArrayContains(singlePort.Tags, os.clusterName) {
+				filteredPorts = append(filteredPorts, singlePort)
+			}
+		}
+	} else {
+		filteredPorts = projectPorts
+	}
+
+	for _, port := range filteredPorts {
 		resourceTracker := &resources.Resource{
 			Name: port.Name,
 			ID:   port.ID,

--- a/pkg/resources/openstack/ports.go
+++ b/pkg/resources/openstack/ports.go
@@ -28,7 +28,7 @@ const (
 	typePort = "Port"
 )
 
-func (os *clusterDiscoveryOS) ListPorts(network networks.Network, shared bool) ([]*resources.Resource, error) {
+func (os *clusterDiscoveryOS) ListPorts(network networks.Network) ([]*resources.Resource, error) {
 	var resourceTrackers []*resources.Resource
 
 	projectPorts, err := os.osCloud.ListPorts(ports.ListOpts{
@@ -39,9 +39,14 @@ func (os *clusterDiscoveryOS) ListPorts(network networks.Network, shared bool) (
 		return nil, err
 	}
 
+	preExistingNet := true
+	if os.clusterName == network.Name {
+		preExistingNet = false
+	}
+
 	filteredPorts := []ports.Port{}
-	if shared {
-		// if we have sharednetwork, the port must have cluster tag
+	if preExistingNet {
+		// if we have preExistingNet, the port must have cluster tag
 		for _, singlePort := range projectPorts {
 			if fi.ArrayContains(singlePort.Tags, os.clusterName) {
 				filteredPorts = append(filteredPorts, singlePort)

--- a/protokube/pkg/gossip/openstack/seeds.go
+++ b/protokube/pkg/gossip/openstack/seeds.go
@@ -50,7 +50,12 @@ func (p *SeedProvider) GetSeeds() ([]string, error) {
 		for _, server := range s {
 			if clusterName, ok := server.Metadata[openstack.TagClusterName]; ok {
 				var err error
-				addr, err := openstack.GetServerFixedIP(&server, clusterName)
+				// find kopsNetwork from metadata, fallback to clustername
+				ifName := clusterName
+				if val, ok := server.Metadata["kopsNetwork"]; ok {
+					ifName = val
+				}
+				addr, err := openstack.GetServerFixedIP(&server, ifName)
 				if err != nil {
 					klog.Warningf("Failed to list seeds: %v", err)
 					continue

--- a/protokube/pkg/gossip/openstack/seeds.go
+++ b/protokube/pkg/gossip/openstack/seeds.go
@@ -52,7 +52,7 @@ func (p *SeedProvider) GetSeeds() ([]string, error) {
 				var err error
 				// find kopsNetwork from metadata, fallback to clustername
 				ifName := clusterName
-				if val, ok := server.Metadata["kopsNetwork"]; ok {
+				if val, ok := server.Metadata[openstack.TagKopsNetwork]; ok {
 					ifName = val
 				}
 				addr, err := openstack.GetServerFixedIP(&server, ifName)

--- a/protokube/pkg/protokube/openstack_volume.go
+++ b/protokube/pkg/protokube/openstack_volume.go
@@ -173,7 +173,12 @@ func (a *OpenstackVolumes) discoverTags() error {
 	// Internal IP
 	{
 		server, err := a.cloud.GetInstance(strings.TrimSpace(a.meta.ServerID))
-		ip, err := openstack.GetServerFixedIP(server, a.clusterName)
+		// find kopsNetwork from metadata, fallback to clustername
+		ifName := a.clusterName
+		if val, ok := server.Metadata["kopsNetwork"]; ok {
+			ifName = val
+		}
+		ip, err := openstack.GetServerFixedIP(server, ifName)
 		if err != nil {
 			return fmt.Errorf("error querying InternalIP from name: %v", err)
 		}

--- a/protokube/pkg/protokube/openstack_volume.go
+++ b/protokube/pkg/protokube/openstack_volume.go
@@ -175,7 +175,7 @@ func (a *OpenstackVolumes) discoverTags() error {
 		server, err := a.cloud.GetInstance(strings.TrimSpace(a.meta.ServerID))
 		// find kopsNetwork from metadata, fallback to clustername
 		ifName := a.clusterName
-		if val, ok := server.Metadata["kopsNetwork"]; ok {
+		if val, ok := server.Metadata[openstack.TagKopsNetwork]; ok {
 			ifName = val
 		}
 		ip, err := openstack.GetServerFixedIP(server, ifName)

--- a/upup/pkg/fi/cloudup/openstack/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/openstack/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools:go_default_library",
+        "//vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers:go_default_library",

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -64,6 +64,9 @@ const (
 	TagClusterName           = "KubernetesCluster"
 	TagRoleMaster            = "master"
 	TagKopsNetwork           = "KopsNetwork"
+	ResourceTypePort         = "ports"
+	ResourceTypeNetwork      = "networks"
+	ResourceTypeSubnet       = "subnets"
 )
 
 // ErrNotFound is used to inform that the object is not found

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -162,6 +162,12 @@ type OpenstackCloud interface {
 	//DeleteNetwork will delete neutron network
 	DeleteNetwork(networkID string) error
 
+	//AppendTag appends tag to resource
+	AppendTag(resource string, id string, tag string) error
+
+	//DeleteTag removes tag from resource
+	DeleteTag(resource string, id string, tag string) error
+
 	//ListRouters will return the Neutron routers which match the options
 	ListRouters(opt routers.ListOpts) ([]routers.Router, error)
 

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -63,6 +63,7 @@ const (
 	TagNameRolePrefix        = "k8s.io/role/"
 	TagClusterName           = "KubernetesCluster"
 	TagRoleMaster            = "master"
+	TagKopsNetwork           = "KopsNetwork"
 )
 
 // ErrNotFound is used to inform that the object is not found

--- a/upup/pkg/fi/cloudup/openstack/floatingip.go
+++ b/upup/pkg/fi/cloudup/openstack/floatingip.go
@@ -142,7 +142,7 @@ func (c *openstackCloud) DeleteFloatingIP(id string) (err error) {
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
 		err = l3floatingip.Delete(c.ComputeClient(), id).ExtractErr()
-		if err != nil {
+		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("Failed to delete floating ip %s: %v", id, err)
 		}
 		return true, nil
@@ -157,7 +157,7 @@ func (c *openstackCloud) DeleteL3FloatingIP(id string) (err error) {
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
 		err = l3floatingip.Delete(c.NetworkingClient(), id).ExtractErr()
-		if err != nil {
+		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("Failed to delete L3 floating ip %s: %v", id, err)
 		}
 		return true, nil

--- a/upup/pkg/fi/cloudup/openstacktasks/network.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/network.go
@@ -136,9 +136,8 @@ func (_ *Network) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes
 		if err != nil {
 			return fmt.Errorf("Error appending tag to network: %v", err)
 		}
-		return nil
 	}
-
-	klog.V(2).Infof("Openstack task Network::RenderOpenstack did nothing")
+	e.ID = a.ID
+	klog.V(2).Infof("Using an existing Openstack network, id=%s", fi.StringValue(e.ID))
 	return nil
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/network.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/network.go
@@ -41,7 +41,7 @@ func (n *Network) CompareWithID() *string {
 
 func NewNetworkTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecycle, network *networks.Network, clusterName *string) (*Network, error) {
 	tag := ""
-	if fi.ArrayContains(network.Tags, fi.StringValue(clusterName)) {
+	if clusterName != nil && fi.ArrayContains(network.Tags, fi.StringValue(clusterName)) {
 		tag = fi.StringValue(clusterName)
 	}
 

--- a/upup/pkg/fi/cloudup/openstacktasks/port.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port.go
@@ -175,7 +175,6 @@ func (_ *Port) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *P
 		if err != nil {
 			return fmt.Errorf("Error appending tag to port: %v", err)
 		}
-		return nil
 	}
 	e.ID = a.ID
 	klog.V(2).Infof("Using an existing Openstack port, id=%s", fi.StringValue(e.ID))

--- a/upup/pkg/fi/cloudup/openstacktasks/port.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port.go
@@ -76,7 +76,7 @@ func NewPortTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecycl
 	}
 
 	tag := ""
-	if fi.ArrayContains(port.Tags, fi.StringValue(find.AppendTag)) {
+	if find != nil && fi.ArrayContains(port.Tags, fi.StringValue(find.AppendTag)) {
 		tag = fi.StringValue(find.AppendTag)
 	}
 

--- a/upup/pkg/fi/cloudup/openstacktasks/port.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port.go
@@ -33,7 +33,7 @@ type Port struct {
 	Subnets        []*Subnet
 	SecurityGroups []*SecurityGroup
 	Lifecycle      *fi.Lifecycle
-	AppendTag      *string
+	Tag            *string
 }
 
 // GetDependencies returns the dependencies of the Port task
@@ -76,8 +76,8 @@ func NewPortTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecycl
 	}
 
 	tag := ""
-	if find != nil && fi.ArrayContains(port.Tags, fi.StringValue(find.AppendTag)) {
-		tag = fi.StringValue(find.AppendTag)
+	if find != nil && fi.ArrayContains(port.Tags, fi.StringValue(find.Tag)) {
+		tag = fi.StringValue(find.Tag)
 	}
 
 	actual := &Port{
@@ -87,7 +87,7 @@ func NewPortTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecycl
 		SecurityGroups: sgs,
 		Subnets:        subnets,
 		Lifecycle:      lifecycle,
-		AppendTag:      fi.String(tag),
+		Tag:            fi.String(tag),
 	}
 	if find != nil {
 		find.ID = actual.ID
@@ -162,7 +162,7 @@ func (_ *Port) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *P
 			return fmt.Errorf("Error creating port: %v", err)
 		}
 
-		err = t.Cloud.AppendTag("ports", v.ID, fi.StringValue(e.AppendTag))
+		err = t.Cloud.AppendTag(openstack.ResourceTypePort, v.ID, fi.StringValue(e.Tag))
 		if err != nil {
 			return fmt.Errorf("Error appending tag to port: %v", err)
 		}
@@ -171,7 +171,7 @@ func (_ *Port) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *P
 		klog.V(2).Infof("Creating a new Openstack port, id=%s", v.ID)
 		return nil
 	} else {
-		err := t.Cloud.AppendTag("ports", fi.StringValue(a.ID), fi.StringValue(changes.AppendTag))
+		err := t.Cloud.AppendTag(openstack.ResourceTypePort, fi.StringValue(a.ID), fi.StringValue(changes.Tag))
 		if err != nil {
 			return fmt.Errorf("Error appending tag to port: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/openstacktasks/port.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port.go
@@ -33,6 +33,7 @@ type Port struct {
 	Subnets        []*Subnet
 	SecurityGroups []*SecurityGroup
 	Lifecycle      *fi.Lifecycle
+	AppendTag      *string
 }
 
 // GetDependencies returns the dependencies of the Port task
@@ -74,6 +75,11 @@ func NewPortTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecycl
 		}
 	}
 
+	tag := ""
+	if fi.ArrayContains(port.Tags, fi.StringValue(find.AppendTag)) {
+		tag = fi.StringValue(find.AppendTag)
+	}
+
 	actual := &Port{
 		ID:             fi.String(port.ID),
 		Name:           fi.String(port.Name),
@@ -81,6 +87,7 @@ func NewPortTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecycl
 		SecurityGroups: sgs,
 		Subnets:        subnets,
 		Lifecycle:      lifecycle,
+		AppendTag:      fi.String(tag),
 	}
 	if find != nil {
 		find.ID = actual.ID
@@ -102,7 +109,6 @@ func (s *Port) Find(context *fi.Context) (*Port, error) {
 	} else if len(rs) != 1 {
 		return nil, fmt.Errorf("found multiple ports with name: %s", fi.StringValue(s.Name))
 	}
-
 	return NewPortTaskFromCloud(cloud, s.Lifecycle, &rs[0], s)
 }
 
@@ -122,7 +128,7 @@ func (_ *Port) CheckChanges(a, e, changes *Port) error {
 		if changes.Name != nil {
 			return fi.CannotChangeField("Name")
 		}
-		if e.Network != nil {
+		if changes.Network != nil {
 			return fi.CannotChangeField("Network")
 		}
 	}
@@ -156,8 +162,19 @@ func (_ *Port) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *P
 			return fmt.Errorf("Error creating port: %v", err)
 		}
 
+		err = t.Cloud.AppendTag("ports", v.ID, fi.StringValue(e.AppendTag))
+		if err != nil {
+			return fmt.Errorf("Error appending tag to port: %v", err)
+		}
+
 		e.ID = fi.String(v.ID)
 		klog.V(2).Infof("Creating a new Openstack port, id=%s", v.ID)
+		return nil
+	} else {
+		err := t.Cloud.AppendTag("ports", fi.StringValue(a.ID), fi.StringValue(changes.AppendTag))
+		if err != nil {
+			return fmt.Errorf("Error appending tag to port: %v", err)
+		}
 		return nil
 	}
 	e.ID = a.ID

--- a/upup/pkg/fi/cloudup/openstacktasks/subnet.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/subnet.go
@@ -33,7 +33,7 @@ type Subnet struct {
 	Network    *Network
 	CIDR       *string
 	DNSServers []*string
-	AppendTag  *string
+	Tag        *string
 	Lifecycle  *fi.Lifecycle
 }
 
@@ -59,7 +59,7 @@ func NewSubnetTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecy
 	if err != nil {
 		return nil, fmt.Errorf("NewSubnetTaskFromCloud: Failed to get network with ID %s: %v", subnet.NetworkID, err)
 	}
-	networkTask, err := NewNetworkTaskFromCloud(cloud, lifecycle, network, find.AppendTag)
+	networkTask, err := NewNetworkTaskFromCloud(cloud, lifecycle, network, find.Tag)
 
 	nameservers := make([]*string, len(subnet.DNSNameservers))
 	for i, ns := range subnet.DNSNameservers {
@@ -67,8 +67,8 @@ func NewSubnetTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecy
 	}
 
 	tag := ""
-	if find != nil && fi.ArrayContains(subnet.Tags, fi.StringValue(find.AppendTag)) {
-		tag = fi.StringValue(find.AppendTag)
+	if find != nil && fi.ArrayContains(subnet.Tags, fi.StringValue(find.Tag)) {
+		tag = fi.StringValue(find.Tag)
 	}
 
 	actual := &Subnet{
@@ -78,7 +78,7 @@ func NewSubnetTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecy
 		CIDR:       fi.String(subnet.CIDR),
 		Lifecycle:  lifecycle,
 		DNSServers: nameservers,
-		AppendTag:  fi.String(tag),
+		Tag:        fi.String(tag),
 	}
 	if find != nil {
 		find.ID = actual.ID
@@ -164,7 +164,7 @@ func (_ *Subnet) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes 
 			return fmt.Errorf("Error creating subnet: %v", err)
 		}
 
-		err = t.Cloud.AppendTag("subnets", v.ID, fi.StringValue(e.AppendTag))
+		err = t.Cloud.AppendTag(openstack.ResourceTypeSubnet, v.ID, fi.StringValue(e.Tag))
 		if err != nil {
 			return fmt.Errorf("Error appending tag to subnet: %v", err)
 		}
@@ -173,7 +173,7 @@ func (_ *Subnet) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes 
 		klog.V(2).Infof("Creating a new Openstack subnet, id=%s", v.ID)
 		return nil
 	} else {
-		err := t.Cloud.AppendTag("subnets", fi.StringValue(a.ID), fi.StringValue(changes.AppendTag))
+		err := t.Cloud.AppendTag(openstack.ResourceTypeSubnet, fi.StringValue(a.ID), fi.StringValue(changes.Tag))
 		if err != nil {
 			return fmt.Errorf("Error appending tag to subnet: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/openstacktasks/subnet.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/subnet.go
@@ -177,7 +177,6 @@ func (_ *Subnet) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes 
 		if err != nil {
 			return fmt.Errorf("Error appending tag to subnet: %v", err)
 		}
-		return nil
 	}
 	e.ID = a.ID
 	klog.V(2).Infof("Using an existing Openstack subnet, id=%s", fi.StringValue(e.ID))

--- a/upup/pkg/fi/cloudup/openstacktasks/subnet.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/subnet.go
@@ -67,7 +67,7 @@ func NewSubnetTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecy
 	}
 
 	tag := ""
-	if fi.ArrayContains(subnet.Tags, fi.StringValue(find.AppendTag)) {
+	if find != nil && fi.ArrayContains(subnet.Tags, fi.StringValue(find.AppendTag)) {
 		tag = fi.StringValue(find.AppendTag)
 	}
 

--- a/upup/pkg/fi/cloudup/utils.go
+++ b/upup/pkg/fi/cloudup/utils.go
@@ -139,6 +139,13 @@ func BuildCloud(cluster *kops.Cluster) (fi.Cloud, error) {
 			if err != nil {
 				return nil, err
 			}
+			var zoneNames []string
+			for _, subnet := range cluster.Spec.Subnets {
+				if !fi.ArrayContains(zoneNames, subnet.Zone) {
+					zoneNames = append(zoneNames, subnet.Zone)
+				}
+			}
+			osc.AddZones(zoneNames)
 			cloud = osc
 		}
 

--- a/upup/pkg/fi/values.go
+++ b/upup/pkg/fi/values.go
@@ -125,6 +125,16 @@ func Uint64Value(v *uint64) uint64 {
 	return *v
 }
 
+// ArrayContains is checking does array contain single word
+func ArrayContains(array []string, word string) bool {
+	for _, item := range array {
+		if item == word {
+			return true
+		}
+	}
+	return false
+}
+
 func DebugPrint(o interface{}) string {
 	if o == nil {
 		return "<nil>"

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/BUILD.bazel
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "requests.go",
+        "results.go",
+        "urls.go",
+    ],
+    importmap = "k8s.io/kops/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags",
+    importpath = "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/gophercloud/gophercloud:go_default_library"],
+)

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/doc.go
@@ -1,0 +1,37 @@
+/*
+Package attributestags manages Tags on Resources created by the OpenStack Neutron Service.
+
+This enables tagging via a standard interface for resources types which support it.
+
+See https://developer.openstack.org/api-ref/network/v2/#standard-attributes-tag-extension for more information on the underlying API.
+
+Example to ReplaceAll Resource Tags
+
+    network, err := networks.Create(conn, createOpts).Extract()
+
+    tagReplaceAllOpts := attributestags.ReplaceAllOpts{
+        Tags:         []string{"abc", "123"},
+    }
+    attributestags.ReplaceAll(conn, "networks", network.ID, tagReplaceAllOpts)
+
+Example to List all Resource Tags
+
+	tags, err = attributestags.List(conn, "networks", network.ID).Extract()
+
+Example to Delete all Resource Tags
+
+	err = attributestags.DeleteAll(conn, "networks", network.ID).ExtractErr()
+
+Example to Add a tag to a Resource
+
+    err = attributestags.Add(client, "networks", network.ID, "atag").ExtractErr()
+
+Example to Delete a tag from a Resource
+
+    err = attributestags.Delete(client, "networks", network.ID, "atag").ExtractErr()
+
+Example to confirm if a tag exists on a resource
+
+	exists, _ := attributestags.Confirm(client, "networks", network.ID, "atag").Extract()
+*/
+package attributestags

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/requests.go
@@ -1,0 +1,81 @@
+package attributestags
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// ReplaceAllOptsBuilder allows extensions to add additional parameters to
+// the ReplaceAll request.
+type ReplaceAllOptsBuilder interface {
+	ToAttributeTagsReplaceAllMap() (map[string]interface{}, error)
+}
+
+// ReplaceAllOpts provides options used to create Tags on a Resource
+type ReplaceAllOpts struct {
+	Tags []string `json:"tags" required:"true"`
+}
+
+// ToAttributeTagsReplaceAllMap formats a ReplaceAllOpts into the body of the
+// replace request
+func (opts ReplaceAllOpts) ToAttributeTagsReplaceAllMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// ReplaceAll updates all tags on a resource, replacing any existing tags
+func ReplaceAll(client *gophercloud.ServiceClient, resourceType string, resourceID string, opts ReplaceAllOptsBuilder) (r ReplaceAllResult) {
+	b, err := opts.ToAttributeTagsReplaceAllMap()
+	url := replaceURL(client, resourceType, resourceID)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(url, &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// List all tags on a resource
+func List(client *gophercloud.ServiceClient, resourceType string, resourceID string) (r ListResult) {
+	url := listURL(client, resourceType, resourceID)
+	_, r.Err = client.Get(url, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// DeleteAll deletes all tags on a resource
+func DeleteAll(client *gophercloud.ServiceClient, resourceType string, resourceID string) (r DeleteResult) {
+	url := deleteAllURL(client, resourceType, resourceID)
+	_, r.Err = client.Delete(url, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
+// Add a tag on a resource
+func Add(client *gophercloud.ServiceClient, resourceType string, resourceID string, tag string) (r AddResult) {
+	url := addURL(client, resourceType, resourceID, tag)
+	_, r.Err = client.Put(url, nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}
+
+// Delete a tag on a resource
+func Delete(client *gophercloud.ServiceClient, resourceType string, resourceID string, tag string) (r DeleteResult) {
+	url := deleteURL(client, resourceType, resourceID, tag)
+	_, r.Err = client.Delete(url, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
+// Confirm if a tag exists on a resource
+func Confirm(client *gophercloud.ServiceClient, resourceType string, resourceID string, tag string) (r ConfirmResult) {
+	url := confirmURL(client, resourceType, resourceID, tag)
+	_, r.Err = client.Get(url, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/results.go
@@ -1,0 +1,57 @@
+package attributestags
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+type tagResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets tagResult to return the list of tags
+func (r tagResult) Extract() ([]string, error) {
+	var s struct {
+		Tags []string `json:"tags"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Tags, err
+}
+
+// ReplaceAllResult represents the result of a replace operation.
+// Call its Extract method to interpret it as a slice of strings.
+type ReplaceAllResult struct {
+	tagResult
+}
+
+type ListResult struct {
+	tagResult
+}
+
+// DeleteResult is the result from a Delete/DeleteAll operation.
+// Call its ExtractErr method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// AddResult is the result from an Add operation.
+// Call its ExtractErr method to determine if the call succeeded or failed.
+type AddResult struct {
+	gophercloud.ErrResult
+}
+
+// ConfirmResult is the result from an Confirm operation.
+type ConfirmResult struct {
+	gophercloud.Result
+}
+
+func (r ConfirmResult) Extract() (bool, error) {
+	exists := r.Err == nil
+
+	if r.Err != nil {
+		if _, ok := r.Err.(gophercloud.ErrDefault404); ok {
+			r.Err = nil
+		}
+	}
+
+	return exists, r.Err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/urls.go
@@ -1,0 +1,31 @@
+package attributestags
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	tagsPath = "tags"
+)
+
+func replaceURL(c *gophercloud.ServiceClient, r_type string, id string) string {
+	return c.ServiceURL(r_type, id, tagsPath)
+}
+
+func listURL(c *gophercloud.ServiceClient, r_type string, id string) string {
+	return c.ServiceURL(r_type, id, tagsPath)
+}
+
+func deleteAllURL(c *gophercloud.ServiceClient, r_type string, id string) string {
+	return c.ServiceURL(r_type, id, tagsPath)
+}
+
+func addURL(c *gophercloud.ServiceClient, r_type string, id string, tag string) string {
+	return c.ServiceURL(r_type, id, tagsPath, tag)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, r_type string, id string, tag string) string {
+	return c.ServiceURL(r_type, id, tagsPath, tag)
+}
+
+func confirmURL(c *gophercloud.ServiceClient, r_type string, id string, tag string) string {
+	return c.ServiceURL(r_type, id, tagsPath, tag)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -250,6 +250,7 @@ github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups
 github.com/gophercloud/gophercloud/openstack/compute/v2/flavors
 github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners
 github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools
+github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints
 github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers


### PR DESCRIPTION
hold until #7568 is merged, I will then rebase this one

There is experimental feature to use existing network and subnets in OpenStack project. When you create new cluster you can specify flag `--subnets <commaseparated list of subnetids>` and it will then use existing subnet. There is similar flag for utility subnets `--utility-subnets <commaseparated list of subnetids>`.

This PR is going to contain only two last commits.