### PR TITLE
Fix typo in export kubeconfig

### DIFF
--- a/cmd/kops/export_kubecfg.go
+++ b/cmd/kops/export_kubecfg.go
@@ -82,7 +82,7 @@ func RunExportKubecfg(f *util.Factory, out io.Writer, options *ExportKubecfgOpti
 	var clusterList []*api.Cluster
 	if options.all {
 		if len(args) != 0 {
-			return fmt.Errorf("Cannot use both --args flag and positional arguments")
+			return fmt.Errorf("Cannot use both --all flag and positional arguments")
 		}
 		list, err := clientset.ListClusters(metav1.ListOptions{})
 		if err != nil {


### PR DESCRIPTION
Fix typo mentioned in #8179 
@justinsb 