### PR TITLE
Add support for newer Docker versions

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -778,6 +778,133 @@ var dockerVersions = []dockerVersion{
 		Dependencies:  []string{"container-selinux", "libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python-utils", "python3-policycoreutils"},
 	},
 
+	// 18.09.9 - k8s 1.14 - https://github.com/kubernetes/kubernetes/pull/72823
+
+	// 18.09.9 - Debian Stretch
+	{
+		DockerVersion: "18.09.9",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionDebian9},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "18.09.9~3-0~debian-stretch",
+		Source:        "https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_18.09.9~3-0~debian-stretch_amd64.deb",
+		Hash:          "9d564b56f5531a08e24c8c7724445d128742572e",
+		ExtraPackages: map[string]packageInfo{
+			"docker-ce-cli": {
+				Version: "18.09.9~3-0~debian-stretch",
+				Source:  "https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce-cli_18.09.9~3-0~debian-stretch_amd64.deb",
+				Hash:    "88f8f3103d2e5011e2f1a73b9e6dbf03d6e6698a",
+			},
+			"containerd.io": {
+				Version: "1.2.10-3",
+				Source:  "https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/containerd.io_1.2.10-3_amd64.deb",
+				Hash:    "186f2f2c570f37b363102e6b879073db6dec671d",
+			},
+		},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
+	},
+
+	// 18.09.9 - Debian Buster
+	{
+		DockerVersion: "18.09.9",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionDebian10},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "18.09.9~3-0~debian-buster",
+		Source:        "https://download.docker.com/linux/debian/dists/buster/pool/stable/amd64/docker-ce_18.09.9~3-0~debian-buster_amd64.deb",
+		Hash:          "97620eede9ca9fd379eef41b9d14347fe1d82ded",
+		ExtraPackages: map[string]packageInfo{
+			"docker-ce-cli": {
+				Version: "18.09.9~3-0~debian-buster",
+				Source:  "https://download.docker.com/linux/debian/dists/buster/pool/stable/amd64/docker-ce-cli_18.09.9~3-0~debian-buster_amd64.deb",
+				Hash:    "510eee5b6884867be0d2b360f8ff8cf7f0c0d11a",
+			},
+			"containerd.io": {
+				Version: "1.2.10-3",
+				Source:  "https://download.docker.com/linux/debian/dists/buster/pool/stable/amd64/containerd.io_1.2.10-3_amd64.deb",
+				Hash:    "365e4a7541ce2cf3c3036ea2a9bf6b40a50893a8",
+			},
+		},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
+	},
+
+	// 18.09.9 - Bionic
+	{
+		DockerVersion: "18.09.9",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionBionic},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "18.09.9~3-0~ubuntu-bionic",
+		Source:        "https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce_18.09.9~3-0~ubuntu-bionic_amd64.deb",
+		Hash:          "edabe6602521927b6e9ad70fc7650329333b51a3",
+		ExtraPackages: map[string]packageInfo{
+			"docker-ce-cli": {
+				Version: "18.09.9~3-0~ubuntu-bionic",
+				Source:  "https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce-cli_18.09.9~3-0~ubuntu-bionic_amd64.deb",
+				Hash:    "bca089a50ea22f02abe88f68d7ca35c26be9967b",
+			},
+			"containerd.io": {
+				Version: "1.2.10-3",
+				Source:  "https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/containerd.io_1.2.10-3_amd64.deb",
+				Hash:    "f4c941807310e3fa470dddfb068d599174a3daec",
+			},
+		},
+		Dependencies: []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+	},
+
+	// 18.09.9 - CentOS / Rhel7
+	{
+		DockerVersion: "18.09.9",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "18.09.9",
+		Source:        "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-18.09.9-3.el7.x86_64.rpm",
+		Hash:          "0b656dcdbddfc231f871ae78e3f5ac76716b5914",
+		ExtraPackages: map[string]packageInfo{
+			"docker-ce-cli": {
+				Version: "18.09.9",
+				Source:  "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-cli-18.09.9-3.el7.x86_64.rpm",
+				Hash:    "0c51b1339a95bd732ca305f07b7bcc95f132b9c8",
+			},
+			"containerd.io": {
+				Version: "1.2.10",
+				Source:  "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.10-3.2.el7.x86_64.rpm",
+				Hash:    "f6447e84479df3a58ce04a3da87ccc384663493b",
+			},
+			"container-selinux": {
+				Version: "2.107",
+				Source:  "http://vault.centos.org/7.6.1810/extras/x86_64/Packages/container-selinux-2.107-1.el7_6.noarch.rpm",
+				Hash:    "7de4211fa0dfd240d8827b93763e1eb5f0d56411",
+			},
+		},
+		Dependencies: []string{"libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python"},
+	},
+
+	// 18.09.9 - CentOS / Rhel8
+	{
+		DockerVersion: "18.09.9",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionRhel8, distros.DistributionCentos8},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "18.09.9",
+		Source:        "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-18.09.9-3.el7.x86_64.rpm",
+		Hash:          "0b656dcdbddfc231f871ae78e3f5ac76716b5914",
+		ExtraPackages: map[string]packageInfo{
+			"docker-ce-cli": {
+				Version: "18.09.9",
+				Source:  "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-cli-18.09.9-3.el7.x86_64.rpm",
+				Hash:    "0c51b1339a95bd732ca305f07b7bcc95f132b9c8",
+			},
+			"containerd.io": {
+				Version: "1.2.10",
+				Source:  "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.10-3.2.el7.x86_64.rpm",
+				Hash:    "f6447e84479df3a58ce04a3da87ccc384663493b",
+			},
+		},
+		Dependencies: []string{"container-selinux", "libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python-utils", "python3-policycoreutils"},
+	},
+
 	// 19.03.4 - k8s 1.17 - https://github.com/kubernetes/kubernetes/pull/84476
 
 	// 19.03.4 - Debian Stretch

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -778,6 +778,133 @@ var dockerVersions = []dockerVersion{
 		Dependencies:  []string{"container-selinux", "libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python-utils", "python3-policycoreutils"},
 	},
 
+	// 19.03.4 - k8s 1.17 - https://github.com/kubernetes/kubernetes/pull/84476
+
+	// 19.03.4 - Debian Stretch
+	{
+		DockerVersion: "19.03.4",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionDebian9},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "19.03.4~3-0~debian-stretch",
+		Source:        "https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_19.03.4~3-0~debian-stretch_amd64.deb",
+		Hash:          "2b8dcb2d75334fab29242ac069d1fbcfb65e88e3",
+		ExtraPackages: map[string]packageInfo{
+			"docker-ce-cli": {
+				Version: "19.03.4~3-0~debian-stretch",
+				Source:  "https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce-cli_19.03.4~3-0~debian-stretch_amd64.deb",
+				Hash:    "57f71ee764abb19a0b4c580ff14b1eb3de3a9e08",
+			},
+			"containerd.io": {
+				Version: "1.2.10-3",
+				Source:  "https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/containerd.io_1.2.10-3_amd64.deb",
+				Hash:    "186f2f2c570f37b363102e6b879073db6dec671d",
+			},
+		},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
+	},
+
+	// 19.03.4 - Debian Buster
+	{
+		DockerVersion: "19.03.4",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionDebian10},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "19.03.4~3-0~debian-buster",
+		Source:        "https://download.docker.com/linux/debian/dists/buster/pool/stable/amd64/docker-ce_19.03.4~3-0~debian-buster_amd64.deb",
+		Hash:          "492a70f29ceffd315ee9712b33004491c6f59e49",
+		ExtraPackages: map[string]packageInfo{
+			"docker-ce-cli": {
+				Version: "19.03.4~3-0~debian-buster",
+				Source:  "https://download.docker.com/linux/debian/dists/buster/pool/stable/amd64/docker-ce-cli_19.03.4~3-0~debian-buster_amd64.deb",
+				Hash:    "2549a364f0e5ce489c79b292b78e349751385dd5",
+			},
+			"containerd.io": {
+				Version: "1.2.10-3",
+				Source:  "https://download.docker.com/linux/debian/dists/buster/pool/stable/amd64/containerd.io_1.2.10-3_amd64.deb",
+				Hash:    "365e4a7541ce2cf3c3036ea2a9bf6b40a50893a8",
+			},
+		},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
+	},
+
+	// 19.03.4 - Bionic
+	{
+		DockerVersion: "19.03.4",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionBionic},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "19.03.4~3-0~ubuntu-bionic",
+		Source:        "https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce_19.03.4~3-0~ubuntu-bionic_amd64.deb",
+		Hash:          "ee640d9258fd4d3f4c7017ab2a71da63cbbead55",
+		ExtraPackages: map[string]packageInfo{
+			"docker-ce-cli": {
+				Version: "19.03.4~3-0~ubuntu-bionic",
+				Source:  "https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce-cli_19.03.4~3-0~ubuntu-bionic_amd64.deb",
+				Hash:    "09402bf5dac40f0c50f1071b17f38f6584a42ad1",
+			},
+			"containerd.io": {
+				Version: "1.2.10-3",
+				Source:  "https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/containerd.io_1.2.10-3_amd64.deb",
+				Hash:    "f4c941807310e3fa470dddfb068d599174a3daec",
+			},
+		},
+		Dependencies: []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+	},
+
+	// 19.03.4 - CentOS / Rhel7
+	{
+		DockerVersion: "19.03.4",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "19.03.4",
+		Source:        "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-19.03.4-3.el7.x86_64.rpm",
+		Hash:          "02a9db54fa40b8d94e2a4c1b5572ad911873a4c8",
+		ExtraPackages: map[string]packageInfo{
+			"docker-ce-cli": {
+				Version: "19.03.4",
+				Source:  "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-cli-19.03.4-3.el7.x86_64.rpm",
+				Hash:    "1fffcc716e74a59f753f8898ba96693a00e79e26",
+			},
+			"containerd.io": {
+				Version: "1.2.10",
+				Source:  "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.10-3.2.el7.x86_64.rpm",
+				Hash:    "f6447e84479df3a58ce04a3da87ccc384663493b",
+			},
+			"container-selinux": {
+				Version: "2.107",
+				Source:  "http://vault.centos.org/7.6.1810/extras/x86_64/Packages/container-selinux-2.107-1.el7_6.noarch.rpm",
+				Hash:    "7de4211fa0dfd240d8827b93763e1eb5f0d56411",
+			},
+		},
+		Dependencies: []string{"libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python"},
+	},
+
+	// 19.03.4 - CentOS / Rhel8
+	{
+		DockerVersion: "19.03.4",
+		Name:          "docker-ce",
+		Distros:       []distros.Distribution{distros.DistributionRhel8, distros.DistributionCentos8},
+		Architectures: []Architecture{ArchitectureAmd64},
+		Version:       "19.03.4",
+		Source:        "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-19.03.4-3.el7.x86_64.rpm",
+		Hash:          "02a9db54fa40b8d94e2a4c1b5572ad911873a4c8",
+		ExtraPackages: map[string]packageInfo{
+			"docker-ce-cli": {
+				Version: "19.03.4",
+				Source:  "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-cli-19.03.4-3.el7.x86_64.rpm",
+				Hash:    "1fffcc716e74a59f753f8898ba96693a00e79e26",
+			},
+			"containerd.io": {
+				Version: "1.2.10",
+				Source:  "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.10-3.2.el7.x86_64.rpm",
+				Hash:    "f6447e84479df3a58ce04a3da87ccc384663493b",
+			},
+		},
+		Dependencies: []string{"container-selinux", "libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python-utils", "python3-policycoreutils"},
+	},
+
 	// TIP: When adding the next version, copy the previous
 	// version, string replace the version, run `VERIFY_HASHES=1
 	// go test ./nodeup/pkg/model` (you might want to temporarily

