### PR TITLE
Automated cherry pick of #7714: Update DigitalOcean CCM to v0.1.20

### DIFF
--- a/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
@@ -47,7 +47,7 @@ spec:
           operator: Exists
           tolerationSeconds: 300
       containers:
-      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.16
+      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.20
         name: digitalocean-cloud-controller-manager
         command:
           - "/bin/digitalocean-cloud-controller-manager"


### PR DESCRIPTION
Cherry pick of #7714 on release-1.15.

#7714: Update DigitalOcean CCM to v0.1.20

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.