### PR TITLE
Bump cilium version to 1.6.4

### DIFF
--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -155,7 +155,7 @@ type AmazonVPCNetworkingSpec struct {
 	ImageName string `json:"imageName,omitempty"`
 }
 
-const CiliumDefaultVersion = "v1.6.1"
+const CiliumDefaultVersion = "v1.6.4"
 
 // CiliumNetworkingSpec declares that we want Cilium networking
 type CiliumNetworkingSpec struct {

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -1117,7 +1117,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 	if b.cluster.Spec.Networking.Cilium != nil {
 		key := "networking.cilium.io"
-		version := "1.6.1-kops.1"
+		version := "1.6.4-kops.1"
 
 		{
 			id := "k8s-1.7"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -123,7 +123,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: cc7937066cb472dce20e13fe9a76faefd74dee19
+    manifestHash: 2d40b9ab7453b4a0a413196fae4c8bdcd62c69ce
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -115,11 +115,11 @@ spec:
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0 <1.12.0'
     manifest: networking.cilium.io/k8s-1.7.yaml
-    manifestHash: cc7937066cb472dce20e13fe9a76faefd74dee19
+    manifestHash: 2d40b9ab7453b4a0a413196fae4c8bdcd62c69ce
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.6.1-kops.1
+    version: 1.6.4-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
@@ -127,4 +127,4 @@ spec:
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.6.1-kops.1
+    version: 1.6.4-kops.1


### PR DESCRIPTION
Most importantly, this fixes a bug in the 1.6.4 branch causing `externalTrafficPolicy: local` to fail.