### PR TITLE
Fix typo in KubeProxy model

### DIFF
--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -38,7 +38,7 @@ type KubeProxyBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &KubeAPIServerBuilder{}
+var _ fi.ModelBuilder = &KubeProxyBuilder{}
 
 // Build is responsible for building the kube-proxy manifest
 // @TODO we should probably change this to a daemonset in the future and follow the kubeadm path


### PR DESCRIPTION
very minor, but meant to ensure that KubeProxyBuilder satisfies the ModelBuilder interface. likely a copy/paste typo based on other files in the same package.