### PR TITLE
Fix some bugs reported by staticcheck

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -563,6 +563,9 @@ func EvaluateHostnameOverride(hostnameOverride string) (string, error) {
 	result, err := svc.DescribeInstances(&ec2.DescribeInstancesInput{
 		InstanceIds: []*string{&instanceID},
 	})
+	if err != nil {
+		return "", fmt.Errorf("error describing instances: %v", err)
+	}
 
 	if len(result.Reservations) != 1 {
 		return "", fmt.Errorf("Too many reservations returned for the single instance-id")

--- a/pkg/apis/kops/validation/gce.go
+++ b/pkg/apis/kops/validation/gce.go
@@ -46,5 +46,5 @@ func gceValidateCluster(c *kops.Cluster) field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(fieldSpec.Child("Subnets"), strings.Join(regions.List(), ","), "clusters cannot span GCE regions"))
 	}
 
-	return nil
+	return allErrs
 }

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -213,14 +213,6 @@ func run() error {
 			os.Exit(1)
 		}
 		volumes = aliVolumes
-	} else if cloud == "alicloud" {
-		klog.Info("Initializing AliCloud volumes")
-		aliVolumes, err := protokube.NewALIVolumes()
-		if err != nil {
-			klog.Errorf("Error initializing Aliyun: %q", err)
-			os.Exit(1)
-		}
-		volumes = aliVolumes
 
 		if clusterID == "" {
 			clusterID = aliVolumes.ClusterID()


### PR DESCRIPTION
I noticed these issues when running staticcheck:
```
nodeup/pkg/model/context.go:563:10: this value of err is never used (SA4006)
pkg/apis/kops/validation/gce.go:46:3: this value of allErrs is never used (SA4006)
protokube/cmd/protokube/main.go:216:12: this condition occurs multiple times in this if/else if chain (SA4014)
```

If we think its beneficial I'll see about integrating staticcheck into our CI process [similar to how k/k did](https://groups.google.com/forum/#!searchin/kubernetes-dev/staticcheck%7Csort:date/kubernetes-dev/XKBtVRE_d_Q/76cNLhMCBAAJ).