### PR TITLE
added kube api audit logs to logrotate when enabled

### DIFF
--- a/nodeup/pkg/model/logrotate.go
+++ b/nodeup/pkg/model/logrotate.go
@@ -71,6 +71,10 @@ func (b *LogrotateBuilder) Build(c *fi.ModelBuilderContext) error {
 	b.addLogRotate(c, "etcd", "/var/log/etcd.log", logRotateOptions{})
 	b.addLogRotate(c, "etcd-events", "/var/log/etcd-events.log", logRotateOptions{})
 
+	if *b.Cluster.Spec.KubeAPIServer.AuditLogPath != "" {
+		b.addLogRotate(c, "kube-audit", *b.Cluster.Spec.KubeAPIServer.AuditLogPath, logRotateOptions{})
+	}
+	
 	if err := b.addLogrotateService(c); err != nil {
 		return err
 	}

--- a/nodeup/pkg/model/logrotate.go
+++ b/nodeup/pkg/model/logrotate.go
@@ -71,7 +71,7 @@ func (b *LogrotateBuilder) Build(c *fi.ModelBuilderContext) error {
 	b.addLogRotate(c, "etcd", "/var/log/etcd.log", logRotateOptions{})
 	b.addLogRotate(c, "etcd-events", "/var/log/etcd-events.log", logRotateOptions{})
 
-	if *b.Cluster.Spec.KubeAPIServer.AuditLogPath != "" {
+	if b.Cluster.Spec.KubeAPIServer.AuditLogPath != nil {
 		b.addLogRotate(c, "kube-audit", *b.Cluster.Spec.KubeAPIServer.AuditLogPath, logRotateOptions{})
 	}
 	


### PR DESCRIPTION

This is just a tiny PR which adds the api server audit logs to logrotate when its enabled on the kops cluster spec.

