### PR TITLE
stable channel: promote kubernetes 1.13.12, 1.14.8 etc

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -42,14 +42,17 @@ spec:
     networking:
       kubenet: {}
   kubernetesVersions:
+  - range: ">=1.16.0"
+    recommendedVersion: 1.16.2
+    requiredVersion: 1.16.0
   - range: ">=1.15.0"
-    recommendedVersion: 1.15.4
+    recommendedVersion: 1.15.5
     requiredVersion: 1.15.0
   - range: ">=1.14.0"
-    recommendedVersion: 1.14.6
+    recommendedVersion: 1.14.8
     requiredVersion: 1.14.0
   - range: ">=1.13.0"
-    recommendedVersion: 1.13.11
+    recommendedVersion: 1.13.12
     requiredVersion: 1.13.0
   - range: ">=1.12.0"
     recommendedVersion: 1.12.10
@@ -61,18 +64,22 @@ spec:
     recommendedVersion: 1.11.10
     requiredVersion: 1.11.10
   kopsVersions:
+  - range: ">=1.16.0-alpha.1"
+    #recommendedVersion: "1.16.0"
+    #requiredVersion: 1.16.0
+    kubernetesVersion: 1.16.2
   - range: ">=1.15.0-alpha.1"
-    #recommendedVersion: "1.14.0"
-    #requiredVersion: 1.14.0
-    kubernetesVersion: 1.15.4
+    #recommendedVersion: "1.15.0"
+    #requiredVersion: 1.15.0
+    kubernetesVersion: 1.15.5
   - range: ">=1.14.0-alpha.1"
     #recommendedVersion: "1.14.0"
     #requiredVersion: 1.14.0
-    kubernetesVersion: 1.14.6
+    kubernetesVersion: 1.14.8
   - range: ">=1.13.0-alpha.1"
     #recommendedVersion: "1.13.0"
     #requiredVersion: 1.13.0
-    kubernetesVersion: 1.13.11
+    kubernetesVersion: 1.13.12
   - range: ">=1.12.0-alpha.1"
     recommendedVersion: "1.12.1"
     #requiredVersion: 1.12.0


### PR DESCRIPTION
Promote kubernetes versions from alpha to stable:

* 1.16.2
* 1.15.5
* 1.14.8
* 1.13.12