### PR TITLE
Build dns-controller using bazel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -439,25 +439,14 @@ nodeup-dist:
 	tools/sha1 .build/dist/nodeup .build/dist/nodeup.sha1
 	tools/sha256 .build/dist/nodeup .build/dist/nodeup.sha256
 
-.PHONY: dns-controller-gocode
-dns-controller-gocode:
-	go install ${GCFLAGS} -tags 'peer_name_alternative peer_name_hash' ${LDFLAGS}"${EXTRA_LDFLAGS} -X main.BuildVersion=${DNS_CONTROLLER_TAG}" k8s.io/kops/dns-controller/cmd/dns-controller
+.PHONY: bazel-crossbuild-dns-controller
+bazel-crossbuild-dns-controller:
+	bazel build ${BAZEL_CONFIG} --features=pure --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //dns-controller/...
 
-.PHONY: dns-controller-builder-image
-dns-controller-builder-image:
-	docker build -t dns-controller-builder images/dns-controller-builder
-
-.PHONY: dns-controller-build-in-docker
-dns-controller-build-in-docker: dns-controller-builder-image
-	docker run -t -e HOST_UID=${UID} -e HOST_GID=${GID} -v `pwd`:/src dns-controller-builder /onbuild.sh
-
-.PHONY: dns-controller-image
-dns-controller-image: dns-controller-build-in-docker
-	docker build -t ${DOCKER_REGISTRY}/dns-controller:${DNS_CONTROLLER_TAG}  -f images/dns-controller/Dockerfile .
 
 .PHONY: dns-controller-push
-dns-controller-push: dns-controller-image
-	docker push ${DOCKER_REGISTRY}/dns-controller:${DNS_CONTROLLER_TAG}
+dns-controller-push:
+	DOCKER_REGISTRY=${DOCKER_REGISTRY} DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX} DNS_CONTROLLER_TAG=${DNS_CONTROLLER_TAG} bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //dns-controller/cmd/dns-controller:push-image
 
 # --------------------------------------------------
 # static utils
@@ -690,14 +679,6 @@ bazel-crossbuild-nodeup:
 .PHONY: bazel-crossbuild-protokube
 bazel-crossbuild-protokube:
 	bazel build ${BAZEL_CONFIG} --features=pure --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //protokube/...
-
-.PHONY: bazel-crossbuild-dns-controller
-bazel-crossbuild-dns-controller:
-	bazel build ${BAZEL_CONFIG} --features=pure --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //dns-controller/...
-
-.PHONY: bazel-crossbuild-dns-controller-image
-bazel-crossbuild-dns-controller-image:
-	bazel build ${BAZEL_CONFIG} --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //images:dns-controller.tar
 
 .PHONY: bazel-crossbuild-protokube-image
 bazel-crossbuild-protokube-image:

--- a/images/BUILD.bazel
+++ b/images/BUILD.bazel
@@ -5,17 +5,6 @@ load(
     "container_bundle",
     "container_image",
 )
-
-container_image(
-    name = "dns-controller",
-    base = "@debian_hyperkube_base_amd64//image",
-    cmd = ["/usr/bin/dns-controller"],
-    directory = "/usr/bin/",
-    files = [
-        "//dns-controller/cmd/dns-controller",
-    ],
-)
-
 load("@package_bundle//file:packages.bzl", "packages")
 
 container_image(


### PR DESCRIPTION
We were previously building it in development using bazel, but then
using go build for the release.  That is risky, better to just use
bazel everywhere.