### PR TITLE
Update Calico to v3.10.2

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template
@@ -314,7 +314,7 @@ spec:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: calico-node
+  name: calico
   labels:
     role.kubernetes.io/networking: "1"
 rules:
@@ -465,7 +465,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: calico-node
+  name: calico
 subjects:
 - kind: ServiceAccount
   name: canal

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template
@@ -1,12 +1,6 @@
-# Canal Version v3.10.2
-# https://docs.projectcalico.org/v3.10/release-notes/#v3101
-# This manifest includes the following component versions:
-#   calico/cni:v3.10.2
-#   calico/node:v3.10.2
-#   calico/pod2daemon-flexvol:v3.10.2
-#   calico/typha:v3.10.2
-#   quay.io/coreos/flannel:v0.11.0
+{{- /* Pulled and modified from: https://docs.projectcalico.org/v3.10/manifests/canal.yaml */ -}}
 
+---
 # Source: calico/templates/calico-config.yaml
 # This ConfigMap is used to configure a self-hosted Canal installation.
 kind: ConfigMap
@@ -15,6 +9,7 @@ metadata:
   name: canal-config
   namespace: kube-system
 data:
+  # Typha is disabled.
   typha_service_name: "{{ if .Networking.Canal.TyphaReplicas }}calico-typha{{ else }}none{{ end }}"
   # The interface used by canal for host <-> host communication.
   # If left blank, then the interface is chosen using the node's
@@ -70,7 +65,6 @@ data:
     }
 
 ---
-
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -278,15 +272,15 @@ spec:
     kind: NetworkSet
     plural: networksets
     singular: networkset
-
 ---
+# Source: calico/templates/rbac.yaml
 
 # Include a clusterrole for the calico-node DaemonSet,
 # and bind it to the calico-node serviceaccount.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: calico
+  name: calico-node
 rules:
   # The CNI plugin needs to get pods, nodes, and namespaces.
   - apiGroups: [""]
@@ -422,7 +416,6 @@ subjects:
   name: canal
   namespace: kube-system
 ---
-# Bind the Calico ClusterRole to the canal ServiceAccount.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -430,17 +423,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: calico
+  name: calico-node
 subjects:
 - kind: ServiceAccount
-  name: canal
-  namespace: kube-system
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
   name: canal
   namespace: kube-system
 
@@ -500,14 +485,11 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
+      nodeSelector:
+        kubernetes.io/role: master
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       hostNetwork: true
-      nodeSelector:
-        kubernetes.io/role: master
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
@@ -583,9 +565,9 @@ spec:
 
 {{- end }}
 ---
-
-# This manifest installs the calico/node container, as well
-# as the Calico CNI plugins and network config on
+# Source: calico/templates/calico-node.yaml
+# This manifest installs the canal container, as well
+# as the CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
 apiVersion: apps/v1
@@ -613,7 +595,6 @@ spec:
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: system-node-critical
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
@@ -630,8 +611,9 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
+      priorityClassName: system-node-critical
       initContainers:
-        # This container installs the Calico CNI binaries
+        # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
           image: calico/cni:v3.10.2
@@ -673,7 +655,7 @@ spec:
           - name: flexvol-driver-host
             mountPath: /host/driver
       containers:
-        # Runs calico/node container on each Kubernetes node.  This
+        # Runs canal container on each Kubernetes node.  This
         # container programs network policy and routes on each
         # host.
         - name: calico-node
@@ -716,6 +698,17 @@ spec:
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "{{- or .Networking.Canal.DefaultEndpointToHostAction "ACCEPT" }}"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Set Felix logging to "INFO"
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "{{- or .Networking.Canal.LogSeveritySys "INFO" }}"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
             - name: FELIX_IPINIPMTU
               valueFrom:
                 configMapKeyRef:
@@ -724,15 +717,6 @@ spec:
             # Set Felix iptables binary variant, Legacy or NFT
             - name: FELIX_IPTABLESBACKEND
               value: "{{- or .Networking.Canal.IptablesBackend "Legacy" }}"
-            # Disable IPv6 on Kubernetes.
-            - name: FELIX_IPV6SUPPORT
-              value: "false"
-            # Set Felix logging to "INFO"
-            - name: FELIX_LOGSEVERITYSCREEN
-              value: "{{- or .Networking.Canal.LogSeveritySys "INFO" }}"
-            # Set Felix endpoint to host default action to ACCEPT.
-            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
-              value: "{{- or .Networking.Canal.DefaultEndpointToHostAction "ACCEPT" }}"
             # Controls whether Felix inserts rules to the top of iptables chains, or appends to the bottom
             - name: FELIX_CHAININSERTMODE
               value: "{{- or .Networking.Canal.ChainInsertMode "insert" }}"
