### PR TITLE
WIP: Use existing subnets in OpenStack

### DIFF
--- a/cmd/kops/BUILD.bazel
+++ b/cmd/kops/BUILD.bazel
@@ -93,6 +93,7 @@ go_library(
         "//upup/pkg/fi/cloudup/aliup:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//upup/pkg/fi/cloudup/gce:go_default_library",
+        "//upup/pkg/fi/cloudup/openstack:go_default_library",
         "//upup/pkg/fi/utils:go_default_library",
         "//upup/pkg/kutil:go_default_library",
         "//util/pkg/tables:go_default_library",

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/aliup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
+	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 	"k8s.io/kops/upup/pkg/fi/utils"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 	"k8s.io/kubernetes/pkg/kubectl/util/templates"
@@ -511,6 +512,50 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		cluster.Spec.NetworkID = *res.Subnets[0].VpcId
 	}
 
+	if api.CloudProviderID(cluster.Spec.CloudProvider) == api.CloudProviderOpenstack {
+		if cluster.Spec.CloudConfig == nil {
+			cluster.Spec.CloudConfig = &api.CloudConfiguration{}
+		}
+		cluster.Spec.CloudConfig.Openstack = &api.OpenstackConfiguration{
+			Router: &api.OpenstackRouter{
+				ExternalNetwork: fi.String(c.OpenstackExternalNet),
+			},
+			BlockStorage: &api.OpenstackBlockStorageConfig{
+				Version:  fi.String("v2"),
+				IgnoreAZ: fi.Bool(c.OpenstackStorageIgnoreAZ),
+			},
+			Monitor: &api.OpenstackMonitor{
+				Delay:      fi.String("1m"),
+				Timeout:    fi.String("30s"),
+				MaxRetries: fi.Int(3),
+			},
+		}
+
+		if c.OpenstackNetworkID != "" {
+			cluster.Spec.NetworkID = c.OpenstackNetworkID
+		} else if len(c.SubnetIDs) > 0 {
+			tags := make(map[string]string)
+			tags[openstack.TagClusterName] = c.ClusterName
+			osCloud, err := openstack.NewOpenstackCloud(tags, &cluster.Spec)
+			if err != nil {
+				return fmt.Errorf("error loading cloud: %v", err)
+			}
+
+			res, err := osCloud.FindNetworkBySubnetID(c.SubnetIDs[0])
+			if err != nil {
+				return fmt.Errorf("error finding network: %v", err)
+			}
+			cluster.Spec.NetworkID = res.ID
+		}
+
+		if c.OpenstackDNSServers != "" {
+			cluster.Spec.CloudConfig.Openstack.Router.DNSServers = fi.String(c.OpenstackDNSServers)
+		}
+		if c.OpenstackExternalSubnet != "" {
+			cluster.Spec.CloudConfig.Openstack.Router.ExternalSubnet = fi.String(c.OpenstackExternalSubnet)
+		}
+	}
+
 	if cluster.Spec.CloudProvider == "" {
 		for _, zone := range allZones.List() {
 			cloud, known := fi.GuessCloudForZone(zone)
@@ -602,10 +647,19 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		}
 	} else {
 		var zoneToSubnetProviderID map[string]string
-		if len(c.Zones) > 0 && len(c.SubnetIDs) > 0 && api.CloudProviderID(cluster.Spec.CloudProvider) == api.CloudProviderAWS {
-			zoneToSubnetProviderID, err = getZoneToSubnetProviderID(cluster.Spec.NetworkID, c.Zones[0][:len(c.Zones[0])-1], c.SubnetIDs)
-			if err != nil {
-				return err
+		if len(c.Zones) > 0 && len(c.SubnetIDs) > 0 {
+			if api.CloudProviderID(cluster.Spec.CloudProvider) == api.CloudProviderAWS {
+				zoneToSubnetProviderID, err = getZoneToSubnetProviderID(cluster.Spec.NetworkID, c.Zones[0][:len(c.Zones[0])-1], c.SubnetIDs)
+				if err != nil {
+					return err
+				}
+			} else if api.CloudProviderID(cluster.Spec.CloudProvider) == api.CloudProviderOpenstack {
+				tags := make(map[string]string)
+				tags[openstack.TagClusterName] = c.ClusterName
+				zoneToSubnetProviderID, err = getSubnetProviderID(&cluster.Spec, allZones.List(), c.SubnetIDs, tags)
+				if err != nil {
+					return err
+				}
 			}
 		}
 		for _, zoneName := range allZones.List() {
@@ -906,35 +960,6 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 				cluster.Spec.CloudConfig.SpotinstOrientation = fi.String(c.SpotinstOrientation)
 			}
 		}
-
-		if c.Cloud == "openstack" {
-			if cluster.Spec.CloudConfig == nil {
-				cluster.Spec.CloudConfig = &api.CloudConfiguration{}
-			}
-			cluster.Spec.CloudConfig.Openstack = &api.OpenstackConfiguration{
-				Router: &api.OpenstackRouter{
-					ExternalNetwork: fi.String(c.OpenstackExternalNet),
-				},
-				BlockStorage: &api.OpenstackBlockStorageConfig{
-					Version:  fi.String("v2"),
-					IgnoreAZ: fi.Bool(c.OpenstackStorageIgnoreAZ),
-				},
-				Monitor: &api.OpenstackMonitor{
-					Delay:      fi.String("1m"),
-					Timeout:    fi.String("30s"),
-					MaxRetries: fi.Int(3),
-				},
-			}
-			if c.OpenstackNetworkID != "" {
-				cluster.Spec.NetworkID = c.OpenstackNetworkID
-			}
-			if c.OpenstackDNSServers != "" {
-				cluster.Spec.CloudConfig.Openstack.Router.DNSServers = fi.String(c.OpenstackDNSServers)
-			}
-			if c.OpenstackExternalSubnet != "" {
-				cluster.Spec.CloudConfig.Openstack.Router.ExternalSubnet = fi.String(c.OpenstackExternalSubnet)
-			}
-		}
 	}
 
 	// Populate project
@@ -1066,10 +1091,19 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		var utilitySubnets []api.ClusterSubnetSpec
 
 		var zoneToSubnetProviderID map[string]string
-		if len(c.Zones) > 0 && len(c.UtilitySubnetIDs) > 0 && api.CloudProviderID(cluster.Spec.CloudProvider) == api.CloudProviderAWS {
-			zoneToSubnetProviderID, err = getZoneToSubnetProviderID(cluster.Spec.NetworkID, c.Zones[0][:len(c.Zones[0])-1], c.UtilitySubnetIDs)
-			if err != nil {
-				return err
+		if len(c.Zones) > 0 && len(c.UtilitySubnetIDs) > 0 {
+			if api.CloudProviderID(cluster.Spec.CloudProvider) == api.CloudProviderAWS {
+				zoneToSubnetProviderID, err = getZoneToSubnetProviderID(cluster.Spec.NetworkID, c.Zones[0][:len(c.Zones[0])-1], c.UtilitySubnetIDs)
+				if err != nil {
+					return err
+				}
+			} else if api.CloudProviderID(cluster.Spec.CloudProvider) == api.CloudProviderOpenstack {
+				tags := make(map[string]string)
+				tags[openstack.TagClusterName] = c.ClusterName
+				zoneToSubnetProviderID, err = getSubnetProviderID(&cluster.Spec, allZones.List(), c.UtilitySubnetIDs, tags)
+				if err != nil {
+					return err
+				}
 			}
 		}
 
@@ -1480,6 +1514,41 @@ func getZoneToSubnetProviderID(VPCID string, region string, subnetIDs []string) 
 		if !ok {
 			return res, fmt.Errorf("subnet %s not found in VPC %s", subnetID, VPCID)
 		}
+		if res[subnet.Zone] != "" {
+			return res, fmt.Errorf("subnet %s and %s have the same zone", subnetID, res[subnet.Zone])
+		}
+		res[subnet.Zone] = subnetID
+	}
+	return res, nil
+}
+
+func getSubnetProviderID(spec *api.ClusterSpec, zones []string, subnetIDs []string, tags map[string]string) (map[string]string, error) {
+	res := make(map[string]string)
+	osCloud, err := openstack.NewOpenstackCloud(tags, spec)
+	if err != nil {
+		return res, fmt.Errorf("error loading cloud: %v", err)
+	}
+	osCloud.AddZones(zones)
+
+	networkInfo, err := osCloud.FindVPCInfo(spec.NetworkID)
+	if err != nil {
+		return res, fmt.Errorf("error describing Network: %v", err)
+	}
+	if networkInfo == nil {
+		return res, fmt.Errorf("network %q not found", spec.NetworkID)
+	}
+
+	subnetByID := make(map[string]*fi.SubnetInfo)
+	for _, subnetInfo := range networkInfo.Subnets {
+		subnetByID[subnetInfo.ID] = subnetInfo
+	}
+
+	for _, subnetID := range subnetIDs {
+		subnet, ok := subnetByID[subnetID]
+		if !ok {
+			return res, fmt.Errorf("subnet %s not found in network %s", subnetID, spec.NetworkID)
+		}
+
 		if res[subnet.Zone] != "" {
 			return res, fmt.Errorf("subnet %s and %s have the same zone", subnetID, res[subnet.Zone])
 		}

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -155,7 +155,7 @@ type CreateClusterOptions struct {
 	OpenstackStorageIgnoreAZ bool
 	OpenstackDNSServers      string
 	OpenstackLbSubnet        string
-
+	OpenstackNetworkID       string
 	// OpenstackLBOctavia is boolean value should we use octavia or old loadbalancer api
 	OpenstackLBOctavia bool
 
@@ -389,6 +389,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVar(&options.OpenstackStorageIgnoreAZ, "os-kubelet-ignore-az", options.OpenstackStorageIgnoreAZ, "If true kubernetes may attach volumes across availability zones")
 	cmd.Flags().BoolVar(&options.OpenstackLBOctavia, "os-octavia", options.OpenstackLBOctavia, "If true octavia loadbalancer api will be used")
 	cmd.Flags().StringVar(&options.OpenstackDNSServers, "os-dns-servers", options.OpenstackDNSServers, "comma separated list of DNS Servers which is used in network")
+	cmd.Flags().StringVar(&options.OpenstackNetworkID, "os-network", options.OpenstackNetworkID, "The ID of the existing OpenStack network to use")
 
 	return cmd
 }
@@ -923,6 +924,9 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 					Timeout:    fi.String("30s"),
 					MaxRetries: fi.Int(3),
 				},
+			}
+			if c.OpenstackNetworkID != "" {
+				cluster.Spec.NetworkID = c.OpenstackNetworkID
 			}
 			if c.OpenstackDNSServers != "" {
 				cluster.Spec.CloudConfig.Openstack.Router.DNSServers = fi.String(c.OpenstackDNSServers)

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -102,6 +102,7 @@ kops create cluster [flags]
       --os-ext-subnet string             The name of the external floating subnet to use with the openstack router
       --os-kubelet-ignore-az             If true kubernetes may attach volumes across availability zones
       --os-lb-floating-subnet string     The name of the external subnet to use with the kubernetes api
+      --os-network string                The ID of the existing OpenStack network to use
       --os-octavia                       If true octavia loadbalancer api will be used
       --out string                       Path to write any local output
   -o, --output string                    Output format. One of json|yaml. Used with the --dry-run flag.

--- a/docs/tutorial/openstack.md
+++ b/docs/tutorial/openstack.md
@@ -150,6 +150,25 @@ kops create cluster \
 
 The biggest problem currently when installing without loadbalancer is that kubectl requests outside cluster is always going to first master. External loadbalancer is one option which can solve this issue.
 
+# Using existing OpenStack network
+**Warning!** This feature is **experimental** use only if you know what you are doing.
+
+By default KOPS will always create new network to your OpenStack project which name matches to your clustername. However, there is experimental feature to use existing network in OpenStack project. When you create new cluster you can specify flag `--os-network <netname>` and it will then use existing network.
+
+Using yaml this can be specified to yaml:
+
+```
+spec:
+  ...
+  cloudConfig:
+    openstack:
+      networkName: <netname>
+  ...
+```
+
+**Warning!** when deleting cluster, you need to be really careful that you do not break another dependencies under same network. Run `kops delete cluster` without `--yes` flag and go through the list. Otherwise you might see situation that you broke something else.
+
+
 # Using with self-signed certificates in OpenStack
 
 Kops can be configured to use insecure mode towards OpenStack. However, this is **NOT** recommended as OpenStack cloudprovider in kubernetes does not support it.

--- a/docs/tutorial/openstack.md
+++ b/docs/tutorial/openstack.md
@@ -168,6 +168,39 @@ spec:
 
 **Warning!** when deleting cluster, you need to be really careful that you do not break another dependencies under same network. Run `kops delete cluster` without `--yes` flag and go through the list. Otherwise you might see situation that you broke something else.
 
+# Using existing OpenStack subnets
+**Warning!** This feature is **experimental** use only if you know what you are doing.
+
+By default KOPS will always create new network and subnet to your OpenStack project. However, there is experimental feature to use existing network and subnets in OpenStack project. When you create new cluster you can specify flag `--subnets <commaseparated list of subnetids>` and it will then use existing subnet. There is similar flag for utility subnets `--utility-subnets <commaseparated list of subnetids>`.
+
+Example:
+
+```
+kops create cluster \
+  --cloud openstack \
+  --name sharedsub2.k8s.local \
+  --state ${KOPS_STATE_STORE} \
+  --zones zone-1 \
+  --network-cidr 10.1.0.0/16 \
+  --image debian-10-160819-devops \
+  --master-count=3 \
+  --node-count=2 \
+  --node-size m1.small \
+  --master-size m1.small \
+  --etcd-storage-type default \
+  --topology private \
+  --bastion \
+  --networking calico \
+  --api-loadbalancer-type public \
+  --os-kubelet-ignore-az=true \
+  --os-ext-net ext-net \
+  --subnets c7d20c0f-df3a-4e5b-842f-f633c182961f \
+  --utility-subnets 90871d21-b546-4c4a-a7c9-2337ddf5375f \
+  --os-octavia=true --yes
+```
+
+**Warning!** when deleting cluster, you need to be really careful that you do not break another dependencies under same network & subnet. Run `kops delete cluster` without `--yes` flag and go through the list. Otherwise you might see situation that you broke something else.
+
 
 # Using with self-signed certificates in OpenStack
 

--- a/pkg/model/openstackmodel/firewall.go
+++ b/pkg/model/openstackmodel/firewall.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstacktasks"
 
-	//TODO: Replace with klog
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/dns"
 )

--- a/pkg/model/openstackmodel/network.go
+++ b/pkg/model/openstackmodel/network.go
@@ -35,10 +35,15 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	clusterName := b.ClusterName()
 	routerName := strings.Replace(clusterName, ".", "-", -1)
 
+	netName, err := b.GetNetworkName()
+	if err != nil {
+		return err
+	}
 	{
 		t := &openstacktasks.Network{
-			Name:      s(clusterName),
+			Name:      s(netName),
 			ID:        s(b.Cluster.Spec.NetworkID),
+			Tag:       s(clusterName),
 			Lifecycle: b.Lifecycle,
 		}
 
@@ -62,6 +67,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			CIDR:       s(sp.CIDR),
 			DNSServers: make([]*string, 0),
 			Lifecycle:  b.Lifecycle,
+			Tag:        s(clusterName),
 		}
 		if b.Cluster.Spec.CloudConfig.Openstack.Router.DNSServers != nil {
 			dnsSplitted := strings.Split(fi.StringValue(b.Cluster.Spec.CloudConfig.Openstack.Router.DNSServers), ",")

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -111,7 +111,12 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 			} else {
 				az = fi.String(subnet)
 			}
-			subnets = append(subnets, b.LinkToSubnet(s(fmt.Sprintf("%s.%s", subnet, b.ClusterName()))))
+
+			subnetName, err := b.findSubnetClusterSpec(subnet)
+			if err != nil {
+				return err
+			}
+			subnets = append(subnets, b.LinkToSubnet(s(subnetName)))
 		}
 		// Create instance port task
 		portTask := &openstacktasks.Port{
@@ -216,10 +221,23 @@ func (b *ServerGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 
 	if b.Cluster.Spec.CloudConfig.Openstack.Loadbalancer != nil {
-		lbSubnetName := b.MasterInstanceGroups()[0].Spec.Subnets[0]
+		var lbSubnetName string
+		var err error
+		for _, sp := range b.Cluster.Spec.Subnets {
+			if sp.Type == kops.SubnetTypePrivate {
+				lbSubnetName, err = b.findSubnetNameByID(sp.ProviderID, sp.Name)
+				if err != nil {
+					return err
+				}
+				break
+			}
+		}
+		if lbSubnetName == "" {
+			return fmt.Errorf("could not find subnet for master loadbalancer")
+		}
 		lbTask := &openstacktasks.LB{
 			Name:          fi.String(b.Cluster.Spec.MasterPublicName),
-			Subnet:        fi.String(lbSubnetName + "." + b.ClusterName()),
+			Subnet:        fi.String(lbSubnetName),
 			Lifecycle:     b.Lifecycle,
 			SecurityGroup: b.LinkToSecurityGroup(b.Cluster.Spec.MasterPublicName),
 		}

--- a/pkg/model/openstackmodel/servergroup_test.go
+++ b/pkg/model/openstackmodel/servergroup_test.go
@@ -52,6 +52,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					},
 					Subnets: []kops.ClusterSubnetSpec{
 						{
+							Name:   "subnet",
 							Region: "region",
 						},
 					},
@@ -121,6 +122,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "master",
 						"KopsRole":           "Master",
 						"ig_generation":      "0",
@@ -166,6 +168,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "node",
 						"KopsRole":           "Node",
 						"ig_generation":      "0",
@@ -203,6 +206,11 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					},
 					Subnets: []kops.ClusterSubnetSpec{
 						{
+							Name:   "subnet",
+							Region: "region",
+						},
+						{
+							Name:   "utility-subnet",
 							Region: "region",
 						},
 					},
@@ -292,6 +300,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "master",
 						"KopsRole":           "Master",
 						"ig_generation":      "0",
@@ -337,6 +346,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "node",
 						"KopsRole":           "Node",
 						"ig_generation":      "0",
@@ -377,6 +387,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"k8s":                "cluster",
 						"KopsInstanceGroup":  "bastion",
+						"KopsNetwork":        "cluster",
 						"KopsRole":           "Bastion",
 						"ig_generation":      "0",
 						"cluster_generation": "0",
@@ -416,6 +427,15 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					},
 					Subnets: []kops.ClusterSubnetSpec{
 						{
+							Name:   "subnet-a",
+							Region: "region",
+						},
+						{
+							Name:   "subnet-b",
+							Region: "region",
+						},
+						{
+							Name:   "subnet-c",
 							Region: "region",
 						},
 					},
