### PR TITLE
Update kubernetes versions used in integration tests

### DIFF
--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -27,9 +27,11 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.7.1
+  kubernetesVersion: v1.15.6
   masterPublicName: api.complex.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -58,7 +60,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -78,7 +80,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/complex/options.yaml
+++ b/tests/integration/create_cluster/complex/options.yaml
@@ -2,7 +2,7 @@ ClusterName: complex.example.com
 Zones:
 - us-test-1a
 Cloud: aws
-KubernetesVersion: v1.7.1
+KubernetesVersion: v1.15.6
 # We specify SSHAccess but _not_ AdminAccess
 SSHAccess:
 - 1.2.3.4/32

--- a/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha1.yaml
@@ -37,7 +37,9 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
-  kubernetesVersion: v1.6.0-alpha.3
+  kubelet:
+    anonymousAuth: false
+  kubernetesVersion: v1.15.0-alpha.3
   masterPublicName: api.ha.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -66,7 +68,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -86,7 +88,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -106,7 +108,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1c
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -126,7 +128,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -35,9 +35,11 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.6.0-alpha.3
+  kubernetesVersion: v1.15.0-alpha.3
   masterPublicName: api.ha.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -74,7 +76,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -94,7 +96,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -114,7 +116,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1c
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -134,7 +136,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/ha/options.yaml
+++ b/tests/integration/create_cluster/ha/options.yaml
@@ -8,4 +8,4 @@ MasterZones:
 - us-test-1b
 - us-test-1c
 Cloud: aws
-KubernetesVersion: v1.6.0-alpha.3
+KubernetesVersion: v1.15.0-alpha.3

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha1.yaml
@@ -43,7 +43,9 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
-  kubernetesVersion: v1.6.0-alpha.3
+  kubelet:
+    anonymousAuth: false
+  kubernetesVersion: v1.15.0-alpha.3
   masterPublicName: api.ha.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -72,7 +74,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -92,7 +94,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -112,7 +114,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1c
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -132,7 +134,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -41,9 +41,11 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.6.0-alpha.3
+  kubernetesVersion: v1.15.0-alpha.3
   masterPublicName: api.ha.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -80,7 +82,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -100,7 +102,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -120,7 +122,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1c
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -140,7 +142,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/ha_encrypt/options.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/options.yaml
@@ -8,5 +8,5 @@ MasterZones:
 - us-test-1b
 - us-test-1c
 Cloud: aws
-KubernetesVersion: v1.6.0-alpha.3
+KubernetesVersion: v1.15.0-alpha.3
 EncryptEtcdStorage: true

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -35,9 +35,11 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.8.0-beta.1
+  kubernetesVersion: v1.15.6-beta.1
   masterPublicName: api.ha-gce.example.com
   networking:
     kubenet: {}

--- a/tests/integration/create_cluster/ha_gce/options.yaml
+++ b/tests/integration/create_cluster/ha_gce/options.yaml
@@ -8,5 +8,5 @@ MasterZones:
 - us-test1-b
 - us-test1-c
 Cloud: gce
-KubernetesVersion: v1.8.0-beta.1
+KubernetesVersion: v1.15.6-beta.1
 Project: testproject

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -43,9 +43,11 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.4.8
+  kubernetesVersion: v1.15.6
   masterPublicName: api.ha.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -78,7 +80,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a-1
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -98,7 +100,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a-2
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -118,7 +120,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a-3
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -138,7 +140,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b-1
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -158,7 +160,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b-2
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -178,7 +180,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/ha_shared_zones/options.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/options.yaml
@@ -4,4 +4,4 @@ Zones:
 - us-test-1b
 MasterCount: 5
 Cloud: aws
-KubernetesVersion: v1.4.8
+KubernetesVersion: v1.15.6

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha1.yaml
@@ -30,7 +30,9 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
-  kubernetesVersion: v1.4.8
+  kubelet:
+    anonymousAuth: false
+  kubernetesVersion: v1.15.6
   masterPublicName: api.private.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -60,7 +62,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -80,7 +82,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -100,7 +102,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -28,9 +28,11 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.4.8
+  kubernetesVersion: v1.15.6
   masterPublicName: api.private.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -66,7 +68,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -86,7 +88,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -106,7 +108,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/ingwspecified/options.yaml
+++ b/tests/integration/create_cluster/ingwspecified/options.yaml
@@ -6,4 +6,4 @@ Topology: private
 Networking: kopeio-vxlan
 Bastion: true
 Egress: i-09123456
-KubernetesVersion: v1.4.8
+KubernetesVersion: v1.15.6

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha1.yaml
@@ -30,7 +30,9 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
-  kubernetesVersion: v1.4.8
+  kubelet:
+    anonymousAuth: false
+  kubernetesVersion: v1.15.6
   masterPublicName: api.private.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -60,7 +62,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -80,7 +82,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -100,7 +102,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -28,9 +28,11 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.4.8
+  kubernetesVersion: v1.15.6
   masterPublicName: api.private.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -66,7 +68,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -86,7 +88,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -106,7 +108,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/ngwspecified/options.yaml
