### PR TITLE
Template the calico flex volume based on the kubelet spec

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -903,7 +903,7 @@ spec:
         - name: flexvol-driver-host
           hostPath:
             type: DirectoryOrCreate
-            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+            path: "{{- or .Kubelet.VolumePluginDirectory "/usr/libexec/kubernetes/kubelet-plugins/volume/exec" }}/nodeagent~uds"
 ---
 
 apiVersion: v1


### PR DESCRIPTION
The calico spec uses a flex dir that doesn't work on CoreOS
and probably other platforms.  This PR templates the spec
dir with the value from the kubelet spec that is set here:

https://github.com/kubernetes/kops/blob/master/docs/cluster_spec.md#configure-a-flex-volume-plugin-directory

Note that without this, kops 1.15 fails to provision on CoreOS nodes.