--- a/nodeup/pkg/model/docker_test.go
+++ b/nodeup/pkg/model/docker_test.go
@@ -55,8 +55,8 @@ func sanityCheckPackageName(t *testing.T, u string, version string, name string)
 
 	expectedNames := []string{}
 	// Match known RPM formats
-	for _, v := range []string{"-1.", "-2.", "-3."} {
-		for _, d := range []string{"el7", "el7.centos"} {
+	for _, v := range []string{"-1.", "-2.", "-3.", "-3.2."} {
+		for _, d := range []string{"el7", "el7.centos", "el7_6"} {
 			for _, a := range []string{"noarch", "x86_64"} {
 				expectedNames = append(expectedNames, name+"-"+version+v+d+"."+a+".rpm")
 			}

--- a/pkg/model/components/docker.go
+++ b/pkg/model/components/docker.go
@@ -53,7 +53,11 @@ func (b *DockerOptionsBuilder) BuildOptions(o interface{}) error {
 		}
 
 		dockerVersion := ""
-		if sv.Major == 1 && sv.Minor >= 12 {
+		if sv.Major == 1 && sv.Minor >= 17 {
+			dockerVersion = "19.03.4"
+		} else if sv.Major == 1 && sv.Minor >= 16 {
+			dockerVersion = "18.09.9"
+		} else if sv.Major == 1 && sv.Minor >= 12 {
 			dockerVersion = "18.06.3"
 		} else if sv.Major == 1 && sv.Minor >= 9 {
 			dockerVersion = "17.03.2"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it:**
Updates supported Docker versions to latest stable. Previous versions for Docker CE are EOL.

**Which issue(s) this PR fixes:**
Fixes #7463
Fixes #7853

**Special notes for your reviewer:**
At the moment the default Docker version in Kops is 18.06.3, quite old and EOL. Docker version 18.09 has been officially validated since k8s 1.14, but it's EOL also at the moment also.

Docker 19.03 has been stable for some time and has been validated for k8s 1.14+ since June, just not documented. https://github.com/kubernetes/kubernetes/issues/82326#issuecomment-546464495
Test infrastructure has been moved to Docker 19.03 also. https://github.com/kubernetes/test-infra/pull/14784
Website should be getting updated instructions for installing Docker soon. https://github.com/kubernetes/website/pull/17405

IMHO, adding support Docker 19.03 and 18.09 should be a useful from stability and security point of view.

Hash check passed for all packages:
```
$ VERIFY_HASHES=1 go test ./nodeup/pkg/model
ok  	k8s.io/kops/nodeup/pkg/model	191.029s
```

I tested the changes with Debian Stretch and Buster, Ubuntu Bionic, RHEL 7 and 8.
The only issue I noticed was the `iptables-legacy` setup that will be addressed by #7379.
```
$ kubectl get nodes -o wide

NAME                     STATUS   ROLES    AGE   VERSION    INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                      KERNEL-VERSION                  CONTAINER-RUNTIME
ip-10-2-1-85.internal    Ready    node     46m   v1.11.10   10.2.1.85     <none>        Debian GNU/Linux 9 (stretch)                  4.9.0-11-amd64                  docker://19.3.4
ip-10-2-1-104.internal   Ready    node     56m   v1.11.10   10.2.1.104    <none>        Debian GNU/Linux 10 (buster)                  4.19.0-6-amd64                  docker://19.3.4
ip-10-2-1-122.internal   Ready    node     10m   v1.11.10   10.2.1.122    <none>        Ubuntu 18.04.3 LTS                            4.15.0-1051-aws                 docker://19.3.4
ip-10-2-1-15.internal    Ready    node     12h   v1.11.10   10.2.1.15     <none>        Red Hat Enterprise Linux Server 7.7 (Maipo)   3.10.0-1062.1.2.el7.x86_64      docker://19.3.4
ip-10-2-1-79.internal    Ready    node     1m    v1.11.10   10.2.1.79     <none>        Red Hat Enterprise Linux 8.0 (Ootpa)          4.18.0-80.4.2.el8_0.x86_64      docker://19.3.4
```

**Does this PR introduce a user-facing change?:**

Default Docker version will change to 18.09.9 for k8s >= 1.14 and 19.03.4 for k8s >= 1.17.
Users will be able to manually select version 19.03.4.
```
spec:
  docker:
    version: 19.03.4
```