### PR TITLE
[aws-iam-authenticator] Docs - Steps to disable DaemonSet Temporarily

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -135,4 +135,6 @@ kubectl get pods -n kube-system | grep aws-iam-authenticator | awk '{print $1}' 
 * Create an aws-iam-authenticator configMap on the cluster `kubectl apply -f aws-iam-authenticator_example-config.yaml`
 * Edit the clusters configuration `kops edit cluster ${NAME}` and add the Authentication and Authorization configs to the YAML config.
 * Update the clusters configuration `kops update cluster ${CLUSTER_NAME} --yes`
+* Temporarily disable aws-iam-authenticator DaemonSet `kubectl patch daemonset -n kube-system aws-iam-authenticator -p '{"spec": {"template": {"spec": {"nodeSelector": {"disable-aws-iam-authenticator": "true"}}}}}'`
 * Perform a rolling update of the masters `kops rolling-update cluster ${CLUSTER_NAME} --instance-group-roles=Master --force --yes`
+* Re-enable aws-iam-authenticator DaemonSet `kubectl patch daemonset -n kube-system aws-iam-authenticator --type json -p='[{"op": "remove", "path": "/spec/template/spec/nodeSelector/disable-aws-iam-authenticator"}]'` 


### PR DESCRIPTION
```
> kops version
Version 1.15.0-beta.1 (git-1a662bf87)
```
Not sure if this is only happens on kops 1.15 beta.
When enabling `aws-iam-authenticator` after cluster creation I get `error validating cluster` when rolling-update:

```
I1114 15:45:15.171972   40767 instancegroups.go:275] Cluster did not pass validation, will try again in "30s" until duration "15m0s" expires: kube-system pod "aws-iam-authenticator-fw64l" is not ready (aws-iam-authenticator), kube-system pod "aws-iam-authenticator-qq84m" is not ready (aws-iam-authenticator).
E1114 15:45:44.436473   40767 instancegroups.go:212] Cluster did not validate within 15m0s

master not healthy after update, stopping rolling-update: "error validating cluster after removing a node: cluster did not validate within a duration of \"15m0s\""
```

To avoid cluster validation error I have to temporarily disable the DaemonSet

This PR is just to update docs to avoid `error validating cluster` error.

Thanks