### PR TITLE
For dev, don't preload docker images on nodes

### DIFF
--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -55,6 +55,15 @@ func (t *ProtokubeBuilder) Build(c *fi.ModelBuilderContext) error {
 		return nil
 	}
 
+	if protokubeImage := t.NodeupConfig.ProtokubeImage; protokubeImage != nil {
+		c.AddTask(&nodetasks.LoadImageTask{
+			Name:    "protokube",
+			Sources: protokubeImage.Sources,
+			Hash:    protokubeImage.Hash,
+			Runtime: t.Cluster.Spec.ContainerRuntime,
+		})
+	}
+
 	if t.IsMaster {
 		kubeconfig, err := t.BuildPKIKubeconfig("kops")
 		if err != nil {

--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
@@ -485,13 +485,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
   - _aws
   channels:
   - memfs://clusters.example.com/additionalcidr.example.com/addons/bootstrap-channel.yaml
-  protokubeImage:
-    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
-    name: protokube:1.15.0
-    sources:
-    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -514,13 +514,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
   - _aws
   channels:
   - memfs://clusters.example.com/additionaluserdata.example.com/addons/bootstrap-channel.yaml
-  protokubeImage:
-    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
-    name: protokube:1.15.0
-    sources:
-    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
@@ -487,13 +487,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodescomplexexamplecom.Properties.Use
   - _aws
   channels:
   - memfs://clusters.example.com/complex.example.com/addons/bootstrap-channel.yaml
-  protokubeImage:
-    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
-    name: protokube:1.15.0
-    sources:
-    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
@@ -473,13 +473,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodescontainerdexamplecom.Properties.
   - _aws
   channels:
   - memfs://clusters.example.com/containerd.example.com/addons/bootstrap-channel.yaml
-  protokubeImage:
-    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
-    name: protokube:1.15.0
-    sources:
-    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -485,13 +485,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   - _aws
   channels:
   - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml
-  protokubeImage:
-    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
-    name: protokube:1.15.0
-    sources:
-    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -485,13 +485,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
   - _aws
   channels:
   - memfs://clusters.example.com/externallb.example.com/addons/bootstrap-channel.yaml
-  protokubeImage:
-    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
-    name: protokube:1.15.0
-    sources:
-    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -485,13 +485,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   - _aws
   channels:
   - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml
-  protokubeImage:
-    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
-    name: protokube:1.15.0
-    sources:
-    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
@@ -1076,13 +1076,6 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
   - _aws
   channels:
   - memfs://clusters.example.com/mixedinstances.example.com/addons/bootstrap-channel.yaml
-  protokubeImage:
-    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
-    name: protokube:1.15.0
-    sources:
-    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
@@ -1076,13 +1076,6 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
   - _aws
   channels:
   - memfs://clusters.example.com/mixedinstances.example.com/addons/bootstrap-channel.yaml
-  protokubeImage:
-    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
-    name: protokube:1.15.0
-    sources:
-    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
@@ -482,13 +482,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesprivatecalicoexamplecom.Properti
   - _aws
   channels:
   - memfs://clusters.example.com/privatecalico.example.com/addons/bootstrap-channel.yaml
-  protokubeImage:
-    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
-    name: protokube:1.15.0
-    sources:
-    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1298,12 +1298,15 @@ func (c *ApplyClusterCmd) BuildNodeUpConfig(assetBuilder *assets.AssetBuilder, i
 	config.ConfigBase = fi.String(configBase.Path())
 	config.InstanceGroupName = ig.ObjectMeta.Name
 
+	useGossip := dns.IsGossipHostname(cluster.Spec.MasterInternalName)
+	isMaster := role == kops.InstanceGroupRoleMaster
+
 	var images []*nodeup.Image
 
 	if components.IsBaseURL(cluster.Spec.KubernetesVersion) {
 		// When using a custom version, we want to preload the images over http
 		components := []string{"kube-proxy"}
-		if role == kops.InstanceGroupRoleMaster {
+		if isMaster {
 			components = append(components, "kube-apiserver", "kube-controller-manager", "kube-scheduler")
 		}
 
@@ -1330,7 +1333,7 @@ func (c *ApplyClusterCmd) BuildNodeUpConfig(assetBuilder *assets.AssetBuilder, i
 
 	// `docker load` our images when using a KOPS_BASE_URL, so we
 	// don't need to push/pull from a registry
-	if os.Getenv("KOPS_BASE_URL") != "" {
+	if os.Getenv("KOPS_BASE_URL") != "" && isMaster {
 		for _, name := range []string{"kops-controller", "dns-controller"} {
 			baseURL, err := url.Parse(os.Getenv("KOPS_BASE_URL"))
 			if err != nil {
@@ -1352,7 +1355,7 @@ func (c *ApplyClusterCmd) BuildNodeUpConfig(assetBuilder *assets.AssetBuilder, i
 		}
 	}
 
-	{
+	if isMaster || useGossip {
 		u, hash, err := ProtokubeImageSource(assetBuilder)
 		if err != nil {
 			return nil, err

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -301,13 +301,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 			Runtime: c.cluster.Spec.ContainerRuntime,
 		}
 	}
-	if c.config.ProtokubeImage != nil {
-		taskMap["LoadImage.protokube"] = &nodetasks.LoadImageTask{
-			Sources: c.config.ProtokubeImage.Sources,
-			Hash:    c.config.ProtokubeImage.Hash,
-			Runtime: c.cluster.Spec.ContainerRuntime,
-		}
-	}
+	// Protokube load image task is in ProtokubeBuilder
 
 	var cloud fi.Cloud
 	var keyStore fi.Keystore

--- a/upup/pkg/fi/nodeup/nodetasks/load_image.go
+++ b/upup/pkg/fi/nodeup/nodetasks/load_image.go
@@ -40,6 +40,7 @@ const (
 
 // LoadImageTask is responsible for downloading a docker image
 type LoadImageTask struct {
+	Name    string
 	Sources []string
 	Hash    string
 	Runtime string
@@ -62,6 +63,19 @@ func (t *LoadImageTask) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 		}
 	}
 	return deps
+}
+
+var _ fi.HasName = &LoadImageTask{}
+
+func (t *LoadImageTask) GetName() *string {
+	if t.Name == "" {
+		return nil
+	}
+	return &t.Name
+}
+
+func (t *LoadImageTask) SetName(name string) {
+	klog.Fatalf("SetName not supported for LoadImageTask")
 }
 
 func (t *LoadImageTask) String() string {


### PR DESCRIPTION
If we're not going to use the docker images, we don't need to preload
them - saves a bit off the boot time.