@@ -748,8 +732,6 @@ spec:
             # Enable Prometheus process metrics collection
             - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
               value: "{{- or .Networking.Canal.PrometheusProcessMetricsEnabled "true" }}"
-            - name: FELIX_HEALTHENABLED
-              value: "true"
           securityContext:
             privileged: true
           resources:
@@ -856,3 +838,10 @@ spec:
           hostPath:
             type: DirectoryOrCreate
             path: "{{- or .Kubelet.VolumePluginDirectory "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/" }}nodeagent~uds"
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: canal
+  namespace: kube-system

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template
@@ -22,8 +22,12 @@ data:
   # the pod network.
   masquerade: "true"
 
-  # MTU default is 1500, can be overridden
-  veth_mtu: "{{- or .Networking.Canal.MTU "1500" }}"
+  # Configure the MTU to use
+  {{- if .Networking.Canal.MTU }}
+  veth_mtu: "{{ .Networking.Canal.MTU }}"
+  {{- else }}
+  veth_mtu: "{{- if eq .CloudProvider "openstack" -}}1430{{- else -}}1440{{- end -}}"
+  {{- end }}
 
   # The CNI network configuration to install on each node.  The special
   # values in this config will be automatically populated.
@@ -36,8 +40,8 @@ data:
           "type": "calico",
           "log_level": "info",
           "datastore_type": "kubernetes",
-          "mtu": __CNI_MTU__,
           "nodename": "__KUBERNETES_NODE_NAME__",
