### PR TITLE
Additional leader election options

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -295,6 +295,39 @@ spec:
                         gain leadership before executing the main loop. Enable this
                         when running replicated components for high availability.
                       type: boolean
+                    leaderElectLeaseDuration:
+                      description: leaderElectLeaseDuration is the length in time
+                        non-leader candidates will wait after observing a leadership
+                        renewal until attempting to acquire leadership of a led but
+                        unrenewed leader slot. This is effectively the maximum duration
+                        that a leader can be stopped before it is replaced by another
+                        candidate
+                      type: string
+                    leaderElectRenewDeadlineDuration:
+                      description: LeaderElectRenewDeadlineDuration is the interval
+                        between attempts by the acting master to renew a leadership
+                        slot before it stops leading. This must be less than or equal
+                        to the lease duration.
+                      type: string
+                    leaderElectResourceLock:
+                      description: LeaderElectResourceLock is the type of resource
+                        object that is used for locking during leader election. Supported
+                        options are endpoints (default) and `configmaps`.
+                      type: string
+                    leaderElectResourceName:
+                      description: LeaderElectResourceName is the name of resource
+                        object that is used for locking during leader election.
+                      type: string
+                    leaderElectResourceNamespace:
+                      description: LeaderElectResourceNamespace is the namespace of
+                        resource object that is used for locking during leader election.
+                      type: string
+                    leaderElectRetryPeriod:
+                      description: LeaderElectRetryPeriod is The duration the clients
+                        should wait between attempting acquisition and renewal of
+                        a leadership. This is only applicable if leader election is
+                        enabled.
+                      type: string
                   type: object
                 logLevel:
                   description: LogLevel is the verbosity of the logs.
@@ -1253,6 +1286,39 @@ spec:
                         gain leadership before executing the main loop. Enable this
                         when running replicated components for high availability.
                       type: boolean
+                    leaderElectLeaseDuration:
+                      description: leaderElectLeaseDuration is the length in time
+                        non-leader candidates will wait after observing a leadership
+                        renewal until attempting to acquire leadership of a led but
+                        unrenewed leader slot. This is effectively the maximum duration
+                        that a leader can be stopped before it is replaced by another
+                        candidate
+                      type: string
+                    leaderElectRenewDeadlineDuration:
+                      description: LeaderElectRenewDeadlineDuration is the interval
+                        between attempts by the acting master to renew a leadership
+                        slot before it stops leading. This must be less than or equal
+                        to the lease duration.
+                      type: string
+                    leaderElectResourceLock:
+                      description: LeaderElectResourceLock is the type of resource
+                        object that is used for locking during leader election. Supported
+                        options are endpoints (default) and `configmaps`.
+                      type: string
+                    leaderElectResourceName:
+                      description: LeaderElectResourceName is the name of resource
+                        object that is used for locking during leader election.
+                      type: string
+                    leaderElectResourceNamespace:
+                      description: LeaderElectResourceNamespace is the namespace of
+                        resource object that is used for locking during leader election.
+                      type: string
+                    leaderElectRetryPeriod:
+                      description: LeaderElectRetryPeriod is The duration the clients
+                        should wait between attempting acquisition and renewal of
+                        a leadership. This is only applicable if leader election is
+                        enabled.
+                      type: string
                   type: object
                 logLevel:
                   description: LogLevel is the defined logLevel
@@ -1485,6 +1551,39 @@ spec:
                         gain leadership before executing the main loop. Enable this
                         when running replicated components for high availability.
                       type: boolean
