### PR TITLE
networking: Bump default Cilium version to v1.6.4

### DIFF
--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -155,7 +155,7 @@ type AmazonVPCNetworkingSpec struct {
 	ImageName string `json:"imageName,omitempty"`
 }
 
-const CiliumDefaultVersion = "v1.6.1"
+const CiliumDefaultVersion = "v1.6.4"
 
 // CiliumNetworkingSpec declares that we want Cilium networking
 type CiliumNetworkingSpec struct {


### PR DESCRIPTION
This commit bumps Cilium (a CNI plugin) version to v1.6.4 which contains a fix to avoid SNAT for `externalTrafficPolicy=Local` services.

Full release notes: https://github.com/cilium/cilium/releases/tag/v1.6.4.