+          "mtu": __CNI_MTU__,
           "ipam": {
               "type": "host-local",
               "subnet": "usePodCidr"
@@ -467,9 +471,9 @@ subjects:
   name: canal
   namespace: kube-system
 
+{{ if .Networking.Canal.TyphaReplicas -}}
 ---
-{{- if .Networking.Canal.TyphaReplicas }}
-
+# Source: calico/templates/calico-typha.yaml
 # This manifest creates a Service, which will be backed by Calico's Typha daemon.
 # Typha sits in between Felix and the API server, reducing Calico's load on the API server.
 
@@ -527,9 +531,8 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
       nodeSelector:
+        beta.kubernetes.io/os: linux
         kubernetes.io/role: master
-      # Since Calico can't network a pod until Typha is up, we need to run Typha itself
-      # as a host-networked pod.
       hostNetwork: true
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.
@@ -537,6 +540,8 @@ spec:
           operator: Exists
         - key: "node-role.kubernetes.io/master"
           effect: NoSchedule
+      # Since Calico can't network a pod until Typha is up, we need to run Typha itself
+      # as a host-networked pod.
       serviceAccountName: canal
       priorityClassName: system-cluster-critical
       # fsGroup allows using projected serviceaccount tokens as described here kubernetes/kubernetes#82573
@@ -604,8 +609,8 @@ spec:
   selector:
     matchLabels:
       k8s-app: calico-typha
-
 {{- end }}
+
 ---
 # Source: calico/templates/calico-node.yaml
 # This manifest installs the canal container, as well
@@ -666,12 +671,6 @@ spec:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
               value: "10-canal.conflist"
-            # CNI MTU Config variable
-            - name: CNI_MTU
-              valueFrom:
-                configMapKeyRef:
-                  name: canal-config
-                  key: veth_mtu
             # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG
               valueFrom:
@@ -683,6 +682,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # CNI MTU Config variable
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  name: canal-config
+                  key: veth_mtu
             # Prevents the container from sleeping forever.
             - name: SLEEP
               value: "false"
@@ -732,13 +737,17 @@ spec:
               value: "none"
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
+              # was value: "k8s,bgp"
               value: "k8s,canal"
-            # Period, in seconds, at which felix re-applies all iptables state
-            - name: FELIX_IPTABLESREFRESHINTERVAL
-              value: "60"
             # No IP address needed.
             - name: IP
               value: ""
+            # Set MTU for tunnel device used if ipip is enabled
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  name: canal-config
+                  key: veth_mtu
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
@@ -753,17 +762,17 @@ spec:
               value: "{{- or .Networking.Canal.LogSeveritySys "INFO" }}"
             - name: FELIX_HEALTHENABLED
               value: "true"
-            - name: FELIX_IPINIPMTU
-              valueFrom:
-                configMapKeyRef:
-                  name: canal-config
-                  key: veth_mtu
-            # Set Felix iptables binary variant, Legacy or NFT
-            - name: FELIX_IPTABLESBACKEND
-              value: "{{- or .Networking.Canal.IptablesBackend "Legacy" }}"
+
+            # kops additions
             # Controls whether Felix inserts rules to the top of iptables chains, or appends to the bottom
             - name: FELIX_CHAININSERTMODE
               value: "{{- or .Networking.Canal.ChainInsertMode "insert" }}"
+            # Set Felix iptables binary variant, Legacy or NFT
+            - name: FELIX_IPTABLESBACKEND
+              value: "{{- or .Networking.Canal.IptablesBackend "Legacy" }}"
+            # Period, in seconds, at which felix re-applies all iptables state
+            - name: FELIX_IPTABLESREFRESHINTERVAL
+              value: "60"
             # Set to enable the experimental Prometheus metrics server
             - name: FELIX_PROMETHEUSMETRICSENABLED
               value: "{{- or .Networking.Canal.PrometheusMetricsEnabled "false" }}"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template
@@ -8,6 +8,8 @@ apiVersion: v1
 metadata:
   name: canal-config
   namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
 data:
   # Typha is disabled.
   typha_service_name: "{{ if .Networking.Canal.TyphaReplicas }}calico-typha{{ else }}none{{ end }}"
@@ -70,6 +72,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -84,6 +88,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: ipamblocks.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -99,6 +105,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: blockaffinities.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -114,6 +122,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: ipamhandles.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -129,6 +139,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: ipamconfigs.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -144,6 +156,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: bgppeers.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -159,6 +173,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -174,6 +190,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -189,6 +207,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -204,6 +224,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -219,6 +241,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -234,6 +258,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -249,6 +275,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
@@ -264,6 +292,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: networksets.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
@@ -281,6 +311,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-node
+  labels:
+    role.kubernetes.io/networking: "1"
 rules:
   # The CNI plugin needs to get pods, nodes, and namespaces.
   - apiGroups: [""]
@@ -384,6 +416,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
+  labels:
+    role.kubernetes.io/networking: "1"
 rules:
   - apiGroups: [""]
     resources:
@@ -407,6 +441,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: canal-flannel
+  labels:
+    role.kubernetes.io/networking: "1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -420,6 +456,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: canal-calico
+  labels:
+    role.kubernetes.io/networking: "1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -442,6 +480,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha
+    role.kubernetes.io/networking: "1"
 spec:
   ports:
     - port: 5473
@@ -462,6 +501,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha
+    role.kubernetes.io/networking: "1"
 spec:
   # Number of Typha replicas.  To enable Typha, set this to a non-zero value *and* set the
   # typha_service_name variable in the canal-config ConfigMap above.
@@ -478,6 +518,7 @@ spec:
     metadata:
       labels:
         k8s-app: calico-typha
+        role.kubernetes.io/networking: "1"
       annotations:
         # This, along with the CriticalAddonsOnly toleration below, marks the pod as a critical
         # add-on, ensuring it gets priority scheduling and that its resources are reserved
@@ -557,6 +598,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha
+    role.kubernetes.io/networking: "1"
 spec:
   maxUnavailable: 1
   selector:
@@ -576,6 +618,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: canal
+    role.kubernetes.io/networking: "1"
 spec:
   selector:
     matchLabels:
@@ -588,6 +631,7 @@ spec:
     metadata:
       labels:
         k8s-app: canal
+        role.kubernetes.io/networking: "1"
       annotations:
         # This, along with the CriticalAddonsOnly toleration below,
         # marks the pod as a critical add-on, ensuring it gets
@@ -845,3 +889,5 @@ kind: ServiceAccount
 metadata:
   name: canal
   namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template
@@ -69,7 +69,7 @@ data:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-   name: felixconfigurations.crd.projectcalico.org
+  name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -1,6 +1,6 @@
----
-# Pulled and modified from: https://docs.projectcalico.org/v3.9/manifests/calico-typha.yaml
+{{- /* Pulled and modified from: https://docs.projectcalico.org/v3.10/manifests/calico-typha.yaml */ -}}
 
+---
 # Source: calico/templates/calico-config.yaml
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
@@ -570,8 +570,9 @@ spec:
         beta.kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node
@@ -723,12 +724,6 @@ spec:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
               value: "10-calico.conflist"
-            # CNI MTU Config variable
-            - name: CNI_MTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
             # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG
               valueFrom:
@@ -740,6 +735,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # CNI MTU Config variable
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
             # Prevents the container from sleeping forever.
             - name: SLEEP
               value: "false"
@@ -815,7 +816,7 @@ spec:
             # Disable IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"
-            # Set Felix logging to the desired level
+            # Set Felix logging to "info"
             - name: FELIX_LOGSEVERITYSCREEN
               value: "{{- or .Networking.Calico.LogSeverityScreen "info" }}"
             - name: FELIX_HEALTHENABLED

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -1,32 +1,27 @@
-# Canal Version v3.10.2
-# https://docs.projectcalico.org/v3.10/release-notes/#v3101
-# This manifest includes the following component versions:
-#   calico/cni:v3.10.2
-#   calico/node:v3.10.2
-#   calico/pod2daemon-flexvol:v3.10.2
-#   calico/typha:v3.10.2
-#   quay.io/coreos/flannel:v0.11.0
+---
+# Pulled and modified from: https://docs.projectcalico.org/v3.9/manifests/calico-typha.yaml
 
 # Source: calico/templates/calico-config.yaml
-# This ConfigMap is used to configure a self-hosted Canal installation.
+# This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: canal-config
+  name: calico-config
   namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
 data:
-  typha_service_name: "{{ if .Networking.Canal.TyphaReplicas }}calico-typha{{ else }}none{{ end }}"
-  # The interface used by canal for host <-> host communication.
-  # If left blank, then the interface is chosen using the node's
-  # default route.
-  canal_iface: ""
+  # You must set a non-zero value for Typha replicas below.
+  typha_service_name: "{{- if .Networking.Calico.TyphaReplicas -}}calico-typha{{- else -}}none{{- end -}}"
+  # Configure the backend to use.
+  calico_backend: "bird"
 
-  # Whether or not to masquerade traffic to destinations not within
-  # the pod network.
-  masquerade: "true"
-
-  # MTU default is 1500, can be overridden
-  veth_mtu: "{{- or .Networking.Canal.MTU "1500" }}"
+  # Configure the MTU to use
+  {{- if .Networking.Calico.MTU }}
+  veth_mtu: "{{ .Networking.Calico.MTU }}"
+  {{- else }}
+  veth_mtu: "{{- if eq .CloudProvider "openstack" -}}1430{{- else -}}1440{{- end -}}"
+  {{- end }}
 
   # The CNI network configuration to install on each node.  The special
   # values in this config will be automatically populated.
@@ -39,11 +34,10 @@ data:
           "type": "calico",
           "log_level": "info",
           "datastore_type": "kubernetes",
-          "mtu": __CNI_MTU__,
           "nodename": "__KUBERNETES_NODE_NAME__",
+          "mtu": __CNI_MTU__,
           "ipam": {
-              "type": "host-local",
-              "subnet": "usePodCidr"
+              "type": "calico-ipam"
           },
           "policy": {
               "type": "k8s"
@@ -60,22 +54,14 @@ data:
       ]
     }
 
