### PR TITLE
retry nvidia-device-plugin.sh when failed

### DIFF
--- a/hooks/nvidia-device-plugin/image/files/nvidia-device-plugin.service
+++ b/hooks/nvidia-device-plugin/image/files/nvidia-device-plugin.service
@@ -3,7 +3,9 @@ Description=Prepare AWS GPU instances for Nvidia Kubernetes Device Plugin
 After=cloud-config.target cloud-init.target kops-configuration.service apt-daily-upgrade.timer install-xfs.service
 
 [Service]
-Type=oneshot
+Type=simple
+Restart=on-failure
+RestartSec=3
 ExecStart=/bin/bash -c "/nvidia-device-plugin/nvidia-device-plugin.sh"
 
 [Install]


### PR DESCRIPTION
**What this PR does / why we need it**:

nvidia-device-plugin.sh could failed due to network issues, apt issues, etc. But the `oneshot` service can't be restarted on failure.

> Service has Restart= setting other than no, which isn't allowed for Type=oneshot services. Refusing.

Changed to `Type=simple` and set `Restart=on-failure`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**: