### PR TITLE
enable authenticationTokenWebhook for metrics-server

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -1185,6 +1185,16 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		if cluster.Spec.Kubelet.AnonymousAuth == nil {
 			cluster.Spec.Kubelet.AnonymousAuth = fi.Bool(false)
 		}
+
+		// set AuthenticationTokenWebhook and AuthorizationMode so that metrics-server and HPA are able to operate correctly
+
+                if cluster.Spec.Kubelet.AuthenticationTokenWebhook == nil {
+                        cluster.Spec.Kubelet.AuthenticationTokenWebhook = fi.Bool(true)
+                }
+
+                if cluster.Spec.Kubelet.AuthorizationMode == "" {
+                        cluster.Spec.Kubelet.AuthorizationMode = "Webhook"
+                }
 	}
 
 	// Populate the API access, so that it can be discoverable


### PR DESCRIPTION
From https://github.com/kubernetes/kops/issues/7200

Horizontal Pod Autoscaling is a core feature of kubernetes, which ideally would work out-of-the-box, like Deployments and Services. If it does require setup, then hopefully the configuration is relatively easy. 

Adding this configuration removes the need to manually make those changes on every new cluster.