### PR TITLE
Automated cherry pick of #8176 and #8209: Add deprecation warning for older k8s versions

### DIFF
--- a/permalinks/upgrade_k8s.md
+++ b/permalinks/upgrade_k8s.md
@@ -1,5 +1,11 @@
 # Kubernetes Upgrade Recommended
 
+Kops has established a deprecation policy for Kubernetes version support.
+Kops 1.18 will drop support for Kubernetes 1.8 and below.
+
+
 You are running a version of kubernetes that we recommend upgrading.
 
 Please see the [instructions for how to upgrade kubernetes](https://kops.sigs.k8s.io/operations/updates_and_upgrades/#upgrading-kubernetes)
+
+Please see the deprecation policy [GitHub issue](https://github.com/kubernetes/kops/issues/7999) for more information and to leave feedback.

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -91,6 +91,8 @@ var (
 	AlphaAllowALI = featureflag.New("AlphaAllowALI", featureflag.Bool(false))
 	// CloudupModels a list of supported models
 	CloudupModels = []string{"proto", "cloudup"}
+	// OldestSupportedKubernetesVersion is the oldest kubernetes version that is supported in Kops
+	OldestSupportedKubernetesVersion = "1.9.0"
 )
 
 type ApplyClusterCmd struct {
@@ -1038,6 +1040,20 @@ func (c *ApplyClusterCmd) validateKubernetesVersion() error {
 		klog.Warningf("unable to parse kubernetes version %q", c.Cluster.Spec.KubernetesVersion)
 		// Not a hard-error
 		return nil
+	}
+
+	if !util.IsKubernetesGTE(OldestSupportedKubernetesVersion, *parsed) {
+		fmt.Printf("\n")
+		fmt.Printf(starline)
+		fmt.Printf("\n")
+		fmt.Printf("Kops support for this Kubernetes version is deprecated and will be removed in a future release.\n")
+		fmt.Printf("\n")
+		fmt.Printf("Upgrading is recommended\n")
+		fmt.Printf("More information: %s\n", buildPermalink("upgrade_kops", ""))
+		fmt.Printf("\n")
+		fmt.Printf(starline)
+		fmt.Printf("\n")
+
 	}
 
 	// TODO: make util.ParseKubernetesVersion not return a pointer

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1049,7 +1049,7 @@ func (c *ApplyClusterCmd) validateKubernetesVersion() error {
 		fmt.Printf("Kops support for this Kubernetes version is deprecated and will be removed in a future release.\n")
 		fmt.Printf("\n")
 		fmt.Printf("Upgrading is recommended\n")
-		fmt.Printf("More information: %s\n", buildPermalink("upgrade_kops", ""))
+		fmt.Printf("More information: %s\n", buildPermalink("upgrade_k8s", ""))
 		fmt.Printf("\n")
 		fmt.Printf(starline)
 		fmt.Printf("\n")


### PR DESCRIPTION
Cherry pick of #8176 on release-1.16.

#8176: Add deprecation warning for older k8s versions

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

also cherry picks a typo fix in #8209