### PR TITLE
More staticcheck bugfixes and cleanup

### DIFF
--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53.go
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53.go
@@ -63,7 +63,11 @@ func newRoute53(config io.Reader) (*Interface, error) {
 	// e.g. https://github.com/kubernetes/kops/issues/605
 	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true)
 
-	svc := route53.New(session.New(), awsConfig)
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil, err
+	}
+	svc := route53.New(sess, awsConfig)
 
 	// Add our handler that will log requests
 	svc.Handlers.Sign.PushFrontNamed(request.NamedHandler{

--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -7,7 +7,6 @@ dnsprovider/pkg/dnsprovider/providers/google/clouddns
 dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal
 dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs
 dnsprovider/pkg/dnsprovider/providers/openstack/designate
-hack/machine_types
 node-authorizer/pkg/authorizers/aws
 node-authorizer/pkg/server
 nodeup/pkg/model

--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -13,7 +13,6 @@ nodeup/pkg/model
 pkg/apis/kops/v1alpha1
 pkg/apis/kops/v1alpha2
 pkg/apis/kops/validation
-pkg/assets
 pkg/client/simple/api
 pkg/diff
 pkg/instancegroups
@@ -42,10 +41,8 @@ upup/pkg/fi/cloudup/awsup
 upup/pkg/fi/cloudup/gcetasks
 upup/pkg/fi/cloudup/openstack
 upup/pkg/fi/cloudup/openstacktasks
-upup/pkg/fi/fitasks
 upup/pkg/fi/nodeup
 upup/pkg/kutil
 upup/tools/generators/pkg/codegen
 util/pkg/reflectutils
 util/pkg/tables
-util/pkg/ui

--- a/hack/machine_types/machine_types.go
+++ b/hack/machine_types/machine_types.go
@@ -85,7 +85,11 @@ func run() error {
 	// Default to us-east-1
 	config = config.WithRegion("us-east-1")
 
-	svc := pricing.New(session.New(), config)
+	sess, err := session.NewSession()
+	if err != nil {
+		return err
+	}
+	svc := pricing.New(sess, config)
 	typeTerm := pricing.FilterTypeTermMatch
 	input := &pricing.GetProductsInput{
 		Filters: []*pricing.Filter{

--- a/node-authorizer/pkg/authorizers/aws/authorizer.go
+++ b/node-authorizer/pkg/authorizers/aws/authorizer.go
@@ -89,12 +89,14 @@ func NewAuthorizer(config *server.Config) (server.Authorizer, error) {
 		zap.String("region", document.Region))
 
 	// @step: we create a ec2 and autoscaling client
-	client := ec2.New(session.New(&aws.Config{
+	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(document.Region),
-	}))
-	asgc := autoscaling.New(session.New(&aws.Config{
-		Region: aws.String(document.Region),
-	}))
+	})
+	if err != nil {
+		return nil, err
+	}
+	client := ec2.New(sess)
+	asgc := autoscaling.New(sess)
 
 	// @step: get information on the instance we are running
 	instance, err := getInstance(client, document.InstanceID)
@@ -283,12 +285,15 @@ func hasInstanceTags(name, value string, tags []*ec2.Tag) bool {
 // getInstanceIdentityDocument is responsible for retrieving the instance identity document
 func getInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error) {
 	var document ec2metadata.EC2InstanceIdentityDocument
-
-	client := ec2metadata.New(session.New())
+	sess, err := session.NewSession()
+	if err != nil {
+		return document, err
+	}
+	client := ec2metadata.New(sess)
 	maxInterval := 500 * time.Millisecond
 	maxTime := 5 * time.Second
 
-	err := utils.Retry(context.TODO(), maxInterval, maxTime, func() error {
+	err = utils.Retry(context.TODO(), maxInterval, maxTime, func() error {
 		x, err := client.GetInstanceIdentityDocument()
 		if err != nil {
 			return err

--- a/node-authorizer/pkg/authorizers/aws/authorizer_test.go
+++ b/node-authorizer/pkg/authorizers/aws/authorizer_test.go
@@ -31,7 +31,7 @@ func newTestAuthorizer(t *testing.T, config *server.Config) *awsNodeAuthorizer {
 		config = &server.Config{}
 	}
 	c := &awsNodeAuthorizer{
-		config: &server.Config{},
+		config: config,
 		vpcID:  "test",
 	}
 	if err := GetPublicCertificates(); err != nil {

--- a/node-authorizer/pkg/authorizers/aws/verifier.go
+++ b/node-authorizer/pkg/authorizers/aws/verifier.go
@@ -55,7 +55,11 @@ func (a *awsNodeVerifier) VerifyIdentity(ctx context.Context) ([]byte, error) {
 	go func() {
 		encoded, err := func() ([]byte, error) {
 			// @step: create a metadata client
-			client := ec2metadata.New(session.New())
+			sess, err := session.NewSession()
+			if err != nil {
+				return []byte{}, err
+			}
+			client := ec2metadata.New(sess)
 
 			// @step: get the pkcs7 signature from the metadata service
 			signature, err := client.GetDynamicData("/instance-identity/pkcs7")

--- a/pkg/assets/builder_test.go
+++ b/pkg/assets/builder_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package assets
 
 import (
-	"errors"
 	"testing"
 
 	"k8s.io/kops/pkg/apis/kops"
@@ -144,10 +143,9 @@ func TestValidate_RemapImage_ContainerRegistry_MappingMultipleTimesConverges(t *
 	builder.AssetsLocation.ContainerRegistry = &mirrorUrl
 
 	remapped := image
-	err := errors.New("")
 	iterations := make([]map[int]int, 2)
 	for i := range iterations {
-		remapped, err = builder.RemapImage(remapped)
+		remapped, err := builder.RemapImage(remapped)
 		if err != nil {
 			t.Errorf("Error remapping image (iteration %d): %s", i, err)
 		}

--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -136,7 +136,7 @@ func (b *EtcdOptionsBuilder) BuildOptions(o interface{}) error {
 			if c.Backups != nil {
 				image := c.Backups.Image
 				if image == "" {
-					image = fmt.Sprintf(DefaultBackupImage)
+					image = DefaultBackupImage
 				}
 
 				if image != "" {

--- a/protokube/pkg/protokube/openstack_volume.go
+++ b/protokube/pkg/protokube/openstack_volume.go
@@ -173,6 +173,9 @@ func (a *OpenstackVolumes) discoverTags() error {
 	// Internal IP
 	{
 		server, err := a.cloud.GetInstance(strings.TrimSpace(a.meta.ServerID))
+		if err != nil {
+			return fmt.Errorf("error getting instance from ID: %v", err)
+		}
 		ip, err := openstack.GetServerFixedIP(server, a.clusterName)
 		if err != nil {
 			return fmt.Errorf("error querying InternalIP from name: %v", err)

--- a/upup/pkg/fi/dryrun_target.go
+++ b/upup/pkg/fi/dryrun_target.go
@@ -69,7 +69,7 @@ type DeletionByTaskName []Deletion
 func (a DeletionByTaskName) Len() int      { return len(a) }
 func (a DeletionByTaskName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a DeletionByTaskName) Less(i, j int) bool {
-	return a[i].TaskName() < a[i].TaskName()
+	return a[i].TaskName() < a[j].TaskName()
 }
 
 var _ Target = &DryRunTarget{}

--- a/upup/pkg/fi/fitasks/keypair.go
+++ b/upup/pkg/fi/fitasks/keypair.go
@@ -200,7 +200,7 @@ func (_ *Keypair) Render(c *fi.Context, a, e, changes *Keypair) error {
 	if createCertificate {
 		klog.V(2).Infof("Creating PKI keypair %q", name)
 
-		cert, privateKey, _, err := c.Keystore.FindKeypair(name)
+		_, privateKey, _, err := c.Keystore.FindKeypair(name)
 		if err != nil {
 			return err
 		}
@@ -222,7 +222,7 @@ func (_ *Keypair) Render(c *fi.Context, a, e, changes *Keypair) error {
 			signer = fi.StringValue(e.Signer.Name)
 		}
 
-		cert, err = c.Keystore.CreateKeypair(signer, name, template, privateKey)
+		cert, err := c.Keystore.CreateKeypair(signer, name, template, privateKey)
 		if err != nil {
 			return err
 		}

--- a/util/pkg/ui/user.go
+++ b/util/pkg/ui/user.go
@@ -49,7 +49,7 @@ func GetConfirm(c *ConfirmArgs) (bool, error) {
 
 	for {
 		answerTemplate := " (%s/%s)"
-		message := c.Message
+		var message string
 		switch c.Default {
 		case "yes", "y":
 			message = c.Message + fmt.Sprintf(answerTemplate, "Y", "n")


### PR DESCRIPTION

* `dnsprovider/pkg/dnsprovider/providers/aws/route53/route53.go:66:21: session.New is deprecated: Use NewSession functions to create sessions instead. NewSession has the same functionality as New except an error can be returned when the func is called instead of waiting to receive an error until a request is made.  (SA1019)`
  (same with other instances of `session.New()`)

* `node-authorizer/pkg/authorizers/aws/authorizer_test.go:31:3: this value of config is never used (SA4006)`
* `pkg/assets/builder_test.go:147:2: this value of err is never used (SA4006)
pkg/assets/builder_test.go:147:19: New is a pure function but its return value is ignored (SA4017)`
* `pkg/model/components/etcd.go:139:26: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)`
* `protokube/pkg/protokube/openstack_volume.go:175:11: this value of err is never used (SA4006)`
* `upup/pkg/fi/dryrun_target.go:72:9: identical expressions on the left and right side of the '<' operator (SA4000)`
* `upup/pkg/fi/fitasks/keypair.go:203:3: this value of cert is never used (SA4006)`
* `util/pkg/ui/user.go:52:3: this value of message is never used (SA4006)`