### PR TITLE
containerd: Add support for tar.gz package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,21 +371,21 @@ push: crossbuild-nodeup
 
 .PHONY: push-gce-dry
 push-gce-dry: push
-	ssh ${TARGET} sudo SKIP_PACKAGE_UPDATE=1 /tmp/nodeup --conf=metadata://gce/config --dryrun --v=8
+	ssh ${TARGET} sudo /tmp/nodeup --conf=metadata://gce/config --dryrun --v=8
 
 .PHONY: push-gce-dry
 push-aws-dry: push
-	ssh ${TARGET} sudo SKIP_PACKAGE_UPDATE=1 /tmp/nodeup --conf=/var/cache/kubernetes-install/kube_env.yaml --dryrun --v=8
+	ssh ${TARGET} sudo /tmp/nodeup --conf=/opt/kops/conf/kube_env.yaml --dryrun --v=8
 
 .PHONY: push-gce-run
 push-gce-run: push
 	ssh ${TARGET} sudo cp /tmp/nodeup /var/lib/toolbox/kubernetes-install/nodeup
-	ssh ${TARGET} sudo SKIP_PACKAGE_UPDATE=1 /var/lib/toolbox/kubernetes-install/nodeup --conf=/var/lib/toolbox/kubernetes-install/kube_env.yaml --v=8
+	ssh ${TARGET} sudo /var/lib/toolbox/kubernetes-install/nodeup --conf=/var/lib/toolbox/kubernetes-install/kube_env.yaml --v=8
 
 # -t is for CentOS http://unix.stackexchange.com/questions/122616/why-do-i-need-a-tty-to-run-sudo-if-i-can-sudo-without-a-password
 .PHONY: push-aws-run
 push-aws-run: push
-	ssh -t ${TARGET} sudo SKIP_PACKAGE_UPDATE=1 /tmp/nodeup --conf=/var/cache/kubernetes-install/kube_env.yaml --v=8
+	ssh -t ${TARGET} sudo /tmp/nodeup --conf=/opt/kops/conf/kube_env.yaml --v=8
 
 .PHONY: ${PROTOKUBE}
 ${PROTOKUBE}:
@@ -727,7 +727,7 @@ bazel-push-gce-run: bazel-push
 .PHONY: bazel-push-aws-run
 bazel-push-aws-run: bazel-push
 	ssh ${TARGET} chmod +x /tmp/nodeup
-	ssh -t ${TARGET} sudo SKIP_PACKAGE_UPDATE=1 /tmp/nodeup --conf=/var/cache/kubernetes-install/kube_env.yaml --v=8
+	ssh -t ${TARGET} sudo SKIP_PACKAGE_UPDATE=1 /tmp/nodeup --conf=/opt/kops/conf/kube_env.yaml --v=8
 
 .PHONY: gazelle
 gazelle:

--- a/nodeup/pkg/distros/identify.go
+++ b/nodeup/pkg/distros/identify.go
@@ -113,7 +113,8 @@ func FindDistribution(rootfs string) (Distribution, error) {
 				return DistributionContainerOS, nil
 			}
 			if strings.HasPrefix(line, "PRETTY_NAME=\"Amazon Linux 2") {
-				return DistributionCentos7, nil
+				// TODO: This is a hack. Amazon Linux is "special" and should get its own distro entry
+				return DistributionRhel7, nil
 			}
 		}
 		klog.Warningf("unhandled /etc/os-release info %q", string(osRelease))

--- a/nodeup/pkg/model/convenience.go
+++ b/nodeup/pkg/model/convenience.go
@@ -158,10 +158,15 @@ func (d *packageVersion) matches(arch Architecture, packageVersion string, distr
 		return false
 	}
 	foundDistro := false
