### PR TITLE
pkg/instancegroups - fix static check

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -7,7 +7,6 @@ dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal
 dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs
 node-authorizer/pkg/authorizers/aws
 node-authorizer/pkg/server
-pkg/instancegroups
 pkg/resources/ali
 pkg/resources/aws
 pkg/resources/digitalocean

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -230,14 +230,15 @@ func (r *RollingUpdateInstanceGroup) validateClusterWithDuration(rollingUpdateDa
 	}
 
 	timeout := time.After(duration)
-	tick := time.Tick(rollingUpdateData.ValidateTickDuration)
+	ticker := time.NewTicker(rollingUpdateData.ValidateTickDuration)
+	defer ticker.Stop()
 	// Keep trying until we're timed out or got a result or got an error
 	for {
 		select {
 		case <-timeout:
 			// Got a timeout fail with a timeout error
 			return fmt.Errorf("cluster did not validate within a duration of %q", duration)
-		case <-tick:
+		case <-ticker.C:
 			// Got a tick, validate cluster
 			if r.tryValidateCluster(rollingUpdateData, duration, rollingUpdateData.ValidateTickDuration) {
 				return nil


### PR DESCRIPTION
Ref: #7800

Error from staticcheck:

```
pkg/instancegroups/instancegroups.go:233:19: using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here (SA1015)
```