### PR TITLE
Run goimports in make ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -561,7 +561,7 @@ verify-staticcheck:
 # verify-package has to be after verify-gendoc, because with .gitignore for federation bindata
 # it bombs in travis. verify-gendoc generates the bindata file.
 .PHONY: ci
-ci: govet verify-gofmt verify-gomod verify-goimports verify-boilerplate verify-bazel verify-misspelling nodeup examples test | verify-gendocs verify-packages verify-apimachinery
+ci: govet goimports verify-gofmt verify-gomod verify-goimports verify-boilerplate verify-bazel verify-misspelling nodeup examples test | verify-gendocs verify-packages verify-apimachinery
 	echo "Done!"
 
 # travis-ci is the target that travis-ci calls


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When running `make ci`, assures that autogenerated files are properly indented when developing locally. It also fixes the scenario where `upup/models/bindata.go` is generated locally, not indented, and breaks the `verify-goimports` test.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
The discussion started here: https://github.com/kubernetes/kops/pull/7865#issuecomment-558312020

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```