### PR TITLE
Add deprecation warning for older k8s versions

### DIFF
--- a/permalinks/upgrade_k8s.md
+++ b/permalinks/upgrade_k8s.md
@@ -1,5 +1,11 @@
 # Kubernetes Upgrade Recommended
 
+Kops has established a deprecation policy for Kubernetes version support.
+Kops 1.18 will drop support for Kubernetes 1.8 and below.
+
+
 You are running a version of kubernetes that we recommend upgrading.
 
 Please see the [instructions for how to upgrade kubernetes](https://kops.sigs.k8s.io/operations/updates_and_upgrades/#upgrading-kubernetes)
+
+Please see the deprecation policy [GitHub issue](https://github.com/kubernetes/kops/issues/7999) for more information and to leave feedback.

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -91,6 +91,8 @@ var (
 	AlphaAllowALI = featureflag.New("AlphaAllowALI", featureflag.Bool(false))
 	// CloudupModels a list of supported models
 	CloudupModels = []string{"proto", "cloudup"}
+	// OldestSupportedKubernetesVersion is the oldest kubernetes version that is supported in Kops
+	OldestSupportedKubernetesVersion = "1.9.0"
 )
 
 type ApplyClusterCmd struct {
@@ -1042,6 +1044,20 @@ func (c *ApplyClusterCmd) validateKubernetesVersion() error {
 		klog.Warningf("unable to parse kubernetes version %q", c.Cluster.Spec.KubernetesVersion)
 		// Not a hard-error
 		return nil
+	}
+
+	if !util.IsKubernetesGTE(OldestSupportedKubernetesVersion, *parsed) {
+		fmt.Printf("\n")
+		fmt.Printf(starline)
+		fmt.Printf("\n")
+		fmt.Printf("Kops support for this Kubernetes version is deprecated and will be removed in a future release.\n")
+		fmt.Printf("\n")
+		fmt.Printf("Upgrading is recommended\n")
+		fmt.Printf("More information: %s\n", buildPermalink("upgrade_kops", ""))
+		fmt.Printf("\n")
+		fmt.Printf(starline)
+		fmt.Printf("\n")
+
 	}
 
 	// TODO: make util.ParseKubernetesVersion not return a pointer


### PR DESCRIPTION
As discussed during yesterday's office hours.

This should be cherry-picked back to 1.16.

We'll need to bump the minor version in the 1.17 and master branches. Once we officially drop support we could make this a sliding window that uses the `kops.Version` variable.

I think we could have deprecation warnings for the 2 oldest versions still supported by the kops version, announcing that the n+2 Kops version will no longer support the specified k8s version.