### PR TITLE
Add wget and nfs-utils deps needed for e2e tests

### DIFF
--- a/nodeup/pkg/model/miscutils.go
+++ b/nodeup/pkg/model/miscutils.go
@@ -52,11 +52,14 @@ func (b *MiscUtilsBuilder) Build(c *fi.ModelBuilderContext) error {
 	if b.Distribution.IsDebianFamily() {
 		packages = append(packages, "socat")
 		packages = append(packages, "curl")
+		packages = append(packages, "wget")
 		packages = append(packages, "nfs-common")
 		packages = append(packages, "python-apt")
 		packages = append(packages, "apt-transport-https")
 	} else if b.Distribution.IsRHELFamily() {
 		packages = append(packages, "curl")
+		packages = append(packages, "wget")
+		packages = append(packages, "nfs-utils")
 		packages = append(packages, "python2")
 		packages = append(packages, "git")
 	} else {


### PR DESCRIPTION
Periodic e2e tests are failing for both CentOS 7 and RHEL 8 because of missing `wget` and `nfs-utils` deps.
Debian family usually has `wget` already installed and Kops adds `nfs-common` alternative to utils already.

`nfs-utils` is required for NFS mounts to work in general, not just for e2e.

https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-imagecentos7/1214370995477942272
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-containerd/1214741461090701315