### PR TITLE
Automated cherry pick of #8274: Set CLUSTER_NAME env var on amazon-vpc-cni pods

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.10.yaml.template
@@ -73,6 +73,8 @@ spec:
           name: metrics
         name: aws-node
         env:
+          - name: CLUSTER_NAME
+            value: {{ ClusterName }}
           - name: AWS_VPC_K8S_CNI_LOGLEVEL
             value: DEBUG
           - name: MY_NODE_NAME

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.7.yaml.template
@@ -73,6 +73,8 @@ spec:
           name: metrics
         name: aws-node
         env:
+          - name: CLUSTER_NAME
+            value: {{ ClusterName }}
           - name: AWS_VPC_K8S_CNI_LOGLEVEL
             value: DEBUG
           - name: MY_NODE_NAME

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.8.yaml.template
@@ -73,6 +73,8 @@ spec:
           name: metrics
         name: aws-node
         env:
+          - name: CLUSTER_NAME
+            value: {{ ClusterName }}
           - name: AWS_VPC_K8S_CNI_LOGLEVEL
             value: DEBUG
           - name: MY_NODE_NAME

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
@@ -44,6 +44,7 @@ func TestBootstrapChannelBuilder_BuildTasks(t *testing.T) {
 	// Use cilium networking, proxy
 	runChannelBuilderTest(t, "cilium", []string{"dns-controller.addons.k8s.io-k8s-1.12", "kops-controller.addons.k8s.io-k8s-1.16"})
 	runChannelBuilderTest(t, "weave", []string{})
+	runChannelBuilderTest(t, "amazonvpc", []string{"networking.amazon-vpc-routed-eni-k8s-1.12"})
 }
 
 func runChannelBuilderTest(t *testing.T, key string, addonManifests []string) {
@@ -88,7 +89,13 @@ func runChannelBuilderTest(t *testing.T, key string, addonManifests []string) {
 		t.Error(err)
 	}
 
-	tf := &TemplateFunctions{cluster: cluster, modelContext: &model.KopsModelContext{Cluster: cluster}}
+	tf := &TemplateFunctions{
+		cluster: cluster,
+		modelContext: &model.KopsModelContext{
+			Cluster: cluster,
+		},
+		region: "us-east-1",
+	}
 	tf.AddTo(templates.TemplateFunctions, secretStore)
 
 	bcb := BootstrapChannelBuilder{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/cluster.yaml
@@ -1,0 +1,41 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2016-12-10T22:42:27Z"
+  name: minimal.example.com
+spec:
+  addons:
+    - manifest: s3://somebucket/example.yaml
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  etcdClusters:
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: master-us-test-1a
+    name: main
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: master-us-test-1a
+    name: events
+  kubernetesVersion: v1.16.0
+  masterInternalName: api.internal.minimal.example.com
+  masterPublicName: api.minimal.example.com
+  additionalSans:
+  - proxy.api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    amazonvpc: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+    - 0.0.0.0/0
+  topology:
+    masters: public
+    nodes: public
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -11,7 +11,7 @@ spec:
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.17.0-alpha.1
+    version: 1.16.0-alpha.2
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
     name: core.addons.k8s.io
@@ -67,27 +67,27 @@ spec:
   - id: pre-k8s-1.6
     kubernetesVersion: <1.6.0
     manifest: dns-controller.addons.k8s.io/pre-k8s-1.6.yaml
-    manifestHash: e19c5456a31381c08dd166ce1faf85ce7acc15e3
+    manifestHash: 6d2c352741133a91c7f3c8b180ac2531ba99ef19
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.17.0-alpha.1
+    version: 1.16.0-alpha.2
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 2d6fa6910077fecdf1c98da4303631588cfc9c01
+    manifestHash: f2db26feebbead9b072a3d986c9f5f3411e35eac
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.17.0-alpha.1
+    version: 1.16.0-alpha.2
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: a304440f4f7d2e289eb12c37adeac04253d84906
+    manifestHash: b850cb2fd1321e85a2300ea03f1785ac44670877
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.17.0-alpha.1
+    version: 1.16.0-alpha.2
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -1,0 +1,146 @@
+kind: Addons
+metadata:
+  creationTimestamp: null
+  name: bootstrap
+spec:
+  addons:
+  - id: k8s-1.16
+    kubernetesVersion: '>=1.16.0-alpha.0'
+    manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
+    manifestHash: efb1399217d403fa5207e2bc8cf1fbef58c7f8b2
+    name: kops-controller.addons.k8s.io
+    selector:
+      k8s-addon: kops-controller.addons.k8s.io
+    version: 1.17.0-alpha.1
+  - manifest: core.addons.k8s.io/v1.4.0.yaml
+    manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
+    name: core.addons.k8s.io
+    selector:
+      k8s-addon: core.addons.k8s.io
+    version: 1.4.0
+  - id: pre-k8s-1.6
+    kubernetesVersion: <1.6.0
+    manifest: kube-dns.addons.k8s.io/pre-k8s-1.6.yaml
+    manifestHash: 895c961cb9365cbedb22edd20a7648182ae7ed3f
+    name: kube-dns.addons.k8s.io
+    selector:
+      k8s-addon: kube-dns.addons.k8s.io
+    version: 1.14.13-kops.1
+  - id: k8s-1.6
+    kubernetesVersion: '>=1.6.0 <1.12.0'
+    manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
+    manifestHash: 191685ca6fe009302e55512b0eefc5a676433f10
+    name: kube-dns.addons.k8s.io
+    selector:
+      k8s-addon: kube-dns.addons.k8s.io
+    version: 1.14.13-kops.1
+  - id: k8s-1.12
+    kubernetesVersion: '>=1.12.0'
+    manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
+    manifestHash: b4dff071aa340fd71650c96f213fdf4b4f799c71
+    name: kube-dns.addons.k8s.io
+    selector:
+      k8s-addon: kube-dns.addons.k8s.io
+    version: 1.14.13-kops.1
+  - id: k8s-1.8
+    kubernetesVersion: '>=1.8.0'
+    manifest: rbac.addons.k8s.io/k8s-1.8.yaml
+    manifestHash: 5d53ce7b920cd1e8d65d2306d80a041420711914
+    name: rbac.addons.k8s.io
+    selector:
+      k8s-addon: rbac.addons.k8s.io
+    version: 1.8.0
+  - id: k8s-1.9
+    kubernetesVersion: '>=1.9.0'
+    manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
+    manifestHash: e1508d77cb4e527d7a2939babe36dc350dd83745
+    name: kubelet-api.rbac.addons.k8s.io
+    selector:
+      k8s-addon: kubelet-api.rbac.addons.k8s.io
+    version: v0.0.1
+  - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
+    manifestHash: 2ea50e23f1a5aa41df3724630ac25173738cc90c
+    name: limit-range.addons.k8s.io
+    selector:
+      k8s-addon: limit-range.addons.k8s.io
+    version: 1.5.0
+  - id: pre-k8s-1.6
+    kubernetesVersion: <1.6.0
+    manifest: dns-controller.addons.k8s.io/pre-k8s-1.6.yaml
+    manifestHash: e19c5456a31381c08dd166ce1faf85ce7acc15e3
+    name: dns-controller.addons.k8s.io
+    selector:
+      k8s-addon: dns-controller.addons.k8s.io
+    version: 1.17.0-alpha.1
+  - id: k8s-1.6
+    kubernetesVersion: '>=1.6.0 <1.12.0'
+    manifest: dns-controller.addons.k8s.io/k8s-1.6.yaml
+    manifestHash: 2d6fa6910077fecdf1c98da4303631588cfc9c01
+    name: dns-controller.addons.k8s.io
+    selector:
+      k8s-addon: dns-controller.addons.k8s.io
+    version: 1.17.0-alpha.1
+  - id: k8s-1.12
+    kubernetesVersion: '>=1.12.0'
+    manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
+    manifestHash: a304440f4f7d2e289eb12c37adeac04253d84906
+    name: dns-controller.addons.k8s.io
+    selector:
+      k8s-addon: dns-controller.addons.k8s.io
+    version: 1.17.0-alpha.1
+  - id: v1.15.0
+    kubernetesVersion: '>=1.15.0'
+    manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
+    manifestHash: 23459f7be52d7c818dc060a8bcf5e3565bd87a7b
+    name: storage-aws.addons.k8s.io
+    selector:
+      k8s-addon: storage-aws.addons.k8s.io
+    version: 1.15.0
+  - id: v1.7.0
+    kubernetesVersion: '>=1.7.0 <1.15.0'
+    manifest: storage-aws.addons.k8s.io/v1.7.0.yaml
+    manifestHash: 62705a596142e6cc283280e8aa973e51536994c5
+    name: storage-aws.addons.k8s.io
+    selector:
+      k8s-addon: storage-aws.addons.k8s.io
+    version: 1.15.0
+  - id: v1.6.0
+    kubernetesVersion: <1.7.0
+    manifest: storage-aws.addons.k8s.io/v1.6.0.yaml
+    manifestHash: 7de4b2eb0521d669172038759c521418711d8266
+    name: storage-aws.addons.k8s.io
+    selector:
+      k8s-addon: storage-aws.addons.k8s.io
+    version: 1.15.0
+  - id: k8s-1.7
+    kubernetesVersion: '>=1.7.0 <1.8.0'
+    manifest: networking.amazon-vpc-routed-eni/k8s-1.7.yaml
+    manifestHash: 394edf46a78e6d1f6dda920b0214afcd4ce34bc3
+    name: networking.amazon-vpc-routed-eni
+    selector:
+      role.kubernetes.io/networking: "1"
+    version: 1.5.0-kops.1
+  - id: k8s-1.8
+    kubernetesVersion: '>=1.8.0 <1.10.0'
+    manifest: networking.amazon-vpc-routed-eni/k8s-1.8.yaml
+    manifestHash: 544fd24d754b32e8896dba6113f1053a4ba86694
+    name: networking.amazon-vpc-routed-eni
+    selector:
+      role.kubernetes.io/networking: "1"
+    version: 1.5.0-kops.1
+  - id: k8s-1.10
+    kubernetesVersion: '>=1.10.0 <1.12.0'
+    manifest: networking.amazon-vpc-routed-eni/k8s-1.10.yaml
+    manifestHash: 672f2fdfc6286512e9918014f7853728db2f6dad
+    name: networking.amazon-vpc-routed-eni
+    selector:
+      role.kubernetes.io/networking: "1"
+    version: 1.5.0-kops.1
+  - id: k8s-1.12
+    kubernetesVersion: '>=1.12.0'
+    manifest: networking.amazon-vpc-routed-eni/k8s-1.12.yaml
+    manifestHash: 7b91bf39d562157bd45b6a29e5f58d817c6ea4e1
+    name: networking.amazon-vpc-routed-eni
+    selector:
+      role.kubernetes.io/networking: "1"
+    version: 1.5.5-kops.1

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.12.yaml
@@ -1,4 +1,3 @@
-# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.5.5/config/v1.5/aws-k8s-cni.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -7,27 +6,38 @@ rules:
 - apiGroups:
   - crd.k8s.amazonaws.com
   resources:
-  - "*"
+  - '*'
   - namespaces
   verbs:
-  - "*"
-- apiGroups: [""]
+  - '*'
+- apiGroups:
+  - ""
   resources:
   - pods
   - nodes
   - namespaces
-  verbs: ["list", "watch", "get"]
-- apiGroups: ["extensions"]
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - extensions
   resources:
   - daemonsets
-  verbs: ["list", "watch"]
+  verbs:
+  - list
+  - watch
+
 ---
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aws-node
   namespace: kube-system
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -40,17 +50,17 @@ subjects:
 - kind: ServiceAccount
   name: aws-node
   namespace: kube-system
+
 ---
-kind: DaemonSet
+
 apiVersion: apps/v1
+kind: DaemonSet
 metadata:
-  name: aws-node
-  namespace: kube-system
   labels:
     k8s-app: aws-node
+  name: aws-node
+  namespace: kube-system
 spec:
-  updateStrategy:
-    type: RollingUpdate
   selector:
     matchLabels:
       k8s-app: aws-node
@@ -59,44 +69,39 @@ spec:
       labels:
         k8s-app: aws-node
     spec:
-      priorityClassName: system-node-critical
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: "beta.kubernetes.io/os"
-                    operator: In
-                    values:
-                      - linux
-                  - key: "beta.kubernetes.io/arch"
-                    operator: In
-                    values:
-                      - amd64
-      serviceAccountName: aws-node
-      hostNetwork: true
-      tolerations:
-      - operator: Exists
+            - matchExpressions:
+              - key: beta.kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
       containers:
-      - image: "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.5" }}"
+      - env:
+        - name: CLUSTER_NAME
+          value: minimal.example.com
+        - name: AWS_VPC_K8S_CNI_LOGLEVEL
+          value: DEBUG
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.5
         imagePullPolicy: Always