-  # Flannel network configuration. Mounted into the flannel container.
-  net-conf.json: |
-    {
-      "Network": "{{ .NonMasqueradeCIDR }}",
-      "Backend": {
-        "Type": "vxlan"
-      }
-    }
-
 ---
-
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
    name: felixconfigurations.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -90,6 +76,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: ipamblocks.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -105,6 +93,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: blockaffinities.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -120,6 +110,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: ipamhandles.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -135,6 +127,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: ipamconfigs.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -150,6 +144,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: bgppeers.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -165,6 +161,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -180,6 +178,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -195,6 +195,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -210,6 +212,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -225,6 +229,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -240,6 +246,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -255,6 +263,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
@@ -270,6 +280,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: networksets.crd.projectcalico.org
+  labels:
+    role.kubernetes.io/networking: "1"
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
@@ -278,15 +290,81 @@ spec:
     kind: NetworkSet
     plural: networksets
     singular: networkset
-
 ---
+# Source: calico/templates/rbac.yaml
 
+# Include a clusterrole for the kube-controllers component,
+# and bind it to the calico-kube-controllers serviceaccount.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-kube-controllers
+  labels:
+    role.kubernetes.io/networking: "1"
+rules:
+  # Nodes are watched to monitor for deletions.
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - watch
+      - list
+      - get
+  # Pods are queried to check for existence.
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+  # IPAM resources are manipulated when nodes are deleted.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ippools
+    verbs:
+      - list
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+  # Needs access to update clusterinformations.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - clusterinformations
+    verbs:
+      - get
+      - create
+      - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-kube-controllers
+  labels:
+    role.kubernetes.io/networking: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-kube-controllers
+subjects:
+- kind: ServiceAccount
+  name: calico-kube-controllers
+  namespace: kube-system
+---
 # Include a clusterrole for the calico-node DaemonSet,
 # and bind it to the calico-node serviceaccount.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: calico
+  name: calico-node
+  labels:
+    role.kubernetes.io/networking: "1"
 rules:
   # The CNI plugin needs to get pods, nodes, and namespaces.
   - apiGroups: [""]
@@ -383,70 +461,55 @@ rules:
     verbs:
       - create
       - update
----
-# Flannel ClusterRole
-# Pulled from https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel-rbac.yml
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: flannel
-rules:
-  - apiGroups: [""]
+  # These permissions are required for Calico CNI to perform IPAM allocations.
+  - apiGroups: ["crd.projectcalico.org"]
     resources:
-      - pods
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
     verbs:
       - get
-  - apiGroups: [""]
-    resources:
-      - nodes
-    verbs:
       - list
-      - watch
-  - apiGroups: [""]
+      - create
+      - update
+      - delete
+  - apiGroups: ["crd.projectcalico.org"]
     resources:
