### PR TITLE
Move nodeup to /opt/kops/bin

### DIFF
--- a/nodeup/pkg/model/firewall.go
+++ b/nodeup/pkg/model/firewall.go
@@ -46,7 +46,7 @@ func (b *FirewallBuilder) buildSystemdService() *nodetasks.Service {
 	manifest.Set("Unit", "Before", "network.target")
 	manifest.Set("Service", "Type", "oneshot")
 	manifest.Set("Service", "RemainAfterExit", "yes")
-	manifest.Set("Service", "ExecStart", "/opt/kops/helpers/iptables-setup")
+	manifest.Set("Service", "ExecStart", "/opt/kops/bin/iptables-setup")
 	manifest.Set("Install", "WantedBy", "basic.target")
 
 	manifestString := manifest.Render()
@@ -87,7 +87,7 @@ iptables -A FORWARD -w -p ICMP -j ACCEPT
 fi
 `
 	return &nodetasks.File{
-		Path:     "/opt/kops/helpers/iptables-setup",
+		Path:     "/opt/kops/bin/iptables-setup",
 		Contents: fi.NewStringResource(script),
 		Type:     nodetasks.FileType_File,
 		Mode:     s("0755"),

--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -53,12 +53,9 @@ NODEUP_HASH={{ NodeUpSourceHash }}
 {{ ProxyEnv }}
 
 function ensure-install-dir() {
-  INSTALL_DIR="/var/cache/kubernetes-install"
-  # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-  if [[ -d /var/lib/toolbox ]]; then
-    INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-  fi
-  mkdir -p ${INSTALL_DIR}
+  INSTALL_DIR="/opt/kops"
+  mkdir -p ${INSTALL_DIR}/bin
+  mkdir -p ${INSTALL_DIR}/conf
   cd ${INSTALL_DIR}
 }
 
@@ -140,6 +137,7 @@ function try-download-release() {
 
 function download-release() {
   # In case of failure checking integrity of release, retry.
+  cd ${INSTALL_DIR}/bin
   until try-download-release; do
     sleep 15
     echo "Couldn't download release. Retrying..."
@@ -147,7 +145,7 @@ function download-release() {
 
   echo "Running nodeup"
   # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-  ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+  ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
 }
 
 ####################################################################################
@@ -157,15 +155,15 @@ function download-release() {
 echo "== nodeup node config starting =="
 ensure-install-dir
 
-cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 {{ ClusterSpec }}
 __EOF_CLUSTER_SPEC
 
-cat > ig_spec.yaml << '__EOF_IG_SPEC'
+cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
 {{ IGSpec }}
 __EOF_IG_SPEC
 
-cat > kube_env.yaml << '__EOF_KUBE_ENV'
+cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 {{ KubeEnv }}
 __EOF_KUBE_ENV
 

--- a/pkg/model/tests/data/bootstrapscript_0.txt
+++ b/pkg/model/tests/data/bootstrapscript_0.txt
@@ -42,12 +42,9 @@ systemctl daemon-reexec
 
 
 function ensure-install-dir() {
-  INSTALL_DIR="/var/cache/kubernetes-install"
-  # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-  if [[ -d /var/lib/toolbox ]]; then
-    INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-  fi
-  mkdir -p ${INSTALL_DIR}
+  INSTALL_DIR="/opt/kops"
+  mkdir -p ${INSTALL_DIR}/bin
+  mkdir -p ${INSTALL_DIR}/conf
   cd ${INSTALL_DIR}
 }
 
@@ -129,6 +126,7 @@ function try-download-release() {
 
 function download-release() {
   # In case of failure checking integrity of release, retry.
+  cd ${INSTALL_DIR}/bin
   until try-download-release; do
     sleep 15
     echo "Couldn't download release. Retrying..."
@@ -136,7 +134,7 @@ function download-release() {
 
   echo "Running nodeup"
   # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-  ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+  ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
 }
 
 ####################################################################################
@@ -146,7 +144,7 @@ function download-release() {
 echo "== nodeup node config starting =="
 ensure-install-dir
 
-cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   nodeTags: something
 containerRuntime: docker
@@ -181,7 +179,7 @@ masterKubelet:
 
 __EOF_CLUSTER_SPEC
 
-cat > ig_spec.yaml << '__EOF_IG_SPEC'
+cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
 fileAssets:
 - content: xYagtQLwBAAi3V8Wc2Jrojz28I0= (fingerprint)
   name: tokens
@@ -200,7 +198,7 @@ taints:
 
 __EOF_IG_SPEC
 
-cat > kube_env.yaml << '__EOF_KUBE_ENV'
+cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 {}
 
 __EOF_KUBE_ENV

--- a/pkg/model/tests/data/bootstrapscript_1.txt
+++ b/pkg/model/tests/data/bootstrapscript_1.txt
@@ -42,12 +42,9 @@ systemctl daemon-reexec
 
 
 function ensure-install-dir() {
-  INSTALL_DIR="/var/cache/kubernetes-install"
-  # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-  if [[ -d /var/lib/toolbox ]]; then
-    INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-  fi
-  mkdir -p ${INSTALL_DIR}
+  INSTALL_DIR="/opt/kops"
+  mkdir -p ${INSTALL_DIR}/bin
+  mkdir -p ${INSTALL_DIR}/conf
   cd ${INSTALL_DIR}
 }
 
@@ -129,6 +126,7 @@ function try-download-release() {
 
 function download-release() {
   # In case of failure checking integrity of release, retry.
+  cd ${INSTALL_DIR}/bin
   until try-download-release; do
     sleep 15
     echo "Couldn't download release. Retrying..."
@@ -136,7 +134,7 @@ function download-release() {
 
   echo "Running nodeup"
   # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-  ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+  ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
 }
 
 ####################################################################################
@@ -146,7 +144,7 @@ function download-release() {
 echo "== nodeup node config starting =="
 ensure-install-dir
 
-cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   nodeTags: something
 containerRuntime: docker
@@ -190,7 +188,7 @@ masterKubelet:
 
 __EOF_CLUSTER_SPEC
 
-cat > ig_spec.yaml << '__EOF_IG_SPEC'
+cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
 fileAssets:
 - content: E1oeAbrnQsSldrIP1BpoP2SDykM= (fingerprint)
   name: iptables-restore
@@ -217,7 +215,7 @@ taints:
 
 __EOF_IG_SPEC
 
-cat > kube_env.yaml << '__EOF_KUBE_ENV'
+cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 {}
 
 __EOF_KUBE_ENV

--- a/pkg/model/tests/data/bootstrapscript_2.txt
+++ b/pkg/model/tests/data/bootstrapscript_2.txt
@@ -42,12 +42,9 @@ systemctl daemon-reexec
 
 
 function ensure-install-dir() {
-  INSTALL_DIR="/var/cache/kubernetes-install"
-  # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-  if [[ -d /var/lib/toolbox ]]; then
-    INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-  fi
-  mkdir -p ${INSTALL_DIR}
+  INSTALL_DIR="/opt/kops"
+  mkdir -p ${INSTALL_DIR}/bin
+  mkdir -p ${INSTALL_DIR}/conf
   cd ${INSTALL_DIR}
 }
 
@@ -129,6 +126,7 @@ function try-download-release() {
 
 function download-release() {
   # In case of failure checking integrity of release, retry.
+  cd ${INSTALL_DIR}/bin
   until try-download-release; do
     sleep 15
     echo "Couldn't download release. Retrying..."
@@ -136,7 +134,7 @@ function download-release() {
 
   echo "Running nodeup"
   # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-  ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+  ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
 }
 
 ####################################################################################
@@ -146,7 +144,7 @@ function download-release() {
 echo "== nodeup node config starting =="
 ensure-install-dir
 
-cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   nodeTags: something
 containerRuntime: docker
@@ -190,7 +188,7 @@ masterKubelet:
 
 __EOF_CLUSTER_SPEC
 
-cat > ig_spec.yaml << '__EOF_IG_SPEC'
+cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
 fileAssets:
 - content: E1oeAbrnQsSldrIP1BpoP2SDykM= (fingerprint)
   name: iptables-restore
@@ -217,7 +215,7 @@ taints:
 
 __EOF_IG_SPEC
 
-cat > kube_env.yaml << '__EOF_KUBE_ENV'
+cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 {}
 
 __EOF_KUBE_ENV

--- a/pkg/model/tests/data/bootstrapscript_3.txt
+++ b/pkg/model/tests/data/bootstrapscript_3.txt
@@ -42,12 +42,9 @@ systemctl daemon-reexec
 
 
 function ensure-install-dir() {
-  INSTALL_DIR="/var/cache/kubernetes-install"
-  # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-  if [[ -d /var/lib/toolbox ]]; then
-    INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-  fi
-  mkdir -p ${INSTALL_DIR}
+  INSTALL_DIR="/opt/kops"
+  mkdir -p ${INSTALL_DIR}/bin
+  mkdir -p ${INSTALL_DIR}/conf
   cd ${INSTALL_DIR}
 }
 
@@ -129,6 +126,7 @@ function try-download-release() {
 
 function download-release() {
   # In case of failure checking integrity of release, retry.
+  cd ${INSTALL_DIR}/bin
   until try-download-release; do
     sleep 15
     echo "Couldn't download release. Retrying..."
@@ -136,7 +134,7 @@ function download-release() {
 
   echo "Running nodeup"
   # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-  ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+  ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
 }
 
 ####################################################################################
@@ -146,7 +144,7 @@ function download-release() {
 echo "== nodeup node config starting =="
 ensure-install-dir
 
-cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   nodeTags: something
 containerRuntime: docker
@@ -166,7 +164,7 @@ kubelet:
 
 __EOF_CLUSTER_SPEC
 
-cat > ig_spec.yaml << '__EOF_IG_SPEC'
+cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
 fileAssets:
 - content: xYagtQLwBAAi3V8Wc2Jrojz28I0= (fingerprint)
   name: tokens
@@ -185,7 +183,7 @@ taints:
 
 __EOF_IG_SPEC
 
-cat > kube_env.yaml << '__EOF_KUBE_ENV'
+cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 {}
 
 __EOF_KUBE_ENV

--- a/pkg/model/tests/data/bootstrapscript_4.txt
+++ b/pkg/model/tests/data/bootstrapscript_4.txt
@@ -42,12 +42,9 @@ systemctl daemon-reexec
 
 
 function ensure-install-dir() {
-  INSTALL_DIR="/var/cache/kubernetes-install"
-  # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-  if [[ -d /var/lib/toolbox ]]; then
-    INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-  fi
-  mkdir -p ${INSTALL_DIR}
+  INSTALL_DIR="/opt/kops"
+  mkdir -p ${INSTALL_DIR}/bin
+  mkdir -p ${INSTALL_DIR}/conf
   cd ${INSTALL_DIR}
 }
 
@@ -129,6 +126,7 @@ function try-download-release() {
 
 function download-release() {
   # In case of failure checking integrity of release, retry.
+  cd ${INSTALL_DIR}/bin
   until try-download-release; do
     sleep 15
     echo "Couldn't download release. Retrying..."
@@ -136,7 +134,7 @@ function download-release() {
 
   echo "Running nodeup"
   # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-  ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+  ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
 }
 
 ####################################################################################
@@ -146,7 +144,7 @@ function download-release() {
 echo "== nodeup node config starting =="
 ensure-install-dir
 
-cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   nodeTags: something
 containerRuntime: docker
@@ -175,7 +173,7 @@ kubelet:
 
 __EOF_CLUSTER_SPEC
 
-cat > ig_spec.yaml << '__EOF_IG_SPEC'
+cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
 fileAssets:
 - content: E1oeAbrnQsSldrIP1BpoP2SDykM= (fingerprint)
   name: iptables-restore
@@ -202,7 +200,7 @@ taints:
 
 __EOF_IG_SPEC
 
-cat > kube_env.yaml << '__EOF_KUBE_ENV'
+cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 {}
 
 __EOF_KUBE_ENV

--- a/pkg/model/tests/data/bootstrapscript_5.txt
+++ b/pkg/model/tests/data/bootstrapscript_5.txt
@@ -42,12 +42,9 @@ systemctl daemon-reexec
 
 
 function ensure-install-dir() {
-  INSTALL_DIR="/var/cache/kubernetes-install"
-  # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-  if [[ -d /var/lib/toolbox ]]; then
-    INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-  fi
-  mkdir -p ${INSTALL_DIR}
+  INSTALL_DIR="/opt/kops"
+  mkdir -p ${INSTALL_DIR}/bin
+  mkdir -p ${INSTALL_DIR}/conf
   cd ${INSTALL_DIR}
 }
 
@@ -129,6 +126,7 @@ function try-download-release() {
 
 function download-release() {
   # In case of failure checking integrity of release, retry.
+  cd ${INSTALL_DIR}/bin
   until try-download-release; do
     sleep 15
     echo "Couldn't download release. Retrying..."
@@ -136,7 +134,7 @@ function download-release() {
 
   echo "Running nodeup"
   # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-  ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+  ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
 }
 
 ####################################################################################
@@ -146,7 +144,7 @@ function download-release() {
 echo "== nodeup node config starting =="
 ensure-install-dir
 
-cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   nodeTags: something
 containerRuntime: docker
@@ -175,7 +173,7 @@ kubelet:
 
 __EOF_CLUSTER_SPEC
 
-cat > ig_spec.yaml << '__EOF_IG_SPEC'
+cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
 fileAssets:
 - content: E1oeAbrnQsSldrIP1BpoP2SDykM= (fingerprint)
   name: iptables-restore
@@ -202,7 +200,7 @@ taints:
 
 __EOF_IG_SPEC
 
-cat > kube_env.yaml << '__EOF_KUBE_ENV'
+cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 {}
 
 __EOF_KUBE_ENV

--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
@@ -27,12 +27,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -114,6 +111,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -121,7 +119,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -131,7 +129,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -254,14 +252,14 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
@@ -319,12 +317,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -406,6 +401,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -413,7 +409,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -423,7 +419,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -464,14 +460,14 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -36,12 +36,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -123,6 +120,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -130,7 +128,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -140,7 +138,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -263,14 +261,14 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
@@ -348,12 +346,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -435,6 +430,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -442,7 +438,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -452,7 +448,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -493,14 +489,14 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl

--- a/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
@@ -27,12 +27,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscomplexexampleco
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -114,6 +111,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscomplexexampleco
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -121,7 +119,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscomplexexampleco
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -131,7 +129,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscomplexexampleco
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -256,14 +254,14 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscomplexexampleco
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
@@ -321,12 +319,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodescomplexexamplecom.Properties.Use
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -408,6 +403,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodescomplexexamplecom.Properties.Use
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -415,7 +411,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodescomplexexamplecom.Properties.Use
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -425,7 +421,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodescomplexexamplecom.Properties.Use
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -466,14 +462,14 @@ Resources.AWSAutoScalingLaunchConfigurationnodescomplexexamplecom.Properties.Use
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl

--- a/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
@@ -27,12 +27,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscontainerdexampl
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -114,6 +111,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscontainerdexampl
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -121,7 +119,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscontainerdexampl
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -131,7 +129,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscontainerdexampl
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: containerd
   containerd:
@@ -248,14 +246,14 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscontainerdexampl
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
@@ -313,12 +311,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodescontainerdexamplecom.Properties.
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -400,6 +395,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodescontainerdexamplecom.Properties.
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -407,7 +403,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodescontainerdexamplecom.Properties.
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -417,7 +413,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodescontainerdexamplecom.Properties.
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: containerd
   containerd:
@@ -452,14 +448,14 @@ Resources.AWSAutoScalingLaunchConfigurationnodescontainerdexamplecom.Properties.
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -27,12 +27,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -114,6 +111,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -121,7 +119,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -131,7 +129,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -254,14 +252,14 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
@@ -319,12 +317,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -406,6 +401,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -413,7 +409,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -423,7 +419,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -464,14 +460,14 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -27,12 +27,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -114,6 +111,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -121,7 +119,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -131,7 +129,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -254,14 +252,14 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
@@ -319,12 +317,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -406,6 +401,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -413,7 +409,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -423,7 +419,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -464,14 +460,14 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -27,12 +27,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -114,6 +111,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -121,7 +119,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -131,7 +129,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -254,14 +252,14 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
@@ -319,12 +317,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -406,6 +401,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -413,7 +409,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -423,7 +419,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -464,14 +460,14 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
@@ -27,12 +27,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -114,6 +111,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -121,7 +119,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -131,7 +129,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -256,14 +254,14 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - e914b17532c411cb7c0cc472131b61935fb66b31@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubelet
   - aa3e93897a6999d6c7dedbc41793c90d41eeb000@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl
@@ -321,12 +319,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -408,6 +403,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -415,7 +411,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -425,7 +421,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -550,14 +546,14 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - e914b17532c411cb7c0cc472131b61935fb66b31@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubelet
   - aa3e93897a6999d6c7dedbc41793c90d41eeb000@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl
@@ -615,12 +611,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -702,6 +695,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -709,7 +703,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -719,7 +713,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -844,14 +838,14 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - e914b17532c411cb7c0cc472131b61935fb66b31@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubelet
   - aa3e93897a6999d6c7dedbc41793c90d41eeb000@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl
@@ -909,12 +903,9 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -996,6 +987,7 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -1003,7 +995,7 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -1013,7 +1005,7 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -1055,14 +1047,14 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - e914b17532c411cb7c0cc472131b61935fb66b31@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubelet
   - aa3e93897a6999d6c7dedbc41793c90d41eeb000@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
@@ -27,12 +27,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -114,6 +111,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -121,7 +119,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -131,7 +129,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -256,14 +254,14 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - e914b17532c411cb7c0cc472131b61935fb66b31@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubelet
   - aa3e93897a6999d6c7dedbc41793c90d41eeb000@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl
@@ -321,12 +319,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -408,6 +403,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -415,7 +411,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -425,7 +421,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -550,14 +546,14 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - e914b17532c411cb7c0cc472131b61935fb66b31@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubelet
   - aa3e93897a6999d6c7dedbc41793c90d41eeb000@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl
@@ -615,12 +611,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -702,6 +695,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -709,7 +703,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -719,7 +713,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -844,14 +838,14 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - e914b17532c411cb7c0cc472131b61935fb66b31@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubelet
   - aa3e93897a6999d6c7dedbc41793c90d41eeb000@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl
@@ -909,12 +903,9 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -996,6 +987,7 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -1003,7 +995,7 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -1013,7 +1005,7 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -1055,14 +1047,14 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - e914b17532c411cb7c0cc472131b61935fb66b31@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubelet
   - aa3e93897a6999d6c7dedbc41793c90d41eeb000@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
@@ -27,12 +27,9 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersprivatecalicoexa
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -114,6 +111,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersprivatecalicoexa
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -121,7 +119,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersprivatecalicoexa
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -131,7 +129,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersprivatecalicoexa
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -252,14 +250,14 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersprivatecalicoexa
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
@@ -317,12 +315,9 @@ Resources.AWSAutoScalingLaunchConfigurationnodesprivatecalicoexamplecom.Properti
 
 
   function ensure-install-dir() {
-    INSTALL_DIR="/var/cache/kubernetes-install"
-    # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kubernetes-install"
-    fi
-    mkdir -p ${INSTALL_DIR}
+    INSTALL_DIR="/opt/kops"
+    mkdir -p ${INSTALL_DIR}/bin
+    mkdir -p ${INSTALL_DIR}/conf
     cd ${INSTALL_DIR}
   }
 
@@ -404,6 +399,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesprivatecalicoexamplecom.Properti
 
   function download-release() {
     # In case of failure checking integrity of release, retry.
+    cd ${INSTALL_DIR}/bin
     until try-download-release; do
       sleep 15
       echo "Couldn't download release. Retrying..."
@@ -411,7 +407,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesprivatecalicoexamplecom.Properti
 
     echo "Running nodeup"
     # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )
+    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
   }
 
   ####################################################################################
@@ -421,7 +417,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesprivatecalicoexamplecom.Properti
   echo "== nodeup node config starting =="
   ensure-install-dir
 
-  cat > cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
   cloudConfig: null
   containerRuntime: docker
   containerd:
@@ -461,14 +457,14 @@ Resources.AWSAutoScalingLaunchConfigurationnodesprivatecalicoexamplecom.Properti
 
   __EOF_CLUSTER_SPEC
 
-  cat > ig_spec.yaml << '__EOF_IG_SPEC'
+  cat > conf/ig_spec.yaml << '__EOF_IG_SPEC'
   kubelet: null
   nodeLabels: null
   taints: null
 
   __EOF_IG_SPEC
 
-  cat > kube_env.yaml << '__EOF_KUBE_ENV'
+  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl


### PR DESCRIPTION
RHEL / CenOS 8 have some restrictions on binaries location for Systemd.
This is why initial configuration for `nodeup` cannot run and e2e tests are failing.
https://testgrid.k8s.io/sig-cluster-lifecycle-kops#kops-aws-containerd

Moving `nodeup` to /opt/kops/bin solves this issue.

At same time, `iptables-setup` script should also move to /opt/kops/bin. https://github.com/kubernetes/kops/pull/8164#discussion_r361681377

```
/opt/kops/
├── bin
│   ├── iptables-setup
│   └── nodeup
└── conf
    ├── cluster_spec.yaml
    ├── ig_spec.yaml
    └── kube_env.yaml
```