### PR TITLE
Allow users to set kube controller manager's concurrent sync flags.

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1175,6 +1175,47 @@ spec:
                 clusterName:
                   description: ClusterName is the instance prefix for the cluster.
                   type: string
+                concurrentDeploymentSyncs:
+                  description: The number of deployment objects that are allowed to
+                    sync concurrently.
+                  format: int32
+                  type: integer
+                concurrentEndpointSyncs:
+                  description: The number of endpoint objects that are allowed to
+                    sync concurrently.
+                  format: int32
+                  type: integer
+                concurrentNamespaceSyncs:
+                  description: The number of namespace objects that are allowed to
+                    sync concurrently.
+                  format: int32
+                  type: integer
+                concurrentRcSyncs:
+                  description: The number of replicationcontroller objects that are
+                    allowed to sync concurrently. This only works on kubernetes >=
+                    1.14
+                  format: int32
+                  type: integer
+                concurrentReplicasetSyncs:
+                  description: The number of replicaset objects that are allowed to
+                    sync concurrently.
+                  format: int32
+                  type: integer
+                concurrentResourceQuotaSyncs:
+                  description: The number of resourcequota objects that are allowed
+                    to sync concurrently.
+                  format: int32
+                  type: integer
+                concurrentServiceSyncs:
+                  description: The number of service objects that are allowed to sync
+                    concurrently.
+                  format: int32
+                  type: integer
+                concurrentServiceaccountTokenSyncs:
+                  description: The number of serviceaccount objects that are allowed
+                    to sync concurrently to create tokens.
+                  format: int32
+                  type: integer
                 configureCloudRoutes:
                   description: ConfigureCloudRoutes enables CIDRs allocated with to
                     be configured on the cloud provider.

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -540,6 +540,22 @@ type KubeControllerManagerConfig struct {
 	KubeAPIQPS *resource.Quantity `json:"kubeAPIQPS,omitempty" flag:"kube-api-qps"`
 	// KubeAPIBurst Burst to use while talking with kubernetes apiserver. (default 30)
 	KubeAPIBurst *int32 `json:"kubeAPIBurst,omitempty" flag:"kube-api-burst"`
+	// The number of deployment objects that are allowed to sync concurrently.
+	ConcurrentDeploymentSyncs *int32 `json:"concurrentDeploymentSyncs,omitempty" flag:"concurrent-deployment-syncs"`
+	// The number of endpoint objects that are allowed to sync concurrently.
+	ConcurrentEndpointSyncs *int32 `json:"concurrentEndpointSyncs,omitempty" flag:"concurrent-endpoint-syncs"`
+	// The number of namespace objects that are allowed to sync concurrently.
+	ConcurrentNamespaceSyncs *int32 `json:"concurrentNamespaceSyncs,omitempty" flag:"concurrent-namespace-syncs"`
+	// The number of replicaset objects that are allowed to sync concurrently.
+	ConcurrentReplicasetSyncs *int32 `json:"concurrentReplicasetSyncs,omitempty" flag:"concurrent-replicaset-syncs"`
+	// The number of service objects that are allowed to sync concurrently.
+	ConcurrentServiceSyncs *int32 `json:"concurrentServiceSyncs,omitempty" flag:"concurrent-service-syncs"`
+	// The number of resourcequota objects that are allowed to sync concurrently.
+	ConcurrentResourceQuotaSyncs *int32 `json:"concurrentResourceQuotaSyncs,omitempty" flag:"concurrent-resource-quota-syncs"`
+	// The number of serviceaccount objects that are allowed to sync concurrently to create tokens.
+	ConcurrentServiceaccountTokenSyncs *int32 `json:"concurrentServiceaccountTokenSyncs,omitempty" flag:"concurrent-serviceaccount-token-syncs"`
+	// The number of replicationcontroller objects that are allowed to sync concurrently.
+	ConcurrentRcSyncs *int32 `json:"concurrentRcSyncs,omitempty" flag:"concurrent-rc-syncs"`
 }
 
 // CloudControllerManagerConfig is the configuration of the cloud controller

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -540,6 +540,22 @@ type KubeControllerManagerConfig struct {
 	KubeAPIQPS *resource.Quantity `json:"kubeAPIQPS,omitempty" flag:"kube-api-qps"`
 	// KubeAPIBurst Burst to use while talking with kubernetes apiserver. (default 30)
 	KubeAPIBurst *int32 `json:"kubeAPIBurst,omitempty" flag:"kube-api-burst"`
+	// The number of deployment objects that are allowed to sync concurrently.
+	ConcurrentDeploymentSyncs *int32 `json:"concurrentDeploymentSyncs,omitempty" flag:"concurrent-deployment-syncs"`
+	// The number of endpoint objects that are allowed to sync concurrently.
+	ConcurrentEndpointSyncs *int32 `json:"concurrentEndpointSyncs,omitempty" flag:"concurrent-endpoint-syncs"`
+	// The number of namespace objects that are allowed to sync concurrently.
+	ConcurrentNamespaceSyncs *int32 `json:"concurrentNamespaceSyncs,omitempty" flag:"concurrent-namespace-syncs"`
+	// The number of replicaset objects that are allowed to sync concurrently.
+	ConcurrentReplicasetSyncs *int32 `json:"concurrentReplicasetSyncs,omitempty" flag:"concurrent-replicaset-syncs"`
+	// The number of service objects that are allowed to sync concurrently.
+	ConcurrentServiceSyncs *int32 `json:"concurrentServiceSyncs,omitempty" flag:"concurrent-service-syncs"`
+	// The number of resourcequota objects that are allowed to sync concurrently.
+	ConcurrentResourceQuotaSyncs *int32 `json:"concurrentResourceQuotaSyncs,omitempty" flag:"concurrent-resource-quota-syncs"`
+	// The number of serviceaccount objects that are allowed to sync concurrently to create tokens.
+	ConcurrentServiceaccountTokenSyncs *int32 `json:"concurrentServiceaccountTokenSyncs,omitempty" flag:"concurrent-serviceaccount-token-syncs"`
+	// The number of replicationcontroller objects that are allowed to sync concurrently.
+	ConcurrentRcSyncs *int32 `json:"concurrentRcSyncs,omitempty" flag:"concurrent-rc-syncs"`
 }
 
 // CloudControllerManagerConfig is the configuration of the cloud controller

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -3380,6 +3380,14 @@ func autoConvert_v1alpha1_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.MinResyncPeriod = in.MinResyncPeriod
 	out.KubeAPIQPS = in.KubeAPIQPS
 	out.KubeAPIBurst = in.KubeAPIBurst
