### PR TITLE
Automated cherry pick of #8263: Replace binary "which" with build in "command"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -763,7 +763,7 @@ push-node-authorizer:
 bazel-protokube-export:
 	mkdir -p ${BAZELIMAGES}
 	bazel build ${BAZEL_CONFIG} --action_env=PROTOKUBE_TAG=${PROTOKUBE_TAG} --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //images:protokube.tar.gz //images:protokube.tar.gz.sha1  //images:protokube.tar.gz.sha256
-	cp -fp bazel-bin/images/bazel-out/k8-fastbuild/bin/images/protokube.tar.gz ${BAZELIMAGES}/protokube.tar.gz
+	cp -fp bazel-bin/images/protokube.tar.gz ${BAZELIMAGES}/protokube.tar.gz
 	cp -fp bazel-bin/images/protokube.tar.gz.sha1 ${BAZELIMAGES}/protokube.tar.gz.sha1
 	cp -fp bazel-bin/images/protokube.tar.gz.sha256 ${BAZELIMAGES}/protokube.tar.gz.sha256
 

--- a/tools/gzip.bzl
+++ b/tools/gzip.bzl
@@ -1,7 +1,8 @@
 def _impl(ctx):
     in_file = ctx.file.src
 
-    out_file = ctx.actions.declare_file("%s.gz" % in_file.path)
+    basename = ctx.attr.src.label.name
+    out_file = ctx.actions.declare_file("%s.gz" % basename)
 
     cmd = "gzip -c '%s' > '%s'" % (in_file.path, out_file.path)
 

--- a/tools/sha1
+++ b/tools/sha1
@@ -7,9 +7,9 @@ set -o pipefail
 in=$1
 out=$2
 
-if ( which sha1sum > /dev/null ); then
+if ( command -v sha1sum > /dev/null ); then
   (sha1sum $in | cut -d' ' -f1) > $out
-elif ( which shasum > /dev/null ); then
+elif ( command -v shasum > /dev/null ); then
   (shasum -a 1 $in | cut -d' ' -f1) > $out
 else
   echo "Neither sha1sum nor shasum command is available"

--- a/tools/sha256
+++ b/tools/sha256
@@ -7,9 +7,9 @@ set -o pipefail
 in=$1
 out=$2
 
-if ( which sha256sum > /dev/null ); then
+if ( command -v sha256sum > /dev/null ); then
   (sha256sum $in | cut -d' ' -f1) > $out
-elif ( which shasum > /dev/null ); then
+elif ( command -v shasum > /dev/null ); then
   (shasum -a 256 $in | cut -d' ' -f1) > $out
 else
   echo "Neither sha256sum nor shasum command is available"


### PR DESCRIPTION
Cherry pick of #8263 on release-1.17.

#8263: Replace binary "which" with build in "command"

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.