### PR TITLE
Cilium standalone continuation

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -87,7 +87,7 @@ data:
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "{{- if .ToFqdnsEnablePoller -}}true{{- else -}}false{{- end -}}"
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
-  wait-bpf-mount: "true"
+  wait-bpf-mount: "false"
   # Enable fetching of container-runtime specific metadata
   #
   # By default, the Kubernetes pod and namespace labels are retrieved and

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: cilium-config
   namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
 data:
 {{ with .Networking.Cilium }}
   # Identity allocation mode selects how identities are shared between cilium
@@ -117,17 +119,23 @@ kind: ServiceAccount
 metadata:
   name: cilium
   namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
+  labels:
+    role.kubernetes.io/networking: "1"
 rules:
 - apiGroups:
   - networking.k8s.io
@@ -203,6 +211,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
+  labels:
+    role.kubernetes.io/networking: "1"
 rules:
 - apiGroups:
   - ""
@@ -249,6 +259,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium
+  labels:
+    role.kubernetes.io/networking: "1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -262,6 +274,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
+  labels:
+    role.kubernetes.io/networking: "1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -277,6 +291,7 @@ metadata:
   labels:
     k8s-app: cilium
     kubernetes.io/cluster-service: "true"
+    role.kubernetes.io/networking: "1"
   name: cilium
   namespace: kube-system
 spec:
@@ -499,6 +514,7 @@ metadata:
   labels:
     io.cilium/app: operator
     name: cilium-operator
+    role.kubernetes.io/networking: "1"
   name: cilium-operator
   namespace: kube-system
 spec:

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
@@ -87,7 +87,7 @@ data:
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "{{- if .ToFqdnsEnablePoller -}}true{{- else -}}false{{- end -}}"
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
-  wait-bpf-mount: "true"
+  wait-bpf-mount: "false"
   # Enable fetching of container-runtime specific metadata
   #
   # By default, the Kubernetes pod and namespace labels are retrieved and

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: cilium-config
   namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
 data:
 {{ with .Networking.Cilium }}
   # Identity allocation mode selects how identities are shared between cilium
@@ -117,17 +119,23 @@ kind: ServiceAccount
 metadata:
   name: cilium
   namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
+  labels:
+    role.kubernetes.io/networking: "1"
 rules:
 - apiGroups:
   - networking.k8s.io
@@ -203,6 +211,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
+  labels:
+    role.kubernetes.io/networking: "1"
 rules:
 - apiGroups:
   - ""
@@ -249,6 +259,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium
+  labels:
+    role.kubernetes.io/networking: "1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -262,6 +274,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
+  labels:
+    role.kubernetes.io/networking: "1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -277,6 +291,7 @@ metadata:
   labels:
     k8s-app: cilium
     kubernetes.io/cluster-service: "true"
+    role.kubernetes.io/networking: "1"
   name: cilium
   namespace: kube-system
 spec:
@@ -499,6 +514,7 @@ metadata:
   labels:
     io.cilium/app: operator
     name: cilium-operator
+    role.kubernetes.io/networking: "1"
   name: cilium-operator
   namespace: kube-system
 spec:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -1090,7 +1090,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 	if b.cluster.Spec.Networking.Cilium != nil {
 		key := "networking.cilium.io"
-		version := "v1.0-kops.2"
+		version := "1.6.1-kops.1"
 
 		{
 			id := "k8s-1.7"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -107,16 +107,16 @@ spec:
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0 <1.12.0'
     manifest: networking.cilium.io/k8s-1.7.yaml
-    manifestHash: 54942553181df199c9be734897ad7047395edc15
+    manifestHash: cc7937066cb472dce20e13fe9a76faefd74dee19
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: v1.0-kops.2
+    version: 1.6.1-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: 54942553181df199c9be734897ad7047395edc15
+    manifestHash: cc7937066cb472dce20e13fe9a76faefd74dee19
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: v1.0-kops.2
+    version: 1.6.1-kops.1


### PR DESCRIPTION
Fixes a couple of smaller issues left unresolved in #7474

Upgrades from Kops 1.13 stable to this PR works as expected.

Note that because bpffs is not mounted on the host before #7474, upgrading cilium will freeze the network on nodes where a cilium pod is being rolled.

Fixes #7575 
Fixes #7046 
Fixes #6496