### PR TITLE
awsup: fix shadowed var when looking for etcd cluster name

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/status.go
+++ b/upup/pkg/fi/cloudup/awsup/status.go
@@ -85,7 +85,7 @@ func findEtcdStatus(c AWSCloud, cluster *kops.Cluster) ([]kops.EtcdClusterStatus
 			v := aws.StringValue(tag.Value)
 
 			if strings.HasPrefix(k, TagNameEtcdClusterPrefix) {
-				etcdClusterName := strings.TrimPrefix(k, TagNameEtcdClusterPrefix)
+				etcdClusterName = strings.TrimPrefix(k, TagNameEtcdClusterPrefix)
 				etcdClusterSpec, err = etcd.ParseEtcdClusterSpec(etcdClusterName, v)
 				if err != nil {
 					return nil, fmt.Errorf("error parsing etcd cluster tag %q on volume %q: %v", v, volumeID, err)


### PR DESCRIPTION
Variable `etcdClusterName` is being reset inside the loop, resulting in the outer `etcdClusterName` never changing from `""`.