### PR TITLE
Alicloud: add OSS as upload dest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,6 +345,12 @@ vsphere-version-dist: nodeup-dist protokube-export
 upload: version-dist # Upload kops to S3
 	aws s3 sync --acl public-read ${UPLOAD}/ ${S3_BUCKET}
 
+# oss-upload builds kops and uploads to OSS
+.PHONY: oss-upload
+oss-upload: version-dist
+	@echo "== Uploading kops =="
+	aliyun oss cp --acl public-read -r -f --include "*" ${UPLOAD}/ ${OSS_BUCKET}
+
 # gcs-upload builds kops and uploads to GCS
 .PHONY: gcs-upload
 gcs-upload: bazel-version-dist

--- a/hack/upload
+++ b/hack/upload
@@ -23,6 +23,10 @@ if [[ "${DEST:0:5}" == "gs://" ]]; then
   exit 0
 fi
 
-echo "Unsupported destination - supports s3:// and gs:// urls: ${DEST}"
-exit 1
+if [[ "${DEST:0:6}" == "oss://" ]]; then
+	aliyun oss cp --acl public-read -r -f --include "*" ${SRC}/ ${DEST}
+  exit 0
+fi
 
+echo "Unsupported destination - supports s3://, gs:// and oss:// urls: ${DEST}"
+exit 1


### PR DESCRIPTION
OSS is the object storage in Alicloud. 

This PR adds the ability to upload artifacts to OSS, this is helpful when someone is developing kops and test kops in Alicloud.

This change is also part of #4127