### PR TITLE
tests: increase timeout in rolling update tests

### DIFF
--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -540,7 +540,7 @@ func TestRollingUpdateFlappingValidation(t *testing.T) {
 
 	// This should only take a few milliseconds,
 	// but we have to pad to allow for random delays (e.g. GC)
-	// TODO: Replace with a virtual clock?	
+	// TODO: Replace with a virtual clock?
 	c.ValidationTimeout = 200 * time.Second
 	
 	c.ClusterValidator = &flappingClusterValidator{

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -542,7 +542,7 @@ func TestRollingUpdateFlappingValidation(t *testing.T) {
 	// but we have to pad to allow for random delays (e.g. GC)
 	// TODO: Replace with a virtual clock?
 	c.ValidationTimeout = 200 * time.Second
-	
+
 	c.ClusterValidator = &flappingClusterValidator{
 		T:     t,
 		Cloud: cloud,
@@ -586,7 +586,7 @@ func TestRollingUpdateValidatesAfterBastion(t *testing.T) {
 	c.ValidationTimeout = 1 * time.Second
 
 	c.ClusterValidator = &failThreeTimesClusterValidator{}
-	
+
 	err := c.RollingUpdate(getGroupsAllNeedUpdate(), cluster, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -541,7 +541,7 @@ func TestRollingUpdateFlappingValidation(t *testing.T) {
 	// This should only take a few milliseconds,
 	// but we have to pad to allow for random delays (e.g. GC)
 	// TODO: Replace with a virtual clock?
-	c.ValidationTimeout = 200 * time.Second
+	c.ValidationTimeout = 1 * time.Second
 
 	c.ClusterValidator = &flappingClusterValidator{
 		T:     t,

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -538,7 +538,11 @@ func (v *flappingClusterValidator) Validate() (*validation.ValidationCluster, er
 func TestRollingUpdateFlappingValidation(t *testing.T) {
 	c, cloud, cluster := getTestSetup()
 
-	c.ValidationTimeout = 20 * time.Millisecond
+	// This should only take a few milliseconds,
+	// but we have to pad to allow for random delays (e.g. GC)
+	// TODO: Replace with a virtual clock?	
+	c.ValidationTimeout = 200 * time.Second
+	
 	c.ClusterValidator = &flappingClusterValidator{
 		T:     t,
 		Cloud: cloud,
@@ -576,9 +580,13 @@ func (v *failThreeTimesClusterValidator) Validate() (*validation.ValidationClust
 func TestRollingUpdateValidatesAfterBastion(t *testing.T) {
 	c, cloud, cluster := getTestSetup()
 
-	c.ValidationTimeout = 10 * time.Millisecond
-	c.ClusterValidator = &failThreeTimesClusterValidator{}
+	// This should only take a few milliseconds,
+	// but we have to pad to allow for random delays (e.g. GC)
+	// TODO: Replace with a virtual clock?
+	c.ValidationTimeout = 1 * time.Second
 
+	c.ClusterValidator = &failThreeTimesClusterValidator{}
+	
 	err := c.RollingUpdate(getGroupsAllNeedUpdate(), cluster, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 


### PR DESCRIPTION
We never know when e.g. a GC is going to delay us, so we need a lot
more padding on these timeouts.