### PR TITLE
Fix flannel CNI version to use 0.2.0

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.12.yaml.template
@@ -59,6 +59,7 @@ metadata:
 data:
   cni-conf.json: |
     {
+      "cniVersion": "0.2.0",
       "name": "cbr0",
       "plugins": [
         {


### PR DESCRIPTION
This issue occurs when using flannel network provider with the latest master.

This issue is mentioned here - https://github.com/coreos/flannel/issues/1178 and it's fix was done few days back as mentioned here - https://github.com/coreos/flannel/pull/1174/files

_After creating a v1.16 cluster by kubeadm init and installing flannel cni by kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/32a765fd19ba45b387fdc5e3812c41fff47cfd55/Documentation/kube-flannel.yml, the network still does not get ready and coredns remain pending._

The same issue was observed with latest KOPS master and this PR should fix the issue.
I tested this change on the latest master and it seems to be working fine.
