### PR TITLE
Validate cluster after updating bastions

### DIFF
--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -413,6 +413,8 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 		ClusterName:       options.ClusterName,
 		PostDrainDelay:    options.PostDrainDelay,
 		ValidationTimeout: options.ValidationTimeout,
+		// TODO should we expose this to the UI?
+		ValidateTickDuration: 30 * time.Second,
 	}
 	return d.RollingUpdate(groups, cluster, list)
 }

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -189,11 +189,7 @@ func (r *RollingUpdateInstanceGroup) RollingUpdate(rollingUpdateData *RollingUpd
 		klog.Infof("waiting for %v after terminating instance", sleepAfterTerminate)
 		time.Sleep(sleepAfterTerminate)
 
-		if isBastion {
-			klog.Infof("Deleted a bastion instance, %s, and continuing with rolling-update.", instanceId)
-
-			continue
-		} else if rollingUpdateData.CloudOnly {
+		if rollingUpdateData.CloudOnly {
 			klog.Warningf("Not validating cluster as cloudonly flag is set.")
 
 		} else if featureflag.DrainAndValidateRollingUpdate.Enabled() {

--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -60,6 +60,9 @@ type RollingUpdateCluster struct {
 
 	// ValidationTimeout is the maximum time to wait for the cluster to validate, once we start validation
 	ValidationTimeout time.Duration
+
+	// ValidateTickDuration is the amount of time to wait between cluster validation attempts
+	ValidateTickDuration time.Duration
 }
 
 // RollingUpdate performs a rolling update on a K8s Cluster.

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -47,14 +47,15 @@ func getTestSetup() (*RollingUpdateCluster, awsup.AWSCloud, *kopsapi.Cluster) {
 	cluster.Name = "test.k8s.local"
 
 	c := &RollingUpdateCluster{
-		Cloud:            mockcloud,
-		MasterInterval:   1 * time.Millisecond,
-		NodeInterval:     1 * time.Millisecond,
-		BastionInterval:  1 * time.Millisecond,
-		Force:            false,
-		K8sClient:        k8sClient,
-		ClusterValidator: &successfulClusterValidator{},
-		FailOnValidate:   true,
+		Cloud:                mockcloud,
+		MasterInterval:       1 * time.Millisecond,
+		NodeInterval:         1 * time.Millisecond,
+		BastionInterval:      1 * time.Millisecond,
+		Force:                false,
+		K8sClient:            k8sClient,
+		ClusterValidator:     &successfulClusterValidator{},
+		FailOnValidate:       true,
+		ValidateTickDuration: 1 * time.Millisecond,
 	}
 
 	return c, mockcloud, cluster

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/stretchr/testify/assert"
-
 	v1 "k8s.io/api/core/v1"
 	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -498,6 +497,41 @@ func TestRollingUpdateClusterErrorsValidationAfterOneNode(t *testing.T) {
 	assert.Error(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 1)
+}
+
+type failThreeTimesClusterValidator struct {
+	invocationCount int
+}
+
+func (v *failThreeTimesClusterValidator) Validate() (*validation.ValidationCluster, error) {
+	v.invocationCount++
+	if v.invocationCount <= 3 {
+		return &validation.ValidationCluster{
+			Failures: []*validation.ValidationError{
+				{
+					Kind:    "testing",
+					Name:    "testingfailure",
+					Message: "testing failure",
+				},
+			},
+		}, nil
+	}
+	return &validation.ValidationCluster{}, nil
+}
+
+func TestRollingUpdateValidatesAfterBastion(t *testing.T) {
+	c, cloud, cluster := getTestSetup()
+
+	c.ValidationTimeout = 10 * time.Millisecond
+	c.ClusterValidator = &failThreeTimesClusterValidator{}
+
+	err := c.RollingUpdate(getGroupsAllNeedUpdate(), cluster, &kopsapi.InstanceGroupList{})
+	assert.NoError(t, err, "rolling update")
+
+	assertGroupInstanceCount(t, cloud, "node-1", 0)
+	assertGroupInstanceCount(t, cloud, "node-2", 0)
+	assertGroupInstanceCount(t, cloud, "master-1", 0)
+	assertGroupInstanceCount(t, cloud, "bastion-1", 0)
 }
 
 func assertGroupInstanceCount(t *testing.T, cloud awsup.AWSCloud, groupName string, expected int) {


### PR DESCRIPTION
/kind bug

The fix #7872 exposed an issue where rolling update starts updating the first master before the terminated bastion is replaced by the ASG. Before that fix, kops was relying on the fact that the resulting validation failure was ignored.

This fixes the issue by waiting for validation to succeed after terminating a bastion. It does not change the behavior of updating the first bastion without validating the cluster.

The other possible fix would be to make validation ignore any shortfall in members of bastion instance groups.

Fixes #8070 
