### PR TITLE
Automated cherry pick of #7611: Check the HTTP response code when downloading URLs

### DIFF
--- a/upup/pkg/fi/http.go
+++ b/upup/pkg/fi/http.go
@@ -80,6 +80,9 @@ func downloadURLAlways(url string, destPath string, dirMode os.FileMode) error {
 	if err != nil {
 		return fmt.Errorf("error doing HTTP fetch of %q: %v", url, err)
 	}
+	if response.StatusCode >= 400 {
+		return fmt.Errorf("error response from %q: HTTP %v", url, response.StatusCode)
+	}
 	defer response.Body.Close()
 
 	_, err = io.Copy(output, response.Body)


### PR DESCRIPTION
Cherry pick of #7611 on release-1.13.

#7611: Check the HTTP response code when downloading URLs