### PR TITLE
channels: bump k8s versions after dec. patch releases

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -49,13 +49,13 @@ spec:
     recommendedVersion: 1.17.0
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
-    recommendedVersion: 1.16.3
+    recommendedVersion: 1.16.4
     requiredVersion: 1.16.0
   - range: ">=1.15.0"
-    recommendedVersion: 1.15.6
+    recommendedVersion: 1.15.7
     requiredVersion: 1.15.0
   - range: ">=1.14.0"
-    recommendedVersion: 1.14.9
+    recommendedVersion: 1.14.10
     requiredVersion: 1.14.0
   - range: ">=1.13.0"
     recommendedVersion: 1.13.12
@@ -77,15 +77,15 @@ spec:
   - range: ">=1.16.0-alpha.1"
     #recommendedVersion: "1.16.0"
     #requiredVersion: 1.16.0
-    kubernetesVersion: 1.16.3
+    kubernetesVersion: 1.16.4
   - range: ">=1.15.0-alpha.1"
     #recommendedVersion: "1.15.0"
     #requiredVersion: 1.15.0
-    kubernetesVersion: 1.15.6
+    kubernetesVersion: 1.15.7
   - range: ">=1.14.0-alpha.1"
     #recommendedVersion: "1.14.0"
     #requiredVersion: 1.14.0
-    kubernetesVersion: 1.14.9
+    kubernetesVersion: 1.14.10
   - range: ">=1.13.0-alpha.1"
     #recommendedVersion: "1.13.0"
     #requiredVersion: 1.13.0

--- a/channels/stable
+++ b/channels/stable
@@ -49,13 +49,13 @@ spec:
     recommendedVersion: 1.17.0
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
-    recommendedVersion: 1.16.2
+    recommendedVersion: 1.16.3
     requiredVersion: 1.16.0
   - range: ">=1.15.0"
-    recommendedVersion: 1.15.5
+    recommendedVersion: 1.15.6
     requiredVersion: 1.15.0
   - range: ">=1.14.0"
-    recommendedVersion: 1.14.8
+    recommendedVersion: 1.14.9
     requiredVersion: 1.14.0
   - range: ">=1.13.0"
     recommendedVersion: 1.13.12
@@ -77,15 +77,15 @@ spec:
   - range: ">=1.16.0-alpha.1"
     #recommendedVersion: "1.16.0"
     #requiredVersion: 1.16.0
-    kubernetesVersion: 1.16.2
+    kubernetesVersion: 1.16.3
   - range: ">=1.15.0-alpha.1"
     #recommendedVersion: "1.15.0"
     #requiredVersion: 1.15.0
-    kubernetesVersion: 1.15.5
+    kubernetesVersion: 1.15.6
   - range: ">=1.14.0-alpha.1"
     #recommendedVersion: "1.14.0"
     #requiredVersion: 1.14.0
-    kubernetesVersion: 1.14.8
+    kubernetesVersion: 1.14.9
   - range: ">=1.13.0-alpha.1"
     #recommendedVersion: "1.13.0"
     #requiredVersion: 1.13.0


### PR DESCRIPTION
ref: https://github.com/kubernetes/sig-release/blob/master/releases/patch-releases.md#116