### PR TITLE
Limit calico cpu request to 100m

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.12.yaml.template
@@ -513,7 +513,7 @@ spec:
             privileged: true
           resources:
             requests:
-              cpu: 250m
+              cpu: 100m
           livenessProbe:
             httpGet:
               path: /liveness

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -820,7 +820,7 @@ spec:
             privileged: true
           resources:
             requests:
-              cpu: 250m
+              cpu: 90m
           livenessProbe:
             httpGet:
               path: /liveness

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -807,7 +807,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.6":     "2.6.9-kops.1",
 			"k8s-1.7":     "2.6.12-kops.1",
 			"k8s-1.7-v3":  "3.8.0-kops.1",
-			"k8s-1.12":    "3.8.2-kops.1",
+			"k8s-1.12":    "3.8.2-kops.2",
 		}
 
 		{


### PR DESCRIPTION
Per docs/development/instancesizes.md we don't have much cpu on a 1
core machine.  Note that this is only requests, not limits, so calico
can still burst.

At least related to issue #7592