### PR TITLE
Fix Handling of LaunchTemplate Versions for MixedInstancePolicy

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -614,7 +614,7 @@ func findAutoscalingGroupLaunchConfiguration(c AWSCloud, g *autoscaling.Group) (
 					version = mixedVersion
 				}
 				klog.V(4).Infof("Launch Template Version Specified By ASG: %v", mixedVersion)
-				klog.V(4).Infof("Luanch Template Version we are using for compare: %v", version)
+				klog.V(4).Infof("Launch Template Version we are using for compare: %v", version)
 				if name != "" {
 					launchTemplate := name + ":" + version
 					return launchTemplate, nil


### PR DESCRIPTION
Correctly detect the version of the LaunchTemplate that should be used, handling Default, Latest, and a specified version.. 

Currently if you are using TF output and using mixed instances policies for your IGs, without this patch in 1.14+ the rolling update always thinks nodes need to be rolled. 

TF issue caused by this PR which was to fix handling of ASG set to use default version of the Launch Template.https://github.com/kubernetes/kops/pull/7445

TF is settings specific version, and not changing the default, so the logic in 7445 broke rolling updates for TF generated ASGs.

Recommend CP to 1.14, 1.15, 1.16 with new releases.