### PR TITLE
Automated cherry pick of #7545: Complete support for Flatcar

### DIFF
--- a/nodeup/pkg/distros/distribution.go
+++ b/nodeup/pkg/distros/distribution.go
@@ -90,7 +90,7 @@ func (d Distribution) IsDebianFamily() bool {
 		return true
 	case DistributionCentos7, DistributionRhel7:
 		return false
-	case DistributionCoreOS, DistributionContainerOS:
+	case DistributionCoreOS, DistributionFlatcar, DistributionContainerOS:
 		return false
 	default:
 		klog.Fatalf("unknown distribution: %s", d)

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -166,6 +166,10 @@ func (b *KubeControllerManagerBuilder) buildPod() (*v1.Pod, error) {
 			// The /usr directory is read-only for CoreOS
 			volumePluginDir = "/var/lib/kubelet/volumeplugins/"
 
+		case distros.DistributionFlatcar:
+			// The /usr directory is read-only for CoreOS
+			volumePluginDir = "/var/lib/kubelet/volumeplugins/"
+
 		default:
 			volumePluginDir = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
 		}

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -167,7 +167,7 @@ func (b *KubeControllerManagerBuilder) buildPod() (*v1.Pod, error) {
 			volumePluginDir = "/var/lib/kubelet/volumeplugins/"
 
 		case distros.DistributionFlatcar:
-			// The /usr directory is read-only for CoreOS
+			// The /usr directory is read-only for Flatcar
 			volumePluginDir = "/var/lib/kubelet/volumeplugins/"
 
 		default:

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -611,6 +611,10 @@ func (b *KubeletBuilder) buildKubeletConfigSpec() (*kops.KubeletConfigSpec, erro
 			// The /usr directory is read-only for CoreOS
 			c.VolumePluginDirectory = "/var/lib/kubelet/volumeplugins/"
 
+		case distros.DistributionFlatcar:
+			// The /usr directory is read-only for Flatcar
+			c.VolumePluginDirectory = "/var/lib/kubelet/volumeplugins/"
+
 		default:
 			c.VolumePluginDirectory = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
 		}

--- a/nodeup/pkg/model/miscutils.go
+++ b/nodeup/pkg/model/miscutils.go
@@ -40,6 +40,9 @@ func (b *MiscUtilsBuilder) Build(c *fi.ModelBuilderContext) error {
 	case distros.DistributionCoreOS:
 		klog.V(2).Infof("Detected CoreOS; won't install misc. utils")
 		return nil
+	case distros.DistributionFlatcar:
+		klog.V(2).Infof("Detected Flatcar; won't install misc. utils")
+		return nil
 	}
 
 	// TODO: These packages have been auto-installed for a long time, and likely we don't need all of them any longer

--- a/nodeup/pkg/model/ntp.go
+++ b/nodeup/pkg/model/ntp.go
@@ -42,7 +42,7 @@ func (b *NTPBuilder) Build(c *fi.ModelBuilderContext) error {
 		klog.Infof("Detected CoreOS; won't install ntp")
 		return nil
 	case distros.DistributionFlatcar:
-		klog.Infof("Detected CoreOS; won't install ntp")
+		klog.Infof("Detected Flatcar; won't install ntp")
 		return nil
 	}
 

--- a/nodeup/pkg/model/ntp.go
+++ b/nodeup/pkg/model/ntp.go
@@ -41,6 +41,9 @@ func (b *NTPBuilder) Build(c *fi.ModelBuilderContext) error {
 	case distros.DistributionCoreOS:
 		klog.Infof("Detected CoreOS; won't install ntp")
 		return nil
+	case distros.DistributionFlatcar:
+		klog.Infof("Detected CoreOS; won't install ntp")
+		return nil
 	}
 
 	if b.Distribution.IsDebianFamily() {


### PR DESCRIPTION
Cherry pick of #7545 on release-1.15.

#7545: Complete support for Flatcar

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.