### PR TITLE
Enable host logging for kops-controller

### DIFF
--- a/nodeup/pkg/model/logrotate.go
+++ b/nodeup/pkg/model/logrotate.go
@@ -70,6 +70,7 @@ func (b *LogrotateBuilder) Build(c *fi.ModelBuilderContext) error {
 	b.addLogRotate(c, "kubelet", "/var/log/kubelet.log", logRotateOptions{})
 	b.addLogRotate(c, "etcd", "/var/log/etcd.log", logRotateOptions{})
 	b.addLogRotate(c, "etcd-events", "/var/log/etcd-events.log", logRotateOptions{})
+	b.addLogRotate(c, "kops-controller", "/var/log/kops-controller.log", logRotateOptions{})
 
 	if err := b.addLogrotateService(c); err != nil {
 		return err

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -87,6 +87,8 @@ spec:
 {{ end }}
         - mountPath: /etc/kubernetes/kops-controller/
           name: kops-controller-config
+        - mountPath: /var/log/kops-controller.log
+          name: logfile
         command:
 {{ range $arg := KopsControllerArgv }}
         - "{{ $arg }}"
@@ -112,7 +114,10 @@ spec:
       - name: kops-controller-config
         configMap:
           name: kops-controller
-
+      - name: logfile
+        hostPath:
+          path: /var/log/kops-controller.log
+          type: FileOrCreate
 ---
 
 apiVersion: v1

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -380,6 +380,8 @@ func (tf *TemplateFunctions) KopsControllerArgv() ([]string, error) {
 
 	argv = append(argv, "--conf=/etc/kubernetes/kops-controller/config.yaml")
 
+	argv = append(argv, "--logtostderr=false", "--alsologtostderr", "--log_file=/var/log/kops-controller.log")
+
 	return argv, nil
 }
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: efb1399217d403fa5207e2bc8cf1fbef58c7f8b2
+    manifestHash: 66e39c304bd9f397ef5d66ba7d41d52291f5eb7f
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -66,6 +66,9 @@ spec:
         - /usr/bin/kops-controller
         - --v=2
         - --conf=/etc/kubernetes/kops-controller/config.yaml
+        - --logtostderr=false
+        - --alsologtostderr
+        - --log_file=/var/log/kops-controller.log
         image: kope/kops-controller:1.15.0-alpha.1
         name: kops-controller
         resources:
@@ -75,6 +78,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/kubernetes/kops-controller/
           name: kops-controller-config
+        - mountPath: /var/log/kops-controller.log
+          name: logfile
       dnsPolicy: Default
       hostNetwork: true
       nodeSelector:
@@ -88,6 +93,10 @@ spec:
       - configMap:
           name: kops-controller
         name: kops-controller-config
+      - hostPath:
+          path: /var/log/kops-controller.log
+          type: FileOrCreate
+        name: logfile
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 24cf09054ddfdcb490b878b04ff321026daa10c7
+    manifestHash: 3cd3e32f7301a675a1cf6b99af05f3528007dd9a
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -66,6 +66,9 @@ spec:
         - /usr/bin/kops-controller
         - --v=2
         - --conf=/etc/kubernetes/kops-controller/config.yaml
+        - --logtostderr=false
+        - --alsologtostderr
+        - --log_file=/var/log/kops-controller.log
         image: kope/kops-controller:1.15.0-alpha.1
         name: kops-controller
         resources:
@@ -75,6 +78,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/kubernetes/kops-controller/
           name: kops-controller-config
+        - mountPath: /var/log/kops-controller.log
+          name: logfile
       dnsPolicy: Default
       hostNetwork: true
       nodeSelector:
@@ -88,6 +93,10 @@ spec:
       - configMap:
           name: kops-controller
         name: kops-controller-config
+      - hostPath:
+          path: /var/log/kops-controller.log
+          type: FileOrCreate
+        name: logfile
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 24cf09054ddfdcb490b878b04ff321026daa10c7
+    manifestHash: 3cd3e32f7301a675a1cf6b99af05f3528007dd9a
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 24cf09054ddfdcb490b878b04ff321026daa10c7
+    manifestHash: 3cd3e32f7301a675a1cf6b99af05f3528007dd9a
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io


### PR DESCRIPTION
This makes it easier to get the kops-controller logs from e2e tests since they [only dump logs](https://github.com/kubernetes/test-infra/blob/ec0fe6bd3603dd927cced9b398a8b3a951ab1157/kubetest/dump.go#L50-L74) from systemd services and /var/log files.

This is a bit different than the other components that we log to the host for... others are static pods that are ran on every master (or every node in the case of kube-proxy) but this is a deployment, so the log file will only be present on the master that happens to have the pod scheduled.
