### PR TITLE
Fix goimports errors

### DIFF
--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -19,11 +19,12 @@ package main
 import (
 	"fmt"
 	"io"
-	"k8s.io/kops/pkg/validation"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"k8s.io/kops/pkg/validation"
 
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -18,9 +18,10 @@ package instancegroups
 
 import (
 	"fmt"
-	"k8s.io/kops/pkg/validation"
 	"sync"
 	"time"
+
+	"k8s.io/kops/pkg/validation"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -18,9 +18,10 @@ package instancegroups
 
 import (
 	"errors"
-	"k8s.io/kops/pkg/validation"
 	"testing"
 	"time"
+
+	"k8s.io/kops/pkg/validation"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"


### PR DESCRIPTION
It turns out we werent running verify-goimports in our CI jobs.

While we work to get that enabled in #7952, we can at least unblock the releases by doing a one-time fix of the failing goimports