### PR TITLE
bazel: fix hashes rule to generate outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -792,10 +792,10 @@ push-node-authorizer:
 .PHONY: bazel-protokube-export
 bazel-protokube-export:
 	mkdir -p ${BAZELIMAGES}
-	bazel build --action_env=PROTOKUBE_TAG=${PROTOKUBE_TAG} --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //images:protokube.tar.gz //images:protokube.tar.gz.hashes
+	bazel build --action_env=PROTOKUBE_TAG=${PROTOKUBE_TAG} --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //images:protokube.tar.gz //images:protokube.tar.gz.sha1  //images:protokube.tar.gz.sha256
 	cp -fp bazel-bin/images/bazel-out/k8-fastbuild/bin/images/protokube.tar.gz ${BAZELIMAGES}/protokube.tar.gz
-	cp -fp bazel-bin/images/protokube.tar.gz.hashes.sha1 ${BAZELIMAGES}/protokube.tar.gz.sha1
-	cp -fp bazel-bin/images/protokube.tar.gz.hashes.sha256 ${BAZELIMAGES}/protokube.tar.gz.sha256
+	cp -fp bazel-bin/images/protokube.tar.gz.sha1 ${BAZELIMAGES}/protokube.tar.gz.sha1
+	cp -fp bazel-bin/images/protokube.tar.gz.sha256 ${BAZELIMAGES}/protokube.tar.gz.sha256
 
 .PHONY: bazel-kops-controller-export
 bazel-kops-controller-export:

--- a/tools/hashes.bzl
+++ b/tools/hashes.bzl
@@ -1,7 +1,7 @@
 def _impl(ctx):
     in_file = ctx.file.src
 
-    basename = ctx.attr.name
+    basename = ctx.attr.src.label.name
     out_sha1 = ctx.actions.declare_file("%s.sha1" % basename)
     ctx.actions.run(
         executable = ctx.executable._cmd_sha1,
@@ -22,6 +22,12 @@ def _impl(ctx):
         files = depset([out_sha1, out_sha256]),
     )
 
+def _get_outputs(src):
+    return {
+        "sha1": src.name + ".sha1",
+        "sha256": src.name + ".sha256",
+    }
+
 hashes = rule(
     implementation = _impl,
     attrs = {
@@ -39,10 +45,7 @@ hashes = rule(
             cfg = "host",
         ),
     },
-    # It looks like we have to do this so that we can reference these outputs in other files
-    # Not entirely sure why, as we can just generate everything ... maybe a bazel bug?
-    outputs = {
-        "sha1": "%{name}.sha1",
-        "sha256": "%{name}.sha256",
-    },
+    # We have to do this so that we can reference these outputs in other files
+    # https://stackoverflow.com/a/50667861
+    outputs = _get_outputs,
 )


### PR DESCRIPTION
So I figured out how to generate the outputs in the correct way so
that we don't need an artificial name; we must construct the outputs
field in the rule using a helper function.