### PR TITLE
Run dns-controller and kops-controller as non-root user

### DIFF
--- a/cmd/kops-controller/BUILD.bazel
+++ b/cmd/kops-controller/BUILD.bazel
@@ -41,6 +41,7 @@ container_image(
     name = "image",
     base = "@distroless_base//image",
     cmd = ["/usr/bin/kops-controller"],
+    user = "1000",
     directory = "/usr/bin/",
     files = [
         "//cmd/kops-controller",

--- a/dns-controller/cmd/dns-controller/BUILD.bazel
+++ b/dns-controller/cmd/dns-controller/BUILD.bazel
@@ -47,6 +47,7 @@ container_image(
     name = "image",
     base = "@distroless_base//image",
     cmd = ["/usr/bin/dns-controller"],
+    user = "1000",
     directory = "/usr/bin/",
     files = [
         "dns-controller",

--- a/images/dns-controller/Dockerfile
+++ b/images/dns-controller/Dockerfile
@@ -21,4 +21,6 @@ RUN apt-get update && apt-get install --yes ca-certificates \
 
 COPY /.build/artifacts/dns-controller /usr/bin/dns-controller
 
+USER 1000
+
 CMD /usr/bin/dns-controller


### PR DESCRIPTION
They do not need root privileges, so should not be given them.
