### PR TITLE
Publish kops-controller container dump to S3/GCS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ unexport SKIP_REGION_CHECK S3_ACCESS_KEY_ID S3_ENDPOINT S3_REGION S3_SECRET_ACCE
 
 # Keep in sync with upup/models/cloudup/resources/addons/dns-controller/
 DNS_CONTROLLER_TAG=1.15.0-alpha.1
+# Keep in sync with upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/
 KOPS_CONTROLLER_TAG=1.15.0-alpha.1
 
 # Keep in sync with logic in get_workspace_status

--- a/cmd/kops-controller/BUILD.bazel
+++ b/cmd/kops-controller/BUILD.bazel
@@ -30,6 +30,7 @@ load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_image",
     "container_push",
+    "container_bundle",
 )
 
 container_image(
@@ -49,4 +50,11 @@ container_push(
     registry = "{STABLE_DOCKER_REGISTRY}",
     repository = "{STABLE_DOCKER_IMAGE_PREFIX}kops-controller",
     tag = "{STABLE_KOPS_CONTROLLER_TAG}",
+)
+
+container_bundle(
+    name = "image-bundle",
+    images = {
+        "{STABLE_DOCKER_IMAGE_PREFIX}kops-controller:{STABLE_KOPS_CONTROLLER_TAG}": "image",
+    },
 )

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.16.0-alpha.1
+    version: v1.15.0-alpha.1
 spec:
   replicas: 1
   selector:
@@ -17,7 +17,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.16.0-alpha.1
+        version: v1.15.0-alpha.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -31,7 +31,7 @@ spec:
       serviceAccount: kops-controller
       containers:
       - name: kops-controller
-        image: kope/kops-controller:1.14.0-alpha.1
+        image: kope/kops-controller:1.15.0-alpha.1
         command:
 {{ range $arg := KopsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -115,7 +115,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 	{
 		key := "kops-controller.addons.k8s.io"
-		version := "1.16.0-alpha.1"
+		version := "1.15.0-alpha.1"
 
 		{
 			location := key + "/k8s-1.16.yaml"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.16.0-alpha.1
+    version: v1.15.0-alpha.1
   name: kops-controller
   namespace: kube-system
 spec:
@@ -19,7 +19,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.16.0-alpha.1
+        version: v1.15.0-alpha.1
     spec:
       containers:
       - command:
@@ -28,7 +28,7 @@ spec:
         - --config=memfs://clusters.example.com/minimal.example.com
         - --metrics-addr=0
         - --v=2
-        image: kope/kops-controller:1.14.0-alpha.1
+        image: kope/kops-controller:1.15.0-alpha.1
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -7,11 +7,11 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: de5108cf5c9a46a8dc13643428cbaddd0875b948
+    manifestHash: 736a3efe35f5edf14a8b7bd6ad723935e12f2a4d
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.16.0-alpha.1
+    version: 1.15.0-alpha.1
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
     name: core.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.16.0-alpha.1
+    version: v1.15.0-alpha.1
   name: kops-controller
   namespace: kube-system
 spec:
@@ -19,7 +19,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.16.0-alpha.1
+        version: v1.15.0-alpha.1
     spec:
       containers:
       - command:
@@ -28,7 +28,7 @@ spec:
         - --config=memfs://clusters.example.com/minimal.example.com
         - --metrics-addr=0
         - --v=2
-        image: kope/kops-controller:1.14.0-alpha.1
+        image: kope/kops-controller:1.15.0-alpha.1
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -7,11 +7,11 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: de5108cf5c9a46a8dc13643428cbaddd0875b948
+    manifestHash: 736a3efe35f5edf14a8b7bd6ad723935e12f2a4d
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.16.0-alpha.1
+    version: 1.15.0-alpha.1
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
     name: core.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -7,11 +7,11 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: de5108cf5c9a46a8dc13643428cbaddd0875b948
+    manifestHash: 736a3efe35f5edf14a8b7bd6ad723935e12f2a4d
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.16.0-alpha.1
+    version: 1.15.0-alpha.1
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
     name: core.addons.k8s.io


### PR DESCRIPTION
We then `docker load` it when using a KOPS_BASE_URL.

This should simplify the development process (particularly once we also do
this for dns-controller; at that point we won't need a registry at all).

This should also fix the problems in CI, where the kops-controller image
isn't available.  We've been getting away with testing with the previous
version for dns-controller, which changes pretty slowly.  But that's not a
good idea for kops-controller, which is likely to be more critical and
evolve more rapidly.

(Builds on #7700)