### PR TITLE
Custom sysctl Parameters

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -852,3 +852,28 @@ spec:
   assets:
     containerProxy: proxy.example.com
 ```
+
+### Setting Custom Kernel Runtime Parameters
+
+To add custom kernel runtime parameters to your all instance groups in the
+cluster, specify the `sysctlParameters` field as an array of strings. Each
+string must take the form of `variable=value` the way it would appear in
+sysctl.conf (see also `sysctl(8)` manpage).
+
+You could also use the `sysctlParameters` field on [the instance group](https://github.com/kubernetes/kops/blob/master/docs/instance_groups.md#setting-custom-kernel-runtime-parameters) to specify different parameters for each instance group.
+
+Unlike a simple file asset, specifying kernel runtime parameters in this manner
+would correctly invoke `sysctl --system` automatically for you to apply said
+parameters.
+
+For example:
+
+```yaml
+spec:
+  sysctlParameters:
+    - fs.pipe-user-pages-soft=524288
+    - net.ipv4.tcp_keepalive_time=200
+```
+
+which would end up in a drop-in file on all masters and nodes of the cluster.
+

--- a/docs/instance_groups.md
+++ b/docs/instance_groups.md
@@ -574,3 +574,31 @@ spec:
 ```
 
 If `openstack.kops.io/osVolumeSize` is not set it will default to the minimum disk specified by the image.
+
+
+## Setting Custom Kernel Runtime Parameters
+
+To add custom kernel runtime parameters to your instance group, specify the
+`sysctlParameters` field as an array of strings. Each string must take the form
+of `variable=value` the way it would appear in sysctl.conf (see also
+`sysctl(8)` manpage).
+
+Unlike a simple file asset, specifying kernel runtime parameters in this manner
+would correctly invoke `sysctl --system` automatically for you to apply said
+parameters.
+
+For example:
+
+```yaml
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  name: nodes
+spec:
+  sysctlParameters:
+    - fs.pipe-user-pages-soft=524288
+    - net.ipv4.tcp_keepalive_time=200
+```
+
+which would end up in a drop-in file on nodes of the instance group in question.
+

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2689,6 +2689,13 @@ spec:
                     type: string
                 type: object
               type: array
+            sysctlParameters:
+              description: SysctlParameters will configure kernel parameters using
+                sysctl(8). When specified, each parameter must follow the form variable=value,
+                the way it would appear in sysctl.conf.
+              items:
+                type: string
+              type: array
             target:
               description: Target allows for us to nest extra config for targets such
                 as terraform

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -657,6 +657,13 @@ spec:
               items:
                 type: string
               type: array
+            sysctlParameters:
+              description: SysctlParameters will configure kernel parameters using
+                sysctl(8). When specified, each parameter must follow the form variable=value,
+                the way it would appear in sysctl.conf.
+              items:
+                type: string
+              type: array
             taints:
               description: Taints indicates the kubernetes taints for nodes in this
                 group

--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -17,6 +17,7 @@ limitations under the License.
 package model
 
 import (
+	"fmt"
 	"strings"
 
 	"k8s.io/kops/pkg/apis/kops"
@@ -128,6 +129,30 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 		"# Prevent docker from changing iptables: https://github.com/kubernetes/kubernetes/issues/40182",
 		"net.ipv4.ip_forward=1",
 		"")
