### PR TITLE
Automated cherry pick of #8321: Add release notes for deleting the kops-controller deployment

### DIFF
--- a/docs/architecture/kops-controller.md
+++ b/docs/architecture/kops-controller.md
@@ -1,6 +1,6 @@
 # Architecture: kops-controller
 
-kops-controller runs as a container on the master node(s).  It is a kubebuilder
+kops-controller runs as a DaemonSet on the master node(s).  It is a kubebuilder
 controller, that performs runtime reconciliation for kops.
 
 Controllers in kops-controller:

--- a/docs/releases/1.16-NOTES.md
+++ b/docs/releases/1.16-NOTES.md
@@ -23,7 +23,9 @@ the notes prior to the release).
 
 # Required Actions
 
-* No required actions yet known.
+* If either a Kops 1.16 alpha release or a custom Kops build was used on a cluster,
+  a kops-controller Deployment may have been created that should get deleted.
+  Run `kubectl -n kube-system delete deployment kops-controller` after upgrading to Kops 1.16.0-beta.1 or later.
 
 # Full change list since 1.15.0 release
 


### PR DESCRIPTION
Cherry pick of #8321 on release-1.16.

#8321: Add release notes for deleting the kops-controller deployment

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.