### PR TITLE
Fix misleading message in "make ci" when imports formatted incorrectly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -561,7 +561,7 @@ verify-staticcheck:
 # verify-package has to be after verify-gendoc, because with .gitignore for federation bindata
 # it bombs in travis. verify-gendoc generates the bindata file.
 .PHONY: ci
-ci: govet goimports verify-gofmt verify-gomod verify-goimports verify-boilerplate verify-bazel verify-misspelling nodeup examples test | verify-gendocs verify-packages verify-apimachinery
+ci: govet verify-gofmt verify-gomod verify-goimports verify-boilerplate verify-bazel verify-misspelling nodeup examples test | verify-gendocs verify-packages verify-apimachinery
 	echo "Done!"
 
 # travis-ci is the target that travis-ci calls

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ kops-gobindata: gobindata-tool ${BINDATA_TARGETS}
 
 UPUP_MODELS_BINDATA_SOURCES:=$(shell find upup/models/ | egrep -v "upup/models/bindata.go")
 upup/models/bindata.go: ${GOBINDATA} ${UPUP_MODELS_BINDATA_SOURCES}
-	cd ${GOPATH_1ST}/src/k8s.io/kops; ${GOBINDATA} -o $@ -pkg models -ignore="\\.DS_Store" -ignore="bindata\\.go" -ignore="vfs\\.go" -prefix upup/models/ upup/models/...
+	cd ${GOPATH_1ST}/src/k8s.io/kops; ${GOBINDATA} -o $@ -pkg models -ignore="\\.DS_Store" -ignore="bindata\\.go" -ignore="vfs\\.go" -prefix upup/models/ upup/models/... && GO111MODULE=on go run golang.org/x/tools/cmd/goimports -w -v upup/models/bindata.go
 
 # Build in a docker container with golang 1.X
 # Used to test we have not broken 1.X


### PR DESCRIPTION
/kind bug

If the current commit contains a file with an import formatting error, such that make verify-goimports would fail, then a make ci will give the wrong error message, giving the user the wrong instructions for fixing the problem.

The added goimports will "fix up" the problem, causing the later verify-goimports to incorrectly pass. Then, verify-gomod will notice the dirty workspace and incorrectly tell the user to run `go mod tidy`.

This bug was introduced by #8023 
The commit introducing the bug was reviewed and approved by @geojaz, so
/assign @geojaz 
