### PR TITLE
Add cloud ntp addresses

### DIFF
--- a/nodeup/pkg/model/ntp.go
+++ b/nodeup/pkg/model/ntp.go
@@ -17,6 +17,10 @@ limitations under the License.
 package model
 
 import (
+	"fmt"
+	"io/ioutil"
+	"regexp"
+
 	"k8s.io/klog"
 	"k8s.io/kops/nodeup/pkg/distros"
 	"k8s.io/kops/upup/pkg/fi"
@@ -32,6 +36,13 @@ type NTPBuilder struct {
 
 var _ fi.ModelBuilder = &NTPBuilder{}
 
+type ntpDaemon string
+
+var (
+	chronyd ntpDaemon = "chronyd"
+	ntpd    ntpDaemon = "ntpd"
+)
+
 // Build is responsible for configuring NTP
 func (b *NTPBuilder) Build(c *fi.ModelBuilderContext) error {
 	switch b.Distribution {
@@ -46,22 +57,107 @@ func (b *NTPBuilder) Build(c *fi.ModelBuilderContext) error {
 		return nil
 	}
 
+	var ntpIP string
+	switch b.Cluster.Spec.CloudProvider {
+	case "aws":
+		ntpIP = "169.254.169.123"
+	case "gce":
+		ntpIP = "time.google.com"
+	default:
+		ntpIP = ""
+	}
+
 	if b.Distribution.IsDebianFamily() {
 		c.AddTask(&nodetasks.Package{Name: "ntp"})
+
+		if ntpIP != "" {
+			bytes, err := updateNtpIP(ntpIP, ntpd)
+			if err != nil {
+				return err
+			}
+			c.AddTask(&nodetasks.File{
+				Path:     "/etc/ntp.conf",
+				Contents: fi.NewBytesResource(bytes),
+				Type:     nodetasks.FileType_File,
+				Mode:     s("0644"),
+			})
+		}
+
 		c.AddTask((&nodetasks.Service{Name: "ntp"}).InitDefaults())
 	} else if b.Distribution.IsRHELFamily() {
 		switch b.Distribution {
 		case distros.DistributionCentos8, distros.DistributionRhel8:
 			c.AddTask(&nodetasks.Package{Name: "chrony"})
+
+			if ntpIP != "" {
+				bytes, err := updateNtpIP(ntpIP, chronyd)
+				if err != nil {
+					return err
+				}
+				c.AddTask(&nodetasks.File{
+					Path:     "/etc/chrony.conf",
+					Contents: fi.NewBytesResource(bytes),
+					Type:     nodetasks.FileType_File,
+					Mode:     s("0644"),
+				})
+			}
 			c.AddTask((&nodetasks.Service{Name: "chronyd"}).InitDefaults())
+
 		default:
 			c.AddTask(&nodetasks.Package{Name: "ntp"})
+
+			if ntpIP != "" {
+				bytes, err := updateNtpIP(ntpIP, ntpd)
+				if err != nil {
+					return err
+				}
+				c.AddTask(&nodetasks.File{
+					Path:     "/etc/ntp.conf",
+					Contents: fi.NewBytesResource(bytes),
+					Type:     nodetasks.FileType_File,
+					Mode:     s("0644"),
+				})
+			}
+
 			c.AddTask((&nodetasks.Service{Name: "ntpd"}).InitDefaults())
 		}
 	} else {
 		klog.Warningf("unknown distribution, skipping ntp install: %v", b.Distribution)
 		return nil
 	}
-
 	return nil
+}
+
+// updateNtpIP takes a ip and a ntpDaemon and will comment out
+// the default server or pool values and append the correct cloud
+// ip to the ntp config file.
+func updateNtpIP(ip string, daemon ntpDaemon) ([]byte, error) {
+	var address string
+	var r *regexp.Regexp
+	var path string
+	switch ntpd {
+	case ntpd:
+		address = fmt.Sprintf("server %s prefer iburst", ip)
+		// the regex strings might need a bit more work
+		r = regexp.MustCompile(`pool\s\d.*[a-z].[a-z].[a-z]\siburst`)
+		path = "/etc/ntp.conf"
+	case chronyd:
+		address = fmt.Sprintf("server %s prefer iburst minpoll 4 maxpoll 4", ip)
+		// the regex strings might need a bit more work
+		r = regexp.MustCompile(`server\s.*iburst.*`)
+		path = "/etc/chrony.conf"
+	default:
+		return nil, fmt.Errorf("%s is not a supported ntp application", ntpd)
+	}
+
+	f, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	new := r.ReplaceAllFunc(f, func(b []byte) []byte {
+		return []byte(fmt.Sprintf("#commented out by kops %s", string(b)))
+	})
+	new = append(new, []byte(address)...)
+	return new, nil
 }

--- a/nodeup/pkg/model/ntp.go
+++ b/nodeup/pkg/model/ntp.go
@@ -135,7 +135,7 @@ func updateNtpIP(ip string, daemon ntpDaemon) ([]byte, error) {
 	var address string
 	var r *regexp.Regexp
 	var path string
-	switch ntpd {
+	switch daemon {
 	case ntpd:
 		address = fmt.Sprintf("server %s prefer iburst", ip)
 		// the regex strings might need a bit more work

--- a/nodeup/pkg/model/ntp.go
+++ b/nodeup/pkg/model/ntp.go
@@ -133,21 +133,17 @@ func (b *NTPBuilder) Build(c *fi.ModelBuilderContext) error {
 // ip to the ntp config file.
 func updateNtpIP(ip string, daemon ntpDaemon) ([]byte, error) {
 	var address string
-	var r *regexp.Regexp
 	var path string
+	r := regexp.MustCompile(`(?m)(^pool|^server)\s.*`)
 	switch daemon {
 	case ntpd:
-		address = fmt.Sprintf("server %s prefer iburst", ip)
-		// the regex strings might need a bit more work
-		r = regexp.MustCompile(`pool\s\d.*[a-z].[a-z].[a-z]\siburst`)
+		address = fmt.Sprintf("server %s prefer iburst\n", ip)
 		path = "/etc/ntp.conf"
 	case chronyd:
-		address = fmt.Sprintf("server %s prefer iburst minpoll 4 maxpoll 4", ip)
-		// the regex strings might need a bit more work
-		r = regexp.MustCompile(`server\s.*iburst.*`)
+		address = fmt.Sprintf("server %s prefer iburst minpoll 4 maxpoll 4\n", ip)
 		path = "/etc/chrony.conf"
 	default:
-		return nil, fmt.Errorf("%s is not a supported ntp application", ntpd)
+		return nil, fmt.Errorf("%s is not a supported ntp application", daemon)
 	}
 
 	f, err := ioutil.ReadFile(path)

--- a/nodeup/pkg/model/ntp.go
+++ b/nodeup/pkg/model/ntp.go
@@ -134,7 +134,7 @@ func (b *NTPBuilder) Build(c *fi.ModelBuilderContext) error {
 func updateNtpIP(ip string, daemon ntpDaemon) ([]byte, error) {
 	var address string
 	var path string
-	r := regexp.MustCompile(`(?m)(^pool|^server)\s.*`)
+	r := regexp.MustCompile(`(?m)^(?:pool|server)\s.*`)
 	switch daemon {
 	case ntpd:
 		address = fmt.Sprintf("server %s prefer iburst\n", ip)


### PR DESCRIPTION

Hi 

This is a in working progress PR which will add the cloud specific NTP server into the NTP config.  This will prevent clock drift which could end up in resulting in downtime.  AWS as an example will prevent you speaking with there APIs once your clock is out by five minutes.

It would be great to get some feedback on whether you feel this is the best approach I am taking and also if you would prefer more parameters in the function I created rather pre determining the values inside the function with switch statements.

I used switch statements to prevent having to have the same logic again and again when determining the ntp install type.

I would like in another PR to maybe offer custom NTPs that a user could pass into the cluster spec.  This might be handy when you have custom NTP servers when hosting Kubernetes on prem.

@mikesplain hope you don't mind me tagging you into this and we already sort of discussed this on slack :)

Simon 




