### PR TITLE
Fix generation of documentation /sitemap.xml file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: Kubernetes Operations - kops
 # strict: true
 repo_name: 'kubernetes/kops'
 repo_url: 'https://github.com/kubernetes/kops'
+site_url: 'https://kubernetes-kops.netlify.com'
 markdown_extensions:
   - admonition
   - codehilite
@@ -11,7 +12,7 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tilde
   - toc:
-      permalink: true
+      permalink: ' ¶'
 theme:
   name: material
   feature:


### PR DESCRIPTION
Without the `site_url` attribute, the `sitemap.xml` file is empty.
Also `permalink: true` concatenates the `¶` character.

![sitemap](https://user-images.githubusercontent.com/161571/69104581-8182a500-0a47-11ea-960e-999430050950.png)