-	for _, d := range d.Distros {
-		if d == distro {
-			foundDistro = true
+	if len(d.Distros) > 0 {
+		for _, d := range d.Distros {
+			if d == distro {
+				foundDistro = true
+			}
 		}
+	} else {
+		// Distro list is empty, assuming ANY
+		foundDistro = true
 	}
 	if !foundDistro {
 		return false

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -188,7 +188,7 @@ var dockerVersions = []packageVersion{
 				Hash:    "a6b0243af348140236ed96f2e902b259c590eefa",
 			},
 		},
-		Dependencies: []string{"libtool-ltdl", "libseccomp"},
+		Dependencies: []string{"libtool-ltdl"},
 	},
 
 	// 1.12.6 - k8s 1.6
@@ -216,7 +216,7 @@ var dockerVersions = []packageVersion{
 		Version:        "1.12.6-0~debian-stretch",
 		Source:         "http://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_1.12.6-0~debian-stretch_amd64.deb",
 		Hash:           "18bb7d024658f27a1221eae4de78d792bf00611b",
-		Dependencies:   []string{"bridge-utils", "libapparmor1", "libltdl7", "perl", "libseccomp2"},
+		Dependencies:   []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 		//Depends: iptables, init-system-helpers (>= 1.18~), libapparmor1 (>= 2.6~devel), libc6 (>= 2.17), libdevmapper1.02.1 (>= 2:1.02.97), libltdl7 (>= 2.4.6), libseccomp2 (>= 2.1.0), libsystemd0
 		//Recommends: aufs-tools, ca-certificates, cgroupfs-mount | cgroup-lite, git, xz-utils
 	},
@@ -242,7 +242,7 @@ var dockerVersions = []packageVersion{
 		Version:        "1.12.6-0~ubuntu-xenial",
 		Source:         "http://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_1.12.6-0~ubuntu-xenial_amd64.deb",
 		Hash:           "fffc22da4ad5b20715bbb6c485b2d2bb7e84fd33",
-		Dependencies:   []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		Dependencies:   []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 		// Depends: iptables, init-system-helpers (>= 1.18~), lsb-base (>= 4.1+Debian11ubuntu7), libapparmor1 (>= 2.6~devel), libc6 (>= 2.17), libdevmapper1.02.1 (>= 2:1.02.97), libltdl7 (>= 2.4.6), libseccomp2 (>= 2.1.0), libsystemd0
 	},
 
@@ -262,7 +262,7 @@ var dockerVersions = []packageVersion{
 				Hash:    "9a6ee0d631ca911b6927450a3c396e9a5be75047",
 			},
 		},
-		Dependencies: []string{"libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python"},
+		Dependencies: []string{"libtool-ltdl", "libcgroup"},
 	},
 
 	// 1.13.1 - k8s 1.8
@@ -316,7 +316,7 @@ var dockerVersions = []packageVersion{
 		Version:        "1.13.1-0~ubuntu-xenial",
 		Source:         "http://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_1.13.1-0~ubuntu-xenial_amd64.deb",
 		Hash:           "d12cbd686f44536c679a03cf0137df163f0bba5f",
-		Dependencies:   []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		Dependencies:   []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 		// Depends: iptables, init-system-helpers (>= 1.18~), lsb-base (>= 4.1+Debian11ubuntu7), libapparmor1 (>= 2.6~devel), libc6 (>= 2.17), libdevmapper1.02.1 (>= 2:1.02.97), libltdl7 (>= 2.4.6), libseccomp2 (>= 2.1.0), libsystemd0
 	},
 
@@ -336,7 +336,7 @@ var dockerVersions = []packageVersion{
 				Hash:    "948c518a610af631fa98aa32d9bcd43e9ddd5ebc",
 			},
 		},
-		Dependencies: []string{"libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python", "selinux-policy-base", "selinux-policy-targeted"},
+		Dependencies: []string{"libtool-ltdl", "libcgroup", "selinux-policy-base", "selinux-policy-targeted"},
 	},
 
 	// 17.03.2 - k8s 1.8
@@ -389,7 +389,7 @@ var dockerVersions = []packageVersion{
 		Version:        "17.03.2~ce-0~ubuntu-xenial",
 		Source:         "http://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_17.03.2~ce-0~ubuntu-xenial_amd64.deb",
 		Hash:           "4dcee1a05ec592e8a76e53e5b464ea43085a2849",
-		Dependencies:   []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		Dependencies:   []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 		MarkImmutable:  []string{"/usr/bin/docker-runc"},
 	},
 
@@ -401,7 +401,7 @@ var dockerVersions = []packageVersion{
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Source:         "http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz",
 		Hash:           "141716ae046016a1792ce232a0f4c8eed7fe37d1",
-		Dependencies:   []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		Dependencies:   []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 		MarkImmutable:  []string{"/usr/bin/docker-runc"},
 	},
 
