### PR TITLE
add missing priorityClassName to flannel DaemonSet

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.12.yaml.template
@@ -106,6 +106,7 @@ spec:
         app: flannel
         role.kubernetes.io/networking: "1"
     spec:
+      priorityClassName: system-node-critical
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -775,7 +775,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		versions := map[string]string{
 			"pre-k8s-1.6": "0.11.0-kops.1",
 			"k8s-1.6":     "0.11.0-kops.2",
-			"k8s-1.12":    "0.11.0-kops.2",
+			"k8s-1.12":    "0.11.0-kops.3",
 		}
 
 		{


### PR DESCRIPTION
Without `priorityClassName` there is a possibility that flannel pod won't be scheduled to a node, or even worse, be preempted