### PR TITLE
Spotinst: Upgrade the Spotinst controller to version 1.0.50

### DIFF
--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
@@ -1,0 +1,197 @@
+# ------------------------------------------------------------------------------
+# Config Map
+# ------------------------------------------------------------------------------
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spotinst-kubernetes-cluster-controller-config
+  namespace: kube-system
+data:
+  spotinst.token: {{ SpotinstToken }}
+  spotinst.account: {{ SpotinstAccount }}
+  spotinst.cluster-identifier: {{ ClusterName }}
+---
+# ------------------------------------------------------------------------------
+# Service Account
+# ------------------------------------------------------------------------------
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spotinst-kubernetes-cluster-controller
+  namespace: kube-system
+---
+# ------------------------------------------------------------------------------
+# Cluster Role
+# ------------------------------------------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: spotinst-kubernetes-cluster-controller
+  namespace: kube-system
+rules:
+  # ----------------------------------------------------------------------------
+  # Required for functional operation (read-only).
+  # ----------------------------------------------------------------------------
+- apiGroups: [""]
+  resources: ["pods", "nodes", "services", "namespaces", "replicationcontrollers", "limitranges", "events", "persistentvolumes", "persistentvolumeclaims"]
+  verbs: ["get", "list"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "daemonsets", "statefulsets"]
+  verbs: ["get","list"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list"]
+- apiGroups: ["extensions"]
+  resources: ["replicasets", "daemonsets"]
+  verbs: ["get","list"]
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["get", "list"]
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: ["autoscaling"]
+  resources: ["horizontalpodautoscalers"]
+  verbs: ["get", "list"]
+- nonResourceURLs: ["/version/", "/version"]
+  verbs: ["get"]
+  # ----------------------------------------------------------------------------
+  # Required by the draining feature and for functional operation.
+  # ----------------------------------------------------------------------------
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["patch", "update"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["delete"]
+- apiGroups: [""]
+  resources: ["pods/eviction"]
+  verbs: ["create"]
+  # ----------------------------------------------------------------------------
+  # Required by the Spotinst Auto Update feature.
+  # ----------------------------------------------------------------------------
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles"]
+  resourceNames: ["spotinst-kubernetes-cluster-controller"]
+  verbs: ["patch", "update", "escalate"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  resourceNames: ["spotinst-kubernetes-cluster-controller"]
+  verbs: ["patch","update"]
+  # ----------------------------------------------------------------------------
+  # Required by the Spotinst Apply feature.
+  # ----------------------------------------------------------------------------
+- apiGroups: ["apps"]
+  resources: ["deployments", "daemonsets"]
+  verbs: ["get", "list", "patch","update","create","delete"]
+- apiGroups: ["extensions"]
+  resources: ["daemonsets"]
+  verbs: ["get", "list", "patch","update","create","delete"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "patch", "update", "create", "delete"]
+---
+# ------------------------------------------
+# Cluster Role Binding
+# ------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: spotinst-kubernetes-cluster-controller
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: spotinst-kubernetes-cluster-controller
+subjects:
+- kind: ServiceAccount
+  name: spotinst-kubernetes-cluster-controller
+  namespace: kube-system
+---
+# ------------------------------------------------------------------------------
+# Deployment
+# ------------------------------------------------------------------------------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-addon: spotinst-kubernetes-cluster-controller.addons.k8s.io
+  name: spotinst-kubernetes-cluster-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-addon: spotinst-kubernetes-cluster-controller.addons.k8s.io
+  template:
+    metadata:
+      labels:
+        k8s-addon: spotinst-kubernetes-cluster-controller.addons.k8s.io
+    spec:
+      priorityClassName: system-cluster-critical
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+      containers:
+      - name: spotinst-kubernetes-cluster-controller
+        imagePullPolicy: Always
+        image: spotinst/kubernetes-cluster-controller:1.0.50
+        livenessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 4401
+          initialDelaySeconds: 300
+          periodSeconds: 20
+          timeoutSeconds: 2
+          successThreshold: 1
+          failureThreshold: 3
+        env:
+        - name: SPOTINST_TOKEN
+          valueFrom:
+            configMapKeyRef:
+              name: spotinst-kubernetes-cluster-controller-config
+              key: spotinst.token
+        - name: SPOTINST_ACCOUNT
+          valueFrom:
+            configMapKeyRef:
+              name: spotinst-kubernetes-cluster-controller-config
+              key: spotinst.account
+        - name: CLUSTER_IDENTIFIER
+          valueFrom:
+            configMapKeyRef:
+              name: spotinst-kubernetes-cluster-controller-config
+              key: spotinst.cluster-identifier
+        - name: POD_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      serviceAccountName: spotinst-kubernetes-cluster-controller
+      tolerations:
+      - key: node.kubernetes.io/not-ready
+        effect: NoExecute
+        operator: Exists
+        tolerationSeconds: 150
+      - key: node.kubernetes.io/unreachable
+        effect: NoExecute
+        operator: Exists
+        tolerationSeconds: 150
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+---

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -592,11 +592,11 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 	if featureflag.Spotinst.Enabled() {
 		key := "spotinst-kubernetes-cluster-controller.addons.k8s.io"
-		version := "1.0.39"
 
 		{
 			id := "v1.8.0"
 			location := key + "/" + id + ".yaml"
+			version := "1.0.39"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
@@ -611,6 +611,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		{
 			id := "v1.9.0"
 			location := key + "/" + id + ".yaml"
+			version := "1.0.39"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),
@@ -618,6 +619,21 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 				Selector:          map[string]string{"k8s-addon": key},
 				Manifest:          fi.String(location),
 				KubernetesVersion: ">=1.9.0",
+				Id:                id,
+			})
+		}
+
+		{
+			id := "v1.14.0"
+			location := key + "/" + id + ".yaml"
+			version := "1.0.50"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(version),
+				Selector:          map[string]string{"k8s-addon": key},
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.14.0",
 				Id:                id,
 			})
 		}


### PR DESCRIPTION
This PR replaces PRs #8019 and #7920, upgrades the Spotinst controller to version 1.0.50 and aligns all resources with the corresponding Helm [chart](https://github.com/spotinst/spotinst-kubernetes-helm-charts).