### PR TITLE
Document eventTTL

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -326,6 +326,16 @@ spec:
     targetRamMb: 4096
 ```
 
+#### eventTTL
+
+How long API server retains events. Note that you must fill empty units of time with zeros.
+
+```yaml
+spec:
+  kubeAPIServer:
+    eventTTL: 03h0m0s
+```
+
 ### externalDns
 
 This block contains configuration options for your `external-DNS` provider.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Documents `eventTTL` usage explaining that you must fill empty units of time with zeros.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
This configuration from ClusterSpec is already inside the release 1.15, but lacks documentation on how to use it.

This flag was added here: https://github.com/kubernetes/kops/pull/7487

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```