### PR TITLE
dnsprovider/pkg/dnsprovider - fix static check

### DIFF
--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53_test.go
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53_test.go
@@ -128,11 +128,6 @@ func getExampleRrs(zone dnsprovider.Zone) dnsprovider.ResourceRecordSet {
 	return rrsets.New("www11."+zone.Name(), []string{"10.10.10.10", "169.20.20.20"}, 180, rrstype.A)
 }
 
-func getInvalidRrs(zone dnsprovider.Zone) dnsprovider.ResourceRecordSet {
-	rrsets, _ := zone.ResourceRecordSets()
-	return rrsets.New("www12."+zone.Name(), []string{"rubbish", "rubbish"}, 180, rrstype.A)
-}
-
 func addRrsetOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets, rrset dnsprovider.ResourceRecordSet) {
 	err := rrsets.StartChangeset().Add(rrset).Apply()
 	if err != nil {

--- a/dnsprovider/pkg/dnsprovider/providers/coredns/coredns_test.go
+++ b/dnsprovider/pkg/dnsprovider/providers/coredns/coredns_test.go
@@ -108,20 +108,6 @@ func rrs(t *testing.T, zone dnsprovider.Zone) (r dnsprovider.ResourceRecordSets)
 	return rrsets
 }
 
-func listRrsOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets) []dnsprovider.ResourceRecordSet {
-	rrset, err := rrsets.List()
-	if err != nil {
-		t.Fatalf("Failed to list recordsets: %v", err)
-	} else {
-		if len(rrset) < 0 {
-			t.Fatalf("Record set length=%d, expected >=0", len(rrset))
-		} else {
-			t.Logf("Got %d recordsets: %v", len(rrset), rrset)
-		}
-	}
-	return rrset
-}
-
 func getRrOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets, name string) []dnsprovider.ResourceRecordSet {
 	rrsetList, err := rrsets.Get(name)
 	if err != nil {

--- a/dnsprovider/pkg/dnsprovider/providers/google/clouddns/clouddns_test.go
+++ b/dnsprovider/pkg/dnsprovider/providers/google/clouddns/clouddns_test.go
@@ -106,11 +106,6 @@ func getExampleRrs(zone dnsprovider.Zone) dnsprovider.ResourceRecordSet {
 	return rrsets.New("www11."+zone.Name(), []string{"10.10.10.10", "169.20.20.20"}, 180, rrstype.A)
 }
 
-func getInvalidRrs(zone dnsprovider.Zone) dnsprovider.ResourceRecordSet {
-	rrsets, _ := zone.ResourceRecordSets()
-	return rrsets.New("www12."+zone.Name(), []string{"rubbish", "rubbish"}, 180, rrstype.A)
-}
-
 func addRrsetOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets, rrset dnsprovider.ResourceRecordSet) {
 	err := rrsets.StartChangeset().Add(rrset).Apply()
 	if err != nil {

--- a/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/clouddns.go
+++ b/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/clouddns.go
@@ -25,11 +25,8 @@ package internal
 import dns "google.golang.org/api/dns/v1"
 
 type (
-	Project struct{ impl *dns.Project }
-
-	ProjectsGetCall struct{ impl *dns.ProjectsGetCall }
-
+	Project         struct{}
+	ProjectsGetCall struct{}
 	ProjectsService struct{ impl *dns.ProjectsService }
-
-	Quota struct{ impl *dns.Quota }
+	Quota           struct{}
 )

--- a/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/BUILD.bazel
+++ b/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
     deps = [
         "//dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/interfaces:go_default_library",
         "//dnsprovider/pkg/dnsprovider/rrstype:go_default_library",
-        "//vendor/google.golang.org/api/dns/v1:go_default_library",
         "//vendor/google.golang.org/api/googleapi:go_default_library",
     ],
 )

--- a/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/clouddns.go
+++ b/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/clouddns.go
@@ -22,12 +22,10 @@ package stubs
 // Only the parts of the API that we use are included.
 // Others can be added as needed.
 
-import dns "google.golang.org/api/dns/v1"
-
 type (
 	// TODO: We don't need these yet, so they remain unimplemented.  Add later as required.
-	Project         struct{ impl *dns.Project }
-	ProjectsGetCall struct{ impl *dns.ProjectsGetCall }
-	ProjectsService struct{ impl *dns.ProjectsService }
-	Quota           struct{ impl *dns.Quota }
+	Project         struct{}
+	ProjectsGetCall struct{}
+	ProjectsService struct{}
+	Quota           struct{}
 )

--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,10 +1,5 @@
 cloudmock/aws/mockelbv2
 cmd/kops
-dnsprovider/pkg/dnsprovider/providers/aws/route53
-dnsprovider/pkg/dnsprovider/providers/coredns
-dnsprovider/pkg/dnsprovider/providers/google/clouddns
-dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal
-dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs
 node-authorizer/pkg/authorizers/aws
 node-authorizer/pkg/server
 pkg/instancegroups


### PR DESCRIPTION
Ref: #7800

Errors from staticcheck:
```
dnsprovider/pkg/dnsprovider/providers/aws/route53/route53_test.go:131:6: func getInvalidRrs is unused (U1000)
dnsprovider/pkg/dnsprovider/providers/coredns/coredns_test.go:111:6: func listRrsOrFail is unused (U1000)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/clouddns_test.go:109:6: func getInvalidRrs is unused (U1000)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/clouddns.go:28:18: field impl is unused (U1000)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/clouddns.go:30:26: field impl is unused (U1000)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/clouddns.go:34:16: field impl is unused (U1000)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/clouddns.go:29:26: field impl is unused (U1000)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/clouddns.go:30:26: field impl is unused (U1000)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/clouddns.go:31:26: field impl is unused (U1000)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/clouddns.go:32:26: field impl is unused (U1000)
```