### PR TITLE
Fix aws-china.md to download SHA-256 checksums for kops assets

### DIFF
--- a/docs/aws-china.md
+++ b/docs/aws-china.md
@@ -249,7 +249,7 @@ for asset in "${KOPS_ASSETS[@]}"; do
   mkdir -p "$dir"
   url="https://kubeupv2.s3.amazonaws.com/kops/$KOPS_VERSION/$asset"
   wget -P "$dir" "$url"
-  wget -P "$dir" "$url.sha1"
+  wget -P "$dir" "$url.sha256"
 done
 
 ## Upload assets


### PR DESCRIPTION
Since kops 1.15.0, nodeup verifies kops assets against the `.sha256` file.

Fixes #8242 
