### PR TITLE
Remove Deprecated KubeDNS image field

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1332,10 +1332,6 @@ spec:
                     CoreFile by the user - ignores other provided flags which modify
                     the CoreFile.
                   type: string
-                image:
-                  description: Image is the name of the docker image to run - @deprecated
-                    as this is now in the addon
-                  type: string
                 memoryLimit:
                   description: MemoryLimit specifies the memory limit of each dns
                     container in the cluster. Default 170m.

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -366,8 +366,6 @@ type KubeDNSConfig struct {
 	Domain string `json:"domain,omitempty"`
 	// ExternalCoreFile is used to provide a complete CoreDNS CoreFile by the user - ignores other provided flags which modify the CoreFile.
 	ExternalCoreFile string `json:"externalCoreFile,omitempty"`
-	// Image is the name of the docker image to run - @deprecated as this is now in the addon
-	Image string `json:"image,omitempty"`
 	// Replicas is the number of pod replicas - @deprecated as this is now in the addon and controlled by autoscaler
 	Replicas int `json:"replicas,omitempty"`
 	// Provider indicates whether CoreDNS or kube-dns will be the default service discovery.

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -364,8 +364,6 @@ type KubeDNSConfig struct {
 	Domain string `json:"domain,omitempty"`
 	// ExternalCoreFile is used to provide a complete CoreDNS CoreFile by the user - ignores other provided flags which modify the CoreFile.
 	ExternalCoreFile string `json:"externalCoreFile,omitempty"`
-	// Image is the name of the docker image to run - @deprecated as this is now in the addon
-	Image string `json:"image,omitempty"`
 	// Replicas is the number of pod replicas - @deprecated as this is now in the addon, and controlled by autoscaler
 	Replicas int `json:"replicas,omitempty"`
 	// Provider indicates whether CoreDNS or kube-dns will be the default service discovery.

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -3443,7 +3443,6 @@ func autoConvert_v1alpha1_KubeDNSConfig_To_kops_KubeDNSConfig(in *KubeDNSConfig,
 	out.CacheMaxConcurrent = in.CacheMaxConcurrent
 	out.Domain = in.Domain
 	out.ExternalCoreFile = in.ExternalCoreFile
-	out.Image = in.Image
 	out.Replicas = in.Replicas
 	out.Provider = in.Provider
 	out.ServerIP = in.ServerIP
@@ -3465,7 +3464,6 @@ func autoConvert_kops_KubeDNSConfig_To_v1alpha1_KubeDNSConfig(in *kops.KubeDNSCo
 	out.CacheMaxConcurrent = in.CacheMaxConcurrent
 	out.Domain = in.Domain
 	out.ExternalCoreFile = in.ExternalCoreFile
-	out.Image = in.Image
 	out.Replicas = in.Replicas
 	out.Provider = in.Provider
 	out.ServerIP = in.ServerIP

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -364,8 +364,6 @@ type KubeDNSConfig struct {
 	Domain string `json:"domain,omitempty"`
 	// ExternalCoreFile is used to provide a complete CoreDNS CoreFile by the user - ignores other provided flags which modify the CoreFile.
 	ExternalCoreFile string `json:"externalCoreFile,omitempty"`
-	// Image is the name of the docker image to run - @deprecated as this is now in the addon
-	Image string `json:"image,omitempty"`
 	// Replicas is the number of pod replicas - @deprecated as this is now in the addon, and controlled by autoscaler
 	Replicas int `json:"replicas,omitempty"`
 	// Provider indicates whether CoreDNS or kube-dns will be the default service discovery.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3713,7 +3713,6 @@ func autoConvert_v1alpha2_KubeDNSConfig_To_kops_KubeDNSConfig(in *KubeDNSConfig,
 	out.CacheMaxConcurrent = in.CacheMaxConcurrent
 	out.Domain = in.Domain
 	out.ExternalCoreFile = in.ExternalCoreFile
-	out.Image = in.Image
 	out.Replicas = in.Replicas
 	out.Provider = in.Provider
 	out.ServerIP = in.ServerIP
@@ -3735,7 +3734,6 @@ func autoConvert_kops_KubeDNSConfig_To_v1alpha2_KubeDNSConfig(in *kops.KubeDNSCo
 	out.CacheMaxConcurrent = in.CacheMaxConcurrent
 	out.Domain = in.Domain
 	out.ExternalCoreFile = in.ExternalCoreFile
-	out.Image = in.Image
 	out.Replicas = in.Replicas
 	out.Provider = in.Provider
 	out.ServerIP = in.ServerIP


### PR DESCRIPTION
Removes the deprecated `image` field from the `KubeDNSConfig` in cluster spec - this no longer appears to be referenced or used anymore and has been marked deprecated for nearly 2 years - since #3771. 
I'm less clear about the also marked deprecated `replicas` field - I think this also isn't used anywhere anymore but I'm not confident enough in my grasp of addon-manager to be sure.