### PR TITLE
Fix mounting Calico "flexvol-driver-host" in CoreOS

### DIFF
--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -243,8 +243,8 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 			instanceGroups = append(instanceGroups, &list.Items[i])
 
 			// Try to guess the path for additional third party volume plugins in CoreOS and Flatcar
-			image := list.Items[i].Spec.Image
-			if strings.HasPrefix(image, "595879546273/CoreOS") || strings.HasPrefix(image, "075585003325/Flatcar") {
+			image := strings.ToLower(list.Items[i].Spec.Image)
+			if strings.Contains(image, "coreos") || strings.Contains(image, "flatcar") {
 				if cluster.Spec.Kubelet == nil {
 					cluster.Spec.Kubelet = &kops.KubeletConfigSpec{}
 				}

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -241,6 +241,17 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 		}
 		for i := range list.Items {
 			instanceGroups = append(instanceGroups, &list.Items[i])
+
+			// Try to guess the path for additional third party volume plugins in CoreOS and Flatcar
+			image := list.Items[i].Spec.Image
+			if strings.HasPrefix(image, "595879546273/CoreOS") || strings.HasPrefix(image, "075585003325/Flatcar") {
+				if cluster.Spec.Kubelet == nil {
+					cluster.Spec.Kubelet = &kops.KubeletConfigSpec{}
+				}
+				if cluster.Spec.Kubelet.VolumePluginDirectory == "" {
+					cluster.Spec.Kubelet.VolumePluginDirectory = "/var/lib/kubelet/volumeplugins/"
+				}
+			}
 		}
 	}
 

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -578,7 +578,7 @@ spec:
       serviceAccountName: calico-node
       priorityClassName: system-cluster-critical
       containers:
-      - image: calico/typha:v3.9.1
+      - image: calico/typha:v3.9.3
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -694,7 +694,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.9.1
+          image: calico/cni:v3.9.3
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -714,7 +714,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.9.1
+          image: calico/cni:v3.9.3
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -748,7 +748,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.9.1
+          image: calico/pod2daemon-flexvol:v3.9.3
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -757,7 +757,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.9.1
+          image: calico/node:v3.9.3
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -903,7 +903,7 @@ spec:
         - name: flexvol-driver-host
           hostPath:
             type: DirectoryOrCreate
-            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+            path: "{{- or .Kubelet.VolumePluginDirectory "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/" }}nodeagent~uds"
 ---
 
 apiVersion: v1
@@ -956,7 +956,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.9.1
+          image: calico/kube-controllers:v3.9.3
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -828,7 +828,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.6":     "2.6.9-kops.1",
 			"k8s-1.7":     "2.6.12-kops.1",
 			"k8s-1.7-v3":  "3.8.0-kops.2",
-			"k8s-1.12":    "3.9.1-kops.3",
+			"k8s-1.12":    "3.9.3-kops.1",
 		}
 
 		{


### PR DESCRIPTION
Calico has been broken in CoreOS since 1.15, as discussed in #7592, #7931 and in #kops-users.

There is a simple workaround, but still annoying for inexperienced users:
https://docs.projectcalico.org/v3.9/reference/faq#are-the-calico-manifests-compatible-with-coreos

To fix this I am passing the kubelet volume for external plugins as parameter to the template, same way it's done for Canal:
https://github.com/kubernetes/kops/blob/ebbebc5af34168d00834d32416323bb1a743f67b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template#L701

To make things easier I also added a naive approach of detecting the distro based on image location like `595879546273/CoreOS-stable-2303.3.0-hvm`.  This should make it easier to get started for those that use the image location instead of ID when creating a new cluster.

/cc @zetaab 