### PR TITLE
Terraform GCE output: setting google provider to at least 3.0.0

### DIFF
--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -19,6 +19,7 @@ output "region" {
 provider "google" {
   project = "us-test1"
   region  = "us-test1"
+  version = ">= 3.0.0"
 }
 
 resource "google_compute_disk" "d1-etcd-events-ha-gce-example-com" {

--- a/upup/pkg/fi/cloudup/terraform/target.go
+++ b/upup/pkg/fi/cloudup/terraform/target.go
@@ -197,6 +197,7 @@ func (t *TerraformTarget) Finish(taskMap map[string]fi.Task) error {
 			providerGoogle[k] = v
 		}
 		providersByName["google"] = providerGoogle
+		providerGoogle["version"] = ">= 3.0.0"
 	} else if t.Cloud.ProviderID() == kops.CloudProviderAWS {
 		providerAWS := make(map[string]interface{})
 		providerAWS["region"] = t.Region


### PR DESCRIPTION
From #8103: added google provider verison to 3.0.0. For terraform 0.11 it needs to go into the provider block (see https://www.terraform.io/docs/configuration-0-11/providers.html)
Alternative to #8106.

@justinsb : sorry for the duplicate effort. I think the change of the required_provider version needs to go onto the bucket list for moving to terraform 0.12