### PR TITLE
"Force" k8s 1.11.10 in stable channel

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -23,15 +23,18 @@ spec:
       providerID: aws
       kubernetesVersion: ">=1.10.0 <1.11.0"
     # Stretch is the default for 1.11 (for nvme)
-    - name: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2018-08-17
+    - name: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2019-08-16
       providerID: aws
       kubernetesVersion: ">=1.11.0 <1.12.0"
-    - name: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21
+    - name: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-08-16
       providerID: aws
       kubernetesVersion: ">=1.12.0 <1.13.0"
     - name: kope.io/k8s-1.13-debian-stretch-amd64-hvm-ebs-2019-08-16
       providerID: aws
-      kubernetesVersion: ">=1.13.0"
+      kubernetesVersion: ">=1.13.0 <1.14.0"
+    - name: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
+      providerID: aws
+      kubernetesVersion: ">=1.14.0"
     - providerID: gce
       name: "cos-cloud/cos-stable-65-10323-99-0"
   cluster:

--- a/channels/stable
+++ b/channels/stable
@@ -57,27 +57,9 @@ spec:
   - range: ">=1.11.0"
     recommendedVersion: 1.11.10
     requiredVersion: 1.11.0
-  - range: ">=1.10.0"
-    recommendedVersion: 1.10.13
-    requiredVersion: 1.10.0
-  - range: ">=1.9.0"
-    recommendedVersion: 1.9.11
-    requiredVersion: 1.9.0
-  - range: ">=1.8.0"
-    recommendedVersion: 1.8.15
-    requiredVersion: 1.8.0
-  - range: ">=1.7.0"
-    recommendedVersion: 1.7.16
-    requiredVersion: 1.7.0
-  - range: ">=1.6.0"
-    recommendedVersion: 1.6.13
-    requiredVersion: 1.6.0
-  - range: ">=1.5.0"
-    recommendedVersion: 1.5.8
-    requiredVersion: 1.5.1
-  - range: "<1.5.0"
-    recommendedVersion: 1.4.12
-    requiredVersion: 1.4.2
+  - range: "<1.11.0"
+    recommendedVersion: 1.11.10
+    requiredVersion: 1.11.10
   kopsVersions:
   - range: ">=1.15.0-alpha.1"
     #recommendedVersion: "1.14.0"
@@ -96,34 +78,10 @@ spec:
     #requiredVersion: 1.12.0
     kubernetesVersion: 1.12.10
   - range: ">=1.11.0-alpha.1"
-    #recommendedVersion: "1.11.0"
+    #recommendedVersion: "1.11.1"
     #requiredVersion: 1.11.0
     kubernetesVersion: 1.11.10
-  - range: ">=1.10.0-alpha.1"
-    recommendedVersion: "1.10.0"
+  - range: "<1.11.0-alpha.1"
+    recommendedVersion: "1.10.1"
     #requiredVersion: 1.10.0
-    kubernetesVersion: 1.10.13
-  - range: ">=1.9.0-alpha.1"
-    recommendedVersion: 1.9.2
-    #requiredVersion: 1.9.0
-    kubernetesVersion: 1.9.11
-  - range: ">=1.8.0-alpha.1"
-    recommendedVersion: 1.8.1
-    requiredVersion: 1.7.1
-    kubernetesVersion: 1.8.15
-  - range: ">=1.7.0-alpha.1"
-    recommendedVersion: 1.8.1
-    requiredVersion: 1.7.1
-    kubernetesVersion: 1.7.16
-  - range: ">=1.6.0-alpha.1"
-    recommendedVersion: 1.8.1
-    requiredVersion: 1.7.1
-    kubernetesVersion: 1.6.13
-  - range: ">=1.5.0-alpha1"
-    recommendedVersion: 1.8.1
-    requiredVersion: 1.7.1
-    kubernetesVersion: 1.5.8
-  - range: "<1.5.0"
-    recommendedVersion: 1.8.1
-    requiredVersion: 1.7.1
-    kubernetesVersion: 1.4.12
+    kubernetesVersion: 1.11.10

--- a/hack/update-expected.sh
+++ b/hack/update-expected.sh
@@ -23,5 +23,9 @@ cd ${KOPS_ROOT}
 # Update gobindata to reflect any yaml changes
 make kops-gobindata
 
+# Don't override variables that are commonly used in dev, but shouldn't be in our tests
+export KOPS_BASE_URL=
+export DNSCONTROLLER_IMAGE=
+
 # Run the tests in "autofix mode"
 HACK_UPDATE_EXPECTED_IN_PLACE=1 go test ./... -count=1

--- a/pkg/testutils/integrationtestharness.go
+++ b/pkg/testutils/integrationtestharness.go
@@ -167,6 +167,14 @@ func (h *IntegrationTestHarness) SetupMockAWS() *awsup.MockAWSCloud {
 		RootDeviceName: aws.String("/dev/xvda"),
 	})
 
+	mockEC2.Images = append(mockEC2.Images, &ec2.Image{
+		CreationDate:   aws.String("2019-08-06T00:00:00.000Z"),
+		ImageId:        aws.String("ami-11400000"),
+		Name:           aws.String("k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16"),
+		OwnerId:        aws.String(awsup.WellKnownAccountKopeio),
+		RootDeviceName: aws.String("/dev/xvda"),
+	})
+
 	mockEC2.CreateVpcWithId(&ec2.CreateVpcInput{
 		CidrBlock: aws.String("172.20.0.0/16"),
 	}, "vpc-12345678")

--- a/tests/integration/conversion/minimal/legacy-v1alpha1.yaml
+++ b/tests/integration/conversion/minimal/legacy-v1alpha1.yaml
@@ -32,7 +32,7 @@ spec:
     name: events
   iam:
     legacy: true
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/minimal/legacy-v1alpha2.yaml
+++ b/tests/integration/conversion/minimal/legacy-v1alpha2.yaml
@@ -32,7 +32,7 @@ spec:
     legacy: true
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/minimal/v1alpha0.yaml
+++ b/tests/integration/conversion/minimal/v1alpha0.yaml
@@ -25,7 +25,7 @@ spec:
       zone: us-test-1a
     memoryRequest: 100Mi
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/minimal/v1alpha1.yaml
+++ b/tests/integration/conversion/minimal/v1alpha1.yaml
@@ -32,7 +32,7 @@ spec:
     name: events
   iam:
     legacy: true
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/minimal/v1alpha2.yaml
+++ b/tests/integration/conversion/minimal/v1alpha2.yaml
@@ -32,7 +32,7 @@ spec:
     legacy: true
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/create_cluster/minimal/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha1.yaml
@@ -56,7 +56,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -76,7 +76,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
@@ -60,7 +60,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -80,7 +80,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha1.yaml
@@ -29,7 +29,9 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
-  kubernetesVersion: v1.4.8
+  kubelet:
+    anonymousAuth: false
+  kubernetesVersion: v1.14.0
   masterPublicName: api.vpc.example.com
   networkCIDR: 10.0.0.0/12
   networkID: vpc-12345678
