### PR TITLE
[DO-7442] Add gossip cluster implementation for Digital Ocean cloud provider

### DIFF
--- a/hack/.packages
+++ b/hack/.packages
@@ -149,6 +149,7 @@ k8s.io/kops/protokube/pkg/gossip/aws
 k8s.io/kops/protokube/pkg/gossip/dns
 k8s.io/kops/protokube/pkg/gossip/dns/hosts
 k8s.io/kops/protokube/pkg/gossip/dns/provider
+k8s.io/kops/protokube/pkg/gossip/do
 k8s.io/kops/protokube/pkg/gossip/gce
 k8s.io/kops/protokube/pkg/gossip/memberlist
 k8s.io/kops/protokube/pkg/gossip/mesh

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -364,7 +364,7 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) (*Protokube
 				f.GossipSecretSecondary = t.Cluster.Spec.GossipConfig.Secondary.Secret
 			}
 		}
-
+		
 		// @TODO: This is hacky, but we want it so that we can have a different internal & external name
 		internalSuffix := t.Cluster.Spec.MasterInternalName
 		internalSuffix = strings.TrimPrefix(internalSuffix, "api.")
@@ -380,7 +380,7 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) (*Protokube
 				f.DNSProvider = fi.String("aws-route53")
 			case kops.CloudProviderDO:
 				f.DNSProvider = fi.String("digitalocean")
-				f.ClusterID = fi.String(t.Cluster.Name)
+				f.ClusterID = fi.String(t.Cluster.ObjectMeta.Name)
 			case kops.CloudProviderGCE:
 				f.DNSProvider = fi.String("google-clouddns")
 			case kops.CloudProviderVSphere:

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -364,7 +364,7 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) (*Protokube
 				f.GossipSecretSecondary = t.Cluster.Spec.GossipConfig.Secondary.Secret
 			}
 		}
-		
+
 		// @TODO: This is hacky, but we want it so that we can have a different internal & external name
 		internalSuffix := t.Cluster.Spec.MasterInternalName
 		internalSuffix = strings.TrimPrefix(internalSuffix, "api.")
