### PR TITLE
[Issue-7956] - [Digital Ocean] Minor fix to have proper indexing for digital ocean regions

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -726,10 +726,16 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		for i := 0; i < int(masterCount); i++ {
 			zone := masterZones[i%len(masterZones)]
 			name := zone
-			if int(masterCount) > len(masterZones) {
-				name += "-" + strconv.Itoa(1+(i/len(masterZones)))
-			}
-
+			if api.CloudProviderID(cluster.Spec.CloudProvider) == api.CloudProviderDO {
+				if int(masterCount) >= len(masterZones) {
+					name += "-" + strconv.Itoa(1+(i/len(masterZones)))
+				}
+			} else {
+				if int(masterCount) > len(masterZones) {
+					name += "-" + strconv.Itoa(1+(i/len(masterZones)))
+				}
+			} 
+			
 			g := &api.InstanceGroup{}
 			g.Spec.Role = api.InstanceGroupRoleMaster
 			g.Spec.MinSize = fi.Int32(1)

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -734,8 +734,8 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 				if int(masterCount) > len(masterZones) {
 					name += "-" + strconv.Itoa(1+(i/len(masterZones)))
 				}
-			} 
-			
+			}
+
 			g := &api.InstanceGroup{}
 			g.Spec.Role = api.InstanceGroupRoleMaster
 			g.Spec.MinSize = fi.Int32(1)


### PR DESCRIPTION
Found an issue where regions ending with characters other than "1" like sfo2 had problems with etcdmanager.
The index was set to 2 instead of 1 because of the way we are currently trimming in https://github.com/kubernetes/kops/blob/master/cmd/kops/create_cluster.go#L802
Since this is a common code, I added special check for DO to use the logic differently that suits DO.
You now see the instanceGroup as below and the name is properly set to "1" instead of "2".

`  configBase: do://sri-kops-space/dev5.techthreads.co.in
  etcdClusters:
  - cpuRequest: 200m
    etcdMembers:
    - instanceGroup: **master-sfo2-1**
      name: "1"
    memoryRequest: 100Mi
    name: main
  - cpuRequest: 100m
    etcdMembers:
    - instanceGroup: **master-sfo2-1**
      name: "1"
    memoryRequest: 100Mi
    name: events
`
