### PR TITLE
Add release notes for deleting the kops-controller deployment

### DIFF
--- a/docs/architecture/kops-controller.md
+++ b/docs/architecture/kops-controller.md
@@ -1,6 +1,6 @@
 # Architecture: kops-controller
 
-kops-controller runs as a container on the master node(s).  It is a kubebuilder
+kops-controller runs as a DaemonSet on the master node(s).  It is a kubebuilder
 controller, that performs runtime reconciliation for kops.
 
 Controllers in kops-controller:

--- a/docs/releases/1.16-NOTES.md
+++ b/docs/releases/1.16-NOTES.md
@@ -23,7 +23,9 @@ the notes prior to the release).
 
 # Required Actions
 
-* No required actions yet known.
+* If either a Kops 1.16 alpha release or a custom Kops build was used on a cluster,
+  a kops-controller Deployment may have been created that should get deleted.
+  Run `kubectl -n kube-system delete deployment kops-controller` after upgrading to Kops 1.16.0-beta.1 or later.
 
 # Full change list since 1.15.0 release
 

--- a/docs/releases/1.17-NOTES.md
+++ b/docs/releases/1.17-NOTES.md
@@ -19,7 +19,9 @@ the notes prior to the release).
 
 # Required Actions
 
-* No required actions yet known.
+* If either a Kops 1.17 alpha release or a custom Kops build was used on a cluster,
+  a kops-controller Deployment may have been created that should get deleted because it has been replaced with a DaemonSet.
+  Run `kubectl -n kube-system delete deployment kops-controller` after upgrading to Kops 1.17.0-alpha.2 or later.
 
 # Full change list since 1.16.0 release
 

--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -1,0 +1,22 @@
+## Release notes for kops 1.18 series
+
+(The kops 1.18 release has not been released yet, this is a document to gather
+the notes prior to the release).
+
+# Breaking changes
+
+* Please see the notes in the 1.15 release about the apiGroup changing from kops
+  to kops.k8s.io
+
+* Since 1.16, a controller is now used to apply labels to nodes.  If
+  you are not using AWS, GCE or OpenStack your (non-master) nodes may
+  not have labels applied correctly.
+
+# Significant changes
+
+# Required Actions
+
+* If a custom Kops build was used on a cluster, a kops-controller Deployment may have been created that should get deleted.
+  Run `kubectl -n kube-system delete deployment kops-controller` after upgrading to Kops 1.16.0-beta.1 or later.
+
+# Full change list since 1.16.0 release


### PR DESCRIPTION
This is a followup to #8273. I guessed at the exact release names for the next 1.16 and 1.17 releases but we can adjust those if necessary.