### PR TITLE
Exclude one Travis osx job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ script:
   - GOPROXY=https://proxy.golang.org make nodeup examples test
 
 jobs:
+  exclude:
+    - os: osx
+      go: "1.12"
   include:
     - name: Verify
       os: linux


### PR DESCRIPTION
We don't need it and Travis OS/X resources appear to be scarce.