### PR TITLE
Update Weave Net to version 2.6.0

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -168,7 +168,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.5.2'
+          image: 'weaveworks/weave-kube:2.6.0'
           ports:
             - name: metrics
               containerPort: 6782
@@ -208,7 +208,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.5.2'
+          image: 'weaveworks/weave-npc:2.6.0'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -160,7 +160,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.5.2'
+          image: 'weaveworks/weave-kube:2.6.0'
           ports:
             - name: metrics
               containerPort: 6782
@@ -200,7 +200,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.5.2'
+          image: 'weaveworks/weave-npc:2.6.0'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -164,7 +164,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.5.2'
+          image: 'weaveworks/weave-kube:2.6.0'
           ports:
             - name: metrics
               containerPort: 6782
@@ -204,7 +204,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.5.2'
+          image: 'weaveworks/weave-npc:2.6.0'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -694,9 +694,9 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		versions := map[string]string{
 			"pre-k8s-1.6": "2.3.0-kops.3",
 			"k8s-1.6":     "2.3.0-kops.3",
-			"k8s-1.7":     "2.5.2-kops.2",
-			"k8s-1.8":     "2.5.2-kops.2",
-			"k8s-1.12":    "2.5.2-kops.3",
+			"k8s-1.7":     "2.6.0-kops.2",
+			"k8s-1.8":     "2.6.0-kops.2",
+			"k8s-1.12":    "2.6.0-kops.3",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -131,24 +131,24 @@ spec:
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0 <1.8.0'
     manifest: networking.weave/k8s-1.7.yaml
-    manifestHash: 258ad76c3ef165f216980c96367df13a8bffb1d8
+    manifestHash: 0cd4e69658afad4925e27ad8b05704fe7afe8fca
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.2-kops.2
+    version: 2.6.0-kops.2
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: 748a1526515a719058b99c203cd943a740675e21
+    manifestHash: f9d056a15c55dd906fb0d41583d457542f7136e2
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.2-kops.2
+    version: 2.6.0-kops.2
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: 96334bfcfa6a3ec9791b50c94674a8821cb6ad67
+    manifestHash: c6614394aa5efaf6d12dedd8df66b5ee3e63aa46
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.2-kops.3
+    version: 2.6.0-kops.3


### PR DESCRIPTION
This release reduces CPU and memory usage in larger clusters, by sending notifications to a smaller set of peers and coalescing updates to reduce topology recalculation. #3715, #3732

Also several bug-fixes and smaller enhancements.

The default soft limit on connections has been raised from 100 to 200.

More details at https://github.com/weaveworks/weave/releases/tag/v2.6.0
