### PR TITLE
Docs: Fix some broken development links

### DIFF
--- a/docs/development/rolling_update.md
+++ b/docs/development/rolling_update.md
@@ -4,6 +4,6 @@ Upgrading and modifying a k8s cluster often requires the replacement of nodes.  
 
 When starting the rolling update, kops will check each instance in the instance group if it needs to be updated, so when you just update nodes, the master will not be updated. When your rolling update is interrupted and you run another rolling update, instances that have been updated before will not be updated again.
 
-![Rolling Update Diagram](/docs/development/images/rolling-update.png?raw=true "Rolling Updates Diagram")
+![Rolling Update Diagram](/development/images/rolling-update.png?raw=true "Rolling Updates Diagram")
 
 `kops` executes steps 2-4 for all the masters until the masters are replaced.   Then the same process is followed to replaces all nodes.

--- a/docs/welcome/contributing.md
+++ b/docs/welcome/contributing.md
@@ -23,15 +23,15 @@ What this means:
 
 __Issues__
 
-* Help read and triage issues, assist when possible.
-* Point out issues that are duplicates, out of date, etc.
-    * Even if you don't have tagging permissions, make a note and tag maintainers (`/close`,`/dupe #127`).
+- Help read and triage issues, assist when possible.
+- Point out issues that are duplicates, out of date, etc.
+  - Even if you don't have tagging permissions, make a note and tag maintainers (`/close`,`/dupe #127`).
 
 __Pull Requests__
 
