### PR TITLE
fix(openstack): fix additional security groups on instance groups

### DIFF
--- a/upup/pkg/fi/cloudup/openstacktasks/port_test.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port_test.go
@@ -594,6 +594,7 @@ func Test_Port_RenderOpenstack(t *testing.T) {
 func Test_Port_createOptsFromPortTask(t *testing.T) {
 	tests := []struct {
 		desc               string
+		target             *openstack.OpenstackAPITarget
 		actual             *Port
 		expected           *Port
 		changes            *Port
@@ -602,6 +603,18 @@ func Test_Port_createOptsFromPortTask(t *testing.T) {
 	}{
 		{
 			desc: "all fields set",
+			target: &openstack.OpenstackAPITarget{
+				Cloud: &portCloud{
+					listSecurityGroups: map[string][]sg.SecGroup{
+						"add-1": {
+							{ID: "add-1-id", Name: "add-1"},
+						},
+						"add-2": {
+							{ID: "add-2-id", Name: "add-2"},
+						},
+					},
+				},
+			},
 			expected: &Port{
 				ID:      fi.String("expected-id"),
 				Name:    fi.String("name"),
@@ -625,8 +638,8 @@ func Test_Port_createOptsFromPortTask(t *testing.T) {
 				SecurityGroups: &[]string{
 					"sg-1",
 					"sg-2",
-					"add-1",
-					"add-2",
+					"add-1-id",
+					"add-2-id",
 				},
 				FixedIPs: []ports.IP{
 					{SubnetID: "subnet-a"},
@@ -634,11 +647,40 @@ func Test_Port_createOptsFromPortTask(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "nonexisting additional security groups",
+			target: &openstack.OpenstackAPITarget{
+				Cloud: &portCloud{
+					listSecurityGroups: map[string][]sg.SecGroup{
+						"add-1": {
+							{ID: "add-1-id", Name: "add-1"},
+						},
+					},
+				},
+			},
+			expected: &Port{
+				ID:      fi.String("expected-id"),
+				Name:    fi.String("name"),
+				Network: &Network{ID: fi.String("networkID")},
+				SecurityGroups: []*SecurityGroup{
+					{ID: fi.String("sg-1")},
+					{ID: fi.String("sg-2")},
+				},
+				AdditionalSecurityGroups: []string{
+					"add-2",
+				},
+				Subnets: []*Subnet{
+					{ID: fi.String("subnet-a")},
+					{ID: fi.String("subnet-b")},
+				},
+			},
+			expectedError: fmt.Errorf("Additional SecurityGroup not found for name add-2"),
+		},
 	}
 
 	for _, testCase := range tests {
 		t.Run(testCase.desc, func(t *testing.T) {
-			opts, err := portCreateOptsFromPortTask(testCase.actual, testCase.expected, testCase.changes)
+			opts, err := portCreateOptsFromPortTask(testCase.target, testCase.actual, testCase.expected, testCase.changes)
 
 			if !reflect.DeepEqual(err, testCase.expectedError) {
 				t.Errorf("Error differs:\n%v\n\tinstead of\n%v", err, testCase.expectedError)


### PR DESCRIPTION
Previously we mistakenly used the names of the additional security
groups where the Openstack API is expecting their IDs.