### PR TITLE
Fix Dropped Errors in upup

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/internetgateway_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway_test.go
@@ -74,6 +74,9 @@ func TestSharedInternetGatewayDoesNotRename(t *testing.T) {
 		InternetGatewayId: internetGateway.InternetGateway.InternetGatewayId,
 		VpcId:             vpc.Vpc.VpcId,
 	})
+	if err != nil {
+		t.Fatalf("error attaching igw: %v", err)
+	}
 
 	// We define a function so we can rebuild the tasks, because we modify in-place when running
 	buildTasks := func() map[string]fi.Task {

--- a/upup/pkg/fi/cloudup/openstacktasks/subnet.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/subnet.go
@@ -59,7 +59,9 @@ func NewSubnetTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecy
 		return nil, fmt.Errorf("NewSubnetTaskFromCloud: Failed to get network with ID %s: %v", subnet.NetworkID, err)
 	}
 	networkTask, err := NewNetworkTaskFromCloud(cloud, lifecycle, network)
-
+	if err != nil {
+		return nil, fmt.Errorf("error creating network task from cloud: %v", err)
+	}
 	nameservers := make([]*string, len(subnet.DNSNameservers))
 	for i, ns := range subnet.DNSNameservers {
 		nameservers[i] = fi.String(ns)

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -468,6 +468,9 @@ func evaluateHostnameOverride(hostnameOverride string) (string, error) {
 		result, err := svc.DescribeInstances(&ec2.DescribeInstancesInput{
 			InstanceIds: []*string{&instanceID},
 		})
+		if err != nil {
+			return "", fmt.Errorf("error describing instances: %v", err)
+		}
 
 		if len(result.Reservations) != 1 {
 			return "", fmt.Errorf("Too many reservations returned for the single instance-id")


### PR DESCRIPTION
upup/pkg/fi/cloudup/openstacktasks: fix dropped error
upup/pkg/fi/cloudup/awstasks: fix dropped error
upup/pkg/fi/nodeup: fix dropped error

This PR picks off a few dropped errors under `upup`.