@@ -421,7 +421,7 @@ var dockerVersions = []packageVersion{
 				Hash:    "4659c937b66519c88ef2a82a906bb156db29d191",
 			},
 		},
-		Dependencies:  []string{"libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python"},
+		Dependencies:  []string{"libtool-ltdl", "libcgroup"},
 		MarkImmutable: []string{"/usr/bin/docker-runc"},
 	},
 	// 17.09.0 - k8s 1.8
@@ -471,7 +471,7 @@ var dockerVersions = []packageVersion{
 		Version:        "17.09.0~ce-0~ubuntu",
 		Source:         "http://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_17.09.0~ce-0~ubuntu_amd64.deb",
 		Hash:           "94f6e89be6d45d9988269a237eb27c7d6a844d7f",
-		Dependencies:   []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		Dependencies:   []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 		//Depends: iptables, init-system-helpers, lsb-base, libapparmor1, libc6, libdevmapper1.02.1, libltdl7, libeseccomp2, libsystemd0
 		//Recommends: aufs-tools, ca-certificates, cgroupfs-mount | cgroup-lite, git, xz-utils, apparmor
 	},
@@ -485,7 +485,7 @@ var dockerVersions = []packageVersion{
 		Version:        "18.06.2~ce~3-0~ubuntu",
 		Source:         "https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_18.06.2~ce~3-0~ubuntu_amd64.deb",
 		Hash:           "03e5eaae9c84b144e1140d9b418e43fce0311892",
-		Dependencies:   []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		Dependencies:   []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 		//Depends: iptables, init-system-helpers, lsb-base, libapparmor1, libc6, libdevmapper1.02.1, libltdl7, libeseccomp2, libsystemd0
 		//Recommends: aufs-tools, ca-certificates, cgroupfs-mount | cgroup-lite, git, xz-utils, apparmor
 	},
@@ -499,7 +499,7 @@ var dockerVersions = []packageVersion{
 		Version:        "18.06.3~ce~3-0~ubuntu",
 		Source:         "https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_18.06.3~ce~3-0~ubuntu_amd64.deb",
 		Hash:           "c06eda4e934cce6a7941a6af6602d4315b500a22",
-		Dependencies:   []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		Dependencies:   []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 		//Depends: iptables, init-system-helpers, lsb-base, libc6, libdevmapper1.02.1, libltdl7, libseccomp2, libsystemd0
 		//Recommends: aufs-tools, ca-certificates, cgroupfs-mount | cgroup-lite, git, pigz, xz-utils, apparmor
 	},
@@ -513,14 +513,7 @@ var dockerVersions = []packageVersion{
 		Version:        "17.09.0.ce",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-17.09.0.ce-1.el7.centos.x86_64.rpm",
 		Hash:           "b4ce72e80ff02926de943082821bbbe73958f87a",
-		ExtraPackages: map[string]packageInfo{
-			"container-selinux": {
-				Version: "2.68",
-				Source:  "http://vault.centos.org/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
-				Hash:    "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
-			},
-		},
-		Dependencies: []string{"libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python"},
+		Dependencies:   []string{"libtool-ltdl", "libcgroup"},
 	},
 
 	// 18.03.1 - Bionic
@@ -532,7 +525,7 @@ var dockerVersions = []packageVersion{
 		Version:        "18.03.1~ce~3-0~ubuntu",
 		Source:         "https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce_18.03.1~ce~3-0~ubuntu_amd64.deb",
 		Hash:           "b55b32bd0e9176dd32b1e6128ad9fda10a65cc8b",
-		Dependencies:   []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		Dependencies:   []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 		//Depends: iptables, init-system-helpers, lsb-base, libapparmor1, libc6, libdevmapper1.02.1, libltdl7, libeseccomp2, libsystemd0
 		//Recommends: aufs-tools, ca-certificates, cgroupfs-mount | cgroup-lite, git, xz-utils, apparmor
 	},
