### PR TITLE
Fix unit name for memory request for weave

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -180,12 +180,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.CPURequest "50m" }}
-              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.CPULimit }}
               cpu: {{ .Networking.Weave.CPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200Mi" }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -218,12 +218,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.NPCCPURequest "50m" }}
-              memory: {{ or .Networking.Weave.NPCMemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.NPCMemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.NPCCPULimit }}
               cpu: {{ .Networking.Weave.NPCCPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.NPCMemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.NPCMemoryLimit "200Mi" }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
@@ -162,12 +162,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.CPURequest "50m" }}
-              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.CPULimit }}
               cpu: {{ .Networking.Weave.CPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200Mi" }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -199,12 +199,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.NPCCPURequest "50m" }}
-              memory: {{ or .Networking.Weave.NPCMemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.NPCMemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.NPCCPULimit }}
               cpu: {{ .Networking.Weave.NPCCPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.NPCMemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.NPCMemoryLimit "200Mi" }}
           securityContext:
             privileged: true
       hostNetwork: true

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -172,12 +172,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.CPURequest "50m" }}
-              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.CPULimit }}
               cpu: {{ .Networking.Weave.CPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200Mi" }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -210,12 +210,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.NPCCPURequest "50m" }}
-              memory: {{ or .Networking.Weave.NPCMemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.NPCMemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.NPCCPULimit }}
               cpu: {{ .Networking.Weave.NPCCPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.NPCMemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.NPCMemoryLimit "200Mi" }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -176,12 +176,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.CPURequest "50m" }}
-              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.CPULimit }}
               cpu: {{ .Networking.Weave.CPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200Mi" }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -214,12 +214,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.NPCCPURequest "50m" }}
-              memory: {{ or .Networking.Weave.NPCMemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.NPCMemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.NPCCPULimit }}
               cpu: {{ .Networking.Weave.NPCCPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.NPCMemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.NPCMemoryLimit "200Mi" }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
@@ -60,12 +60,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.CPURequest "50m" }}
-              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.CPULimit }}
               cpu: {{ .Networking.Weave.CPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200Mi" }}
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
Latest changes broke the weave manifests https://github.com/kubernetes/kops/pull/8216#pullrequestreview-340786303:
`unable to parse quantity's suffix, error found in #10 byte of ...|y":"200mi"}`

https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-weave/1214998660220194818/artifacts/ip-172-20-50-49.sa-east-1.compute.internal/protokube.log