### PR TITLE
Make CoreDNS the default DNS server

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -608,23 +608,28 @@ Note that as of Kubernetes 1.8.0 kube-scheduler does not reload its configuratio
 
 ## kubeDNS
 
-This block contains configurations for `kube-dns`.
+This block contains configurations for [CoreDNS](https://coredns.io/).
 
- ```yaml
- spec:
-   kubeDNS:
-     provider: KubeDNS
-```
-
-Specifying KubeDNS will install kube-dns as the default service discovery.
+For Kubernetes version >= 1.18, `CoreDNS` will be installed as the default DNS server.
 
  ```yaml
  spec:
    kubeDNS:
      provider: CoreDNS
 ```
+OR
+```yaml
+spec:
+   kubeDNS:
+```
 
-This will install [CoreDNS](https://coredns.io/) instead of kube-dns.
+Specifying KubeDNS will install kube-dns as the default service discovery instead of [CoreDNS](https://coredns.io/).
+
+ ```yaml
+ spec:
+   kubeDNS:
+     provider: KubeDNS
+```
 
 If you are using CoreDNS and want to use an entirely custom CoreFile you can do this by specifying the file. This will not work with any other options which interact with the default CoreFile. You can also override the version of the CoreDNS image used to use a different registry or version by specifying `CoreDNSImage`.
 

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -262,7 +262,18 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 	}
 
 	kubeDNS := b.Cluster.Spec.KubeDNS
-	if kubeDNS.Provider == "KubeDNS" || kubeDNS.Provider == "" {
+
+	// This checks if the Kubernetes version is greater than or equal to 1.19
+	// and makes the default DNS server as CoreDNS if the DNS provider is not specified
+	// and the Kubernetes version is >=1.19
+	if kubeDNS.Provider == "" {
+		kubeDNS.Provider = "KubeDNS"
+		if b.Cluster.IsKubernetesGTE("1.19") {
+			kubeDNS.Provider = "CoreDNS"
+		}
+	}
+
+	if kubeDNS.Provider == "KubeDNS" {
 
 		{
 			key := "kube-dns.addons.k8s.io"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -19,12 +19,12 @@ spec:
       k8s-addon: core.addons.k8s.io
     version: 1.4.0
   - id: k8s-1.12
-    manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: db49c98447b9d59dec4fa413461a6614bc6e43e9
-    name: kube-dns.addons.k8s.io
+    manifest: coredns.addons.k8s.io/k8s-1.12.yaml
+    manifestHash: 0af83c370d13df45c6a2db67fa8f28e41502b6e1
+    name: coredns.addons.k8s.io
     selector:
-      k8s-addon: kube-dns.addons.k8s.io
-    version: 1.15.13-kops.3
+      k8s-addon: coredns.addons.k8s.io
+    version: 1.7.0-kops.2
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
     manifestHash: e1508d77cb4e527d7a2939babe36dc350dd83745

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -19,12 +19,12 @@ spec:
       k8s-addon: core.addons.k8s.io
     version: 1.4.0
   - id: k8s-1.12
-    manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: db49c98447b9d59dec4fa413461a6614bc6e43e9
-    name: kube-dns.addons.k8s.io
+    manifest: coredns.addons.k8s.io/k8s-1.12.yaml
+    manifestHash: 0af83c370d13df45c6a2db67fa8f28e41502b6e1
+    name: coredns.addons.k8s.io
     selector:
-      k8s-addon: kube-dns.addons.k8s.io
-    version: 1.15.13-kops.3
+      k8s-addon: coredns.addons.k8s.io
+    version: 1.7.0-kops.2
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
     manifestHash: e1508d77cb4e527d7a2939babe36dc350dd83745

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -19,12 +19,12 @@ spec:
       k8s-addon: core.addons.k8s.io
     version: 1.4.0
   - id: k8s-1.12
-    manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: db49c98447b9d59dec4fa413461a6614bc6e43e9
-    name: kube-dns.addons.k8s.io
+    manifest: coredns.addons.k8s.io/k8s-1.12.yaml
+    manifestHash: 0af83c370d13df45c6a2db67fa8f28e41502b6e1
+    name: coredns.addons.k8s.io
     selector:
-      k8s-addon: kube-dns.addons.k8s.io
-    version: 1.15.13-kops.3
+      k8s-addon: coredns.addons.k8s.io
+    version: 1.7.0-kops.2
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
     manifestHash: e1508d77cb4e527d7a2939babe36dc350dd83745

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/cluster.yaml
@@ -19,7 +19,7 @@ spec:
       name: master-us-test-1a
     name: events
   iam: {}
-  kubernetesVersion: v1.14.6
+  kubernetesVersion: v1.19.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5b7765907ec5720081c13c0cab2d32b99053e7c8
+    manifestHash: 68aa7f9ecd2d264b5b1dbc5c72d161420f455427
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
@@ -19,19 +19,12 @@ spec:
       k8s-addon: core.addons.k8s.io
     version: 1.4.0
   - id: k8s-1.12
-    manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: db49c98447b9d59dec4fa413461a6614bc6e43e9
-    name: kube-dns.addons.k8s.io
+    manifest: coredns.addons.k8s.io/k8s-1.12.yaml
+    manifestHash: 0af83c370d13df45c6a2db67fa8f28e41502b6e1
+    name: coredns.addons.k8s.io
     selector:
-      k8s-addon: kube-dns.addons.k8s.io
-    version: 1.15.13-kops.3
-  - id: k8s-1.8
-    manifest: rbac.addons.k8s.io/k8s-1.8.yaml
-    manifestHash: 5d53ce7b920cd1e8d65d2306d80a041420711914
-    name: rbac.addons.k8s.io
-    selector:
-      k8s-addon: rbac.addons.k8s.io
-    version: 1.8.0
+      k8s-addon: coredns.addons.k8s.io
+    version: 1.7.0-kops.2
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
     manifestHash: e1508d77cb4e527d7a2939babe36dc350dd83745


### PR DESCRIPTION
This will install CoreDNS as the default DNS server instead of kube-dns

Fixes https://github.com/kubernetes/kops/issues/6500