### PR TITLE
Allow to use custom rootCAs

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -768,13 +768,13 @@ spec:
   sshKeyName: myexistingkey
 ```
 
-### mountCertificates
+### useHostCertificates
 
 Self-signed certificates towards Cloud APIs. In some cases Cloud APIs do have self-signed certificates.
 
 ```yaml
 spec:
-  mountCertificates: true
+  useHostCertificates: true
 ```
 
 #### Optional step: add root certificates to instancegroups root ca bundle

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -768,6 +768,34 @@ spec:
   sshKeyName: myexistingkey
 ```
 
+### mountCertificates
+
+Self-signed certificates towards Cloud APIs. In some cases Cloud APIs do have self-signed certificates.
+
+```yaml
+spec:
+  mountCertificates: true
+```
+
+#### Optional step: add root certificates to instancegroups root ca bundle
+
+```yaml
+  additionalUserData:
+  - name: cacert.sh
+    type: text/x-shellscript
+    content: |
+      #!/bin/sh
+      cat > /usr/local/share/ca-certificates/mycert.crt <<EOF
+      -----BEGIN CERTIFICATE-----
+snip
+      -----END CERTIFICATE-----
+      EOF
+      update-ca-certificates
+```
+
+**NOTE**: `update-ca-certificates` is command for debian/ubuntu. That command is different depending your OS.
+
+
 ### target
 
 In some use-cases you may wish to augment the target output with extra options.  `target` supports a minimal amount of options you can do this with.  Currently only the terraform target supports this, but if other use cases present themselves, kops may eventually support more.

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -115,6 +115,11 @@ func (t *ProtokubeBuilder) buildSystemdService() (*nodetasks.Service, error) {
 		"-v", "/run/systemd:/run/systemd",
 	}
 
+	if fi.BoolValue(t.Cluster.Spec.MountCertificates) {
+		dockerArgs = append(dockerArgs, "-v")
+		dockerArgs = append(dockerArgs, "/etc/ssl/certs:/etc/ssl/certs")
+	}
+
 	// add kubectl only if a master
 	// path changes depending on distro, and always mount it on /opt/kops/bin
 	// kubectl is downloaded and installed by other tasks

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -115,7 +115,7 @@ func (t *ProtokubeBuilder) buildSystemdService() (*nodetasks.Service, error) {
 		"-v", "/run/systemd:/run/systemd",
 	}
 
-	if fi.BoolValue(t.Cluster.Spec.MountCertificates) {
+	if fi.BoolValue(t.Cluster.Spec.UseHostCertificates) {
 		dockerArgs = append(dockerArgs, "-v")
 		dockerArgs = append(dockerArgs, "/etc/ssl/certs:/etc/ssl/certs")
 	}

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -172,6 +172,9 @@ type ClusterSpec struct {
 	DisableSubnetTags bool `json:"disableSubnetTags,omitempty"`
 	// Target allows for us to nest extra config for targets such as terraform
 	Target *TargetSpec `json:"target,omitempty"`
+	// MountCertificates will mount /etc/ssl/certs to inside needed containers.
+	// This is needed if some APIs do have self-signed certs
+	MountCertificates *bool `json:"mountCertificates,omitempty"`
 }
 
 // NodeAuthorizationSpec is used to node authorization

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -172,9 +172,9 @@ type ClusterSpec struct {
 	DisableSubnetTags bool `json:"disableSubnetTags,omitempty"`
 	// Target allows for us to nest extra config for targets such as terraform
 	Target *TargetSpec `json:"target,omitempty"`
-	// MountCertificates will mount /etc/ssl/certs to inside needed containers.
+	// UseHostCertificates will mount /etc/ssl/certs to inside needed containers.
 	// This is needed if some APIs do have self-signed certs
-	MountCertificates *bool `json:"mountCertificates,omitempty"`
+	UseHostCertificates *bool `json:"useHostCertificates,omitempty"`
 }
 
 // NodeAuthorizationSpec is used to node authorization

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -170,6 +170,9 @@ type ClusterSpec struct {
 	DisableSubnetTags bool `json:"DisableSubnetTags,omitempty"`
 	// Target allows for us to nest extra config for targets such as terraform
 	Target *TargetSpec `json:"target,omitempty"`
+	// MountCertificates will mount /etc/ssl/certs to inside needed containers.
+	// This is needed if some APIs do have self-signed certs
+	MountCertificates *bool `json:"mountCertificates,omitempty"`
 }
 
 // NodeAuthorizationSpec is used to node authorization

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -170,9 +170,9 @@ type ClusterSpec struct {
 	DisableSubnetTags bool `json:"DisableSubnetTags,omitempty"`
 	// Target allows for us to nest extra config for targets such as terraform
 	Target *TargetSpec `json:"target,omitempty"`
-	// MountCertificates will mount /etc/ssl/certs to inside needed containers.
+	// UseHostCertificates will mount /etc/ssl/certs to inside needed containers.
 	// This is needed if some APIs do have self-signed certs
-	MountCertificates *bool `json:"mountCertificates,omitempty"`
+	UseHostCertificates *bool `json:"useHostCertificates,omitempty"`
 }
 
 // NodeAuthorizationSpec is used to node authorization

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1808,6 +1808,7 @@ func autoConvert_v1alpha1_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 	} else {
 		out.Target = nil
 	}
