### PR TITLE
Fix behavior of mock DescribeAutoScalingGroups when no names supplied

### DIFF
--- a/cloudmock/aws/mockautoscaling/group.go
+++ b/cloudmock/aws/mockautoscaling/group.go
@@ -139,6 +139,8 @@ func (m *MockAutoscaling) DescribeAutoScalingGroups(input *autoscaling.DescribeA
 					match = true
 				}
 			}
+		} else {
+			match = true
 		}
 
 		if match {


### PR DESCRIPTION
Two of the tests in `kops/pkg/instancegroups/rollingupdate_test.go` are invalid, as can be demonstrated by removing the call to `c.RollingUpdate` in `TestRollingUpdateAllNeedUpdate`—the test will still pass because `asgGroups.AutoScalingGroups` is always empty and all the  assertions are dead code.

This patch fixes the behavior of the mock DescribeAutoScalingGroups when its input omits the `AutoScalingGroupNames` field.
