### PR TITLE
Update links printed by Kops to use new docs site

### DIFF
--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -368,7 +368,7 @@ func RunUpdateCluster(f *util.Factory, clusterName string, out io.Writer, c *Upd
 				}
 			}
 			fmt.Fprintf(sb, " * the admin user is specific to Debian. If not using Debian please use the appropriate user based on your OS.\n")
-			fmt.Fprintf(sb, " * read about installing addons at: https://github.com/kubernetes/kops/blob/master/docs/operations/addons.md.\n")
+			fmt.Fprintf(sb, " * read about installing addons at: https://kops.sigs.k8s.io/operations/addons.\n")
 			fmt.Fprintf(sb, "\n")
 		}
 

--- a/cmd/kops/util/factory.go
+++ b/cmd/kops/util/factory.go
@@ -54,7 +54,7 @@ func NewFactory(options *FactoryOptions) *Factory {
 const (
 	STATE_ERROR = `Please set the --state flag or export KOPS_STATE_STORE.
 For example, a valid value follows the format s3://<bucket>.
-You can find the supported stores in https://github.com/kubernetes/kops/blob/master/docs/state.md.`
+You can find the supported stores in https://kops.sigs.k8s.io/state.`
 
 	INVALID_STATE_ERROR = `Unable to read state store.
 Please use a valid state store when setting --state or KOPS_STATE_STORE env var.

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -302,7 +302,7 @@ func (c *ApplyClusterCmd) Run() error {
 			fmt.Println("Kubelet anonymousAuth is currently turned on. This allows RBAC escalation and remote code execution possibilities.")
 			fmt.Println("It is highly recommended you turn it off by setting 'spec.kubelet.anonymousAuth' to 'false' via 'kops edit cluster'")
 			fmt.Println("")
-			fmt.Println("See https://github.com/kubernetes/kops/blob/master/docs/security.md#kubelet-api")
+			fmt.Println("See https://kops.sigs.k8s.io/security/#kubelet-api")
 			fmt.Println("")
 			fmt.Printf(starline)
 			fmt.Println("")


### PR DESCRIPTION
This updates all references to `https://github.com/kubernetes/kops/blob/master/docs` in the source code to instead use the new docs site.