### PR TITLE
Upgrade bazel's rules_go and rules_docker

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,10 +7,10 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 http_archive(
     name = "io_bazel_rules_go",
     urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.19.4/rules_go-0.19.4.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/0.19.4/rules_go-0.19.4.tar.gz",
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.19.5/rules_go-v0.19.5.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.19.5/rules_go-v0.19.5.tar.gz",
     ],
-    sha256 = "ae8c36ff6e565f674c7a3692d6a9ea1096e4c1ade497272c2108a810fb39acd2",
+    sha256 = "513c12397db1bc9aa46dd62f02dd94b49a9b5d17444d49b5a04c5a89f3053c1c",
 )
 
 http_archive(
@@ -40,7 +40,7 @@ gazelle_dependencies()
 git_repository(
     name = "io_bazel_rules_docker",
     remote = "https://github.com/bazelbuild/rules_docker.git",
-    tag = "v0.9.0",
+    tag = "v0.10.1",
 )
 
 load(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,6 +51,13 @@ load(
 container_repositories()
 
 load(
+    "@io_bazel_rules_docker//repositories:go_repositories.bzl",
+    docker_go_deps = "go_deps",
+)
+
+docker_go_deps()
+
+load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_pull",
 )


### PR DESCRIPTION
( rules_go recently started [prefixing their tags with v](https://github.com/bazelbuild/rules_go/tags) )

I was running into [dependency issues](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kops/7727/pull-kops-bazel-test/1179152700873379849) hence the additional load statement, but if theres a simpler way to accomplish that let me know.