### PR TITLE
Remove make command from verify-staticcheck.sh

### DIFF
--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -66,8 +66,6 @@ go install k8s.io/kops/vendor/honnef.co/go/tools/cmd/staticcheck
 
 cd "${KUBE_ROOT}"
 
-make upup/models/bindata.go
-
 # Check that the file is in alphabetical order
 failure_file="${KUBE_ROOT}/hack/.staticcheck_failures"
 if ! diff -u "${failure_file}" <(LC_ALL=C sort "${failure_file}"); then


### PR DESCRIPTION
Followup to https://github.com/kubernetes/kops/pull/8182 and https://github.com/kubernetes/test-infra/pull/15674

This script should now be called using `make verify-staticcheck` which will handle the go-bindata dependency.

Also using this PR to verify the changed prow jobs from the test-infra PR above.