### PR TITLE
Remove extraneous document separator causing failures applying addons

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.12.yaml.template
@@ -1,5 +1,5 @@
 # Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.5.4/config/v1.5/aws-k8s-cni.yaml
----
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
Attempting to use kops 1.15.0-beta.1 with AWS VPC CNI plugin (the networking value `amazon-vpc-routed-eni`) causes these errors on the masters:

```
error: error validating "k8s-1.12.yaml": error validating data: [apiVersion not set, kind not set]; if you choose to ignore these errors, turn validation off with --validate=false
```

in fact, new clusters do not even come up healthy in my tests: the masters never reach `Ready` status.

This tiny change removes `---` from the AWS VPC CNI addon, which directly addresses the above error. Upon fix, the masters showed `Ready` in the order of minutes.

Fixes #7805

