### PR TITLE
Fix link printed in k8s version deprecation message

### DIFF
--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1053,7 +1053,7 @@ func (c *ApplyClusterCmd) validateKubernetesVersion() error {
 		fmt.Printf("Kops support for this Kubernetes version is deprecated and will be removed in a future release.\n")
 		fmt.Printf("\n")
 		fmt.Printf("Upgrading is recommended\n")
-		fmt.Printf("More information: %s\n", buildPermalink("upgrade_kops", ""))
+		fmt.Printf("More information: %s\n", buildPermalink("upgrade_k8s", ""))
 		fmt.Printf("\n")
 		fmt.Printf(starline)
 		fmt.Printf("\n")


### PR DESCRIPTION
Thanks for pointing this out @johngmyers 

It is meant to point [here](https://github.com/kubernetes/kops/blob/master/permalinks/upgrade_k8s.md)