### PR TITLE
alpha channel: image for 1.15 and general update

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -23,18 +23,21 @@ spec:
       providerID: aws
       kubernetesVersion: ">=1.10.0 <1.11.0"
     # Stretch is the default for 1.11 (for nvme)
-    - name: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2019-08-16
+    - name: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2019-09-26
       providerID: aws
       kubernetesVersion: ">=1.11.0 <1.12.0"
-    - name: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-08-16
+    - name: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-09-26
       providerID: aws
       kubernetesVersion: ">=1.12.0 <1.13.0"
-    - name: kope.io/k8s-1.13-debian-stretch-amd64-hvm-ebs-2019-08-16
+    - name: kope.io/k8s-1.13-debian-stretch-amd64-hvm-ebs-2019-09-26
       providerID: aws
       kubernetesVersion: ">=1.13.0 <1.14.0"
-    - name: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
+    - name: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
       providerID: aws
-      kubernetesVersion: ">=1.14.0"
+      kubernetesVersion: ">=1.14.0 <1.15.0"
+    - name: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
+      providerID: aws
+      kubernetesVersion: ">=1.15.0"
     - providerID: gce
       name: "cos-cloud/cos-stable-65-10323-99-0"
   cluster:


### PR DESCRIPTION
alpha channel: image for 1.15 and general update

Note that source of images is now:
https://github.com/kubernetes-sigs/image-builder/tree/master/images/kube-deploy/imagebuilder