-      - nodes/status
+      - ipamconfigs
     verbs:
-      - patch
+      - get
+  # Block affinities must also be watchable by confd for route aggregation.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+    verbs:
+      - watch
+  # The Calico IPAM migration needs to get daemonsets. These permissions can be
+  # removed if not upgrading from an installation using host-local IPAM.
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+    verbs:
+      - get
 ---
-# Bind the flannel ClusterRole to the canal ServiceAccount.
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: canal-flannel
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: flannel
-subjects:
-- kind: ServiceAccount
-  name: canal
-  namespace: kube-system
----
-# Bind the Calico ClusterRole to the canal ServiceAccount.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: canal-calico
+  name: calico-node
+  labels:
+    role.kubernetes.io/networking: "1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: calico
+  name: calico-node
 subjects:
 - kind: ServiceAccount
-  name: canal
+  name: calico-node
   namespace: kube-system
 
+{{ if .Networking.Calico.TyphaReplicas -}}
 ---
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: canal
-  namespace: kube-system
-
----
-{{- if .Networking.Canal.TyphaReplicas }}
-
+# Source: calico/templates/calico-typha.yaml
 # This manifest creates a Service, which will be backed by Calico's Typha daemon.
 # Typha sits in between Felix and the API server, reducing Calico's load on the API server.
 
@@ -457,6 +520,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha
+    role.kubernetes.io/networking: "1"
 spec:
   ports:
     - port: 5473
@@ -477,14 +541,15 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha
+    role.kubernetes.io/networking: "1"
 spec:
   # Number of Typha replicas.  To enable Typha, set this to a non-zero value *and* set the
-  # typha_service_name variable in the canal-config ConfigMap above.
+  # typha_service_name variable in the calico-config ConfigMap above.
   #
   # We recommend using Typha if you have more than 50 nodes.  Above 100 nodes it is essential
   # (when using the Kubernetes datastore).  Use one replica for every 100-200 nodes.  In
   # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