-* Read and review the code. Leave comments, questions, and critiques (`/lgtm` ).
-* Download, compile, and run the code and make sure the tests pass (make test).
-  * Also verify that the new feature seems sane, follows best architectural patterns, and includes tests.
+- Read and review the code. Leave comments, questions, and critiques (`/lgtm` ).
+- Download, compile, and run the code and make sure the tests pass (make test).
+  - Also verify that the new feature seems sane, follows best architectural patterns, and includes tests.
 
 This repository uses the Kubernetes bots.  See a full list of the commands [here](
 https://go.k8s.io/bot-commands).
@@ -54,20 +54,20 @@ Please check in with us in the [#kops-users](https://kubernetes.slack.com/messag
 
 If you think you have found a bug please follow the instructions below.
 
-* Please spend a small amount of time giving due diligence to the issue tracker. Your issue might be a duplicate.
-* Set `-v 10` command line option and save the log output. Please paste this into your issue.
-* Note the version of kops you are running (from `kops version`), and the command line options you are using.
-* Open a [new issue](https://github.com/kubernetes/kops/issues/new).
-* Remember users might be searching for your issue in the future, so please give it a meaningful title to helps others.
-* Feel free to reach out to the kops community on [kubernetes slack](https://github.com/kubernetes/community/blob/master/communication.md#social-media).
+- Please spend a small amount of time giving due diligence to the issue tracker. Your issue might be a duplicate.
+- Set `-v 10` command line option and save the log output. Please paste this into your issue.
+- Note the version of kops you are running (from `kops version`), and the command line options you are using.
+- Open a [new issue](https://github.com/kubernetes/kops/issues/new).
+- Remember users might be searching for your issue in the future, so please give it a meaningful title to helps others.
+- Feel free to reach out to the kops community on [kubernetes slack](https://github.com/kubernetes/community/blob/master/communication.md#social-media).
 
 
 ### Features
 
 We also use the issue tracker to track features. If you have an idea for a feature, or think you can help kops become even more awesome follow the steps below.
 
-* Open a [new issue](https://github.com/kubernetes/kops/issues/new).
-* Remember users might be searching for your issue in the future, so please give it a meaningful title to helps others.
-* Clearly define the use case, using concrete examples. EG: I type `this` and kops does `that`.
-* Some of our larger features will require some design. If you would like to include a technical design for your feature please include it in the issue.
-* After the new feature is well understood, and the design agreed upon we can start coding the feature. We would love for you to code it. So please open up a **WIP** *(work in progress)* pull request, and happy coding.
+- Open a [new issue](https://github.com/kubernetes/kops/issues/new).
+- Remember users might be searching for your issue in the future, so please give it a meaningful title to helps others.
+- Clearly define the use case, using concrete examples. EG: I type `this` and kops does `that`.
+- Some of our larger features will require some design. If you would like to include a technical design for your feature please include it in the issue.
+- After the new feature is well understood, and the design agreed upon we can start coding the feature. We would love for you to code it. So please open up a **WIP** *(work in progress)* pull request, and happy coding.

--- a/docs/welcome/contributing.md
+++ b/docs/welcome/contributing.md
@@ -2,7 +2,7 @@
 
 Are you interested in contributing to kops? We, the maintainers and community,
 would love your suggestions, contributions, and help! We have a quick-start
-guide on [adding a feature](/docs/development/adding_a_feature.md). Also, the
+guide on [adding a feature](../development/adding_a_feature.md). Also, the
 maintainers can be contacted at any time to learn more about how to get
 involved.
 
@@ -19,18 +19,19 @@ that the only people who can get things done around here are the "maintainers".
 We also would love to add more "official" maintainers, so show us what you can
 do!
 
-
 What this means:
 
 __Issues__
+
 * Help read and triage issues, assist when possible.
 * Point out issues that are duplicates, out of date, etc.
-  - Even if you don't have tagging permissions, make a note and tag maintainers (`/close`,`/dupe #127`).
+    * Even if you don't have tagging permissions, make a note and tag maintainers (`/close`,`/dupe #127`).
 
 __Pull Requests__
+
 * Read and review the code. Leave comments, questions, and critiques (`/lgtm` ).
 * Download, compile, and run the code and make sure the tests pass (make test).
-  - Also verify that the new feature seems sane, follows best architectural patterns, and includes tests.
+  * Also verify that the new feature seems sane, follows best architectural patterns, and includes tests.
 
 This repository uses the Kubernetes bots.  See a full list of the commands [here](
 https://go.k8s.io/bot-commands).
@@ -53,20 +54,20 @@ Please check in with us in the [#kops-users](https://kubernetes.slack.com/messag
 
 If you think you have found a bug please follow the instructions below.
 
-- Please spend a small amount of time giving due diligence to the issue tracker. Your issue might be a duplicate.
-- Set `-v 10` command line option and save the log output. Please paste this into your issue.
-- Note the version of kops you are running (from `kops version`), and the command line options you are using.
-- Open a [new issue](https://github.com/kubernetes/kops/issues/new).
-- Remember users might be searching for your issue in the future, so please give it a meaningful title to helps others.
-- Feel free to reach out to the kops community on [kubernetes slack](https://github.com/kubernetes/community/blob/master/communication.md#social-media).
+* Please spend a small amount of time giving due diligence to the issue tracker. Your issue might be a duplicate.
+* Set `-v 10` command line option and save the log output. Please paste this into your issue.
+* Note the version of kops you are running (from `kops version`), and the command line options you are using.
+* Open a [new issue](https://github.com/kubernetes/kops/issues/new).
+* Remember users might be searching for your issue in the future, so please give it a meaningful title to helps others.
+* Feel free to reach out to the kops community on [kubernetes slack](https://github.com/kubernetes/community/blob/master/communication.md#social-media).
 
 
 ### Features
 
 We also use the issue tracker to track features. If you have an idea for a feature, or think you can help kops become even more awesome follow the steps below.
 
-- Open a [new issue](https://github.com/kubernetes/kops/issues/new).
-- Remember users might be searching for your issue in the future, so please give it a meaningful title to helps others.
-- Clearly define the use case, using concrete examples. EG: I type `this` and kops does `that`.
-- Some of our larger features will require some design. If you would like to include a technical design for your feature please include it in the issue.
-- After the new feature is well understood, and the design agreed upon we can start coding the feature. We would love for you to code it. So please open up a **WIP** *(work in progress)* pull request, and happy coding.
+* Open a [new issue](https://github.com/kubernetes/kops/issues/new).
+* Remember users might be searching for your issue in the future, so please give it a meaningful title to helps others.
+* Clearly define the use case, using concrete examples. EG: I type `this` and kops does `that`.
+* Some of our larger features will require some design. If you would like to include a technical design for your feature please include it in the issue.
+* After the new feature is well understood, and the design agreed upon we can start coding the feature. We would love for you to code it. So please open up a **WIP** *(work in progress)* pull request, and happy coding.

--- a/docs/welcome/office_hours.md
+++ b/docs/welcome/office_hours.md
@@ -9,16 +9,18 @@ Office hours are hosted on a [zoom video chat](https://zoom.us/my/k8ssigaws) on 
 We do maintain an [agenda](https://docs.google.com/document/d/12QkyL0FkNbWPcLFxxRGSPt_tNPBHbmni3YLY-lHny7E/edit) and stick to it as much as possible. If you want to hold the floor, put your item in this doc. Bullet/note form is fine. Even if your topic gets in late, we do our best to cover it.
 
 Our office hours call is recorded, but the tone tends to be casual. First-timers are always welcome. Typical areas of discussion can include:
+
 - Contributors with a feature proposal seeking feedback, assistance, etc
 - Members planning for what we want to get done for the next release
 - Strategizing for larger initiatives, such as those that involve more than one sig or potentially more moving pieces
 - Help wanted requests
 - Demonstrations of cool stuff. PoCs. Fresh ideas. Show us how you use kops to go beyond the norm- help us define the future!
 
-Office hours are designed for ALL of those contributing to kops or the community. Contributions are not limited to those who commit source code. There are so many important ways to be involved-
- - helping in the slack channels
- - triaging/writing issues
- - thinking about the topics raised at office hours and forming and advocating for your good ideas forming opinions
- - testing pre-(and official) releases
+Office hours are designed for ALL of those contributing to kops or the community. Contributions are not limited to those who commit source code. There are so many important ways to be involved:
+
+- helping in the slack channels
+- triaging/writing issues
+- thinking about the topics raised at office hours and forming and advocating for your good ideas forming opinions
+- testing pre-(and official) releases
 
 Although not exhaustive, the above activities are extremely important to our continued success and are all worth contributions. If you want to talk about kops and you have doubt, just come.


### PR DESCRIPTION
Couple of minor link fixes to development related docs/images

Also cleans up the lists under issues and pull requests headings in `welcome/contributing.md` and lists in `welcome/office_hours.md`