@@ -380,7 +380,6 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) (*Protokube
 				f.DNSProvider = fi.String("aws-route53")
 			case kops.CloudProviderDO:
 				f.DNSProvider = fi.String("digitalocean")
-				f.ClusterID = fi.String(t.Cluster.ObjectMeta.Name)
 			case kops.CloudProviderGCE:
 				f.DNSProvider = fi.String("google-clouddns")
 			case kops.CloudProviderVSphere:

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -181,7 +181,6 @@ func parseManifest(data []byte) ([]runtime.Object, error) {
 }
 
 // Until we introduce the bundle, we hard-code the manifest
-
 var defaultManifest = `
 apiVersion: v1
 kind: Pod

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -181,6 +181,7 @@ func parseManifest(data []byte) ([]runtime.Object, error) {
 }
 
 // Until we introduce the bundle, we hard-code the manifest
+
 var defaultManifest = `
 apiVersion: v1
 kind: Pod

--- a/pkg/model/domodel/droplets.go
+++ b/pkg/model/domodel/droplets.go
@@ -47,6 +47,7 @@ func (d *DropletBuilder) Build(c *fi.ModelBuilderContext) error {
 
 	// replace "." with "-" since DO API does not accept "."
 	clusterTag := do.TagKubernetesClusterNamePrefix + ":" + strings.Replace(d.ClusterName(), ".", "-", -1)
+	clusterMasterTag := do.TagKubernetesClusterMasterPrefix + ":" + strings.Replace(d.ClusterName(), ".", "-", -1)
 
 	masterIndexCount := 0
 	// In the future, DigitalOcean will use Machine API to manage groups,
@@ -71,6 +72,7 @@ func (d *DropletBuilder) Build(c *fi.ModelBuilderContext) error {
 			masterIndexCount++
 			clusterTagIndex := do.TagKubernetesClusterIndex + ":" + strconv.Itoa(masterIndexCount)
 			droplet.Tags = append(droplet.Tags, clusterTagIndex)
+			droplet.Tags = append(droplet.Tags, clusterMasterTag)
 		}
 
 		userData, err := d.BootstrapScript.ResourceNodeUp(ig, d.Cluster)

--- a/pkg/resources/digitalocean/resources.go
+++ b/pkg/resources/digitalocean/resources.go
@@ -196,8 +196,12 @@ func listDNS(cloud fi.Cloud, clusterName string) ([]*resources.Resource, error) 
 	}
 
 	if domainName == "" {
-		klog.Info("Domain Name is empty. Possible that the cluster is configured as gossip..")
-		return nil, nil
+		if strings.HasSuffix(clusterName, ".k8s.local") {
+			klog.Info("Domain Name is empty. Ok to have an empty domain name since cluster is configured as gossip cluster.")
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("failed to find domain for cluster: %s", clusterName)
 	}
 
 	records, err := getAllRecordsByDomain(c, domainName)

--- a/pkg/resources/digitalocean/resources.go
+++ b/pkg/resources/digitalocean/resources.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/digitalocean/godo"
 
+	"k8s.io/klog"
 	"k8s.io/kops/dns-controller/pkg/dns"
 	"k8s.io/kops/pkg/resources"
 	"k8s.io/kops/upup/pkg/fi"
@@ -195,7 +196,9 @@ func listDNS(cloud fi.Cloud, clusterName string) ([]*resources.Resource, error) 
 	}
 
 	if domainName == "" {
-		return nil, fmt.Errorf("failed to find domain for cluster: %s", clusterName)
+		klog.Info("Domain Name is empty. Could be configured as gossip. Just ignore.")
+		return nil, nil
+		//return nil, fmt.Errorf("failed to find domain for cluster: %s", clusterName)
 	}
 
 	records, err := getAllRecordsByDomain(c, domainName)

--- a/pkg/resources/digitalocean/resources.go
+++ b/pkg/resources/digitalocean/resources.go
@@ -196,9 +196,8 @@ func listDNS(cloud fi.Cloud, clusterName string) ([]*resources.Resource, error) 
 	}
 
 	if domainName == "" {
-		klog.Info("Domain Name is empty. Could be configured as gossip. Just ignore.")
+		klog.Info("Domain Name is empty. Possible that the cluster is configured as gossip..")
 		return nil, nil
-		//return nil, fmt.Errorf("failed to find domain for cluster: %s", clusterName)
 	}
 
 	records, err := getAllRecordsByDomain(c, domainName)

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -52,7 +52,7 @@ var (
 func main() {
 	klog.InitFlags(nil)
 
-	fmt.Printf("srikiz now protokube version %s\n", BuildVersion)
+	fmt.Printf("protokube version %s\n", BuildVersion)
 
 	if err := run(); err != nil {
 		klog.Errorf("Error: %v", err)

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -52,7 +52,7 @@ var (
 func main() {
 	klog.InitFlags(nil)
 
-	fmt.Printf("sriki now protokube version %s\n", BuildVersion)
+	fmt.Printf("srikiz now protokube version %s\n", BuildVersion)
 
 	if err := run(); err != nil {
 		klog.Errorf("Error: %v", err)
@@ -138,13 +138,20 @@ func run() error {
 			internalIP = awsVolumes.InternalIP()
 		}
 	} else if cloud == "digitalocean" {
-		doVolumes, err := protokube.NewDOVolumes(clusterID)
+		doVolumes, err := protokube.NewDOVolumes()
 		if err != nil {
 			klog.Errorf("Error initializing DigitalOcean: %q", err)
 			os.Exit(1)
 		}
-
 		volumes = doVolumes
+
+		if clusterID == "" {
+			clusterID, err = protokube.GetClusterID()
+			if err != nil {
+				klog.Errorf("Error getting clusterid: %s", err)
+				os.Exit(1)
+			}
+		}
 
 		if internalIP == nil {
 			internalIP, err = protokube.GetDropletInternalIP()
@@ -153,7 +160,6 @@ func run() error {
 				os.Exit(1)
 			}
 		}
-
 	} else if cloud == "gce" {
 		gceVolumes, err := protokube.NewGCEVolumes()
 		if err != nil {

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -52,7 +52,7 @@ var (
 func main() {
 	klog.InitFlags(nil)
 
-	fmt.Printf("protokube version %s\n", BuildVersion)
+	fmt.Printf("sriki now protokube version %s\n", BuildVersion)
 
 	if err := run(); err != nil {
 		klog.Errorf("Error: %v", err)
@@ -138,11 +138,6 @@ func run() error {
 			internalIP = awsVolumes.InternalIP()
 		}
 	} else if cloud == "digitalocean" {
-		if clusterID == "" {
-			klog.Error("digitalocean requires --cluster-id")
-			os.Exit(1)
-		}
-
 		doVolumes, err := protokube.NewDOVolumes(clusterID)
 		if err != nil {
 			klog.Errorf("Error initializing DigitalOcean: %q", err)
@@ -294,6 +289,12 @@ func run() error {
 				return err
 			}
 			gossipName = volumes.(*protokube.ALIVolumes).InstanceID()
+		} else if cloud == "digitalocean" {
+			gossipSeeds, err = volumes.(*protokube.DOVolumes).GossipSeeds()
+			if err != nil {
+				return err
+			}
+			gossipName = volumes.(*protokube.DOVolumes).InstanceName()
 		} else {
 			klog.Fatalf("seed provider for %q not yet implemented", cloud)
 		}

--- a/protokube/pkg/gossip/do/BUILD.bazel
+++ b/protokube/pkg/gossip/do/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["seeds.go"],
+    importpath = "k8s.io/kops/protokube/pkg/gossip/do",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//protokube/pkg/gossip:go_default_library"
+    ],
+)

--- a/protokube/pkg/gossip/do/BUILD.bazel
+++ b/protokube/pkg/gossip/do/BUILD.bazel
@@ -6,6 +6,8 @@ go_library(
     importpath = "k8s.io/kops/protokube/pkg/gossip/do",
     visibility = ["//visibility:public"],
     deps = [
-        "//protokube/pkg/gossip:go_default_library"
+        "//pkg/resources/digitalocean:go_default_library",
+        "//protokube/pkg/gossip:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/protokube/pkg/gossip/do/seeds.go
+++ b/protokube/pkg/gossip/do/seeds.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package do
+
+import (
+	"fmt"
+	"context"
+	"k8s.io/klog"
+	"k8s.io/kops/pkg/resources/digitalocean"
+	"k8s.io/kops/protokube/pkg/gossip"
+)
+
+type SeedProvider struct {
+	cloud *digitalocean.Cloud
+	tag    string
+}
+
+var _ gossip.SeedProvider = &SeedProvider{}
+
+func (p *SeedProvider) GetSeeds() ([]string, error) {
+	var seeds []string
+
+	
+	droplets, _, err := p.cloud.Droplets().ListByTag(context.TODO(), p.tag, nil)
+
+	if err != nil {
+		return nil, fmt.Errorf("Droplets.ListByTag returned error: %v", err)
+	}
+
+	for _, droplet := range droplets {
+		ip, err := droplet.PrivateIPv4()
+		if err != nil {
+			klog.V(2).Infof("Appending a seed for cluster tag:%s, with ip=%s", p.tag, ip)
+			seeds = append(seeds, ip)
+		}
+	}
+
+	return seeds, nil
+}
+
+func NewSeedProvider(cloud *digitalocean.Cloud, tag string) (*SeedProvider, error) {
+	return &SeedProvider{
+		cloud:    cloud,
+		tag:    tag,
+	}, nil
+}

--- a/protokube/pkg/gossip/do/seeds.go
+++ b/protokube/pkg/gossip/do/seeds.go
@@ -20,16 +20,16 @@ import (
 	"fmt"
 	//"errors"
 	"context"
-	"strings"
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/resources/digitalocean"
 	"k8s.io/kops/protokube/pkg/gossip"
+	"strings"
 	//"github.com/digitalocean/godo"
 )
 
 type SeedProvider struct {
 	cloud *digitalocean.Cloud
-	tag    string
+	tag   string
 }
 
 var _ gossip.SeedProvider = &SeedProvider{}
@@ -37,7 +37,6 @@ var _ gossip.SeedProvider = &SeedProvider{}
 func (p *SeedProvider) GetSeeds() ([]string, error) {
 	var seeds []string
 
-	
 	droplets, _, err := p.cloud.Droplets().List(context.TODO(), nil)
 
 	if err != nil {
@@ -70,7 +69,7 @@ func NewSeedProvider(cloud *digitalocean.Cloud, tag string) (*SeedProvider, erro
 	klog.V(2).Infof("Trying new seed provider with cluster tag:%s", tag)
 
 	return &SeedProvider{
-		cloud:    cloud,
-		tag:    tag,
+		cloud: cloud,
+		tag:   tag,
 	}, nil
 }

--- a/protokube/pkg/gossip/do/seeds.go
+++ b/protokube/pkg/gossip/do/seeds.go
@@ -44,28 +44,28 @@ func (p *SeedProvider) GetSeeds() ([]string, error) {
 
 	for _, droplet := range droplets {
 		for _, dropTag := range droplet.Tags {
-			klog.V(2).Infof("Get Seeds - droplet found=%s,SeedProvider Tag=%s", dropTag, p.tag)
+			klog.V(4).Infof("Get Seeds - droplet found=%s,SeedProvider Tag=%s", dropTag, p.tag)
 			if strings.Contains(dropTag, strings.Replace(p.tag, ".", "-", -1)) {
-				klog.V(2).Infof("Tag matched for droplet tag =%s. Getting private IP", p.tag)
+				klog.V(4).Infof("Tag matched for droplet tag =%s. Getting private IP", p.tag)
 				ip, err := droplet.PrivateIPv4()
 				if err == nil {
-					klog.V(2).Infof("Appending a seed for cluster tag:%s, with ip=%s", p.tag, ip)
+					klog.V(4).Infof("Appending a seed for cluster tag:%s, with ip=%s", p.tag, ip)
 					seeds = append(seeds, ip)
 				} else {
-					klog.V(2).Infof("Ah ...Private IP failed for tag=%s, error=%v", p.tag, err)
+					klog.V(4).Infof("Ah ...Private IP failed for tag=%s, error=%v", p.tag, err)
 				}
 			} else {
-				klog.V(2).Infof("Tag NOT matched for droplet tag =%s. and pTag=%s", dropTag, p.tag)
+				klog.V(4).Infof("Tag NOT matched for droplet tag =%s. and pTag=%s", dropTag, p.tag)
 			}
 		}
 	}
 
-	klog.V(2).Infof("Get seeds function done now")
+	klog.V(4).Infof("Get seeds function done now")
 	return seeds, nil
 }
 
 func NewSeedProvider(cloud *digitalocean.Cloud, tag string) (*SeedProvider, error) {
-	klog.V(2).Infof("Trying new seed provider with cluster tag:%s", tag)
+	klog.V(4).Infof("Trying new seed provider with cluster tag:%s", tag)
 
 	return &SeedProvider{
 		cloud: cloud,

--- a/protokube/pkg/gossip/do/seeds.go
+++ b/protokube/pkg/gossip/do/seeds.go
@@ -66,23 +66,6 @@ func (p *SeedProvider) GetSeeds() ([]string, error) {
 	return seeds, nil
 }
 
-// func GetPrivateIP(d *godo.Droplet) (string, error) {
-// 	klog.V(2).Infof("Get PrivateIP: droplet name =%s", d.Name)
-// 	if d.Networks == nil {
-// 		return "", errors.New("no networks have been defined")
-// 	}
-
-// 	for _, v4 := range d.Networks.V4 {
-// 		klog.V(2).Infof("Get PrivateIP: droplet name =%s, v4 type=%s, Ip address=%s", d.Name, v4.Type, v4.IPAddress)
-// 		if v4.Type == "private" {
-// 			return v4.IPAddress, nil
-// 		}
-// 	}
-
-// 	return "", errors.New("Could not find v4 network")
-// }
-
-
 func NewSeedProvider(cloud *digitalocean.Cloud, tag string) (*SeedProvider, error) {
 	klog.V(2).Infof("Trying new seed provider with cluster tag:%s", tag)
 

--- a/protokube/pkg/gossip/do/seeds.go
+++ b/protokube/pkg/gossip/do/seeds.go
@@ -17,14 +17,13 @@ limitations under the License.
 package do
 
 import (
-	"fmt"
-	//"errors"
 	"context"
+	"fmt"
+	"strings"
+
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/resources/digitalocean"
 	"k8s.io/kops/protokube/pkg/gossip"
-	"strings"
-	//"github.com/digitalocean/godo"
 )
 
 type SeedProvider struct {

--- a/protokube/pkg/protokube/BUILD.bazel
+++ b/protokube/pkg/protokube/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//protokube/pkg/gossip/ali:go_default_library",
         "//protokube/pkg/gossip/aws:go_default_library",
         "//protokube/pkg/gossip/dns:go_default_library",
+        "//protokube/pkg/gossip/do:go_default_library",
         "//protokube/pkg/gossip/gce:go_default_library",
         "//protokube/pkg/gossip/openstack:go_default_library",
         "//upup/pkg/fi/cloudup/aliup:go_default_library",

--- a/protokube/pkg/protokube/do_volume.go
+++ b/protokube/pkg/protokube/do_volume.go
@@ -248,13 +248,16 @@ func getLocalDeviceName(vol *godo.Volume) string {
 
 func (d *DOVolumes) GossipSeeds() (gossip.SeedProvider, error) {
 	for _, dropletTag := range d.dropletTags {
-        if strings.Contains(dropletTag, d.ClusterID) {
+        if strings.Contains(dropletTag, strings.Replace(d.ClusterID, ".", "-", -1)) {
 			return gossipdo.NewSeedProvider(d.Cloud, dropletTag)
         }
 	}
 	
-	
 	return nil, fmt.Errorf("could not determine a matching droplet tag for gossip seeding")
+}
+
+func (d *DOVolumes) InstanceName() string {
+	return d.dropletName
 }
 
 // GetDropletInternalIP gets the private IP of the droplet running this program

--- a/protokube/pkg/protokube/do_volume.go
+++ b/protokube/pkg/protokube/do_volume.go
@@ -316,9 +316,8 @@ func getMetadataDropletID() (string, error) {
 
 func getMetadataDropletTags() ([]string, error) {
 
-	tagString, error := getMetadata(dropletIDMetadataTags)
-	dropletTags := strings.Split(tagString, "\n")
-	return dropletTags, error
+	tagString, err := getMetadata(dropletIDMetadataTags)
+	return strings.Split(tagString, "\n"), err
 }
 
 func getMetadata(url string) (string, error) {

--- a/upup/pkg/fi/cloudup/do/cloud.go
+++ b/upup/pkg/fi/cloudup/do/cloud.go
@@ -27,6 +27,7 @@ const TagKubernetesClusterIndex = "k8s-index"
 const TagNameEtcdClusterPrefix = "etcdCluster-"
 const TagNameRolePrefix = "k8s.io/role/"
 const TagKubernetesClusterNamePrefix = "KubernetesCluster"
+const TagKubernetesClusterMasterPrefix = "KubernetesCluster-Master"
 
 func SafeClusterName(clusterName string) string {
 	// DO does not support . in tags / names


### PR DESCRIPTION
As part of this PR, it supports multiple HA masters for DO by adding gossip seed support. The necessary changes are already done on the etcd-manager side - https://github.com/kopeio/etcd-manager/pull/254.
I have tested this locally with 3 master nodes, and was able to see the seeding happening Ok. 
This PR doesn't address adding a load balancer for the HA masters. That will be coming up next.