-  replicas: {{ or .Networking.Canal.TyphaReplicas 0 }}
+  replicas: {{ or .Networking.Calico.TyphaReplicas "0" }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:
@@ -493,6 +558,7 @@ spec:
     metadata:
       labels:
         k8s-app: calico-typha
+        role.kubernetes.io/networking: "1"
       annotations:
         # This, along with the CriticalAddonsOnly toleration below, marks the pod as a critical
         # add-on, ensuring it gets priority scheduling and that its resources are reserved
@@ -500,21 +566,15 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      hostNetwork: true
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
-      hostNetwork: true
-      nodeSelector:
-        kubernetes.io/role: master
-      tolerations:
-        # Mark the pod as a critical add-on for rescheduling.
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - key: "node-role.kubernetes.io/master"
-          effect: NoSchedule
-      serviceAccountName: canal
+      serviceAccountName: calico-node
       priorityClassName: system-cluster-critical
       # fsGroup allows using projected serviceaccount tokens as described here kubernetes/kubernetes#82573
       securityContext:
@@ -544,9 +604,9 @@ spec:
           - name: TYPHA_HEALTHENABLED
             value: "true"
           - name: TYPHA_PROMETHEUSMETRICSENABLED
-            value: "{{- or .Networking.Canal.TyphaPrometheusMetricsEnabled "false" }}"
+            value: "{{- or .Networking.Calico.TyphaPrometheusMetricsEnabled "false" }}"
           - name: TYPHA_PROMETHEUSMETRICSPORT
-            value: "{{- or .Networking.Canal.TyphaPrometheusMetricsPort "9093" }}"
+            value: "{{- or .Networking.Calico.TyphaPrometheusMetricsPort "9093" }}"
         livenessProbe:
           httpGet:
             path: /liveness
@@ -575,29 +635,30 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha
+    role.kubernetes.io/networking: "1"
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
       k8s-app: calico-typha
-
-{{- end }}
+{{- end -}}
 ---
-
-# This manifest installs the calico/node container, as well
-# as the Calico CNI plugins and network config on
+# Source: calico/templates/calico-node.yaml
+# This manifest installs the calico-node container, as well
+# as the CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  name: canal
+  name: calico-node
   namespace: kube-system
   labels:
-    k8s-app: canal
+    k8s-app: calico-node
+    role.kubernetes.io/networking: "1"
 spec:
   selector:
     matchLabels:
-      k8s-app: canal
+      k8s-app: calico-node
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -605,7 +666,8 @@ spec:
   template:
     metadata:
       labels:
-        k8s-app: canal
+        k8s-app: calico-node
+        role.kubernetes.io/networking: "1"
       annotations:
         # This, along with the CriticalAddonsOnly toleration below,
         # marks the pod as a critical add-on, ensuring it gets
@@ -613,12 +675,11 @@ spec:
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: system-node-critical
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
-        # Make sure canal gets scheduled on all nodes.
+        # Make sure calico-node gets scheduled on all nodes.
         - effect: NoSchedule
           operator: Exists
         # Mark the pod as a critical add-on for rescheduling.
@@ -626,12 +687,34 @@ spec:
           operator: Exists
         - effect: NoExecute
           operator: Exists
-      serviceAccountName: canal
+      serviceAccountName: calico-node
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
+      priorityClassName: system-node-critical
       initContainers:
-        # This container installs the Calico CNI binaries
+        # This container performs upgrade from host-local IPAM to calico-ipam.
+        # It can be deleted if this is a fresh installation, or if you have already
+        # upgraded to use calico-ipam.
+        - name: upgrade-ipam
+          image: calico/cni:v3.10.2
+          command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
+          env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+          volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+        # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
           image: calico/cni:v3.10.2
@@ -639,18 +722,18 @@ spec:
           env:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
-              value: "10-canal.conflist"
+              value: "10-calico.conflist"
             # CNI MTU Config variable
             - name: CNI_MTU
               valueFrom:
                 configMapKeyRef:
-                  name: canal-config
+                  name: calico-config
                   key: veth_mtu
             # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG
               valueFrom:
                 configMapKeyRef:
-                  name: canal-config
+                  name: calico-config
                   key: cni_network_config
             # Set the hostname based on the k8s node name.
             - name: KUBERNETES_NODE_NAME
@@ -673,7 +756,7 @@ spec:
           - name: flexvol-driver-host
             mountPath: /host/driver
       containers:
-        # Runs calico/node container on each Kubernetes node.  This
+        # Runs calico-node container on each Kubernetes node.  This
         # container programs network policy and routes on each
         # host.
         - name: calico-node
@@ -682,17 +765,12 @@ spec:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
               value: "kubernetes"
-            # Configure route aggregation based on pod CIDR.
-            - name: USE_POD_CIDR
-              value: "true"
-            {{- if .Networking.Canal.TyphaReplicas }}
             # Typha support: controlled by the ConfigMap.
             - name: FELIX_TYPHAK8SSERVICENAME
               valueFrom:
                 configMapKeyRef:
-                  name: canal-config
+                  name: calico-config
                   key: typha_service_name
-            {{- end }}
             # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
               value: "true"
@@ -701,73 +779,84 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            # Don't enable BGP.
+            # Choose the backend to use.
             - name: CALICO_NETWORKING_BACKEND
-              value: "none"
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
-              value: "k8s,canal"
-            # Period, in seconds, at which felix re-applies all iptables state
-            - name: FELIX_IPTABLESREFRESHINTERVAL
-              value: "60"
-            # No IP address needed.
+              # was value: "k8s,bgp"
+              value: "kops,bgp"
+            # Auto-detect the BGP IP address.
             - name: IP
-              value: ""
-            # Disable file logging so `kubectl logs` works.
-            - name: CALICO_DISABLE_FILE_LOGGING
-              value: "true"
+              value: "autodetect"
+            # Enable IPIP
+            - name: CALICO_IPV4POOL_IPIP
+              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}CrossSubnet{{- else -}} {{- or .Networking.Calico.IPIPMode "Always" -}} {{- end -}}"
+            # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:
                 configMapKeyRef:
-                  name: canal-config
+                  name: calico-config
                   key: veth_mtu
-            # Set Felix iptables binary variant, Legacy or NFT
-            - name: FELIX_IPTABLESBACKEND
-              value: "{{- or .Networking.Canal.IptablesBackend "Legacy" }}"
+            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
+            # chosen from this range. Changing this value after installation will have
+            # no effect. This should fall within `--cluster-cidr`.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "{{ .KubeControllerManager.ClusterCIDR }}"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
             # Disable IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"
-            # Set Felix logging to "INFO"
+            # Set Felix logging to the desired level
             - name: FELIX_LOGSEVERITYSCREEN
-              value: "{{- or .Networking.Canal.LogSeveritySys "INFO" }}"
-            # Set Felix endpoint to host default action to ACCEPT.
-            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
-              value: "{{- or .Networking.Canal.DefaultEndpointToHostAction "ACCEPT" }}"
-            # Controls whether Felix inserts rules to the top of iptables chains, or appends to the bottom
-            - name: FELIX_CHAININSERTMODE
-              value: "{{- or .Networking.Canal.ChainInsertMode "insert" }}"
-            # Set to enable the experimental Prometheus metrics server
-            - name: FELIX_PROMETHEUSMETRICSENABLED
-              value: "{{- or .Networking.Canal.PrometheusMetricsEnabled "false" }}"
-            # TCP port that the Prometheus metrics server should bind to
-            - name: FELIX_PROMETHEUSMETRICSPORT
-              value: "{{- or .Networking.Canal.PrometheusMetricsPort "9091" }}"
-            # Enable Prometheus Go runtime metrics collection
-            - name: FELIX_PROMETHEUSGOMETRICSENABLED
-              value: "{{- or .Networking.Canal.PrometheusGoMetricsEnabled "true" }}"
-            # Enable Prometheus process metrics collection
-            - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
-              value: "{{- or .Networking.Canal.PrometheusProcessMetricsEnabled "true" }}"
+              value: "{{- or .Networking.Calico.LogSeverityScreen "info" }}"
             - name: FELIX_HEALTHENABLED
               value: "true"
