### PR TITLE
dns-controller: allow it to run on CNI networking mode and remove dependency on kube-proxy

### DIFF
--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -22,8 +22,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        effect: NoSchedule
+      - operator: Exists
       nodeSelector:
         node-role.kubernetes.io/master: ""
       dnsPolicy: Default  # Don't use cluster DNS (we are likely running before kube-dns)
@@ -36,15 +35,16 @@ spec:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"
 {{ end }}
-{{- if .EgressProxy }}
         env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: "127.0.0.1"
+{{- if .EgressProxy }}
 {{ range $name, $value := ProxyEnv }}
         - name: {{ $name }}
           value: {{ $value }}
 {{ end }}
 {{- end }}
 {{- if eq .CloudProvider "digitalocean" }}
-        env:
         - name: DIGITALOCEAN_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -29,6 +29,9 @@ spec:
         - --zone=*/Z1AFAKE1ZON3YO
         - --zone=*/*
         - -v=2
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: kope/dns-controller:1.17.0-alpha.1
         name: dns-controller
         resources:
@@ -41,8 +44,7 @@ spec:
         node-role.kubernetes.io/master: ""
       serviceAccount: dns-controller
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
 
 ---
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -83,7 +83,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 4ba4be235e96068511965bf296375b45e152369a
+    manifestHash: a304440f4f7d2e289eb12c37adeac04253d84906
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -29,6 +29,9 @@ spec:
         - --zone=*/Z1AFAKE1ZON3YO
         - --zone=*/*
         - -v=2
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: kope/dns-controller:1.17.0-alpha.1
         name: dns-controller
         resources:
@@ -41,8 +44,7 @@ spec:
         node-role.kubernetes.io/master: ""
       serviceAccount: dns-controller
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
 
 ---
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -83,7 +83,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 4ba4be235e96068511965bf296375b45e152369a
+    manifestHash: a304440f4f7d2e289eb12c37adeac04253d84906
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -83,7 +83,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 4ba4be235e96068511965bf296375b45e152369a
+    manifestHash: a304440f4f7d2e289eb12c37adeac04253d84906
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io


### PR DESCRIPTION
## Problem

When booting a cluster with `--networking=cni`, `dns-controller` will not start due to the master node being _tainted_ as "network unreachable". This adds an extra step when managing your own CNI setup, having to SSH into a master and publish the CNI manifests from there.

## Desired behavior

An operator should expect `kops` to provide a managable cluster by the end of `kops update cluster --yes` step, even if managing the CNI externally, so the next step is a natural "`kubectl apply -f my-cni.yaml`".

## Proposal

This PR adds tolerance and configuration that allows `dns-controller` pod to start when running with `--networking=cni`, properly creating the DNS records so the operator can remotely publish the CNI and extra manifests to have a full working cluster.

This also removes the dependency on `kube-proxy`, by adding the `KUBERNETES_SERVICE_HOST` environment variable, bypassing `kube-proxy` when disabled.

Presumably, as a side-effect, this change also allows for "host network only" clusters to work.

## More context

I'm currently running a _kube-proxyless_ Cilum setup, and due to the dns-controller failing to start I had to script around kops to SSH and publish the CNI setup from the master node itself.