### PR TITLE
fix instance name

### DIFF
--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -92,8 +92,8 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 			return fmt.Errorf("Failed to create UUID for instance: %v", err)
 		}
 		// FIXME: Must ensure 63 or less characters
-		// replace all dots with -, this is needed to get external cloudprovider working
-		iName := strings.ToLower(fmt.Sprintf("%s-%d.%s", ig.Name, i+1, b.ClusterName()))
+		// replace all dots and _ with -, this is needed to get external cloudprovider working
+		iName := strings.Replace(strings.ToLower(fmt.Sprintf("%s-%d.%s", ig.Name, i+1, b.ClusterName())), "_", "-", -1)
 		instanceName := fi.String(strings.Replace(iName, ".", "-", -1))
 
 		var az *string


### PR DESCRIPTION
In some cases there is possibility that instance name contains `_` chars which are not valid for k8s:

```
"kube-scheduler-master-foo_ovs_az1-3-1-own-k8s-local": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.',
```