### PR TITLE
Automated cherry pick of #7610: Expose API Server flags needed for aws pod identities

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -431,6 +431,20 @@ type KubeAPIServerConfig struct {
 	// If unspecified, --tls-private-key-file is used.
 	ServiceAccountKeyFile []string `json:"serviceAccountKeyFile,omitempty" flag:"service-account-key-file"`
 
+	// Path to the file that contains the current private key of the service account token issuer.
+	// The issuer will sign issued ID tokens with this private key. (Requires the 'TokenRequest' feature gate.)
+	ServiceAccountSigningKeyFile *string `json:"serviceAccountSigningKeyFile,omitempty" flag:"service-account-signing-key-file"`
+
+	// Identifier of the service account token issuer. The issuer will assert this identifier
+	// in "iss" claim of issued tokens. This value is a string or URI.
+	ServiceAccountIssuer *string `json:"serviceAccountIssuer,omitempty" flag:"service-account-issuer"`
+
+	// Identifiers of the API. The service account token authenticator will validate that
+	// tokens used against the API are bound to at least one of these audiences. If the
+	// --service-account-issuer flag is configured and this flag is not, this field
+	// defaults to a single element list containing the issuer URL.
+	APIAudiences []string `json:"apiAudiences,omitempty" flag:"api-audiences"`
+
 	// CPURequest, cpu request compute resource for api server. Defaults to "150m"
 	CPURequest string `json:"cpuRequest,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -431,6 +431,20 @@ type KubeAPIServerConfig struct {
 	// If unspecified, --tls-private-key-file is used.
 	ServiceAccountKeyFile []string `json:"serviceAccountKeyFile,omitempty" flag:"service-account-key-file"`
 
+	// Path to the file that contains the current private key of the service account token issuer.
+	// The issuer will sign issued ID tokens with this private key. (Requires the 'TokenRequest' feature gate.)
+	ServiceAccountSigningKeyFile *string `json:"serviceAccountSigningKeyFile,omitempty" flag:"service-account-signing-key-file"`
+
+	// Identifier of the service account token issuer. The issuer will assert this identifier
+	// in "iss" claim of issued tokens. This value is a string or URI.
+	ServiceAccountIssuer *string `json:"serviceAccountIssuer,omitempty" flag:"service-account-issuer"`
+
+	// Identifiers of the API. The service account token authenticator will validate that
+	// tokens used against the API are bound to at least one of these audiences. If the
+	// --service-account-issuer flag is configured and this flag is not, this field
+	// defaults to a single element list containing the issuer URL.
+	APIAudiences []string `json:"apiAudiences,omitempty" flag:"api-audiences"`
+
 	// CPURequest, cpu request compute resource for api server. Defaults to "150m"
 	CPURequest string `json:"cpuRequest,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -3045,6 +3045,9 @@ func autoConvert_v1alpha1_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.TargetRamMb = in.TargetRamMb
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
+	out.ServiceAccountSigningKeyFile = in.ServiceAccountSigningKeyFile
+	out.ServiceAccountIssuer = in.ServiceAccountIssuer
+	out.APIAudiences = in.APIAudiences
 	out.CPURequest = in.CPURequest
 	return nil
 }
@@ -3139,6 +3142,9 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha1_KubeAPIServerConfig(in *ko
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.TargetRamMb = in.TargetRamMb
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
+	out.ServiceAccountSigningKeyFile = in.ServiceAccountSigningKeyFile
+	out.ServiceAccountIssuer = in.ServiceAccountIssuer
+	out.APIAudiences = in.APIAudiences
 	out.CPURequest = in.CPURequest
 	return nil
 }

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -1897,6 +1897,21 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ServiceAccountSigningKeyFile != nil {
+		in, out := &in.ServiceAccountSigningKeyFile, &out.ServiceAccountSigningKeyFile
+		*out = new(string)
+		**out = **in
+	}
+	if in.ServiceAccountIssuer != nil {
+		in, out := &in.ServiceAccountIssuer, &out.ServiceAccountIssuer
+		*out = new(string)
+		**out = **in
+	}
+	if in.APIAudiences != nil {
+		in, out := &in.APIAudiences, &out.APIAudiences
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -431,6 +431,20 @@ type KubeAPIServerConfig struct {
 	// If unspecified, --tls-private-key-file is used.
 	ServiceAccountKeyFile []string `json:"serviceAccountKeyFile,omitempty" flag:"service-account-key-file"`
 
+	// Path to the file that contains the current private key of the service account token issuer.
+	// The issuer will sign issued ID tokens with this private key. (Requires the 'TokenRequest' feature gate.)
+	ServiceAccountSigningKeyFile *string `json:"serviceAccountSigningKeyFile,omitempty" flag:"service-account-signing-key-file"`
+
+	// Identifier of the service account token issuer. The issuer will assert this identifier
+	// in "iss" claim of issued tokens. This value is a string or URI.
+	ServiceAccountIssuer *string `json:"serviceAccountIssuer,omitempty" flag:"service-account-issuer"`
+
+	// Identifiers of the API. The service account token authenticator will validate that
+	// tokens used against the API are bound to at least one of these audiences. If the
+	// --service-account-issuer flag is configured and this flag is not, this field
+	// defaults to a single element list containing the issuer URL.
+	APIAudiences []string `json:"apiAudiences,omitempty" flag:"api-audiences"`
+
 	// CPURequest, cpu request compute resource for api server. Defaults to "150m"
 	CPURequest string `json:"cpuRequest,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3315,6 +3315,9 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.TargetRamMb = in.TargetRamMb
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
+	out.ServiceAccountSigningKeyFile = in.ServiceAccountSigningKeyFile
+	out.ServiceAccountIssuer = in.ServiceAccountIssuer
+	out.APIAudiences = in.APIAudiences
 	out.CPURequest = in.CPURequest
 	return nil
 }
@@ -3409,6 +3412,9 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.TargetRamMb = in.TargetRamMb
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
+	out.ServiceAccountSigningKeyFile = in.ServiceAccountSigningKeyFile
+	out.ServiceAccountIssuer = in.ServiceAccountIssuer
+	out.APIAudiences = in.APIAudiences
 	out.CPURequest = in.CPURequest
 	return nil
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1968,6 +1968,21 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ServiceAccountSigningKeyFile != nil {
+		in, out := &in.ServiceAccountSigningKeyFile, &out.ServiceAccountSigningKeyFile
+		*out = new(string)
+		**out = **in
+	}
+	if in.ServiceAccountIssuer != nil {
+		in, out := &in.ServiceAccountIssuer, &out.ServiceAccountIssuer
+		*out = new(string)
+		**out = **in
+	}
+	if in.APIAudiences != nil {
+		in, out := &in.APIAudiences, &out.APIAudiences
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2150,6 +2150,21 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ServiceAccountSigningKeyFile != nil {
+		in, out := &in.ServiceAccountSigningKeyFile, &out.ServiceAccountSigningKeyFile
+		*out = new(string)
+		**out = **in
+	}
+	if in.ServiceAccountIssuer != nil {
+		in, out := &in.ServiceAccountIssuer, &out.ServiceAccountIssuer
+		*out = new(string)
+		**out = **in
+	}
+	if in.APIAudiences != nil {
+		in, out := &in.APIAudiences, &out.APIAudiences
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Cherry pick of #7610 on release-1.15.

#7610: Expose API Server flags needed for aws pod identities