### PR TITLE
Calico: upgrade pod2daemon (only)

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.12.yaml.template
@@ -513,7 +513,7 @@ spec:
             privileged: true
           resources:
             requests:
-              cpu: 250m
+              cpu: 100m
           livenessProbe:
             httpGet:
               path: /liveness

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -747,7 +747,8 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.8.2
+          # We bump this to v3.9.1 to pick up https://github.com/projectcalico/pod2daemon/pull/28
+          image: calico/pod2daemon-flexvol:v3.9.1
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -820,7 +820,7 @@ spec:
             privileged: true
           resources:
             requests:
-              cpu: 250m
+              cpu: 90m
           livenessProbe:
             httpGet:
               path: /liveness

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -807,7 +807,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.6":     "2.6.9-kops.1",
 			"k8s-1.7":     "2.6.12-kops.1",
 			"k8s-1.7-v3":  "3.8.0-kops.1",
-			"k8s-1.12":    "3.8.2-kops.1",
+			"k8s-1.12":    "3.8.2-kops.2",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -807,7 +807,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.6":     "2.6.9-kops.1",
 			"k8s-1.7":     "2.6.12-kops.1",
 			"k8s-1.7-v3":  "3.8.0-kops.1",
-			"k8s-1.12":    "3.8.2-kops.2",
+			"k8s-1.12":    "3.8.2-kops.3",
 		}
 
 		{


### PR DESCRIPTION
We want to pick up https://github.com/projectcalico/pod2daemon/pull/28 , to
address https://github.com/kubernetes/kops/issues/7592 .

This is not ideal, but looking at the commit changes the only potentially
problematic change in the diff is
https://github.com/projectcalico/pod2daemon/pull/21 , which seems like it
shouldn't cause ay skew issues.