### PR TITLE
Cherry pick #8095

### DIFF
--- a/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
+++ b/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
@@ -49,6 +49,14 @@ metadata:
     k8s-addon: openstack.addons.k8s.io
 rules:
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - ""
   resources:
   - events
@@ -115,6 +123,7 @@ rules:
   verbs:
   - list
   - get
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
cherry pick #8095

adds missing RBAC rules for openstack external cloud controller manager. Without this 1.17 CCM does not work

/kind bug