### PR TITLE
[Issue-7870] kops controller support for digital ocean

### DIFF
--- a/cmd/kops-controller/BUILD.bazel
+++ b/cmd/kops-controller/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//cmd/kops-controller/pkg/config:go_default_library",
         "//pkg/nodeidentity:go_default_library",
         "//pkg/nodeidentity/aws:go_default_library",
+        "//pkg/nodeidentity/do:go_default_library",
         "//pkg/nodeidentity/gce:go_default_library",
         "//pkg/nodeidentity/openstack:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -52,6 +52,8 @@ func init() {
 func main() {
 	klog.InitFlags(nil)
 
+	klog.Infof("sri testing")
+
 	// Disable metrics by default (avoid port conflicts, also risky because we are host network)
 	metricsAddress := ":0"
 	//flag.StringVar(&metricsAddr, "metrics-addr", metricsAddress, "The address the metric endpoint binds to.")

--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kops/cmd/kops-controller/pkg/config"
 	"k8s.io/kops/pkg/nodeidentity"
 	nodeidentityaws "k8s.io/kops/pkg/nodeidentity/aws"
+	nodeidentitydo "k8s.io/kops/pkg/nodeidentity/do"
 	nodeidentitygce "k8s.io/kops/pkg/nodeidentity/gce"
 	nodeidentityos "k8s.io/kops/pkg/nodeidentity/openstack"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -136,6 +137,12 @@ func addNodeController(mgr manager.Manager, opt *config.Options) error {
 
 	case "openstack":
 		identifier, err = nodeidentityos.New()
+		if err != nil {
+			return fmt.Errorf("error building identifier: %v", err)
+		}
+
+	case "digitalocean":
+		identifier, err = nodeidentitydo.New()
 		if err != nil {
 			return fmt.Errorf("error building identifier: %v", err)
 		}

--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -53,8 +53,6 @@ func init() {
 func main() {
 	klog.InitFlags(nil)
 
-	klog.Infof("sri testing")
-
 	// Disable metrics by default (avoid port conflicts, also risky because we are host network)
 	metricsAddress := ":0"
 	//flag.StringVar(&metricsAddr, "metrics-addr", metricsAddress, "The address the metric endpoint binds to.")

--- a/hack/.packages
+++ b/hack/.packages
@@ -112,6 +112,7 @@ k8s.io/kops/pkg/model/spotinstmodel
 k8s.io/kops/pkg/model/vspheremodel
 k8s.io/kops/pkg/nodeidentity
 k8s.io/kops/pkg/nodeidentity/aws
+k8s.io/kops/pkg/nodeidentity/do
 k8s.io/kops/pkg/nodeidentity/gce
 k8s.io/kops/pkg/nodeidentity/openstack
 k8s.io/kops/pkg/nodelabels

--- a/pkg/model/domodel/droplets.go
+++ b/pkg/model/domodel/droplets.go
@@ -73,6 +73,9 @@ func (d *DropletBuilder) Build(c *fi.ModelBuilderContext) error {
 			clusterTagIndex := do.TagKubernetesClusterIndex + ":" + strconv.Itoa(masterIndexCount)
 			droplet.Tags = append(droplet.Tags, clusterTagIndex)
 			droplet.Tags = append(droplet.Tags, clusterMasterTag)
+			droplet.Tags = append(droplet.Tags, do.TagKubernetesClusterInstanceGroupPrefix+":"+"master-"+d.Cluster.Spec.Subnets[0].Region)
+		} else {
+			droplet.Tags = append(droplet.Tags, do.TagKubernetesClusterInstanceGroupPrefix+":"+"nodes")
 		}
 
 		userData, err := d.BootstrapScript.ResourceNodeUp(ig, d.Cluster)

--- a/pkg/nodeidentity/do/BUILD.bazel
+++ b/pkg/nodeidentity/do/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["identify.go"],
+    importpath = "k8s.io/kops/pkg/nodeidentity/do",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/nodeidentity:go_default_library",
+        "//vendor/github.com/digitalocean/godo:go_default_library",
+        "//vendor/golang.org/x/oauth2:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+    ],
+)

--- a/pkg/nodeidentity/do/identify.go
+++ b/pkg/nodeidentity/do/identify.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package do
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/oauth2"
+
+	"github.com/digitalocean/godo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kops/pkg/nodeidentity"
+)
+
+// nodeIdentifier identifies a node from EC2
+type nodeIdentifier struct {
+	doClient *godo.Client
+}
+
+const (
+	dropletRegionMetadataURL    = "http://169.254.169.254/metadata/v1/region"
+	dropletTagInstanceGroupName = "kops-instancegroup"
+)
+
+// TokenSource implements oauth2.TokenSource
+type TokenSource struct {
+	AccessToken string
+}
+
+// Token() returns oauth2.Token
+func (t *TokenSource) Token() (*oauth2.Token, error) {
+	token := &oauth2.Token{
+		AccessToken: t.AccessToken,
+	}
+	return token, nil
+}
+
+// New creates and returns a nodeidentity.Identifier for Nodes running on OpenStack
+func New() (nodeidentity.Identifier, error) {
+	region, err := getMetadataRegion()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get droplet region: %s", err)
+	}
+
+	godoClient, err := NewCloud(region)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize digitalocean cloud: %s", err)
+	}
+
+	return &nodeIdentifier{
+		doClient: godoClient,
+	}, nil
+}
+
+func getMetadataRegion() (string, error) {
+	return getMetadata(dropletRegionMetadataURL)
+}
+
+// NewCloud returns a Cloud, expecting the env var DIGITALOCEAN_ACCESS_TOKEN
+// NewCloud will return an err if DIGITALOCEAN_ACCESS_TOKEN is not defined
+func NewCloud(region string) (*godo.Client, error) {
+	accessToken := os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")
+	if accessToken == "" {
+		return nil, errors.New("DIGITALOCEAN_ACCESS_TOKEN is required")
+	}
+
+	tokenSource := &TokenSource{
+		AccessToken: accessToken,
+	}
+
+	oauthClient := oauth2.NewClient(context.TODO(), tokenSource)
+	client := godo.NewClient(oauthClient)
+
+	return client, nil
+}
+
+func getMetadata(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("droplet metadata returned non-200 status code: %d", resp.StatusCode)
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(bodyBytes), nil
+}
+
+// IdentifyNode queries OpenStack for the node identity information
+func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*nodeidentity.Info, error) {
+	providerID := node.Spec.ProviderID
+	if providerID == "" {
+		return nil, fmt.Errorf("providerID was not set for node %s", node.Name)
+	}
+	if !strings.HasPrefix(providerID, "digitalocean://") {
+		return nil, fmt.Errorf("providerID %q not recognized for node %s", providerID, node.Name)
+	}
+
+	instanceID := strings.TrimPrefix(providerID, "digitalocean://")
+	if strings.HasPrefix(instanceID, "/") {
+		instanceID = strings.TrimPrefix(instanceID, "/")
+	}
+
+	kopsGroup, err := i.getInstanceGroup(instanceID)
+	if err != nil {
+		return nil, err
+	}
+
+	info := &nodeidentity.Info{}
+	info.InstanceGroup = kopsGroup
+
+	return info, nil
+}
+
+func (i *nodeIdentifier) getInstanceGroup(instanceID string) (string, error) {
+
+	dropletID, err := strconv.Atoi(instanceID)
+	ctx := context.TODO()
+	droplet, _, err := i.doClient.Droplets.Get(ctx, dropletID)
+
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve droplet via api for dropletid = %d. Error = %v", dropletID, err)
+	}
+
+	for _, dropletTag := range droplet.Tags {
+		if strings.Contains(dropletTag, dropletTagInstanceGroupName) {
+			instancegrouptag := strings.SplitN(dropletTag, ":", 2)
+			if len(instancegrouptag) < 2 {
+				return "", fmt.Errorf("failed to retrieve droplet instance group tag = %s properly", dropletTag)
+			}
+			instancegroupvalue := instancegrouptag[1]
+			return instancegroupvalue, nil
+		}
+	}
+
+	return "", fmt.Errorf("Could not find tag 'kops-instancegroup' from instance metadata")
+}

--- a/upup/pkg/fi/cloudup/do/cloud.go
+++ b/upup/pkg/fi/cloudup/do/cloud.go
@@ -28,6 +28,7 @@ const TagNameEtcdClusterPrefix = "etcdCluster-"
 const TagNameRolePrefix = "k8s.io/role/"
 const TagKubernetesClusterNamePrefix = "KubernetesCluster"
 const TagKubernetesClusterMasterPrefix = "KubernetesCluster-Master"
+const TagKubernetesClusterInstanceGroupPrefix = "kops-instancegroup"
 
 func SafeClusterName(clusterName string) string {
 	// DO does not support . in tags / names


### PR DESCRIPTION
This PR addresses the issue mentioned in https://github.com/kubernetes/kops/issues/7870
for digital ocean cloud provider.

Added a kops-controller that updates the node labels. Tested it and it seems to be working as expected.
Please see the attached image.

![image](https://user-images.githubusercontent.com/8819822/69182567-4cee1680-0b37-11ea-8dd5-3393759c1846.png)

![image](https://user-images.githubusercontent.com/8819822/69182694-89ba0d80-0b37-11ea-94b9-c6f0cb9f78a5.png)
