### PR TITLE
Upgrade go to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ os:
   - linux
   - osx
 go:
-  # 1.10 & 1.11 are now best-effort; we recommend 1.12
-  # - "1.10" gofmt changes mean 1.10 fails testing
+  # 1.11 & 1.12 are now best-effort; we recommend 1.13
   - "1.11"
   - "1.12"
+  - "1.13"
 
 go_import_path: k8s.io/kops
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GCS_URL=$(GCS_LOCATION:gs://%=https://storage.googleapis.com/%)
 LATEST_FILE?=latest-ci.txt
 GOPATH_1ST:=$(shell go env | grep GOPATH | cut -f 2 -d \")
 UNIQUE:=$(shell date +%s)
-GOVERSION=1.12.11
+GOVERSION=1.13.4
 BUILD=$(GOPATH_1ST)/src/k8s.io/kops/.build
 LOCAL=$(BUILD)/local
 BINDATA_TARGETS=upup/models/bindata.go

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,7 +27,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.12.11",
+    go_version = "1.13.4",
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM alpine:3.8
 
-ARG GO_VERSION=1.12.11
+ARG GO_VERSION=1.13.4
 
 # KOPS_GITISH: Modify to build at an explicit tag/gitish
 ARG KOPS_GITISH=release

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops
 
-go 1.12
+go 1.13
 
 // Version kubernetes-1.15.3
 //replace k8s.io/kubernetes => k8s.io/kubernetes v1.15.3

--- a/images/dns-controller-builder/Dockerfile
+++ b/images/dns-controller-builder/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install --yes --reinstall lsb-base \
   && rm -rf /var/lib/apt/lists/*
 
 # Install golang
-RUN curl -L https://storage.googleapis.com/golang/go1.12.11.linux-amd64.tar.gz | tar zx -C /usr/local
+RUN curl -L https://storage.googleapis.com/golang/go1.13.4.linux-amd64.tar.gz | tar zx -C /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 COPY onbuild.sh /onbuild.sh

--- a/images/protokube-builder/Dockerfile
+++ b/images/protokube-builder/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install --yes --reinstall lsb-base \
   && rm -rf /var/lib/apt/lists/*
 
 # Install golang
-RUN curl -L https://storage.googleapis.com/golang/go1.12.11.linux-amd64.tar.gz | tar zx -C /usr/local
+RUN curl -L https://storage.googleapis.com/golang/go1.13.4.linux-amd64.tar.gz | tar zx -C /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 COPY onbuild.sh /onbuild.sh


### PR DESCRIPTION
Now that the master branch is targeting Kops 1.17 and Kubernetes 1.17, we can upgrade all Go version references to use 1.13, matching [Kubernetes itself](https://github.com/kubernetes/kubernetes/pull/82809).

I used #7811 as a reference

I debated having Travis continue to test Go 1.11 or whether we should drop it. Thoughts?