### PR TITLE
Allow removed of additionalUserData on bastion

### DIFF
--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -417,16 +417,9 @@ func runTestAWS(t *testing.T, clusterName string, srcDir string, version string,
 			expectedFilenames = append(expectedFilenames, []string{
 				"aws_iam_role_bastions." + clusterName + "_policy",
 				"aws_iam_role_policy_bastions." + clusterName + "_policy",
-
-				// bastions usually don't have any userdata
-				// "aws_launch_configuration_bastions." + clusterName + "_user_data",
+				"aws_launch_configuration_bastion." + clusterName + "_user_data",
 			}...)
 		}
-	}
-
-	// Special case that tests a bastion with user-data
-	if srcDir == "bastionadditional_user-data" {
-		expectedFilenames = append(expectedFilenames, "aws_launch_configuration_bastion."+clusterName+"_user_data")
 	}
 	runTest(t, h, clusterName, srcDir, version, private, zones, expectedFilenames, "", nil, lifecycleOverrides)
 }
@@ -457,9 +450,7 @@ func runTestPhase(t *testing.T, clusterName string, srcDir string, version strin
 			expectedFilenames = append(expectedFilenames, []string{
 				"aws_iam_role_bastions." + clusterName + "_policy",
 				"aws_iam_role_policy_bastions." + clusterName + "_policy",
-
-				// bastions don't have any userdata
-				// "aws_launch_configuration_bastions." + clusterName + "_user_data",
+				"aws_launch_configuration_bastion." + clusterName + "_user_data",
 			}...)
 		}
 	} else if phase == cloudup.PhaseCluster {

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -132,7 +132,11 @@ func (b *BootstrapScript) buildEnvironmentVariables(cluster *kops.Cluster) (map[
 func (b *BootstrapScript) ResourceNodeUp(ig *kops.InstanceGroup, cluster *kops.Cluster) (*fi.ResourceHolder, error) {
 	// Bastions can have AdditionalUserData, but if there isn't any skip this part
 	if ig.IsBastion() && len(ig.Spec.AdditionalUserData) == 0 {
-		return nil, nil
+		templateResource, err := NewTemplateResource("nodeup", "", nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		return fi.WrapResource(templateResource), nil
 	}
 
 	functions := template.FuncMap{

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -367,6 +367,7 @@ resource "aws_launch_configuration" "bastion-private-shared-subnet-example-com" 
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-private-shared-subnet-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-private-shared-subnet-example-com.id}"]
   associate_public_ip_address = true
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.private-shared-subnet.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -194,6 +194,7 @@
             "Ref": "AWSEC2SecurityGroupbastionprivatecalicoexamplecom"
           }
         ],
+        "UserData": "extracted",
         "InstanceMonitoring": false
       }
     },

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
@@ -1,3 +1,4 @@
+Resources.AWSAutoScalingLaunchConfigurationbastionprivatecalicoexamplecom.Properties.UserData: ""
 Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersprivatecalicoexamplecom.Properties.UserData: |
   #!/bin/bash
   # Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -397,6 +397,7 @@ resource "aws_launch_configuration" "bastion-privatecalico-example-com" {
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-privatecalico-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-privatecalico-example-com.id}"]
   associate_public_ip_address = true
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.privatecalico.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -397,6 +397,7 @@ resource "aws_launch_configuration" "bastion-privatecanal-example-com" {
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-privatecanal-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-privatecanal-example-com.id}"]
   associate_public_ip_address = true
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.privatecanal.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -397,6 +397,7 @@ resource "aws_launch_configuration" "bastion-privatedns1-example-com" {
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-privatedns1-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-privatedns1-example-com.id}"]
   associate_public_ip_address = true
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.privatedns1.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -382,6 +382,7 @@ resource "aws_launch_configuration" "bastion-privatedns2-example-com" {
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-privatedns2-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-privatedns2-example-com.id}"]
   associate_public_ip_address = true
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.privatedns2.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -397,6 +397,7 @@ resource "aws_launch_configuration" "bastion-privateflannel-example-com" {
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-privateflannel-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-privateflannel-example-com.id}"]
   associate_public_ip_address = true
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.privateflannel.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -402,6 +402,7 @@ resource "aws_launch_configuration" "bastion-privatekopeio-example-com" {
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-privatekopeio-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-privatekopeio-example-com.id}"]
   associate_public_ip_address = true
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.privatekopeio.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -397,6 +397,7 @@ resource "aws_launch_configuration" "bastion-privateweave-example-com" {
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-privateweave-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-privateweave-example-com.id}"]
   associate_public_ip_address = true
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.privateweave.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -372,6 +372,7 @@ resource "aws_launch_configuration" "bastion-unmanaged-example-com" {
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-unmanaged-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-unmanaged-example-com.id}"]
   associate_public_ip_address = true
+  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.unmanaged.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"


### PR DESCRIPTION
This PR consistenly add user-data to the bastion instance even if there is no user-data (in this case, an empty user-data is set).
fix #8330 