### PR TITLE
Remove DrainAndValidateRollingUpdate feature flag

### DIFF
--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -24,21 +24,18 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/kops/pkg/validation"
-
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/klog"
 	"k8s.io/kops/cmd/kops/util"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/cloudinstances"
-	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/instancegroups"
 	"k8s.io/kops/pkg/pretty"
+	"k8s.io/kops/pkg/validation"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"k8s.io/kops/util/pkg/tables"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
@@ -187,10 +184,8 @@ func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringSliceVar(&options.InstanceGroups, "instance-group", options.InstanceGroups, "List of instance groups to update (defaults to all if not specified)")
 	cmd.Flags().StringSliceVar(&options.InstanceGroupRoles, "instance-group-roles", options.InstanceGroupRoles, "If specified, only instance groups of the specified role will be updated (e.g. Master,Node,Bastion)")
 
-	if featureflag.DrainAndValidateRollingUpdate.Enabled() {
-		cmd.Flags().BoolVar(&options.FailOnDrainError, "fail-on-drain-error", true, "The rolling-update will fail if draining a node fails.")
-		cmd.Flags().BoolVar(&options.FailOnValidate, "fail-on-validate-error", true, "The rolling-update will fail if the cluster fails to validate.")
-	}
+	cmd.Flags().BoolVar(&options.FailOnDrainError, "fail-on-drain-error", true, "The rolling-update will fail if draining a node fails.")
+	cmd.Flags().BoolVar(&options.FailOnValidate, "fail-on-validate-error", true, "The rolling-update will fail if the cluster fails to validate.")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		err := rootCommand.ProcessArgs(args)
@@ -390,13 +385,10 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 	}
 
 	var clusterValidator validation.ClusterValidator
-	if featureflag.DrainAndValidateRollingUpdate.Enabled() {
-		klog.V(2).Infof("Rolling update with drain and validate enabled.")
-		if !options.CloudOnly {
-			clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, k8sClient)
-			if err != nil {
-				return fmt.Errorf("cannot create cluster validator: %v", err)
-			}
+	if !options.CloudOnly {
+		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, k8sClient)
+		if err != nil {
+			return fmt.Errorf("cannot create cluster validator: %v", err)
 		}
 	}
 	d := &instancegroups.RollingUpdateCluster{

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -49,8 +49,6 @@ var (
 var (
 	// DNSPreCreate controls whether we pre-create DNS records.
 	DNSPreCreate = New("DNSPreCreate", Bool(true))
-	// DrainAndValidateRollingUpdate if set will use new rolling update code that will drain and validate.
-	DrainAndValidateRollingUpdate = New("DrainAndValidateRollingUpdate", Bool(true))
 	// EnableLaunchTemplates indicates we wish to switch to using launch templates rather than launchconfigurations
 	EnableLaunchTemplates = New("EnableLaunchTemplates", Bool(false))
 	//EnableExternalCloudController toggles the use of cloud-controller-manager introduced in v1.7

--- a/pkg/instancegroups/BUILD.bazel
+++ b/pkg/instancegroups/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//pkg/client/simple:go_default_library",
         "//pkg/cloudinstances:go_default_library",
         "//pkg/drain:go_default_library",
-        "//pkg/featureflag:go_default_library",
         "//pkg/validation:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -30,7 +30,6 @@ import (
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kops/pkg/drain"
-	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi"
 )
 
@@ -127,7 +126,7 @@ func (r *RollingUpdateInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpd
 		klog.V(3).Info("Not validating the cluster as instance is a bastion.")
 	} else if rollingUpdateData.CloudOnly {
 		klog.V(3).Info("Not validating cluster as validation is turned off via the cloud-only flag.")
-	} else if featureflag.DrainAndValidateRollingUpdate.Enabled() {
+	} else {
 		if err = r.validateCluster(rollingUpdateData, cluster); err != nil {
 			if rollingUpdateData.FailOnValidate {
 				return err
@@ -151,7 +150,7 @@ func (r *RollingUpdateInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpd
 
 			klog.Warning("Not draining cluster nodes as 'cloudonly' flag is set.")
 
-		} else if featureflag.DrainAndValidateRollingUpdate.Enabled() {
+		} else {
 
 			if u.Node != nil {
 				klog.Infof("Draining the node: %q.", nodeName)
@@ -196,7 +195,7 @@ func (r *RollingUpdateInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpd
 		} else if rollingUpdateData.CloudOnly {
 			klog.Warningf("Not validating cluster as cloudonly flag is set.")
 
-		} else if featureflag.DrainAndValidateRollingUpdate.Enabled() {
+		} else {
 			klog.Info("Validating the cluster.")
 
 			if err = r.validateClusterWithDuration(rollingUpdateData, validationTimeout); err != nil {

--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -48,7 +48,7 @@ type RollingUpdateCluster struct {
 	// K8sClient is the kubernetes client, used for draining etc
 	K8sClient kubernetes.Interface
 
-	// ClusterValidator is used for validating the cluster. Unused if DrainAndValidateRollingUpdate disabled or CloudOnly
+	// ClusterValidator is used for validating the cluster. Unused if CloudOnly
 	ClusterValidator validation.ClusterValidator
 
 	FailOnDrainError bool


### PR DESCRIPTION
It's excessive having this and `CloudOnly` and `FailOnValidate` and `FailOnDrainError`.