### PR TITLE
Add support for weave.npcExtraArgs

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -125,6 +125,20 @@ spec:
 
 Note that it is possible to break the cluster networking if flags are improperly used and as such this option should be used with caution.
 
+### Configuring Weave NPC EXTRA_ARGS
+
+Weave-npc (the Weave network policy controller) allows you to customize arguments of the running binary by setting the EXTRA_ARGS environmental variable.
+This can be used for debugging or for customizing the logging level of weave npc.
+
+```
+spec:
+  networking:
+    weave:
+      npcExtraArgs: "--log-level=info"
+```
+
+Note that it is possible to break the cluster networking if flags are improperly used and as such this option should be used with caution.
+
 ### Configuring Weave network encryption
 
 The Weave network encryption is configurable by creating a weave network secret password.

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2788,7 +2788,8 @@ spec:
                       format: int32
                       type: integer
                     netExtraArgs:
-                      description: Extra arguments that are passed to weave-kube
+                      description: NetExtraArgs are extra arguments that are passed
+                        to weave-kube.
                       type: string
                     noMasqLocal:
                       format: int32
@@ -2801,7 +2802,8 @@ spec:
                         Default 50m
                       type: string
                     npcExtraArgs:
-                      description: Extra arguments that are passed to weave-npc
+                      description: NPCExtraArgs are extra arguments that are passed
+                        to weave-npc.
                       type: string
                     npcMemoryLimit:
                       description: NPCMemoryLimit memory limit of weave npc container.

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2788,6 +2788,7 @@ spec:
                       format: int32
                       type: integer
                     netExtraArgs:
+                      description: Extra arguments that are passed to weave-kube
                       type: string
                     noMasqLocal:
                       format: int32
@@ -2798,6 +2799,9 @@ spec:
                     npcCPURequest:
                       description: NPCCPURequest CPU request of weave npc container.
                         Default 50m
