### PR TITLE
nodeup download: try to use compression

### DIFF
--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -71,35 +71,30 @@ download-or-bust() {
   urls=( $* )
   while true; do
     for url in "${urls[@]}"; do
-      if [[ -e "${file}" ]]; then
-        echo "== File exists for ${url} =="
-
-      # CoreOS runs this script in a container without which (but has curl)
-      # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-      # So we default to wget unless we see curl
-      elif [[ $(curl --version) ]]; then
-        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-          echo "== Failed to curl ${url}. Retrying. =="
+      commands=(
+        "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+      )
+      for cmd in "${commands[@]}"; do
+        echo "Attempting download with: ${cmd} {url}"
+        if ! (${cmd} "${url}"); then
+          echo "== Download failed with ${cmd} =="
           continue
         fi
-      else
-        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-          echo "== Failed to wget ${url}. Retrying. =="
-          continue
-        fi
-      fi
-
-      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-        echo "== Hash validation of ${url} failed. Retrying. =="
-        rm -f "${file}"
-      else
-        if [[ -n "${hash}" ]]; then
-          echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+          echo "== Hash validation of ${url} failed. Retrying. =="
+          rm -f "${file}"
         else
-          echo "== Downloaded ${url} =="
+          if [[ -n "${hash}" ]]; then
+            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          else
+            echo "== Downloaded ${url} =="
+          fi
+          return
         fi
-        return
-      fi
+      done
     done
 
     echo "All downloads failed; sleeping before retrying"

--- a/pkg/model/tests/data/bootstrapscript_0.txt
+++ b/pkg/model/tests/data/bootstrapscript_0.txt
@@ -60,35 +60,30 @@ download-or-bust() {
   urls=( $* )
   while true; do
     for url in "${urls[@]}"; do
-      if [[ -e "${file}" ]]; then
-        echo "== File exists for ${url} =="
-
-      # CoreOS runs this script in a container without which (but has curl)
-      # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-      # So we default to wget unless we see curl
-      elif [[ $(curl --version) ]]; then
-        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-          echo "== Failed to curl ${url}. Retrying. =="
+      commands=(
+        "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+      )
+      for cmd in "${commands[@]}"; do
+        echo "Attempting download with: ${cmd} {url}"
+        if ! (${cmd} "${url}"); then
+          echo "== Download failed with ${cmd} =="
           continue
         fi
-      else
-        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-          echo "== Failed to wget ${url}. Retrying. =="
-          continue
-        fi
-      fi
-
-      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-        echo "== Hash validation of ${url} failed. Retrying. =="
-        rm -f "${file}"
-      else
-        if [[ -n "${hash}" ]]; then
-          echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+          echo "== Hash validation of ${url} failed. Retrying. =="
+          rm -f "${file}"
         else
-          echo "== Downloaded ${url} =="
+          if [[ -n "${hash}" ]]; then
+            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          else
+            echo "== Downloaded ${url} =="
+          fi
+          return
         fi
-        return
-      fi
+      done
     done
 
     echo "All downloads failed; sleeping before retrying"

--- a/pkg/model/tests/data/bootstrapscript_1.txt
+++ b/pkg/model/tests/data/bootstrapscript_1.txt
@@ -60,35 +60,30 @@ download-or-bust() {
   urls=( $* )
   while true; do
     for url in "${urls[@]}"; do
-      if [[ -e "${file}" ]]; then
-        echo "== File exists for ${url} =="
-
-      # CoreOS runs this script in a container without which (but has curl)
-      # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-      # So we default to wget unless we see curl
-      elif [[ $(curl --version) ]]; then
-        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-          echo "== Failed to curl ${url}. Retrying. =="
+      commands=(
+        "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+      )
+      for cmd in "${commands[@]}"; do
+        echo "Attempting download with: ${cmd} {url}"
+        if ! (${cmd} "${url}"); then
+          echo "== Download failed with ${cmd} =="
           continue
         fi
-      else
-        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-          echo "== Failed to wget ${url}. Retrying. =="
-          continue
-        fi
-      fi
-
-      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-        echo "== Hash validation of ${url} failed. Retrying. =="
-        rm -f "${file}"
-      else
-        if [[ -n "${hash}" ]]; then
-          echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+          echo "== Hash validation of ${url} failed. Retrying. =="
+          rm -f "${file}"
         else
-          echo "== Downloaded ${url} =="
+          if [[ -n "${hash}" ]]; then
+            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          else
+            echo "== Downloaded ${url} =="
+          fi
+          return
         fi
-        return
-      fi
+      done
     done
 
     echo "All downloads failed; sleeping before retrying"

--- a/pkg/model/tests/data/bootstrapscript_2.txt
+++ b/pkg/model/tests/data/bootstrapscript_2.txt
@@ -60,35 +60,30 @@ download-or-bust() {
   urls=( $* )
   while true; do
     for url in "${urls[@]}"; do
-      if [[ -e "${file}" ]]; then
-        echo "== File exists for ${url} =="
-
-      # CoreOS runs this script in a container without which (but has curl)
-      # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-      # So we default to wget unless we see curl
-      elif [[ $(curl --version) ]]; then
-        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-          echo "== Failed to curl ${url}. Retrying. =="
+      commands=(
+        "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+      )
+      for cmd in "${commands[@]}"; do
+        echo "Attempting download with: ${cmd} {url}"
+        if ! (${cmd} "${url}"); then
+          echo "== Download failed with ${cmd} =="
           continue
         fi
-      else
-        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-          echo "== Failed to wget ${url}. Retrying. =="
-          continue
-        fi
-      fi
-
-      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-        echo "== Hash validation of ${url} failed. Retrying. =="
-        rm -f "${file}"
-      else
-        if [[ -n "${hash}" ]]; then
-          echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+          echo "== Hash validation of ${url} failed. Retrying. =="
+          rm -f "${file}"
         else
-          echo "== Downloaded ${url} =="
+          if [[ -n "${hash}" ]]; then
+            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          else
+            echo "== Downloaded ${url} =="
+          fi
+          return
         fi
-        return
-      fi
+      done
     done
 
     echo "All downloads failed; sleeping before retrying"

--- a/pkg/model/tests/data/bootstrapscript_3.txt
+++ b/pkg/model/tests/data/bootstrapscript_3.txt
@@ -60,35 +60,30 @@ download-or-bust() {
   urls=( $* )
   while true; do
     for url in "${urls[@]}"; do
-      if [[ -e "${file}" ]]; then
-        echo "== File exists for ${url} =="
-
-      # CoreOS runs this script in a container without which (but has curl)
-      # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-      # So we default to wget unless we see curl
-      elif [[ $(curl --version) ]]; then
-        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-          echo "== Failed to curl ${url}. Retrying. =="
+      commands=(
+        "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+      )
+      for cmd in "${commands[@]}"; do
+        echo "Attempting download with: ${cmd} {url}"
+        if ! (${cmd} "${url}"); then
+          echo "== Download failed with ${cmd} =="
           continue
         fi
-      else
-        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-          echo "== Failed to wget ${url}. Retrying. =="
-          continue
-        fi
-      fi
-
-      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-        echo "== Hash validation of ${url} failed. Retrying. =="
-        rm -f "${file}"
-      else
-        if [[ -n "${hash}" ]]; then
-          echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+          echo "== Hash validation of ${url} failed. Retrying. =="
+          rm -f "${file}"
         else
-          echo "== Downloaded ${url} =="
+          if [[ -n "${hash}" ]]; then
+            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          else
+            echo "== Downloaded ${url} =="
+          fi
+          return
         fi
-        return
-      fi
+      done
     done
 
     echo "All downloads failed; sleeping before retrying"

--- a/pkg/model/tests/data/bootstrapscript_4.txt
+++ b/pkg/model/tests/data/bootstrapscript_4.txt
@@ -60,35 +60,30 @@ download-or-bust() {
   urls=( $* )
   while true; do
     for url in "${urls[@]}"; do
-      if [[ -e "${file}" ]]; then
-        echo "== File exists for ${url} =="
-
-      # CoreOS runs this script in a container without which (but has curl)
-      # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-      # So we default to wget unless we see curl
-      elif [[ $(curl --version) ]]; then
-        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-          echo "== Failed to curl ${url}. Retrying. =="
+      commands=(
+        "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+      )
+      for cmd in "${commands[@]}"; do
+        echo "Attempting download with: ${cmd} {url}"
+        if ! (${cmd} "${url}"); then
+          echo "== Download failed with ${cmd} =="
           continue
         fi
-      else
-        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-          echo "== Failed to wget ${url}. Retrying. =="
-          continue
-        fi
-      fi
-
-      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-        echo "== Hash validation of ${url} failed. Retrying. =="
-        rm -f "${file}"
-      else
-        if [[ -n "${hash}" ]]; then
-          echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+          echo "== Hash validation of ${url} failed. Retrying. =="
+          rm -f "${file}"
         else
-          echo "== Downloaded ${url} =="
+          if [[ -n "${hash}" ]]; then
+            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          else
+            echo "== Downloaded ${url} =="
+          fi
+          return
         fi
-        return
-      fi
+      done
     done
 
     echo "All downloads failed; sleeping before retrying"

--- a/pkg/model/tests/data/bootstrapscript_5.txt
+++ b/pkg/model/tests/data/bootstrapscript_5.txt
@@ -60,35 +60,30 @@ download-or-bust() {
   urls=( $* )
   while true; do
     for url in "${urls[@]}"; do
-      if [[ -e "${file}" ]]; then
-        echo "== File exists for ${url} =="
-
-      # CoreOS runs this script in a container without which (but has curl)
-      # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-      # So we default to wget unless we see curl
-      elif [[ $(curl --version) ]]; then
-        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-          echo "== Failed to curl ${url}. Retrying. =="
+      commands=(
+        "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+      )
+      for cmd in "${commands[@]}"; do
+        echo "Attempting download with: ${cmd} {url}"
+        if ! (${cmd} "${url}"); then
+          echo "== Download failed with ${cmd} =="
           continue
         fi
-      else
-        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-          echo "== Failed to wget ${url}. Retrying. =="
-          continue
-        fi
-      fi
-
-      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-        echo "== Hash validation of ${url} failed. Retrying. =="
-        rm -f "${file}"
-      else
-        if [[ -n "${hash}" ]]; then
-          echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+          echo "== Hash validation of ${url} failed. Retrying. =="
+          rm -f "${file}"
         else
-          echo "== Downloaded ${url} =="
+          if [[ -n "${hash}" ]]; then
+            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          else
+            echo "== Downloaded ${url} =="
+          fi
+          return
         fi
-        return
-      fi
+      done
     done
 
     echo "All downloads failed; sleeping before retrying"

--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
@@ -45,35 +45,30 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"
@@ -338,35 +333,30 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -54,35 +54,30 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"
@@ -367,35 +362,30 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"

--- a/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
@@ -45,35 +45,30 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscomplexexampleco
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"
@@ -340,35 +335,30 @@ Resources.AWSAutoScalingLaunchConfigurationnodescomplexexamplecom.Properties.Use
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -45,35 +45,30 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"
@@ -338,35 +333,30 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -45,35 +45,30 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"
@@ -338,35 +333,30 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -45,35 +45,30 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"
@@ -338,35 +333,30 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
@@ -45,35 +45,30 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"
@@ -340,35 +335,30 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"
@@ -635,35 +625,30 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"
@@ -930,35 +915,30 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
@@ -45,35 +45,30 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"
@@ -340,35 +335,30 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"
@@ -635,35 +625,30 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"
@@ -930,35 +915,30 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
     urls=( $* )
     while true; do
       for url in "${urls[@]}"; do
-        if [[ -e "${file}" ]]; then
-          echo "== File exists for ${url} =="
-
-        # CoreOS runs this script in a container without which (but has curl)
-        # Note also that busybox wget doesn't support wget --version, but busybox doesn't normally have curl
-        # So we default to wget unless we see curl
-        elif [[ $(curl --version) ]]; then
-          if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then
-            echo "== Failed to curl ${url}. Retrying. =="
+        commands=(
+          "curl -f --ipv4 --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+          "curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+          "wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        )
+        for cmd in "${commands[@]}"; do
+          echo "Attempting download with: ${cmd} {url}"
+          if ! (${cmd} "${url}"); then
+            echo "== Download failed with ${cmd} =="
             continue
           fi
-        else
-          if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then
-            echo "== Failed to wget ${url}. Retrying. =="
-            continue
-          fi
-        fi
-
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
+            echo "== Hash validation of ${url} failed. Retrying. =="
+            rm -f "${file}"
           else
-            echo "== Downloaded ${url} =="
+            if [[ -n "${hash}" ]]; then
+              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+            else
+              echo "== Downloaded ${url} =="
+            fi
+            return
           fi
-          return
-        fi
+        done
       done
 
       echo "All downloads failed; sleeping before retrying"


### PR DESCRIPTION
We pass the appropriate flag to curl / wget, but where it fails we fall
back to not using compression.

Also simplify the code paths here, as it has proven so tricky - we simply
try a sequence of commands until we successful download and a hash match.