### PR TITLE
fix staticcheck failures in pkg/resources

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -7,11 +7,9 @@ dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal
 dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs
 node-authorizer/pkg/authorizers/aws
 node-authorizer/pkg/server
-pkg/resources/ali
 pkg/resources/digitalocean
 pkg/resources/digitalocean/dns
 pkg/resources/openstack
-pkg/sshcredentials
 upup/pkg/fi
 upup/pkg/fi/cloudup
 upup/pkg/fi/cloudup/awstasks

--- a/pkg/resources/ali/ali.go
+++ b/pkg/resources/ali/ali.go
@@ -59,9 +59,6 @@ type clusterDiscoveryALI struct {
 }
 
 func ListResourcesALI(aliCloud aliup.ALICloud, clusterName string, region string) (map[string]*resources.Resource, error) {
-	if region == "" {
-		region = aliCloud.Region()
-	}
 
 	resources := make(map[string]*resources.Resource)
 
@@ -412,8 +409,6 @@ func (d *clusterDiscoveryALI) ListRam() ([]*resources.Resource, error) {
 		"bastions-" + clusterName,
 	}
 
-	roleToDelete := []string{}
-
 	response, err := d.aliCloud.RamClient().ListRoles()
 	if err != nil {
 		return nil, fmt.Errorf("err listing RamRole:%v", err)
@@ -424,7 +419,6 @@ func (d *clusterDiscoveryALI) ListRam() ([]*resources.Resource, error) {
 		for _, role := range response.Roles.Role {
 			for _, roleName := range names {
 				if role.RoleName == roleName {
-					roleToDelete = append(roleToDelete, role.RoleId)
 					resourceTracker := &resources.Resource{
 						Name:    role.RoleName,
 						ID:      role.RoleId,

--- a/pkg/sshcredentials/BUILD.bazel
+++ b/pkg/sshcredentials/BUILD.bazel
@@ -5,8 +5,5 @@ go_library(
     srcs = ["fingerprint.go"],
     importpath = "k8s.io/kops/pkg/sshcredentials",
     visibility = ["//visibility:public"],
-    deps = [
-        "//vendor/golang.org/x/crypto/ssh:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
-    ],
+    deps = ["//vendor/golang.org/x/crypto/ssh:go_default_library"],
 )

--- a/pkg/sshcredentials/fingerprint.go
+++ b/pkg/sshcredentials/fingerprint.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"golang.org/x/crypto/ssh"
-	"k8s.io/klog"
 )
 
 func Fingerprint(pubkey string) (string, error) {
@@ -50,29 +49,6 @@ func formatFingerprint(data []byte) string {
 			buf.WriteString(":")
 		}
 		buf.WriteString(s)
-	}
-	return buf.String()
-}
-
-func insertFingerprintColons(id string) string {
-	remaining := id
-
-	var buf bytes.Buffer
-	for {
-		if remaining == "" {
-			break
-		}
-		if buf.Len() != 0 {
-			buf.WriteString(":")
-		}
-		if len(remaining) < 2 {
-			klog.Warningf("unexpected format for SSH public key id: %q", id)
-			buf.WriteString(remaining)
-			break
-		} else {
-			buf.WriteString(remaining[0:2])
-			remaining = remaining[2:]
-		}
 	}
 	return buf.String()
 }


### PR DESCRIPTION
ref:#7800
Special notes:
pkg/resources/ali/ali.go:63:3: this value of region is never used (SA4006)
pkg/resources/ali/ali.go:427:27: this result of append is never used, except maybe in other appends (SA4010)
pkg/sshcredentials/fingerprint.go:57:6: func insertFingerprintColons is unused (U1000)
pkg/sshcredentials/fingerprint.go:25:2: imported and not used: "k8s.io/klog"
pkg/resources/ali/ali.go:427:13: append(roleToDelete, role.RoleId) evaluated but not used
pkg/resources/ali/ali.go:415:2: roleToDelete declared and not used