### PR TITLE
Adding ability to configure resources for weave (#8113)

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2769,6 +2769,21 @@ spec:
                     connLimit:
                       format: int32
                       type: integer
+                    cpuLimit:
+                      description: CPULimit CPU limit of weave container.
+                      type: string
+                    cpuRequest:
+                      description: CPURequest CPU request of weave container. Default
+                        50m
+                      type: string
+                    memoryLimit:
+                      description: MemoryLimit memory limit of weave container. Default
+                        200Mi
+                      type: string
+                    memoryRequest:
+                      description: MemoryRequest memory request of weave container.
+                        Default 200Mi
+                      type: string
                     mtu:
                       format: int32
                       type: integer
@@ -2777,6 +2792,21 @@ spec:
                     noMasqLocal:
                       format: int32
                       type: integer
+                    npcCPULimit:
+                      description: NPCCPULimit CPU limit of weave npc container
+                      type: string
+                    npcCPURequest:
+                      description: NPCCPURequest CPU request of weave npc container.
+                        Default 50m
+                      type: string
+                    npcMemoryLimit:
+                      description: NPCMemoryLimit memory limit of weave npc container.
+                        Default 200Mi
+                      type: string
+                    npcMemoryRequest:
+                      description: NPCMemoryRequest memory request of weave npc container.
+                        Default 200Mi
+                      type: string
                   type: object
               type: object
             nodeAuthorization:

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package kops
 
+import "k8s.io/apimachinery/pkg/api/resource"
+
 // NetworkingSpec allows selection and configuration of a networking plugin
 type NetworkingSpec struct {
 	Classic    *ClassicNetworkingSpec    `json:"classic,omitempty"`
@@ -65,6 +67,23 @@ type WeaveNetworkingSpec struct {
 	ConnLimit    *int32 `json:"connLimit,omitempty"`
 	NoMasqLocal  *int32 `json:"noMasqLocal,omitempty"`
 	NetExtraArgs string `json:"netExtraArgs,omitempty"`
+
+	// MemoryRequest memory request of weave container. Default 200Mi
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest CPU request of weave container. Default 50m
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// MemoryLimit memory limit of weave container. Default 200Mi
+	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
+	// CPULimit CPU limit of weave container.
+	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
+	// NPCMemoryRequest memory request of weave npc container. Default 200Mi
+	NPCMemoryRequest *resource.Quantity `json:"npcMemoryRequest,omitempty"`
+	// NPCCPURequest CPU request of weave npc container. Default 50m
+	NPCCPURequest *resource.Quantity `json:"npcCPURequest,omitempty"`
+	// NPCMemoryLimit memory limit of weave npc container. Default 200Mi
+	NPCMemoryLimit *resource.Quantity `json:"npcMemoryLimit,omitempty"`
+	// NPCCPULimit CPU limit of weave npc container
+	NPCCPULimit *resource.Quantity `json:"npcCPULimit,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/parse_test.go
+++ b/pkg/apis/kops/parse_test.go
@@ -121,3 +121,48 @@ func TestParseConfigYAML(t *testing.T) {
 		})
 	}
 }
+
+func TestWeaveParseConfigYAML(t *testing.T) {
+	grid := []struct {
+		Config        string
+		ExpectedValue string
+	}{
+		{
+			Config:        "networking: {  weave: { memoryRequest: 500Mi, cpuRequest: 100m, npcMemoryRequest: 100Mi, npcCPURequest: 50m} }",
+			ExpectedValue: "50m",
+		},
+		{
+			Config:        "networking: {}",
+			ExpectedValue: "",
+		},
+	}
+	for i := range grid {
+		g := grid[i]
+		t.Run(fmt.Sprintf("%q", g.Config), func(t *testing.T) {
+			config := ClusterSpec{}
+			err := utils.YamlUnmarshal([]byte(g.Config), &config)
+			if err != nil {
+				t.Errorf("error parsing configuration %q: %v", g.Config, err)
+				return
+			}
+			var actual string
+			if nil != config.Networking.Weave {
+				actual = config.Networking.Weave.NPCCPURequest.String()
+			}
+			if g.ExpectedValue == "" {
+				if actual != "" {
+					t.Errorf("expected empty value for Networking.Weave.NPCCPURequest.String(), got %v", actual)
+					return
+				}
+			} else {
+				if actual == "" {
+					t.Errorf("expected %v value for Networking.Weave.NPCCPURequest.String(), got empty string", g.ExpectedValue)
+					return
+				} else if actual != g.ExpectedValue {
+					t.Errorf("expected %v value for Networking.Weave.NPCCPURequest.String(), got %v", g.ExpectedValue, actual)
+					return
+				}
+			}
+		})
+	}
+}

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package v1alpha1
 
+import "k8s.io/apimachinery/pkg/api/resource"
+
 // NetworkingSpec allows selection and configuration of a networking plugin
 type NetworkingSpec struct {
 	Classic    *ClassicNetworkingSpec    `json:"classic,omitempty"`
@@ -65,6 +67,23 @@ type WeaveNetworkingSpec struct {
 	ConnLimit    *int32 `json:"connLimit,omitempty"`
 	NoMasqLocal  *int32 `json:"noMasqLocal,omitempty"`
 	NetExtraArgs string `json:"netExtraArgs,omitempty"`
+
+	// MemoryRequest memory request of weave container. Default 200Mi
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest CPU request of weave container. Default 50m
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// MemoryLimit memory limit of weave container. Default 200Mi
+	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
+	// CPULimit CPU limit of weave container.
+	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
+	// NPCMemoryRequest memory request of weave npc container. Default 200Mi
+	NPCMemoryRequest *resource.Quantity `json:"npcMemoryRequest,omitempty"`
+	// NPCCPURequest CPU request of weave npc container. Default 50m
+	NPCCPURequest *resource.Quantity `json:"npcCPURequest,omitempty"`
+	// NPCMemoryLimit memory limit of weave npc container. Default 200Mi
+	NPCMemoryLimit *resource.Quantity `json:"npcMemoryLimit,omitempty"`
+	// NPCCPULimit CPU limit of weave npc container
+	NPCCPULimit *resource.Quantity `json:"npcCPULimit,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -4849,6 +4849,14 @@ func autoConvert_v1alpha1_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *We
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
 	out.NetExtraArgs = in.NetExtraArgs
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
+	out.MemoryLimit = in.MemoryLimit
+	out.CPULimit = in.CPULimit
+	out.NPCMemoryRequest = in.NPCMemoryRequest
+	out.NPCCPURequest = in.NPCCPURequest
+	out.NPCMemoryLimit = in.NPCMemoryLimit
+	out.NPCCPULimit = in.NPCCPULimit
 	return nil
 }
 
@@ -4862,6 +4870,14 @@ func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha1_WeaveNetworkingSpec(in *ko
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
 	out.NetExtraArgs = in.NetExtraArgs
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
+	out.MemoryLimit = in.MemoryLimit
+	out.CPULimit = in.CPULimit
+	out.NPCMemoryRequest = in.NPCMemoryRequest
+	out.NPCCPURequest = in.NPCCPURequest
+	out.NPCMemoryLimit = in.NPCMemoryLimit
+	out.NPCCPULimit = in.NPCCPULimit
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -3471,6 +3471,46 @@ func (in *WeaveNetworkingSpec) DeepCopyInto(out *WeaveNetworkingSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPULimit != nil {
+		in, out := &in.CPULimit, &out.CPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCMemoryRequest != nil {
+		in, out := &in.NPCMemoryRequest, &out.NPCMemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCCPURequest != nil {
+		in, out := &in.NPCCPURequest, &out.NPCCPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCMemoryLimit != nil {
+		in, out := &in.NPCMemoryLimit, &out.NPCMemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCCPULimit != nil {
+		in, out := &in.NPCCPULimit, &out.NPCCPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package v1alpha2
 
+import "k8s.io/apimachinery/pkg/api/resource"
+
 // NetworkingSpec allows selection and configuration of a networking plugin
 type NetworkingSpec struct {
 	Classic    *ClassicNetworkingSpec    `json:"classic,omitempty"`
@@ -65,6 +67,23 @@ type WeaveNetworkingSpec struct {
 	ConnLimit    *int32 `json:"connLimit,omitempty"`
 	NoMasqLocal  *int32 `json:"noMasqLocal,omitempty"`
 	NetExtraArgs string `json:"netExtraArgs,omitempty"`
+
+	// MemoryRequest memory request of weave container. Default 200Mi
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest CPU request of weave container. Default 50m
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// MemoryLimit memory limit of weave container. Default 200Mi
+	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
+	// CPULimit CPU limit of weave container.
+	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
+	// NPCMemoryRequest memory request of weave npc container. Default 200Mi
+	NPCMemoryRequest *resource.Quantity `json:"npcMemoryRequest,omitempty"`
+	// NPCCPURequest CPU request of weave npc container. Default 50m
+	NPCCPURequest *resource.Quantity `json:"npcCPURequest,omitempty"`
+	// NPCMemoryLimit memory limit of weave npc container. Default 200Mi
+	NPCMemoryLimit *resource.Quantity `json:"npcMemoryLimit,omitempty"`
+	// NPCCPULimit CPU limit of weave npc container
+	NPCCPULimit *resource.Quantity `json:"npcCPULimit,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5177,6 +5177,14 @@ func autoConvert_v1alpha2_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *We
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
 	out.NetExtraArgs = in.NetExtraArgs
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
+	out.MemoryLimit = in.MemoryLimit
+	out.CPULimit = in.CPULimit
+	out.NPCMemoryRequest = in.NPCMemoryRequest
+	out.NPCCPURequest = in.NPCCPURequest
+	out.NPCMemoryLimit = in.NPCMemoryLimit
+	out.NPCCPULimit = in.NPCCPULimit
 	return nil
 }
 
@@ -5190,6 +5198,14 @@ func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha2_WeaveNetworkingSpec(in *ko
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
 	out.NetExtraArgs = in.NetExtraArgs
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
+	out.MemoryLimit = in.MemoryLimit
+	out.CPULimit = in.CPULimit
+	out.NPCMemoryRequest = in.NPCMemoryRequest
+	out.NPCCPURequest = in.NPCCPURequest
+	out.NPCMemoryLimit = in.NPCMemoryLimit
+	out.NPCCPULimit = in.NPCCPULimit
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3542,6 +3542,46 @@ func (in *WeaveNetworkingSpec) DeepCopyInto(out *WeaveNetworkingSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPULimit != nil {
+		in, out := &in.CPULimit, &out.CPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCMemoryRequest != nil {
+		in, out := &in.NPCMemoryRequest, &out.NPCMemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCCPURequest != nil {
+		in, out := &in.NPCCPURequest, &out.NPCCPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCMemoryLimit != nil {
+		in, out := &in.NPCMemoryLimit, &out.NPCMemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCCPULimit != nil {
+		in, out := &in.NPCCPULimit, &out.NPCCPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3756,6 +3756,46 @@ func (in *WeaveNetworkingSpec) DeepCopyInto(out *WeaveNetworkingSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPULimit != nil {
+		in, out := &in.CPULimit, &out.CPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCMemoryRequest != nil {
+		in, out := &in.NPCMemoryRequest, &out.NPCMemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCCPURequest != nil {
+		in, out := &in.NPCCPURequest, &out.NPCCPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCMemoryLimit != nil {
+		in, out := &in.NPCMemoryLimit, &out.NPCMemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCCPULimit != nil {
+		in, out := &in.NPCCPULimit, &out.NPCCPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -179,10 +179,13 @@ spec:
               port: 6784
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.CPURequest "50m" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.CPULimit }}
+              cpu: {{ .Networking.Weave.CPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -214,10 +217,13 @@ spec:
               containerPort: 6781
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.NPCCPURequest "50m" }}
+              memory: {{ or .Networking.Weave.NPCMemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.NPCCPULimit }}
+              cpu: {{ .Networking.Weave.NPCCPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.NPCMemoryLimit "200mi" }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
@@ -161,10 +161,13 @@ spec:
               port: 6784
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.CPURequest "50m" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.CPULimit }}
+              cpu: {{ .Networking.Weave.CPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -195,10 +198,13 @@ spec:
               containerPort: 6781
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.NPCCPURequest "50m" }}
+              memory: {{ or .Networking.Weave.NPCMemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.NPCCPULimit }}
+              cpu: {{ .Networking.Weave.NPCCPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.NPCMemoryLimit "200mi" }}
           securityContext:
             privileged: true
       hostNetwork: true

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -171,10 +171,13 @@ spec:
               port: 6784
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.CPURequest "50m" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.CPULimit }}
+              cpu: {{ .Networking.Weave.CPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -206,10 +209,13 @@ spec:
               containerPort: 6781
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.NPCCPURequest "50m" }}
+              memory: {{ or .Networking.Weave.NPCMemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.NPCCPULimit }}
+              cpu: {{ .Networking.Weave.NPCCPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.NPCMemoryLimit "200mi" }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -175,10 +175,13 @@ spec:
               port: 6784
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.CPURequest "50m" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.CPULimit }}
+              cpu: {{ .Networking.Weave.CPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -210,10 +213,13 @@ spec:
               containerPort: 6781
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.NPCCPURequest "50m" }}
+              memory: {{ or .Networking.Weave.NPCMemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.NPCCPULimit }}
+              cpu: {{ .Networking.Weave.NPCCPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.NPCMemoryLimit "200mi" }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
@@ -59,10 +59,13 @@ spec:
             initialDelaySeconds: 30
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.CPURequest "50m" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.CPULimit }}
+              cpu: {{ .Networking.Weave.CPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/cluster.yaml
@@ -23,7 +23,15 @@ spec:
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16
   networking:
-    weave: {}
+    weave:
+      memoryRequest: 300Mi
+      cpuRequest: 100m
+      memoryLimit: 300Mi
+      cpuLimit: 200m
+      npcMemoryRequest: 300Mi
+      npcCPURequest: 100m
+      npcMemoryLimit: 300Mi
+      npcCPULimit: 200m
   nonMasqueradeCIDR: 100.64.0.0/10
   sshAccess:
     - 0.0.0.0/0

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -115,7 +115,7 @@ spec:
   - id: pre-k8s-1.6
     kubernetesVersion: <1.6.0
     manifest: networking.weave/pre-k8s-1.6.yaml
-    manifestHash: 564f5bea5d9eee61af636dba48c4092a0bedef7f
+    manifestHash: 8e7a361fff381e0ed84e0011506ff3bfdc7bc202
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
@@ -123,7 +123,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.7.0'
     manifest: networking.weave/k8s-1.6.yaml
-    manifestHash: 6897c214a84d8ba960f7c92e237e1f9d8edea394
+    manifestHash: 6dcb06c0178143b534dac093fcad00c331b12319
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
@@ -131,7 +131,7 @@ spec:
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0 <1.8.0'
     manifest: networking.weave/k8s-1.7.yaml
-    manifestHash: 0cd4e69658afad4925e27ad8b05704fe7afe8fca
+    manifestHash: 29f0b9379ffda0cc4288c9769371dc5adc75687a
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
@@ -139,7 +139,7 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: f9d056a15c55dd906fb0d41583d457542f7136e2
+    manifestHash: 75cc6479f36f443600f567e492707efcbb9fbd31
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
@@ -147,7 +147,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: c6614394aa5efaf6d12dedd8df66b5ee3e63aa46
+    manifestHash: eb939be2701cdd0c78468358513d74f9eb2d9308
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
This is a PR to address #8113 whereby kops users can gain the ability to configure resources for the weave and weave-npc containers inside the weave daemonset.
Signed-off-by: mmerrill3 <michael.merrill@vonage.com>