### PR TITLE
fixed yum proxy configuration

### DIFF
--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -402,7 +402,7 @@ func (b *BootstrapScript) createProxyEnv(ps *kops.EgressProxySpec) string {
 		buffer.WriteString("*[Uu]buntu*)\n")
 		buffer.WriteString(`  echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;` + "\n")
 		buffer.WriteString("*[Rr]ed[Hh]at*)\n")
-		buffer.WriteString(`  echo "http_proxy=${http_proxy}" >> /etc/yum.conf ;;` + "\n")
+		buffer.WriteString(`  echo "proxy=${http_proxy}" >> /etc/yum.conf ;;` + "\n")
 		buffer.WriteString("esac\n")
 
 		// Set env variables for systemd

--- a/pkg/model/tests/data/bootstrapscript_0.txt
+++ b/pkg/model/tests/data/bootstrapscript_0.txt
@@ -34,7 +34,7 @@ case `cat /proc/version` in
 *[Uu]buntu*)
   echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
 *[Rr]ed[Hh]at*)
-  echo "http_proxy=${http_proxy}" >> /etc/yum.conf ;;
+  echo "proxy=${http_proxy}" >> /etc/yum.conf ;;
 esac
 echo "DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\"" >> /etc/systemd/system.conf
 systemctl daemon-reload

--- a/pkg/model/tests/data/bootstrapscript_1.txt
+++ b/pkg/model/tests/data/bootstrapscript_1.txt
@@ -34,7 +34,7 @@ case `cat /proc/version` in
 *[Uu]buntu*)
   echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
 *[Rr]ed[Hh]at*)
-  echo "http_proxy=${http_proxy}" >> /etc/yum.conf ;;
+  echo "proxy=${http_proxy}" >> /etc/yum.conf ;;
 esac
 echo "DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\"" >> /etc/systemd/system.conf
 systemctl daemon-reload

--- a/pkg/model/tests/data/bootstrapscript_2.txt
+++ b/pkg/model/tests/data/bootstrapscript_2.txt
@@ -34,7 +34,7 @@ case `cat /proc/version` in
 *[Uu]buntu*)
   echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
 *[Rr]ed[Hh]at*)
-  echo "http_proxy=${http_proxy}" >> /etc/yum.conf ;;
+  echo "proxy=${http_proxy}" >> /etc/yum.conf ;;
 esac
 echo "DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\"" >> /etc/systemd/system.conf
 systemctl daemon-reload

--- a/pkg/model/tests/data/bootstrapscript_3.txt
+++ b/pkg/model/tests/data/bootstrapscript_3.txt
@@ -34,7 +34,7 @@ case `cat /proc/version` in
 *[Uu]buntu*)
   echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
 *[Rr]ed[Hh]at*)
-  echo "http_proxy=${http_proxy}" >> /etc/yum.conf ;;
+  echo "proxy=${http_proxy}" >> /etc/yum.conf ;;
 esac
 echo "DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\"" >> /etc/systemd/system.conf
 systemctl daemon-reload

--- a/pkg/model/tests/data/bootstrapscript_4.txt
+++ b/pkg/model/tests/data/bootstrapscript_4.txt
@@ -34,7 +34,7 @@ case `cat /proc/version` in
 *[Uu]buntu*)
   echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
 *[Rr]ed[Hh]at*)
-  echo "http_proxy=${http_proxy}" >> /etc/yum.conf ;;
+  echo "proxy=${http_proxy}" >> /etc/yum.conf ;;
 esac
 echo "DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\"" >> /etc/systemd/system.conf
 systemctl daemon-reload

--- a/pkg/model/tests/data/bootstrapscript_5.txt
+++ b/pkg/model/tests/data/bootstrapscript_5.txt
@@ -34,7 +34,7 @@ case `cat /proc/version` in
 *[Uu]buntu*)
   echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/30proxy ;;
 *[Rr]ed[Hh]at*)
-  echo "http_proxy=${http_proxy}" >> /etc/yum.conf ;;
+  echo "proxy=${http_proxy}" >> /etc/yum.conf ;;
 esac
 echo "DefaultEnvironment=\"http_proxy=${http_proxy}\" \"https_proxy=${http_proxy}\" \"NO_PROXY=${no_proxy}\" \"no_proxy=${no_proxy}\"" >> /etc/systemd/system.conf
 systemctl daemon-reload


### PR DESCRIPTION
The current yum proxy configuration for rhel is invalid and has no effect on pointing yum operations via a proxy.

Check https://linux.die.net/man/5/yum.conf

The proxy config option for yum is "proxy" not "http_proxy"