### PR TITLE
Upload dns-controller archive, use in KOPS_BASE_URL

### DIFF
--- a/dns-controller/cmd/dns-controller/BUILD.bazel
+++ b/dns-controller/cmd/dns-controller/BUILD.bazel
@@ -1,3 +1,5 @@
+package(default_visibility = ["//visibility:public"])
+
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -31,4 +33,37 @@ go_binary(
     name = "dns-controller",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+)
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_image",
+    "container_push",
+    "container_bundle",
+)
+
+container_image(
+    name = "image",
+    base = "@distroless_base//image",
+    cmd = ["/usr/bin/dns-controller"],
+    directory = "/usr/bin/",
+    files = [
+        "dns-controller",
+    ],
+)
+
+container_push(
+    name = "push-image",
+    format = "Docker",
+    image = ":image",
+    registry = "{STABLE_DOCKER_REGISTRY}",
+    repository = "{STABLE_DOCKER_IMAGE_PREFIX}dns-controller",
+    tag = "{STABLE_DNS_CONTROLLER_TAG}",
+)
+
+container_bundle(
+    name = "image-bundle",
+    images = {
+        "{STABLE_DOCKER_IMAGE_PREFIX}dns-controller:{STABLE_DNS_CONTROLLER_TAG}": "image",
+    },
 )

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1311,7 +1311,7 @@ func (c *ApplyClusterCmd) BuildNodeUpConfig(assetBuilder *assets.AssetBuilder, i
 	// `docker load` our images when using a KOPS_BASE_URL, so we
 	// don't need to push/pull from a registry
 	if os.Getenv("KOPS_BASE_URL") != "" {
-		for _, name := range []string{"kops-controller" /* TODO:  "dns-controller" */} {
+		for _, name := range []string{"kops-controller", "dns-controller"} {
 			baseURL, err := url.Parse(os.Getenv("KOPS_BASE_URL"))
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Like we recently did with kops-controller, this means we aren't
reliant on pushing a docker container for development.  This should
also fix the e2e tests, which otherwise break whenever we make an
incompatible change to dns-controller.