### PR TITLE
Automated cherry pick of #7832: cilium: don't try to mount sys/fs/bpf if already mounted

### DIFF
--- a/nodeup/pkg/model/network.go
+++ b/nodeup/pkg/model/network.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"k8s.io/kops/upup/pkg/fi"
@@ -71,7 +72,21 @@ func (b *NetworkBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 
 	if networking.Cilium != nil {
-		unit := s(`
+		// systemd v238 includes the bpffs mount by default; and gives an error "has a bad unit file setting" if we try to mount it again (see mount_point_is_api)
+		var alreadyMounted bool
+		_, err := os.Stat("/sys/fs/bpf")
+		if err != nil {
+			if os.IsNotExist(err) {
+				alreadyMounted = false
+			} else {
+				return fmt.Errorf("error checking for /sys/fs/bpf: %v", err)
+			}
+		} else {
+			alreadyMounted = true
+		}
+
+		if !alreadyMounted {
+			unit := s(`
 [Unit]
 Description=Cilium BPF mounts
 Documentation=http://docs.cilium.io/
@@ -84,15 +99,16 @@ Where=/sys/fs/bpf
 Type=bpf
 
 [Install]
-WantedBy=multi-user.target		
+WantedBy=multi-user.target
 `)
 
-		service := &nodetasks.Service{
-			Name:       "sys-fs-bpf.mount",
-			Definition: unit,
+			service := &nodetasks.Service{
+				Name:       "sys-fs-bpf.mount",
+				Definition: unit,
+			}
+			service.InitDefaults()
+			c.AddTask(service)
 		}
-		service.InitDefaults()
-		c.AddTask(service)
 	}
 
 	return nil


### PR DESCRIPTION
Cherry pick of #7832 on release-1.17.

#7832: cilium: don't try to mount sys/fs/bpf if already mounted

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.