+
+            # kops additions
+            # Set Felix iptables binary variant, Legacy or NFT
+            - name: FELIX_IPTABLESBACKEND
+              value: "{{- or .Networking.Calico.IptablesBackend "Legacy" }}"
+            # Set to enable the experimental Prometheus metrics server
+            - name: FELIX_PROMETHEUSMETRICSENABLED
+              value: "{{- or .Networking.Calico.PrometheusMetricsEnabled "false" }}"
+            # TCP port that the Prometheus metrics server should bind to
+            - name: FELIX_PROMETHEUSMETRICSPORT
+              value: "{{- or .Networking.Calico.PrometheusMetricsPort "9091" }}"
+            # Enable Prometheus Go runtime metrics collection
+            - name: FELIX_PROMETHEUSGOMETRICSENABLED
+              value: "{{- or .Networking.Calico.PrometheusGoMetricsEnabled "true" }}"
+            # Enable Prometheus process metrics collection
+            - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
+              value: "{{- or .Networking.Calico.PrometheusProcessMetricsEnabled "true" }}"
           securityContext:
             privileged: true
           resources:
             requests:
-              cpu: 250m
+              cpu: 90m
           livenessProbe:
             exec:
               command:
               - /bin/calico-node
               - -felix-live
+              - -bird-live
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
           readinessProbe:
-            httpGet:
-              path: /readiness
-              port: 9099
-              host: localhost
+            exec:
+              command:
+              - /bin/calico-node
+              - -felix-ready
+              - -bird-ready
             periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules
@@ -784,44 +873,8 @@ spec:
               readOnly: false
             - name: policysync
               mountPath: /var/run/nodeagent
-        # This container runs flannel using the kube-subnet-mgr backend
-        # for allocating subnets.
-        - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.11.0
-          command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
-          securityContext:
-            privileged: true
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: FLANNELD_IFACE
-              valueFrom:
-                configMapKeyRef:
-                  name: canal-config
-                  key: canal_iface
-            - name: FLANNELD_IP_MASQ
-              valueFrom:
-                configMapKeyRef:
-                  name: canal-config
-                  key: masquerade
-            {{- if eq .Networking.Canal.DisableFlannelForwardRules true }}
-            - name: FLANNELD_IPTABLES_FORWARD_RULES
-              value: "false"
-            {{- end }}
-          volumeMounts:
-          - mountPath: /run/xtables.lock
-            name: xtables-lock
-            readOnly: false
-          - name: flannel-cfg
-            mountPath: /etc/kube-flannel/
       volumes:
-        # Used by canal.
+        # Used by calico-node.
         - name: lib-modules
           hostPath:
             path: /lib/modules
@@ -835,10 +888,6 @@ spec:
           hostPath:
             path: /run/xtables.lock
             type: FileOrCreate
-        # Used by flannel.
-        - name: flannel-cfg
-          configMap:
-            name: canal-config
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
@@ -846,6 +895,12 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
+        # Mount in the directory for host-local IPAM allocations. This is
+        # used when upgrading from host-local to calico-ipam, and can be removed
+        # if not using the upgrade-ipam init container.
+        - name: host-local-net-dir
+          hostPath:
+            path: /var/lib/cni/networks
         # Used to create per-pod Unix Domain Sockets
         - name: policysync
           hostPath:
