### PR TITLE
dev: ignore kops-controller in hack/update-expected.sh

### DIFF
--- a/hack/update-expected.sh
+++ b/hack/update-expected.sh
@@ -26,6 +26,7 @@ make kops-gobindata
 # Don't override variables that are commonly used in dev, but shouldn't be in our tests
 export KOPS_BASE_URL=
 export DNSCONTROLLER_IMAGE=
+export KOPSCONTROLLER_IMAGE=
 
 # Run the tests in "autofix mode"
 HACK_UPDATE_EXPECTED_IN_PLACE=1 go test ./... -count=1


### PR DESCRIPTION
hack/update-expected.sh should ignore KOPSCONTROLLER_IMAGE when
regenerating the golden test outputs, just as it ignores the local
DNSCONTROLLER_IMAGE override.