### PR TITLE
GCE: Naming of google_compute VPC route now includes cluster name

### DIFF
--- a/pkg/model/gcemodel/context.go
+++ b/pkg/model/gcemodel/context.go
@@ -37,7 +37,7 @@ func (c *GCEModelContext) LinkToNetwork() *gcetasks.Network {
 func (c *GCEModelContext) NameForNetwork() string {
 	networkName := c.Cluster.Spec.NetworkID
 	if networkName == "" {
-		networkName = "default"
+		networkName = c.SafeObjectName("vpc")
 	}
 	return networkName
 }

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -102,7 +102,7 @@ resource "google_compute_disk" "d3-etcd-main-ha-gce-example-com" {
 
 resource "google_compute_firewall" "cidr-to-master-ha-gce-example-com" {
   name    = "cidr-to-master-ha-gce-example-com"
-  network = "${google_compute_network.default.name}"
+  network = "${google_compute_network.vpc-ha-gce-example-com.name}"
 
   allow = {
     protocol = "tcp"
@@ -120,7 +120,7 @@ resource "google_compute_firewall" "cidr-to-master-ha-gce-example-com" {
 
 resource "google_compute_firewall" "cidr-to-node-ha-gce-example-com" {
   name    = "cidr-to-node-ha-gce-example-com"
-  network = "${google_compute_network.default.name}"
+  network = "${google_compute_network.vpc-ha-gce-example-com.name}"
 
   allow = {
     protocol = "tcp"
@@ -152,7 +152,7 @@ resource "google_compute_firewall" "cidr-to-node-ha-gce-example-com" {
 
 resource "google_compute_firewall" "kubernetes-master-https-ha-gce-example-com" {
   name    = "kubernetes-master-https-ha-gce-example-com"
-  network = "${google_compute_network.default.name}"
+  network = "${google_compute_network.vpc-ha-gce-example-com.name}"
 
   allow = {
     protocol = "tcp"
@@ -165,7 +165,7 @@ resource "google_compute_firewall" "kubernetes-master-https-ha-gce-example-com" 
 
 resource "google_compute_firewall" "master-to-master-ha-gce-example-com" {
   name    = "master-to-master-ha-gce-example-com"
-  network = "${google_compute_network.default.name}"
+  network = "${google_compute_network.vpc-ha-gce-example-com.name}"
 
   allow = {
     protocol = "tcp"
@@ -197,7 +197,7 @@ resource "google_compute_firewall" "master-to-master-ha-gce-example-com" {
 
 resource "google_compute_firewall" "master-to-node-ha-gce-example-com" {
   name    = "master-to-node-ha-gce-example-com"
-  network = "${google_compute_network.default.name}"
+  network = "${google_compute_network.vpc-ha-gce-example-com.name}"
 
   allow = {
     protocol = "tcp"
@@ -229,7 +229,7 @@ resource "google_compute_firewall" "master-to-node-ha-gce-example-com" {
 
 resource "google_compute_firewall" "node-to-master-ha-gce-example-com" {
   name    = "node-to-master-ha-gce-example-com"
-  network = "${google_compute_network.default.name}"
+  network = "${google_compute_network.vpc-ha-gce-example-com.name}"
 
   allow = {
     protocol = "tcp"
@@ -247,7 +247,7 @@ resource "google_compute_firewall" "node-to-master-ha-gce-example-com" {
 
 resource "google_compute_firewall" "node-to-node-ha-gce-example-com" {
   name    = "node-to-node-ha-gce-example-com"
-  network = "${google_compute_network.default.name}"
+  network = "${google_compute_network.vpc-ha-gce-example-com.name}"
 
   allow = {
     protocol = "tcp"
@@ -279,7 +279,7 @@ resource "google_compute_firewall" "node-to-node-ha-gce-example-com" {
 
 resource "google_compute_firewall" "nodeport-external-to-node-ha-gce-example-com" {
   name    = "nodeport-external-to-node-ha-gce-example-com"
-  network = "${google_compute_network.default.name}"
+  network = "${google_compute_network.vpc-ha-gce-example-com.name}"
 
   allow = {
     protocol = "tcp"
@@ -297,7 +297,7 @@ resource "google_compute_firewall" "nodeport-external-to-node-ha-gce-example-com
 
 resource "google_compute_firewall" "ssh-external-to-master-ha-gce-example-com" {
   name    = "ssh-external-to-master-ha-gce-example-com"
-  network = "${google_compute_network.default.name}"
+  network = "${google_compute_network.vpc-ha-gce-example-com.name}"
 
   allow = {
     protocol = "tcp"
@@ -310,7 +310,7 @@ resource "google_compute_firewall" "ssh-external-to-master-ha-gce-example-com" {
 
 resource "google_compute_firewall" "ssh-external-to-node-ha-gce-example-com" {
   name    = "ssh-external-to-node-ha-gce-example-com"
-  network = "${google_compute_network.default.name}"
+  network = "${google_compute_network.vpc-ha-gce-example-com.name}"
 
   allow = {
     protocol = "tcp"
@@ -419,7 +419,7 @@ resource "google_compute_instance_template" "master-us-test1-a-ha-gce-example-co
   }
 
   network_interface = {
-    network       = "${google_compute_network.default.name}"
+    network       = "${google_compute_network.vpc-ha-gce-example-com.name}"
     access_config = {}
   }
 
@@ -460,7 +460,7 @@ resource "google_compute_instance_template" "master-us-test1-b-ha-gce-example-co
   }
 
   network_interface = {
-    network       = "${google_compute_network.default.name}"
+    network       = "${google_compute_network.vpc-ha-gce-example-com.name}"
     access_config = {}
   }
 
@@ -501,7 +501,7 @@ resource "google_compute_instance_template" "master-us-test1-c-ha-gce-example-co
   }
 
   network_interface = {
-    network       = "${google_compute_network.default.name}"
+    network       = "${google_compute_network.vpc-ha-gce-example-com.name}"
     access_config = {}
   }
 
@@ -542,7 +542,7 @@ resource "google_compute_instance_template" "nodes-ha-gce-example-com" {
   }
 
   network_interface = {
-    network       = "${google_compute_network.default.name}"
+    network       = "${google_compute_network.vpc-ha-gce-example-com.name}"
     access_config = {}
   }
 
@@ -557,8 +557,8 @@ resource "google_compute_instance_template" "nodes-ha-gce-example-com" {
   name_prefix = "nodes-ha-gce-example-com-"
 }
 
-resource "google_compute_network" "default" {
-  name                    = "default"
+resource "google_compute_network" "vpc-ha-gce-example-com" {
+  name                    = "vpc-ha-gce-example-com"
   auto_create_subnetworks = true
 }
 

--- a/upup/pkg/fi/cloudup/gce/instancegroups.go
+++ b/upup/pkg/fi/cloudup/gce/instancegroups.go
@@ -17,9 +17,7 @@ limitations under the License.
 package gce
 
 import (
-	"encoding/base32"
 	"fmt"
-	"hash/fnv"
 	"strings"
 
 	context "golang.org/x/net/context"
@@ -216,32 +214,6 @@ func NameForInstanceGroupManager(c *kops.Cluster, ig *kops.InstanceGroup, zone s
 	name := SafeObjectName(shortZone+"."+ig.ObjectMeta.Name, c.ObjectMeta.Name)
 	name = LimitedLengthName(name, 63)
 	return name
-}
-
-// LimitedLengthName returns a string subject to a maximum length
-func LimitedLengthName(s string, n int) string {
-	// We only use the hash if we need to
-	if len(s) <= n {
-		return s
-	}
-
-	h := fnv.New32a()
-	if _, err := h.Write([]byte(s)); err != nil {
-		klog.Fatalf("error hashing values: %v", err)
-	}
-	hashString := base32.HexEncoding.EncodeToString(h.Sum(nil))
-	hashString = strings.ToLower(hashString)
-	if len(hashString) > 6 {
-		hashString = hashString[:6]
-	}
-
-	maxBaseLength := n - len(hashString) - 1
-	if len(s) > maxBaseLength {
-		s = s[:maxBaseLength]
-	}
-	s = s + "-" + hashString
-
-	return s
 }
 
 // matchInstanceGroup filters a list of instancegroups for recognized cloud groups

--- a/upup/pkg/fi/cloudup/gce/network.go
+++ b/upup/pkg/fi/cloudup/gce/network.go
@@ -59,7 +59,7 @@ func performNetworkAssignmentsIPAliases(ctx context.Context, c *kops.Cluster, cl
 
 	networkName := c.Spec.NetworkID
 	if networkName == "" {
-		networkName = "default"
+		networkName = SafeObjectName("vpc", c.ClusterName)
 	}
 
 	cloud := cloudObj.(GCECloud)


### PR DESCRIPTION
The VPC was always named "default" when no NetworkID was given in the cluster spec.

* changed it to now be `vpc-{sanitized-cluster-name}`
* moved the length limit function into the util.go 
* SafeObjectName will now limit the name length to 63, only lower case chars. 

Didn't find a documentation on the specifics of the name but the website statet (often) that names should only contain lower alphanumerics and hyphens and should be max 63 chars long.

