### PR TITLE
add missing rbac rules

### DIFF
--- a/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
+++ b/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
@@ -49,6 +49,14 @@ metadata:
     k8s-addon: openstack.addons.k8s.io
 rules:
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - ""
   resources:
   - events
@@ -115,6 +123,7 @@ rules:
   verbs:
   - list
   - get
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/upup/pkg/fi/cloudup/tests/manifests/k8s-1.13.yaml
+++ b/upup/pkg/fi/cloudup/tests/manifests/k8s-1.13.yaml
@@ -49,6 +49,14 @@ metadata:
     k8s-addon: openstack.addons.k8s.io
 rules:
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - ""
   resources:
   - events
@@ -115,6 +123,7 @@ rules:
   verbs:
   - list
   - get
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
E1212 09:15:05.046471       1 leaderelection.go:331] error retrieving resource lock kube-system/cloud-controller-manager: leases.coordination.k8s.io “cloud-controller-manager” is forbidden: User “system:serviceaccount:kube-system:cloud-controller-manager” cannot get resource “leases” in API group “coordination.k8s.io” in the namespace “kube-system”

/kind bug