+        name: aws-node
         ports:
         - containerPort: 61678
           name: metrics
-        name: aws-node
-        env:
-          - name: CLUSTER_NAME
-            value: {{ ClusterName }}
-          - name: AWS_VPC_K8S_CNI_LOGLEVEL
-            value: DEBUG
-          - name: MY_NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: WATCH_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
         resources:
           requests:
             cpu: 10m
@@ -111,32 +116,41 @@ spec:
           name: log-dir
         - mountPath: /var/run/docker.sock
           name: dockersock
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      serviceAccountName: aws-node
+      tolerations:
+      - operator: Exists
       volumes:
-      - name: cni-bin-dir
-        hostPath:
+      - hostPath:
           path: /opt/cni/bin
-      - name: cni-net-dir
-        hostPath:
+        name: cni-bin-dir
+      - hostPath:
           path: /etc/cni/net.d
-      - name: log-dir
-        hostPath:
+        name: cni-net-dir
+      - hostPath:
           path: /var/log
-      - name: dockersock
-        hostPath:
+        name: log-dir
+      - hostPath:
           path: /var/run/docker.sock
+        name: dockersock
+  updateStrategy:
+    type: RollingUpdate
+
 ---
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: eniconfigs.crd.k8s.amazonaws.com
 spec:
-  scope: Cluster
   group: crd.k8s.amazonaws.com
+  names:
+    kind: ENIConfig
+    plural: eniconfigs
+    singular: eniconfig
+  scope: Cluster
   versions:
   - name: v1alpha1
     served: true
     storage: true
-  names:
-    plural: eniconfigs
-    singular: eniconfig
-    kind: ENIConfig


### PR DESCRIPTION
Cherry pick of #8274 on release-1.16.

#8274: Set CLUSTER_NAME env var on amazon-vpc-cni pods

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.