+	out.MountCertificates = in.MountCertificates
 	return nil
 }
 
@@ -2076,6 +2077,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha1_ClusterSpec(in *kops.ClusterSpec, 
 	} else {
 		out.Target = nil
 	}
+	out.MountCertificates = in.MountCertificates
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1808,7 +1808,7 @@ func autoConvert_v1alpha1_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 	} else {
 		out.Target = nil
 	}
-	out.MountCertificates = in.MountCertificates
+	out.UseHostCertificates = in.UseHostCertificates
 	return nil
 }
 
@@ -2077,7 +2077,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha1_ClusterSpec(in *kops.ClusterSpec, 
 	} else {
 		out.Target = nil
 	}
-	out.MountCertificates = in.MountCertificates
+	out.UseHostCertificates = in.UseHostCertificates
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -788,6 +788,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(TargetSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.MountCertificates != nil {
+		in, out := &in.MountCertificates, &out.MountCertificates
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -788,8 +788,8 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(TargetSpec)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.MountCertificates != nil {
-		in, out := &in.MountCertificates, &out.MountCertificates
+	if in.UseHostCertificates != nil {
+		in, out := &in.UseHostCertificates, &out.UseHostCertificates
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -170,6 +170,9 @@ type ClusterSpec struct {
 	DisableSubnetTags bool `json:"DisableSubnetTags,omitempty"`
 	// Target allows for us to nest extra config for targets such as terraform
 	Target *TargetSpec `json:"target,omitempty"`
+	// MountCertificates will mount /etc/ssl/certs to inside needed containers.
+	// This is needed if some APIs do have self-signed certs
+	MountCertificates *bool `json:"mountCertificates,omitempty"`
 }
 
 // NodeAuthorizationSpec is used to node authorization

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -170,9 +170,9 @@ type ClusterSpec struct {
 	DisableSubnetTags bool `json:"DisableSubnetTags,omitempty"`
 	// Target allows for us to nest extra config for targets such as terraform
 	Target *TargetSpec `json:"target,omitempty"`
-	// MountCertificates will mount /etc/ssl/certs to inside needed containers.
+	// UseHostCertificates will mount /etc/ssl/certs to inside needed containers.
 	// This is needed if some APIs do have self-signed certs
-	MountCertificates *bool `json:"mountCertificates,omitempty"`
+	UseHostCertificates *bool `json:"useHostCertificates,omitempty"`
 }
 
 // NodeAuthorizationSpec is used to node authorization

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1861,6 +1861,7 @@ func autoConvert_v1alpha2_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 	} else {
 		out.Target = nil
 	}
+	out.MountCertificates = in.MountCertificates
 	return nil
 }
 
@@ -2144,6 +2145,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, 
 	} else {
 		out.Target = nil
 	}
+	out.MountCertificates = in.MountCertificates
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1861,7 +1861,7 @@ func autoConvert_v1alpha2_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 	} else {
 		out.Target = nil
 	}
-	out.MountCertificates = in.MountCertificates
+	out.UseHostCertificates = in.UseHostCertificates
 	return nil
 }
 
@@ -2145,7 +2145,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, 
 	} else {
 		out.Target = nil
 	}
-	out.MountCertificates = in.MountCertificates
+	out.UseHostCertificates = in.UseHostCertificates
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -761,6 +761,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(TargetSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.MountCertificates != nil {
+		in, out := &in.MountCertificates, &out.MountCertificates
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -761,8 +761,8 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(TargetSpec)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.MountCertificates != nil {
-		in, out := &in.MountCertificates, &out.MountCertificates
+	if in.UseHostCertificates != nil {
+		in, out := &in.UseHostCertificates, &out.UseHostCertificates
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -861,8 +861,8 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(TargetSpec)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.MountCertificates != nil {
-		in, out := &in.MountCertificates, &out.MountCertificates
+	if in.UseHostCertificates != nil {
+		in, out := &in.UseHostCertificates, &out.UseHostCertificates
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -861,6 +861,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(TargetSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.MountCertificates != nil {
+		in, out := &in.MountCertificates, &out.MountCertificates
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -449,6 +449,24 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster *kops.EtcdClusterSpec) (*v1.Po
 				},
 			},
 		})
+
+		if fi.BoolValue(b.Cluster.Spec.MountCertificates) {
+			container.VolumeMounts = append(container.VolumeMounts, v1.VolumeMount{
+				Name:      "ca-certs",
+				MountPath: "/etc/ssl/certs",
+				ReadOnly:  true,
+			})
+			hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate
+			pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+				Name: "ca-certs",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{
+						Path: "/etc/ssl/certs",
+						Type: &hostPathDirectoryOrCreate,
+					},
+				},
+			})
+		}
 	}
 
 	envMap := env.BuildSystemComponentEnvVars(&b.Cluster.Spec)

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -450,15 +450,15 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster *kops.EtcdClusterSpec) (*v1.Po
 			},
 		})
 
