### PR TITLE
Add indent template function and use it to fix KubeDNS.ExternalCoreFile rendering

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -60,7 +60,7 @@ metadata:
 data:
   Corefile: |
   {{- if KubeDNS.ExternalCoreFile }}
-    {{ KubeDNS.ExternalCoreFile }}
+{{ KubeDNS.ExternalCoreFile | indent 4 }}
   {{- else }}
     .:53 {
         errors

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
@@ -60,7 +60,7 @@ metadata:
 data:
   Corefile: |
   {{- if KubeDNS.ExternalCoreFile }}
-    {{ KubeDNS.ExternalCoreFile }}
+{{ KubeDNS.ExternalCoreFile | indent 4 }}
   {{- else }}
     .:53 {
         errors

--- a/upup/pkg/fi/cloudup/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/BUILD.bazel
@@ -83,6 +83,7 @@ go_library(
         "//util/pkg/hashing:go_default_library",
         "//util/pkg/reflectutils:go_default_library",
         "//util/pkg/vfs:go_default_library",
+        "//vendor/github.com/Masterminds/sprig:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -35,6 +35,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/Masterminds/sprig"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
@@ -77,6 +78,9 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["join"] = func(a []string, sep string) string {
 		return strings.Join(a, sep)
 	}
+
+	sprigTxtFuncMap := sprig.TxtFuncMap()
+	dest["indent"] = sprigTxtFuncMap["indent"]
 
 	dest["ClusterName"] = tf.modelContext.ClusterName
 	dest["HasTag"] = tf.HasTag


### PR DESCRIPTION
This PR adds a new `indent` template function and use it to fix KubeDNS.ExternalCoreFile rendering as reported on #7975.

`indent` function was copied from [sprig](https://github.com/Masterminds/sprig/blob/v2.17.1/strings.go#L104-L107).

Fixes #7975