### PR TITLE
Remove kops-controller deployment

### DIFF
--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -11,38 +11,6 @@ data:
 
 ---
 
-# Deployment of size 0, to move from Deployment to DaemonSet
-# TODO: Remove in beta? (it's only been on master branch)
-
-kind: Deployment
-apiVersion: apps/v1
-metadata:
-  name: kops-controller
-  namespace: kube-system
-  labels:
-    k8s-addon: kops-controller.addons.k8s.io
-    k8s-app: kops-controller
-    version: v1.15.0-alpha.1
-spec:
-  replicas: 0
-  selector:
-    matchLabels:
-      k8s-app: kops-controller
-  template:
-    metadata:
-      labels:
-        k8s-addon: kops-controller.addons.k8s.io
-        k8s-app: kops-controller
-        version: v1.15.0-alpha.1
-    spec:
-      serviceAccountName: default
-      containers:
-      - name: sleep
-        image: k8s.gcr.io/pause-amd64:3.0
-        command: [ "/pause" ]
-
----
-
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 66e39c304bd9f397ef5d66ba7d41d52291f5eb7f
+    manifestHash: 026682d4e1e374c6f3e10b015937c8b2ef73b9a6
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -12,36 +12,6 @@ metadata:
 ---
 
 apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    k8s-addon: kops-controller.addons.k8s.io
-    k8s-app: kops-controller
-    version: v1.15.0-alpha.1
-  name: kops-controller
-  namespace: kube-system
-spec:
-  replicas: 0
-  selector:
-    matchLabels:
-      k8s-app: kops-controller
-  template:
-    metadata:
-      labels:
-        k8s-addon: kops-controller.addons.k8s.io
-        k8s-app: kops-controller
-        version: v1.15.0-alpha.1
-    spec:
-      containers:
-      - command:
-        - /pause
-        image: gcr.io/google_containers/pause-amd64:3.0
-        name: sleep
-      serviceAccountName: default
-
----
-
-apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3cd3e32f7301a675a1cf6b99af05f3528007dd9a
+    manifestHash: 026682d4e1e374c6f3e10b015937c8b2ef73b9a6
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -12,36 +12,6 @@ metadata:
 ---
 
 apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    k8s-addon: kops-controller.addons.k8s.io
-    k8s-app: kops-controller
-    version: v1.15.0-alpha.1
-  name: kops-controller
-  namespace: kube-system
-spec:
-  replicas: 0
-  selector:
-    matchLabels:
-      k8s-app: kops-controller
-  template:
-    metadata:
-      labels:
-        k8s-addon: kops-controller.addons.k8s.io
-        k8s-app: kops-controller
-        version: v1.15.0-alpha.1
-    spec:
-      containers:
-      - command:
-        - /pause
-        image: gcr.io/google_containers/pause-amd64:3.0
-        name: sleep
-      serviceAccountName: default
-
----
-
-apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3cd3e32f7301a675a1cf6b99af05f3528007dd9a
+    manifestHash: 026682d4e1e374c6f3e10b015937c8b2ef73b9a6
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3cd3e32f7301a675a1cf6b99af05f3528007dd9a
+    manifestHash: 026682d4e1e374c6f3e10b015937c8b2ef73b9a6
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io


### PR DESCRIPTION
kops-controller now runs as a DaemonSet. The migration was first made in 1.16.0-alpha.1, so that means 2 releases have been out that set the replicas to zero.
This removal negatively impacts anyone that created a cluster from kops HEAD between 1.15.0 and 1.16.0-alpha.1, and then upgraded kops directly to the 1.16.0 release that includes this commit, without having first upgraded to either of the alphas.

That seems like a reasonably small enough audience that this is safe to remove now.
Perhaps we mention in the release notes that anyone using HEAD or one of the alpha releases needs to `kubectl delete -n kube-system deployment kops-controller`

I'll add a release note in a separate PR since the release note wont get cherry-picked back to 1.16.


We'll also need to add a way to provide an iam role annotation to kops-controller or else any cluster running kube2iam with a restricted [--default-role](https://github.com/jtblin/kube2iam/blob/master/cmd/main.go#L23) wont be able to get AWS credentials with the necessary permissions to run, which will cause the rolling update to fail. Perhaps I'll open an issue to discuss this if we think there are multiple possible solutions for that.