### PR TITLE
nodeup/pkg/ pkg/ staticcheck: Fix ST1005

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -567,11 +567,11 @@ func EvaluateHostnameOverride(hostnameOverride string) (string, error) {
 	}
 
 	if len(result.Reservations) != 1 {
-		return "", fmt.Errorf("Too many reservations returned for the single instance-id")
+		return "", fmt.Errorf("too many reservations returned for the single instance-id")
 	}
 
 	if len(result.Reservations[0].Instances) != 1 {
-		return "", fmt.Errorf("Too many instances returned for the single instance-id")
+		return "", fmt.Errorf("too many instances returned for the single instance-id")
 	}
 	return *(result.Reservations[0].Instances[0].PrivateDnsName), nil
 }

--- a/nodeup/pkg/model/file_assets.go
+++ b/nodeup/pkg/model/file_assets.go
@@ -83,7 +83,7 @@ func (f *FileAssetsBuilder) buildFileAssets(c *fi.ModelBuilderContext, assets []
 		if asset.IsBase64 {
 			decoded, err := base64.RawStdEncoding.DecodeString(content)
 			if err != nil {
-				return fmt.Errorf("Failed on file asset: %s is invalid, unable to decode base64, error: %q", asset.Name, err)
+				return fmt.Errorf("failed on file asset: %s is invalid, unable to decode base64, error: %q", asset.Name, err)
 			}
 			content = string(decoded)
 		}

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -275,7 +275,7 @@ func (b *KubeAPIServerBuilder) writeAuthenticationConfig(c *fi.ModelBuilderConte
 		return nil
 	}
 
-	return fmt.Errorf("Unrecognized authentication config %v", b.Cluster.Spec.Authentication)
+	return fmt.Errorf("unrecognized authentication config %v", b.Cluster.Spec.Authentication)
 }
 
 // buildPod is responsible for generating the kube-apiserver pod and thus manifest file

--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -129,7 +129,7 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 
 	cpuRequest, err := resource.ParseQuantity(c.CPURequest)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing CPURequest=%q", c.CPURequest)
+		return nil, fmt.Errorf("error parsing CPURequest=%q", c.CPURequest)
 	}
 
 	resourceRequests["cpu"] = cpuRequest
@@ -137,7 +137,7 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 	if c.CPULimit != "" {
 		cpuLimit, err := resource.ParseQuantity(c.CPULimit)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing CPULimit=%q", c.CPULimit)
+			return nil, fmt.Errorf("error parsing CPULimit=%q", c.CPULimit)
 		}
 		resourceLimits["cpu"] = cpuLimit
 	}
@@ -145,7 +145,7 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 	if c.MemoryRequest != "" {
 		memoryRequest, err := resource.ParseQuantity(c.MemoryRequest)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing MemoryRequest=%q", c.MemoryRequest)
+			return nil, fmt.Errorf("error parsing MemoryRequest=%q", c.MemoryRequest)
 		}
 		resourceRequests["memory"] = memoryRequest
 	}
@@ -153,7 +153,7 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 	if c.MemoryLimit != "" {
 		memoryLimit, err := resource.ParseQuantity(c.MemoryLimit)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing MemoryLimit=%q", c.MemoryLimit)
+			return nil, fmt.Errorf("error parsing MemoryLimit=%q", c.MemoryLimit)
 		}
 		resourceLimits["memory"] = memoryLimit
 	}

