### PR TITLE
Set default image for OpenStack CCM

### DIFF
--- a/docs/getting_started/openstack.md
+++ b/docs/getting_started/openstack.md
@@ -115,7 +115,7 @@ If you want use [External CCM](https://github.com/kubernetes/cloud-provider-open
 Enable featureflag:
 
 ```
-export KOPS_FEATURE_FLAGS=+EnableExternalCloudController
+export KOPS_FEATURE_FLAGS=EnableExternalCloudController
 ```
 
 Create cluster without `--yes` flag (or modify existing cluster):
@@ -127,9 +127,7 @@ kops edit cluster <cluster>
 Add following to clusterspec:
 
 ```
-  cloudControllerManager:
-    image: jesseh/occm:latest <- you can use this or compile your own
-    logLevel: 2
+  cloudControllerManager: {}
 ```
 
 Finally

--- a/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
+++ b/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
@@ -1,0 +1,213 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+  labels:
+    k8s-app: openstack-cloud-provider
+    k8s-addon: openstack.addons.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-node-controller
+  labels:
+    k8s-app: openstack-cloud-provider
+    k8s-addon: openstack.addons.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-node-controller
+subjects:
+- kind: ServiceAccount
+  name: cloud-node-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-controller-manager
+  labels:
+    k8s-app: openstack-cloud-provider
+    k8s-addon: openstack.addons.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:cloud-controller-manager
+  labels:
+    k8s-app: openstack-cloud-provider
+    k8s-addon: openstack.addons.k8s.io
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:cloud-node-controller
+  labels:
+    k8s-app: openstack-cloud-provider
+    k8s-addon: openstack.addons.k8s.io
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: kube-system
+  name: openstack-cloud-provider
+  labels:
+    k8s-app: openstack-cloud-provider
+    k8s-addon: openstack.addons.k8s.io
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: openstack-cloud-provider
+  template:
+    metadata:
+      labels:
+        name: openstack-cloud-provider
+    spec:
+      # run on the host network (don't depend on CNI)
+      hostNetwork: true
+      # run on each master node
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsUser: 1001
+      serviceAccountName: cloud-controller-manager
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      containers:
+      - name: openstack-cloud-controller-manager
+        image: "{{- if .ExternalCloudControllerManager.Image -}} {{ .ExternalCloudControllerManager.Image }} {{- else -}} {{OpenStackCCM}} {{- end -}}"
+        args:
+          - /bin/openstack-cloud-controller-manager
+          - --v={{ if .ExternalCloudControllerManager.LogLevel -}} {{ .ExternalCloudControllerManager.LogLevel }} {{- else }}2{{ end }}
+          - --cloud-config=/etc/kubernetes/cloud.config
+          - --cloud-provider=openstack
+          - --use-service-account-credentials=true
+          - --address=127.0.0.1
+        resources:
+          requests:
+            cpu: 200m
+        volumeMounts:
+        - mountPath: /etc/kubernetes/cloud.config
+          name: cloudconfig
+          readOnly: true
+{{ if .UseHostCertificates }}
+        - mountPath: /etc/ssl/certs
+          name: etc-ssl-certs
+          readOnly: true
+{{ end }}
+      volumes:
+      - hostPath:
+          path: /etc/kubernetes/cloud.config
+        name: cloudconfig
+{{ if .UseHostCertificates }}
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: etc-ssl-certs
+{{ end }}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -1230,7 +1230,23 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 					Version:           fi.String(version),
 					Manifest:          fi.String(location),
 					Selector:          map[string]string{"k8s-addon": key},
-					KubernetesVersion: ">=1.11.0",
+					KubernetesVersion: ">=1.11.0 <1.13.0",
+					Id:                id,
+				})
+			}
+			{
+				key := "openstack.addons.k8s.io"
+				version := "1.13.0"
+
+				location := key + "/k8s-1.13.yaml"
+				id := "k8s-1.13-ccm"
+
+				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+					Name:              fi.String(key),
+					Version:           fi.String(version),
+					Manifest:          fi.String(location),
+					Selector:          map[string]string{"k8s-addon": key},
+					KubernetesVersion: ">=1.13.0",
 					Id:                id,
 				})
 			}


### PR DESCRIPTION
currently people needs to setup openstack cloud-controller-manager images by themselves. This is not that good as it should be. This PR will setup the default image for ccm, but it will still allow to customise the image if needed. This PR will also setup the default loglevel to 2 (which can be changed if needed)

cc @mitch000001 