@@ -856,3 +911,181 @@ spec:
           hostPath:
             type: DirectoryOrCreate
             path: "{{- or .Kubelet.VolumePluginDirectory "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/" }}nodeagent~uds"
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
+
+---
+# Source: calico/templates/calico-kube-controllers.yaml
+
+# See https://github.com/projectcalico/kube-controllers
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+  labels:
+    k8s-app: calico-kube-controllers
+    role.kubernetes.io/networking: "1"
+spec:
+  # The controllers can only have a single active instance.
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-kube-controllers
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+      labels:
+        k8s-app: calico-kube-controllers
+        role.kubernetes.io/networking: "1"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      tolerations:
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      serviceAccountName: calico-kube-controllers
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: calico-kube-controllers
+          image: calico/kube-controllers:v3.10.2
+          env:
+            # Choose which controllers to run.
+            - name: ENABLED_CONTROLLERS
+              value: node
+            - name: DATASTORE_TYPE
+              value: kubernetes
+          readinessProbe:
+            exec:
+              command:
+              - /usr/bin/check-status
+              - -r
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
+
+{{ if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}
+# This manifest installs the k8s-ec2-srcdst container, which disables
+# src/dst ip checks to allow BGP to function for calico for hosts within subnets
+# This only applies for AWS environments.
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: k8s-ec2-srcdst
+  labels:
+    role.kubernetes.io/networking: "1"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-ec2-srcdst
+  namespace: kube-system
+  labels:
+    role.kubernetes.io/networking: "1"
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: k8s-ec2-srcdst
+  labels:
+    role.kubernetes.io/networking: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-ec2-srcdst
+subjects:
+- kind: ServiceAccount
+  name: k8s-ec2-srcdst
+  namespace: kube-system
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8s-ec2-srcdst
+  namespace: kube-system
+  labels:
+    k8s-app: k8s-ec2-srcdst
+    role.kubernetes.io/networking: "1"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: k8s-ec2-srcdst
+  template:
+    metadata:
+      labels:
+        k8s-app: k8s-ec2-srcdst
+        role.kubernetes.io/networking: "1"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+      serviceAccountName: k8s-ec2-srcdst
+      priorityClassName: system-cluster-critical
+      containers:
+        - image: ottoyiu/k8s-ec2-srcdst:v0.2.2
+          name: k8s-ec2-srcdst
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          env:
+            - name: AWS_REGION
+              value: {{ Region }}
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: "/etc/ssl/certs/ca-certificates.crt"
+              readOnly: true
+          imagePullPolicy: "Always"
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: "/etc/ssl/certs/ca-certificates.crt"
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+{{- end -}}

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -59,7 +59,7 @@ data:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-   name: felixconfigurations.crd.projectcalico.org
+  name: felixconfigurations.crd.projectcalico.org
   labels:
     role.kubernetes.io/networking: "1"
 spec:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -568,11 +568,14 @@ spec:
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
+        kubernetes.io/role: master
       hostNetwork: true
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node
@@ -642,7 +645,8 @@ spec:
   selector:
     matchLabels:
       k8s-app: calico-typha
-{{- end -}}
+{{- end }}
+
 ---
 # Source: calico/templates/calico-node.yaml
 # This manifest installs the calico-node container, as well
@@ -766,12 +770,14 @@ spec:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
               value: "kubernetes"
+            {{- if .Networking.Calico.TyphaReplicas }}
             # Typha support: controlled by the ConfigMap.
             - name: FELIX_TYPHAK8SSERVICENAME
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
                   key: typha_service_name
+            {{- end }}
             # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
               value: "true"
@@ -1089,4 +1095,4 @@ spec:
             path: "/etc/ssl/certs/ca-certificates.crt"
       nodeSelector:
         node-role.kubernetes.io/master: ""
-{{- end -}}
+{{ end -}}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -829,6 +829,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.7":     "2.6.12-kops.1",
 			"k8s-1.7-v3":  "3.8.0-kops.2",
 			"k8s-1.12":    "3.9.3-kops.2",
+			"k8s-1.16":    "3.10.2-kops.1",
 		}
 
 		{
@@ -840,7 +841,21 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 				Version:           fi.String(versions[id]),
 				Selector:          networkingSelector,
 				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.12.0",
+				KubernetesVersion: ">=1.12.0 <1.16.0",
+				Id:                id,
+			})
+		}
+
+		{
+			id := "k8s-1.16"
+			location := key + "/" + id + ".yaml"
+
+			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
+				Name:              fi.String(key),
+				Version:           fi.String(versions[id]),
+				Selector:          networkingSelector,
+				Manifest:          fi.String(location),
+				KubernetesVersion: ">=1.16.0",
 				Id:                id,
 			})
 		}
@@ -911,8 +926,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.6":     "2.4.2-kops.2",
 			"k8s-1.8":     "2.6.7-kops.3",
 			"k8s-1.9":     "3.2.3-kops.1",
-			"k8s-1.12":    "3.7.4",
-			"k8s-1.15":    "3.10.1-kops.2",
+			"k8s-1.12":    "3.7.4-kops.1",
+			"k8s-1.15":    "3.10.2-kops.1",
 		}
 		{
 			id := "pre-k8s-1.6"


### PR DESCRIPTION
Calico v3.10 is here with some nice new stuff like bird/bird6 liveness checks.
Canal is already at 3.10 but Calico should be upgraded too.

This PR addresses also some other issues:
* make Calico and Canal templates easier to compare, by moving around some fields
* make Canal easier to compare to official manifest
* add role.kubernetes.io/networking labels to Canal

Commits should be reviewed one by one, as it will be much easier to compare each step.