### PR TITLE
metrics-server run as non-root user

### DIFF
--- a/addons/metrics-server/v1.8.x.yaml
+++ b/addons/metrics-server/v1.8.x.yaml
@@ -142,6 +142,15 @@ spec:
             - /metrics-server
             - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
             - --kubelet-insecure-tls
+            - --cert-dir=/tmp
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["all"]
+          readOnlyRootFilesystem: true
+          runAsGroup: 10001
+          runAsNonRoot: true
+          runAsUser: 10001
         volumeMounts:
         - name: tmp-dir
           mountPath: /tmp


### PR DESCRIPTION
To support metrics-server with non-privileged user.

Related issue #7597 