### PR TITLE
Remove forcing disabled cgos Darwin

### DIFF
--- a/cmd/kops/validate_cluster.go
+++ b/cmd/kops/validate_cluster.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 	"strings"
 	"time"
 
@@ -37,13 +36,6 @@ import (
 	"k8s.io/kops/pkg/validation"
 	"k8s.io/kops/util/pkg/tables"
 )
-
-func init() {
-	if runtime.GOOS == "darwin" {
-		// In order for net.LookupHost(apiAddr.Host) to lookup our placeholder address on darwin, we have to
-		os.Setenv("GODEBUG", "netdns=go")
-	}
-}
 
 type ValidateClusterOptions struct {
 	output string


### PR DESCRIPTION
Unsure if this is the right approach but wanted to get some others input. I often run into issues on macOS where I cannot run `kops validate cluster` due to failed DNS resolution. I am using OpenVPN Connect which does not edit `/etc/resolv.conf` (which is not standard anymore in macOS anyways at least). By forcing `cgos` to be disabled, `kops validate cluster` uses the `net` packages default resolver that only uses the `nameserver` listed in `/etc/resolv.conf`. In this case, that is the DHCP DNS, which fails.

To see the DNS difference, you can see the single `nameserver` listed in `/etc/resolv.conf` and then other resolvers which are populated via my VPN client.

```
(⎈ |kube-development-01.<redacted>)[kops] cat /etc/resolv.conf                                                                                                                                        remove-disabling-darwin-cgos  ✱
#
# macOS Notice
#
# This file is not consulted for DNS hostname resolution, address
# resolution, or the DNS query routing mechanism used by most
# processes on this system.
#
# To view the DNS configuration used by this system, use:
#   scutil --dns
#
# SEE ALSO
#   dns-sd(1), scutil(8)
#
# This file is automatically generated.
#
nameserver 10.0.1.1
```

```
(⎈ |kube-development-01.<redacted>)[kops] scutil --dns                                                                                                                                                   remove-disabling-darwin-cgos  ✱
DNS configuration

resolver #1
  nameserver[0] : 10.0.1.1
  if_index : 8 (en0)
  flags    : Request A records
  reach    : 0x00020002 (Reachable,Directly Reachable Address)

resolver #2
  domain   : ops.<redacted>.com
  nameserver[0] : 172.27.0.2
  flags    : Supplemental, Request A records
  reach    : 0x00000002 (Reachable)
  order    : 101000

resolver #3
  domain   : services.<redacted>.com
  nameserver[0] : 172.27.0.2
  flags    : Supplemental, Request A records
  reach    : 0x00000002 (Reachable)
  order    : 101001
```

The PR that added this functionality was from a few years ago, and it seems all tests still pass and it did resolve my issue. Curious on others thoughts here. Links below for more detail:

PR adding it: https://github.com/kubernetes/kops/pull/3709
Kubernetes/kubernetes PR for building on darwin _for_ darwin_ to use `cgos`: https://github.com/kubernetes/kubernetes/pull/64219