### PR TITLE
upup/pkg/fi-fix staticcheck

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,5 +1,2 @@
 node-authorizer/pkg/server
-upup/pkg/fi
-upup/pkg/fi/cloudup
-upup/pkg/fi/cloudup/awstasks
 upup/pkg/kutil

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -299,14 +299,14 @@ func (c *ApplyClusterCmd) Run() error {
 
 		if warn {
 			fmt.Println("")
-			fmt.Println(starline)
+			fmt.Printf("%s\n", starline)
 			fmt.Println("")
 			fmt.Println("Kubelet anonymousAuth is currently turned on. This allows RBAC escalation and remote code execution possibilities.")
 			fmt.Println("It is highly recommended you turn it off by setting 'spec.kubelet.anonymousAuth' to 'false' via 'kops edit cluster'")
 			fmt.Println("")
 			fmt.Println("See https://kops.sigs.k8s.io/security/#kubelet-api")
 			fmt.Println("")
-			fmt.Println(starline)
+			fmt.Printf("%s\n", starline)
 			fmt.Println("")
 		}
 	}
@@ -1001,20 +1001,20 @@ func (c *ApplyClusterCmd) validateKopsVersion() error {
 	}
 
 	if recommended != nil && !required {
-		fmt.Println("")
-		fmt.Println(starline)
-		fmt.Println("")
+		fmt.Printf("\n")
+		fmt.Printf("%s\n", starline)
+		fmt.Printf("\n")
 		fmt.Printf("A new kops version is available: %s", recommended)
-		fmt.Println("")
-		fmt.Println("upgrading is recommended")
+		fmt.Printf("\n")
+		fmt.Printf("Upgrading is recommended\n")
 		fmt.Printf("More information: %s\n", buildPermalink("upgrade_kops", recommended.String()))
-		fmt.Println("")
-		fmt.Println(starline)
-		fmt.Println("")
+		fmt.Printf("\n")
+		fmt.Printf("%s\n", starline)
+		fmt.Printf("\n")
 	} else if required {
-		fmt.Println("")
-		fmt.Println(starline)
-		fmt.Println("")
+		fmt.Printf("\n")
+		fmt.Printf("%s\n", starline)
+		fmt.Printf("\n")
 		if recommended != nil {
 			fmt.Printf("a new kops version is available: %s\n", recommended)
 		}
@@ -1023,9 +1023,9 @@ func (c *ApplyClusterCmd) validateKopsVersion() error {
 		fmt.Printf("(you can bypass this check by exporting KOPS_RUN_OBSOLETE_VERSION)\n")
 		fmt.Println("")
 		fmt.Printf("More information: %s\n", buildPermalink("upgrade_kops", recommended.String()))
-		fmt.Println("")
-		fmt.Printf(starline)
-		fmt.Println("")
+		fmt.Printf("\n")
+		fmt.Printf("%s\n", starline)
+		fmt.Printf("\n")
 	}
 
 	if required {
@@ -1048,14 +1048,14 @@ func (c *ApplyClusterCmd) validateKubernetesVersion() error {
 
 	if !util.IsKubernetesGTE(OldestSupportedKubernetesVersion, *parsed) {
 		fmt.Printf("\n")
-		fmt.Printf(starline)
+		fmt.Printf("%s\n", starline)
 		fmt.Printf("\n")
 		fmt.Printf("Kops support for this Kubernetes version is deprecated and will be removed in a future release.\n")
 		fmt.Printf("\n")
 		fmt.Printf("Upgrading is recommended\n")
 		fmt.Printf("More information: %s\n", buildPermalink("upgrade_k8s", ""))
 		fmt.Printf("\n")
-		fmt.Printf(starline)
+		fmt.Printf("%s\n", starline)
 		fmt.Printf("\n")
 
 	}
@@ -1082,18 +1082,18 @@ func (c *ApplyClusterCmd) validateKubernetesVersion() error {
 
 	if recommended != nil && !required {
 		fmt.Printf("\n")
-		fmt.Printf(starline)
+		fmt.Printf("%s\n", starline)
 		fmt.Printf("\n")
 		fmt.Printf("A new kubernetes version is available: %s\n", recommended)
 		fmt.Printf("Upgrading is recommended (try kops upgrade cluster)\n")
 		fmt.Printf("\n")
 		fmt.Printf("More information: %s\n", buildPermalink("upgrade_k8s", recommended.String()))
 		fmt.Printf("\n")
-		fmt.Printf(starline)
+		fmt.Printf("%s\n", starline)
 		fmt.Printf("\n")
 	} else if required {
 		fmt.Printf("\n")
-		fmt.Printf(starline)
+		fmt.Printf("%s\n", starline)
 		fmt.Printf("\n")
 		if recommended != nil {
 			fmt.Printf("A new kubernetes version is available: %s\n", recommended)
@@ -1104,7 +1104,7 @@ func (c *ApplyClusterCmd) validateKubernetesVersion() error {
 		fmt.Printf("\n")
 		fmt.Printf("More information: %s\n", buildPermalink("upgrade_k8s", recommended.String()))
 		fmt.Printf("\n")
-		fmt.Printf(starline)
+		fmt.Printf("%s\n", starline)
 		fmt.Printf("\n")
 	}
 

--- a/upup/pkg/fi/cloudup/awstasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/awstasks/sshkey.go
@@ -208,12 +208,12 @@ func (_ *SSHKey) RenderCloudformation(t *cloudformation.CloudformationTarget, a,
 
 	klog.Warningf("Cloudformation does not manage SSH keys; pre-creating SSH key")
 
-	a, err := e.find(cloud)
+	keypair, err := e.find(cloud)
 	if err != nil {
 		return err
 	}
 
-	if a == nil {
+	if keypair == nil {
 		err := e.createKeypair(cloud)
 		if err != nil {
 			return err

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -330,7 +330,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		enableRBACAddon = false
 	}
 	if b.cluster.Spec.KubeAPIServer != nil {
-		if b.cluster.Spec.KubeAPIServer.EnableBootstrapAuthToken != nil && *b.cluster.Spec.KubeAPIServer.EnableBootstrapAuthToken == true {
+		if b.cluster.Spec.KubeAPIServer.EnableBootstrapAuthToken != nil && *b.cluster.Spec.KubeAPIServer.EnableBootstrapAuthToken {
 			enableRBACAddon = false
 		}
 	}

--- a/upup/pkg/fi/cloudup/loader.go
+++ b/upup/pkg/fi/cloudup/loader.go
@@ -55,8 +55,6 @@ type Loader struct {
 
 	typeMap map[string]reflect.Type
 
-	templates []*template.Template
-
 	Resources map[string]fi.Resource
 
 	Builders []fi.ModelBuilder

--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -222,9 +222,7 @@ func (c *populateClusterSpec) run(clientset simple.Clientset) error {
 
 	// Normalize k8s version
 	versionWithoutV := strings.TrimSpace(cluster.Spec.KubernetesVersion)
-	if strings.HasPrefix(versionWithoutV, "v") {
-		versionWithoutV = versionWithoutV[1:]
-	}
+	versionWithoutV = strings.TrimPrefix(versionWithoutV, "v")
 	if cluster.Spec.KubernetesVersion != versionWithoutV {
 		klog.V(2).Infof("Normalizing kubernetes version: %q -> %q", cluster.Spec.KubernetesVersion, versionWithoutV)
 		cluster.Spec.KubernetesVersion = versionWithoutV

--- a/upup/pkg/fi/executor.go
+++ b/upup/pkg/fi/executor.go
@@ -159,8 +159,6 @@ func (e *executor) RunTasks(taskMap map[string]Task) error {
 	return nil
 }
 
-type runnable func() error
-
 func (e *executor) forkJoin(tasks []*taskState) []error {
 	if len(tasks) == 0 {
 		return nil


### PR DESCRIPTION
ref:#7800
special notes:
upup/pkg/fi/cloudup/apply_cluster.go:300:15: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
upup/pkg/fi/cloudup/apply_cluster.go:307:15: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
upup/pkg/fi/cloudup/apply_cluster.go:1003:14: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
upup/pkg/fi/cloudup/apply_cluster.go:1010:14: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
upup/pkg/fi/cloudup/apply_cluster.go:1014:14: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
upup/pkg/fi/cloudup/apply_cluster.go:1025:14: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
upup/pkg/fi/cloudup/apply_cluster.go:1069:14: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
upup/pkg/fi/cloudup/apply_cluster.go:1076:14: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
upup/pkg/fi/cloudup/apply_cluster.go:1080:14: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
upup/pkg/fi/cloudup/apply_cluster.go:1091:14: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
upup/pkg/fi/cloudup/awstasks/sshkey.go:206:79: argument a is overwritten before first use (SA4009)
upup/pkg/fi/cloudup/loader.go:58:2: field templates is unused (U1000)
upup/pkg/fi/executor.go:162:6: type runnable is unused (U1000)