### PR TITLE
Docs: Remove references to EnableCustomMetrics

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -382,16 +382,6 @@ spec:
     cpuCFSQuotaPeriod: "100ms"
 ```
 
-#### Enable Custom metrics support
-To use custom metrics in kubernetes as per [custom metrics doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics)
-we have to set the flag `--enable-custom-metrics` to `true` on all the kubelets. We can specify that in the `kubelet` spec in our cluster.yml.
-
-```
-spec:
-  kubelet:
-    enableCustomMetrics: true
-```
-
 #### Setting kubelet CPU management policies
 Kops 1.12.0 added support for enabling cpu management policies in kubernetes as per [cpu management doc](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies)
 we have to set the flag `--cpu-manager-policy` to the appropriate value on all the kubelets. This must be specified in the `kubelet` spec in our cluster.yml.
@@ -408,7 +398,6 @@ Setting kubelet configurations together with the networking Amazon VPC backend r
 ```yaml
 spec:
   kubelet:
-    enableCustomMetrics: true
     cloudProvider: aws
 ...
 ...

--- a/docs/horizontal_pod_autoscaling.md
+++ b/docs/horizontal_pod_autoscaling.md
@@ -74,16 +74,6 @@ Metrics Server | Metrics API group/version | Supported Kubernetes version
 
 ### Support For Custom Metrics
 
-Enable gathering custom metrics:
-
-```yaml
-spec:
-  kubelet:
-    enableCustomMetrics: true
-```
-
-Note that the deprecated and inactive option '--enable-custom-metrics' has been removed in Kubernetes 1.11 [#60699](https://github.com/kubernetes/kubernetes/pull/60699)
-
 Enable the horizontal pod autoscaler REST client:
 
 ```yaml

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1582,7 +1582,8 @@ spec:
                     for containers in a pod.
                   type: boolean
                 enableCustomMetrics:
-                  description: Enable gathering custom metrics.
+                  description: Deprecated as of k8s 1.11 - enable gathering custom
+                    metrics.
                   type: boolean
                 enableDebuggingHandlers:
                   description: EnableDebuggingHandlers enables server endpoints for
@@ -1937,7 +1938,8 @@ spec:
                     for containers in a pod.
                   type: boolean
                 enableCustomMetrics:
-                  description: Enable gathering custom metrics.
+                  description: Deprecated as of k8s 1.11 - enable gathering custom
+                    metrics.
                   type: boolean
                 enableDebuggingHandlers:
                   description: EnableDebuggingHandlers enables server endpoints for

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -297,7 +297,8 @@ spec:
                     for containers in a pod.
                   type: boolean
                 enableCustomMetrics:
-                  description: Enable gathering custom metrics.
+                  description: Deprecated as of k8s 1.11 - enable gathering custom
+                    metrics.
                   type: boolean
                 enableDebuggingHandlers:
                   description: EnableDebuggingHandlers enables server endpoints for

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -121,7 +121,7 @@ type KubeletConfigSpec struct {
 	NodeLabels map[string]string `json:"nodeLabels,omitempty" flag:"node-labels"`
 	// NonMasqueradeCIDR configures masquerading: traffic to IPs outside this range will use IP masquerade.
 	NonMasqueradeCIDR string `json:"nonMasqueradeCIDR,omitempty" flag:"non-masquerade-cidr"`
-	// Enable gathering custom metrics.
+	// Deprecated as of k8s 1.11 - enable gathering custom metrics.
 	EnableCustomMetrics *bool `json:"enableCustomMetrics,omitempty" flag:"enable-custom-metrics"`
 	// NetworkPluginMTU is the MTU to be passed to the network plugin,
 	// and overrides the default MTU for cases where it cannot be automatically

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -121,7 +121,7 @@ type KubeletConfigSpec struct {
 	NodeLabels map[string]string `json:"nodeLabels,omitempty" flag:"node-labels"`
 	// NonMasqueradeCIDR configures masquerading: traffic to IPs outside this range will use IP masquerade.
 	NonMasqueradeCIDR string `json:"nonMasqueradeCIDR,omitempty" flag:"non-masquerade-cidr"`
-	// Enable gathering custom metrics.
+	// Deprecated as of k8s 1.11 - enable gathering custom metrics.
 	EnableCustomMetrics *bool `json:"enableCustomMetrics,omitempty" flag:"enable-custom-metrics"`
 	// NetworkPluginMTU is the MTU to be passed to the network plugin,
 	// and overrides the default MTU for cases where it cannot be automatically

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -121,7 +121,7 @@ type KubeletConfigSpec struct {
 	NodeLabels map[string]string `json:"nodeLabels,omitempty" flag:"node-labels"`
 	// NonMasqueradeCIDR configures masquerading: traffic to IPs outside this range will use IP masquerade.
 	NonMasqueradeCIDR string `json:"nonMasqueradeCIDR,omitempty" flag:"non-masquerade-cidr"`
-	// Enable gathering custom metrics.
+	// Deprecated as of k8s 1.11 - enable gathering custom metrics.
 	EnableCustomMetrics *bool `json:"enableCustomMetrics,omitempty" flag:"enable-custom-metrics"`
 	// NetworkPluginMTU is the MTU to be passed to the network plugin,
 	// and overrides the default MTU for cases where it cannot be automatically


### PR DESCRIPTION
EnableCustomMetrics has been removed from k8s since 1.11  ( https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md#removed-deprecations ) - removing docs references to this flag and adding clarifying comment to flag description.