-		if fi.BoolValue(b.Cluster.Spec.MountCertificates) {
+		if fi.BoolValue(b.Cluster.Spec.UseHostCertificates) {
 			container.VolumeMounts = append(container.VolumeMounts, v1.VolumeMount{
-				Name:      "ca-certs",
+				Name:      "etc-ssl-certs",
 				MountPath: "/etc/ssl/certs",
 				ReadOnly:  true,
 			})
 			hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate
 			pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
-				Name: "ca-certs",
+				Name: "etc-ssl-certs",
 				VolumeSource: v1.VolumeSource{
 					HostPath: &v1.HostPathVolumeSource{
 						Path: "/etc/ssl/certs",

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -32,6 +32,12 @@ spec:
       containers:
       - name: kops-controller
         image: kope/kops-controller:1.15.0-alpha.1
+{{ if .MountCertificates }}
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+{{ end }}
         command:
 {{ range $arg := KopsControllerArgv }}
         - "{{ $arg }}"
@@ -47,7 +53,13 @@ spec:
           requests:
             cpu: 50m
             memory: 50Mi
-
+{{ if .MountCertificates }}
+      volumes:
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+{{ end }}
 ---
 
 apiVersion: v1

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -60,6 +60,7 @@ spec:
           type: DirectoryOrCreate
         name: ca-certs
 {{ end }}
+
 ---
 
 apiVersion: v1

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -32,10 +32,10 @@ spec:
       containers:
       - name: kops-controller
         image: kope/kops-controller:1.15.0-alpha.1
-{{ if .MountCertificates }}
+{{ if .UseHostCertificates }}
         volumeMounts:
         - mountPath: /etc/ssl/certs
-          name: ca-certs
+          name: etc-ssl-certs
           readOnly: true
 {{ end }}
         command:
@@ -53,12 +53,12 @@ spec:
           requests:
             cpu: 50m
             memory: 50Mi
-{{ if .MountCertificates }}
+{{ if .UseHostCertificates }}
       volumes:
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate
-        name: ca-certs
+        name: etc-ssl-certs
 {{ end }}
 
 ---

--- a/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.11.yaml.template
@@ -213,18 +213,18 @@ spec:
         - mountPath: /etc/kubernetes/cloud.config
           name: cloudconfig
           readOnly: true
-{{ if .MountCertificates }}
+{{ if .UseHostCertificates }}
         - mountPath: /etc/ssl/certs
-          name: ca-certs
+          name: etc-ssl-certs
           readOnly: true
 {{ end }}
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config
         name: cloudconfig
-{{ if .MountCertificates }}
+{{ if .UseHostCertificates }}
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate
-        name: ca-certs
+        name: etc-ssl-certs
 {{ end }}

--- a/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.11.yaml.template
@@ -213,7 +213,18 @@ spec:
         - mountPath: /etc/kubernetes/cloud.config
           name: cloudconfig
           readOnly: true
+{{ if .MountCertificates }}
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+{{ end }}
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config
         name: cloudconfig
+{{ if .MountCertificates }}
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+{{ end }}


### PR DESCRIPTION
In some cases (in OpenStack) we have situations that OpenStack API certificates are coming from vendors (and in some cases vendors do use self-signed certificates). This lead to situation that we do have self-signed certificates in OpenStack API. However, we can get self-signed certificates working with mounting ca-certificates.crt (assuming that self-signed rootCA is added to instance root ca bundle) from the instance itself inside the official kops containers.

Adding certificates to root ca bundle can be done for instance in following way (in debian/ubuntu):

```
  additionalUserData:
  - name: cacert.sh
    type: text/x-shellscript
    content: |
      #!/bin/sh
      cat > /usr/local/share/ca-certificates/openstack.crt <<EOF
      -----BEGIN CERTIFICATE-----
snip
      -----END CERTIFICATE-----
      EOF
      update-ca-certificates
```

Or another option is build the OS image which contains self signed root CA already.