### PR TITLE
Fix upup/tools/generators/pkg/codegen staticcheck failures

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -9,4 +9,3 @@ upup/pkg/fi
 upup/pkg/fi/cloudup
 upup/pkg/fi/cloudup/awstasks
 upup/pkg/kutil
-upup/tools/generators/pkg/codegen

--- a/upup/tools/generators/pkg/codegen/parse.go
+++ b/upup/tools/generators/pkg/codegen/parse.go
@@ -36,9 +36,6 @@ type GoParser struct {
 type File struct {
 	pkg  *Package  // Package to which this file belongs.
 	file *ast.File // Parsed AST.
-	// These fields are reset for each type being generated.
-	typeName string // Name of the constant type.
-	//values   []Value // Accumulator for constant values of that type.
 }
 
 type Package struct {
@@ -110,7 +107,7 @@ func (g *GoParser) parsePackage(directory string, names []string, text interface
 // check type-checks the package. The package must be OK to proceed.
 func (pkg *Package) check(fs *token.FileSet, astFiles []*ast.File) {
 	pkg.defs = make(map[*ast.Ident]types.Object)
-	config := types.Config{Importer: importer.For("source", nil), FakeImportC: true}
+	config := types.Config{Importer: importer.ForCompiler(token.NewFileSet(), "source", nil), FakeImportC: true}
 	info := &types.Info{
 		Defs: pkg.defs,
 	}


### PR DESCRIPTION
Ref:#7800

```
upup/tools/generators/pkg/codegen/parse.go:40:2: field typeName is unused (U1000)
upup/tools/generators/pkg/codegen/parse.go:113:35: importer.For is deprecated: Use ForCompiler, which populates a FileSet with the positions of objects created by the importer.  (SA1019)
```