### PR TITLE
docs(advanced): fix broken links on doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -101,7 +101,7 @@
 
 * [Download `kops` configuration](download_config.md)
     * methods to download the current generated `kops` configuration
-* [Get AWS subdomain NS records](ns.md)
+* [Get AWS subdomain NS records](advanced/ns.md)
 
 
 ## Development


### PR DESCRIPTION
- Broken link on https://github.com/pshanoop/kops/tree/master/docs#inspection for **Get AWS subdomain NS records.**