### PR TITLE
containerd: Use containerd 1.2.4 with Docker 18.09.3

### DIFF
--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -38,6 +38,18 @@ type ContainerdBuilder struct {
 var _ fi.ModelBuilder = &ContainerdBuilder{}
 
 var containerdVersions = []packageVersion{
+	// 1.2.4 - Debian Stretch
+	{
+		PackageVersion: "1.2.4",
+		Name:           "containerd.io",
+		Distros:        []distros.Distribution{distros.DistributionDebian9},
+		Architectures:  []Architecture{ArchitectureAmd64},
+		Version:        "1.2.4-1",
+		Source:         "https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/containerd.io_1.2.4-1_amd64.deb",
+		Hash:           "48c6ab0c908316af9a183de5aad64703bc516bdf",
+		Dependencies:   []string{"libseccomp2", "pigz"},
+	},
+
 	// 1.2.10 - Debian Stretch
 	{
 		PackageVersion: "1.2.10",
@@ -117,11 +129,9 @@ var containerdVersions = []packageVersion{
 		Dependencies:   []string{"container-selinux", "libseccomp", "pigz"},
 	},
 
-	// TIP: When adding the next version, copy the previous
-	// version, string replace the version, run `VERIFY_HASHES=1
-	// go test ./nodeup/pkg/model` (you might want to temporarily
-	// comment out older versions on a slower connection), and
-	// then validate the dependencies etc
+	// TIP: When adding the next version, copy the previous version, string replace the version and run:
+	//   VERIFY_HASHES=1 go test ./nodeup/pkg/model -run TestContainerdPackageHashes
+	// (you might want to temporarily comment out older versions on a slower connection and then validate)
 }
 
 func (b *ContainerdBuilder) containerdVersion() (string, error) {

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -963,11 +963,9 @@ var dockerVersions = []packageVersion{
 		Dependencies: []string{"libtool-ltdl", "iptables"},
 	},
 
-	// TIP: When adding the next version, copy the previous
-	// version, string replace the version, run `VERIFY_HASHES=1
-	// go test ./nodeup/pkg/model` (you might want to temporarily
-	// comment out older versions on a slower connection), and
-	// then validate the dependencies etc
+	// TIP: When adding the next version, copy the previous version, string replace the version and run:
+	//   VERIFY_HASHES=1 go test ./nodeup/pkg/model -run TestDockerPackageHashes
+	// (you might want to temporarily comment out older versions on a slower connection and then validate)
 }
 
 func (b *DockerBuilder) dockerVersion() string {

--- a/pkg/model/components/containerd_test.go
+++ b/pkg/model/components/containerd_test.go
@@ -60,8 +60,36 @@ func Test_Build_Containerd_Unsupported_Version(t *testing.T) {
 	}
 }
 
-func Test_Build_Containerd_Supported_Version(t *testing.T) {
+func Test_Build_Containerd_Untested_Version(t *testing.T) {
 	kubernetesVersions := []string{"1.11.0", "1.11.2", "1.14.0", "1.16.3"}
+
+	for _, v := range kubernetesVersions {
+
+		c := buildContainerdCluster(v)
+		c.Spec.ContainerRuntime = "containerd"
+		b := assets.NewAssetBuilder(c, "")
+
+		version, err := util.ParseKubernetesVersion(v)
+		if err != nil {
+			t.Fatalf("unexpected error from ParseKubernetesVersion %s: %v", v, err)
+		}
+
+		ob := &ContainerdOptionsBuilder{
+			&OptionsContext{
+				AssetBuilder:      b,
+				KubernetesVersion: *version,
+			},
+		}
+
+		err = ob.BuildOptions(&c.Spec)
+		if err == nil {
+			t.Fatalf("expecting error when Kubernetes version >= 1.11 and < 1.18: %s", v)
+		}
+	}
+}
+
+func Test_Build_Containerd_Supported_Version(t *testing.T) {
+	kubernetesVersions := []string{"1.18.0", "1.18.3"}
 
 	for _, v := range kubernetesVersions {
 

--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
@@ -135,9 +135,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false
@@ -430,9 +427,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -144,9 +144,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false
@@ -459,9 +456,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false

--- a/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
@@ -135,9 +135,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscomplexexampleco
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false
@@ -432,9 +429,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodescomplexexamplecom.Properties.Use
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false

--- a/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
@@ -139,16 +139,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscontainerdexampl
     logLevel: warn
     version: 1.2.10
   docker:
-    ipMasq: false
-    ipTables: false
-    logDriver: json-file
-    logLevel: warn
-    logOpt:
-    - max-size=10m
-    - max-file=5
     skipInstall: true
-    storage: overlay2,overlay,aufs
-    version: 18.06.3
   encryptionConfig: null
   etcdClusters:
     events:
@@ -434,16 +425,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodescontainerdexamplecom.Properties.
     logLevel: warn
     version: 1.2.10
   docker:
-    ipMasq: false
-    ipTables: false
-    logDriver: json-file
-    logLevel: warn
-    logOpt:
-    - max-size=10m
-    - max-file=5
     skipInstall: true
-    storage: overlay2,overlay,aufs
-    version: 18.06.3
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m

--- a/tests/integration/update_cluster/containerd-cloudformation/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/containerd-cloudformation/in-v1alpha2.yaml
@@ -10,6 +10,8 @@ spec:
   cloudProvider: aws
   configBase: memfs://clusters.example.com/containerd.example.com
   containerRuntime: containerd
+  containerd:
+    version: 1.2.10
   etcdClusters:
   - etcdMembers:
     - instanceGroup: master-us-test-1a

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -135,9 +135,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false
@@ -430,9 +427,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -135,9 +135,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false
@@ -430,9 +427,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -135,9 +135,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false
@@ -430,9 +427,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
@@ -135,9 +135,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false
@@ -432,9 +429,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false
@@ -729,9 +723,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false
@@ -1026,9 +1017,6 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
@@ -135,9 +135,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false
@@ -432,9 +429,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false
@@ -729,9 +723,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false
@@ -1026,9 +1017,6 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
@@ -135,9 +135,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersprivatecalicoexa
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false
@@ -428,9 +425,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesprivatecalicoexamplecom.Properti
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: warn
     skipInstall: true
   docker:
     ipMasq: false


### PR DESCRIPTION
This PR is related to #7986:
1. adds the `containerd-1.2.4` package for a previously released Docker version
2. sets the default version only for Kubernetes versions >= 1.18
3. warns that Kubernetes versions >= 1.11 and < 1.18 are untested
4. exits with error when Kubernetes versions < 1.11 