### PR TITLE
containerd: Fix tiny nits

### DIFF
--- a/nodeup/pkg/model/containerd_test.go
+++ b/nodeup/pkg/model/containerd_test.go
@@ -85,11 +85,13 @@ func TestContainerdPackageHashes(t *testing.T) {
 	}
 
 	for _, containerdVersion := range containerdVersions {
-		verifyContainerdPackageHash(t, containerdVersion.Source, containerdVersion.Hash)
+		t.Run(containerdVersion.Source, func(t *testing.T) {
+			verifyContainerdPackageHash(t, containerdVersion.Source, containerdVersion.Hash)
 
-		for _, p := range containerdVersion.ExtraPackages {
-			verifyContainerdPackageHash(t, p.Source, p.Hash)
-		}
+			for _, p := range containerdVersion.ExtraPackages {
+				verifyContainerdPackageHash(t, p.Source, p.Hash)
+			}
+		})
 	}
 }
 

--- a/nodeup/pkg/model/docker_test.go
+++ b/nodeup/pkg/model/docker_test.go
@@ -85,11 +85,13 @@ func TestDockerPackageHashes(t *testing.T) {
 	}
 
 	for _, dockerVersion := range dockerVersions {
-		verifyPackageHash(t, dockerVersion.Source, dockerVersion.Hash)
+		t.Run(dockerVersion.Source, func(t *testing.T) {
+			verifyPackageHash(t, dockerVersion.Source, dockerVersion.Hash)
 
-		for _, p := range dockerVersion.ExtraPackages {
-			verifyPackageHash(t, p.Source, p.Hash)
-		}
+			for _, p := range dockerVersion.ExtraPackages {
+				verifyPackageHash(t, p.Source, p.Hash)
+			}
+		})
 	}
 }
 

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -270,7 +270,14 @@ func (b *KubeletBuilder) buildSystemdService() *nodetasks.Service {
 	manifest := &systemd.Manifest{}
 	manifest.Set("Unit", "Description", "Kubernetes Kubelet Server")
 	manifest.Set("Unit", "Documentation", "https://github.com/kubernetes/kubernetes")
-	manifest.Set("Unit", "After", "docker.service")
+	switch b.Cluster.Spec.ContainerRuntime {
+	case "docker":
+		manifest.Set("Unit", "After", "docker.service")
+	case "containerd":
+		manifest.Set("Unit", "After", "containerd.service")
+	default:
+		klog.Warningf("unknown container runtime %q", b.Cluster.Spec.ContainerRuntime)
+	}
 
 	if b.Distribution == distros.DistributionCoreOS {
 		// We add /opt/kubernetes/bin for our utilities (socat, conntrack)

--- a/nodeup/pkg/model/node_authorizer.go
+++ b/nodeup/pkg/model/node_authorizer.go
@@ -77,8 +77,15 @@ func (b *NodeAuthorizationBuilder) Build(c *fi.ModelBuilderContext) error {
 		man := &systemd.Manifest{}
 		man.Set("Unit", "Description", "Node Authorization Client")
 		man.Set("Unit", "Documentation", "https://github.com/kubernetes/kops")
-		man.Set("Unit", "After", "docker.service")
 		man.Set("Unit", "Before", "kubelet.service")
+		switch b.Cluster.Spec.ContainerRuntime {
+		case "docker":
+			man.Set("Unit", "After", "docker.service")
+		case "containerd":
+			man.Set("Unit", "After", "containerd.service")
+		default:
+			klog.Warningf("unknown container runtime %q", b.Cluster.Spec.ContainerRuntime)
+		}
 
 		clientCert := filepath.Join(b.PathSrvKubernetes(), authorizerDir, "tls.pem")
 		man.Set("Service", "Type", "oneshot")

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -184,7 +184,7 @@ func (t *ProtokubeBuilder) ProtokubeImagePullCommand() (string, error) {
 	if t.Cluster.Spec.ContainerRuntime == "docker" {
 		protokubeImagePullCommand = "-/usr/bin/docker pull " + sources[0]
 	} else if t.Cluster.Spec.ContainerRuntime == "containerd" {
-		protokubeImagePullCommand = "-/usr/bin/ctr --namespace k8s.io images pull docker.io/" + sources[0]
+		protokubeImagePullCommand = "-/usr/bin/ctr images pull docker.io/" + sources[0]
 	} else {
 		return "", fmt.Errorf("unable to create protokube image pull command for unsupported runtime %q", t.Cluster.Spec.ContainerRuntime)
 	}
@@ -197,7 +197,7 @@ func (t *ProtokubeBuilder) ProtokubeContainerStopCommand() (string, error) {
 	if t.Cluster.Spec.ContainerRuntime == "docker" {
 		containerStopCommand = "-/usr/bin/docker stop protokube"
 	} else if t.Cluster.Spec.ContainerRuntime == "containerd" {
-		containerStopCommand = "-/usr/bin/ctr --namespace k8s.io task pause protokube"
+		containerStopCommand = "/bin/true"
 	} else {
 		return "", fmt.Errorf("unable to create protokube stop command for unsupported runtime %q", t.Cluster.Spec.ContainerRuntime)
 	}
@@ -210,7 +210,7 @@ func (t *ProtokubeBuilder) ProtokubeContainerRemoveCommand() (string, error) {
 	if t.Cluster.Spec.ContainerRuntime == "docker" {
 		containerRemoveCommand = "-/usr/bin/docker rm protokube"
 	} else if t.Cluster.Spec.ContainerRuntime == "containerd" {
-		containerRemoveCommand = "-/usr/bin/ctr --namespace k8s.io container rm protokube"
+		containerRemoveCommand = "-/usr/bin/ctr container rm protokube"
 	} else {
 		return "", fmt.Errorf("unable to create protokube remove command for unsupported runtime %q", t.Cluster.Spec.ContainerRuntime)
 	}
@@ -263,7 +263,7 @@ func (t *ProtokubeBuilder) ProtokubeContainerRunCommand() (string, error) {
 
 	} else if t.Cluster.Spec.ContainerRuntime == "containerd" {
 		containerRunArgs = append(containerRunArgs, []string{
-			"/usr/bin/ctr --namespace k8s.io run",
+			"/usr/bin/ctr run",
 			"--net-host",
 			"--with-ns pid:/proc/1/ns/pid",
 			"--privileged",

--- a/nodeup/pkg/model/tests/kubelet/featuregates/cluster.yaml
+++ b/nodeup/pkg/model/tests/kubelet/featuregates/cluster.yaml
@@ -9,6 +9,7 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://clusters.example.com/minimal.example.com
+  containerRuntime: docker
   etcdClusters:
   - etcdMembers:
     - instanceGroup: master-us-test-1a

--- a/nodeup/pkg/model/tests/protokube/containerd/tasks.yaml
+++ b/nodeup/pkg/model/tests/protokube/containerd/tasks.yaml
@@ -5,10 +5,10 @@ definition: |
   Documentation=https://github.com/kubernetes/kops
 
   [Service]
-  ExecStartPre=-/usr/bin/ctr --namespace k8s.io task pause protokube
-  ExecStartPre=-/usr/bin/ctr --namespace k8s.io container rm protokube
   ExecStartPre=/bin/true
-  ExecStart=/usr/bin/ctr --namespace k8s.io run --net-host --with-ns pid:/proc/1/ns/pid --privileged --mount type=bind,src=/,dst=/rootfs,options=rbind:rslave --mount type=bind,src=/var/run/dbus,dst=/var/run/dbus,options=rbind:rprivate --mount type=bind,src=/run/systemd,dst=/run/systemd,options=rbind:rprivate --env KUBECONFIG=/rootfs/var/lib/kops/kubeconfig --mount type=bind,src=/usr/local/bin,dst=/opt/kops/bin,options=rbind:ro:rprivate --env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/kops/bin docker.io/library/protokube:test protokube /usr/bin/protokube --bootstrap-master-node-labels=true --cloud=aws --containerized=true --dns-internal-suffix=.internal.minimal.example.com --dns=aws-route53 --initialize-rbac=true --manage-etcd=false --master=true --node-name=example-hostname --remove-dns-names=etcd-master-us-test-1a.internal.minimal.example.com,etcd-events-master-us-test-1a.internal.minimal.example.com --v=4
+  ExecStartPre=-/usr/bin/ctr container rm protokube
+  ExecStartPre=/bin/true
+  ExecStart=/usr/bin/ctr run --net-host --with-ns pid:/proc/1/ns/pid --privileged --mount type=bind,src=/,dst=/rootfs,options=rbind:rslave --mount type=bind,src=/var/run/dbus,dst=/var/run/dbus,options=rbind:rprivate --mount type=bind,src=/run/systemd,dst=/run/systemd,options=rbind:rprivate --env KUBECONFIG=/rootfs/var/lib/kops/kubeconfig --mount type=bind,src=/usr/local/bin,dst=/opt/kops/bin,options=rbind:ro:rprivate --env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/kops/bin docker.io/library/protokube:test protokube /usr/bin/protokube --bootstrap-master-node-labels=true --cloud=aws --containerized=true --dns-internal-suffix=.internal.minimal.example.com --dns=aws-route53 --initialize-rbac=true --manage-etcd=false --master=true --node-name=example-hostname --remove-dns-names=etcd-master-us-test-1a.internal.minimal.example.com,etcd-events-master-us-test-1a.internal.minimal.example.com --v=4
   Restart=always
   RestartSec=2s
   StartLimitInterval=0

--- a/upup/pkg/fi/nodeup/nodetasks/load_image.go
+++ b/upup/pkg/fi/nodeup/nodetasks/load_image.go
@@ -145,7 +145,7 @@ func (_ *LoadImageTask) RenderLocal(t *local.LocalTarget, a, e, changes *LoadIma
 	case "docker":
 		args = []string{"docker", "load", "-i", tarFile}
 	case "containerd":
-		args = []string{"ctr", "--namespace", "k8s.io", "images", "import", tarFile}
+		args = []string{"ctr", "images", "import", tarFile}
 	default:
 		return fmt.Errorf("unknown container runtime: %s", runtime)
 	}


### PR DESCRIPTION
This fixes various tiny nits observed after #7986 :
* run Protokube in the "default" container namespace instead of "k8s.io", same way is done with Docker
* delete Protokube container on restart without pausing first, not needed and can cause a deadlock
* update hardcoded service dependencies on "docker.service" to "containerd.service" when needed
* run each package hash check as a separate test, some feedback is nice when it takes 3 min
