### PR TITLE
dnsprovider staticcheck

### DIFF
--- a/dnsprovider/pkg/dnsprovider/plugins.go
+++ b/dnsprovider/pkg/dnsprovider/plugins.go
@@ -87,7 +87,7 @@ func InitDnsProvider(name string, configFilePath string) (Interface, error) {
 		var config *os.File
 		config, err = os.Open(configFilePath)
 		if err != nil {
-			return nil, fmt.Errorf("Couldn't open DNS provider configuration %s: %#v", configFilePath, err)
+			return nil, fmt.Errorf("couldn't open DNS provider configuration %s: %#v", configFilePath, err)
 		}
 
 		defer config.Close()

--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/stubs/route53api.go
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/stubs/route53api.go
@@ -80,12 +80,12 @@ func (r *Route53APIStub) ChangeResourceRecordSets(input *route53.ChangeResourceR
 		switch *change.Action {
 		case route53.ChangeActionCreate:
 			if _, found := recordSets[key]; found {
-				return nil, fmt.Errorf("Attempt to create duplicate rrset %s", key) // TODO: Return AWS errors with codes etc
+				return nil, fmt.Errorf("attempt to create duplicate rrset %s", key) // TODO: Return AWS errors with codes etc
 			}
 			recordSets[key] = append(recordSets[key], change.ResourceRecordSet)
 		case route53.ChangeActionDelete:
 			if _, found := recordSets[key]; !found {
-				return nil, fmt.Errorf("Attempt to delete non-existent rrset %s", key) // TODO: Check other fields too
+				return nil, fmt.Errorf("attempt to delete non-existent rrset %s", key) // TODO: Check other fields too
 			}
 			delete(recordSets, key)
 		case route53.ChangeActionUpsert:
@@ -110,7 +110,7 @@ func (r *Route53APIStub) CreateHostedZone(input *route53.CreateHostedZoneInput) 
 	name := aws.StringValue(input.Name)
 	id := "/hostedzone/" + name
 	if _, ok := r.zones[id]; ok {
-		return nil, fmt.Errorf("Error creating hosted DNS zone: %s already exists", id)
+		return nil, fmt.Errorf("error creating hosted DNS zone: %s already exists", id)
 	}
 	r.zones[id] = &route53.HostedZone{
 		Id:   aws.String(id),
@@ -121,10 +121,10 @@ func (r *Route53APIStub) CreateHostedZone(input *route53.CreateHostedZoneInput) 
 
 func (r *Route53APIStub) DeleteHostedZone(input *route53.DeleteHostedZoneInput) (*route53.DeleteHostedZoneOutput, error) {
 	if _, ok := r.zones[*input.Id]; !ok {
-		return nil, fmt.Errorf("Error deleting hosted DNS zone: %s does not exist", *input.Id)
+		return nil, fmt.Errorf("error deleting hosted DNS zone: %s does not exist", *input.Id)
 	}
 	if len(r.recordSets[*input.Id]) > 0 {
-		return nil, fmt.Errorf("Error deleting hosted DNS zone: %s has resource records", *input.Id)
+		return nil, fmt.Errorf("error deleting hosted DNS zone: %s has resource records", *input.Id)
 	}
 	delete(r.zones, *input.Id)
 	return &route53.DeleteHostedZoneOutput{}, nil

--- a/dnsprovider/pkg/dnsprovider/providers/coredns/coredns.go
+++ b/dnsprovider/pkg/dnsprovider/providers/coredns/coredns.go
@@ -68,7 +68,7 @@ func newCoreDNSProviderInterface(config io.Reader) (*Interface, error) {
 	klog.Infof("Using CoreDNS DNS provider")
 
 	if dnsZones == "" {
-		return nil, fmt.Errorf("Need to provide at least one DNS Zone")
+		return nil, fmt.Errorf("need to provide at least one DNS Zone")
 	}
 
 	etcdCfg := etcdc.Config{
@@ -78,7 +78,7 @@ func newCoreDNSProviderInterface(config io.Reader) (*Interface, error) {
 
 	c, err := etcdc.New(etcdCfg)
 	if err != nil {
-		return nil, fmt.Errorf("Create etcd client from the config failed")
+		return nil, fmt.Errorf("create etcd client from the config failed")
 	}
 	etcdKeysAPI := etcdc.NewKeysAPI(c)
 

--- a/dnsprovider/pkg/dnsprovider/providers/coredns/rrchangeset.go
+++ b/dnsprovider/pkg/dnsprovider/providers/coredns/rrchangeset.go
@@ -97,7 +97,7 @@ func (c *ResourceRecordChangeset) Apply() error {
 				if checkNotExists {
 					response, err := c.zone.zones.intf.etcdKeysAPI.Get(ctx, dnsmsg.Path(recordKey, etcdPathPrefix), getOpts)
 					if err == nil && response != nil {
-						return fmt.Errorf("Key already exist, key: %v", recordKey)
+						return fmt.Errorf("key already exist, key: %v", recordKey)
 					}
 				}
 

--- a/dnsprovider/pkg/dnsprovider/providers/coredns/rrsets.go
+++ b/dnsprovider/pkg/dnsprovider/providers/coredns/rrsets.go
@@ -52,7 +52,7 @@ func (rrsets ResourceRecordSets) Get(name string) ([]dnsprovider.ResourceRecordS
 			klog.V(2).Infof("Subdomain %q does not exist", name)
 			return nil, nil
 		}
-		return nil, fmt.Errorf("Failed to get service from etcd, err: %v", err)
+		return nil, fmt.Errorf("failed to get service from etcd, err: %v", err)
 	}
 	if emptyResponse(response) {
 		klog.V(2).Infof("Subdomain %q does not exist in etcd", name)
@@ -65,7 +65,7 @@ func (rrsets ResourceRecordSets) Get(name string) ([]dnsprovider.ResourceRecordS
 		service := dnsmsg.Service{}
 		err = json.Unmarshal([]byte(node.Value), &service)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to unmarshall json data, err: %v", err)
+			return nil, fmt.Errorf("failed to unmarshall json data, err: %v", err)
 		}
 
 		rrset := ResourceRecordSet{name: name, rrdatas: []string{}, rrsets: &rrsets}

--- a/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/changes_create_call.go
+++ b/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/changes_create_call.go
@@ -49,13 +49,13 @@ func (c ChangesCreateCall) Do(opts ...googleapi.CallOption) (interfaces.Change, 
 	}
 	for _, del := range c.Change.Deletions() {
 		if _, found := rrsets[hashKey(del)]; !found {
-			return nil, fmt.Errorf("Attempt to delete non-existent rrset %v", del)
+			return nil, fmt.Errorf("attempt to delete non-existent rrset %v", del)
 		}
 		delete(rrsets, hashKey(del))
 	}
 	for _, add := range c.Change.Additions() {
 		if _, found := rrsets[hashKey(add)]; found {
-			return nil, fmt.Errorf("Attempt to insert duplicate rrset %v", add)
+			return nil, fmt.Errorf("attempt to insert duplicate rrset %v", add)
 		}
 		rrsets[hashKey(add)] = add.(ResourceRecordSet)
 	}

--- a/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zone_create_call.go
+++ b/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zone_create_call.go
@@ -38,7 +38,7 @@ func (call ManagedZonesCreateCall) Do(opts ...googleapi.CallOption) (interfaces.
 		return nil, *call.Error
 	}
 	if call.Service.Impl[call.Project][call.ManagedZone.DnsName()] != nil {
-		return nil, fmt.Errorf("Error - attempt to create duplicate zone %s in project %s.",
+		return nil, fmt.Errorf("error - attempt to create duplicate zone %s in project %s",
 			call.ManagedZone.DnsName(), call.Project)
 	}
 	if call.Service.Impl == nil {

--- a/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_delete_call.go
+++ b/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_delete_call.go
@@ -45,7 +45,7 @@ func (call ManagedZonesDeleteCall) Do(opts ...googleapi.CallOption) error {
 			delete(project, zone.Name())
 			return nil
 		}
-		return fmt.Errorf("Failed to find zone %s in project %s to delete it", call.ZoneName, call.Project)
+		return fmt.Errorf("failed to find zone %s in project %s to delete it", call.ZoneName, call.Project)
 	}
-	return fmt.Errorf("Failed to find project %s to delete zone %s from it", call.Project, call.ZoneName)
+	return fmt.Errorf("failed to find project %s to delete zone %s from it", call.Project, call.ZoneName)
 }

--- a/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_list_call.go
+++ b/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_list_call.go
@@ -40,7 +40,7 @@ func (call *ManagedZonesListCall) Do(opts ...googleapi.CallOption) (interfaces.M
 	}
 	proj, projectFound := call.Service.Impl[call.Project]
 	if !projectFound {
-		return nil, fmt.Errorf("Project %s not found.", call.Project)
+		return nil, fmt.Errorf("project %s not found", call.Project)
 	}
 	if call.DnsName_ != "" {
 		return &ManagedZonesListResponse{[]interfaces.ManagedZone{proj[call.DnsName_]}}, nil

--- a/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/rrsets_service.go
+++ b/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/rrsets_service.go
@@ -38,7 +38,7 @@ func (s ResourceRecordSetsService) managedZone(project, managedZone string) (*Ma
 	}
 	z := s.Service.ManagedZones_.Impl[project][managedZone]
 	if z == nil {
-		return nil, fmt.Errorf("Zone %s not found in project %s", managedZone, project)
+		return nil, fmt.Errorf("zone %s not found in project %s", managedZone, project)
 	}
 	return z.(*ManagedZone), nil
 }

--- a/dnsprovider/pkg/dnsprovider/providers/google/clouddns/rrchangeset.go
+++ b/dnsprovider/pkg/dnsprovider/providers/google/clouddns/rrchangeset.go
@@ -104,11 +104,11 @@ func (c *ResourceRecordChangeset) Apply() error {
 	}
 	newAdditions := newChange.Additions()
 	if len(newAdditions) != len(additions) {
-		return fmt.Errorf("Internal error when adding resource record set.  Call succeeded but number of records returned is incorrect.  Records sent=%d, records returned=%d, additions:%v", len(additions), len(newAdditions), c.additions)
+		return fmt.Errorf("internal error when adding resource record set.  Call succeeded but number of records returned is incorrect.  Records sent=%d, records returned=%d, additions:%v", len(additions), len(newAdditions), c.additions)
 	}
 	newDeletions := newChange.Deletions()
 	if len(newDeletions) != len(deletions) {
-		return fmt.Errorf("Internal error when deleting resource record set.  Call succeeded but number of records returned is incorrect.  Records sent=%d, records returned=%d, deletions:%v", len(deletions), len(newDeletions), c.removals)
+		return fmt.Errorf("internal error when deleting resource record set.  Call succeeded but number of records returned is incorrect.  Records sent=%d, records returned=%d, deletions:%v", len(deletions), len(newDeletions), c.removals)
 	}
 
 	return nil


### PR DESCRIPTION
ref:https://github.com/kubernetes/kops/issues/7800

dnsprovider/pkg/dnsprovider/plugins.go:90:26: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/aws/route53/stubs/route53api.go:83:27: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/aws/route53/stubs/route53api.go:88:27: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/aws/route53/stubs/route53api.go:113:25: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/aws/route53/stubs/route53api.go:124:25: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/aws/route53/stubs/route53api.go:127:25: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/coredns/coredns.go:71:25: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/coredns/coredns.go:81:25: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/coredns/rrchangeset.go:100:24: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/coredns/rrsets.go:55:25: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/coredns/rrsets.go:68:26: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/changes_create_call.go:52:26: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/changes_create_call.go:58:26: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zone_create_call.go:41:25: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zone_create_call.go:41:25: error strings should not end with punctuation or a newline (ST1005)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_delete_call.go:48:20: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_delete_call.go:50:19: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_list_call.go:43:25: error strings should not end with punctuation or a newline (ST1005)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/rrsets_service.go:41:25: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/rrchangeset.go:107:20: error strings should not be capitalized (ST1005)
dnsprovider/pkg/dnsprovider/providers/google/clouddns/rrchangeset.go:111:20: error strings should not be capitalized (ST1005)

