### PR TITLE
Guard External cloud controller manager with its feature flag

### DIFF
--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kops/cmd/kops/util"
 	kopsapi "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/v1alpha1"
+	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/kopscodecs"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"k8s.io/kops/util/pkg/text"
@@ -147,6 +148,9 @@ func RunCreate(f *util.Factory, out io.Writer, c *CreateOptions) error {
 
 			switch v := o.(type) {
 			case *kopsapi.Cluster:
+				if v.Spec.ExternalCloudControllerManager != nil && !featureflag.EnableExternalCloudController.Enabled() {
+					klog.Warningf("Without setting the feature flag `+EnableExternalCloudController` the external cloud controller manager configuration will be discarded")
+				}
 				// Adding a PerformAssignments() call here as the user might be trying to use
 				// the new `-f` feature, with an old cluster definition.
 				err = cloudup.PerformAssignments(v)

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -1217,6 +1217,10 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		return fmt.Errorf("error populating configuration: %v", err)
 	}
 
+	if cluster.Spec.ExternalCloudControllerManager != nil && !featureflag.EnableExternalCloudController.Enabled() {
+		klog.Warningf("Without setting the feature flag `+EnableExternalCloudController` the external cloud controller manager configuration will be discarded")
+	}
+
 	strict := false
 	err = validation.DeepValidate(cluster, instanceGroups, strict)
 	if err != nil {

--- a/cmd/kops/replace.go
+++ b/cmd/kops/replace.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kops/cmd/kops/util"
 	kopsapi "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/commands"
+	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/kopscodecs"
 	"k8s.io/kops/util/pkg/text"
 	"k8s.io/kops/util/pkg/vfs"
@@ -117,6 +118,9 @@ func RunReplace(f *util.Factory, cmd *cobra.Command, out io.Writer, c *replaceOp
 			switch v := o.(type) {
 			case *kopsapi.Cluster:
 				{
+					if v.Spec.ExternalCloudControllerManager != nil && !featureflag.EnableExternalCloudController.Enabled() {
+						klog.Warningf("Without setting the feature flag `+EnableExternalCloudController` the external cloud controller manager configuration will be discarded")
+					}
 					// Retrieve the current status of the cluster.  This will eventually be part of the cluster object.
 					statusDiscovery := &commands.CloudDiscoveryStatusStore{}
 					status, err := statusDiscovery.FindClusterStatus(v)

--- a/pkg/model/components/BUILD.bazel
+++ b/pkg/model/components/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/apis/kops:go_default_library",
         "//pkg/apis/kops/util:go_default_library",
         "//pkg/assets:go_default_library",
+        "//pkg/featureflag:go_default_library",
         "//pkg/k8sversion:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/gce:go_default_library",

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/loader"
 
@@ -167,7 +168,7 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 		return fmt.Errorf("unknown cloudprovider %q", clusterSpec.CloudProvider)
 	}
 
-	if clusterSpec.ExternalCloudControllerManager != nil {
+	if featureflag.EnableExternalCloudController.Enabled() && clusterSpec.ExternalCloudControllerManager != nil {
 		c.CloudProvider = "external"
 	}
 

--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/util"
+	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/loader"
@@ -123,7 +124,7 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 		return fmt.Errorf("unknown cloudprovider %q", clusterSpec.CloudProvider)
 	}
 
-	if clusterSpec.ExternalCloudControllerManager != nil {
+	if featureflag.EnableExternalCloudController.Enabled() && clusterSpec.ExternalCloudControllerManager != nil {
 		kcm.CloudProvider = "external"
 	}
 

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/loader"
 )
@@ -215,7 +216,7 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.Kubelet.CloudProvider = "alicloud"
 	}
 
-	if clusterSpec.ExternalCloudControllerManager != nil {
+	if featureflag.EnableExternalCloudController.Enabled() && clusterSpec.ExternalCloudControllerManager != nil {
 		clusterSpec.Kubelet.CloudProvider = "external"
 	}
 


### PR DESCRIPTION
Previously when setting the external cloud controller manager configuration the core components `kubelet`, `apiserver` and `kubecontroller-manager` were configured to use the external cloud controller manager. Without setting the feature flag `EnableExternalCloudController` this lead to a cluster in which the masters had the node taint `node.cloudprovider.kubernetes.io/uninitialized` which prevents essential pods, like dns-controller to not be scheduled and leaves a cluster where worker nodes can't connect to the api server because they cannot resolve its hostname.