### PR TITLE
Fix verify-staticcheck prow job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -553,7 +553,7 @@ verify-bazel:
 	hack/verify-bazel.sh
 
 .PHONY: verify-staticcheck
-verify-staticcheck:
+verify-staticcheck: ${BINDATA_TARGETS}
 	hack/verify-staticcheck.sh
 
 # ci target is for developers, it aims to cover all the CI jobs

--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,12 +1,10 @@
 cloudmock/aws/mockelbv2
 cmd/kops
-dnsprovider/pkg/dnsprovider
 dnsprovider/pkg/dnsprovider/providers/aws/route53
 dnsprovider/pkg/dnsprovider/providers/coredns
 dnsprovider/pkg/dnsprovider/providers/google/clouddns
 dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal
 dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs
-dnsprovider/pkg/dnsprovider/providers/openstack/designate
 node-authorizer/pkg/authorizers/aws
 node-authorizer/pkg/server
 pkg/instancegroups

--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -66,6 +66,8 @@ go install k8s.io/kops/vendor/honnef.co/go/tools/cmd/staticcheck
 
 cd "${KUBE_ROOT}"
 
+make upup/models/bindata.go
+
 # Check that the file is in alphabetical order
 failure_file="${KUBE_ROOT}/hack/.staticcheck_failures"
 if ! diff -u "${failure_file}" <(LC_ALL=C sort "${failure_file}"); then


### PR DESCRIPTION
The new job was missing the generated files from go-bindata. I tested this locally on a clean checkout.

I noticed some of the prow jobs use make and others call hack/ scripts directly.

I think it'd be better to use make so we can more easily add dependencies like this, therefor I'd like to propose that we merge this, update the job to call `make verify-staticcheck` then remove the make command from hack/verify-staticcheck.sh

By fixing the existing job as well as the make target, we can unblock other PRs and not get another swarm of failure notifications when the job gets updated to use make.