+                    leaderElectLeaseDuration:
+                      description: leaderElectLeaseDuration is the length in time
+                        non-leader candidates will wait after observing a leadership
+                        renewal until attempting to acquire leadership of a led but
+                        unrenewed leader slot. This is effectively the maximum duration
+                        that a leader can be stopped before it is replaced by another
+                        candidate
+                      type: string
+                    leaderElectRenewDeadlineDuration:
+                      description: LeaderElectRenewDeadlineDuration is the interval
+                        between attempts by the acting master to renew a leadership
+                        slot before it stops leading. This must be less than or equal
+                        to the lease duration.
+                      type: string
+                    leaderElectResourceLock:
+                      description: LeaderElectResourceLock is the type of resource
+                        object that is used for locking during leader election. Supported
+                        options are endpoints (default) and `configmaps`.
+                      type: string
+                    leaderElectResourceName:
+                      description: LeaderElectResourceName is the name of resource
+                        object that is used for locking during leader election.
+                      type: string
+                    leaderElectResourceNamespace:
+                      description: LeaderElectResourceNamespace is the namespace of
+                        resource object that is used for locking during leader election.
+                      type: string
+                    leaderElectRetryPeriod:
+                      description: LeaderElectRetryPeriod is The duration the clients
+                        should wait between attempting acquisition and renewal of
+                        a leadership. This is only applicable if leader election is
+                        enabled.
+                      type: string
                   type: object
                 logLevel:
                   description: LogLevel is the logging level

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -600,6 +600,24 @@ type LeaderElectionConfiguration struct {
 	// before executing the main loop. Enable this when running replicated
 	// components for high availability.
 	LeaderElect *bool `json:"leaderElect,omitempty" flag:"leader-elect"`
+	// leaderElectLeaseDuration is the length in time non-leader candidates
+	// will wait after observing a leadership renewal until attempting to acquire
+	// leadership of a led but unrenewed leader slot. This is effectively the
+	// maximum duration that a leader can be stopped before it is replaced by another candidate
+	LeaderElectLeaseDuration *metav1.Duration `json:"leaderElectLeaseDuration,omitempty" flag:"leader-elect-lease-duration"`
+	// LeaderElectRenewDeadlineDuration is the interval between attempts by the acting master to
+	// renew a leadership slot before it stops leading. This must be less than or equal to the lease duration.
+	LeaderElectRenewDeadlineDuration *metav1.Duration `json:"leaderElectRenewDeadlineDuration,omitempty" flag:"leader-elect-renew-deadline"`
+	// LeaderElectResourceLock is the type of resource object that is used for locking during
+	// leader election. Supported options are endpoints (default) and `configmaps`.
+	LeaderElectResourceLock *string `json:"leaderElectResourceLock,omitempty" flag:"leader-elect-resource-lock"`
+	// LeaderElectResourceName is the name of resource object that is used for locking during leader election.
+	LeaderElectResourceName *string `json:"leaderElectResourceName,omitempty" flag:"leader-elect-resource-name"`
+	// LeaderElectResourceNamespace is the namespace of resource object that is used for locking during leader election.
+	LeaderElectResourceNamespace *string `json:"leaderElectResourceNamespace,omitempty" flag:"leader-elect-resource-namespace"`
+	// LeaderElectRetryPeriod is The duration the clients should wait between attempting acquisition
+	// and renewal of a leadership. This is only applicable if leader election is enabled.
+	LeaderElectRetryPeriod *metav1.Duration `json:"leaderElectRetryPeriod,omitempty" flag:"leader-elect-retry-period"`
 }
 
 // OpenstackLoadbalancerConfig defines the config for a neutron loadbalancer

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -600,6 +600,24 @@ type LeaderElectionConfiguration struct {
 	// before executing the main loop. Enable this when running replicated
 	// components for high availability.
 	LeaderElect *bool `json:"leaderElect,omitempty" flag:"leader-elect"`
+	// leaderElectLeaseDuration is the length in time non-leader candidates
+	// will wait after observing a leadership renewal until attempting to acquire
+	// leadership of a led but unrenewed leader slot. This is effectively the
+	// maximum duration that a leader can be stopped before it is replaced by another candidate
+	LeaderElectLeaseDuration *metav1.Duration `json:"leaderElectLeaseDuration,omitempty" flag:"leader-elect-lease-duration"`
+	// LeaderElectRenewDeadlineDuration is the interval between attempts by the acting master to
+	// renew a leadership slot before it stops leading. This must be less than or equal to the lease duration.
+	LeaderElectRenewDeadlineDuration *metav1.Duration `json:"leaderElectRenewDeadlineDuration,omitempty" flag:"leader-elect-renew-deadline"`
+	// LeaderElectResourceLock is the type of resource object that is used for locking during
+	// leader election. Supported options are endpoints (default) and `configmaps`.
+	LeaderElectResourceLock *string `json:"leaderElectResourceLock,omitempty" flag:"leader-elect-resource-lock"`
+	// LeaderElectResourceName is the name of resource object that is used for locking during leader election.
+	LeaderElectResourceName *string `json:"leaderElectResourceName,omitempty" flag:"leader-elect-resource-name"`
+	// LeaderElectResourceNamespace is the namespace of resource object that is used for locking during leader election.
+	LeaderElectResourceNamespace *string `json:"leaderElectResourceNamespace,omitempty" flag:"leader-elect-resource-namespace"`
+	// LeaderElectRetryPeriod is The duration the clients should wait between attempting acquisition
+	// and renewal of a leadership. This is only applicable if leader election is enabled.
+	LeaderElectRetryPeriod *metav1.Duration `json:"leaderElectRetryPeriod,omitempty" flag:"leader-elect-retry-period"`
 }
 
 // OpenstackLoadbalancerConfig defines the config for a neutron loadbalancer

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -3798,6 +3798,12 @@ func Convert_kops_KuberouterNetworkingSpec_To_v1alpha1_KuberouterNetworkingSpec(
 
 func autoConvert_v1alpha1_LeaderElectionConfiguration_To_kops_LeaderElectionConfiguration(in *LeaderElectionConfiguration, out *kops.LeaderElectionConfiguration, s conversion.Scope) error {
 	out.LeaderElect = in.LeaderElect
+	out.LeaderElectLeaseDuration = in.LeaderElectLeaseDuration
+	out.LeaderElectRenewDeadlineDuration = in.LeaderElectRenewDeadlineDuration
+	out.LeaderElectResourceLock = in.LeaderElectResourceLock
+	out.LeaderElectResourceName = in.LeaderElectResourceName
+	out.LeaderElectResourceNamespace = in.LeaderElectResourceNamespace
+	out.LeaderElectRetryPeriod = in.LeaderElectRetryPeriod
 	return nil
 }
 
@@ -3808,6 +3814,12 @@ func Convert_v1alpha1_LeaderElectionConfiguration_To_kops_LeaderElectionConfigur
 
 func autoConvert_kops_LeaderElectionConfiguration_To_v1alpha1_LeaderElectionConfiguration(in *kops.LeaderElectionConfiguration, out *LeaderElectionConfiguration, s conversion.Scope) error {
 	out.LeaderElect = in.LeaderElect
+	out.LeaderElectLeaseDuration = in.LeaderElectLeaseDuration
+	out.LeaderElectRenewDeadlineDuration = in.LeaderElectRenewDeadlineDuration
+	out.LeaderElectResourceLock = in.LeaderElectResourceLock
+	out.LeaderElectResourceName = in.LeaderElectResourceName
+	out.LeaderElectResourceNamespace = in.LeaderElectResourceNamespace
+	out.LeaderElectRetryPeriod = in.LeaderElectRetryPeriod
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2586,6 +2586,36 @@ func (in *LeaderElectionConfiguration) DeepCopyInto(out *LeaderElectionConfigura
 		*out = new(bool)
 		**out = **in
 	}
+	if in.LeaderElectLeaseDuration != nil {
+		in, out := &in.LeaderElectLeaseDuration, &out.LeaderElectLeaseDuration
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.LeaderElectRenewDeadlineDuration != nil {
+		in, out := &in.LeaderElectRenewDeadlineDuration, &out.LeaderElectRenewDeadlineDuration
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.LeaderElectResourceLock != nil {
+		in, out := &in.LeaderElectResourceLock, &out.LeaderElectResourceLock
+		*out = new(string)
+		**out = **in
+	}
+	if in.LeaderElectResourceName != nil {
+		in, out := &in.LeaderElectResourceName, &out.LeaderElectResourceName
+		*out = new(string)
+		**out = **in
+	}
+	if in.LeaderElectResourceNamespace != nil {
+		in, out := &in.LeaderElectResourceNamespace, &out.LeaderElectResourceNamespace
+		*out = new(string)
+		**out = **in
+	}
+	if in.LeaderElectRetryPeriod != nil {
+		in, out := &in.LeaderElectRetryPeriod, &out.LeaderElectRetryPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -600,6 +600,24 @@ type LeaderElectionConfiguration struct {
 	// before executing the main loop. Enable this when running replicated
 	// components for high availability.
 	LeaderElect *bool `json:"leaderElect,omitempty" flag:"leader-elect"`
+	// leaderElectLeaseDuration is the length in time non-leader candidates
+	// will wait after observing a leadership renewal until attempting to acquire
+	// leadership of a led but unrenewed leader slot. This is effectively the
+	// maximum duration that a leader can be stopped before it is replaced by another candidate
+	LeaderElectLeaseDuration *metav1.Duration `json:"leaderElectLeaseDuration,omitempty" flag:"leader-elect-lease-duration"`
+	// LeaderElectRenewDeadlineDuration is the interval between attempts by the acting master to
+	// renew a leadership slot before it stops leading. This must be less than or equal to the lease duration.
+	LeaderElectRenewDeadlineDuration *metav1.Duration `json:"leaderElectRenewDeadlineDuration,omitempty" flag:"leader-elect-renew-deadline"`
+	// LeaderElectResourceLock is the type of resource object that is used for locking during
+	// leader election. Supported options are endpoints (default) and `configmaps`.
+	LeaderElectResourceLock *string `json:"leaderElectResourceLock,omitempty" flag:"leader-elect-resource-lock"`
+	// LeaderElectResourceName is the name of resource object that is used for locking during leader election.
+	LeaderElectResourceName *string `json:"leaderElectResourceName,omitempty" flag:"leader-elect-resource-name"`
+	// LeaderElectResourceNamespace is the namespace of resource object that is used for locking during leader election.
+	LeaderElectResourceNamespace *string `json:"leaderElectResourceNamespace,omitempty" flag:"leader-elect-resource-namespace"`
+	// LeaderElectRetryPeriod is The duration the clients should wait between attempting acquisition
+	// and renewal of a leadership. This is only applicable if leader election is enabled.
+	LeaderElectRetryPeriod *metav1.Duration `json:"leaderElectRetryPeriod,omitempty" flag:"leader-elect-retry-period"`
 }
 
 // OpenstackLoadbalancerConfig defines the config for a neutron loadbalancer

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4068,6 +4068,12 @@ func Convert_kops_KuberouterNetworkingSpec_To_v1alpha2_KuberouterNetworkingSpec(
 
 func autoConvert_v1alpha2_LeaderElectionConfiguration_To_kops_LeaderElectionConfiguration(in *LeaderElectionConfiguration, out *kops.LeaderElectionConfiguration, s conversion.Scope) error {
 	out.LeaderElect = in.LeaderElect
+	out.LeaderElectLeaseDuration = in.LeaderElectLeaseDuration
+	out.LeaderElectRenewDeadlineDuration = in.LeaderElectRenewDeadlineDuration
+	out.LeaderElectResourceLock = in.LeaderElectResourceLock
+	out.LeaderElectResourceName = in.LeaderElectResourceName
+	out.LeaderElectResourceNamespace = in.LeaderElectResourceNamespace
+	out.LeaderElectRetryPeriod = in.LeaderElectRetryPeriod
 	return nil
 }
 
@@ -4078,6 +4084,12 @@ func Convert_v1alpha2_LeaderElectionConfiguration_To_kops_LeaderElectionConfigur
 
 func autoConvert_kops_LeaderElectionConfiguration_To_v1alpha2_LeaderElectionConfiguration(in *kops.LeaderElectionConfiguration, out *LeaderElectionConfiguration, s conversion.Scope) error {
 	out.LeaderElect = in.LeaderElect
+	out.LeaderElectLeaseDuration = in.LeaderElectLeaseDuration
+	out.LeaderElectRenewDeadlineDuration = in.LeaderElectRenewDeadlineDuration
+	out.LeaderElectResourceLock = in.LeaderElectResourceLock
+	out.LeaderElectResourceName = in.LeaderElectResourceName
+	out.LeaderElectResourceNamespace = in.LeaderElectResourceNamespace
+	out.LeaderElectRetryPeriod = in.LeaderElectRetryPeriod
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2657,6 +2657,36 @@ func (in *LeaderElectionConfiguration) DeepCopyInto(out *LeaderElectionConfigura
 		*out = new(bool)
 		**out = **in
 	}
+	if in.LeaderElectLeaseDuration != nil {
+		in, out := &in.LeaderElectLeaseDuration, &out.LeaderElectLeaseDuration
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.LeaderElectRenewDeadlineDuration != nil {
+		in, out := &in.LeaderElectRenewDeadlineDuration, &out.LeaderElectRenewDeadlineDuration
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.LeaderElectResourceLock != nil {
+		in, out := &in.LeaderElectResourceLock, &out.LeaderElectResourceLock
+		*out = new(string)
+		**out = **in
+	}
+	if in.LeaderElectResourceName != nil {
+		in, out := &in.LeaderElectResourceName, &out.LeaderElectResourceName
+		*out = new(string)
+		**out = **in
+	}
+	if in.LeaderElectResourceNamespace != nil {
+		in, out := &in.LeaderElectResourceNamespace, &out.LeaderElectResourceNamespace
+		*out = new(string)
+		**out = **in
+	}
+	if in.LeaderElectRetryPeriod != nil {
+		in, out := &in.LeaderElectRetryPeriod, &out.LeaderElectRetryPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2855,6 +2855,36 @@ func (in *LeaderElectionConfiguration) DeepCopyInto(out *LeaderElectionConfigura
 		*out = new(bool)
 		**out = **in
 	}
+	if in.LeaderElectLeaseDuration != nil {
+		in, out := &in.LeaderElectLeaseDuration, &out.LeaderElectLeaseDuration
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.LeaderElectRenewDeadlineDuration != nil {
+		in, out := &in.LeaderElectRenewDeadlineDuration, &out.LeaderElectRenewDeadlineDuration
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.LeaderElectResourceLock != nil {
+		in, out := &in.LeaderElectResourceLock, &out.LeaderElectResourceLock
+		*out = new(string)
+		**out = **in
+	}
+	if in.LeaderElectResourceName != nil {
+		in, out := &in.LeaderElectResourceName, &out.LeaderElectResourceName
+		*out = new(string)
+		**out = **in
+	}
+	if in.LeaderElectResourceNamespace != nil {
+		in, out := &in.LeaderElectResourceNamespace, &out.LeaderElectResourceNamespace
+		*out = new(string)
+		**out = **in
+	}
+	if in.LeaderElectRetryPeriod != nil {
+		in, out := &in.LeaderElectRetryPeriod, &out.LeaderElectRetryPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
This PR adds support for the remaining `leader-elect` flags that can be utilized by both the `kube-controller-manager` and the `kube-scheduler`.