### PR TITLE
fix(apiserver): allow multiple service-account-key-file

### DIFF
--- a/nodeup/pkg/model/kube_apiserver_test.go
+++ b/nodeup/pkg/model/kube_apiserver_test.go
@@ -98,6 +98,12 @@ func Test_KubeAPIServer_BuildFlags(t *testing.T) {
 			},
 			"--insecure-port=0 --secure-port=0 --target-ram-mb=320",
 		},
+		{
+			kops.KubeAPIServerConfig{
+				ServiceAccountKeyFile: []string{"/srv/kubernetes/server.key", "/srv/kubernetes/service-account.key"},
+			},
+			"--insecure-port=0 --secure-port=0 --service-account-key-file=/srv/kubernetes/server.key --service-account-key-file=/srv/kubernetes/service-account.key",
+		},
 	}
 
 	for _, g := range grid {

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -432,7 +432,7 @@ type KubeAPIServerConfig struct {
 	// File containing PEM-encoded x509 RSA or ECDSA private or public keys, used to verify ServiceAccount tokens.
 	// The specified file can contain multiple keys, and the flag can be specified multiple times with different files.
 	// If unspecified, --tls-private-key-file is used.
-	ServiceAccountKeyFile []string `json:"serviceAccountKeyFile,omitempty" flag:"service-account-key-file"`
+	ServiceAccountKeyFile []string `json:"serviceAccountKeyFile,omitempty" flag:"service-account-key-file,repeat"`
 
 	// Path to the file that contains the current private key of the service account token issuer.
 	// The issuer will sign issued ID tokens with this private key. (Requires the 'TokenRequest' feature gate.)

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -432,7 +432,7 @@ type KubeAPIServerConfig struct {
 	// File containing PEM-encoded x509 RSA or ECDSA private or public keys, used to verify ServiceAccount tokens.
 	// The specified file can contain multiple keys, and the flag can be specified multiple times with different files.
 	// If unspecified, --tls-private-key-file is used.
-	ServiceAccountKeyFile []string `json:"serviceAccountKeyFile,omitempty" flag:"service-account-key-file"`
+	ServiceAccountKeyFile []string `json:"serviceAccountKeyFile,omitempty" flag:"service-account-key-file,repeat"`
 
 	// Path to the file that contains the current private key of the service account token issuer.
 	// The issuer will sign issued ID tokens with this private key. (Requires the 'TokenRequest' feature gate.)

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -432,7 +432,7 @@ type KubeAPIServerConfig struct {
 	// File containing PEM-encoded x509 RSA or ECDSA private or public keys, used to verify ServiceAccount tokens.
 	// The specified file can contain multiple keys, and the flag can be specified multiple times with different files.
 	// If unspecified, --tls-private-key-file is used.
-	ServiceAccountKeyFile []string `json:"serviceAccountKeyFile,omitempty" flag:"service-account-key-file"`
+	ServiceAccountKeyFile []string `json:"serviceAccountKeyFile,omitempty" flag:"service-account-key-file,repeat"`
 
 	// Path to the file that contains the current private key of the service account token issuer.
 	// The issuer will sign issued ID tokens with this private key. (Requires the 'TokenRequest' feature gate.)


### PR DESCRIPTION
<!--
Thanks for contributing to kubernetes/kops!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines:

 https://git.k8s.io/kops/CONTRIBUTING.md

2. Also, you'll probably want to checkout our development documentation:

https://git.k8s.io/kops/docs/development

3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests

4. Finally, make sure all verifications and tests pass by running:
```
 make pr
```
-->

**What this PR does / why we need it**:
Currently, an error occurs when multiple [service-account-key-file](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) are specified for kube-apiserver.
This PR will fix it.

**Which issue(s) this PR fixes**:
fixed #7645 

**Special notes for your reviewer**:
