### PR TITLE
docker.go

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -556,8 +556,8 @@ var dockerVersions = []dockerVersion{
 		Hash:          "b4ce72e80ff02926de943082821bbbe73958f87a",
 		ExtraPackages: map[string]packageInfo{
 			"container-selinux": {
-				Version: "2.68",
-				Source:  "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
+				Version: "2.107",
+				Source:  "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-3.el7.noarch.rpm",
 				Hash:    "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
 			},
 		},
@@ -653,8 +653,8 @@ var dockerVersions = []dockerVersion{
 		Hash:          "0a1325e570c5e54111a79623c9fd0c0c714d3a11",
 		ExtraPackages: map[string]packageInfo{
 			"container-selinux": {
-				Version: "2.68",
-				Source:  "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
+				Version: "2.107",
+				Source:  "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-3.el7.noarch.rpm",
 				Hash:    "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
 			},
 		},
@@ -691,8 +691,8 @@ var dockerVersions = []dockerVersion{
 		Name:          "container-selinux",
 		Distros:       []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
 		Architectures: []Architecture{ArchitectureAmd64},
-		Version:       "2.68",
-		Source:        "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
+		Version:       "2.107",
+		Source:        "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-3.el7.noarch.rpm",
 		Hash:          "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
 		Dependencies:  []string{"policycoreutils-python"},
 	},
@@ -759,8 +759,8 @@ var dockerVersions = []dockerVersion{
 		Hash:          "5369602f88406d4fb9159dc1d3fd44e76fb4cab8",
 		ExtraPackages: map[string]packageInfo{
 			"container-selinux": {
-				Version: "2.68",
-				Source:  "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
+				Version: "2.107",
+				Source:  "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-3.el7.noarch.rpm",
 				Hash:    "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
 			},
 		},


### PR DESCRIPTION
temporary fix to this container-linux versioning mismatch that changes in the centos repositories have caused.