@@ -537,6 +557,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "master-a",
 						"KopsRole":           "Master",
 						"ig_generation":      "0",
@@ -583,6 +604,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "master-b",
 						"KopsRole":           "Master",
 						"ig_generation":      "0",
@@ -629,6 +651,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "master-c",
 						"KopsRole":           "Master",
 						"ig_generation":      "0",
@@ -674,6 +697,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "node-a",
 						"KopsRole":           "Node",
 						"ig_generation":      "0",
@@ -719,6 +743,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "node-b",
 						"KopsRole":           "Node",
 						"ig_generation":      "0",
@@ -764,6 +789,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "node-c",
 						"KopsRole":           "Node",
 						"ig_generation":      "0",
@@ -819,7 +845,19 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					},
 					Subnets: []kops.ClusterSubnetSpec{
 						{
+							Name:   "subnet-a",
 							Region: "region",
+							Type:   kops.SubnetTypePrivate,
+						},
+						{
+							Name:   "subnet-b",
+							Region: "region",
+							Type:   kops.SubnetTypePrivate,
+						},
+						{
+							Name:   "subnet-c",
+							Region: "region",
+							Type:   kops.SubnetTypePrivate,
 						},
 					},
 				},
@@ -939,6 +977,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "master-a",
 						"KopsRole":           "Master",
 						"ig_generation":      "0",