@@ -546,7 +539,7 @@ var dockerVersions = []packageVersion{
 		Version:        "18.06.2~ce~3-0~ubuntu",
 		Source:         "https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce_18.06.2~ce~3-0~ubuntu_amd64.deb",
 		Hash:           "9607c67644e3e1ad9661267c99499004f2e84e05",
-		Dependencies:   []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		Dependencies:   []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 		//Depends: iptables, init-system-helpers, lsb-base, libapparmor1, libc6, libdevmapper1.02.1, libltdl7, libeseccomp2, libsystemd0
 		//Recommends: aufs-tools, ca-certificates, cgroupfs-mount | cgroup-lite, git, xz-utils, apparmor
 	},
@@ -610,14 +603,7 @@ var dockerVersions = []packageVersion{
 		Version:        "18.06.1.ce",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-18.06.1.ce-3.el7.x86_64.rpm",
 		Hash:           "0a1325e570c5e54111a79623c9fd0c0c714d3a11",
-		ExtraPackages: map[string]packageInfo{
-			"container-selinux": {
-				Version: "2.68",
-				Source:  "http://vault.centos.org/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
-				Hash:    "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
-			},
-		},
-		Dependencies: []string{"libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python"},
+		Dependencies:   []string{"libtool-ltdl", "libcgroup"},
 	},
 
 	// 18.09.3 - Debian Stretch
@@ -641,23 +627,13 @@ var dockerVersions = []packageVersion{
 	// 18.06.2 - CentOS / Rhel7 (two packages)
 	{
 		PackageVersion: "18.06.2",
-		Name:           "container-selinux",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
-		Architectures:  []Architecture{ArchitectureAmd64},
-		Version:        "2.68",
-		Source:         "http://vault.centos.org/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
-		Hash:           "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
-		Dependencies:   []string{"policycoreutils-python"},
-	},
-	{
-		PackageVersion: "18.06.2",
 		Name:           "docker-ce",
 		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "18.06.2.ce",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-18.06.2.ce-3.el7.x86_64.rpm",
 		Hash:           "456eb7c5bfb37fac342e9ade21b602c076c5b367",
-		Dependencies:   []string{"libtool-ltdl", "libseccomp", "libcgroup"},
+		Dependencies:   []string{"libtool-ltdl", "libcgroup"},
 	},
 
 	// 18.06.3 (contains fix for CVE-2019-5736)
@@ -671,7 +647,7 @@ var dockerVersions = []packageVersion{
 		Version:        "18.06.3~ce~3-0~ubuntu",
 		Source:         "https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce_18.06.3~ce~3-0~ubuntu_amd64.deb",
 		Hash:           "b396678a8b70f0503a7b944fa6e3297ab27b345b",
-		Dependencies:   []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		Dependencies:   []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 		//Depends: iptables, init-system-helpers, lsb-base, libapparmor1, libc6, libdevmapper1.02.1, libltdl7, libeseccomp2, libsystemd0
 		//Recommends: aufs-tools, ca-certificates, cgroupfs-mount | cgroup-lite, git, xz-utils, apparmor
 	},
@@ -710,14 +686,7 @@ var dockerVersions = []packageVersion{
 		Version:        "18.06.3.ce",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-18.06.3.ce-3.el7.x86_64.rpm",
 		Hash:           "5369602f88406d4fb9159dc1d3fd44e76fb4cab8",
-		ExtraPackages: map[string]packageInfo{
-			"container-selinux": {
-				Version: "2.68",
-				Source:  "http://vault.centos.org/7.6.1810/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm",
-				Hash:    "d9f87f7f4f2e8e611f556d873a17b8c0c580fec0",
-			},
-		},
-		Dependencies: []string{"libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python"},
+		Dependencies:   []string{"libtool-ltdl", "libcgroup"},
 	},
 	// 18.06.3 - CentOS / Rhel8 (two packages)
 	{
@@ -728,7 +697,7 @@ var dockerVersions = []packageVersion{
 		Version:        "18.06.3.ce",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-18.06.3.ce-3.el7.x86_64.rpm",
 		Hash:           "5369602f88406d4fb9159dc1d3fd44e76fb4cab8",
-		Dependencies:   []string{"container-selinux", "libtool-ltdl", "libseccomp", "libcgroup", "policycoreutils-python-utils", "python3-policycoreutils"},
+		Dependencies:   []string{"libtool-ltdl", "libcgroup", "policycoreutils-python-utils", "python3-policycoreutils"},
 	},
 
 	// 18.09.9 - k8s 1.14 - https://github.com/kubernetes/kubernetes/pull/72823
@@ -749,7 +718,7 @@ var dockerVersions = []packageVersion{
 				Hash:    "88f8f3103d2e5011e2f1a73b9e6dbf03d6e6698a",
 			},
 		},
-		Dependencies: []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 	},
 
 	// 18.09.9 - Debian Buster