+++ b/tests/integration/create_cluster/ngwspecified/options.yaml
@@ -6,4 +6,4 @@ Topology: private
 Networking: kopeio-vxlan
 Bastion: true
 Egress: nat-09123456
-KubernetesVersion: v1.4.8
+KubernetesVersion: v1.15.6

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -27,9 +27,11 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.7.5
+  kubernetesVersion: v1.15.6
   masterPublicName: api.overrides.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -61,7 +63,7 @@ metadata:
     kops.k8s.io/cluster: overrides.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -81,7 +83,7 @@ metadata:
     kops.k8s.io/cluster: overrides.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2018-08-17
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/overrides/options.yaml
+++ b/tests/integration/create_cluster/overrides/options.yaml
@@ -2,7 +2,7 @@ ClusterName: overrides.example.com
 Zones:
 - us-test-1a
 Cloud: aws
-KubernetesVersion: v1.7.5
+KubernetesVersion: v1.15.6
 Overrides:
 - cluster.spec.nodePortAccess=1.2.3.4/32
 - cluster.spec.nodePortAccess=10.20.30.0/24

--- a/tests/integration/create_cluster/private/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha1.yaml
@@ -34,7 +34,9 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
-  kubernetesVersion: v1.4.8
+  kubelet:
+    anonymousAuth: false
+  kubernetesVersion: v1.15.6
   masterPublicName: api.private.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -63,7 +65,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -86,7 +88,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid3
   - sg-exampleid4
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -109,7 +111,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid
   - sg-exampleid2
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -32,9 +32,11 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.4.8
+  kubernetesVersion: v1.15.6
   masterPublicName: api.private.example.com
   networkCIDR: 172.20.0.0/16
   networking:
@@ -69,7 +71,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -92,7 +94,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid3
   - sg-exampleid4
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -115,7 +117,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid
   - sg-exampleid2
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/private/options.yaml
+++ b/tests/integration/create_cluster/private/options.yaml
@@ -11,5 +11,5 @@ NodeSecurityGroups:
 MasterSecurityGroups:
 - sg-exampleid3
 - sg-exampleid4
-KubernetesVersion: v1.4.8
+KubernetesVersion: v1.15.6
 cloudLabels: "Owner=John Doe,dn=\"cn=John Doe: dc=example dc=com\", foo/bar=fib+baz"

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -28,9 +28,11 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.4.8
+  kubernetesVersion: v1.15.6
   masterPublicName: api.private-subnets.example.com
   networkCIDR: 10.0.0.0/12
   networkID: vpc-12345678
@@ -66,7 +68,7 @@ metadata:
     kops.k8s.io/cluster: private-subnets.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -86,7 +88,7 @@ metadata:
     kops.k8s.io/cluster: private-subnets.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/private_shared_subnets/options.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/options.yaml
@@ -9,4 +9,4 @@ SubnetIDs:
 - subnet-1
 UtilitySubnetIDs:
 - subnet-2
-KubernetesVersion: v1.4.8
+KubernetesVersion: v1.15.6

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha1.yaml
@@ -29,7 +29,9 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
-  kubernetesVersion: v1.4.8
+  kubelet:
+    anonymousAuth: false
+  kubernetesVersion: v1.15.6
   masterPublicName: api.subnet.example.com
   networkCIDR: 10.0.0.0/12
   networkID: vpc-12345678
@@ -56,7 +58,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -76,7 +78,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
@@ -27,9 +27,11 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.4.8
+  kubernetesVersion: v1.15.6
   masterPublicName: api.subnet.example.com
   networkCIDR: 10.0.0.0/12
   networkID: vpc-12345678
@@ -60,7 +62,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -80,7 +82,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/shared_subnets/options.yaml
+++ b/tests/integration/create_cluster/shared_subnets/options.yaml
@@ -5,4 +5,4 @@ Cloud: aws
 VPCID: vpc-12345678
 SubnetIDs:
 - subnet-1
-KubernetesVersion: v1.4.8
+KubernetesVersion: v1.15.6

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha1.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha1.yaml
@@ -29,7 +29,9 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
-  kubernetesVersion: v1.4.8
+  kubelet:
+    anonymousAuth: false
+  kubernetesVersion: v1.15.6
   masterPublicName: api.subnet.example.com
   networkCIDR: 10.0.0.0/12
   networkID: vpc-12345678
@@ -56,7 +58,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -76,7 +78,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
@@ -27,9 +27,11 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.4.8
+  kubernetesVersion: v1.15.6
   masterPublicName: api.subnet.example.com
   networkCIDR: 10.0.0.0/12
   networkID: vpc-12345678
@@ -60,7 +62,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -80,7 +82,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: nodes
 spec:
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
   maxSize: 2
   minSize: 2

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/options.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/options.yaml
@@ -4,4 +4,4 @@ Zones:
 Cloud: aws
 SubnetIDs:
 - subnet-1
-KubernetesVersion: v1.4.8
+KubernetesVersion: v1.15.6


### PR DESCRIPTION
In preparation for deprecating support for older Kubernetes versions, this updates our integration tests to use supported versions.

The only fields that change in the output are `kubernetesVersion`, `image`, and `kubelet.anonymousAuth`