### PR TITLE
fix DigitalOcean getting start link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ launching a Kubernetes cluster hosted on AWS.
 
 To install a Kubernetes cluster on GCE please follow this [guide](/docs/getting_started/gce.md).
 
-To install a Kubernetes cluster on DigitalOcean, follow this [guide](/docs/tutorial/digitalocean.md).
+To install a Kubernetes cluster on DigitalOcean, follow this [guide](/docs/getting_started/digitalocean.md).
 
 To install a Kubernetes cluster on OpenStack, follow this [guide](/docs/tutorial/openstack.md).
 


### PR DESCRIPTION
It fixes the README link to getting the start of Digital Ocean Documents.