### PR TITLE
Automated cherry pick of #7565: Fix 'unable to infer CloudProvider from Zones' for

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -259,6 +259,8 @@ func (b *PolicyBuilder) IAMPrefix() string {
 		return "arn:aws-cn"
 	case "cn-northwest-1":
 		return "arn:aws-cn"
+	case "us-gov-east-1":
+		return "arn:aws-us-gov"
 	case "us-gov-west-1":
 		return "arn:aws-us-gov"
 	default:

--- a/upup/pkg/fi/cloud.go
+++ b/upup/pkg/fi/cloud.go
@@ -162,8 +162,13 @@ var zonesToCloud = map[string]kops.CloudProviderID{
 	"cn-northwest-1b": kops.CloudProviderAWS,
 	"cn-northwest-1c": kops.CloudProviderAWS,
 
+	"us-gov-east-1a": kops.CloudProviderAWS,
+	"us-gov-east-1b": kops.CloudProviderAWS,
+	"us-gov-east-1c": kops.CloudProviderAWS,
+
 	"us-gov-west-1a": kops.CloudProviderAWS,
 	"us-gov-west-1b": kops.CloudProviderAWS,
+	"us-gov-west-1c": kops.CloudProviderAWS,
 
 	// GCE
 	"asia-east1-a": kops.CloudProviderGCE,


### PR DESCRIPTION
Cherry pick of #7565 on release-1.14.

#7565: Fix 'unable to infer CloudProvider from Zones' for