### PR TITLE
replace TrimRight with TrimSuffix

### DIFF
--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -160,7 +160,7 @@ func (a *AssetBuilder) RemapImage(image string) (string, error) {
 	}
 
 	if a.AssetsLocation != nil && a.AssetsLocation.ContainerProxy != nil {
-		containerProxy := strings.TrimRight(*a.AssetsLocation.ContainerProxy, "/")
+		containerProxy := strings.TrimSuffix(*a.AssetsLocation.ContainerProxy, "/")
 		normalized := image
 
 		// If the image name contains only a single / we need to determine if the image is located on docker-hub or if it's using a convenient URL like k8s.gcr.io/<image-name>


### PR DESCRIPTION
In string based trim scenarios,we shall always use string based TrimPrefix/TrimSuffix instead of char based TrimLeft/TrimRight.
See the diff here: https://play.golang.org/p/S7cBaoIxPQy