@@ -55,7 +57,7 @@ metadata:
     kops.k8s.io/cluster: vpc.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -75,7 +77,7 @@ metadata:
     kops.k8s.io/cluster: vpc.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -27,9 +27,11 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.4.8
+  kubernetesVersion: v1.14.0
   masterPublicName: api.vpc.example.com
   networkCIDR: 10.0.0.0/12
   networkID: vpc-12345678
@@ -59,7 +61,7 @@ metadata:
     kops.k8s.io/cluster: vpc.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -79,7 +81,7 @@ metadata:
     kops.k8s.io/cluster: vpc.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/shared_vpc/options.yaml
+++ b/tests/integration/create_cluster/shared_vpc/options.yaml
@@ -3,4 +3,4 @@ Zones:
 - us-test-1a
 Cloud: aws
 VPCID: vpc-12345678
-KubernetesVersion: v1.4.8
+KubernetesVersion: v1.14.0

--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
@@ -141,40 +141,60 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
   docker:
     ipMasq: false
     ipTables: false
+    logDriver: json-file
     logLevel: warn
-    storage: overlay,aufs
-    version: 1.11.2
+    logOpt:
+    - max-size=10m
+    - max-file=5
+    storage: overlay2,overlay,aufs
+    version: 18.06.3
   encryptionConfig: null
   etcdClusters:
     events:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      version: 3.3.10
     main:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      version: 3.3.10
   kubeAPIServer:
-    address: 127.0.0.1
-    admissionControl:
+    allowPrivileged: true
+    anonymousAuth: false
+    apiServerCount: 1
+    authorizationMode: AlwaysAllow
+    bindAddress: 0.0.0.0
+    cloudProvider: aws
+    enableAdmissionPlugins:
     - NamespaceLifecycle
     - LimitRanger
     - ServiceAccount
     - PersistentVolumeLabel
     - DefaultStorageClass
+    - DefaultTolerationSeconds
+    - MutatingAdmissionWebhook
+    - ValidatingAdmissionWebhook
+    - NodeRestriction
     - ResourceQuota
-    allowPrivileged: true
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    cloudProvider: aws
     etcdServers:
     - http://127.0.0.1:4001
     etcdServersOverrides:
     - /events#http://127.0.0.1:4002
-    image: gcr.io/google_containers/kube-apiserver:v1.4.12
+    image: k8s.gcr.io/kube-apiserver:v1.14.0
+    insecureBindAddress: 127.0.0.1
     insecurePort: 8080
+    kubeletPreferredAddressTypes:
+    - InternalIP
+    - Hostname
+    - ExternalIP
     logLevel: 2
+    requestheaderAllowedNames:
+    - aggregator
+    requestheaderExtraHeaderPrefixes:
+    - X-Remote-Extra-
+    requestheaderGroupHeaders:
+    - X-Remote-Group
+    requestheaderUsernameHeaders:
+    - X-Remote-User
     securePort: 443
     serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd2
+    storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
     attachDetachReconcileSyncPeriod: 1m0s
@@ -182,60 +202,56 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
     clusterCIDR: 100.96.0.0/11
     clusterName: additionalcidr.example.com
     configureCloudRoutes: true
-    image: gcr.io/google_containers/kube-controller-manager:v1.4.12
+    image: k8s.gcr.io/kube-controller-manager:v1.14.0
     leaderElection:
       leaderElect: true
     logLevel: 2
-    master: 127.0.0.1:8080
+    useServiceAccountCredentials: true
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
     hostnameOverride: '@aws'
-    image: gcr.io/google_containers/kube-proxy:v1.4.12
+    image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubeScheduler:
-    image: gcr.io/google_containers/kube-scheduler:v1.4.12
+    image: k8s.gcr.io/kube-scheduler:v1.14.0
     leaderElection:
       leaderElect: true
     logLevel: 2
-    master: http://127.0.0.1:8080
   kubelet:
-    allowPrivileged: true
-    apiServers: https://api.internal.additionalcidr.example.com
-    babysitDaemons: true
-    cgroupRoot: docker
+    cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+    featureGates:
+      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
+    kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
     networkPluginMTU: 9001
     networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
+    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    reconcileCIDR: true
   masterKubelet:
-    allowPrivileged: true
-    apiServers: http://127.0.0.1:8080
-    babysitDaemons: true
-    cgroupRoot: docker
+    cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+    featureGates:
+      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
+    kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
     networkPluginMTU: 9001
     networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podCIDR: 10.123.45.0/28
-    podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
+    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    reconcileCIDR: true
     registerSchedulable: false
 
   __EOF_CLUSTER_SPEC
@@ -249,9 +265,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
 
   cat > kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
-  - c4871c7315817ee114f5c554a58da8ebc54f08c3@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubelet
-  - d9fdb6b37597d371ef853cde76170f38a553aa78@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubectl
-  - 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
+  - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
+  - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
+  - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
   - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: additionalcidr.example.com
   ConfigBase: memfs://clusters.example.com/additionalcidr.example.com
@@ -261,6 +277,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
   - _aws
   channels:
   - memfs://clusters.example.com/additionalcidr.example.com/addons/bootstrap-channel.yaml
+  etcdManifests:
+  - memfs://clusters.example.com/additionalcidr.example.com/manifests/etcd/main.yaml
+  - memfs://clusters.example.com/additionalcidr.example.com/manifests/etcd/events.yaml
   protokubeImage:
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
@@ -415,33 +434,36 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
   docker:
     ipMasq: false
     ipTables: false
+    logDriver: json-file
     logLevel: warn
-    storage: overlay,aufs
-    version: 1.11.2
+    logOpt:
+    - max-size=10m
+    - max-file=5
+    storage: overlay2,overlay,aufs
+    version: 18.06.3
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
     hostnameOverride: '@aws'
-    image: gcr.io/google_containers/kube-proxy:v1.4.12
+    image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubelet:
-    allowPrivileged: true
-    apiServers: https://api.internal.additionalcidr.example.com
-    babysitDaemons: true
-    cgroupRoot: docker
+    cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+    featureGates:
+      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
+    kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
     networkPluginMTU: 9001
     networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
+    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    reconcileCIDR: true
 
   __EOF_CLUSTER_SPEC
 
