### PR TITLE
Create tools/sha1 and sha256 helpers, simply Makefile

### DIFF
--- a/tools/sha1
+++ b/tools/sha1
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+in=$1
+out=$2
+
+if ( which sha1sum > /dev/null ); then
+  (sha1sum $in | cut -d' ' -f1) > $out
+elif ( which shasum > /dev/null ); then
+  (shasum -a 1 $in | cut -d' ' -f1) > $out
+else
+  echo "Neither sha1sum nor shasum command is available"
+  exit 1
+fi

--- a/tools/sha256
+++ b/tools/sha256
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+in=$1
+out=$2
+
+if ( which sha256sum ); then
+  (sha256sum $in | cut -d' ' -f1) > $out
+elif ( which shasum ); then
+  (shasum -a 256 $in | cut -d' ' -f1) > $out
+else
+  echo "Neither sha256sum nor shasum command is available"
+  exit 1
+fi


### PR DESCRIPTION
We can continue to support platforms that have either shasum or
sha1sum / sha256sum.  but we can move that logic to a helper so that
our makefile is simpler, and also so that we can use the same helper
in bazel in future.