### PR TITLE
bazel: remove deprecated stamp attribute from container building

### DIFF
--- a/images/BUILD.bazel
+++ b/images/BUILD.bazel
@@ -64,7 +64,6 @@ container_bundle(
     images = {
         "protokube:{STABLE_PROTOKUBE_TAG}": "protokube-image",
     },
-    stamp = True,
 )
 
 load("//tools:gzip.bzl", "gzip")


### PR DESCRIPTION
Attribute is now automatically inferred.