### PR TITLE
OpenStack: Possibility to detach instance from the group

### DIFF
--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -67,6 +67,7 @@ const (
 	ResourceTypePort         = "ports"
 	ResourceTypeNetwork      = "networks"
 	ResourceTypeSubnet       = "subnets"
+	TagNameDetach            = "KopsDetach"
 )
 
 // ErrNotFound is used to inform that the object is not found

--- a/upup/pkg/fi/cloudup/openstacktasks/instance.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance.go
@@ -107,14 +107,22 @@ func (e *Instance) Find(c *fi.Context) (*Instance, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error extracting server page: %v", err)
 	}
-	if len(serverList) == 0 {
+	filteredList := []servers.Server{}
+	for _, server := range serverList {
+		_, ok := server.Metadata[openstack.TagNameDetach]
+		if !ok {
+			filteredList = append(filteredList, server)
+		}
+	}
+
+	if len(filteredList) == 0 {
 		return nil, nil
 	}
-	if len(serverList) > 1 {
+	if len(filteredList) > 1 {
 		return nil, fmt.Errorf("Multiple servers found with name %s", fi.StringValue(e.Name))
 	}
 
-	server := serverList[0]
+	server := filteredList[0]
 	actual := &Instance{
 		ID:               fi.String(server.ID),
 		Name:             fi.String(server.Name),

--- a/upup/pkg/fi/cloudup/openstacktasks/port.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port.go
@@ -126,12 +126,21 @@ func (s *Port) Find(context *fi.Context) (*Port, error) {
 	if err != nil {
 		return nil, err
 	}
-	if rs == nil {
+
+	filteredList := []ports.Port{}
+	for _, port := range rs {
+		if fi.ArrayContains(port.Tags, openstack.TagNameDetach) {
+			continue
+		}
+		filteredList = append(filteredList, port)
+	}
+
+	if len(filteredList) == 0 {
 		return nil, nil
-	} else if len(rs) != 1 {
+	} else if len(filteredList) > 1 {
 		return nil, fmt.Errorf("found multiple ports with name: %s", fi.StringValue(s.Name))
 	}
-	return NewPortTaskFromCloud(cloud, s.Lifecycle, &rs[0], s)
+	return NewPortTaskFromCloud(cloud, s.Lifecycle, &filteredList[0], s)
 }
 
 func (s *Port) Run(context *fi.Context) error {


### PR DESCRIPTION
This PR makes it possible to detach instance from the OpenStack kops instancegroup. If tag `KopsDetach` is added to port AND/OR `KopsDetach` is added to instance metadata. These resources are recreated when `kops update cluster` is executed again.

I am thinking to build support for different rolling update strategy, which could work on following way:
1. rolling update masters like currently, one by one
2. each node instancegroup:
     - detach all instances from instancegroup
     - `kops update cluster --yes`
     - wait few minutes (we should have old nodes still serving the pods and new ones coming up)
     - after new ones are up, drain and delete the old nodes one by one

However, in case of OpenStack we do have bigger problem because k8s cannot have node which name is equal to some another instance. So we cannot have old and new instance at the same time in cluster. I will try to solve that problem in another PR.