@@ -979,6 +1018,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "master-b",
 						"KopsRole":           "Master",
 						"ig_generation":      "0",
@@ -1019,6 +1059,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "master-c",
 						"KopsRole":           "Master",
 						"ig_generation":      "0",
@@ -1059,6 +1100,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "node-a",
 						"KopsRole":           "Node",
 						"ig_generation":      "0",
@@ -1104,6 +1146,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "node-b",
 						"KopsRole":           "Node",
 						"ig_generation":      "0",
@@ -1149,6 +1192,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "node-c",
 						"KopsRole":           "Node",
 						"ig_generation":      "0",
@@ -1253,6 +1297,15 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					},
 					Subnets: []kops.ClusterSubnetSpec{
 						{
+							Name:   "subnet-a",
+							Region: "region",
+						},
+						{
+							Name:   "subnet-b",
+							Region: "region",
+						},
+						{
+							Name:   "subnet-c",
 							Region: "region",
 						},
 					},
@@ -1330,6 +1383,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "master",
 						"KopsRole":           "Master",
 						"ig_generation":      "0",
@@ -1368,6 +1422,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "master",
 						"KopsRole":           "Master",
 						"ig_generation":      "0",
@@ -1406,6 +1461,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "master",
 						"KopsRole":           "Master",
 						"ig_generation":      "0",
