### PR TITLE
Automated cherry pick of #7847: Revert "Upgrade Amazon VPC CNI plugin to 1.5.4"

### DIFF
--- a/k8s/crds/kops_v1alpha2_cluster.yaml
+++ b/k8s/crds/kops_v1alpha2_cluster.yaml
@@ -2019,7 +2019,7 @@ spec:
                   properties:
                     imageName:
                       description: 'The container image name to use, which by default
-                        is: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.4'
+                        is: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.0.0'
                       type: string
                   type: object
                 calico:

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -151,7 +151,7 @@ type RomanaNetworkingSpec struct {
 // AmazonVPCNetworkingSpec declares that we want Amazon VPC CNI networking
 type AmazonVPCNetworkingSpec struct {
 	// The container image name to use, which by default is:
-	// 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.4
+	// 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.0
 	ImageName string `json:"imageName,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -151,7 +151,7 @@ type RomanaNetworkingSpec struct {
 // AmazonVPCNetworkingSpec declares that we want Amazon VPC CNI networking
 type AmazonVPCNetworkingSpec struct {
 	// The container image name to use, which by default is:
-	// 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.4
+	// 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.0.0
 	ImageName string `json:"imageName,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -151,7 +151,7 @@ type RomanaNetworkingSpec struct {
 // AmazonVPCNetworkingSpec declares that we want Amazon VPC CNI networking
 type AmazonVPCNetworkingSpec struct {
 	// The container image name to use, which by default is:
-	// 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.4
+	// 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.0.0
 	ImageName string `json:"imageName,omitempty"`
 }
 

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.12.yaml.template
@@ -1,4 +1,4 @@
-# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.5.4/config/v1.5/aws-k8s-cni.yaml
+# Vendored from https://github.com/aws/amazon-vpc-cni-k8s/blob/v1.5.0/config/v1.5/aws-k8s-cni.yaml
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -79,7 +79,7 @@ spec:
       tolerations:
       - operator: Exists
       containers:
-      - image: "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.4" }}"
+      - image: "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.0" }}"
         imagePullPolicy: Always
         ports:
         - containerPort: 61678

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -1029,19 +1029,15 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 	if b.cluster.Spec.Networking.AmazonVPC != nil {
 		key := "networking.amazon-vpc-routed-eni"
-		versions := map[string]string{
-			"k8s-1.7":  "1.5.0-kops.1",
-			"k8s-1.8":  "1.5.0-kops.1",
-			"k8s-1.10": "1.5.0-kops.1",
-			"k8s-1.12": "1.5.4-kops.1",
-		}
+		version := "1.5.0-kops.1"
+
 		{
 			id := "k8s-1.7"
 			location := key + "/" + id + ".yaml"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
-				Version:           fi.String(versions[id]),
+				Version:           fi.String(version),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
 				KubernetesVersion: ">=1.7.0 <1.8.0",
@@ -1055,7 +1051,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
-				Version:           fi.String(versions[id]),
+				Version:           fi.String(version),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
 				KubernetesVersion: ">=1.8.0 <1.10.0",
@@ -1069,7 +1065,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
-				Version:           fi.String(versions[id]),
+				Version:           fi.String(version),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
 				KubernetesVersion: ">=1.10.0 <1.12.0",
@@ -1083,7 +1079,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
-				Version:           fi.String(versions[id]),
+				Version:           fi.String(version),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
 				KubernetesVersion: ">=1.12.0",


### PR DESCRIPTION
Cherry pick of #7847 on release-1.15.

#7847: Revert "Upgrade Amazon VPC CNI plugin to 1.5.4"