### PR TITLE
Update default instance types for AWS

### DIFF
--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -1,20 +1,18 @@
 ## Release notes for kops 1.18 series
 
-(The kops 1.18 release has not been released yet, this is a document to gather
-the notes prior to the release).
+(The kops 1.18 release has not been released yet, this is a document to gather the notes prior to the release).
 
 # Breaking changes
 
 * Terraform users on AWS may need to rename some resources in their state file in order to prepare for Terraform 0.12 support. See Required Actions below.
 
-* Please see the notes in the 1.15 release about the apiGroup changing from kops
-  to kops.k8s.io
+* A controller is now used to apply labels to nodes.  If you are not using AWS, GCE or OpenStack your (non-master) nodes may not have labels applied correctly.
 
-* Since 1.16, a controller is now used to apply labels to nodes.  If
-  you are not using AWS, GCE or OpenStack your (non-master) nodes may
-  not have labels applied correctly.
+* Please see the notes in the 1.15 release about the apiGroup changing from kops to kops.k8s.io
 
 # Significant changes
+
+* The default instance type for AWS is now t3.medium. This should provide better performance and reduced costs in clusters where the average CPU usage is low.
 
 # Required Actions
 
@@ -39,4 +37,4 @@ the notes prior to the release).
 * If a custom Kops build was used on a cluster, a kops-controller Deployment may have been created that should get deleted.
   Run `kubectl -n kube-system delete deployment kops-controller` after upgrading to Kops 1.16.0-beta.1 or later.
 
-# Full change list since 1.16.0 release
+# Full change list since 1.17.0 release

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -1341,17 +1341,13 @@ func (c *awsCloudImplementation) DefaultInstanceType(cluster *kops.Cluster, ig *
 	var candidates []string
 
 	switch ig.Spec.Role {
-	case kops.InstanceGroupRoleMaster:
-		// Some regions do not (currently) support the m3 family; the c4 large is the cheapest non-burstable instance
-		// (us-east-2, ca-central-1, eu-west-2, ap-northeast-2).
-		// Also some accounts are no longer supporting m3 in us-east-1 zones
-		candidates = []string{"m3.medium", "c4.large"}
-
-	case kops.InstanceGroupRoleNode:
-		candidates = []string{"t2.medium"}
+	case kops.InstanceGroupRoleMaster, kops.InstanceGroupRoleNode:
+		// t3.medium is the cheapest instance with 4GB of mem, unlimited by default, fast and has decent network
+		// c5.large and c4.large are a good second option in case t3.medium is not available in the AZ
+		candidates = []string{"t3.medium", "c5.large", "c4.large"}
 
 	case kops.InstanceGroupRoleBastion:
-		candidates = []string{"t2.micro"}
+		candidates = []string{"t3.micro", "t2.micro"}
 
 	default:
 		return "", fmt.Errorf("unhandled role %q", ig.Spec.Role)


### PR DESCRIPTION
While doing the setup for some e2e I noticed that Kops has still defaults to some quite old types of instances. Any reason for not changing to *c5*, *t3*? These should be cheaper and faster.

```
t3.medium - $0.041600 hourly
t2.medium - $0.046400 hourly
c5.large  - $0.085000 hourly
c4.large  - $0.100000 hourly
```

PS: m3.medium is so old that it becomes irrelevant.