### PR TITLE
Update mock kops version in integration tests

### DIFF
--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -387,7 +387,7 @@ func runTestAWS(t *testing.T, clusterName string, srcDir string, version string,
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
-	h.MockKopsVersion("1.8.1")
+	h.MockKopsVersion("1.15.0")
 	h.SetupMockAWS()
 
 	expectedFilenames := []string{
@@ -434,7 +434,7 @@ func runTestPhase(t *testing.T, clusterName string, srcDir string, version strin
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
-	h.MockKopsVersion("1.8.1")
+	h.MockKopsVersion("1.15.0")
 	h.SetupMockAWS()
 	phaseName := string(phase)
 	if phaseName == "" {
@@ -482,7 +482,7 @@ func runTestGCE(t *testing.T, clusterName string, srcDir string, version string,
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
-	h.MockKopsVersion("1.8.1")
+	h.MockKopsVersion("1.15.0")
 	h.SetupMockGCE()
 
 	expectedFilenames := []string{
@@ -518,7 +518,7 @@ func runTestCloudformation(t *testing.T, clusterName string, srcDir string, vers
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
-	h.MockKopsVersion("1.8.1")
+	h.MockKopsVersion("1.15.0")
 	h.SetupMockAWS()
 
 	factory := util.NewFactory(factoryOptions)

--- a/cmd/kops/lifecycle_integration_test.go
+++ b/cmd/kops/lifecycle_integration_test.go
@@ -269,7 +269,7 @@ func runLifecycleTestAWS(o *LifecycleTestOptions) {
 	h := testutils.NewIntegrationTestHarness(o.t)
 	defer h.Close()
 
-	h.MockKopsVersion("1.8.1")
+	h.MockKopsVersion("1.15.0")
 	cloud := h.SetupMockAWS()
 
 	var beforeIds []string

--- a/pkg/resources/aws/vpc_test.go
+++ b/pkg/resources/aws/vpc_test.go
@@ -30,7 +30,7 @@ func TestListVPCs(t *testing.T) {
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
-	h.MockKopsVersion("1.8.1")
+	h.MockKopsVersion("1.15.0")
 	awsCloud := h.SetupMockAWS()
 
 	mockEC2 := awsCloud.EC2().(*mockec2.MockEC2)

--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
@@ -18,8 +18,8 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -266,7 +266,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: additionalcidr.example.com
   ConfigBase: memfs://clusters.example.com/additionalcidr.example.com
   InstanceGroupName: master-us-test-1b
@@ -279,12 +279,12 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
   - memfs://clusters.example.com/additionalcidr.example.com/manifests/etcd/main.yaml
   - memfs://clusters.example.com/additionalcidr.example.com/manifests/etcd/events.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -310,8 +310,8 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -476,7 +476,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: additionalcidr.example.com
   ConfigBase: memfs://clusters.example.com/additionalcidr.example.com
   InstanceGroupName: nodes
@@ -486,12 +486,12 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
   channels:
   - memfs://clusters.example.com/additionalcidr.example.com/addons/bootstrap-channel.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -27,8 +27,8 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -275,7 +275,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: additionaluserdata.example.com
   ConfigBase: memfs://clusters.example.com/additionaluserdata.example.com
   InstanceGroupName: master-us-test-1a
@@ -288,12 +288,12 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
   - memfs://clusters.example.com/additionaluserdata.example.com/manifests/etcd/main.yaml
   - memfs://clusters.example.com/additionaluserdata.example.com/manifests/etcd/events.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -339,8 +339,8 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -505,7 +505,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: additionaluserdata.example.com
   ConfigBase: memfs://clusters.example.com/additionaluserdata.example.com
   InstanceGroupName: nodes
@@ -515,12 +515,12 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
   channels:
   - memfs://clusters.example.com/additionaluserdata.example.com/addons/bootstrap-channel.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
@@ -18,8 +18,8 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscomplexexampleco
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -268,7 +268,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscomplexexampleco
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: complex.example.com
   ConfigBase: memfs://clusters.example.com/complex.example.com
   InstanceGroupName: master-us-test-1a
@@ -281,12 +281,12 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscomplexexampleco
   - memfs://clusters.example.com/complex.example.com/manifests/etcd/main.yaml
   - memfs://clusters.example.com/complex.example.com/manifests/etcd/events.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -312,8 +312,8 @@ Resources.AWSAutoScalingLaunchConfigurationnodescomplexexamplecom.Properties.Use
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -478,7 +478,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodescomplexexamplecom.Properties.Use
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: complex.example.com
   ConfigBase: memfs://clusters.example.com/complex.example.com
   InstanceGroupName: nodes
@@ -488,12 +488,12 @@ Resources.AWSAutoScalingLaunchConfigurationnodescomplexexamplecom.Properties.Use
   channels:
   - memfs://clusters.example.com/complex.example.com/addons/bootstrap-channel.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
@@ -18,8 +18,8 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscontainerdexampl
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -260,7 +260,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscontainerdexampl
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: containerd.example.com
   ConfigBase: memfs://clusters.example.com/containerd.example.com
   InstanceGroupName: master-us-test-1a
@@ -273,12 +273,12 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscontainerdexampl
   - memfs://clusters.example.com/containerd.example.com/manifests/etcd/main.yaml
   - memfs://clusters.example.com/containerd.example.com/manifests/etcd/events.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -304,8 +304,8 @@ Resources.AWSAutoScalingLaunchConfigurationnodescontainerdexamplecom.Properties.
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -464,7 +464,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodescontainerdexamplecom.Properties.
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: containerd.example.com
   ConfigBase: memfs://clusters.example.com/containerd.example.com
   InstanceGroupName: nodes
@@ -474,12 +474,12 @@ Resources.AWSAutoScalingLaunchConfigurationnodescontainerdexamplecom.Properties.
   channels:
   - memfs://clusters.example.com/containerd.example.com/addons/bootstrap-channel.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -18,8 +18,8 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -266,7 +266,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: minimal.example.com
   ConfigBase: memfs://clusters.example.com/minimal.example.com
   InstanceGroupName: master-us-test-1a
@@ -279,12 +279,12 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main.yaml
   - memfs://clusters.example.com/minimal.example.com/manifests/etcd/events.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -310,8 +310,8 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -476,7 +476,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: minimal.example.com
   ConfigBase: memfs://clusters.example.com/minimal.example.com
   InstanceGroupName: nodes
@@ -486,12 +486,12 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   channels:
   - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_master-us-west-2a.masters.k8s-iam.us-west-2.td.priv_user_data
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_master-us-west-2a.masters.k8s-iam.us-west-2.td.priv_user_data
@@ -17,8 +17,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-NODEUP_URL=https://github.com/kubernetes/kops/releases/download/1.8.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.0/linux/amd64/nodeup
-NODEUP_HASH=02185512f78dc9d15a8c10774c4cb11f67e4bc20
+NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
 
 export AWS_REGION=us-west-2
@@ -271,7 +271,7 @@ Assets:
 - 125993c220d1a9b5b60ad20a867a0e7cda63e64c@https://storage.googleapis.com/kubernetes-release/release/v1.8.4/bin/linux/amd64/kubelet
 - 8e2314db816b9b4465c5f713c1152cb0603db15e@https://storage.googleapis.com/kubernetes-release/release/v1.8.4/bin/linux/amd64/kubectl
 - 1d9788b0f5420e1a219aad2cb8681823fc515e7c@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz
-- f62360d3351bed837ae3ffcdee65e9d57511695a@https://kubeupv2.s3.amazonaws.com/kops/1.8.0/linux/amd64/utils.tar.gz
+- 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
 ClusterName: k8s-iam.us-west-2.td.priv
 ConfigBase: s3://tune-k8s-kops-test/k8s-iam.us-west-2.td.priv
 InstanceGroupName: master-us-west-2a
@@ -282,9 +282,12 @@ Tags:
 channels:
 - s3://tune-k8s-kops-test/k8s-iam.us-west-2.td.priv/addons/bootstrap-channel.yaml
 protokubeImage:
-  hash: 1b972e92520b3cafd576893ae3daeafdd1bc9ffd
-  name: protokube:1.8.0
-  source: https://kubeupv2.s3.amazonaws.com/kops/1.8.0/images/protokube.tar.gz
+  hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+  name: protokube:1.15.0
+  sources:
+  - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+  - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+  - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_nodes.k8s-iam.us-west-2.td.priv_user_data
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_nodes.k8s-iam.us-west-2.td.priv_user_data
@@ -17,8 +17,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-NODEUP_URL=https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-NODEUP_HASH=02185512f78dc9d15a8c10774c4cb11f67e4bc20
+NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
 
 export AWS_REGION=us-west-2
@@ -191,7 +191,7 @@ Assets:
 - 125993c220d1a9b5b60ad20a867a0e7cda63e64c@https://storage.googleapis.com/kubernetes-release/release/v1.8.4/bin/linux/amd64/kubelet
 - 8e2314db816b9b4465c5f713c1152cb0603db15e@https://storage.googleapis.com/kubernetes-release/release/v1.8.4/bin/linux/amd64/kubectl
 - 1d9788b0f5420e1a219aad2cb8681823fc515e7c@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz
-- f62360d3351bed837ae3ffcdee65e9d57511695a@https://kubeupv2.s3.amazonaws.com/kops/1.8.0/linux/amd64/utils.tar.gz
+- 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
 ClusterName: k8s-iam.us-west-2.td.priv
 ConfigBase: s3://tune-k8s-kops-test/k8s-iam.us-west-2.td.priv
 InstanceGroupName: nodes
@@ -202,9 +202,12 @@ Tags:
 channels:
 - s3://tune-k8s-kops-test/k8s-iam.us-west-2.td.priv/addons/bootstrap-channel.yaml
 protokubeImage:
-  hash: 1b972e92520b3cafd576893ae3daeafdd1bc9ffd
-  name: protokube:1.8.0
-  source: https://kubeupv2.s3.amazonaws.com/kops/1.8.0/images/protokube.tar.gz
+  hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+  name: protokube:1.15.0
+  sources:
+  - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+  - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+  - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -18,8 +18,8 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -266,7 +266,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: externallb.example.com
   ConfigBase: memfs://clusters.example.com/externallb.example.com
   InstanceGroupName: master-us-test-1a
@@ -279,12 +279,12 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
   - memfs://clusters.example.com/externallb.example.com/manifests/etcd/main.yaml
   - memfs://clusters.example.com/externallb.example.com/manifests/etcd/events.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -310,8 +310,8 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -476,7 +476,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: externallb.example.com
   ConfigBase: memfs://clusters.example.com/externallb.example.com
   InstanceGroupName: nodes
@@ -486,12 +486,12 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
   channels:
   - memfs://clusters.example.com/externallb.example.com/addons/bootstrap-channel.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -18,8 +18,8 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -266,7 +266,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: minimal.example.com
   ConfigBase: memfs://clusters.example.com/minimal.example.com
   InstanceGroupName: master-us-test-1a
@@ -279,12 +279,12 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main.yaml
   - memfs://clusters.example.com/minimal.example.com/manifests/etcd/events.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -310,8 +310,8 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -476,7 +476,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: minimal.example.com
   ConfigBase: memfs://clusters.example.com/minimal.example.com
   InstanceGroupName: nodes
@@ -486,12 +486,12 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   channels:
   - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
@@ -18,8 +18,8 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -268,7 +268,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
   - e914b17532c411cb7c0cc472131b61935fb66b31@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubelet
   - aa3e93897a6999d6c7dedbc41793c90d41eeb000@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: mixedinstances.example.com
   ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
   InstanceGroupName: master-us-test-1a
@@ -281,12 +281,12 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
   - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/main.yaml
   - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/events.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -312,8 +312,8 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -562,7 +562,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
   - e914b17532c411cb7c0cc472131b61935fb66b31@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubelet
   - aa3e93897a6999d6c7dedbc41793c90d41eeb000@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: mixedinstances.example.com
   ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
   InstanceGroupName: master-us-test-1b
@@ -575,12 +575,12 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
   - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/main.yaml
   - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/events.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -606,8 +606,8 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -856,7 +856,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
   - e914b17532c411cb7c0cc472131b61935fb66b31@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubelet
   - aa3e93897a6999d6c7dedbc41793c90d41eeb000@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: mixedinstances.example.com
   ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
   InstanceGroupName: master-us-test-1c
@@ -869,12 +869,12 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
   - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/main.yaml
   - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/events.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -900,8 +900,8 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -1067,7 +1067,7 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
   - e914b17532c411cb7c0cc472131b61935fb66b31@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubelet
   - aa3e93897a6999d6c7dedbc41793c90d41eeb000@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: mixedinstances.example.com
   ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
   InstanceGroupName: nodes
@@ -1077,12 +1077,12 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
   channels:
   - memfs://clusters.example.com/mixedinstances.example.com/addons/bootstrap-channel.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
@@ -18,8 +18,8 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -268,7 +268,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
   - e914b17532c411cb7c0cc472131b61935fb66b31@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubelet
   - aa3e93897a6999d6c7dedbc41793c90d41eeb000@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: mixedinstances.example.com
   ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
   InstanceGroupName: master-us-test-1a
@@ -281,12 +281,12 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
   - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/main.yaml
   - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/events.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -312,8 +312,8 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -562,7 +562,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
   - e914b17532c411cb7c0cc472131b61935fb66b31@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubelet
   - aa3e93897a6999d6c7dedbc41793c90d41eeb000@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: mixedinstances.example.com
   ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
   InstanceGroupName: master-us-test-1b
@@ -575,12 +575,12 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
   - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/main.yaml
   - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/events.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -606,8 +606,8 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -856,7 +856,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
   - e914b17532c411cb7c0cc472131b61935fb66b31@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubelet
   - aa3e93897a6999d6c7dedbc41793c90d41eeb000@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: mixedinstances.example.com
   ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
   InstanceGroupName: master-us-test-1c
@@ -869,12 +869,12 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
   - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/main.yaml
   - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/events.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -900,8 +900,8 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -1067,7 +1067,7 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
   - e914b17532c411cb7c0cc472131b61935fb66b31@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubelet
   - aa3e93897a6999d6c7dedbc41793c90d41eeb000@https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: mixedinstances.example.com
   ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
   InstanceGroupName: nodes
@@ -1077,12 +1077,12 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
   channels:
   - memfs://clusters.example.com/mixedinstances.example.com/addons/bootstrap-channel.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
@@ -18,8 +18,8 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersprivatecalicoexa
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -264,7 +264,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersprivatecalicoexa
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: privatecalico.example.com
   ConfigBase: memfs://clusters.example.com/privatecalico.example.com
   InstanceGroupName: master-us-test-1a
@@ -277,12 +277,12 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersprivatecalicoexa
   - memfs://clusters.example.com/privatecalico.example.com/manifests/etcd/main.yaml
   - memfs://clusters.example.com/privatecalico.example.com/manifests/etcd/events.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 
@@ -308,8 +308,8 @@ Resources.AWSAutoScalingLaunchConfigurationnodesprivatecalicoexamplecom.Properti
   set -o nounset
   set -o pipefail
 
-  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/nodeup
-  NODEUP_HASH=bb41724c37d15ab7e039e06230e742b9b38d0808
+  NODEUP_URL=https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-nodeup,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/nodeup
+  NODEUP_HASH=9604ef18267ad7b5cf4cebbf7ab64423cf5bb0342d169c608ac6376e6af26d81
 
   export AWS_REGION=us-test-1
 
@@ -473,7 +473,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesprivatecalicoexamplecom.Properti
   - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
   - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
   - 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-  - 42b15a0a0a56531750bde3c7b08d0cf27c170c48@https://artifacts.k8s.io/binaries/kops/1.8.1/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.8.1/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.8.1/linux/amd64/utils.tar.gz
+  - 71b7bc444ba0a5f7cd7a36e91b594c1c3d13890e160d85e0dfde38c46a24e416@https://artifacts.k8s.io/binaries/kops/1.15.0/linux/amd64/utils.tar.gz,https://github.com/kubernetes/kops/releases/download/1.15.0/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz
   ClusterName: privatecalico.example.com
   ConfigBase: memfs://clusters.example.com/privatecalico.example.com
   InstanceGroupName: nodes
@@ -483,12 +483,12 @@ Resources.AWSAutoScalingLaunchConfigurationnodesprivatecalicoexamplecom.Properti
   channels:
   - memfs://clusters.example.com/privatecalico.example.com/addons/bootstrap-channel.yaml
   protokubeImage:
-    hash: 0b1f26208f8f6cc02468368706d0236670fec8a2
-    name: protokube:1.8.1
+    hash: 42a9c4324fe26d63ce11f3dd7836371bc93fa06ca8f479807728f3746e27061b
+    name: protokube:1.15.0
     sources:
-    - https://artifacts.k8s.io/binaries/kops/1.8.1/images/protokube.tar.gz
-    - https://github.com/kubernetes/kops/releases/download/1.8.1/images-protokube.tar.gz
-    - https://kubeupv2.s3.amazonaws.com/kops/1.8.1/images/protokube.tar.gz
+    - https://artifacts.k8s.io/binaries/kops/1.15.0/images/protokube.tar.gz
+    - https://github.com/kubernetes/kops/releases/download/1.15.0/images-protokube.tar.gz
+    - https://kubeupv2.s3.amazonaws.com/kops/1.15.0/images/protokube.tar.gz
 
   __EOF_KUBE_ENV
 


### PR DESCRIPTION
To go along with our version deprecation we should update our mocked kops versions