### PR TITLE
Automated cherry pick of #8273: Remove kops-controller deployment

### DIFF
--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -11,38 +11,6 @@ data:
 
 ---
 
-# Deployment of size 0, to move from Deployment to DaemonSet
-# TODO: Remove in beta? (it's only been on master branch)
-
-kind: Deployment
-apiVersion: apps/v1
-metadata:
-  name: kops-controller
-  namespace: kube-system
-  labels:
-    k8s-addon: kops-controller.addons.k8s.io
-    k8s-app: kops-controller
-    version: v1.15.0-alpha.1
-spec:
-  replicas: 0
-  selector:
-    matchLabels:
-      k8s-app: kops-controller
-  template:
-    metadata:
-      labels:
-        k8s-addon: kops-controller.addons.k8s.io
-        k8s-app: kops-controller
-        version: v1.15.0-alpha.1
-    spec:
-      serviceAccountName: default
-      containers:
-      - name: sleep
-        image: k8s.gcr.io/pause-amd64:3.0
-        command: [ "/pause" ]
-
----
-
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: efb1399217d403fa5207e2bc8cf1fbef58c7f8b2
+    manifestHash: eb8989571b15af1f02677a0eb4e0dfd1442feda5
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -12,36 +12,6 @@ metadata:
 ---
 
 apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    k8s-addon: kops-controller.addons.k8s.io
-    k8s-app: kops-controller
-    version: v1.15.0-alpha.1
-  name: kops-controller
-  namespace: kube-system
-spec:
-  replicas: 0
-  selector:
-    matchLabels:
-      k8s-app: kops-controller
-  template:
-    metadata:
-      labels:
-        k8s-addon: kops-controller.addons.k8s.io
-        k8s-app: kops-controller
-        version: v1.15.0-alpha.1
-    spec:
-      containers:
-      - command:
-        - /pause
-        image: gcr.io/google_containers/pause-amd64:3.0
-        name: sleep
-      serviceAccountName: default
-
----
-
-apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 24cf09054ddfdcb490b878b04ff321026daa10c7
+    manifestHash: eb8989571b15af1f02677a0eb4e0dfd1442feda5
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -12,36 +12,6 @@ metadata:
 ---
 
 apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    k8s-addon: kops-controller.addons.k8s.io
-    k8s-app: kops-controller
-    version: v1.15.0-alpha.1
-  name: kops-controller
-  namespace: kube-system
-spec:
-  replicas: 0
-  selector:
-    matchLabels:
-      k8s-app: kops-controller
-  template:
-    metadata:
-      labels:
-        k8s-addon: kops-controller.addons.k8s.io
-        k8s-app: kops-controller
-        version: v1.15.0-alpha.1
-    spec:
-      containers:
-      - command:
-        - /pause
-        image: gcr.io/google_containers/pause-amd64:3.0
-        name: sleep
-      serviceAccountName: default
-
----
-
-apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 24cf09054ddfdcb490b878b04ff321026daa10c7
+    manifestHash: eb8989571b15af1f02677a0eb4e0dfd1442feda5
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 24cf09054ddfdcb490b878b04ff321026daa10c7
+    manifestHash: eb8989571b15af1f02677a0eb4e0dfd1442feda5
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #8273 on release-1.17.

#8273: Remove kops-controller deployment

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.