### PR TITLE
Don't update first node in instancegroup if cluster fails validation

### DIFF
--- a/cmd/kops/validate_cluster.go
+++ b/cmd/kops/validate_cluster.go
@@ -134,8 +134,13 @@ func RunValidateCluster(f *util.Factory, cmd *cobra.Command, args []string, out 
 	timeout := time.Now().Add(options.wait)
 	pollInterval := 10 * time.Second
 
+	validator, err := validation.NewClusterValidator(cluster, list, k8sClient)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error creating validatior: %v", err)
+	}
+
 	for {
-		result, err := validation.ValidateCluster(cluster, list, k8sClient)
+		result, err := validator.Validate()
 		if err != nil {
 			if time.Now().After(timeout) {
 				return nil, fmt.Errorf("unexpected error during validation: %v", err)

--- a/pkg/instancegroups/BUILD.bazel
+++ b/pkg/instancegroups/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "//cloudmock/aws/mockautoscaling:go_default_library",
         "//pkg/apis/kops:go_default_library",
         "//pkg/cloudinstances:go_default_library",
+        "//pkg/validation:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/autoscaling:go_default_library",

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package instancegroups
 
 import (
+	"errors"
+	"k8s.io/kops/pkg/validation"
 	"testing"
 	"time"
 
@@ -79,6 +81,18 @@ func setUpCloud(c *RollingUpdateCluster) {
 	})
 }
 
+type successfulClusterValidator struct{}
+
+func (*successfulClusterValidator) Validate() (*validation.ValidationCluster, error) {
+	return &validation.ValidationCluster{}, nil
+}
+
+type erroringClusterValidator struct{}
+
+func (*erroringClusterValidator) Validate() (*validation.ValidationCluster, error) {
+	return nil, errors.New("testing validation error")
+}
+
 func TestRollingUpdateAllNeedUpdate(t *testing.T) {
 	k8sClient := fake.NewSimpleClientset()
 
@@ -89,18 +103,19 @@ func TestRollingUpdateAllNeedUpdate(t *testing.T) {
 	cluster.Name = "test.k8s.local"
 
 	c := &RollingUpdateCluster{
-		Cloud:           mockcloud,
-		MasterInterval:  1 * time.Millisecond,
-		NodeInterval:    1 * time.Millisecond,
-		BastionInterval: 1 * time.Millisecond,
-		Force:           false,
-		K8sClient:       k8sClient,
+		Cloud:            mockcloud,
+		MasterInterval:   1 * time.Millisecond,
+		NodeInterval:     1 * time.Millisecond,
+		BastionInterval:  1 * time.Millisecond,
+		Force:            false,
+		K8sClient:        k8sClient,
+		ClusterValidator: &successfulClusterValidator{},
+		FailOnValidate:   true,
 	}
 
 	cloud := c.Cloud.(awsup.AWSCloud)
 	setUpCloud(c)
 
-	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	groups["node-1"] = &cloudinstances.CloudInstanceGroup{
 		InstanceGroup: &kopsapi.InstanceGroup{
@@ -215,7 +230,7 @@ func TestRollingUpdateAllNeedUpdate(t *testing.T) {
 		t.Errorf("Error on rolling update: %v", err)
 	}
 
-	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
 	for _, group := range asgGroups.AutoScalingGroups {
 		if len(group.Instances) > 0 {
 			t.Error("Not all instances terminated")
@@ -233,18 +248,18 @@ func TestRollingUpdateNoneNeedUpdate(t *testing.T) {
 	cluster.Name = "test.k8s.local"
 
 	c := &RollingUpdateCluster{
-		Cloud:           mockcloud,
-		MasterInterval:  1 * time.Millisecond,
-		NodeInterval:    1 * time.Millisecond,
-		BastionInterval: 1 * time.Millisecond,
-		Force:           false,
-		K8sClient:       k8sClient,
+		Cloud:            mockcloud,
+		MasterInterval:   1 * time.Millisecond,
+		NodeInterval:     1 * time.Millisecond,
+		BastionInterval:  1 * time.Millisecond,
+		Force:            false,
+		K8sClient:        k8sClient,
+		ClusterValidator: &successfulClusterValidator{},
+		FailOnValidate:   true,
 	}
 
 	cloud := c.Cloud.(awsup.AWSCloud)
 	setUpCloud(c)
-
-	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	groups["node-1"] = &cloudinstances.CloudInstanceGroup{
@@ -328,7 +343,7 @@ func TestRollingUpdateNoneNeedUpdate(t *testing.T) {
 		t.Errorf("Error on rolling update: %v", err)
 	}
 
-	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
 		AutoScalingGroupNames: []*string{aws.String("node-1")},
 	})
 	for _, group := range asgGroups.AutoScalingGroups {
@@ -375,17 +390,17 @@ func TestRollingUpdateNoneNeedUpdateWithForce(t *testing.T) {
 	cluster.Name = "test.k8s.local"
 
 	c := &RollingUpdateCluster{
-		Cloud:           mockcloud,
-		MasterInterval:  1 * time.Millisecond,
-		NodeInterval:    1 * time.Millisecond,
-		BastionInterval: 1 * time.Millisecond,
-		Force:           true,
-		K8sClient:       k8sClient,
+		Cloud:            mockcloud,
+		MasterInterval:   1 * time.Millisecond,
+		NodeInterval:     1 * time.Millisecond,
+		BastionInterval:  1 * time.Millisecond,
+		Force:            true,
+		K8sClient:        k8sClient,
+		ClusterValidator: &successfulClusterValidator{},
+		FailOnValidate:   true,
 	}
 	cloud := c.Cloud.(awsup.AWSCloud)
 	setUpCloud(c)
-
-	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	groups["node-1"] = &cloudinstances.CloudInstanceGroup{
@@ -469,7 +484,7 @@ func TestRollingUpdateNoneNeedUpdateWithForce(t *testing.T) {
 		t.Errorf("Error on rolling update: %v", err)
 	}
 
-	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
 	for _, group := range asgGroups.AutoScalingGroups {
 		if len(group.Instances) > 0 {
 			t.Error("Not all instances terminated")
@@ -484,17 +499,18 @@ func TestRollingUpdateEmptyGroup(t *testing.T) {
 	mockcloud.MockAutoscaling = &mockautoscaling.MockAutoscaling{}
 
 	c := &RollingUpdateCluster{
-		Cloud:           mockcloud,
-		MasterInterval:  1 * time.Millisecond,
-		NodeInterval:    1 * time.Millisecond,
-		BastionInterval: 1 * time.Millisecond,
-		K8sClient:       k8sClient,
-		Force:           false,
+		Cloud:            mockcloud,
+		MasterInterval:   1 * time.Millisecond,
+		NodeInterval:     1 * time.Millisecond,
+		BastionInterval:  1 * time.Millisecond,
+		K8sClient:        k8sClient,
+		ClusterValidator: &successfulClusterValidator{},
+		Force:            false,
+		FailOnValidate:   true,
 	}
 	cloud := c.Cloud.(awsup.AWSCloud)
 	setUpCloud(c)
 
-	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 
 	err := c.RollingUpdate(groups, &kopsapi.Cluster{}, &kopsapi.InstanceGroupList{})
@@ -502,7 +518,7 @@ func TestRollingUpdateEmptyGroup(t *testing.T) {
 		t.Errorf("Error on rolling update: %v", err)
 	}
 
-	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
 		AutoScalingGroupNames: []*string{aws.String("node-1")},
 	})
 	for _, group := range asgGroups.AutoScalingGroups {
@@ -549,17 +565,17 @@ func TestRollingUpdateUnknownRole(t *testing.T) {
 	cluster.Name = "test.k8s.local"
 
 	c := &RollingUpdateCluster{
-		Cloud:           mockcloud,
-		MasterInterval:  1 * time.Millisecond,
-		NodeInterval:    1 * time.Millisecond,
-		BastionInterval: 1 * time.Millisecond,
-		Force:           false,
-		K8sClient:       k8sClient,
+		Cloud:            mockcloud,
+		MasterInterval:   1 * time.Millisecond,
+		NodeInterval:     1 * time.Millisecond,
+		BastionInterval:  1 * time.Millisecond,
+		Force:            false,
+		K8sClient:        k8sClient,
+		ClusterValidator: &successfulClusterValidator{},
+		FailOnValidate:   true,
 	}
 	cloud := c.Cloud.(awsup.AWSCloud)
 	setUpCloud(c)
-
-	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	groups["node-1"] = &cloudinstances.CloudInstanceGroup{
@@ -643,7 +659,7 @@ func TestRollingUpdateUnknownRole(t *testing.T) {
 		t.Errorf("Error expected on rolling update: %v", err)
 	}
 
-	asgGroups, _ = cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
 		AutoScalingGroupNames: []*string{aws.String("node-1")},
 	})
 	for _, group := range asgGroups.AutoScalingGroups {
@@ -676,6 +692,205 @@ func TestRollingUpdateUnknownRole(t *testing.T) {
 	for _, group := range asgGroups.AutoScalingGroups {
 		if len(group.Instances) != 1 {
 			t.Errorf("Expected 1 instances got: %v", len(group.Instances))
+		}
+	}
+}
+
+func getGroupsNodes1NeedsUpdating() map[string]*cloudinstances.CloudInstanceGroup {
+	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
+	groups["node-1"] = &cloudinstances.CloudInstanceGroup{
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "node-1",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleNode,
+			},
+		},
+		Ready: []*cloudinstances.CloudInstanceGroupMember{
+			{
+				ID:   "node-1a",
+				Node: &v1.Node{},
+			},
+			{
+				ID:   "node-1b",
+				Node: &v1.Node{},
+			},
+		},
+		NeedUpdate: []*cloudinstances.CloudInstanceGroupMember{
+			{
+				ID:   "node-1a",
+				Node: &v1.Node{},
+			},
+			{
+				ID:   "node-1b",
+				Node: &v1.Node{},
+			},
+		},
+	}
+	groups["master-1"] = &cloudinstances.CloudInstanceGroup{
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: "master-1",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleMaster,
+			},
+		},
+		Ready: []*cloudinstances.CloudInstanceGroupMember{
+			{
+				ID:   "master-1a",
+				Node: &v1.Node{},
+			},
+		},
+	}
+	return groups
+}
+
+func TestRollingUpdateClusterErrorsValidation(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+
+	mockcloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
+	mockcloud.MockAutoscaling = &mockautoscaling.MockAutoscaling{}
+
+	cluster := &kopsapi.Cluster{}
+	cluster.Name = "test.k8s.local"
+
+	c := &RollingUpdateCluster{
+		Cloud:            mockcloud,
+		MasterInterval:   1 * time.Millisecond,
+		NodeInterval:     1 * time.Millisecond,
+		BastionInterval:  1 * time.Millisecond,
+		Force:            false,
+		K8sClient:        k8sClient,
+		ClusterValidator: &erroringClusterValidator{},
+		FailOnValidate:   true,
+	}
+
+	cloud := c.Cloud.(awsup.AWSCloud)
+	setUpCloud(c)
+
+	err := c.RollingUpdate(getGroupsNodes1NeedsUpdating(), cluster, &kopsapi.InstanceGroupList{})
+	if err == nil {
+		t.Error("Expected error from rolling update, got nil")
+	}
+
+	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("node-1")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) != 2 {
+			t.Errorf("Expected two instances in group got %v", len(group.Instances))
+		}
+	}
+}
+
+type failAfterOneNodeClusterValidator struct {
+	Cloud       awsup.AWSCloud
+	ReturnError bool
+}
+
+func (v *failAfterOneNodeClusterValidator) Validate() (*validation.ValidationCluster, error) {
+	asgGroups, _ := v.Cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("node-1")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) < 2 {
+			if v.ReturnError {
+				return nil, errors.New("testing validation error")
+			}
+			return &validation.ValidationCluster{
+				Failures: []*validation.ValidationError{
+					{
+						Kind:    "testing",
+						Name:    "testingfailure",
+						Message: "testing failure",
+					},
+				},
+			}, nil
+		}
+	}
+	return &validation.ValidationCluster{}, nil
+}
+
+func TestRollingUpdateClusterFailsValidationAfterOneNode(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+
+	mockcloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
+	mockcloud.MockAutoscaling = &mockautoscaling.MockAutoscaling{}
+
+	cluster := &kopsapi.Cluster{}
+	cluster.Name = "test.k8s.local"
+
+	c := &RollingUpdateCluster{
+		Cloud:           mockcloud,
+		MasterInterval:  1 * time.Millisecond,
+		NodeInterval:    1 * time.Millisecond,
+		BastionInterval: 1 * time.Millisecond,
+		Force:           false,
+		K8sClient:       k8sClient,
+		ClusterValidator: &failAfterOneNodeClusterValidator{
+			Cloud:       mockcloud,
+			ReturnError: false,
+		},
+		FailOnValidate: true,
+	}
+
+	cloud := c.Cloud.(awsup.AWSCloud)
+	setUpCloud(c)
+
+	err := c.RollingUpdate(getGroupsNodes1NeedsUpdating(), cluster, &kopsapi.InstanceGroupList{})
+	if err == nil {
+		t.Error("Expected error from rolling update, got nil")
+	}
+
+	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("node-1")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) != 1 {
+			t.Errorf("Expected one instance in group got %v", len(group.Instances))
+		}
+	}
+}
+
+func TestRollingUpdateClusterErrorsValidationAfterOneNode(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+
+	mockcloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
+	mockcloud.MockAutoscaling = &mockautoscaling.MockAutoscaling{}
+
+	cluster := &kopsapi.Cluster{}
+	cluster.Name = "test.k8s.local"
+
+	c := &RollingUpdateCluster{
+		Cloud:           mockcloud,
+		MasterInterval:  1 * time.Millisecond,
+		NodeInterval:    1 * time.Millisecond,
+		BastionInterval: 1 * time.Millisecond,
+		Force:           false,
+		K8sClient:       k8sClient,
+		ClusterValidator: &failAfterOneNodeClusterValidator{
+			Cloud:       mockcloud,
+			ReturnError: true,
+		},
+		FailOnValidate: true,
+	}
+
+	cloud := c.Cloud.(awsup.AWSCloud)
+	setUpCloud(c)
+
+	err := c.RollingUpdate(getGroupsNodes1NeedsUpdating(), cluster, &kopsapi.InstanceGroupList{})
+	if err == nil {
+		t.Error("Expected error from rolling update, got nil")
+	}
+
+	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("node-1")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		if len(group.Instances) != 1 {
+			t.Errorf("Expected one instance in group got %v", len(group.Instances))
 		}
 	}
 }

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -48,6 +48,17 @@ type ValidationError struct {
 	Message string `json:"message,omitempty"`
 }
 
+type ClusterValidator interface {
+	// Validate validates a k8s cluster
+	Validate() (*ValidationCluster, error)
+}
+
+type clusterValidatorImpl struct {
+	cluster           *kops.Cluster
+	instanceGroupList *kops.InstanceGroupList
+	k8sClient         kubernetes.Interface
+}
+
 func (v *ValidationCluster) addError(failure *ValidationError) {
 	v.Failures = append(v.Failures, failure)
 }
@@ -89,8 +100,20 @@ func hasPlaceHolderIP(clusterName string) (bool, error) {
 	return false, nil
 }
 
-// ValidateCluster validates a k8s cluster with a provided instance group list
-func ValidateCluster(cluster *kops.Cluster, instanceGroupList *kops.InstanceGroupList, k8sClient kubernetes.Interface) (*ValidationCluster, error) {
+func NewClusterValidator(cluster *kops.Cluster, instanceGroupList *kops.InstanceGroupList, k8sClient kubernetes.Interface) (ClusterValidator, error) {
+	return &clusterValidatorImpl{
+		cluster:           cluster,
+		instanceGroupList: instanceGroupList,
+		k8sClient:         k8sClient,
+	}, nil
+}
+
+func (v *clusterValidatorImpl) Validate() (*ValidationCluster, error) {
+	return validateCluster(v.cluster, v.instanceGroupList, v.k8sClient)
+}
+
+// validateCluster validates a k8s cluster with a provided instance group list
+func validateCluster(cluster *kops.Cluster, instanceGroupList *kops.InstanceGroupList, k8sClient kubernetes.Interface) (*ValidationCluster, error) {
 	clusterName := cluster.Name
 
 	v := &ValidationCluster{}


### PR DESCRIPTION
A rolling update will drain and terminate the first node in a nodes instancegroup even when the cluster is in a state where it fails validation.

Fixes #7258 
