### PR TITLE
Stop directing new fields be added to old API versions

### DIFF
--- a/docs/development/api_updates.md
+++ b/docs/development/api_updates.md
@@ -19,7 +19,7 @@ need for `&& make`.
 The most common task you will do will be to add a new field.  This is relatively straightforward, because
 it is backwards compatible (you have to make sure that the field is optional).
 
-* Add the field to pkg/apis/kops, and then also to each versioned copy: pkg/apis/kops/v1alpha1, pkg/apis/kops/v1alpha2, etc
+* Add the field to pkg/apis/kops and the most recent versioned copy, pkg/apis/kops/v1alpha2
 * Run the apimachinery update as above (`make apimachinery && make crds && make`)
 * You likely want to update the validation logic
 * You likely want to update the defaulting logic


### PR DESCRIPTION
The v1alpha2 API was created over two and a half years ago. It is not reasonable to expect people to spend any effort adding new features to the obsolete v1alpha1 API. If users with v1alpha1 specs want to use the new features, it is reasonable to expect them to upgrade the API in order to do so.
