### PR TITLE
Cherry-pick #7807 to release-1.15

### DIFF
--- a/upup/pkg/fi/cloudup/openstacktasks/port.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port.go
@@ -144,7 +144,7 @@ func (_ *Port) CheckChanges(a, e, changes *Port) error {
 		if changes.Name != nil {
 			return fi.CannotChangeField("Name")
 		}
-		if e.Network != nil {
+		if changes.Network != nil {
 			return fi.CannotChangeField("Network")
 		}
 	}

--- a/upup/pkg/fi/cloudup/openstacktasks/port_test.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port_test.go
@@ -389,9 +389,25 @@ func Test_Port_CheckChanges(t *testing.T) {
 			},
 			changes: &Port{
 				Name:    nil,
-				Network: &Network{ID: fi.String("networkID")},
+				Network: nil,
 			},
 			expectedError: nil,
+		},
+		{
+			desc: "actual not nil all changeable fields set",
+			actual: &Port{
+				Name:    fi.String("name"),
+				Network: nil,
+			},
+			expected: &Port{
+				Name:    fi.String("name"),
+				Network: nil,
+			},
+			changes: &Port{
+				Name:    nil,
+				Network: &Network{ID: fi.String("networkID")},
+			},
+			expectedError: fi.CannotChangeField("Network"),
 		},
 		{
 			desc: "actual not nil unchangeable field Name set",


### PR DESCRIPTION
When updating from 1.15.0-alpha.1 to 1.15.0-beta.1 we cannot update any of the clusters. I do not want to start searching git blame which is causing this. However, I will just fix it. This needs to be backported to release-1.15

When I run kops update cluster <foo> in existing cluster (created before 1.15.0-beta.1)
The error log is

```
W1017 09:57:08.188375   32485 executor.go:130] error running task "Port/port-nodes-4-kaasprod-k8s-local" (9m59s remaining to succeed): Field cannot be changed: Network
W1017 09:57:08.188396   32485 executor.go:130] error running task "Port/port-nodes-2-kaasprod-k8s-local" (9m59s remaining to succeed): Field cannot be changed: Network
W1017 09:57:08.188409   32485 executor.go:130] error running task "Port/port-master-zone-2-1-1-kaasprod-k8s-local" (9m59s remaining to succeed): Field cannot be changed: Network
W1017 09:57:08.188422   32485 executor.go:130] error running task "Port/port-bastions-1-kaasprod-k8s-local" (9m59s remaining to succeed): Field cannot be changed: Network
W1017 09:57:08.188432   32485 executor.go:130] error running task "Port/port-nodes-1-kaasprod-k8s-local" (9m59s remaining to succeed): Field cannot be changed: Network
W1017 09:57:08.188443   32485 executor.go:130] error running task "Port/port-master-zone-1-1-1-kaasprod-k8s-local" (9m59s remaining to succeed): Field cannot be changed: Network
After this fix I can execute the command like usually.
```

/kind bug