### PR TITLE
Automated cherry pick of #7660: Align AWS and kops validation for spot allocation strategy

### DIFF
--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -154,10 +154,10 @@ type InstanceGroupSpec struct {
 }
 
 const (
-	// SpotAllocationStrategyLowestPrices indicates a lowest price strategy
-	SpotAllocationStrategyLowestPrices = "LowestPrice"
+	// SpotAllocationStrategyLowestPrices indicates a lowest-price strategy
+	SpotAllocationStrategyLowestPrices = "lowest-price"
 	// SpotAllocationStrategyDiversified indicates a diversified strategy
-	SpotAllocationStrategyDiversified = "Diversified"
+	SpotAllocationStrategyDiversified = "diversified"
 )
 
 // SpotAllocationStrategies is a collection of supported strategies

--- a/pkg/apis/kops/v1alpha1/instancegroup.go
+++ b/pkg/apis/kops/v1alpha1/instancegroup.go
@@ -141,10 +141,10 @@ type InstanceGroupSpec struct {
 }
 
 const (
-	// SpotAllocationStrategyLowestPrices indicates a lowest price strategy
-	SpotAllocationStrategyLowestPrices = "LowestPrice"
+	// SpotAllocationStrategyLowestPrices indicates a lowest-price strategy
+	SpotAllocationStrategyLowestPrices = "lowest-price"
 	// SpotAllocationStrategyDiversified indicates a diversified strategy
-	SpotAllocationStrategyDiversified = "Diversified"
+	SpotAllocationStrategyDiversified = "diversified"
 )
 
 // SpotAllocationStrategies is a collection of supported strategies

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -148,10 +148,10 @@ type InstanceGroupSpec struct {
 }
 
 const (
-	// SpotAllocationStrategyLowestPrices indicates a lowest price strategy
-	SpotAllocationStrategyLowestPrices = "LowestPrice"
+	// SpotAllocationStrategyLowestPrices indicates a lowest-price strategy
+	SpotAllocationStrategyLowestPrices = "lowest-price"
 	// SpotAllocationStrategyDiversified indicates a diversified strategy
-	SpotAllocationStrategyDiversified = "Diversified"
+	SpotAllocationStrategyDiversified = "diversified"
 )
 
 // SpotAllocationStrategies is a collection of supported strategies


### PR DESCRIPTION
Cherry pick of #7660 on release-1.15.

#7660: Align AWS and kops validation for spot allocation strategy