+                      type: string
+                    npcExtraArgs:
+                      description: Extra arguments that are passed to weave-npc
                       type: string
                     npcMemoryLimit:
                       description: NPCMemoryLimit memory limit of weave npc container.

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -67,6 +67,7 @@ type WeaveNetworkingSpec struct {
 	ConnLimit    *int32 `json:"connLimit,omitempty"`
 	NoMasqLocal  *int32 `json:"noMasqLocal,omitempty"`
 	NetExtraArgs string `json:"netExtraArgs,omitempty"`
+	NpcExtraArgs string `json:"npcExtraArgs,omitempty"`
 
 	// MemoryRequest memory request of weave container. Default 200Mi
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -63,11 +63,9 @@ type KopeioNetworkingSpec struct {
 
 // WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU          *int32 `json:"mtu,omitempty"`
-	ConnLimit    *int32 `json:"connLimit,omitempty"`
-	NoMasqLocal  *int32 `json:"noMasqLocal,omitempty"`
-	NetExtraArgs string `json:"netExtraArgs,omitempty"`
-	NpcExtraArgs string `json:"npcExtraArgs,omitempty"`
+	MTU         *int32 `json:"mtu,omitempty"`
+	ConnLimit   *int32 `json:"connLimit,omitempty"`
+	NoMasqLocal *int32 `json:"noMasqLocal,omitempty"`
 
 	// MemoryRequest memory request of weave container. Default 200Mi
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
@@ -77,6 +75,9 @@ type WeaveNetworkingSpec struct {
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 	// CPULimit CPU limit of weave container.
 	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
+	// Extra arguments that are passed to weave-kube
+	NetExtraArgs string `json:"netExtraArgs,omitempty"`
+
 	// NPCMemoryRequest memory request of weave npc container. Default 200Mi
 	NPCMemoryRequest *resource.Quantity `json:"npcMemoryRequest,omitempty"`
 	// NPCCPURequest CPU request of weave npc container. Default 50m
@@ -85,6 +86,8 @@ type WeaveNetworkingSpec struct {
 	NPCMemoryLimit *resource.Quantity `json:"npcMemoryLimit,omitempty"`
 	// NPCCPULimit CPU limit of weave npc container
 	NPCCPULimit *resource.Quantity `json:"npcCPULimit,omitempty"`
+	// Extra arguments that are passed to weave-npc
+	NPCExtraArgs string `json:"npcExtraArgs,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -75,7 +75,7 @@ type WeaveNetworkingSpec struct {
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 	// CPULimit CPU limit of weave container.
 	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
-	// Extra arguments that are passed to weave-kube
+	// NetExtraArgs are extra arguments that are passed to weave-kube.
 	NetExtraArgs string `json:"netExtraArgs,omitempty"`
 
 	// NPCMemoryRequest memory request of weave npc container. Default 200Mi
@@ -86,7 +86,7 @@ type WeaveNetworkingSpec struct {
 	NPCMemoryLimit *resource.Quantity `json:"npcMemoryLimit,omitempty"`
 	// NPCCPULimit CPU limit of weave npc container
 	NPCCPULimit *resource.Quantity `json:"npcCPULimit,omitempty"`
-	// Extra arguments that are passed to weave-npc
+	// NPCExtraArgs are extra arguments that are passed to weave-npc.
 	NPCExtraArgs string `json:"npcExtraArgs,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -67,6 +67,7 @@ type WeaveNetworkingSpec struct {
 	ConnLimit    *int32 `json:"connLimit,omitempty"`
 	NoMasqLocal  *int32 `json:"noMasqLocal,omitempty"`
 	NetExtraArgs string `json:"netExtraArgs,omitempty"`
+	NpcExtraArgs string `json:"npcExtraArgs,omitempty"`
 
 	// MemoryRequest memory request of weave container. Default 200Mi
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -63,11 +63,9 @@ type KopeioNetworkingSpec struct {
 
 // WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU          *int32 `json:"mtu,omitempty"`
-	ConnLimit    *int32 `json:"connLimit,omitempty"`
-	NoMasqLocal  *int32 `json:"noMasqLocal,omitempty"`
-	NetExtraArgs string `json:"netExtraArgs,omitempty"`
-	NpcExtraArgs string `json:"npcExtraArgs,omitempty"`
+	MTU         *int32 `json:"mtu,omitempty"`
+	ConnLimit   *int32 `json:"connLimit,omitempty"`
+	NoMasqLocal *int32 `json:"noMasqLocal,omitempty"`
 
 	// MemoryRequest memory request of weave container. Default 200Mi
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
@@ -77,6 +75,9 @@ type WeaveNetworkingSpec struct {
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 	// CPULimit CPU limit of weave container.
 	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
+	// Extra arguments that are passed to weave-kube
+	NetExtraArgs string `json:"netExtraArgs,omitempty"`
+
 	// NPCMemoryRequest memory request of weave npc container. Default 200Mi
 	NPCMemoryRequest *resource.Quantity `json:"npcMemoryRequest,omitempty"`
 	// NPCCPURequest CPU request of weave npc container. Default 50m
@@ -85,6 +86,8 @@ type WeaveNetworkingSpec struct {
 	NPCMemoryLimit *resource.Quantity `json:"npcMemoryLimit,omitempty"`
 	// NPCCPULimit CPU limit of weave npc container
 	NPCCPULimit *resource.Quantity `json:"npcCPULimit,omitempty"`
+	// Extra arguments that are passed to weave-npc
+	NPCExtraArgs string `json:"npcExtraArgs,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -75,7 +75,7 @@ type WeaveNetworkingSpec struct {
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 	// CPULimit CPU limit of weave container.
 	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
-	// Extra arguments that are passed to weave-kube
+	// NetExtraArgs are extra arguments that are passed to weave-kube.
 	NetExtraArgs string `json:"netExtraArgs,omitempty"`
 
 	// NPCMemoryRequest memory request of weave npc container. Default 200Mi
@@ -86,7 +86,7 @@ type WeaveNetworkingSpec struct {
 	NPCMemoryLimit *resource.Quantity `json:"npcMemoryLimit,omitempty"`
 	// NPCCPULimit CPU limit of weave npc container
 	NPCCPULimit *resource.Quantity `json:"npcCPULimit,omitempty"`
-	// Extra arguments that are passed to weave-npc
+	// NPCExtraArgs are extra arguments that are passed to weave-npc.
 	NPCExtraArgs string `json:"npcExtraArgs,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -4852,16 +4852,16 @@ func autoConvert_v1alpha1_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *We
 	out.MTU = in.MTU
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
-	out.NetExtraArgs = in.NetExtraArgs
-	out.NpcExtraArgs = in.NpcExtraArgs
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.MemoryLimit = in.MemoryLimit
 	out.CPULimit = in.CPULimit
+	out.NetExtraArgs = in.NetExtraArgs
 	out.NPCMemoryRequest = in.NPCMemoryRequest
 	out.NPCCPURequest = in.NPCCPURequest
 	out.NPCMemoryLimit = in.NPCMemoryLimit
 	out.NPCCPULimit = in.NPCCPULimit
+	out.NPCExtraArgs = in.NPCExtraArgs
 	return nil
 }
 
@@ -4874,16 +4874,16 @@ func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha1_WeaveNetworkingSpec(in *ko
 	out.MTU = in.MTU
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
-	out.NetExtraArgs = in.NetExtraArgs
-	out.NpcExtraArgs = in.NpcExtraArgs
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.MemoryLimit = in.MemoryLimit
 	out.CPULimit = in.CPULimit
+	out.NetExtraArgs = in.NetExtraArgs
 	out.NPCMemoryRequest = in.NPCMemoryRequest
 	out.NPCCPURequest = in.NPCCPURequest
 	out.NPCMemoryLimit = in.NPCMemoryLimit
 	out.NPCCPULimit = in.NPCCPULimit
+	out.NPCExtraArgs = in.NPCExtraArgs
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -4853,6 +4853,7 @@ func autoConvert_v1alpha1_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *We
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
 	out.NetExtraArgs = in.NetExtraArgs
+	out.NpcExtraArgs = in.NpcExtraArgs
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.MemoryLimit = in.MemoryLimit
@@ -4874,6 +4875,7 @@ func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha1_WeaveNetworkingSpec(in *ko
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
 	out.NetExtraArgs = in.NetExtraArgs
+	out.NpcExtraArgs = in.NpcExtraArgs
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.MemoryLimit = in.MemoryLimit

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -67,6 +67,7 @@ type WeaveNetworkingSpec struct {
 	ConnLimit    *int32 `json:"connLimit,omitempty"`
 	NoMasqLocal  *int32 `json:"noMasqLocal,omitempty"`
 	NetExtraArgs string `json:"netExtraArgs,omitempty"`
+	NpcExtraArgs string `json:"npcExtraArgs,omitempty"`
 
 	// MemoryRequest memory request of weave container. Default 200Mi
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -63,11 +63,9 @@ type KopeioNetworkingSpec struct {
 
 // WeaveNetworkingSpec declares that we want Weave networking
 type WeaveNetworkingSpec struct {
-	MTU          *int32 `json:"mtu,omitempty"`
-	ConnLimit    *int32 `json:"connLimit,omitempty"`
-	NoMasqLocal  *int32 `json:"noMasqLocal,omitempty"`
-	NetExtraArgs string `json:"netExtraArgs,omitempty"`
-	NpcExtraArgs string `json:"npcExtraArgs,omitempty"`
+	MTU         *int32 `json:"mtu,omitempty"`
+	ConnLimit   *int32 `json:"connLimit,omitempty"`
+	NoMasqLocal *int32 `json:"noMasqLocal,omitempty"`
 
 	// MemoryRequest memory request of weave container. Default 200Mi
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
@@ -77,6 +75,9 @@ type WeaveNetworkingSpec struct {
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 	// CPULimit CPU limit of weave container.
 	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
+	// Extra arguments that are passed to weave-kube
+	NetExtraArgs string `json:"netExtraArgs,omitempty"`
+
 	// NPCMemoryRequest memory request of weave npc container. Default 200Mi
 	NPCMemoryRequest *resource.Quantity `json:"npcMemoryRequest,omitempty"`
 	// NPCCPURequest CPU request of weave npc container. Default 50m
@@ -85,6 +86,8 @@ type WeaveNetworkingSpec struct {
 	NPCMemoryLimit *resource.Quantity `json:"npcMemoryLimit,omitempty"`
 	// NPCCPULimit CPU limit of weave npc container
 	NPCCPULimit *resource.Quantity `json:"npcCPULimit,omitempty"`
+	// Extra arguments that are passed to weave-npc
+	NPCExtraArgs string `json:"npcExtraArgs,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -75,7 +75,7 @@ type WeaveNetworkingSpec struct {
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 	// CPULimit CPU limit of weave container.
 	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
-	// Extra arguments that are passed to weave-kube
+	// NetExtraArgs are extra arguments that are passed to weave-kube.
 	NetExtraArgs string `json:"netExtraArgs,omitempty"`
 
 	// NPCMemoryRequest memory request of weave npc container. Default 200Mi
@@ -86,7 +86,7 @@ type WeaveNetworkingSpec struct {
 	NPCMemoryLimit *resource.Quantity `json:"npcMemoryLimit,omitempty"`
 	// NPCCPULimit CPU limit of weave npc container
 	NPCCPULimit *resource.Quantity `json:"npcCPULimit,omitempty"`
-	// Extra arguments that are passed to weave-npc
+	// NPCExtraArgs are extra arguments that are passed to weave-npc.
 	NPCExtraArgs string `json:"npcExtraArgs,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5181,6 +5181,7 @@ func autoConvert_v1alpha2_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *We
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
 	out.NetExtraArgs = in.NetExtraArgs
+	out.NpcExtraArgs = in.NpcExtraArgs
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.MemoryLimit = in.MemoryLimit
@@ -5202,6 +5203,7 @@ func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha2_WeaveNetworkingSpec(in *ko
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
 	out.NetExtraArgs = in.NetExtraArgs
+	out.NpcExtraArgs = in.NpcExtraArgs
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.MemoryLimit = in.MemoryLimit

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5180,16 +5180,16 @@ func autoConvert_v1alpha2_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *We
 	out.MTU = in.MTU
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
-	out.NetExtraArgs = in.NetExtraArgs
-	out.NpcExtraArgs = in.NpcExtraArgs
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.MemoryLimit = in.MemoryLimit
 	out.CPULimit = in.CPULimit
+	out.NetExtraArgs = in.NetExtraArgs
 	out.NPCMemoryRequest = in.NPCMemoryRequest
 	out.NPCCPURequest = in.NPCCPURequest
 	out.NPCMemoryLimit = in.NPCMemoryLimit
 	out.NPCCPULimit = in.NPCCPULimit
+	out.NPCExtraArgs = in.NPCExtraArgs
 	return nil
 }
 
@@ -5202,16 +5202,16 @@ func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha2_WeaveNetworkingSpec(in *ko
 	out.MTU = in.MTU
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
-	out.NetExtraArgs = in.NetExtraArgs
-	out.NpcExtraArgs = in.NpcExtraArgs
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.MemoryLimit = in.MemoryLimit
 	out.CPULimit = in.CPULimit
+	out.NetExtraArgs = in.NetExtraArgs
 	out.NPCMemoryRequest = in.NPCMemoryRequest
 	out.NPCCPURequest = in.NPCCPURequest
 	out.NPCMemoryLimit = in.NPCMemoryLimit
 	out.NPCCPULimit = in.NPCCPULimit
+	out.NPCExtraArgs = in.NPCExtraArgs
 	return nil
 }
 

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -211,6 +211,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            {{- if .Networking.Weave.NpcExtraArgs }}
+            - name: EXTRA_ARGS
+              value: "{{ .Networking.Weave.NpcExtraArgs }}"
+            {{- end }}
           image: 'weaveworks/weave-npc:2.6.0'
           ports:
             - name: metrics

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -211,9 +211,9 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            {{- if .Networking.Weave.NpcExtraArgs }}
+            {{- if .Networking.Weave.NPCExtraArgs }}
             - name: EXTRA_ARGS
-              value: "{{ .Networking.Weave.NpcExtraArgs }}"
+              value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
           image: 'weaveworks/weave-npc:2.6.0'
           ports:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -203,10 +203,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            {{- if .Networking.Weave.NPCExtraArgs }}
-            - name: EXTRA_ARGS
-              value: "{{ .Networking.Weave.NPCExtraArgs }}"
-            {{- end }}
           image: 'weaveworks/weave-npc:2.6.0'
           ports:
             - name: metrics

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -203,9 +203,9 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            {{- if .Networking.Weave.NpcExtraArgs }}
+            {{- if .Networking.Weave.NPCExtraArgs }}
             - name: EXTRA_ARGS
-              value: "{{ .Networking.Weave.NpcExtraArgs }}"
+              value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
           image: 'weaveworks/weave-npc:2.6.0'
           ports:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -203,6 +203,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            {{- if .Networking.Weave.NpcExtraArgs }}
+            - name: EXTRA_ARGS
+              value: "{{ .Networking.Weave.NpcExtraArgs }}"
+            {{- end }}
           image: 'weaveworks/weave-npc:2.6.0'
           ports:
             - name: metrics

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -207,9 +207,9 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            {{- if .Networking.Weave.NpcExtraArgs }}
+            {{- if .Networking.Weave.NPCExtraArgs }}
             - name: EXTRA_ARGS
-              value: "{{ .Networking.Weave.NpcExtraArgs }}"
+              value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
           image: 'weaveworks/weave-npc:2.6.0'
           ports:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -207,6 +207,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            {{- if .Networking.Weave.NpcExtraArgs }}
+            - name: EXTRA_ARGS
+              value: "{{ .Networking.Weave.NpcExtraArgs }}"
+            {{- end }}
           image: 'weaveworks/weave-npc:2.6.0'
           ports:
             - name: metrics

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/cluster.yaml
@@ -28,10 +28,12 @@ spec:
       cpuRequest: 100m
       memoryLimit: 300Mi
       cpuLimit: 200m
+      netExtraArgs: --log-level=info
       npcMemoryRequest: 300Mi
       npcCPURequest: 100m
       npcMemoryLimit: 300Mi
       npcCPULimit: 200m
+      npcExtraArgs: --log-level=info
   nonMasqueradeCIDR: 100.64.0.0/10
   sshAccess:
     - 0.0.0.0/0

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -123,7 +123,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.7.0'
     manifest: networking.weave/k8s-1.6.yaml
-    manifestHash: 6dcb06c0178143b534dac093fcad00c331b12319
+    manifestHash: 3f021695840729640da3910d8da357e905d3450c
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
@@ -131,7 +131,7 @@ spec:
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0 <1.8.0'
     manifest: networking.weave/k8s-1.7.yaml
-    manifestHash: 29f0b9379ffda0cc4288c9769371dc5adc75687a
+    manifestHash: 0725cf9a9f3651209a0b726ed00a078d7fb2e7f6
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
@@ -139,7 +139,7 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: 75cc6479f36f443600f567e492707efcbb9fbd31
+    manifestHash: 50a20409003956b7c31a479408ca42ec97774854
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
@@ -147,7 +147,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: eb939be2701cdd0c78468358513d74f9eb2d9308
+    manifestHash: d2df87d90f8877a201f5cad93de296697191d4ae
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -131,7 +131,7 @@ spec:
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0 <1.8.0'
     manifest: networking.weave/k8s-1.7.yaml
-    manifestHash: 0725cf9a9f3651209a0b726ed00a078d7fb2e7f6
+    manifestHash: 990772f9809ffb0cff4ea9341a9ab7e9094d7587
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
Closes #7390

References Weaveworks/Weave#3683

This change is excluded from k8s-1.6.yaml.template as this environmental variable is only effective on Weave 2.6.0 and above.