### PR TITLE
Remove "pigz" containerd dependency for RHEL/CentOS 7

### DIFF
--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -114,7 +114,7 @@ var containerdVersions = []packageVersion{
 				Hash:    "7de4211fa0dfd240d8827b93763e1eb5f0d56411",
 			},
 		},
-		Dependencies: []string{"libseccomp", "pigz", "policycoreutils-python"},
+		Dependencies: []string{"libseccomp", "policycoreutils-python"},
 	},
 
 	// 1.2.10 - CentOS / Rhel 8


### PR DESCRIPTION
Pigz is an optional dependency that makes container image decompression faster in some cases.
On RHEL 7 it fails to install being part of the "extras" repo. This makes RHEL 7 e2e to fail:
https://testgrid.k8s.io/sig-cluster-lifecycle-kops#kops-aws-rhel-7

A more elegant will be to handle this dependency in a `packages.go` later:
https://github.com/kubernetes/kops/pull/8199/files#diff-a0fc0755ee3c8b91f928e7c0c517d906