@@ -454,9 +476,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
 
   cat > kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
-  - c4871c7315817ee114f5c554a58da8ebc54f08c3@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubelet
-  - d9fdb6b37597d371ef853cde76170f38a553aa78@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubectl
-  - 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
+  - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
+  - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
+  - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
   - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: additionalcidr.example.com
   ConfigBase: memfs://clusters.example.com/additionalcidr.example.com

--- a/tests/integration/update_cluster/additional_cidr/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/additional_cidr/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1b
       name: us-test-1b
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.additionalcidr.example.com
   masterPublicName: api.additionalcidr.example.com
   networkCIDR: 10.0.0.0/16

--- a/tests/integration/update_cluster/additional_cidr/in-v1alpha3.yaml
+++ b/tests/integration/update_cluster/additional_cidr/in-v1alpha3.yaml
@@ -26,7 +26,7 @@ spec:
     - instanceGroup: master-us-test-1c
       name: us-test-1c
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.additionalcidr.example.com
   masterPublicName: api.additionalcidr.example.com
   networkCIDR: 10.0.0.0/16

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -150,40 +150,60 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
   docker:
     ipMasq: false
     ipTables: false
+    logDriver: json-file
     logLevel: warn
-    storage: overlay,aufs
-    version: 1.11.2
+    logOpt:
+    - max-size=10m
+    - max-file=5
+    storage: overlay2,overlay,aufs
+    version: 18.06.3
   encryptionConfig: null
   etcdClusters:
     events:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      version: 3.3.10
     main:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      version: 3.3.10
   kubeAPIServer:
-    address: 127.0.0.1
-    admissionControl:
+    allowPrivileged: true
+    anonymousAuth: false
+    apiServerCount: 1
+    authorizationMode: AlwaysAllow
+    bindAddress: 0.0.0.0
+    cloudProvider: aws
+    enableAdmissionPlugins:
     - NamespaceLifecycle
     - LimitRanger
     - ServiceAccount
     - PersistentVolumeLabel
     - DefaultStorageClass
+    - DefaultTolerationSeconds
+    - MutatingAdmissionWebhook
+    - ValidatingAdmissionWebhook
+    - NodeRestriction
     - ResourceQuota
-    allowPrivileged: true
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    cloudProvider: aws
     etcdServers:
     - http://127.0.0.1:4001
     etcdServersOverrides:
     - /events#http://127.0.0.1:4002
-    image: gcr.io/google_containers/kube-apiserver:v1.4.12
+    image: k8s.gcr.io/kube-apiserver:v1.14.0
+    insecureBindAddress: 127.0.0.1
     insecurePort: 8080
+    kubeletPreferredAddressTypes:
+    - InternalIP
+    - Hostname
+    - ExternalIP
     logLevel: 2
+    requestheaderAllowedNames:
+    - aggregator
+    requestheaderExtraHeaderPrefixes:
+    - X-Remote-Extra-
+    requestheaderGroupHeaders:
+    - X-Remote-Group
+    requestheaderUsernameHeaders:
+    - X-Remote-User
     securePort: 443
     serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd2
+    storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
     attachDetachReconcileSyncPeriod: 1m0s
@@ -191,60 +211,56 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
     clusterCIDR: 100.96.0.0/11
     clusterName: additionaluserdata.example.com
     configureCloudRoutes: true
-    image: gcr.io/google_containers/kube-controller-manager:v1.4.12
+    image: k8s.gcr.io/kube-controller-manager:v1.14.0
     leaderElection:
       leaderElect: true
     logLevel: 2
-    master: 127.0.0.1:8080
+    useServiceAccountCredentials: true
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
     hostnameOverride: '@aws'
-    image: gcr.io/google_containers/kube-proxy:v1.4.12
+    image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubeScheduler:
-    image: gcr.io/google_containers/kube-scheduler:v1.4.12
+    image: k8s.gcr.io/kube-scheduler:v1.14.0
     leaderElection:
       leaderElect: true
     logLevel: 2
-    master: http://127.0.0.1:8080
   kubelet:
-    allowPrivileged: true
-    apiServers: https://api.internal.additionaluserdata.example.com
-    babysitDaemons: true
-    cgroupRoot: docker
+    cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+    featureGates:
+      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
+    kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
     networkPluginMTU: 9001
     networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
+    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    reconcileCIDR: true
   masterKubelet:
-    allowPrivileged: true
-    apiServers: http://127.0.0.1:8080
-    babysitDaemons: true
-    cgroupRoot: docker
+    cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+    featureGates:
+      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
+    kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
     networkPluginMTU: 9001
     networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podCIDR: 10.123.45.0/28
-    podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
+    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    reconcileCIDR: true
     registerSchedulable: false
 
   __EOF_CLUSTER_SPEC
@@ -258,9 +274,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
 
   cat > kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
-  - c4871c7315817ee114f5c554a58da8ebc54f08c3@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubelet
-  - d9fdb6b37597d371ef853cde76170f38a553aa78@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubectl
-  - 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
+  - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
+  - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
+  - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
   - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: additionaluserdata.example.com
   ConfigBase: memfs://clusters.example.com/additionaluserdata.example.com
@@ -270,6 +286,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
   - _aws
   channels:
   - memfs://clusters.example.com/additionaluserdata.example.com/addons/bootstrap-channel.yaml
+  etcdManifests:
+  - memfs://clusters.example.com/additionaluserdata.example.com/manifests/etcd/main.yaml
+  - memfs://clusters.example.com/additionaluserdata.example.com/manifests/etcd/events.yaml
   protokubeImage:
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
@@ -444,33 +463,36 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
   docker:
     ipMasq: false
     ipTables: false
+    logDriver: json-file
     logLevel: warn
-    storage: overlay,aufs
-    version: 1.11.2
+    logOpt:
+    - max-size=10m
+    - max-file=5
+    storage: overlay2,overlay,aufs
+    version: 18.06.3
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
     hostnameOverride: '@aws'
-    image: gcr.io/google_containers/kube-proxy:v1.4.12
+    image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubelet:
-    allowPrivileged: true
-    apiServers: https://api.internal.additionaluserdata.example.com
-    babysitDaemons: true
-    cgroupRoot: docker
+    cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+    featureGates:
+      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
+    kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
     networkPluginMTU: 9001
     networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
+    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    reconcileCIDR: true
 
   __EOF_CLUSTER_SPEC
 
@@ -483,9 +505,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
 
   cat > kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
-  - c4871c7315817ee114f5c554a58da8ebc54f08c3@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubelet
-  - d9fdb6b37597d371ef853cde76170f38a553aa78@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubectl
-  - 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
+  - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
+  - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
+  - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
   - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: additionaluserdata.example.com
   ConfigBase: memfs://clusters.example.com/additionaluserdata.example.com

