### PR TITLE
Alicloud: external cloud controller manager addon

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1736,6 +1736,10 @@ spec:
                   description: config is the path to the config file or directory
                     of files
                   type: string
+                providerID:
+                  description: ProviderID is a unique identifier for identifying the
+                    node in a machine database, i.e cloudprovider.
+                  type: string
                 readOnlyPort:
                   description: ReadOnlyPort is the port used by the kubelet api for
                     read-only access (default 10255)
@@ -2090,6 +2094,10 @@ spec:
                 podManifestPath:
                   description: config is the path to the config file or directory
                     of files
+                  type: string
+                providerID:
+                  description: ProviderID is a unique identifier for identifying the
+                    node in a machine database, i.e cloudprovider.
                   type: string
                 readOnlyPort:
                   description: ReadOnlyPort is the port used by the kubelet api for

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -451,6 +451,10 @@ spec:
                   description: config is the path to the config file or directory
                     of files
                   type: string
+                providerID:
+                  description: ProviderID is a unique identifier for identifying the
+                    node in a machine database, i.e cloudprovider.
+                  type: string
                 readOnlyPort:
                   description: ReadOnlyPort is the port used by the kubelet api for
                     read-only access (default 10255)

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -51,6 +51,8 @@ type KubeletConfigSpec struct {
 	PodManifestPath string `json:"podManifestPath,omitempty" flag:"pod-manifest-path"`
 	// HostnameOverride is the hostname used to identify the kubelet instead of the actual hostname.
 	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
+	// ProviderID is a unique identifier for identifying the node in a machine database, i.e cloudprovider.
+	ProviderID string `json:"providerID,omitempty" flag:"provider-id"`
 	// PodInfraContainerImage is the image whose network/ipc containers in each pod will use.
 	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty" flag:"pod-infra-container-image"`
 	// SeccompProfileRoot is the directory path for seccomp profiles.

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -51,6 +51,8 @@ type KubeletConfigSpec struct {
 	PodManifestPath string `json:"podManifestPath,omitempty" flag:"pod-manifest-path"`
 	// HostnameOverride is the hostname used to identify the kubelet instead of the actual hostname.
 	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
+	// ProviderID is a unique identifier for identifying the node in a machine database, i.e cloudprovider.
+	ProviderID string `json:"providerID,omitempty" flag:"provider-id"`
 	// PodInfraContainerImage is the image whose network/ipc containers in each pod will use.
 	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty" flag:"pod-infra-container-image"`
 	// SeccompProfileRoot is the directory path for seccomp profiles.

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -3605,6 +3605,7 @@ func autoConvert_v1alpha1_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.LogLevel = in.LogLevel
 	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride
+	out.ProviderID = in.ProviderID
 	out.PodInfraContainerImage = in.PodInfraContainerImage
 	out.SeccompProfileRoot = in.SeccompProfileRoot
 	out.AllowPrivileged = in.AllowPrivileged
@@ -3689,6 +3690,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha1_KubeletConfigSpec(in *kops.K
 	out.LogLevel = in.LogLevel
 	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride
+	out.ProviderID = in.ProviderID
 	out.PodInfraContainerImage = in.PodInfraContainerImage
 	out.SeccompProfileRoot = in.SeccompProfileRoot
 	out.AllowPrivileged = in.AllowPrivileged

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -51,6 +51,8 @@ type KubeletConfigSpec struct {
 	PodManifestPath string `json:"podManifestPath,omitempty" flag:"pod-manifest-path"`
 	// HostnameOverride is the hostname used to identify the kubelet instead of the actual hostname.
 	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
+	// ProviderID is a unique identifier for identifying the node in a machine database, i.e cloudprovider.
+	ProviderID string `json:"providerID,omitempty" flag:"provider-id"`
 	// PodInfraContainerImage is the image whose network/ipc containers in each pod will use.
 	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty" flag:"pod-infra-container-image"`
 	// SeccompProfileRoot is the directory path for seccomp profiles.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3875,6 +3875,7 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.LogLevel = in.LogLevel
 	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride
+	out.ProviderID = in.ProviderID
 	out.PodInfraContainerImage = in.PodInfraContainerImage
 	out.SeccompProfileRoot = in.SeccompProfileRoot
 	out.AllowPrivileged = in.AllowPrivileged
@@ -3959,6 +3960,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.LogLevel = in.LogLevel
 	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride
+	out.ProviderID = in.ProviderID
 	out.PodInfraContainerImage = in.PodInfraContainerImage
 	out.SeccompProfileRoot = in.SeccompProfileRoot
 	out.AllowPrivileged = in.AllowPrivileged

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -162,7 +162,7 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 	case kops.CloudProviderOpenstack:
 		c.CloudProvider = "openstack"
 	case kops.CloudProviderALI:
-		c.CloudProvider = "alicloud"
+		c.CloudProvider = "external"
 	default:
 		return fmt.Errorf("unknown cloudprovider %q", clusterSpec.CloudProvider)
 	}

--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -117,7 +117,7 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 		kcm.CloudProvider = "openstack"
 
 	case kops.CloudProviderALI:
-		kcm.CloudProvider = "alicloud"
+		kcm.CloudProvider = "external"
 
 	default:
 		return fmt.Errorf("unknown cloudprovider %q", clusterSpec.CloudProvider)

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -212,8 +212,9 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if cloudProvider == kops.CloudProviderALI {
-		clusterSpec.Kubelet.CloudProvider = "alicloud"
+		clusterSpec.Kubelet.CloudProvider = "external"
 		clusterSpec.Kubelet.HostnameOverride = "@alicloud"
+		clusterSpec.Kubelet.ProviderID = "@alicloud"
 	}
 
 	if clusterSpec.ExternalCloudControllerManager != nil {

--- a/upup/models/cloudup/resources/addons/alicloud-cloud-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/alicloud-cloud-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -1,0 +1,255 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-config
+  namespace: kube-system
+stringData:
+  access-key-id: {{ ALIYUN_ACCESS_KEY_ID }}
+  access-key-secret: {{ ALIYUN_ACCESS_KEY_SECRET }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: alicloud-cloud-controller-manager
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: alicloud-cloud-controller-manager
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        k8s-app: alicloud-cloud-controller-manager
+    spec:
+      containers:
+        - command:
+          - /cloud-controller-manager
+          - --address=127.0.0.1
+          - --allow-untagged-cloud=true
+          - --leader-elect=true
+          - --cloud-provider=alicloud
+          - --use-service-account-credentials=true
+          - --feature-gates=ServiceNodeExclusion=true
+          - --route-reconciliation-period=3m
+          - --configure-cloud-routes=true
+          - --allocate-node-cidrs=true
+          - --cluster-cidr={{ .NonMasqueradeCIDR }}
+          image: bittopaz/alicloud-ccm-amd64:v1.9.3.164
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: cloud-config
+                  key: access-key-id
+            - name: ACCESS_KEY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: cloud-config
+                  key: access-key-secret
+          livenessProbe:
+            failureThreshold: 8
+            httpGet:
+              host: 127.0.0.1
+              path: /healthz
+              port: 10252
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 15
+          name: cloud-controller-manager
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              host: 127.0.0.1
+              path: /healthz
+              port: 10252
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 100m
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+            privileged: false
+            procMount: Default
+            readOnlyRootFilesystem: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/ssl/certs
+              name: certs
+            - mountPath: /etc/pki
+              name: pki
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: cloud-controller-manager
+      serviceAccountName: cloud-controller-manager
+      terminationGracePeriodSeconds: 30
+      tolerations:
+        - key: "node.cloudprovider.kubernetes.io/uninitialized"
+          value: "true"
+          effect: "NoSchedule"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 300
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 300
+      volumes:
+        - hostPath:
+            path: /etc/ssl/certs
+            type: ""
+          name: certs
+        - hostPath:
+            path: /etc/pki
+            type: ""
+          name: pki
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: system:cloud-controller-manager
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+      - services
+      - secrets
+      - endpoints
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+      - endpoints
+    verbs:
+      - create
+      - patch
+      - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: system:shared-informers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: shared-informers
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: system:cloud-node-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-node-controller
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: system:pvl-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: pvl-controller
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: system:route-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: route-controller
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -557,6 +557,25 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		}
 	}
 
+	if kops.CloudProviderID(b.cluster.Spec.CloudProvider) == kops.CloudProviderALI {
+		key := "alicloud-cloud-controller.addons.k8s.io"
+		version := "1.12"
+
+		{
+			id := "k8s-1.12"
+			location := key + "/" + id + ".yaml"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(version),
+				Selector:          map[string]string{"k8s-addon": key},
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.12.0",
+				Id:                id,
+			})
+		}
+	}
+
 	if kops.CloudProviderID(b.cluster.Spec.CloudProvider) == kops.CloudProviderGCE {
 		key := "storage-gce.addons.k8s.io"
 		version := "1.7.0"

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -116,6 +116,16 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 		return os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")
 	}
 
+	// TODO: Will use instance role instead of the environment secrets for Alicloud.
+	if kops.CloudProviderID(tf.cluster.Spec.CloudProvider) == kops.CloudProviderALI {
+		dest["ALIYUN_ACCESS_KEY_ID"] = func() string {
+			return os.Getenv("ALIYUN_ACCESS_KEY_ID")
+		}
+		dest["ALIYUN_ACCESS_KEY_SECRET"] = func() string {
+			return os.Getenv("ALIYUN_ACCESS_KEY_SECRET")
+		}
+	}
+
 	if featureflag.Spotinst.Enabled() {
 		if creds, err := spotinst.LoadCredentials(); err == nil {
 			dest["SpotinstToken"] = func() string { return creds.Token }


### PR DESCRIPTION
This is part of #4127.

One thing that worth to mention is that, I'm currently asking Alicloud to provide an official docker image for Alicloud CCM [here](https://github.com/kubernetes/cloud-provider-alibaba-cloud/issues/111).

Before they provide official docker image, I currently refer the image as bittopaz/alicloud-ccm-amd64:v1.9.3.164, this is under my personal namespace.
If this bothers you, I will be very happy to change it to a better image url, eg: image under kope namespace.

Thanks.