### PR TITLE
Always consider spot instance node readiness in cluster validation

### DIFF
--- a/pkg/validation/BUILD.bazel
+++ b/pkg/validation/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/kops:go_default_library",
-        "//pkg/apis/kops/util:go_default_library",
         "//pkg/cloudinstances:go_default_library",
         "//pkg/dns:go_default_library",
         "//upup/pkg/fi:go_default_library",

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/apis/kops"
-	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kops/pkg/dns"
 )
@@ -267,7 +266,7 @@ func (v *ValidationCluster) validateNodes(cloudGroups map[string]*cloudinstances
 				continue
 			}
 
-			role := util.GetNodeRole(node)
+			role := strings.ToLower(string(cloudGroup.InstanceGroup.Spec.Role))
 			if role == "" {
 				role = "node"
 			}
@@ -282,7 +281,6 @@ func (v *ValidationCluster) validateNodes(cloudGroups map[string]*cloudinstances
 
 			ready := isNodeReady(node)
 
-			// TODO: Use instance group role instead...
 			if n.Role == "master" {
 				if !ready {
 					v.addError(&ValidationError{


### PR DESCRIPTION
/kind bug

When performing cluster validation on a cluster with spot instance nodes (nodes annotated with `node-role.kubernetes.io/spot-worker: "true"`), kops will ignore the node readiness roughly 50% of the time, instead printing the message:

```
W1219 06:35:47.885028    1605 validate_cluster.go:291] ignoring node with role "spot-worker"
```

This means that cluster validation can randomly incorrectly succeed.

This change has cluster validation determine the node's role using the instancegroup spec, not an annotation chosen depending on the randomization of Go map ordering.

Fixes #5038