+	out.ConcurrentDeploymentSyncs = in.ConcurrentDeploymentSyncs
+	out.ConcurrentEndpointSyncs = in.ConcurrentEndpointSyncs
+	out.ConcurrentNamespaceSyncs = in.ConcurrentNamespaceSyncs
+	out.ConcurrentReplicasetSyncs = in.ConcurrentReplicasetSyncs
+	out.ConcurrentServiceSyncs = in.ConcurrentServiceSyncs
+	out.ConcurrentResourceQuotaSyncs = in.ConcurrentResourceQuotaSyncs
+	out.ConcurrentServiceaccountTokenSyncs = in.ConcurrentServiceaccountTokenSyncs
+	out.ConcurrentRcSyncs = in.ConcurrentRcSyncs
 	return nil
 }
 
@@ -3430,6 +3438,14 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha1_KubeControllerMana
 	out.MinResyncPeriod = in.MinResyncPeriod
 	out.KubeAPIQPS = in.KubeAPIQPS
 	out.KubeAPIBurst = in.KubeAPIBurst
+	out.ConcurrentDeploymentSyncs = in.ConcurrentDeploymentSyncs
+	out.ConcurrentEndpointSyncs = in.ConcurrentEndpointSyncs
+	out.ConcurrentNamespaceSyncs = in.ConcurrentNamespaceSyncs
+	out.ConcurrentReplicasetSyncs = in.ConcurrentReplicasetSyncs
+	out.ConcurrentServiceSyncs = in.ConcurrentServiceSyncs
+	out.ConcurrentResourceQuotaSyncs = in.ConcurrentResourceQuotaSyncs
+	out.ConcurrentServiceaccountTokenSyncs = in.ConcurrentServiceaccountTokenSyncs
+	out.ConcurrentRcSyncs = in.ConcurrentRcSyncs
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2142,6 +2142,46 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ConcurrentDeploymentSyncs != nil {
+		in, out := &in.ConcurrentDeploymentSyncs, &out.ConcurrentDeploymentSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentEndpointSyncs != nil {
+		in, out := &in.ConcurrentEndpointSyncs, &out.ConcurrentEndpointSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentNamespaceSyncs != nil {
+		in, out := &in.ConcurrentNamespaceSyncs, &out.ConcurrentNamespaceSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentReplicasetSyncs != nil {
+		in, out := &in.ConcurrentReplicasetSyncs, &out.ConcurrentReplicasetSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentServiceSyncs != nil {
+		in, out := &in.ConcurrentServiceSyncs, &out.ConcurrentServiceSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentResourceQuotaSyncs != nil {
+		in, out := &in.ConcurrentResourceQuotaSyncs, &out.ConcurrentResourceQuotaSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentServiceaccountTokenSyncs != nil {
+		in, out := &in.ConcurrentServiceaccountTokenSyncs, &out.ConcurrentServiceaccountTokenSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentRcSyncs != nil {
+		in, out := &in.ConcurrentRcSyncs, &out.ConcurrentRcSyncs
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -555,6 +555,7 @@ type KubeControllerManagerConfig struct {
 	// The number of serviceaccount objects that are allowed to sync concurrently to create tokens.
 	ConcurrentServiceaccountTokenSyncs *int32 `json:"concurrentServiceaccountTokenSyncs,omitempty" flag:"concurrent-serviceaccount-token-syncs"`
 	// The number of replicationcontroller objects that are allowed to sync concurrently.
+	// This only works on kubernetes >= 1.14
 	ConcurrentRcSyncs *int32 `json:"concurrentRcSyncs,omitempty" flag:"concurrent-rc-syncs"`
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -540,6 +540,22 @@ type KubeControllerManagerConfig struct {
 	KubeAPIQPS *resource.Quantity `json:"kubeAPIQPS,omitempty" flag:"kube-api-qps"`
 	// KubeAPIBurst Burst to use while talking with kubernetes apiserver. (default 30)
 	KubeAPIBurst *int32 `json:"kubeAPIBurst,omitempty" flag:"kube-api-burst"`
+	// The number of deployment objects that are allowed to sync concurrently.
+	ConcurrentDeploymentSyncs *int32 `json:"concurrentDeploymentSyncs,omitempty" flag:"concurrent-deployment-syncs"`
+	// The number of endpoint objects that are allowed to sync concurrently.
+	ConcurrentEndpointSyncs *int32 `json:"concurrentEndpointSyncs,omitempty" flag:"concurrent-endpoint-syncs"`
+	// The number of namespace objects that are allowed to sync concurrently.
+	ConcurrentNamespaceSyncs *int32 `json:"concurrentNamespaceSyncs,omitempty" flag:"concurrent-namespace-syncs"`
+	// The number of replicaset objects that are allowed to sync concurrently.
+	ConcurrentReplicasetSyncs *int32 `json:"concurrentReplicasetSyncs,omitempty" flag:"concurrent-replicaset-syncs"`
+	// The number of service objects that are allowed to sync concurrently.
+	ConcurrentServiceSyncs *int32 `json:"concurrentServiceSyncs,omitempty" flag:"concurrent-service-syncs"`
+	// The number of resourcequota objects that are allowed to sync concurrently.
+	ConcurrentResourceQuotaSyncs *int32 `json:"concurrentResourceQuotaSyncs,omitempty" flag:"concurrent-resource-quota-syncs"`
+	// The number of serviceaccount objects that are allowed to sync concurrently to create tokens.
+	ConcurrentServiceaccountTokenSyncs *int32 `json:"concurrentServiceaccountTokenSyncs,omitempty" flag:"concurrent-serviceaccount-token-syncs"`
+	// The number of replicationcontroller objects that are allowed to sync concurrently.
+	ConcurrentRcSyncs *int32 `json:"concurrentRcSyncs,omitempty" flag:"concurrent-rc-syncs"`
 }
 
 // CloudControllerManagerConfig is the configuration of the cloud controller

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3650,6 +3650,14 @@ func autoConvert_v1alpha2_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.MinResyncPeriod = in.MinResyncPeriod
 	out.KubeAPIQPS = in.KubeAPIQPS
 	out.KubeAPIBurst = in.KubeAPIBurst
+	out.ConcurrentDeploymentSyncs = in.ConcurrentDeploymentSyncs
+	out.ConcurrentEndpointSyncs = in.ConcurrentEndpointSyncs
+	out.ConcurrentNamespaceSyncs = in.ConcurrentNamespaceSyncs
+	out.ConcurrentReplicasetSyncs = in.ConcurrentReplicasetSyncs
+	out.ConcurrentServiceSyncs = in.ConcurrentServiceSyncs
+	out.ConcurrentResourceQuotaSyncs = in.ConcurrentResourceQuotaSyncs
+	out.ConcurrentServiceaccountTokenSyncs = in.ConcurrentServiceaccountTokenSyncs
+	out.ConcurrentRcSyncs = in.ConcurrentRcSyncs
 	return nil
 }
 
@@ -3700,6 +3708,14 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha2_KubeControllerMana
 	out.MinResyncPeriod = in.MinResyncPeriod
 	out.KubeAPIQPS = in.KubeAPIQPS
 	out.KubeAPIBurst = in.KubeAPIBurst
+	out.ConcurrentDeploymentSyncs = in.ConcurrentDeploymentSyncs
+	out.ConcurrentEndpointSyncs = in.ConcurrentEndpointSyncs
+	out.ConcurrentNamespaceSyncs = in.ConcurrentNamespaceSyncs
+	out.ConcurrentReplicasetSyncs = in.ConcurrentReplicasetSyncs
+	out.ConcurrentServiceSyncs = in.ConcurrentServiceSyncs
+	out.ConcurrentResourceQuotaSyncs = in.ConcurrentResourceQuotaSyncs
+	out.ConcurrentServiceaccountTokenSyncs = in.ConcurrentServiceaccountTokenSyncs
+	out.ConcurrentRcSyncs = in.ConcurrentRcSyncs
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2213,6 +2213,46 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ConcurrentDeploymentSyncs != nil {
+		in, out := &in.ConcurrentDeploymentSyncs, &out.ConcurrentDeploymentSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentEndpointSyncs != nil {
+		in, out := &in.ConcurrentEndpointSyncs, &out.ConcurrentEndpointSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentNamespaceSyncs != nil {
+		in, out := &in.ConcurrentNamespaceSyncs, &out.ConcurrentNamespaceSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentReplicasetSyncs != nil {
+		in, out := &in.ConcurrentReplicasetSyncs, &out.ConcurrentReplicasetSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentServiceSyncs != nil {
+		in, out := &in.ConcurrentServiceSyncs, &out.ConcurrentServiceSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentResourceQuotaSyncs != nil {
+		in, out := &in.ConcurrentResourceQuotaSyncs, &out.ConcurrentResourceQuotaSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentServiceaccountTokenSyncs != nil {
+		in, out := &in.ConcurrentServiceaccountTokenSyncs, &out.ConcurrentServiceaccountTokenSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentRcSyncs != nil {
+		in, out := &in.ConcurrentRcSyncs, &out.ConcurrentRcSyncs
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2395,6 +2395,46 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ConcurrentDeploymentSyncs != nil {
+		in, out := &in.ConcurrentDeploymentSyncs, &out.ConcurrentDeploymentSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentEndpointSyncs != nil {
+		in, out := &in.ConcurrentEndpointSyncs, &out.ConcurrentEndpointSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentNamespaceSyncs != nil {
+		in, out := &in.ConcurrentNamespaceSyncs, &out.ConcurrentNamespaceSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentReplicasetSyncs != nil {
+		in, out := &in.ConcurrentReplicasetSyncs, &out.ConcurrentReplicasetSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentServiceSyncs != nil {
+		in, out := &in.ConcurrentServiceSyncs, &out.ConcurrentServiceSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentResourceQuotaSyncs != nil {
+		in, out := &in.ConcurrentResourceQuotaSyncs, &out.ConcurrentResourceQuotaSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentServiceaccountTokenSyncs != nil {
+		in, out := &in.ConcurrentServiceaccountTokenSyncs, &out.ConcurrentServiceaccountTokenSyncs
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConcurrentRcSyncs != nil {
+		in, out := &in.ConcurrentRcSyncs, &out.ConcurrentRcSyncs
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
This commit adds only api changes to allow users to configure the following flags in kube-controller-manager:
- `-concurrent-deployment-syncs`
- `--concurrent-endpoint-sync`
- `--concurrent-namespace-syncs`
- `--concurrent-replicaset-syncs`
- `--concurrent-resource-quota-syncs`
- `--concurrent-service-syncs`
- `--concurrent-serviceaccount-token-syncs`
- `--concurrent_rc_syncs`

We have been using to spin up integration testing environments and we needed the controller to be able to do more syncs concurrently to be able to spin these environments faster.
