### PR TITLE
GCE: Delete cluster will also delete the DNS entries created by kubernetes

### DIFF
--- a/pkg/resources/gce/BUILD.bazel
+++ b/pkg/resources/gce/BUILD.bazel
@@ -9,10 +9,12 @@ go_library(
     importpath = "k8s.io/kops/pkg/resources/gce",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/dns:go_default_library",
         "//pkg/resources:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/gce:go_default_library",
         "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
+        "//vendor/google.golang.org/api/dns/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/upup/pkg/fi/cloudup/gce/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/gce/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//vendor/golang.org/x/net/context:go_default_library",
         "//vendor/golang.org/x/oauth2/google:go_default_library",
         "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
+        "//vendor/google.golang.org/api/dns/v1:go_default_library",
         "//vendor/google.golang.org/api/googleapi:go_default_library",
         "//vendor/google.golang.org/api/iam/v1:go_default_library",
         "//vendor/google.golang.org/api/oauth2/v2:go_default_library",

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v0.beta"
+	"google.golang.org/api/dns/v1"
 	"google.golang.org/api/iam/v1"
 	oauth2 "google.golang.org/api/oauth2/v2"
 	"google.golang.org/api/storage/v1"
@@ -41,6 +42,7 @@ type GCECloud interface {
 	Compute() *compute.Service
 	Storage() *storage.Service
 	IAM() *iam.Service
+	CloudDNS() *dns.Service
 
 	Project() string
 	WaitForOp(op *compute.Operation) error
@@ -60,6 +62,7 @@ type gceCloudImplementation struct {
 	compute *compute.Service
 	storage *storage.Service
 	iam     *iam.Service
+	dns     *dns.Service
 
 	region  string
 	project string
@@ -141,6 +144,12 @@ func NewGCECloud(region string, project string, labels map[string]string) (GCECl
 	}
 	c.iam = iamService
 
+	dnsService, err := dns.New(client)
+	if err != nil {
+		return nil, fmt.Errorf("error building DNS API client: %v", err)
+	}
+	c.dns = dnsService
+
 	gceCloudInstances[region+"::"+project] = c
 
 	{
@@ -184,6 +193,11 @@ func (c *gceCloudImplementation) Storage() *storage.Service {
 // IAM returns the IAM client
 func (c *gceCloudImplementation) IAM() *iam.Service {
 	return c.iam
+}
+
+// NameService returns the DNS client
+func (c *gceCloudImplementation) CloudDNS() *dns.Service {
+	return c.dns
 }
 
 // Region returns private struct element region.

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -144,7 +144,7 @@ func NewGCECloud(region string, project string, labels map[string]string) (GCECl
 	}
 	c.iam = iamService
 
-	dnsService, err := dns.New(client)
+	dnsService, err := dns.NewService(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error building DNS API client: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	compute "google.golang.org/api/compute/v0.beta"
+	"google.golang.org/api/dns/v1"
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/storage/v1"
 	v1 "k8s.io/api/core/v1"
@@ -102,6 +103,12 @@ func (c *mockGCECloud) Storage() *storage.Service {
 // IAM returns the IAM client
 func (c *mockGCECloud) IAM() *iam.Service {
 	klog.Fatalf("mockGCECloud::IAM not implemented")
+	return nil
+}
+
+// NameService returns the DNS client
+func (c *mockGCECloud) CloudDNS() *dns.Service {
+	klog.Fatalf("mockGCECloud::CloudDNS not implemented")
 	return nil
 }
 


### PR DESCRIPTION
`Kops delete cluster` will now also delete the GCE DNS entries.

GCE DNS deletion is done by creating a Change object with resource record deletions/additions for one zone. So the implementation is using the GroupDeleter and the GroupKey.

For deletion the zone.name was needed and was not present in the dns.ResourceRecordSet. So I passed it along as the name of the ResourceRecord to be deleted. 

Any hints or pointers on how to write tests for this change very much appreciated. Works in my use case (example cluster on GCE). 