@@ -1451,6 +1507,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "node",
 						"KopsRole":           "Node",
 						"ig_generation":      "0",
@@ -1488,6 +1545,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "node",
 						"KopsRole":           "Node",
 						"ig_generation":      "0",
@@ -1525,6 +1583,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 					Metadata: map[string]string{
 						"KubernetesCluster":  "cluster",
 						"k8s":                "cluster",
+						"KopsNetwork":        "cluster",
 						"KopsInstanceGroup":  "node",
 						"KopsRole":           "Node",
 						"ig_generation":      "0",

--- a/pkg/resources/openstack/network.go
+++ b/pkg/resources/openstack/network.go
@@ -29,26 +29,38 @@ import (
 )
 
 const (
-	typeRouterIF = "Router-IF"
-	typeRouter   = "Router"
-	typeSubnet   = "Subnet"
-	typeNetwork  = "Network"
+	typeRouterIF   = "Router-IF"
+	typeRouter     = "Router"
+	typeSubnet     = "Subnet"
+	typeNetwork    = "Network"
+	typeNetworkTag = "NetworkTag"
 )
 
 func (os *clusterDiscoveryOS) ListNetwork() ([]*resources.Resource, error) {
 	var resourceTrackers []*resources.Resource
+	routerName := strings.Replace(os.clusterName, ".", "-", -1)
 
-	opt := networks.ListOpts{
-		Name: os.clusterName,
-	}
-	networks, err := os.osCloud.ListNetworks(opt)
+	projectNetworks, err := os.osCloud.ListNetworks(networks.ListOpts{})
 	if err != nil {
 		return resourceTrackers, err
 	}
 
-	for _, network := range networks {
+	filteredNetwork := []networks.Network{}
+	for _, net := range projectNetworks {
+		if net.Name == os.clusterName || fi.ArrayContains(net.Tags, os.clusterName) {
+			filteredNetwork = append(filteredNetwork, net)
+		}
+	}
+
+	for _, network := range filteredNetwork {
+
+		preExistingNet := true
+		if os.clusterName == network.Name {
+			preExistingNet = false
+		}
+
 		optRouter := osrouter.ListOpts{
-			Name: strings.Replace(os.clusterName, ".", "-", -1),
+			Name: routerName,
 		}
 		routers, err := os.osCloud.ListRouters(optRouter)
 		if err != nil {
@@ -73,15 +85,26 @@ func (os *clusterDiscoveryOS) ListNetwork() ([]*resources.Resource, error) {
 			}
 			resourceTrackers = append(resourceTrackers, resourceTracker)
 		}
-
 		optSubnet := subnets.ListOpts{
 			NetworkID: network.ID,
 		}
-		subnets, err := os.osCloud.ListSubnets(optSubnet)
+		networkSubnets, err := os.osCloud.ListSubnets(optSubnet)
 		if err != nil {
 			return resourceTrackers, err
 		}
-		for _, subnet := range subnets {
+		filteredSubnets := []subnets.Subnet{}
+		if preExistingNet {
+			// if we have preExistingNet network, the subnet must have cluster tag
+			for _, sub := range networkSubnets {
+				if fi.ArrayContains(sub.Tags, os.clusterName) {
+					filteredSubnets = append(filteredSubnets, sub)
+				}
+			}
+		} else {
+			filteredSubnets = networkSubnets
+		}
+
+		for _, subnet := range filteredSubnets {
 			// router interfaces
 			for _, router := range routers {
 				resourceTracker := &resources.Resource{
@@ -123,15 +146,27 @@ func (os *clusterDiscoveryOS) ListNetwork() ([]*resources.Resource, error) {
 		}
 		resourceTrackers = append(resourceTrackers, portTrackers...)
 
-		resourceTracker := &resources.Resource{
-			Name: network.Name,
-			ID:   network.ID,
-			Type: typeNetwork,
-			Deleter: func(cloud fi.Cloud, r *resources.Resource) error {
-				return cloud.(openstack.OpenstackCloud).DeleteNetwork(r.ID)
-			},
+		if !preExistingNet {
+			resourceTracker := &resources.Resource{
+				Name: network.Name,
+				ID:   network.ID,
+				Type: typeNetwork,
+				Deleter: func(cloud fi.Cloud, r *resources.Resource) error {
+					return cloud.(openstack.OpenstackCloud).DeleteNetwork(r.ID)
+				},
+			}
+			resourceTrackers = append(resourceTrackers, resourceTracker)
+		} else {
+			resourceTracker := &resources.Resource{
+				Name: os.clusterName,
+				ID:   network.ID,
+				Type: typeNetworkTag,
+				Deleter: func(cloud fi.Cloud, r *resources.Resource) error {
+					return cloud.(openstack.OpenstackCloud).DeleteTag(openstack.ResourceTypeNetwork, r.ID, r.Name)
+				},
+			}
+			resourceTrackers = append(resourceTrackers, resourceTracker)
 		}
-		resourceTrackers = append(resourceTrackers, resourceTracker)
 	}
 	return resourceTrackers, nil
 }

--- a/protokube/pkg/gossip/openstack/seeds.go
+++ b/protokube/pkg/gossip/openstack/seeds.go
@@ -50,7 +50,12 @@ func (p *SeedProvider) GetSeeds() ([]string, error) {
 		for _, server := range s {
 			if clusterName, ok := server.Metadata[openstack.TagClusterName]; ok {
 				var err error
-				addr, err := openstack.GetServerFixedIP(&server, clusterName)
+				// find kopsNetwork from metadata, fallback to clustername
+				ifName := clusterName
+				if val, ok := server.Metadata[openstack.TagKopsNetwork]; ok {
+					ifName = val
+				}
+				addr, err := openstack.GetServerFixedIP(&server, ifName)
 				if err != nil {
 					klog.Warningf("Failed to list seeds: %v", err)
 					continue

--- a/protokube/pkg/protokube/openstack_volume.go
+++ b/protokube/pkg/protokube/openstack_volume.go
@@ -173,7 +173,12 @@ func (a *OpenstackVolumes) discoverTags() error {
 	// Internal IP
 	{
 		server, err := a.cloud.GetInstance(strings.TrimSpace(a.meta.ServerID))
-		ip, err := openstack.GetServerFixedIP(server, a.clusterName)
+		// find kopsNetwork from metadata, fallback to clustername
+		ifName := a.clusterName
+		if val, ok := server.Metadata[openstack.TagKopsNetwork]; ok {
+			ifName = val
+		}
+		ip, err := openstack.GetServerFixedIP(server, ifName)
 		if err != nil {
 			return fmt.Errorf("error querying InternalIP from name: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/openstack/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/openstack/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools:go_default_library",
+        "//vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers:go_default_library",

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -152,6 +152,12 @@ type OpenstackCloud interface {
 	//GetNetwork will return the Neutron network which match the id
 	GetNetwork(networkID string) (*networks.Network, error)
 
+	//FindNetworkBySubnetID will return network
+	FindNetworkBySubnetID(subnetID string) (*networks.Network, error)
+
+	//GetSubnet returns subnet using subnet id
+	GetSubnet(subnetID string) (*subnets.Subnet, error)
+
 	//ListNetworks will return the Neutron networks which match the options
 	ListNetworks(opt networks.ListOptsBuilder) ([]networks.Network, error)
 
@@ -322,12 +328,6 @@ func NewOpenstackCloud(tags map[string]string, spec *kops.ClusterSpec) (Openstac
 		return nil, err
 	}
 
-	/*
-		provider, err := os.AuthenticatedClient(authOption)
-		if err != nil {
-			return nil, fmt.Errorf("error building openstack authenticated client: %v", err)
-		}*/
-
 	provider, err := os.NewClient(authOption.IdentityEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("error building openstack provider client: %v", err)
@@ -462,13 +462,13 @@ func NewOpenstackCloud(tags map[string]string, spec *kops.ClusterSpec) (Openstac
 	return c, nil
 }
 
-func (c *openstackCloud) UseOctavia() bool {
-	return c.useOctavia
-}
-
 // AddZones add unique zone names to openstackcloud
 func (c *openstackCloud) AddZones(zones []string) {
 	c.zones = zones
+}
+
+func (c *openstackCloud) UseOctavia() bool {
+	return c.useOctavia
 }
 
 func (c *openstackCloud) ComputeClient() *gophercloud.ServiceClient {

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -63,6 +63,10 @@ const (
 	TagNameRolePrefix        = "k8s.io/role/"
 	TagClusterName           = "KubernetesCluster"
 	TagRoleMaster            = "master"
+	TagKopsNetwork           = "KopsNetwork"
+	ResourceTypePort         = "ports"
+	ResourceTypeNetwork      = "networks"
+	ResourceTypeSubnet       = "subnets"
 )
 
 // ErrNotFound is used to inform that the object is not found
@@ -164,6 +168,12 @@ type OpenstackCloud interface {
 
 	//DeleteNetwork will delete neutron network
 	DeleteNetwork(networkID string) error
+
+	//AppendTag appends tag to resource
+	AppendTag(resource string, id string, tag string) error
+
+	//DeleteTag removes tag from resource
+	DeleteTag(resource string, id string, tag string) error
 
 	//ListRouters will return the Neutron routers which match the options
 	ListRouters(opt routers.ListOpts) ([]routers.Router, error)

--- a/upup/pkg/fi/cloudup/openstack/floatingip.go
+++ b/upup/pkg/fi/cloudup/openstack/floatingip.go
@@ -142,7 +142,7 @@ func (c *openstackCloud) DeleteFloatingIP(id string) (err error) {
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
 		err = l3floatingip.Delete(c.ComputeClient(), id).ExtractErr()
-		if err != nil {
+		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("Failed to delete floating ip %s: %v", id, err)
 		}
 		return true, nil
@@ -157,7 +157,7 @@ func (c *openstackCloud) DeleteL3FloatingIP(id string) (err error) {
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
 		err = l3floatingip.Delete(c.NetworkingClient(), id).ExtractErr()
-		if err != nil {
+		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("Failed to delete L3 floating ip %s: %v", id, err)
 		}
 		return true, nil

--- a/upup/pkg/fi/cloudup/openstacktasks/network.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/network.go
@@ -30,6 +30,7 @@ type Network struct {
 	ID        *string
 	Name      *string
 	Lifecycle *fi.Lifecycle
+	Tag       *string
 }
 
 var _ fi.CompareWithID = &Network{}
@@ -38,11 +39,17 @@ func (n *Network) CompareWithID() *string {
 	return n.ID
 }
 
-func NewNetworkTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecycle, network *networks.Network) (*Network, error) {
+func NewNetworkTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecycle, network *networks.Network, networkName *string) (*Network, error) {
+	tag := ""
+	if networkName != nil && fi.ArrayContains(network.Tags, fi.StringValue(networkName)) {
+		tag = fi.StringValue(networkName)
+	}
+
 	task := &Network{
 		ID:        fi.String(network.ID),
 		Name:      fi.String(network.Name),
 		Lifecycle: lifecycle,
+		Tag:       fi.String(tag),
 	}
 	return task, nil
 }
@@ -67,7 +74,7 @@ func (n *Network) Find(context *fi.Context) (*Network, error) {
 		return nil, fmt.Errorf("found multiple networks with name: %s", fi.StringValue(n.Name))
 	}
 	v := ns[0]
-	actual, err := NewNetworkTaskFromCloud(cloud, n.Lifecycle, &v)
+	actual, err := NewNetworkTaskFromCloud(cloud, n.Lifecycle, &v, n.Tag)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create new Network object: %v", err)
 	}
@@ -96,7 +103,10 @@ func (_ *Network) CheckChanges(a, e, changes *Network) error {
 }
 
 func (_ *Network) ShouldCreate(a, e, changes *Network) (bool, error) {
-	return a == nil, nil
+	if a == nil || changes.Tag != nil {
+		return true, nil
+	}
+	return false, nil
 }
 
 func (_ *Network) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *Network) error {
@@ -113,11 +123,21 @@ func (_ *Network) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes
 			return fmt.Errorf("Error creating network: %v", err)
 		}
 
+		err = t.Cloud.AppendTag(openstack.ResourceTypeNetwork, v.ID, fi.StringValue(e.Tag))
+		if err != nil {
+			return fmt.Errorf("Error appending tag to network: %v", err)
+		}
+
 		e.ID = fi.String(v.ID)
 		klog.V(2).Infof("Creating a new Openstack network, id=%s", v.ID)
 		return nil
+	} else {
+		err := t.Cloud.AppendTag(openstack.ResourceTypeNetwork, fi.StringValue(a.ID), fi.StringValue(changes.Tag))
+		if err != nil {
+			return fmt.Errorf("Error appending tag to network: %v", err)
+		}
 	}
-
-	klog.V(2).Infof("Openstack task Network::RenderOpenstack did nothing")
+	e.ID = a.ID
+	klog.V(2).Infof("Using an existing Openstack network, id=%s", fi.StringValue(e.ID))
 	return nil
 }

--- a/upup/pkg/fi/cloudup/utils.go
+++ b/upup/pkg/fi/cloudup/utils.go
@@ -139,6 +139,13 @@ func BuildCloud(cluster *kops.Cluster) (fi.Cloud, error) {
 			if err != nil {
 				return nil, err
 			}
+			var zoneNames []string
+			for _, subnet := range cluster.Spec.Subnets {
+				if !fi.ArrayContains(zoneNames, subnet.Zone) {
+					zoneNames = append(zoneNames, subnet.Zone)
+				}
+			}
+			osc.AddZones(zoneNames)
 			cloud = osc
 		}
 

--- a/upup/pkg/fi/values.go
+++ b/upup/pkg/fi/values.go
@@ -125,6 +125,16 @@ func Uint64Value(v *uint64) uint64 {
 	return *v
 }
 
+// ArrayContains is checking does array contain single word
+func ArrayContains(array []string, word string) bool {
+	for _, item := range array {
+		if item == word {
+			return true
+		}
+	}
+	return false
+}
+
 func DebugPrint(o interface{}) string {
 	if o == nil {
 		return "<nil>"

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/BUILD.bazel
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "requests.go",
+        "results.go",
+        "urls.go",
+    ],
+    importmap = "k8s.io/kops/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags",
+    importpath = "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/gophercloud/gophercloud:go_default_library"],
+)

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/doc.go
@@ -1,0 +1,37 @@
+/*
+Package attributestags manages Tags on Resources created by the OpenStack Neutron Service.
+
+This enables tagging via a standard interface for resources types which support it.
+
+See https://developer.openstack.org/api-ref/network/v2/#standard-attributes-tag-extension for more information on the underlying API.
+
+Example to ReplaceAll Resource Tags
+
+    network, err := networks.Create(conn, createOpts).Extract()
+
+    tagReplaceAllOpts := attributestags.ReplaceAllOpts{
+        Tags:         []string{"abc", "123"},
+    }
+    attributestags.ReplaceAll(conn, "networks", network.ID, tagReplaceAllOpts)
+
+Example to List all Resource Tags
+
+	tags, err = attributestags.List(conn, "networks", network.ID).Extract()
+
+Example to Delete all Resource Tags
+
+	err = attributestags.DeleteAll(conn, "networks", network.ID).ExtractErr()
+
+Example to Add a tag to a Resource
+
+    err = attributestags.Add(client, "networks", network.ID, "atag").ExtractErr()
+
+Example to Delete a tag from a Resource
+
+    err = attributestags.Delete(client, "networks", network.ID, "atag").ExtractErr()
+
+Example to confirm if a tag exists on a resource
+
+	exists, _ := attributestags.Confirm(client, "networks", network.ID, "atag").Extract()
+*/
+package attributestags

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/requests.go
@@ -1,0 +1,81 @@
+package attributestags
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// ReplaceAllOptsBuilder allows extensions to add additional parameters to
+// the ReplaceAll request.
+type ReplaceAllOptsBuilder interface {
+	ToAttributeTagsReplaceAllMap() (map[string]interface{}, error)
+}
+
+// ReplaceAllOpts provides options used to create Tags on a Resource
+type ReplaceAllOpts struct {
+	Tags []string `json:"tags" required:"true"`
+}
+
+// ToAttributeTagsReplaceAllMap formats a ReplaceAllOpts into the body of the
+// replace request
+func (opts ReplaceAllOpts) ToAttributeTagsReplaceAllMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// ReplaceAll updates all tags on a resource, replacing any existing tags
+func ReplaceAll(client *gophercloud.ServiceClient, resourceType string, resourceID string, opts ReplaceAllOptsBuilder) (r ReplaceAllResult) {
+	b, err := opts.ToAttributeTagsReplaceAllMap()
+	url := replaceURL(client, resourceType, resourceID)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(url, &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// List all tags on a resource
+func List(client *gophercloud.ServiceClient, resourceType string, resourceID string) (r ListResult) {
+	url := listURL(client, resourceType, resourceID)
+	_, r.Err = client.Get(url, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// DeleteAll deletes all tags on a resource
+func DeleteAll(client *gophercloud.ServiceClient, resourceType string, resourceID string) (r DeleteResult) {
+	url := deleteAllURL(client, resourceType, resourceID)
+	_, r.Err = client.Delete(url, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
+// Add a tag on a resource
+func Add(client *gophercloud.ServiceClient, resourceType string, resourceID string, tag string) (r AddResult) {
+	url := addURL(client, resourceType, resourceID, tag)
+	_, r.Err = client.Put(url, nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}
+
+// Delete a tag on a resource
+func Delete(client *gophercloud.ServiceClient, resourceType string, resourceID string, tag string) (r DeleteResult) {
+	url := deleteURL(client, resourceType, resourceID, tag)
+	_, r.Err = client.Delete(url, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
+// Confirm if a tag exists on a resource
+func Confirm(client *gophercloud.ServiceClient, resourceType string, resourceID string, tag string) (r ConfirmResult) {
+	url := confirmURL(client, resourceType, resourceID, tag)
+	_, r.Err = client.Get(url, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/results.go
@@ -1,0 +1,57 @@
+package attributestags
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+type tagResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets tagResult to return the list of tags
+func (r tagResult) Extract() ([]string, error) {
+	var s struct {
+		Tags []string `json:"tags"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Tags, err
+}
+
+// ReplaceAllResult represents the result of a replace operation.
+// Call its Extract method to interpret it as a slice of strings.
+type ReplaceAllResult struct {
+	tagResult
+}
+
+type ListResult struct {
+	tagResult
+}
+
+// DeleteResult is the result from a Delete/DeleteAll operation.
+// Call its ExtractErr method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// AddResult is the result from an Add operation.
+// Call its ExtractErr method to determine if the call succeeded or failed.
+type AddResult struct {
+	gophercloud.ErrResult
+}
+
+// ConfirmResult is the result from an Confirm operation.
+type ConfirmResult struct {
+	gophercloud.Result
+}
+
+func (r ConfirmResult) Extract() (bool, error) {
+	exists := r.Err == nil
+
+	if r.Err != nil {
+		if _, ok := r.Err.(gophercloud.ErrDefault404); ok {
+			r.Err = nil
+		}
+	}
+
+	return exists, r.Err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags/urls.go
@@ -1,0 +1,31 @@
+package attributestags
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	tagsPath = "tags"
+)
+
+func replaceURL(c *gophercloud.ServiceClient, r_type string, id string) string {
+	return c.ServiceURL(r_type, id, tagsPath)
+}
+
+func listURL(c *gophercloud.ServiceClient, r_type string, id string) string {
+	return c.ServiceURL(r_type, id, tagsPath)
+}
+
+func deleteAllURL(c *gophercloud.ServiceClient, r_type string, id string) string {
+	return c.ServiceURL(r_type, id, tagsPath)
+}
+
+func addURL(c *gophercloud.ServiceClient, r_type string, id string, tag string) string {
+	return c.ServiceURL(r_type, id, tagsPath, tag)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, r_type string, id string, tag string) string {
+	return c.ServiceURL(r_type, id, tagsPath, tag)
+}
+
+func confirmURL(c *gophercloud.ServiceClient, r_type string, id string, tag string) string {
+	return c.ServiceURL(r_type, id, tagsPath, tag)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -250,6 +250,7 @@ github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups
 github.com/gophercloud/gophercloud/openstack/compute/v2/flavors
 github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners
 github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools
+github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints
 github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers


### PR DESCRIPTION
hold until #7568 is merged, I will then rebase this one

There is experimental feature to use existing network and subnets in OpenStack project. When you create new cluster you can specify flag --subnets <commaseparated list of subnetids> and it will then use existing subnet. There is similar flag for utility subnets --utility-subnets <commaseparated list of subnetids>.
