### PR TITLE
Fix issues with older versions of k8s for basic clusters

### DIFF
--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -6,6 +6,8 @@
 
 * Terraform users on AWS may need to rename some resources in their state file in order to prepare for Terraform 0.12 support. See Required Actions below.
 
+* Kubernetes 1.9 users will need to enable the PodPriority feature gate. See Required Actions below.
+
 * A controller is now used to apply labels to nodes.  If you are not using AWS, GCE or OpenStack your (non-master) nodes may not have labels applied correctly.
 
 * Please see the notes in the 1.15 release about the apiGroup changing from kops to kops.k8s.io
@@ -34,6 +36,18 @@
   terraform apply
   ```
 
+* Kubernetes 1.9 users will need to enable the PodPriority feature gate. This is required for newer versions of Kops.
+
+  To enable the Pod priority feature, follow these steps:
+  ```
+  kops edit cluster
+  # Add the following section
+  spec:
+    kubelet:
+      featureGates:
+        PodPriority: "true"
+  ```
+ 
 * If a custom Kops build was used on a cluster, a kops-controller Deployment may have been created that should get deleted.
   Run `kubectl -n kube-system delete deployment kops-controller` after upgrading to Kops 1.16.0-beta.1 or later.
 

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 {{- if or (.KubeDNS.UpstreamNameservers) (.KubeDNS.StubDomains) }}
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -28,9 +27,9 @@ data:
   stubDomains: |
     {{ ToJSON .KubeDNS.StubDomains }}
   {{- end }}
-{{- end }}
 
 ---
+{{- end }}
 
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
Currently, Kops is not able to start a basic cluster with Kubernetes < 1.12 for a few reasons:
* PodPriority feature gate is needed for various manifests with Kubernetes < 1.11
* the kube-dns manifest cannot be applied because of an empty resource `{}`