### PR TITLE
Automatically install dependencies with local packages

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -878,7 +878,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "7de4211fa0dfd240d8827b93763e1eb5f0d56411",
 			},
 		},
-		Dependencies: []string{"libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python"},
+		Dependencies: []string{"libtool-ltdl"},
 	},
 
 	// 18.09.9 - CentOS / Rhel8
@@ -902,7 +902,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "f6447e84479df3a58ce04a3da87ccc384663493b",
 			},
 		},
-		Dependencies: []string{"container-selinux", "libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python-utils", "python3-policycoreutils"},
+		Dependencies: []string{"libtool-ltdl"},
 	},
 
 	// 19.03.4 - k8s 1.17 - https://github.com/kubernetes/kubernetes/pull/84476
@@ -1005,7 +1005,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "7de4211fa0dfd240d8827b93763e1eb5f0d56411",
 			},
 		},
-		Dependencies: []string{"libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python"},
+		Dependencies: []string{"libtool-ltdl"},
 	},
 
 	// 19.03.4 - CentOS / Rhel8
@@ -1029,7 +1029,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "f6447e84479df3a58ce04a3da87ccc384663493b",
 			},
 		},
-		Dependencies: []string{"container-selinux", "libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python-utils", "python3-policycoreutils"},
+		Dependencies: []string{"libtool-ltdl"},
 	},
 
 	// TIP: When adding the next version, copy the previous

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -801,7 +801,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "186f2f2c570f37b363102e6b879073db6dec671d",
 			},
 		},
-		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl", "pigz"},
 	},
 
 	// 18.09.9 - Debian Buster
@@ -825,7 +825,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "365e4a7541ce2cf3c3036ea2a9bf6b40a50893a8",
 			},
 		},
-		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl", "pigz"},
 	},
 
 	// 18.09.9 - Bionic
@@ -849,7 +849,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "f4c941807310e3fa470dddfb068d599174a3daec",
 			},
 		},
-		Dependencies: []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl", "pigz"},
 	},
 
 	// 18.09.9 - CentOS / Rhel7
@@ -928,7 +928,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "186f2f2c570f37b363102e6b879073db6dec671d",
 			},
 		},
-		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl", "pigz"},
 	},
 
 	// 19.03.4 - Debian Buster
@@ -952,7 +952,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "365e4a7541ce2cf3c3036ea2a9bf6b40a50893a8",
 			},
 		},
-		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl", "pigz"},
 	},
 
 	// 19.03.4 - Bionic
@@ -976,7 +976,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "f4c941807310e3fa470dddfb068d599174a3daec",
 			},
 		},
-		Dependencies: []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl", "pigz"},
 	},
 
 	// 19.03.4 - CentOS / Rhel7

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -801,7 +801,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "186f2f2c570f37b363102e6b879073db6dec671d",
 			},
 		},
-		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl", "pigz"},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 	},
 
 	// 18.09.9 - Debian Buster
@@ -825,7 +825,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "365e4a7541ce2cf3c3036ea2a9bf6b40a50893a8",
 			},
 		},
-		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl", "pigz"},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 	},
 
 	// 18.09.9 - Bionic
@@ -849,7 +849,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "f4c941807310e3fa470dddfb068d599174a3daec",
 			},
 		},
-		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl", "pigz"},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 	},
 
 	// 18.09.9 - CentOS / Rhel7
@@ -928,7 +928,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "186f2f2c570f37b363102e6b879073db6dec671d",
 			},
 		},
-		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl", "pigz"},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 	},
 
 	// 19.03.4 - Debian Buster
@@ -952,7 +952,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "365e4a7541ce2cf3c3036ea2a9bf6b40a50893a8",
 			},
 		},
-		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl", "pigz"},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 	},
 
 	// 19.03.4 - Bionic
@@ -976,7 +976,7 @@ var dockerVersions = []dockerVersion{
 				Hash:    "f4c941807310e3fa470dddfb068d599174a3daec",
 			},
 		},
-		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl", "pigz"},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 	},
 
 	// 19.03.4 - CentOS / Rhel7

--- a/upup/pkg/fi/nodeup/nodetasks/package.go
+++ b/upup/pkg/fi/nodeup/nodetasks/package.go
@@ -308,7 +308,7 @@ func (_ *Package) RenderLocal(t *local.LocalTarget, a, e, changes *Package) erro
 				if t.HasTag("_jessie") {
 					args = []string{"dpkg", "-i"}
 				} else {
-					args = []string{"apt-get", "install", "--yes"}
+					args = []string{"apt-get", "install", "--yes", "--no-install-recommends"}
 					env = append(env, "DEBIAN_FRONTEND=noninteractive")
 				}
 			} else if t.HasTag(tags.TagOSFamilyRHEL) {
@@ -329,7 +329,7 @@ func (_ *Package) RenderLocal(t *local.LocalTarget, a, e, changes *Package) erro
 			var args []string
 			env := os.Environ()
 			if t.HasTag(tags.TagOSFamilyDebian) {
-				args = []string{"apt-get", "install", "--yes", e.Name}
+				args = []string{"apt-get", "install", "--yes", "--no-install-recommends", e.Name}
 				env = append(env, "DEBIAN_FRONTEND=noninteractive")
 			} else if t.HasTag(tags.TagOSFamilyRHEL) {
 				args = []string{"/usr/bin/yum", "install", "-y", e.Name}

--- a/upup/pkg/fi/nodeup/tags/tags.go
+++ b/upup/pkg/fi/nodeup/tags/tags.go
@@ -20,6 +20,10 @@ const (
 	TagOSFamilyRHEL   = "_rhel_family"
 	TagOSFamilyDebian = "_debian_family"
 
+	TagOSDebianJessie = "_jessie"
+	TagOSCentOS8      = "_centos8"
+	TagOSRHEL8        = "_rhel8"
+
 	TagSystemd = "_systemd"
 )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it?**
Changes the way local packages are installed from using the low level dpkg and rpm tools to their higher level alternatives apt and and yum.
This reduces the work needed to maintain the dependencies by letting the package manager take care of this task. Optional dependencies can still be provided if needed.

**Which issue(s) this PR fixes?**
May be a solution for #7878

**Special notes for your reviewer**
At the moment Kops relies on a list of dependencies for each local package that is installed.
Providing a list of dependencies is prone to errors over time and may not know exactly why each dep was added.
Dependencies are only checked if they are installed, not also if the version is the minimum required. This can lead to failure to install in some cases as discussed in the refferenced issue.
The update script would upgrade the packages anyway later, but I guess it's probably best to start with the freshes dependencies.

**Does this PR introduce a user-facing change?**
No
