### PR TITLE
Expose etcd metrics.

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -130,6 +130,24 @@ etcdClusters:
   memoryRequest: 512Mi
 ```
 
+### etcd v3 and metrics
+
+You cam expose /metrics endpoint for `main` and `event` etcd instances and control their type (`basic` or `extensive`) by defining env vars:
+
+```yaml
+etcdClusters:
+- etcdMembers:
+  - instanceGroup: master-us-east-1a
+    name: a
+  name: main
+  manager:
+    env:
+    - name: ETCD_LISTEN_METRICS_URLS
+      value: http://__address__:8081
+    - name: ETCD_METRICS
+      value: basic
+```
+
 ### sshAccess
 
 This array configures the CIDRs that are able to ssh into nodes. On AWS this is manifested as inbound security group rules on the `nodes` and `master` security groups.
@@ -258,7 +276,7 @@ spec:
 
 By enabling this feature you are allowing for auditsinks to be registered with the API server.  For information on audit sinks please read [Audit Sink](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#auditsink-v1alpha1-auditregistration).  This feature is only supported in kubernetes versions greater than 1.13.  Currently, this feature is alpha and requires enabling the feature gate and a runtime config.
 
-**Note** For kubernetes versions greater than 1.13, this is an alpha feature that requires the API auditregistration.k8s.io/v1alpha1 to be enabled as a runtime-config option, and the feature gate DynamicAuditing to be also enabled.  The options --feature-gates=DynamicAuditing=true and --runtime-config=auditregistration.k8s.io/v1alpha1=true must be enabled on the API server in addition to this flag.  See the sections for how to enable feature gates [here](https://github.com/kubernetes/kops/blob/master/docs/cluster_spec.md#feature-gates).  See the section on how to enable alphas APIs in the runtime config [here](https://github.com/kubernetes/kops/blob/master/docs/cluster_spec.md#runtimeconfig).  
+**Note** For kubernetes versions greater than 1.13, this is an alpha feature that requires the API auditregistration.k8s.io/v1alpha1 to be enabled as a runtime-config option, and the feature gate DynamicAuditing to be also enabled.  The options --feature-gates=DynamicAuditing=true and --runtime-config=auditregistration.k8s.io/v1alpha1=true must be enabled on the API server in addition to this flag.  See the sections for how to enable feature gates [here](https://github.com/kubernetes/kops/blob/master/docs/cluster_spec.md#feature-gates).  See the section on how to enable alphas APIs in the runtime config [here](https://github.com/kubernetes/kops/blob/master/docs/cluster_spec.md#runtimeconfig).
 Also, an audit policy should be provided in the file assets section.  If the flag is omitted, no events are logged.
 You could use the [fileAssets](https://github.com/kubernetes/kops/blob/master/docs/cluster_spec.md#fileassets)  feature to push an advanced audit policy file on the master nodes.
 
@@ -760,7 +778,7 @@ It is possible to override the [containerd](https://github.com/containerd/contai
 ```yaml
 spec:
   containerd:
-    version: 1.3.3   
+    version: 1.3.3
     logLevel: info
     configOverride: ""
 ```
@@ -792,7 +810,7 @@ If you want nodeup to skip the Docker installation tasks, you can do so with:
 spec:
   docker:
     skipInstall: true
-``` 
+```
 
 **NOTE:** When this field is set to `true`, it is entirely up to the user to install and configure Docker.
 


### PR DESCRIPTION
After moving to etcdmanager I've noticed I lost an ability to fetch etcd metrics (by datadog agent).

Raising a question [here](https://github.com/kopeio/etcd-manager/issues/286) lead me to successfully expose the endpoint on master nodes (by manually editing etcd static pod manifests) and being able again to fetch them.

This is an approach to make kops expose the endpoint by default.