### PR TITLE
Disable check for adding etcd members to the cluster

### DIFF
--- a/docs/single-to-multi-master.md
+++ b/docs/single-to-multi-master.md
@@ -196,6 +196,8 @@ etcdClusters:
     name: events
 ```
 
+If you are running etcd-manager (kops version >= 0.12), skip to step 5.
+
 ## 3 - Add a new master
 
 ### a - Add a new member to the etcd clusters
@@ -346,8 +348,22 @@ fully configured by Kops and that there is no residual manual configuration.
 If there is any configuration problem, they will be detected during this step
 and not during a future upgrade or, worse, during a master failure.
 
+## 6 - Test operation (optional)
 
-## 6 - Restore (if migration to multi-master failed)
+If you want to set and retrieve a key in etcd, connect to a master node and put a key. Connect to a different master node and retrieve the key. 
+
+```
+export ETCDCTL_CERT=/etc/kubernetes/pki/kube-apiserver/etcd-client.crt
+export ETCDCTL_CACERT=/etc/kubernetes/pki/kube-apiserver/etcd-ca.crt
+export ETCDCTL_API=3
+export ETCDCTL_KEY=/etc/kubernetes/pki/kube-apiserver/etcd-client.key
+export ETCDCTL_ENDPOINTS=https://127.0.0.1:4001
+sudo  -E etcdctl --debug  put foo bar
+sudo  -E etcdctl --debug  get foo
+```
+
+
+## 7 - Restore (if migration to multi-master failed)
 
 In case you failed to upgrade to multi-master you will need to restore from the backup you have taken previously.
 

--- a/pkg/apis/kops/validation/cluster.go
+++ b/pkg/apis/kops/validation/cluster.go
@@ -92,9 +92,7 @@ func validateEtcdClusterUpdate(fp *field.Path, obj *kops.EtcdClusterSpec, status
 			fp := fp.Child("Members").Key(k)
 
 			oldMember := oldMembers[k]
-			if oldMember == nil {
-				allErrs = append(allErrs, field.Forbidden(fp, "EtcdCluster members cannot be added"))
-			} else {
+			if oldMember != nil {
 				allErrs = append(allErrs, validateEtcdMemberUpdate(fp, newMember, etcdClusterStatus, oldMember)...)
 			}
 		}


### PR DESCRIPTION
Currently the cluster validation will disallow adding etcd members. (See #8091) IMHO Since etcd-manager supports adding members to the cluster, the check is not needed any more.

I've tested to go from a one master cluster to a three master cluster and it worked. It is probably still a risky operation. 

Added a section in the docs to test for a read/write into etcd to see if it works as expected. Are there other health checks that I could document to see if the etcd cluster started successfully? 

Or should this be gated with a feature flag?