### PR TITLE
Update "Guide" links for DigitalOcean & OpenStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ launching a Kubernetes cluster hosted on AWS.
 
 To install a Kubernetes cluster on GCE please follow this [guide](/docs/getting_started/gce.md).
 
-To install a Kubernetes cluster on DigitalOcean, follow this [guide](/docs/tutorial/digitalocean.md).
+To install a Kubernetes cluster on DigitalOcean, follow this [guide](/docs/getting_started/digitalocean.md).
 
-To install a Kubernetes cluster on OpenStack, follow this [guide](/docs/tutorial/openstack.md).
+To install a Kubernetes cluster on OpenStack, follow this [guide](/docs/getting_started/openstack.md).
 
 **For anything beyond experimental clusters it is highly encouraged to [version control the cluster manifest files](/docs/manifests_and_customizing_via_api.md) and [run kops in a CI environment](/docs/continuous_integration.md).**
 


### PR DESCRIPTION
#7593 moved the docs for DigitalOcean & OpenStack without updating links.  This PR corrects the links.