### PR TITLE
containerd: Set a default version even with Kubernetes 1.17

### DIFF
--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -53,7 +53,7 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 
 		// Set containerd based on Kubernetes version
 		if fi.StringValue(containerd.Version) == "" {
-			if b.IsKubernetesGTE("1.18") {
+			if b.IsKubernetesGTE("1.17") {
 				containerd.Version = fi.String("1.2.10")
 			} else if b.IsKubernetesGTE("1.11") {
 				return fmt.Errorf("containerd version is required")


### PR DESCRIPTION
For testing I need to be able to enable the containerd container runtime with Kubernetes 1.17 without setting the version in cluster spec.
It is a tiny change that should have minimal effect outside e2e tests.