### PR TITLE
Automated cherry pick of #8088: validate cluster twice #8105: Add unit test for flapping validation

### DIFF
--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -414,7 +414,8 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 		PostDrainDelay:    options.PostDrainDelay,
 		ValidationTimeout: options.ValidationTimeout,
 		// TODO should we expose this to the UI?
-		ValidateTickDuration: 30 * time.Second,
+		ValidateTickDuration:    30 * time.Second,
+		ValidateSuccessDuration: 10 * time.Second,
 	}
 	return d.RollingUpdate(groups, cluster, list)
 }

--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -63,6 +63,10 @@ type RollingUpdateCluster struct {
 
 	// ValidateTickDuration is the amount of time to wait between cluster validation attempts
 	ValidateTickDuration time.Duration
+
+	// ValidateSuccessDuration is the amount of time a cluster must continue to validate successfully
+	// before updating the next node
+	ValidateSuccessDuration time.Duration
 }
 
 // RollingUpdate performs a rolling update on a K8s Cluster.

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -947,6 +947,59 @@ func TestRollingUpdateClusterErrorsValidationAfterOneNode(t *testing.T) {
 	}
 }
 
+type flappingClusterValidator struct {
+	T               *testing.T
+	Cloud           awsup.AWSCloud
+	invocationCount int
+}
+
+func (v *flappingClusterValidator) Validate() (*validation.ValidationCluster, error) {
+	asgGroups, _ := v.Cloud.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String("master-1")},
+	})
+	for _, group := range asgGroups.AutoScalingGroups {
+		switch len(group.Instances) {
+		case 1:
+			return &validation.ValidationCluster{}, nil
+		case 0:
+			assert.GreaterOrEqual(v.T, v.invocationCount, 7, "validator invocation count")
+		}
+	}
+
+	v.invocationCount++
+	switch v.invocationCount {
+	case 1, 3, 5:
+		return &validation.ValidationCluster{
+			Failures: []*validation.ValidationError{
+				{
+					Kind:    "testing",
+					Name:    "testingfailure",
+					Message: "testing failure",
+				},
+			},
+		}, nil
+	}
+	return &validation.ValidationCluster{}, nil
+}
+
+func TestRollingUpdateFlappingValidation(t *testing.T) {
+	c, cloud, cluster := getTestSetup()
+
+	c.ValidationTimeout = 20 * time.Millisecond
+	c.ClusterValidator = &flappingClusterValidator{
+		T:     t,
+		Cloud: cloud,
+	}
+
+	err := c.RollingUpdate(getGroupsAllNeedUpdate(), cluster, &kopsapi.InstanceGroupList{})
+	assert.NoError(t, err, "rolling update")
+
+	assertGroupInstanceCount(t, cloud, "node-1", 0)
+	assertGroupInstanceCount(t, cloud, "node-2", 0)
+	assertGroupInstanceCount(t, cloud, "master-1", 0)
+	assertGroupInstanceCount(t, cloud, "bastion-1", 0)
+}
+
 type failThreeTimesClusterValidator struct {
 	invocationCount int
 }


### PR DESCRIPTION
Cherry pick of #8088 #8105 on release-1.17.

#8088: validate cluster twice
#8105: Add unit test for flapping validation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.