### PR TITLE
Misleading description for KubeProxy MetricsBindAddress

### DIFF
--- a/k8s/crds/kops_v1alpha2_cluster.yaml
+++ b/k8s/crds/kops_v1alpha2_cluster.yaml
@@ -1282,8 +1282,8 @@ spec:
                     kube proxy e.g. "30Mi"
                   type: string
                 metricsBindAddress:
-                  description: MetricsBindAddress is the IP address and port for the
-                    metrics server to serve on
+                  description: MetricsBindAddress is the IP address for the metrics
+                    server to serve on
                   type: string
                 proxyMode:
                   description: 'Which proxy mode to use: (userspace, iptables, ipvs)'

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -217,7 +217,7 @@ type KubeProxyConfig struct {
 	BindAddress string `json:"bindAddress,omitempty" flag:"bind-address"`
 	// Master is the address of the Kubernetes API server (overrides any value in kubeconfig)
 	Master string `json:"master,omitempty" flag:"master"`
-	// MetricsBindAddress is the IP address and port for the metrics server to serve on
+	// MetricsBindAddress is the IP address for the metrics server to serve on
 	MetricsBindAddress *string `json:"metricsBindAddress,omitempty" flag:"metrics-bind-address"`
 	// Enabled allows enabling or disabling kube-proxy
 	Enabled *bool `json:"enabled,omitempty"`

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -217,7 +217,7 @@ type KubeProxyConfig struct {
 	BindAddress string `json:"bindAddress,omitempty" flag:"bind-address"`
 	// Master is the address of the Kubernetes API server (overrides any value in kubeconfig)
 	Master string `json:"master,omitempty" flag:"master"`
-	// MetricsBindAddress is the IP address and port for the metrics server to serve on
+	// MetricsBindAddress is the IP address for the metrics server to serve on
 	MetricsBindAddress *string `json:"metricsBindAddress,omitempty" flag:"metrics-bind-address"`
 	// Enabled allows enabling or disabling kube-proxy
 	Enabled *bool `json:"enabled,omitempty"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -217,7 +217,7 @@ type KubeProxyConfig struct {
 	BindAddress string `json:"bindAddress,omitempty" flag:"bind-address"`
 	// Master is the address of the Kubernetes API server (overrides any value in kubeconfig)
 	Master string `json:"master,omitempty" flag:"master"`
-	// MetricsBindAddress is the IP address and port for the metrics server to serve on
+	// MetricsBindAddress is the IP address for the metrics server to serve on
 	MetricsBindAddress *string `json:"metricsBindAddress,omitempty" flag:"metrics-bind-address"`
 	// Enabled allows enabling or disabling kube-proxy
 	Enabled *bool `json:"enabled,omitempty"`


### PR DESCRIPTION
I noticed that the documentation on KubeProxyConfig.MetricsBindAddress is no longer correct.

Since release 1.11 of kube-proxy the `--metrics-bind-address` needs to be an IP address. See [kube-proxy commit](https://github.com/kubernetes/kubernetes/pull/72682).

To overwrite the port an additional parameter would be needed.