### PR TITLE
Add optional RBE support for kops

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,23 +6,23 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "io_bazel_rules_go",
+    sha256 = "513c12397db1bc9aa46dd62f02dd94b49a9b5d17444d49b5a04c5a89f3053c1c",
     urls = [
         "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.19.5/rules_go-v0.19.5.tar.gz",
         "https://github.com/bazelbuild/rules_go/releases/download/v0.19.5/rules_go-v0.19.5.tar.gz",
     ],
-    sha256 = "513c12397db1bc9aa46dd62f02dd94b49a9b5d17444d49b5a04c5a89f3053c1c",
 )
 
 http_archive(
     name = "bazel_gazelle",
+    sha256 = "7fc87f4170011201b1690326e8c16c5d802836e3a0d617d8f75c3af2b23180c4",
     urls = [
         "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-gazelle/releases/download/0.18.2/bazel-gazelle-0.18.2.tar.gz",
         "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.2/bazel-gazelle-0.18.2.tar.gz",
     ],
-    sha256 = "7fc87f4170011201b1690326e8c16c5d802836e3a0d617d8f75c3af2b23180c4",
 )
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
@@ -39,8 +39,10 @@ gazelle_dependencies()
 
 git_repository(
     name = "io_bazel_rules_docker",
+    commit = "267cc613f61921caa5540a6a9437d939f953a90b",
     remote = "https://github.com/bazelbuild/rules_docker.git",
-    tag = "v0.10.1",
+    shallow_since = "1568404961 -0400",
+    # tag = "v0.10.1",
 )
 
 load(
@@ -49,6 +51,10 @@ load(
 )
 
 container_repositories()
+
+load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
+
+container_deps()
 
 load(
     "@io_bazel_rules_docker//repositories:go_repositories.bzl",
@@ -73,8 +79,9 @@ container_pull(
 
 git_repository(
     name = "distroless",
+    commit = "f905a6636c5106c36cc979bdcc19f0fe4fc01ede",
     remote = "https://github.com/googlecloudplatform/distroless.git",
-    commit = "fa0765cc86064801e42a3b35f50ff2242aca9998",
+    shallow_since = "1570036739 -0700",
 )
 
 load(
@@ -86,8 +93,8 @@ package_manager_repositories()
 
 load(
     "@distroless//package_manager:dpkg.bzl",
-    "dpkg_src",
     "dpkg_list",
+    "dpkg_src",
 )
 
 dpkg_src(
@@ -114,8 +121,8 @@ dpkg_list(
         "libprocps6",
         "libseccomp2",
         "procps",
-        "systemd-shim",
         "systemd",
+        "systemd-shim",
     ],
     sources = [
         "@debian_stretch//file:Packages.json",
@@ -127,16 +134,31 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 http_file(
     name = "utils_tar_gz",
-    urls = ["https://kubeupv2.s3.amazonaws.com/kops/1.12.1/linux/amd64/utils.tar.gz"],
     sha256 = "5c956247241dd94300ba13c6dd9cb5843382d4255125a7a6639d2aad68b9050c",
+    urls = ["https://kubeupv2.s3.amazonaws.com/kops/1.12.1/linux/amd64/utils.tar.gz"],
 )
 
+# TODO(fejta): use load.bzl, repos.bzl from repo-infra
 git_repository(
     name = "io_k8s_repo_infra",
-    commit = "f85734f673056977d8ba04b0386394b684ca2acb",
+    commit = "db6ceb5f992254db76af7c25db2edc5469b5ea82",
     remote = "https://github.com/kubernetes/repo-infra.git",
-    shallow_since = "1563324513 -0800",
+    shallow_since = "1570128715 -0700",
 )
+
+http_archive(
+    name = "bazel_toolchains",
+    sha256 = "a019fbd579ce5aed0239de865b2d8281dbb809efd537bf42e0d366783e8dec65",
+    strip_prefix = "bazel-toolchains-0.29.2",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.29.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/archive/0.29.2.tar.gz",
+    ],
+)
+
+load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
+
+rbe_autoconfig(name = "rbe_default")
 
 go_repository(
     name = "com_github_google_go_containerregistry",

--- a/images/BUILD.bazel
+++ b/images/BUILD.bazel
@@ -2,8 +2,8 @@ package(default_visibility = ["//visibility:public"])
 
 load(
     "@io_bazel_rules_docker//container:container.bzl",
-    "container_image",
     "container_bundle",
+    "container_image",
 )
 
 container_image(
@@ -56,6 +56,7 @@ container_image(
         "/usr/bin/channels": "/channels",
         "/usr/bin/protokube": "/protokube",
     },
+    tags = ["local"],  # TODO(fejta): make xz toolchain hermetic
 )
 
 container_bundle(

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -16,3 +16,45 @@ build --verbose_failures
 build --host_force_python=PY2
 
 test --test_output=errors
+
+
+# RBE configuration
+# Note needs an instance name
+# https://github.com/bazelbuild/bazel-toolchains/blob/master/bazelrc/bazel-0.27.0.bazelrc
+build:remote --jobs=500
+build:remote --host_javabase=@rbe_default//java:jdk
+build:remote --javabase=@rbe_default//java:jdk
+build:remote --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:remote --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:remote --crosstool_top=@rbe_default//cc:toolchain
+build:remote --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+
+build:remote --extra_toolchains=@rbe_default//config:cc-toolchain
+build:remote --extra_execution_platforms=@io_k8s_repo_infra//:rbe_with_network
+build:remote --host_platform=@io_k8s_repo_infra//:rbe_with_network
+build:remote --platforms=@io_k8s_repo_infra//:rbe_with_network
+
+build:remote --define=EXECUTOR=remote
+build:remote --remote_executor=grpcs://remotebuildexecution.googleapis.com
+build:remote --remote_timeout=3600
+
+# Alt: --google_credentials=some_file.json
+build:remote --google_default_credentials=true
+
+# Minimize what is downloaded
+build:inmemory --experimental_inmemory_jdeps_files
+build:inmemory --experimental_inmemory_dotd_files
+
+# Minimize what is downloaded
+build:toplevel --config=inmemory
+build:toplevel --experimental_remote_download_outputs=toplevel
+
+build:minimal --config=inmemory
+build:minimal --experimental_remote_download_outputs=minimal
+
+build:remote --config=toplevel
+test:remote --incompatible_allow_tags_propagation # //images:protokube-image fails to find xz on rbe
+
+run:remote --experimental_remote_download_outputs=all --noexperimental_inmemory_jdeps_files --noexperimental_inmemory_dotd_files
+
+build:ci --host_force_python=PY2 # TODO(fejta): noop stub to allow CI to use --config=ci


### PR DESCRIPTION
* Run WORKSPACE and tools/BUILD.bazel through buildifier
* Translate tag into commit for rules_docker (better caching/performance)
* Update repo-infra to latest
* Add rbe_autoconfig repo
* Add rbe config to bazelrc
  - enable with `--config=remote --remote_instance_name=projects/PROJ/instances/default_instance`, see https://github.com/kubernetes/test-infra/blob/master/rbe/configure.sh

/assign @justinsb 

Next things to do:
* Configure this repo's prow jobs to start using --config=ci (currently does nothing)
* Configure CI jobs to start using RBE
* Start using more interesting stuff from repo-infra