### PR TITLE
Always require confirmation for update cluster

### DIFF
--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -267,6 +267,7 @@ func runTest(t *testing.T, h *testutils.IntegrationTestHarness, clusterName stri
 	{
 		options := &UpdateClusterOptions{}
 		options.InitDefaults()
+		options.Yes = true
 		options.Target = "terraform"
 		options.OutDir = path.Join(h.TempDir, "out")
 		options.RunTasksOptions.MaxTaskDuration = 30 * time.Second
@@ -544,6 +545,7 @@ func runTestCloudformation(t *testing.T, clusterName string, srcDir string, vers
 	{
 		options := &UpdateClusterOptions{}
 		options.InitDefaults()
+		options.Yes = true
 		options.Target = "cloudformation"
 		options.OutDir = path.Join(h.TempDir, "out")
 		options.RunTasksOptions.MaxTaskDuration = 30 * time.Second

--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -60,7 +60,7 @@ var (
 	validation.
 
 	Note: terraform users will need to run all of the following commands from the same directory
-	` + pretty.Bash("kops update cluster --target=terraform") + ` then ` + pretty.Bash("terraform plan") + ` then
+	` + pretty.Bash("kops update cluster --target=terraform --yes") + ` then ` + pretty.Bash("terraform plan") + ` then
 	` + pretty.Bash("terraform apply") + ` prior to running ` + pretty.Bash("kops rolling-update cluster") + `.`))
 
 	rollingupdateExample = templates.Examples(i18n.T(`

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -140,10 +140,10 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 			isDryrun = true
 			targetName = cloudup.TargetDryRun
 		} else if c.Target == cloudup.TargetTerraform {
-			fmt.Fprintf(out, "Must specify --yes to apply changes and generate terraform output \n")
+			fmt.Fprintf(out, "Must specify --yes to apply changes and generate terraform output\n")
 			return results, nil
 		} else if c.Target == cloudup.TargetCloudformation {
-			fmt.Fprintf(out, "Must specify --yes to apply changes and generate cloudformation output \n")
+			fmt.Fprintf(out, "Must specify --yes to apply changes and generate cloudformation output\n")
 			return results, nil
 		}
 	}

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -135,7 +135,20 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 	isDryrun := false
 	targetName := c.Target
 
-	if c.Target == cloudup.TargetDryRun || !c.Yes {
+	if !c.Yes {
+		if c.Target == cloudup.TargetDirect {
+			isDryrun = true
+			targetName = cloudup.TargetDryRun
+		} else if c.Target == cloudup.TargetTerraform {
+			fmt.Fprintf(out, "Must specify --yes to apply changes and generate terraform output \n")
+			return results, nil
+		} else if c.Target == cloudup.TargetCloudformation {
+			fmt.Fprintf(out, "Must specify --yes to apply changes and generate cloudformation output \n")
+			return results, nil
+		}
+	}
+
+	if c.Target == cloudup.TargetDryRun {
 		isDryrun = true
 		targetName = cloudup.TargetDryRun
 	}

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -135,14 +135,7 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 	isDryrun := false
 	targetName := c.Target
 
-	// direct requires --yes (others do not, because they don't do anything!)
-	if c.Target == cloudup.TargetDirect {
-		if !c.Yes {
-			isDryrun = true
-			targetName = cloudup.TargetDryRun
-		}
-	}
-	if c.Target == cloudup.TargetDryRun {
+	if c.Target == cloudup.TargetDryRun || !c.Yes {
 		isDryrun = true
 		targetName = cloudup.TargetDryRun
 	}

--- a/docs/cli/kops_rolling-update.md
+++ b/docs/cli/kops_rolling-update.md
@@ -21,7 +21,7 @@ to wait for 3 minutes after a master is rolled, and another 3 minutes for the cl
 validation.
 
 Note: terraform users will need to run all of the following commands from the same directory
-`kops update cluster --target=terraform` then `terraform plan` then
+`kops update cluster --target=terraform --yes` then `terraform plan` then
 `terraform apply` prior to running `kops rolling-update cluster`.
 
 ### Examples

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -21,7 +21,7 @@ to wait for 3 minutes after a master is rolled, and another 3 minutes for the cl
 validation.
 
 Note: terraform users will need to run all of the following commands from the same directory
-`kops update cluster --target=terraform` then `terraform plan` then
+`kops update cluster --target=terraform --yes` then `terraform plan` then
 `terraform apply` prior to running `kops rolling-update cluster`.
 
 ```

--- a/docs/operations/updates_and_upgrades.md
+++ b/docs/operations/updates_and_upgrades.md
@@ -69,7 +69,7 @@ Upgrade uses the latest Kubernetes version considered stable by kops, defined in
 * `kops edit cluster $NAME`
 * set the kubernetesVersion to the target version (e.g. `v1.3.5`)
 * NOTE: The next 3 steps must all be run in the same directory. Here, `--out=.` specifies that the Terraform files will be written to the current directory. It should point to wherever your Terraform files from `kops create cluster` exist. The default is `out/terraform`.
-* `kops update cluster $NAME --target=terraform --out=.`
+* `kops update cluster $NAME --target=terraform --out=. --yes`
 * `terraform plan`
 * `terraform apply`
 * `kops rolling-update cluster $NAME` to preview, then `kops rolling-update cluster $NAME --yes`

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -69,14 +69,15 @@ $ kops edit cluster \
 # editor opens, make your changes ...
 ```
 
-Then output your changes/edits to kops cluster state into the Terraform files. Run `kops update` with `--target` and `--out` parameters:
+Then output your changes/edits to kops cluster state into the Terraform files. Run `kops update` with `--target`, `--out` and `--yes` parameters:
 
 ```
 $ kops update cluster \
   --name=kubernetes.mydomain.com \
   --state=s3://mycompany.kubernetes \
   --out=. \
-  --target=terraform
+  --target=terraform \
+  --yes
 ```
 
 Then apply your changes after previewing what changes will be applied:
@@ -148,7 +149,8 @@ $ kops update cluster \
   --state=s3://mycompany.kubernetes \
   --model=cloudup \
   --out=. \
-  --target=terraform
+  --target=terraform \
+  --yes
 ```
 
 Then, to apply using terraform:


### PR DESCRIPTION
Even if the target is not direct (i.e. terraform) running the `kops update cluster` command can still update addon manifests which may result newer addons being applied.

To provide consistency across commands, ensuring that no changes are effected without the user specifying the `--yes` flag seems prudent.