### PR TITLE
Check the HTTP response code when downloading URLs

### DIFF
--- a/upup/pkg/fi/http.go
+++ b/upup/pkg/fi/http.go
@@ -80,6 +80,9 @@ func downloadURLAlways(url string, destPath string, dirMode os.FileMode) error {
 	if err != nil {
 		return fmt.Errorf("error doing HTTP fetch of %q: %v", url, err)
 	}
+	if response.StatusCode >= 400 {
+		return fmt.Errorf("error response from %q: HTTP %v", url, response.StatusCode)
+	}
 	defer response.Body.Close()
 
 	_, err = io.Copy(output, response.Body)


### PR DESCRIPTION
I noticed that the recent container-selinux issue on centos was reporting a hash mismatch rather than a 404.

See the error message here: https://github.com/kubernetes/kops/issues/7608 and the "actual" sha1 reported in the current error message is that of the 404 page:

```
curl http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm
curl http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm | shasum -a 1
```

This should now report a more descriptive error message if this happens again.