### PR TITLE
WIP add cloudbuild.yaml used by image pushing postsubmit job

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,21 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20191019-6567e5c'
+    entrypoint: make
+    env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - TAG=$_GIT_TAG
+    - PULL_BASE_REF=$_PULL_BASE_REF
+    - DOCKER_REGISTRY=??????
+    args:
+    - dns-controller-push
+    - kops-controller-push
+    - protokube-push
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '12345'
+  _PULL_BASE_REF: 'dev'


### PR DESCRIPTION
I dont know what to put for the docker registry, so leaving this as WIP until I get an answer

It will be used by the currently-failing [postsubmit job](https://testgrid.k8s.io/sig-cluster-lifecycle-kops#kops-postsubmit-push-to-staging).
Following [this example](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/master/cloudbuild.yaml).