### PR TITLE
Add code simplifications for staticheck

### DIFF
--- a/cmd/kops/toolbox_template.go
+++ b/cmd/kops/toolbox_template.go
@@ -135,7 +135,7 @@ func runToolBoxTemplate(f *util.Factory, out io.Writer, options *toolboxTemplate
 		templates = append(templates, list...)
 	}
 
-	snippets := make(map[string]string, 0)
+	snippets := make(map[string]string)
 	for _, x := range options.snippetsPath {
 		list, err := expandFiles(utils.ExpandPath(x))
 		if err != nil {
@@ -212,7 +212,7 @@ func runToolBoxTemplate(f *util.Factory, out io.Writer, options *toolboxTemplate
 
 // newTemplateContext is responsible for loading the --values and build a context for the template
 func newTemplateContext(files []string, values []string, stringValues []string) (map[string]interface{}, error) {
-	context := make(map[string]interface{}, 0)
+	context := make(map[string]interface{})
 
 	for _, x := range files {
 		list, err := expandFiles(utils.ExpandPath(x))
@@ -225,7 +225,7 @@ func newTemplateContext(files []string, values []string, stringValues []string) 
 				return nil, fmt.Errorf("unable to configuration file: %s, error: %s", j, err)
 			}
 
-			ctx := make(map[string]interface{}, 0)
+			ctx := make(map[string]interface{})
 			if err := utils.YamlUnmarshal(content, &ctx); err != nil {
 				return nil, fmt.Errorf("unable decode the configuration file: %s, error: %v", j, err)
 			}

--- a/dns-controller/pkg/watchers/ingress.go
+++ b/dns-controller/pkg/watchers/ingress.go
@@ -167,8 +167,7 @@ func (c *IngressController) updateIngressRecords(ingress *v1beta1.Ingress) strin
 
 		fqdn := dns.EnsureDotSuffix(rule.Host)
 		for _, ingress := range ingresses {
-			var r dns.Record
-			r = ingress
+			r := ingress
 			r.FQDN = fqdn
 			records = append(records, r)
 		}

--- a/dns-controller/pkg/watchers/service.go
+++ b/dns-controller/pkg/watchers/service.go
@@ -203,8 +203,7 @@ func (c *ServiceController) updateServiceRecords(service *v1.Service) string {
 
 			fqdn := dns.EnsureDotSuffix(token)
 			for _, ingress := range ingresses {
-				var r dns.Record
-				r = ingress
+				r := ingress
 				r.FQDN = fqdn
 				records = append(records, r)
 			}

--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -48,8 +48,12 @@ FOCUS="${FOCUS%/}"
 # See https://staticcheck.io/docs/checks
 CHECKS=(
   "all"
-  "-S1*"   # Omit code simplifications for now.
-  "-ST1*"  # Mostly stylistic, redundant w/ golint
+  "-ST1000"  # Incorrect or missing package comment
+  "-ST1003"  # Poorly chosen identifier
+  "-ST1005"  # Incorrectly formatted error string
+  "-ST1006"  # Poorly chosen receiver name
+  "-ST1012"  # Poorly chosen name for error variable
+  "-ST1016"  # Use consistent method receiver names
 )
 export IFS=','; checks="${CHECKS[*]}"; unset IFS
 

--- a/upup/pkg/fi/cloudup/alitasks/vpc.go
+++ b/upup/pkg/fi/cloudup/alitasks/vpc.go
@@ -61,7 +61,7 @@ func (e *VPC) Find(c *fi.Context) (*VPC, error) {
 		return nil, fmt.Errorf("error listing VPCs: %v", err)
 	}
 
-	if vpcs == nil || len(vpcs) == 0 {
+	if len(vpcs) == 0 {
 		return nil, nil
 	}
 

--- a/upup/pkg/fi/cloudup/openstacktasks/volume.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/volume.go
@@ -70,12 +70,8 @@ func (c *Volume) Find(context *fi.Context) (*Volume, error) {
 	}
 	// remove tags "readonly" and "attached_mode", openstack are adding these and if not removed
 	// kops will always try to update volumes
-	if _, ok := actual.Tags["readonly"]; ok {
-		delete(actual.Tags, "readonly")
-	}
-	if _, ok := actual.Tags["attached_mode"]; ok {
-		delete(actual.Tags, "attached_mode")
-	}
+	delete(actual.Tags, "readonly")
+	delete(actual.Tags, "attached_mode")
 	c.ID = actual.ID
 	c.AvailabilityZone = actual.AvailabilityZone
 	return actual, nil


### PR DESCRIPTION
Ref: #7800

This change adds back code simplification checks.
It also makes the style rules we are breaking explicit, to prevent other types of style checks to break and to make it easier to fix style these later if wanted.

```
Errors from staticcheck:
cmd/kops/toolbox_template.go:138:38: should use make(map[string]string) instead (S1019)
cmd/kops/toolbox_template.go:215:42: should use make(map[string]interface{}) instead (S1019)
cmd/kops/toolbox_template.go:228:40: should use make(map[string]interface{}) instead (S1019)
dns-controller/pkg/watchers/ingress.go:170:4: should merge variable declaration with assignment on next line (S1021)
dns-controller/pkg/watchers/service.go:206:5: should merge variable declaration with assignment on next line (S1021)
upup/pkg/fi/cloudup/alitasks/vpc.go:64:5: should omit nil check; len() for nil slices is defined as zero (S1009)
upup/pkg/fi/cloudup/openstacktasks/volume.go:73:2: unnecessary guard around call to delete (S1033)
upup/pkg/fi/cloudup/openstacktasks/volume.go:76:2: unnecessary guard around call to delete (S1033)
```