### PR TITLE
Cilium nodeport

### DIFF
--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -602,6 +602,10 @@ func ValidateCluster(c *kops.Cluster, strict bool) field.ErrorList {
 
 	allErrs = append(allErrs, newValidateCluster(c)...)
 
+	if c.Spec.Networking != nil && c.Spec.Networking.Cilium != nil && c.Spec.Networking.Cilium.EnableNodePort && c.Spec.KubeProxy != nil && *c.Spec.KubeProxy.Enabled {
+		allErrs = append(allErrs, field.Invalid(fieldSpec.Child("KubeProxy"), "enabled", "When Cilium NodePort is enabled, KubeProxy must be disabled"))
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -603,7 +603,7 @@ func ValidateCluster(c *kops.Cluster, strict bool) field.ErrorList {
 	allErrs = append(allErrs, newValidateCluster(c)...)
 
 	if c.Spec.Networking != nil && c.Spec.Networking.Cilium != nil && c.Spec.Networking.Cilium.EnableNodePort && c.Spec.KubeProxy != nil && *c.Spec.KubeProxy.Enabled {
-		allErrs = append(allErrs, field.Invalid(fieldSpec.Child("KubeProxy"), "enabled", "When Cilium NodePort is enabled, KubeProxy must be disabled"))
+		allErrs = append(allErrs, field.Forbidden(fieldSpec.Child("KubeProxy").Child("enabled"), "When Cilium NodePort is enabled, KubeProxy must be disabled"))
 	}
 
 	return allErrs

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -363,6 +363,10 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{.MasterInternalName}}"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "443"
         {{ with .Networking.Cilium.EnablePolicy }}
         - name: CILIUM_ENABLE_POLICY
           value: {{ . }}
@@ -563,6 +567,7 @@ spec:
         {{ if .EnablePrometheusMetrics }}
         - --enable-metrics
         {{ end }}
+{{ end }}
         command:
         - cilium-operator
         env:
@@ -642,6 +647,11 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{.MasterInternalName}}"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "443"
+{{ with .Networking.Cilium }}
         image: "docker.io/cilium/operator:{{ .Version }}"
         imagePullPolicy: IfNotPresent
         name: cilium-operator

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
@@ -363,6 +363,10 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{ .MasterInternalName }}"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "443"
         {{ with .Networking.Cilium.EnablePolicy }}
         - name: CILIUM_ENABLE_POLICY
           value: {{ . }}
@@ -561,6 +565,7 @@ spec:
         {{ if .EnablePrometheusMetrics }}
         - --enable-metrics
         {{ end }}
+{{ end }}
         command:
         - cilium-operator
         env:
@@ -634,6 +639,11 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{ .MasterInternalName }}"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "443"
+{{ with .Networking.Cilium }}
         image: "docker.io/cilium/operator:{{ .Version }}"
         imagePullPolicy: IfNotPresent
         name: cilium-operator

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -909,7 +909,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 	if b.cluster.Spec.Networking.Cilium != nil {
 		key := "networking.cilium.io"
-		version := "1.6.4-kops.3"
+		version := "1.6.6-kops.0"
 
 		{
 			id := "k8s-1.7"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -89,16 +89,16 @@ spec:
   - id: k8s-1.7
     kubernetesVersion: <1.12.0
     manifest: networking.cilium.io/k8s-1.7.yaml
-    manifestHash: 6928e95ec4b8359075e3dfb069f74e290e2e6eb2
+    manifestHash: 48b2e968039622b7dd5941497d0cda203334b508
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.6.4-kops.3
+    version: 1.6.6-kops.0
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: 84295d293c8a461f7d510721c48b969cd1d99e54
+    manifestHash: f52e9593af72a8caa8b8230f120594344f8418f1
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.6.4-kops.3
+    version: 1.6.6-kops.0


### PR DESCRIPTION
Cilium is capable of fully replacing kube-proxy by running in NodePort mode.
This PR will prevent kops from installing kube-proxy if NodePort is enabled on the Cilium addon.

This is implemented similar to how kube-proxy is disabled by kube-router. I do wonder if forcing `kubeProxy.enabled=false` would be a bit cleaner than just disabling it implicitly by the `cilium.enableNodePort` setting.

Note: This feature requires kernel version 4.19.57 or later