+
+	if params := b.InstanceGroup.Spec.SysctlParameters; len(params) > 0 {
+		sysctls = append(sysctls,
+			"# Custom sysctl parameters from instance group spec",
+			"")
+		for _, param := range params {
+			if !strings.ContainsRune(param, '=') {
+				return fmt.Errorf("Invalid SysctlParameter: expected %q to contain '='", param)
+			}
+			sysctls = append(sysctls, param)
+		}
+	}
+
+	if params := b.Cluster.Spec.SysctlParameters; len(params) > 0 {
+		sysctls = append(sysctls,
+			"# Custom sysctl parameters from cluster spec",
+			"")
+		for _, param := range params {
+			if !strings.ContainsRune(param, '=') {
+				return fmt.Errorf("Invalid SysctlParameter: expected %q to contain '='", param)
+			}
+			sysctls = append(sysctls, param)
+		}
+	}
 
 	c.AddTask(&nodetasks.File{
 		Path:            "/etc/sysctl.d/99-k8s-general.conf",

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -179,6 +179,10 @@ type ClusterSpec struct {
 	// UseHostCertificates will mount /etc/ssl/certs to inside needed containers.
 	// This is needed if some APIs do have self-signed certs
 	UseHostCertificates *bool `json:"useHostCertificates,omitempty"`
+	// SysctlParameters will configure kernel parameters using sysctl(8). When
+	// specified, each parameter must follow the form variable=value, the way
+	// it would appear in sysctl.conf.
+	SysctlParameters []string `json:"sysctlParameters,omitempty"`
 }
 
 // NodeAuthorizationSpec is used to node authorization

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -151,6 +151,10 @@ type InstanceGroupSpec struct {
 	SecurityGroupOverride *string `json:"securityGroupOverride,omitempty"`
 	// InstanceProtection makes new instances in an autoscaling group protected from scale in
 	InstanceProtection *bool `json:"instanceProtection,omitempty"`
+	// SysctlParameters will configure kernel parameters using sysctl(8). When
+	// specified, each parameter must follow the form variable=value, the way
+	// it would appear in sysctl.conf.
+	SysctlParameters []string `json:"sysctlParameters,omitempty"`
 }
 
 const (

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -177,6 +177,10 @@ type ClusterSpec struct {
 	// UseHostCertificates will mount /etc/ssl/certs to inside needed containers.
 	// This is needed if some APIs do have self-signed certs
 	UseHostCertificates *bool `json:"useHostCertificates,omitempty"`
+	// SysctlParameters will configure kernel parameters using sysctl(8). When
+	// specified, each parameter must follow the form variable=value, the way
+	// it would appear in sysctl.conf.
+	SysctlParameters []string `json:"sysctlParameters,omitempty"`
 }
 
 // NodeAuthorizationSpec is used to node authorization

--- a/pkg/apis/kops/v1alpha1/instancegroup.go
+++ b/pkg/apis/kops/v1alpha1/instancegroup.go
@@ -138,6 +138,10 @@ type InstanceGroupSpec struct {
 	SecurityGroupOverride *string `json:"securityGroupOverride,omitempty"`
 	// InstanceProtection makes new instances in an autoscaling group protected from scale in
 	InstanceProtection *bool `json:"instanceProtection,omitempty"`
+	// SysctlParameters will configure kernel parameters using sysctl(8). When
+	// specified, each parameter must follow the form variable=value, the way
+	// it would appear in sysctl.conf.
+	SysctlParameters []string `json:"sysctlParameters,omitempty"`
 }
 
 const (

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1847,6 +1847,7 @@ func autoConvert_v1alpha1_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 		out.Target = nil
 	}
 	out.UseHostCertificates = in.UseHostCertificates
+	out.SysctlParameters = in.SysctlParameters
 	return nil
 }
 
@@ -2134,6 +2135,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha1_ClusterSpec(in *kops.ClusterSpec, 
 		out.Target = nil
 	}
 	out.UseHostCertificates = in.UseHostCertificates
+	out.SysctlParameters = in.SysctlParameters
 	return nil
 }
 
@@ -2982,6 +2984,7 @@ func autoConvert_v1alpha1_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	}
 	out.SecurityGroupOverride = in.SecurityGroupOverride
 	out.InstanceProtection = in.InstanceProtection
+	out.SysctlParameters = in.SysctlParameters
 	return nil
 }
 