--- a/nodeup/pkg/model/volumes.go
+++ b/nodeup/pkg/model/volumes.go
@@ -45,7 +45,7 @@ func (b *VolumesBuilder) Build(c *fi.ModelBuilderContext) error {
 	for _, x := range b.InstanceGroup.Spec.VolumeMounts {
 		// @check the directory exists, else create it
 		if err := b.EnsureDirectory(x.Path); err != nil {
-			return fmt.Errorf("Failed to ensure the directory: %s, error: %s", x.Path, err)
+			return fmt.Errorf("failed to ensure the directory: %s, error: %s", x.Path, err)
 		}
 
 		m := &mount.SafeFormatAndMount{
@@ -64,7 +64,7 @@ func (b *VolumesBuilder) Build(c *fi.ModelBuilderContext) error {
 		klog.Infof("Attempting to format and mount device: %s, path: %s", x.Device, x.Path)
 
 		if err := m.FormatAndMount(x.Device, x.Path, x.Filesystem, x.MountOptions); err != nil {
-			klog.Errorf("Failed to mount the device: %s on: %s, error: %s", x.Device, x.Path, err)
+			klog.Errorf("failed to mount the device: %s on: %s, error: %s", x.Device, x.Path, err)
 
 			return err
 		}

--- a/pkg/model/components/context.go
+++ b/pkg/model/components/context.go
@@ -127,7 +127,7 @@ func WellKnownServiceIP(clusterSpec *kops.ClusterSpec, id int) (net.IP, error) {
 		return serviceIP, nil
 	}
 
-	return nil, fmt.Errorf("Unexpected IP address type for ServiceClusterIPRange: %s", clusterSpec.ServiceClusterIPRange)
+	return nil, fmt.Errorf("unexpected IP address type for ServiceClusterIPRange: %s", clusterSpec.ServiceClusterIPRange)
 }
 
 func IsBaseURL(kubernetesVersion string) bool {

--- a/pkg/nodeidentity/do/identify.go
+++ b/pkg/nodeidentity/do/identify.go
@@ -169,5 +169,5 @@ func (i *nodeIdentifier) getInstanceGroup(instanceID int) (string, error) {
 		}
 	}
 
-	return "", errors.New("Could not find tag 'kops-instancegroup' from instance metadata")
+	return "", errors.New("could not find tag 'kops-instancegroup' from instance metadata")
 }

--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -267,7 +267,7 @@ func FindAutoscalingLaunchConfiguration(cloud awsup.AWSCloud, name string) (*aut
 		return nil, nil
 	}
 	if len(results) != 1 {
-		return nil, fmt.Errorf("Found multiple LaunchConfigurations with name %q", name)
+		return nil, fmt.Errorf("found multiple LaunchConfigurations with name %q", name)
 	}
 	return results[0], nil
 }
@@ -362,7 +362,7 @@ func ListCloudFormationStacks(cloud fi.Cloud, clusterName string) ([]*resources.
 	c := cloud.(awsup.AWSCloud)
 	response, err := c.CloudFormation().ListStacks(request)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to list CloudFormation stacks: %v", err)
+		return nil, fmt.Errorf("unable to list CloudFormation stacks: %v", err)
 	}
 	for _, stack := range response.StackSummaries {
 		if *stack.StackName == clusterName {

--- a/pkg/testutils/modelharness.go
+++ b/pkg/testutils/modelharness.go
@@ -71,7 +71,7 @@ func LoadModel(basedir string) (*Model, error) {
 			spec.InstanceGroups = append(spec.InstanceGroups, v)
 
 		default:
-			return nil, fmt.Errorf("Unhandled kind %q", gvk)
+			return nil, fmt.Errorf("unhandled kind %q", gvk)
 		}
 	}
 

--- a/pkg/util/subnet/subnet.go
+++ b/pkg/util/subnet/subnet.go
@@ -61,7 +61,7 @@ func SplitInto8(parent *net.IPNet) ([]*net.IPNet, error) {
 				Mask: net.CIDRMask(networkLength, 32),
 			})
 		} else {
-			return nil, fmt.Errorf("Unexpected IP address type: %s", parent)
+			return nil, fmt.Errorf("unexpected IP address type: %s", parent)
 		}
 	}
 


### PR DESCRIPTION
ref:https://github.com/kubernetes/kops/issues/7800

nodeup/pkg/model/context.go:570:24: error strings should not be capitalized (ST1005)
nodeup/pkg/model/context.go:574:24: error strings should not be capitalized (ST1005)
nodeup/pkg/model/file_assets.go:86:22: error strings should not be capitalized (ST1005)
nodeup/pkg/model/kube_apiserver.go:278:19: error strings should not be capitalized (ST1005)
nodeup/pkg/model/kube_proxy.go:132:25: error strings should not be capitalized (ST1005)
nodeup/pkg/model/kube_proxy.go:140:26: error strings should not be capitalized (ST1005)
nodeup/pkg/model/kube_proxy.go:148:26: error strings should not be capitalized (ST1005)
nodeup/pkg/model/kube_proxy.go:156:26: error strings should not be capitalized (ST1005)
nodeup/pkg/model/volumes.go:48:21: error strings should not be capitalized (ST1005)
nodeup/pkg/model/volumes.go:58:21: error strings should not be capitalized (ST1005)
pkg/model/components/context.go:130:24: error strings should not be capitalized (ST1005)
pkg/nodeidentity/do/identify.go:172:23: error strings should not be capitalized (ST1005)
pkg/resources/aws/aws.go:270:25: error strings should not be capitalized (ST1005)
pkg/resources/aws/aws.go:365:25: error strings should not be capitalized (ST1005)
pkg/testutils/modelharness.go:74:26: error strings should not be capitalized (ST1005)
pkg/util/subnet/subnet.go:64:26: error strings should not be capitalized (ST1005)