### PR TITLE
docker/centos7 - Add missing selinux-policy dependency

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -561,7 +561,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
 			},
 		},
-		Dependencies: []string{"libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python"},
+		Dependencies: []string{"libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python", "selinux-policy-targeted"},
 	},
 
 	// 18.03.1 - Bionic
@@ -658,7 +658,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
 			},
 		},
-		Dependencies: []string{"libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python"},
+		Dependencies: []string{"libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python", "selinux-policy-targeted"},
 	},
 
 	// 18.09.3 - Debian Stretch
@@ -694,7 +694,7 @@ var dockerVersions = []dockerVersion{
 		Version:       "2.68",
 		Source:        "http://vault.centos.org/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
 		Hash:          "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
-		Dependencies:  []string{"policycoreutils-python"},
+		Dependencies:  []string{"policycoreutils-python", "selinux-policy-targeted"},
 	},
 	{
 		DockerVersion: "18.06.2",
@@ -764,7 +764,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
 			},
 		},
-		Dependencies: []string{"libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python"},
+		Dependencies: []string{"libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python", "selinux-policy-targeted"},
 	},
 	// 18.06.3 - CentOS / Rhel8 (two packages)
 	{


### PR DESCRIPTION
The centos7 periodic E2E jobs are [currently failing](https://testgrid.k8s.io/sig-cluster-lifecycle-kops#kops-aws-imagecentos7)
Specifically, nodeup is [failing to install docker and its dependencies](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-imagecentos7/1191326677003669507/artifacts/3.220.164.29/journal.log) due to an additional missing dependency:

```
W1104 12:12:14.918640    2848 executor.go:128] error running task "Package/docker-ce" (9m57s remaining to succeed): error installing package "docker-ce": exit status 2: warning: /var/cache/nodeup/packages/docker-ce: Header V4 RSA/SHA512 Signature, key ID 621e9f35: NOKEY
error: Failed dependencies:
selinux-policy >= 3.13.1-192 is needed by container-selinux-2:2.68-1.el7.noarch
selinux-policy-base >= 3.13.1-192 is needed by container-selinux-2:2.68-1.el7.noarch
selinux-policy-targeted >= 3.13.1-192 is needed by container-selinux-2:2.68-1.el7.noarch
```

I reproduced this issue by manually downloading the RPMs into a centos:7 docker container and confirmed installing `selinux-policy-targeted` fixed it, but i don't have access to a centos7 Kops cluster to confirm this at the moment. Unless someone else can test my fix, I guess we'll see how the periodic job responds once this is merged to confirm whether this fixes the issue or not.