### PR TITLE
Fix CloudFormation template tags for NatGateway

### DIFF
--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -333,11 +333,20 @@
         "SubnetId": {
           "Ref": "AWSEC2Subnetutilityustest1aprivatecalicoexamplecom"
         },
-        "tags": {
-          "KubernetesCluster": "privatecalico.example.com",
-          "Name": "us-test-1a.privatecalico.example.com",
-          "kubernetes.io/cluster/privatecalico.example.com": "owned"
-        }
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "privatecalico.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "us-test-1a.privatecalico.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/privatecalico.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSEC2Route00000": {

--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -399,7 +399,7 @@ func (e *NatGateway) TerraformLink() *terraform.Literal {
 type cloudformationNATGateway struct {
 	AllocationID *cloudformation.Literal `json:"AllocationId,omitempty"`
 	SubnetID     *cloudformation.Literal `json:"SubnetId,omitempty"`
-	Tag          map[string]string       `json:"tags,omitempty"`
+	Tags         []cloudformationTag     `json:"Tags,omitempty"`
 }
 
 func (_ *NatGateway) RenderCloudformation(t *cloudformation.CloudformationTarget, a, e, changes *NatGateway) error {
@@ -412,13 +412,13 @@ func (_ *NatGateway) RenderCloudformation(t *cloudformation.CloudformationTarget
 		return nil
 	}
 
-	tf := &cloudformationNATGateway{
+	cf := &cloudformationNATGateway{
 		AllocationID: e.ElasticIP.CloudformationAllocationID(),
 		SubnetID:     e.Subnet.CloudformationLink(),
-		Tag:          e.Tags,
+		Tags:         buildCloudformationTags(e.Tags),
 	}
 
-	return t.RenderResource("AWS::EC2::NatGateway", *e.Name, tf)
+	return t.RenderResource("AWS::EC2::NatGateway", *e.Name, cf)
 }
 
 func (e *NatGateway) CloudformationLink() *cloudformation.Literal {


### PR DESCRIPTION
CloudFormation template that is generated by Kops has the tags in the AWS::EC2::NatGateway incorrectly formatted and fails to install, as described in #7452 .

I cannot confirm that the Tags section is unsupported anymore for AWS::EC2::EIP. For me works without any problem.

Fixes #7452