@@ -3103,6 +3106,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha1_InstanceGroupSpec(in *kops.I
 	}
 	out.SecurityGroupOverride = in.SecurityGroupOverride
 	out.InstanceProtection = in.InstanceProtection
+	out.SysctlParameters = in.SysctlParameters
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -803,6 +803,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SysctlParameters != nil {
+		in, out := &in.SysctlParameters, &out.SysctlParameters
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -1666,6 +1671,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		in, out := &in.InstanceProtection, &out.InstanceProtection
 		*out = new(bool)
 		**out = **in
+	}
+	if in.SysctlParameters != nil {
+		in, out := &in.SysctlParameters, &out.SysctlParameters
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -177,6 +177,10 @@ type ClusterSpec struct {
 	// UseHostCertificates will mount /etc/ssl/certs to inside needed containers.
 	// This is needed if some APIs do have self-signed certs
 	UseHostCertificates *bool `json:"useHostCertificates,omitempty"`
+	// SysctlParameters will configure kernel parameters using sysctl(8). When
+	// specified, each parameter must follow the form variable=value, the way
+	// it would appear in sysctl.conf.
+	SysctlParameters []string `json:"sysctlParameters,omitempty"`
 }
 
 // NodeAuthorizationSpec is used to node authorization

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -145,6 +145,10 @@ type InstanceGroupSpec struct {
 	SecurityGroupOverride *string `json:"securityGroupOverride,omitempty"`
 	// InstanceProtection makes new instances in an autoscaling group protected from scale in
 	InstanceProtection *bool `json:"instanceProtection,omitempty"`
+	// SysctlParameters will configure kernel parameters using sysctl(8). When
+	// specified, each parameter must follow the form variable=value, the way
+	// it would appear in sysctl.conf.
+	SysctlParameters []string `json:"sysctlParameters,omitempty"`
 }
 
 const (

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1900,6 +1900,7 @@ func autoConvert_v1alpha2_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 		out.Target = nil
 	}
 	out.UseHostCertificates = in.UseHostCertificates
+	out.SysctlParameters = in.SysctlParameters
 	return nil
 }
 
@@ -2202,6 +2203,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, 
 		out.Target = nil
 	}
 	out.UseHostCertificates = in.UseHostCertificates
+	out.SysctlParameters = in.SysctlParameters
 	return nil
 }
 
@@ -3100,6 +3102,7 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	}
 	out.SecurityGroupOverride = in.SecurityGroupOverride
 	out.InstanceProtection = in.InstanceProtection
+	out.SysctlParameters = in.SysctlParameters
 	return nil
 }
 
@@ -3226,6 +3229,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	}
 	out.SecurityGroupOverride = in.SecurityGroupOverride
 	out.InstanceProtection = in.InstanceProtection
+	out.SysctlParameters = in.SysctlParameters
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -776,6 +776,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SysctlParameters != nil {
+		in, out := &in.SysctlParameters, &out.SysctlParameters
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -1628,6 +1633,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		in, out := &in.InstanceProtection, &out.InstanceProtection
 		*out = new(bool)
 		**out = **in
+	}
+	if in.SysctlParameters != nil {
+		in, out := &in.SysctlParameters, &out.SysctlParameters
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -876,6 +876,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SysctlParameters != nil {
+		in, out := &in.SysctlParameters, &out.SysctlParameters
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -1794,6 +1799,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		in, out := &in.InstanceProtection, &out.InstanceProtection
 		*out = new(bool)
 		**out = **in
+	}
+	if in.SysctlParameters != nil {
+		in, out := &in.SysctlParameters, &out.SysctlParameters
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }


### PR DESCRIPTION
This adds a new `sysctlParameters` to cluster spec and instance group spec to allow setting custom runtime kernel parameters.

I needed to be able to set sysctl parameters on our nodes. I considered adding a file asset, but we can't currently set the `OnChangeExecute` of a `File` nodetask that way. Since we already have a sysctl builder, this change seemed to be an obvious one.