### PR TITLE
fix string trim func in main

### DIFF
--- a/hack/machine_types/machine_types.go
+++ b/hack/machine_types/machine_types.go
@@ -177,7 +177,7 @@ func run() error {
 					Cores: stringToInt(attributes["vcpu"]),
 				}
 
-				memory := strings.TrimRight(attributes["memory"], " GiB")
+				memory := strings.TrimSuffix(attributes["memory"], " GiB")
 				machine.MemoryGB = stringToFloat32(memory)
 
 				if attributes["storage"] != "EBS only" {


### PR DESCRIPTION
`TrimRight` is char based, and `TrimSuffix` is word based, I think that's what we want here.