### PR TITLE
Fix cmd/kops staticcheck failures

### DIFF
--- a/cmd/kops/delete_cluster.go
+++ b/cmd/kops/delete_cluster.go
@@ -92,8 +92,6 @@ func NewCmdDeleteCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	return cmd
 }
 
-type getter func(o interface{}) interface{}
-
 func RunDeleteCluster(f *util.Factory, out io.Writer, options *DeleteClusterOptions) error {
 	clusterName := options.ClusterName
 	if clusterName == "" {

--- a/cmd/kops/export.go
+++ b/cmd/kops/export.go
@@ -37,9 +37,6 @@ var (
 	exportShort = i18n.T(`Export configuration.`)
 )
 
-type ExportOptions struct {
-}
-
 func NewCmdExport(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{

--- a/cmd/kops/export_kubecfg.go
+++ b/cmd/kops/export_kubecfg.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/kops/cmd/kops/util"
 	"k8s.io/kops/pkg/commands"
 	"k8s.io/kops/pkg/kubeconfig"
-	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 	"k8s.io/kubernetes/pkg/kubectl/util/templates"
 )
@@ -45,8 +44,6 @@ var (
 )
 
 type ExportKubecfgOptions struct {
-	tmpdir         string
-	keyStore       fi.CAStore
 	KubeConfigPath string
 }
 

--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -99,9 +99,7 @@ func TestExistingIAMCloudformation(t *testing.T) {
 
 // TestExistingSG runs the test with existing Security Group, similar to kops create cluster minimal.example.com --zones us-west-1a
 func TestExistingSG(t *testing.T) {
-	lifecycleOverrides := []string{"SecurityGroup=ExistsAndWarnIfChanges", "SecurityGroupRule=ExistsAndWarnIfChanges"}
-	lifecycleOverrides = nil
-	runTestAWS(t, "existingsg.example.com", "existing_sg", "v1alpha2", false, 3, true, false, lifecycleOverrides)
+	runTestAWS(t, "existingsg.example.com", "existing_sg", "v1alpha2", false, 3, true, false, nil)
 }
 
 // TestAdditionalUserData runs the test on passing additional user-data to an instance at bootstrap.

--- a/cmd/kops/pkix.go
+++ b/cmd/kops/pkix.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"crypto/x509/pkix"
 	"fmt"
-	"strings"
 )
 
 func pkixNameToString(name *pkix.Name) string {
@@ -56,28 +55,4 @@ func pkixNameToString(name *pkix.Name) string {
 		}
 	}
 	return s.String()
-}
-
-func parsePkixName(s string) (*pkix.Name, error) {
-	name := new(pkix.Name)
-
-	tokens := strings.Split(s, ",")
-	for _, token := range tokens {
-		token = strings.TrimSpace(token)
-		kv := strings.SplitN(token, "=", 2)
-		if len(kv) != 2 {
-			return nil, fmt.Errorf("unrecognized token (expected k=v): %q", token)
-		}
-		k := strings.ToLower(kv[0])
-		v := kv[1]
-
-		switch k {
-		case "cn":
-			name.CommonName = v
-		default:
-			return nil, fmt.Errorf("unrecognized key %q in token %q", k, token)
-		}
-	}
-
-	return name, nil
 }

--- a/cmd/kops/root.go
+++ b/cmd/kops/root.go
@@ -34,8 +34,6 @@ import (
 	"k8s.io/kops/cmd/kops/util"
 	kopsapi "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/client/simple"
-	"k8s.io/kops/pkg/kubeconfig"
-	"k8s.io/kops/upup/pkg/kutil"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 	"k8s.io/kubernetes/pkg/kubectl/util/templates"
 )
@@ -270,27 +268,6 @@ func ClusterNameFromKubecfg() string {
 	//}
 
 	return clusterName
-}
-
-func readKubectlClusterConfig() (*kubeconfig.KubectlClusterWithName, error) {
-	kubectl := &kutil.Kubectl{}
-	context, err := kubectl.GetCurrentContext()
-	if err != nil {
-		return nil, fmt.Errorf("error getting current context from kubectl: %v", err)
-	}
-	klog.V(4).Infof("context = %q", context)
-
-	config, err := kubectl.GetConfig(true)
-	if err != nil {
-		return nil, fmt.Errorf("error getting current config from kubectl: %v", err)
-	}
-
-	// Minify should have done this
-	if len(config.Clusters) != 1 {
-		return nil, fmt.Errorf("expected exactly one cluster in kubectl config, found %d", len(config.Clusters))
-	}
-
-	return config.Clusters[0], nil
 }
 
 func (c *RootCmd) Clientset() (simple.Clientset, error) {

--- a/cmd/kops/toolbox_bundle.go
+++ b/cmd/kops/toolbox_bundle.go
@@ -17,9 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"fmt"
 	"io"
 	"os"
@@ -32,7 +30,6 @@ import (
 	"k8s.io/klog"
 	"k8s.io/kops/cmd/kops/util"
 	"k8s.io/kops/pkg/bundle"
-	"k8s.io/kops/pkg/try"
 	"k8s.io/kops/upup/pkg/kutil"
 	"k8s.io/kops/util/pkg/vfs"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
@@ -182,31 +179,6 @@ func runSshCommand(sshClient *ssh.Client, cmd string) error {
 
 	klog.Infof("stdout: %s", stdout.String())
 	klog.Infof("stderr: %s", stderr.String())
-	return nil
-}
-
-func writeToTar(files []*bundle.DataFile, bundlePath string) error {
-	f, err := os.Create(bundlePath)
-	if err != nil {
-		return fmt.Errorf("error creating output bundle file %q: %v", bundlePath, err)
-	}
-	defer try.CloseFile(f)
-
-	gw := gzip.NewWriter(f)
-	defer gw.Close()
-	tw := tar.NewWriter(gw)
-	defer tw.Close()
-
-	for _, file := range files {
-		if err := tw.WriteHeader(&file.Header); err != nil {
-			return fmt.Errorf("error writing tar file header: %v", err)
-		}
-
-		if _, err := tw.Write(file.Data); err != nil {
-			return fmt.Errorf("error writing tar file data: %v", err)
-		}
-	}
-
 	return nil
 }
 

--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,5 +1,4 @@
 cloudmock/aws/mockelbv2
-cmd/kops
 node-authorizer/pkg/authorizers/aws
 node-authorizer/pkg/server
 pkg/resources/digitalocean


### PR DESCRIPTION
Ref:#7800

```
cmd/kops/delete_cluster.go:95:6: type getter is unused (U1000)
cmd/kops/export.go:40:6: type ExportOptions is unused (U1000)
cmd/kops/export_kubecfg.go:48:2: field tmpdir is unused (U1000)
cmd/kops/export_kubecfg.go:49:2: field keyStore is unused (U1000)
cmd/kops/integration_test.go:102:2: this value of lifecycleOverrides is never used (SA4006)
cmd/kops/pkix.go:61:6: func parsePkixName is unused (U1000)
cmd/kops/root.go:275:6: func readKubectlClusterConfig is unused (U1000)
cmd/kops/toolbox_bundle.go:188:6: func writeToTar is unused (U1000)
```