### PR TITLE
some resources upgraded to google provider 3.0

### DIFF
--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -324,48 +324,72 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-ha-gce-exa
   name               = "a-master-us-test1-a-ha-gce-example-com"
   zone               = "us-test1-a"
   base_instance_name = "master-us-test1-a"
-  instance_template  = "${google_compute_instance_template.master-us-test1-a-ha-gce-example-com.self_link}"
-  target_size        = 1
+
+  version = {
+    instance_template = "${google_compute_instance_template.master-us-test1-a-ha-gce-example-com.self_link}"
+  }
+
+  target_size = 1
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-ha-gce-example-com" {
   name               = "a-nodes-ha-gce-example-com"
   zone               = "us-test1-a"
   base_instance_name = "nodes"
-  instance_template  = "${google_compute_instance_template.nodes-ha-gce-example-com.self_link}"
-  target_size        = 1
+
+  version = {
+    instance_template = "${google_compute_instance_template.nodes-ha-gce-example-com.self_link}"
+  }
+
+  target_size = 1
 }
 
 resource "google_compute_instance_group_manager" "b-master-us-test1-b-ha-gce-example-com" {
   name               = "b-master-us-test1-b-ha-gce-example-com"
   zone               = "us-test1-b"
   base_instance_name = "master-us-test1-b"
-  instance_template  = "${google_compute_instance_template.master-us-test1-b-ha-gce-example-com.self_link}"
-  target_size        = 1
+
+  version = {
+    instance_template = "${google_compute_instance_template.master-us-test1-b-ha-gce-example-com.self_link}"
+  }
+
+  target_size = 1
 }
 
 resource "google_compute_instance_group_manager" "b-nodes-ha-gce-example-com" {
   name               = "b-nodes-ha-gce-example-com"
   zone               = "us-test1-b"
   base_instance_name = "nodes"
-  instance_template  = "${google_compute_instance_template.nodes-ha-gce-example-com.self_link}"
-  target_size        = 1
+
+  version = {
+    instance_template = "${google_compute_instance_template.nodes-ha-gce-example-com.self_link}"
+  }
+
+  target_size = 1
 }
 
 resource "google_compute_instance_group_manager" "c-master-us-test1-c-ha-gce-example-com" {
   name               = "c-master-us-test1-c-ha-gce-example-com"
   zone               = "us-test1-c"
   base_instance_name = "master-us-test1-c"
-  instance_template  = "${google_compute_instance_template.master-us-test1-c-ha-gce-example-com.self_link}"
-  target_size        = 1
+
+  version = {
+    instance_template = "${google_compute_instance_template.master-us-test1-c-ha-gce-example-com.self_link}"
+  }
+
+  target_size = 1
 }
 
 resource "google_compute_instance_group_manager" "c-nodes-ha-gce-example-com" {
   name               = "c-nodes-ha-gce-example-com"
   zone               = "us-test1-c"
   base_instance_name = "nodes"
-  instance_template  = "${google_compute_instance_template.nodes-ha-gce-example-com.self_link}"
-  target_size        = 0
+
+  version = {
+    instance_template = "${google_compute_instance_template.nodes-ha-gce-example-com.self_link}"
+  }
+
+  target_size = 0
 }
 
 resource "google_compute_instance_template" "master-us-test1-a-ha-gce-example-com" {
@@ -406,7 +430,7 @@ resource "google_compute_instance_template" "master-us-test1-a-ha-gce-example-co
   }
 
   tags        = ["ha-gce-example-com-k8s-io-role-master"]
-  name_prefix = "master-us-test1-a-ha-gce-example-com-"
+  name_prefix = "master-us-test1-a-ha-gce--ke5ah6-"
 }
 
 resource "google_compute_instance_template" "master-us-test1-b-ha-gce-example-com" {
@@ -447,7 +471,7 @@ resource "google_compute_instance_template" "master-us-test1-b-ha-gce-example-co
   }
 
   tags        = ["ha-gce-example-com-k8s-io-role-master"]
-  name_prefix = "master-us-test1-b-ha-gce-example-com-"
+  name_prefix = "master-us-test1-b-ha-gce--c8u7qq-"
 }
 
 resource "google_compute_instance_template" "master-us-test1-c-ha-gce-example-com" {
@@ -488,7 +512,7 @@ resource "google_compute_instance_template" "master-us-test1-c-ha-gce-example-co
   }
 
   tags        = ["ha-gce-example-com-k8s-io-role-master"]
-  name_prefix = "master-us-test1-c-ha-gce-example-com-"
+  name_prefix = "master-us-test1-c-ha-gce--3unp7l-"
 }
 
 resource "google_compute_instance_template" "nodes-ha-gce-example-com" {

--- a/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager.go
@@ -182,9 +182,13 @@ type terraformInstanceGroupManager struct {
 	Name             *string              `json:"name"`
 	Zone             *string              `json:"zone"`
 	BaseInstanceName *string              `json:"base_instance_name"`
-	InstanceTemplate *terraform.Literal   `json:"instance_template"`
+	Version          *terraformVersion    `json:"version"`
 	TargetSize       *int64               `json:"target_size"`
 	TargetPools      []*terraform.Literal `json:"target_pools,omitempty"`
+}
+
+type terraformVersion struct {
+	InstanceTemplate *terraform.Literal `json:"instance_template"`
 }
 
 func (_ *InstanceGroupManager) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *InstanceGroupManager) error {
@@ -192,8 +196,10 @@ func (_ *InstanceGroupManager) RenderTerraform(t *terraform.TerraformTarget, a, 
 		Name:             e.Name,
 		Zone:             e.Zone,
 		BaseInstanceName: e.BaseInstanceName,
-		InstanceTemplate: e.InstanceTemplate.TerraformLink(),
 		TargetSize:       e.TargetSize,
+	}
+	tf.Version = &terraformVersion{
+		InstanceTemplate: e.InstanceTemplate.TerraformLink(),
 	}
 
 	for _, targetPool := range e.TargetPools {

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -32,9 +32,8 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
 )
 
-// InstanceTemplateNamePrefixMaxLength is the max length for the NamePrefix of an InstanceTemplate
-//  52 = 63 - 10 - 1; 63 is the GCE limit; 10 is the length of seconds since epoch; and one for the dash
-const InstanceTemplateNamePrefixMaxLength = 63 - 10 - 1
+// terraform 0.12 with google cloud provider 3.2 will complain if the length of the name_prefix is more than 32
+const InstanceTemplateNamePrefixMaxLength = 32
 
 // InstanceTemplate represents a GCE InstanceTemplate
 //go:generate fitask -type=InstanceTemplate


### PR DESCRIPTION
Upgraded some google cloud terraform resources to fit google cloud provider 3.0

* instance template name_prefix is maximum length of 32
* instance group manager needs the instance_template in a version block 

See also https://www.terraform.io/docs/providers/google/guides/version_3_upgrade.html

Btw, syntax is still terraform 0.11 and needs to be transformed with terraform 0.12upgrade