### PR TITLE
Add ci postsubmit script for pushing images to staging

### DIFF
--- a/ci/postsubmit/push-to-staging/cloudbuild.yaml
+++ b/ci/postsubmit/push-to-staging/cloudbuild.yaml
@@ -1,0 +1,22 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+# Start by just pushing the image
+- name: 'gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1'
+  entrypoint: make
+  env:
+  - VERSION=$_GIT_TAG
+  - PULL_BASE_REF=$_PULL_BASE_REF
+  - DOCKER_REGISTRY=$_DOCKER_REGISTRY
+  - DOCKER_IMAGE_PREFIX=$_DOCKER_IMAGE_PREFIX
+  args:
+  - kops-controller-push
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '12345'
+  _PULL_BASE_REF: 'dev'
+  _DOCKER_REGISTRY: 'gcr.io'
+  _DOCKER_IMAGE_PREFIX: 'k8s-staging-kops/'


### PR DESCRIPTION
This is the GCB script that will be called to automatically push images to our staging repo from a prow postsubmit job.  That job is https://github.com/kubernetes/test-infra/pull/14503