@@ -768,7 +737,7 @@ var dockerVersions = []packageVersion{
 				Hash:    "510eee5b6884867be0d2b360f8ff8cf7f0c0d11a",
 			},
 		},
-		Dependencies: []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 	},
 
 	// 18.09.9 - Xenial
@@ -825,7 +794,7 @@ var dockerVersions = []packageVersion{
 				Hash:    "0c51b1339a95bd732ca305f07b7bcc95f132b9c8",
 			},
 		},
-		Dependencies: []string{"libtool-ltdl", "iptables"},
+		Dependencies: []string{"libtool-ltdl"},
 	},
 
 	// 18.09.9 - CentOS / Rhel8
@@ -844,7 +813,7 @@ var dockerVersions = []packageVersion{
 				Hash:    "0c51b1339a95bd732ca305f07b7bcc95f132b9c8",
 			},
 		},
-		Dependencies: []string{"libtool-ltdl", "iptables"},
+		Dependencies: []string{"libtool-ltdl"},
 	},
 
 	// 19.03.4 - k8s 1.17 - https://github.com/kubernetes/kubernetes/pull/84476
@@ -865,7 +834,7 @@ var dockerVersions = []packageVersion{
 				Hash:    "57f71ee764abb19a0b4c580ff14b1eb3de3a9e08",
 			},
 		},
-		Dependencies: []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 	},
 
 	// 19.03.4 - Debian Buster
@@ -884,7 +853,7 @@ var dockerVersions = []packageVersion{
 				Hash:    "2549a364f0e5ce489c79b292b78e349751385dd5",
 			},
 		},
-		Dependencies: []string{"bridge-utils", "iptables", "libapparmor1", "libltdl7", "perl"},
+		Dependencies: []string{"bridge-utils", "libapparmor1", "libltdl7", "perl"},
 	},
 
 	// 19.03.4 - Xenial
@@ -941,7 +910,7 @@ var dockerVersions = []packageVersion{
 				Hash:    "1fffcc716e74a59f753f8898ba96693a00e79e26",
 			},
 		},
-		Dependencies: []string{"libtool-ltdl", "iptables"},
+		Dependencies: []string{"libtool-ltdl"},
 	},
 
 	// 19.03.4 - CentOS / Rhel8
@@ -960,7 +929,7 @@ var dockerVersions = []packageVersion{
 				Hash:    "1fffcc716e74a59f753f8898ba96693a00e79e26",
 			},
 		},
-		Dependencies: []string{"libtool-ltdl", "iptables"},
+		Dependencies: []string{"libtool-ltdl"},
 	},
 
 	// TIP: When adding the next version, copy the previous version, string replace the version and run:

--- a/nodeup/pkg/model/miscutils.go
+++ b/nodeup/pkg/model/miscutils.go
@@ -50,7 +50,6 @@ func (b *MiscUtilsBuilder) Build(c *fi.ModelBuilderContext) error {
 
 	var packages []string
 	if b.Distribution.IsDebianFamily() {
-		packages = append(packages, "socat")
 		packages = append(packages, "curl")
 		packages = append(packages, "wget")
 		packages = append(packages, "nfs-common")

--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -17,6 +17,7 @@ limitations under the License.
 package model
 
 import (
+	"k8s.io/kops/nodeup/pkg/distros"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 
@@ -37,17 +38,39 @@ func (b *PackagesBuilder) Build(c *fi.ModelBuilderContext) error {
 	//   ebtables - kops #1711
 	//   ethtool - kops #1830
 	if b.Distribution.IsDebianFamily() {
+		// From containerd: https://github.com/containerd/cri/blob/master/contrib/ansible/tasks/bootstrap_ubuntu.yaml
 		c.AddTask(&nodetasks.Package{Name: "conntrack"})
 		c.AddTask(&nodetasks.Package{Name: "ebtables"})
 		c.AddTask(&nodetasks.Package{Name: "ethtool"})
+		c.AddTask(&nodetasks.Package{Name: "iptables"})
+		c.AddTask(&nodetasks.Package{Name: "libseccomp2"})
+		c.AddTask(&nodetasks.Package{Name: "pigz"})
+		c.AddTask(&nodetasks.Package{Name: "socat"})
+		c.AddTask(&nodetasks.Package{Name: "util-linux"})
 	} else if b.Distribution.IsRHELFamily() {
+		// From containerd: https://github.com/containerd/cri/blob/master/contrib/ansible/tasks/bootstrap_centos.yaml
 		c.AddTask(&nodetasks.Package{Name: "conntrack-tools"})
 		c.AddTask(&nodetasks.Package{Name: "ebtables"})
 		c.AddTask(&nodetasks.Package{Name: "ethtool"})
+		c.AddTask(&nodetasks.Package{Name: "iptables"})
+		c.AddTask(&nodetasks.Package{Name: "libseccomp"})
 		c.AddTask(&nodetasks.Package{Name: "socat"})
+		c.AddTask(&nodetasks.Package{Name: "util-linux"})
+
+		// Handle RHEL 7 and Amazon Linux 2 differently when installing "extras"
+		if b.Distribution != distros.DistributionRhel7 {
+			c.AddTask(&nodetasks.Package{Name: "container-selinux"})
+			c.AddTask(&nodetasks.Package{Name: "pigz"})
+		} else {
+			c.AddTask(&nodetasks.Package{
+				Name:   "container-selinux",
+				Source: s("http://vault.centos.org/7.6.1810/extras/x86_64/Packages/container-selinux-2.107-1.el7_6.noarch.rpm"),
+				Hash:   s("7de4211fa0dfd240d8827b93763e1eb5f0d56411"),
+			})
+		}
 	} else {
-		// Hopefully it's already installed
-		klog.Infof("ebtables package not known for distro %q", b.Distribution)
+		// Hopefully they are already installed
+		klog.Warningf("unknown distribution, skipping required packages install: %v", b.Distribution)
 	}
 
 	return nil

--- a/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
@@ -208,10 +208,6 @@ preventStart: true
 source: https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/containerd.io_1.2.10-3_amd64.deb
 version: 1.2.10-3
 ---
-Name: libseccomp2
----
-Name: pigz
----
 Name: containerd.service
 definition: |
   [Unit]
@@ -224,16 +220,15 @@ definition: |
   EnvironmentFile=/etc/environment
   ExecStartPre=-/sbin/modprobe overlay
   ExecStart=/usr/bin/containerd -c /etc/containerd/config-kops.toml "$CONTAINERD_OPTS"
-  KillMode=process
+  Restart=always
+  RestartSec=5
   Delegate=yes
+  KillMode=process
+  OOMScoreAdjust=-999
   LimitNOFILE=1048576
   LimitNPROC=infinity
   LimitCORE=infinity
   TasksMax=infinity
-  Restart=always
-  RestartSec=2s
-  StartLimitInterval=0
-  TimeoutStartSec=0
 
   [Install]
   WantedBy=multi-user.target

--- a/upup/pkg/fi/nodeup/nodetasks/archive.go
+++ b/upup/pkg/fi/nodeup/nodetasks/archive.go
@@ -23,8 +23,10 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"k8s.io/klog"
 	"k8s.io/kops/upup/pkg/fi"
@@ -47,6 +49,9 @@ type Archive struct {
 
 	// StripComponents is the number of components to remove when expanding the archive
 	StripComponents int `json:"stripComponents,omitempty"`
+
+	// MapFiles is the list of files to extract with corresponding directories to extract
+	MapFiles map[string]string `json:"mapFiles,omitempty"`
 }
 
 const (
@@ -155,20 +160,38 @@ func (_ *Archive) RenderLocal(t *local.LocalTarget, a, e, changes *Archive) erro
 			return err
 		}
 
-		targetDir := e.TargetDir
-		if err := os.MkdirAll(targetDir, 0755); err != nil {
-			return fmt.Errorf("error creating directories %q: %v", targetDir, err)
-		}
+		if len(e.MapFiles) == 0 {
+			targetDir := e.TargetDir
+			if err := os.MkdirAll(targetDir, 0755); err != nil {
+				return fmt.Errorf("error creating directories %q: %v", targetDir, err)
+			}
 
-		args := []string{"tar", "xf", localFile, "-C", targetDir}
-		if e.StripComponents != 0 {
-			args = append(args, "--strip-components="+strconv.Itoa(e.StripComponents))
-		}
+			args := []string{"tar", "xf", localFile, "-C", targetDir}
+			if e.StripComponents != 0 {
+				args = append(args, "--strip-components="+strconv.Itoa(e.StripComponents))
+			}
 
-		klog.Infof("running command %s", args)
-		cmd := exec.Command(args[0], args[1:]...)
-		if output, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("error installing archive %q: %v: %s", e.Name, err, string(output))
+			klog.Infof("running command %s", args)
+			cmd := exec.Command(args[0], args[1:]...)
+			if output, err := cmd.CombinedOutput(); err != nil {
+				return fmt.Errorf("error installing archive %q: %v: %s", e.Name, err, string(output))
+			}
+		} else {
+			for src, dest := range e.MapFiles {
+				stripCount := strings.Count(src, "/")
+				targetDir := filepath.Join(e.TargetDir, dest)
+				if err := os.MkdirAll(targetDir, 0755); err != nil {
+					return fmt.Errorf("error creating directories %q: %v", targetDir, err)
+				}
+
+				args := []string{"tar", "xf", localFile, "-C", targetDir, "--strip-components=" + strconv.Itoa(stripCount), src}
+
+				klog.Infof("running command %s", args)
+				cmd := exec.Command(args[0], args[1:]...)
+				if output, err := cmd.CombinedOutput(); err != nil {
+					return fmt.Errorf("error installing archive %q: %v: %s", e.Name, err, string(output))
+				}
+			}
 		}
 
 		// We write a marker file to prevent re-execution

--- a/upup/pkg/fi/nodeup/nodetasks/package.go
+++ b/upup/pkg/fi/nodeup/nodetasks/package.go
@@ -54,9 +54,10 @@ type Package struct {
 }
 
 const (
-	localPackageDir       = "/var/cache/nodeup/packages/"
-	containerdPackageName = "containerd.io"
-	dockerPackageName     = "docker-ce"
+	localPackageDir             = "/var/cache/nodeup/packages/"
+	containerSelinuxPackageName = "container-selinux"
+	containerdPackageName       = "containerd.io"
+	dockerPackageName           = "docker-ce"
 )
 
 var _ fi.HasDependencies = &Package{}
@@ -83,10 +84,24 @@ func (e *Package) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 		}
 	}
 
-	// Docker should wait for containerd to be installed
+	// containerd should wait for container-selinux to be installed
+	if e.Name == containerdPackageName {
+		for _, v := range tasks {
+			if vp, ok := v.(*Package); ok {
+				if vp.Name == containerSelinuxPackageName {
+					deps = append(deps, v)
+				}
+			}
+		}
+	}
+
+	// Docker should wait for container-selinux and containerd to be installed
 	if e.Name == dockerPackageName {
 		for _, v := range tasks {
 			if vp, ok := v.(*Package); ok {
+				if vp.Name == containerSelinuxPackageName {
+					deps = append(deps, v)
+				}
 				if vp.Name == containerdPackageName {
 					deps = append(deps, v)
 				}


### PR DESCRIPTION
Each containerd release comes with a tar.gz that can be used to install it with minimal effort.
Ref: https://github.com/kubernetes/kops/pull/7986#discussion_r357925711

Summary of changes:
* Archive task will extract each required file to the desired location - easier to control what goes where, but may need versioning in the future
* the package contains static binaries, so no need to provide a distro like with each rpm/deb
* having a single package means dependencies need to go to Packages
* support for CentOS should be much simpler now that `container-selinux` is installed from repo and not vault (vault package is still needed for RHEL and Amazon Linux)

**PS1**: Docker could get some similar upgrade by moving the deps to Packages and would open the way to multi-arch.

**PS2**: Amazon Linux 2 doesn't have the packages required to run the latest containerd (and Docker). At least the deps for `container-selinux` from CentOS are missing. I suspect this distro will need special care if support for it is desired.