### PR TITLE
nodeup: Add some dependencies for Service

### DIFF
--- a/upup/pkg/fi/nodeup/nodetasks/service.go
+++ b/upup/pkg/fi/nodeup/nodetasks/service.go
@@ -71,7 +71,7 @@ func (p *Service) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 		// launching a custom Kubernetes build), they all depend on
 		// the "docker.service" Service task.
 		switch v.(type) {
-		case *File, *Package, *UpdatePackages, *UserTask, *GroupTask, *MountDiskTask, *Chattr:
+		case *File, *Package, *UpdatePackages, *UserTask, *GroupTask, *MountDiskTask, *Chattr, *BindMount, *Archive:
 			deps = append(deps, v)
 		case *Service, *LoadImageTask:
 			// ignore


### PR DESCRIPTION
We handle service dependencies on BindMount and Archive tasks; this
avoids some false-positive warning messages.