--- a/tests/integration/update_cluster/additional_user-data/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/additional_user-data/in-v1alpha2.yaml
@@ -27,7 +27,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.additionaluserdata.example.com
   masterPublicName: api.additionaluserdata.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/api_elb_cross_zone/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/api_elb_cross_zone/in-v1alpha2.yaml
@@ -30,7 +30,7 @@ spec:
     name: events
   kubeAPIServer:
     serviceNodePortRange: 28000-32767
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.crosszone.example.com
   masterPublicName: api.crosszone.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/bastionadditional_user-data/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/bastionadditional_user-data/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.8.0
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.bastionuserdata.example.com
   masterPublicName: api.bastionuserdata.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -29,7 +29,7 @@ spec:
     name: events
   kubeAPIServer:
     serviceNodePortRange: 28000-32767
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.complex.example.com
   masterPublicName: api.complex.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -29,7 +29,7 @@ spec:
     name: events
   kubeAPIServer:
     serviceNodePortRange: 28000-32767
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.complex.example.com
   masterPublicName: api.complex.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/existing_iam/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/existing_iam/in-v1alpha2.yaml
@@ -20,7 +20,7 @@ spec:
     name: events
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.6.4
+  kubernetesVersion: v1.14.0
   masterPublicName: api.existing-iam.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -62,7 +62,7 @@ metadata:
 spec:
   iam:
     profile: arn:aws:iam::4222917490108:instance-profile/kops-custom-master-role
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -82,7 +82,7 @@ metadata:
 spec:
   iam:
     profile: arn:aws:iam::4222917490108:instance-profile/kops-custom-master-role
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -102,7 +102,7 @@ metadata:
 spec:
   iam:
     profile: arn:aws:iam::4222917490108:instance-profile/kops-custom-master-role
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -122,7 +122,7 @@ metadata:
 spec:
   iam:
     profile: arn:aws:iam::422917490108:instance-profile/kops-custom-node-role
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -257,7 +257,7 @@ resource "aws_key_pair" "kubernetes-existing-iam-example-com-c4a6ed9aa889b9e2c39
 
 resource "aws_launch_configuration" "master-us-test-1a-masters-existing-iam-example-com" {
   name_prefix                 = "master-us-test-1a.masters.existing-iam.example.com-"
-  image_id                    = "ami-15000000"
+  image_id                    = "ami-11400000"
   instance_type               = "m3.medium"
   key_name                    = "${aws_key_pair.kubernetes-existing-iam-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
   iam_instance_profile        = "kops-custom-master-role"
@@ -285,7 +285,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-existing-iam-exam
 
 resource "aws_launch_configuration" "master-us-test-1b-masters-existing-iam-example-com" {
   name_prefix                 = "master-us-test-1b.masters.existing-iam.example.com-"
-  image_id                    = "ami-15000000"
+  image_id                    = "ami-11400000"
   instance_type               = "m3.medium"
   key_name                    = "${aws_key_pair.kubernetes-existing-iam-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
   iam_instance_profile        = "kops-custom-master-role"
@@ -313,7 +313,7 @@ resource "aws_launch_configuration" "master-us-test-1b-masters-existing-iam-exam
 
 resource "aws_launch_configuration" "master-us-test-1c-masters-existing-iam-example-com" {
   name_prefix                 = "master-us-test-1c.masters.existing-iam.example.com-"
-  image_id                    = "ami-15000000"
+  image_id                    = "ami-11400000"
   instance_type               = "m3.medium"
   key_name                    = "${aws_key_pair.kubernetes-existing-iam-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
   iam_instance_profile        = "kops-custom-master-role"
@@ -341,7 +341,7 @@ resource "aws_launch_configuration" "master-us-test-1c-masters-existing-iam-exam
 
 resource "aws_launch_configuration" "nodes-existing-iam-example-com" {
   name_prefix                 = "nodes.existing-iam.example.com-"
-  image_id                    = "ami-15000000"
+  image_id                    = "ami-11400000"
   instance_type               = "t2.medium"
   key_name                    = "${aws_key_pair.kubernetes-existing-iam-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
   iam_instance_profile        = "kops-custom-node-role"

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -141,40 +141,60 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   docker:
     ipMasq: false
     ipTables: false
+    logDriver: json-file
     logLevel: warn
-    storage: overlay,aufs
-    version: 1.11.2
+    logOpt:
+    - max-size=10m
+    - max-file=5
+    storage: overlay2,overlay,aufs
+    version: 18.06.3
   encryptionConfig: null
   etcdClusters:
     events:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      version: 3.3.10
     main:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      version: 3.3.10
   kubeAPIServer:
-    address: 127.0.0.1
-    admissionControl:
+    allowPrivileged: true
+    anonymousAuth: false
+    apiServerCount: 1
+    authorizationMode: AlwaysAllow
+    bindAddress: 0.0.0.0
+    cloudProvider: aws
+    enableAdmissionPlugins:
     - NamespaceLifecycle
     - LimitRanger
     - ServiceAccount
     - PersistentVolumeLabel
     - DefaultStorageClass
+    - DefaultTolerationSeconds
+    - MutatingAdmissionWebhook
+    - ValidatingAdmissionWebhook
+    - NodeRestriction
     - ResourceQuota
-    allowPrivileged: true
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    cloudProvider: aws
     etcdServers:
     - http://127.0.0.1:4001
     etcdServersOverrides:
     - /events#http://127.0.0.1:4002
-    image: gcr.io/google_containers/kube-apiserver:v1.4.12
+    image: k8s.gcr.io/kube-apiserver:v1.14.0
+    insecureBindAddress: 127.0.0.1
     insecurePort: 8080
+    kubeletPreferredAddressTypes:
+    - InternalIP
+    - Hostname
+    - ExternalIP
     logLevel: 2
+    requestheaderAllowedNames:
+    - aggregator
+    requestheaderExtraHeaderPrefixes:
+    - X-Remote-Extra-
+    requestheaderGroupHeaders:
+    - X-Remote-Group
+    requestheaderUsernameHeaders:
+    - X-Remote-User
     securePort: 443
     serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd2
+    storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
     attachDetachReconcileSyncPeriod: 1m0s
@@ -182,60 +202,56 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: true
-    image: gcr.io/google_containers/kube-controller-manager:v1.4.12
+    image: k8s.gcr.io/kube-controller-manager:v1.14.0
     leaderElection:
       leaderElect: true
     logLevel: 2
-    master: 127.0.0.1:8080
+    useServiceAccountCredentials: true
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
     hostnameOverride: '@aws'
-    image: gcr.io/google_containers/kube-proxy:v1.4.12
+    image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubeScheduler:
-    image: gcr.io/google_containers/kube-scheduler:v1.4.12
+    image: k8s.gcr.io/kube-scheduler:v1.14.0
     leaderElection:
       leaderElect: true
     logLevel: 2
-    master: http://127.0.0.1:8080
   kubelet:
-    allowPrivileged: true
-    apiServers: https://api.internal.minimal.example.com
-    babysitDaemons: true
-    cgroupRoot: docker
+    cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+    featureGates:
+      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
+    kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
     networkPluginMTU: 9001
     networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
+    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    reconcileCIDR: true
   masterKubelet:
-    allowPrivileged: true
-    apiServers: http://127.0.0.1:8080
-    babysitDaemons: true
-    cgroupRoot: docker
+    cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+    featureGates:
+      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
+    kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
     networkPluginMTU: 9001
     networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podCIDR: 10.123.45.0/28
-    podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
+    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    reconcileCIDR: true
     registerSchedulable: false
 
   __EOF_CLUSTER_SPEC
@@ -249,9 +265,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
 
   cat > kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
-  - c4871c7315817ee114f5c554a58da8ebc54f08c3@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubelet
-  - d9fdb6b37597d371ef853cde76170f38a553aa78@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubectl
-  - 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
+  - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
+  - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
+  - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
   - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: minimal.example.com
   ConfigBase: memfs://clusters.example.com/minimal.example.com
@@ -261,6 +277,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   - _aws
   channels:
   - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml
+  etcdManifests:
+  - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main.yaml
+  - memfs://clusters.example.com/minimal.example.com/manifests/etcd/events.yaml
   protokubeImage:
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
@@ -415,33 +434,36 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   docker:
     ipMasq: false
     ipTables: false
+    logDriver: json-file
     logLevel: warn
-    storage: overlay,aufs
-    version: 1.11.2
+    logOpt:
+    - max-size=10m
+    - max-file=5
+    storage: overlay2,overlay,aufs
+    version: 18.06.3
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
     hostnameOverride: '@aws'
-    image: gcr.io/google_containers/kube-proxy:v1.4.12
+    image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubelet:
-    allowPrivileged: true
-    apiServers: https://api.internal.minimal.example.com
-    babysitDaemons: true
-    cgroupRoot: docker
+    cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+    featureGates:
+      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
+    kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
     networkPluginMTU: 9001
     networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
+    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    reconcileCIDR: true
 
   __EOF_CLUSTER_SPEC
 
@@ -454,9 +476,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
 
   cat > kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
-  - c4871c7315817ee114f5c554a58da8ebc54f08c3@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubelet
-  - d9fdb6b37597d371ef853cde76170f38a553aa78@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubectl
-  - 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
+  - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
+  - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
+  - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
   - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: minimal.example.com
   ConfigBase: memfs://clusters.example.com/minimal.example.com

--- a/tests/integration/update_cluster/existing_iam_cloudformation/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/existing_sg/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/existing_sg/in-v1alpha2.yaml
@@ -29,7 +29,7 @@ spec:
     - instanceGroup: master-us-test-1c
       name: c
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.existingsg.example.com
   masterPublicName: api.existingsg.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -146,38 +146,38 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
     logOpt:
     - max-size=10m
     - max-file=5
-    storage: overlay,aufs
-    version: 1.13.1
+    storage: overlay2,overlay,aufs
+    version: 18.06.3
   encryptionConfig: null
   etcdClusters:
     events:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      version: 3.3.10
     main:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      version: 3.3.10
   kubeAPIServer:
-    address: 127.0.0.1
-    admissionControl:
-    - Initializers
+    allowPrivileged: true
+    anonymousAuth: false
+    apiServerCount: 1
+    authorizationMode: AlwaysAllow
+    bindAddress: 0.0.0.0
+    cloudProvider: aws
+    enableAdmissionPlugins:
     - NamespaceLifecycle
     - LimitRanger
     - ServiceAccount
     - PersistentVolumeLabel
     - DefaultStorageClass
     - DefaultTolerationSeconds
+    - MutatingAdmissionWebhook
+    - ValidatingAdmissionWebhook
     - NodeRestriction
     - ResourceQuota
-    allowPrivileged: true
-    anonymousAuth: false
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    cloudProvider: aws
     etcdServers:
     - http://127.0.0.1:4001
     etcdServersOverrides:
     - /events#http://127.0.0.1:4002
-    image: gcr.io/google_containers/kube-apiserver:v1.8.0
+    image: k8s.gcr.io/kube-apiserver:v1.14.0
+    insecureBindAddress: 127.0.0.1
     insecurePort: 8080
     kubeletPreferredAddressTypes:
     - InternalIP
@@ -194,7 +194,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
     - X-Remote-User
     securePort: 443
     serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd2
+    storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
     attachDetachReconcileSyncPeriod: 1m0s
@@ -202,7 +202,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
     clusterCIDR: 100.96.0.0/11
     clusterName: externallb.example.com
     configureCloudRoutes: true
-    image: gcr.io/google_containers/kube-controller-manager:v1.8.0
+    image: k8s.gcr.io/kube-controller-manager:v1.14.0
     leaderElection:
       leaderElect: true
     logLevel: 2
@@ -211,15 +211,14 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
     hostnameOverride: '@aws'
-    image: gcr.io/google_containers/kube-proxy:v1.8.0
+    image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubeScheduler:
-    image: gcr.io/google_containers/kube-scheduler:v1.8.0
+    image: k8s.gcr.io/kube-scheduler:v1.14.0
     leaderElection:
       leaderElect: true
     logLevel: 2
   kubelet:
-    allowPrivileged: true
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -234,11 +233,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
     networkPluginMTU: 9001
     networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
+    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    requireKubeconfig: true
   masterKubelet:
-    allowPrivileged: true
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -253,10 +250,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
     networkPluginMTU: 9001
     networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
+    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    requireKubeconfig: true
 
   __EOF_CLUSTER_SPEC
 
@@ -269,9 +265,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
 
   cat > kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
-  - 4c7b8aafe652ae107c9131754a2ad4e9641a025b@https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubelet
-  - 006fd43085e6ba2dc6b35b89af4d68cee3f689c9@https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl
-  - 1d9788b0f5420e1a219aad2cb8681823fc515e7c@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz
+  - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
+  - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
+  - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
   - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: externallb.example.com
   ConfigBase: memfs://clusters.example.com/externallb.example.com
@@ -281,6 +277,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
   - _aws
   channels:
   - memfs://clusters.example.com/externallb.example.com/addons/bootstrap-channel.yaml
+  etcdManifests:
+  - memfs://clusters.example.com/externallb.example.com/manifests/etcd/main.yaml
+  - memfs://clusters.example.com/externallb.example.com/manifests/etcd/events.yaml
   protokubeImage:
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
@@ -440,16 +439,15 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
     logOpt:
     - max-size=10m
     - max-file=5
-    storage: overlay,aufs
-    version: 1.13.1
+    storage: overlay2,overlay,aufs
+    version: 18.06.3
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
     hostnameOverride: '@aws'
-    image: gcr.io/google_containers/kube-proxy:v1.8.0
+    image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubelet:
-    allowPrivileged: true
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -464,9 +462,8 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
     networkPluginMTU: 9001
     networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
+    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    requireKubeconfig: true
 
   __EOF_CLUSTER_SPEC
 
@@ -479,9 +476,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
 
   cat > kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
-  - 4c7b8aafe652ae107c9131754a2ad4e9641a025b@https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubelet
-  - 006fd43085e6ba2dc6b35b89af4d68cee3f689c9@https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl
-  - 1d9788b0f5420e1a219aad2cb8681823fc515e7c@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz
+  - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
+  - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
+  - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
   - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: externallb.example.com
   ConfigBase: memfs://clusters.example.com/externallb.example.com

--- a/tests/integration/update_cluster/externallb/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/externallb/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.8.0
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.externallb.example.com
   masterPublicName: api.externallb.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/ha/in-v1alpha1.yaml
+++ b/tests/integration/update_cluster/ha/in-v1alpha1.yaml
@@ -28,7 +28,7 @@ spec:
     - name: c
       zone: us-test-1c
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterPublicName: api.ha.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/update_cluster/ha/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/ha/in-v1alpha2.yaml
@@ -28,7 +28,7 @@ spec:
     name: events
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterPublicName: api.ha.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/update_cluster/ha_gce/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/ha_gce/in-v1alpha2.yaml
@@ -32,7 +32,7 @@ spec:
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.8.0-beta.1
+  kubernetesVersion: v1.14.0
   masterPublicName: api.ha-gce.example.com
   networking:
     kubenet: {}

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -373,7 +373,7 @@ resource "google_compute_instance_template" "master-us-test1-a-ha-gce-example-co
   machine_type   = "n1-standard-1"
 
   service_account = {
-    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
+    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
   }
 
   scheduling = {
@@ -413,7 +413,7 @@ resource "google_compute_instance_template" "master-us-test1-b-ha-gce-example-co
   machine_type   = "n1-standard-1"
 
   service_account = {
-    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
+    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
   }
 
   scheduling = {
@@ -453,7 +453,7 @@ resource "google_compute_instance_template" "master-us-test1-c-ha-gce-example-co
   machine_type   = "n1-standard-1"
 
   service_account = {
-    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
+    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
   }
 
   scheduling = {

--- a/tests/integration/update_cluster/lifecycle_phases/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/lifecycle_phases/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.lifecyclephases.example.com
   masterPublicName: api.lifecyclephases.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/minimal-141/in-v1alpha0.yaml
+++ b/tests/integration/update_cluster/minimal-141/in-v1alpha0.yaml
@@ -17,7 +17,7 @@ spec:
     - name: us-test-1a
       zone: us-test-1a
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterPublicName: api.minimal-141.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -141,40 +141,60 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   docker:
     ipMasq: false
     ipTables: false
+    logDriver: json-file
     logLevel: warn
-    storage: overlay,aufs
-    version: 1.11.2
+    logOpt:
+    - max-size=10m
+    - max-file=5
+    storage: overlay2,overlay,aufs
+    version: 18.06.3
   encryptionConfig: null
   etcdClusters:
     events:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      version: 3.3.10
     main:
-      image: gcr.io/google_containers/etcd:2.2.1
-      version: 2.2.1
+      version: 3.3.10
   kubeAPIServer:
-    address: 127.0.0.1
-    admissionControl:
+    allowPrivileged: true
+    anonymousAuth: false
+    apiServerCount: 1
+    authorizationMode: AlwaysAllow
+    bindAddress: 0.0.0.0
+    cloudProvider: aws
+    enableAdmissionPlugins:
     - NamespaceLifecycle
     - LimitRanger
     - ServiceAccount
     - PersistentVolumeLabel
     - DefaultStorageClass
+    - DefaultTolerationSeconds
+    - MutatingAdmissionWebhook
+    - ValidatingAdmissionWebhook
+    - NodeRestriction
     - ResourceQuota
-    allowPrivileged: true
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    cloudProvider: aws
     etcdServers:
     - http://127.0.0.1:4001
     etcdServersOverrides:
     - /events#http://127.0.0.1:4002
-    image: gcr.io/google_containers/kube-apiserver:v1.4.12
+    image: k8s.gcr.io/kube-apiserver:v1.14.0
+    insecureBindAddress: 127.0.0.1
     insecurePort: 8080
+    kubeletPreferredAddressTypes:
+    - InternalIP
+    - Hostname
+    - ExternalIP
     logLevel: 2
+    requestheaderAllowedNames:
+    - aggregator
+    requestheaderExtraHeaderPrefixes:
+    - X-Remote-Extra-
+    requestheaderGroupHeaders:
+    - X-Remote-Group
+    requestheaderUsernameHeaders:
+    - X-Remote-User
     securePort: 443
     serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd2
+    storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
     attachDetachReconcileSyncPeriod: 1m0s
@@ -182,60 +202,56 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: true
-    image: gcr.io/google_containers/kube-controller-manager:v1.4.12
+    image: k8s.gcr.io/kube-controller-manager:v1.14.0
     leaderElection:
       leaderElect: true
     logLevel: 2
-    master: 127.0.0.1:8080
+    useServiceAccountCredentials: true
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
     hostnameOverride: '@aws'
-    image: gcr.io/google_containers/kube-proxy:v1.4.12
+    image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubeScheduler:
-    image: gcr.io/google_containers/kube-scheduler:v1.4.12
+    image: k8s.gcr.io/kube-scheduler:v1.14.0
     leaderElection:
       leaderElect: true
     logLevel: 2
-    master: http://127.0.0.1:8080
   kubelet:
-    allowPrivileged: true
-    apiServers: https://api.internal.minimal.example.com
-    babysitDaemons: true
-    cgroupRoot: docker
+    cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+    featureGates:
+      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
+    kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
     networkPluginMTU: 9001
     networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
+    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    reconcileCIDR: true
   masterKubelet:
-    allowPrivileged: true
-    apiServers: http://127.0.0.1:8080
-    babysitDaemons: true
-    cgroupRoot: docker
+    cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+    featureGates:
+      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
+    kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
     networkPluginMTU: 9001
     networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podCIDR: 10.123.45.0/28
-    podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
+    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    reconcileCIDR: true
     registerSchedulable: false
 
   __EOF_CLUSTER_SPEC
@@ -249,9 +265,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
 
   cat > kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
-  - c4871c7315817ee114f5c554a58da8ebc54f08c3@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubelet
-  - d9fdb6b37597d371ef853cde76170f38a553aa78@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubectl
-  - 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
+  - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
+  - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
+  - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
   - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: minimal.example.com
   ConfigBase: memfs://clusters.example.com/minimal.example.com
@@ -261,6 +277,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   - _aws
   channels:
   - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml
+  etcdManifests:
+  - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main.yaml
+  - memfs://clusters.example.com/minimal.example.com/manifests/etcd/events.yaml
   protokubeImage:
     hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
     name: protokube:1.8.1
@@ -415,33 +434,36 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   docker:
     ipMasq: false
     ipTables: false
+    logDriver: json-file
     logLevel: warn
-    storage: overlay,aufs
-    version: 1.11.2
+    logOpt:
+    - max-size=10m
+    - max-file=5
+    storage: overlay2,overlay,aufs
+    version: 18.06.3
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
     hostnameOverride: '@aws'
-    image: gcr.io/google_containers/kube-proxy:v1.4.12
+    image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubelet:
-    allowPrivileged: true
-    apiServers: https://api.internal.minimal.example.com
-    babysitDaemons: true
-    cgroupRoot: docker
+    cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+    featureGates:
+      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
+    kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
     networkPluginMTU: 9001
     networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
+    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    reconcileCIDR: true
 
   __EOF_CLUSTER_SPEC
 
@@ -454,9 +476,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
 
   cat > kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
-  - c4871c7315817ee114f5c554a58da8ebc54f08c3@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubelet
-  - d9fdb6b37597d371ef853cde76170f38a553aa78@https://storage.googleapis.com/kubernetes-release/release/v1.4.12/bin/linux/amd64/kubectl
-  - 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
+  - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
+  - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
+  - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
   - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
   ClusterName: minimal.example.com
   ConfigBase: memfs://clusters.example.com/minimal.example.com

--- a/tests/integration/update_cluster/minimal-cloudformation/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/minimal/in-v1alpha0.yaml
+++ b/tests/integration/update_cluster/minimal/in-v1alpha0.yaml
@@ -17,7 +17,7 @@ spec:
     - name: us-test-1a
       zone: us-test-1a
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/minimal/in-v1alpha1.yaml
+++ b/tests/integration/update_cluster/minimal/in-v1alpha1.yaml
@@ -18,7 +18,7 @@ spec:
     - name: us-test-1a
       zone: us-test-1a
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/minimal/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.8.0
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/private-shared-subnet/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/private-shared-subnet/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.8.2
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.private-shared-subnet.example.com
   masterPublicName: api.private-shared-subnet.example.com
   networkCIDR: 172.20.0.0/16
@@ -55,7 +55,7 @@ metadata:
     kops.k8s.io/cluster: private-shared-subnet.example.com
 spec:
   associatePublicIp: true
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -74,7 +74,7 @@ metadata:
     kops.k8s.io/cluster: private-shared-subnet.example.com
 spec:
   associatePublicIp: true
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: t2.medium
   maxSize: 2
   minSize: 2
@@ -94,7 +94,7 @@ metadata:
     kops.k8s.io/cluster: private-shared-subnet.example.com
 spec:
   associatePublicIp: true
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: t2.micro
   maxSize: 1
   minSize: 1

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -361,7 +361,7 @@ resource "aws_key_pair" "kubernetes-private-shared-subnet-example-com-c4a6ed9aa8
 
 resource "aws_launch_configuration" "bastion-private-shared-subnet-example-com" {
   name_prefix                 = "bastion.private-shared-subnet.example.com-"
-  image_id                    = "ami-15000000"
+  image_id                    = "ami-11400000"
   instance_type               = "t2.micro"
   key_name                    = "${aws_key_pair.kubernetes-private-shared-subnet-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-private-shared-subnet-example-com.id}"
@@ -383,7 +383,7 @@ resource "aws_launch_configuration" "bastion-private-shared-subnet-example-com" 
 
 resource "aws_launch_configuration" "master-us-test-1a-masters-private-shared-subnet-example-com" {
   name_prefix                 = "master-us-test-1a.masters.private-shared-subnet.example.com-"
-  image_id                    = "ami-15000000"
+  image_id                    = "ami-11400000"
   instance_type               = "m3.medium"
   key_name                    = "${aws_key_pair.kubernetes-private-shared-subnet-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
   iam_instance_profile        = "${aws_iam_instance_profile.masters-private-shared-subnet-example-com.id}"
@@ -411,7 +411,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-private-shared-su
 
 resource "aws_launch_configuration" "nodes-private-shared-subnet-example-com" {
   name_prefix                 = "nodes.private-shared-subnet.example.com-"
-  image_id                    = "ami-15000000"
+  image_id                    = "ami-11400000"
   instance_type               = "t2.medium"
   key_name                    = "${aws_key_pair.kubernetes-private-shared-subnet-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
   iam_instance_profile        = "${aws_iam_instance_profile.nodes-private-shared-subnet-example-com.id}"

--- a/tests/integration/update_cluster/privatecalico/in-v1alpha1.yaml
+++ b/tests/integration/update_cluster/privatecalico/in-v1alpha1.yaml
@@ -18,7 +18,7 @@ spec:
     - name: us-test-1a
       zone: us-test-1a
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privatecalico.example.com
   masterPublicName: api.privatecalico.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/privatecalico/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatecalico/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.8.0
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privatecalico.example.com
   masterPublicName: api.privatecalico.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/privatecanal/in-v1alpha1.yaml
+++ b/tests/integration/update_cluster/privatecanal/in-v1alpha1.yaml
@@ -18,7 +18,7 @@ spec:
     - name: us-test-1a
       zone: us-test-1a
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privatecanal.example.com
   masterPublicName: api.privatecanal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/privatecanal/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatecanal/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.8.0
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privatecanal.example.com
   masterPublicName: api.privatecanal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/privatedns1/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatedns1/in-v1alpha2.yaml
@@ -19,7 +19,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privatedns1.example.com
   masterPublicName: api.privatedns1.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/privatedns2/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatedns2/in-v1alpha2.yaml
@@ -19,7 +19,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privatedns2.example.com
   masterPublicName: api.privatedns2.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/privateflannel/in-v1alpha1.yaml
+++ b/tests/integration/update_cluster/privateflannel/in-v1alpha1.yaml
@@ -18,7 +18,7 @@ spec:
     - name: us-test-1a
       zone: us-test-1a
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privateflannel.example.com
   masterPublicName: api.privateflannel.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/privateflannel/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privateflannel/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privateflannel.example.com
   masterPublicName: api.privateflannel.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/privatekopeio/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatekopeio/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.8.2
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privatekopeio.example.com
   masterPublicName: api.privatekopeio.example.com
   networkCIDR: 172.20.0.0/16
@@ -61,7 +61,7 @@ metadata:
     kops.k8s.io/cluster: privatekopeio.example.com
 spec:
   associatePublicIp: true
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -80,7 +80,7 @@ metadata:
     kops.k8s.io/cluster: privatekopeio.example.com
 spec:
   associatePublicIp: true
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: t2.medium
   maxSize: 2
   minSize: 2
@@ -101,7 +101,7 @@ metadata:
     kops.k8s.io/cluster: privatekopeio.example.com
 spec:
   associatePublicIp: true
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: t2.micro
   maxSize: 1
   minSize: 1

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -396,7 +396,7 @@ resource "aws_key_pair" "kubernetes-privatekopeio-example-com-c4a6ed9aa889b9e2c3
 
 resource "aws_launch_configuration" "bastion-privatekopeio-example-com" {
   name_prefix                 = "bastion.privatekopeio.example.com-"
-  image_id                    = "ami-15000000"
+  image_id                    = "ami-11400000"
   instance_type               = "t2.micro"
   key_name                    = "${aws_key_pair.kubernetes-privatekopeio-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-privatekopeio-example-com.id}"
@@ -418,7 +418,7 @@ resource "aws_launch_configuration" "bastion-privatekopeio-example-com" {
 
 resource "aws_launch_configuration" "master-us-test-1a-masters-privatekopeio-example-com" {
   name_prefix                 = "master-us-test-1a.masters.privatekopeio.example.com-"
-  image_id                    = "ami-15000000"
+  image_id                    = "ami-11400000"
   instance_type               = "m3.medium"
   key_name                    = "${aws_key_pair.kubernetes-privatekopeio-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
   iam_instance_profile        = "${aws_iam_instance_profile.masters-privatekopeio-example-com.id}"
@@ -446,7 +446,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-privatekopeio-exa
 
 resource "aws_launch_configuration" "nodes-privatekopeio-example-com" {
   name_prefix                 = "nodes.privatekopeio.example.com-"
-  image_id                    = "ami-15000000"
+  image_id                    = "ami-11400000"
   instance_type               = "t2.medium"
   key_name                    = "${aws_key_pair.kubernetes-privatekopeio-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
   iam_instance_profile        = "${aws_iam_instance_profile.nodes-privatekopeio-example-com.id}"

--- a/tests/integration/update_cluster/privateweave/in-v1alpha1.yaml
+++ b/tests/integration/update_cluster/privateweave/in-v1alpha1.yaml
@@ -18,7 +18,7 @@ spec:
     - name: us-test-1a
       zone: us-test-1a
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privateweave.example.com
   masterPublicName: api.privateweave.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/privateweave/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privateweave/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.4.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privateweave.example.com
   masterPublicName: api.privateweave.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/restrict_access/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/restrict_access/in-v1alpha2.yaml
@@ -19,7 +19,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.8.0
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.restrictaccess.example.com
   masterPublicName: api.restrictaccess.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/shared_subnet/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/shared_subnet/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.8.6
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.sharedsubnet.example.com
   masterPublicName: api.sharedsubnet.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/shared_vpc/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/shared_vpc/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.7.12
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.sharedvpc.example.com
   masterPublicName: api.sharedvpc.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/unmanaged/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/unmanaged/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.8.2
+  kubernetesVersion: v1.14.0
   masterInternalName: api.internal.unmanaged.example.com
   masterPublicName: api.unmanaged.example.com
   networkID: vpc-12345678
@@ -64,7 +64,7 @@ metadata:
     kops.k8s.io/cluster: unmanaged.example.com
 spec:
   associatePublicIp: true
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -83,7 +83,7 @@ metadata:
     kops.k8s.io/cluster: unmanaged.example.com
 spec:
   associatePublicIp: true
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: t2.medium
   maxSize: 2
   minSize: 2
@@ -104,7 +104,7 @@ metadata:
     kops.k8s.io/cluster: unmanaged.example.com
 spec:
   associatePublicIp: true
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: t2.micro
   maxSize: 1
   minSize: 1

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -366,7 +366,7 @@ resource "aws_key_pair" "kubernetes-unmanaged-example-com-c4a6ed9aa889b9e2c39cd6
 
 resource "aws_launch_configuration" "bastion-unmanaged-example-com" {
   name_prefix                 = "bastion.unmanaged.example.com-"
-  image_id                    = "ami-15000000"
+  image_id                    = "ami-11400000"
   instance_type               = "t2.micro"
   key_name                    = "${aws_key_pair.kubernetes-unmanaged-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-unmanaged-example-com.id}"
@@ -388,7 +388,7 @@ resource "aws_launch_configuration" "bastion-unmanaged-example-com" {
 
 resource "aws_launch_configuration" "master-us-test-1a-masters-unmanaged-example-com" {
   name_prefix                 = "master-us-test-1a.masters.unmanaged.example.com-"
-  image_id                    = "ami-15000000"
+  image_id                    = "ami-11400000"
   instance_type               = "m3.medium"
   key_name                    = "${aws_key_pair.kubernetes-unmanaged-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
   iam_instance_profile        = "${aws_iam_instance_profile.masters-unmanaged-example-com.id}"
@@ -416,7 +416,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-unmanaged-example
 
 resource "aws_launch_configuration" "nodes-unmanaged-example-com" {
   name_prefix                 = "nodes.unmanaged.example.com-"
-  image_id                    = "ami-15000000"
+  image_id                    = "ami-11400000"
   instance_type               = "t2.medium"
   key_name                    = "${aws_key_pair.kubernetes-unmanaged-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
   iam_instance_profile        = "${aws_iam_instance_profile.nodes-unmanaged-example-com.id}"


### PR DESCRIPTION
Bringing this from the alpha channel (#7423) to the stable channel.

As discussed in office hours, and from the notes on #7423:

Even 1.11 and 1.12 are technically unsupported, but this should get users
off the very oldest unsupported versions of k8s.

Users that want to stay on those versions can pass the
KOPS_RUN_OBSOLETE_VERSION env var.