### PR TITLE
Automated cherry pick of #7609: Updated container-selinux url to pint to the right path

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -557,7 +557,7 @@ var dockerVersions = []dockerVersion{
 		ExtraPackages: map[string]packageInfo{
 			"container-selinux": {
 				Version: "2.68",
-				Source:  "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
+        Source:  "http://mirror.centos.org/centos/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
 				Hash:    "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
 			},
 		},
@@ -654,7 +654,7 @@ var dockerVersions = []dockerVersion{
 		ExtraPackages: map[string]packageInfo{
 			"container-selinux": {
 				Version: "2.68",
-				Source:  "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
+        Source:  "http://mirror.centos.org/centos/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
 				Hash:    "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
 			},
 		},
@@ -692,7 +692,7 @@ var dockerVersions = []dockerVersion{
 		Distros:       []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
 		Architectures: []Architecture{ArchitectureAmd64},
 		Version:       "2.68",
-		Source:        "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
+    Source:        "http://mirror.centos.org/centos/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
 		Hash:          "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
 		Dependencies:  []string{"policycoreutils-python"},
 	},
@@ -760,7 +760,7 @@ var dockerVersions = []dockerVersion{
 		ExtraPackages: map[string]packageInfo{
 			"container-selinux": {
 				Version: "2.68",
-				Source:  "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
+        Source:  "http://mirror.centos.org/centos/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
 				Hash:    "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
 			},
 		},

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -557,7 +557,7 @@ var dockerVersions = []dockerVersion{
 		ExtraPackages: map[string]packageInfo{
 			"container-selinux": {
 				Version: "2.68",
-        Source:  "http://mirror.centos.org/centos/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
+				Source:  "http://mirror.centos.org/centos/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
 				Hash:    "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
 			},
 		},
@@ -654,7 +654,7 @@ var dockerVersions = []dockerVersion{
 		ExtraPackages: map[string]packageInfo{
 			"container-selinux": {
 				Version: "2.68",
-        Source:  "http://mirror.centos.org/centos/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
+				Source:  "http://mirror.centos.org/centos/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
 				Hash:    "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
 			},
 		},
@@ -692,7 +692,7 @@ var dockerVersions = []dockerVersion{
 		Distros:       []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
 		Architectures: []Architecture{ArchitectureAmd64},
 		Version:       "2.68",
-    Source:        "http://mirror.centos.org/centos/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
+		Source:        "http://mirror.centos.org/centos/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
 		Hash:          "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
 		Dependencies:  []string{"policycoreutils-python"},
 	},
@@ -760,7 +760,7 @@ var dockerVersions = []dockerVersion{
 		ExtraPackages: map[string]packageInfo{
 			"container-selinux": {
 				Version: "2.68",
-        Source:  "http://mirror.centos.org/centos/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
+				Source:  "http://mirror.centos.org/centos/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
 				Hash:    "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
 			},
 		},


### PR DESCRIPTION
Cherry pick of #7609 on release-1.15.

#7609: Updated container-selinux url to pint to the right path