### PR TITLE
Automated cherry pick of #7406: Add CapacityOptimized to list of supported spot allocation

### DIFF
--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -158,10 +158,12 @@ const (
 	SpotAllocationStrategyLowestPrices = "lowest-price"
 	// SpotAllocationStrategyDiversified indicates a diversified strategy
 	SpotAllocationStrategyDiversified = "diversified"
+	// SpotAllocationStrategyCapacityOptimized indicates a capacity optimized strategy
+	SpotAllocationStrategyCapacityOptimized = "capacity-optimized"
 )
 
 // SpotAllocationStrategies is a collection of supported strategies
-var SpotAllocationStrategies = []string{SpotAllocationStrategyLowestPrices, SpotAllocationStrategyDiversified}
+var SpotAllocationStrategies = []string{SpotAllocationStrategyLowestPrices, SpotAllocationStrategyDiversified, SpotAllocationStrategyCapacityOptimized}
 
 // MixedInstancesPolicySpec defines the specification for an autoscaling backed by a ec2 fleet
 type MixedInstancesPolicySpec struct {

--- a/pkg/apis/kops/v1alpha1/instancegroup.go
+++ b/pkg/apis/kops/v1alpha1/instancegroup.go
@@ -145,10 +145,12 @@ const (
 	SpotAllocationStrategyLowestPrices = "lowest-price"
 	// SpotAllocationStrategyDiversified indicates a diversified strategy
 	SpotAllocationStrategyDiversified = "diversified"
+	// SpotAllocationStrategyCapacityOptimized indicates a capacity optimized strategy
+	SpotAllocationStrategyCapacityOptimized = "capacity-optimized"
 )
 
 // SpotAllocationStrategies is a collection of supported strategies
-var SpotAllocationStrategies = []string{SpotAllocationStrategyLowestPrices, SpotAllocationStrategyDiversified}
+var SpotAllocationStrategies = []string{SpotAllocationStrategyLowestPrices, SpotAllocationStrategyDiversified, SpotAllocationStrategyCapacityOptimized}
 
 // MixedInstancesPolicySpec defines the specification for an autoscaling backed by a ec2 fleet
 type MixedInstancesPolicySpec struct {

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -152,10 +152,12 @@ const (
 	SpotAllocationStrategyLowestPrices = "lowest-price"
 	// SpotAllocationStrategyDiversified indicates a diversified strategy
 	SpotAllocationStrategyDiversified = "diversified"
+	// SpotAllocationStrategyCapacityOptimized indicates a capacity optimized strategy
+	SpotAllocationStrategyCapacityOptimized = "capacity-optimized"
 )
 
 // SpotAllocationStrategies is a collection of supported strategies
-var SpotAllocationStrategies = []string{SpotAllocationStrategyLowestPrices, SpotAllocationStrategyDiversified}
+var SpotAllocationStrategies = []string{SpotAllocationStrategyLowestPrices, SpotAllocationStrategyDiversified, SpotAllocationStrategyCapacityOptimized}
 
 // MixedInstancesPolicySpec defines the specification for an autoscaling backed by a ec2 fleet
 type MixedInstancesPolicySpec struct {

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -180,7 +180,7 @@ func (e *AutoscalingGroup) Find(c *fi.Context) (*AutoscalingGroup, error) {
 	return actual, nil
 }
 
-// findAutoscalingGroup is responsilble for finding all the autoscaling groups for us
+// findAutoscalingGroup is responsible for finding all the autoscaling groups for us
 func findAutoscalingGroup(cloud awsup.AWSCloud, name string) (*autoscaling.Group, error) {
 	request := &autoscaling.DescribeAutoScalingGroupsInput{
 		AutoScalingGroupNames: []*string{&name},
@@ -671,6 +671,11 @@ func (_ *AutoscalingGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, c
 	}
 
 	if e.UseMixedInstancesPolicy() {
+		// Temporary warning until https://github.com/terraform-providers/terraform-provider-aws/issues/9750 is resolved
+		if e.MixedSpotAllocationStrategy == fi.String("capacity-optimized") {
+			fmt.Print("Terraform does not currently support a capacity optimized strategy - please see https://github.com/terraform-providers/terraform-provider-aws/issues/9750")
+		}
+
 		tf.MixedInstancesPolicy = []*terraformMixedInstancesPolicy{
 			{
 				LaunchTemplate: []*terraformAutoscalingLaunchTemplate{

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
@@ -252,14 +252,15 @@ terraform = {
 		},
 		{
 			Resource: &AutoscalingGroup{
-				Name:                   fi.String("test1"),
-				LaunchTemplate:         &LaunchTemplate{Name: fi.String("test_lt")},
-				MaxSize:                fi.Int64(10),
-				Metrics:                []string{"test"},
-				MinSize:                fi.Int64(5),
-				MixedInstanceOverrides: []string{"t2.medium", "t2.large"},
-				MixedOnDemandBase:      fi.Int64(4),
-				MixedOnDemandAboveBase: fi.Int64(30),
+				Name:                        fi.String("test1"),
+				LaunchTemplate:              &LaunchTemplate{Name: fi.String("test_lt")},
+				MaxSize:                     fi.Int64(10),
+				Metrics:                     []string{"test"},
+				MinSize:                     fi.Int64(5),
+				MixedInstanceOverrides:      []string{"t2.medium", "t2.large"},
+				MixedOnDemandBase:           fi.Int64(4),
+				MixedOnDemandAboveBase:      fi.Int64(30),
+				MixedSpotAllocationStrategy: fi.String("capacity-optimized"),
 				Subnets: []*Subnet{
 					{
 						Name: fi.String("test-sg"),
@@ -299,6 +300,7 @@ resource "aws_autoscaling_group" "test1" {
     instances_distribution = {
       on_demand_base_capacity                  = 4
       on_demand_percentage_above_base_capacity = 30
+      spot_allocation_strategy                 = "capacity-optimized"
     }
   }
 


### PR DESCRIPTION
Cherry pick of #7406 on release-1.17.

#7406: Add CapacityOptimized to list of supported spot allocation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.