### PR TITLE
Cleanup make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -475,35 +475,17 @@ bazel-utils-dist:
 # --------------------------------------------------
 # development targets
 
-.PHONY: dep-prereqs
-dep-prereqs:
-	(which hg > /dev/null) || (echo "dep requires that mercurial is installed"; exit 1)
-	(which dep > /dev/null) || (echo "dep-ensure requires that dep is installed"; exit 1)
-	(which bazel > /dev/null) || (echo "dep-ensure requires that bazel is installed"; exit 1)
+.PHONY: gomod-prereqs
+gomod-prereqs:
+	(which bazel > /dev/null) || (echo "gomod requires that bazel is installed"; exit 1)
 
 .PHONY: dep-ensure
-dep-ensure: dep-prereqs
+dep-ensure:
 	echo "`make dep-ensure` has been replaced by `make gomod`"
 	exit 1
-	dep ensure -v
-	# Switch weavemesh to use peer_name_hash - bazel rule-go doesn't support build tags yet
-	rm vendor/github.com/weaveworks/mesh/peer_name_mac.go
-	sed -i -e 's/peer_name_hash/!peer_name_mac/g' vendor/github.com/weaveworks/mesh/peer_name_hash.go
-	# Remove all bazel build files that were vendored and regenerate (we assume they are go-gettable)
-	find vendor/ -name "BUILD" -delete
-	find vendor/ -name "BUILD.bazel" -delete
-	# Remove recursive symlinks that really confuse bazel
-	rm -rf vendor/github.com/coreos/etcd/cmd/
-	rm -rf vendor/github.com/jteeuwen/go-bindata/testdata/
-	# Remove dependencies that dep just can't figure out
-	rm -rf vendor/k8s.io/code-generator/cmd/set-gen/
-	rm -rf vendor/k8s.io/code-generator/cmd/go-to-protobuf/
-	rm -rf vendor/k8s.io/code-generator/cmd/import-boss/
-	rm -rf vendor/github.com/docker/docker/contrib/
-	make gazelle
 
 .PHONY: gomod
-gomod:
+gomod: gomod-prereqs
 	GO111MODULE=on go mod vendor
 	# Switch weavemesh to use peer_name_hash - bazel rule-go doesn't support build tags yet
 	rm vendor/github.com/weaveworks/mesh/peer_name_mac.go

--- a/Makefile
+++ b/Makefile
@@ -389,7 +389,7 @@ push-aws-run: push
 
 .PHONY: ${PROTOKUBE}
 ${PROTOKUBE}:
-	go build ${GCFLAGS} -o $@ -tags 'peer_name_alternative peer_name_hash' k8s.io/kops/protokube/cmd/protokube
+	go build ${GCFLAGS} ${EXTRA_BUILDFLAGS} -o $@ -tags 'peer_name_alternative peer_name_hash' k8s.io/kops/protokube/cmd/protokube
 
 .PHONY: protokube
 protokube: ${PROTOKUBE}

--- a/Makefile
+++ b/Makefile
@@ -184,23 +184,17 @@ upup/models/bindata.go: ${GOBINDATA} ${UPUP_MODELS_BINDATA_SOURCES}
 
 # Build in a docker container with golang 1.X
 # Used to test we have not broken 1.X
-# 1.10 is the default for k8s 1.11.  Others are best-effort
-.PHONY: check-builds-in-go18
-check-builds-in-go18:
-	# Note we only check that kops builds; we know the tests don't compile because of type aliasing in uber zap
-	docker run -v ${GOPATH_1ST}/src/k8s.io/kops:/go/src/k8s.io/kops golang:1.8 make -C /go/src/k8s.io/kops kops
-
-.PHONY: check-builds-in-go19
-check-builds-in-go19:
-	docker run -v ${GOPATH_1ST}/src/k8s.io/kops:/go/src/k8s.io/kops golang:1.9 make -C /go/src/k8s.io/kops ci
-
-.PHONY: check-builds-in-go110
-check-builds-in-go110:
-	docker run -v ${GOPATH_1ST}/src/k8s.io/kops:/go/src/k8s.io/kops golang:1.10 make -C /go/src/k8s.io/kops ci
-
 .PHONY: check-builds-in-go111
 check-builds-in-go111:
-	docker run -v ${GOPATH_1ST}/src/k8s.io/kops:/go/src/k8s.io/kops golang:1.11 make -C /go/src/k8s.io/kops ci
+	docker run -e GO111MODULE=on -e EXTRA_BUILDFLAGS=-mod=vendor -v ${GOPATH_1ST}/src/k8s.io/kops:/go/src/k8s.io/kops golang:1.11 make -C /go/src/k8s.io/kops all
+
+.PHONY: check-builds-in-go112
+check-builds-in-go112:
+	docker run -e GO111MODULE=on -e EXTRA_BUILDFLAGS=-mod=vendor -v ${GOPATH_1ST}/src/k8s.io/kops:/go/src/k8s.io/kops golang:1.12 make -C /go/src/k8s.io/kops all
+
+.PHONY: check-builds-in-go113
+check-builds-in-go113:
+	docker run -e EXTRA_BUILDFLAGS=-mod=vendor -v ${GOPATH_1ST}/src/k8s.io/kops:/go/src/k8s.io/kops golang:1.13 make -C /go/src/k8s.io/kops all
 
 .PHONY: codegen
 codegen: kops-gobindata

--- a/Makefile
+++ b/Makefile
@@ -98,20 +98,7 @@ PROTOKUBE_TAG := $(subst +,-,${VERSION})
 KOPS_SERVER_TAG := $(subst +,-,${VERSION})
 
 # Go exports:
-
-GO15VENDOREXPERIMENT=1
-export GO15VENDOREXPERIMENT
-
-COMPILERVERSION := $(shell go version | cut -d' ' -f3 | sed 's/go//g' | tr -d '\n')
-COMPILER_VER_MAJOR := $(shell echo $(COMPILERVERSION) | cut -f1 -d.)
-COMPILER_VER_MINOR := $(shell echo $(COMPILERVERSION) | cut -f2 -d.)
-COMPILER_GT_1_10 := $(shell [ $(COMPILER_VER_MAJOR) -gt 1 -o \( $(COMPILER_VER_MAJOR) -eq 1 -a $(COMPILER_VER_MINOR) -ge 10 \) ] && echo true)
-
-ifeq ($(COMPILER_GT_1_10), true)
 LDFLAGS := -ldflags=all=
-else
-LDFLAGS := -ldflags=
-endif
 
 ifdef STATIC_BUILD
   CGO_ENABLED=0


### PR DESCRIPTION
* Removed `LDFLAGS` workarounds for older (unsupported) versions of go
* Updated `check-builds-in-go*` targets for more recent versions of go. Since the `ci` target requires bazel, rather than trying to install that in a docker container I opted to just use the `all` target which should provide sufficient coverage. Note that the 1.11 target isnt currently working (`build k8s.io/cloud-provider: cannot find module for path k8s.io/cloud-provider`) I'll need to troubleshoot that more unless we decide to just drop go 1.11 support entirely.
* `make protokube` now respects `EXTRA_BUILDFLAGS`
* Removed unused `dep-ensure` code and updated the prereqs task so that `gomod` now checks for the presence of bazel.