### PR TITLE
CoreDNS default image bump to 1.6.6 to resolve CVE

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -64,7 +64,9 @@ data:
   {{- else }}
     .:53 {
         errors
-        health
+        health {
+          lameduck 5s
+        }
         kubernetes {{ KubeDNS.Domain }}. in-addr.arpa ip6.arpa {
           pods insecure
           upstream
@@ -165,7 +167,7 @@ spec:
           beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}k8s.gcr.io/coredns:1.3.1{{ end }}
+        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}k8s.gcr.io/coredns:1.6.6{{ end }}
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -175,9 +177,6 @@ spec:
             memory: {{ KubeDNS.MemoryRequest }}
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
-        # Workaround for 1.3.1 bug, can be removed after bumping to 1.4+. See: https://github.com/coredns/coredns/pull/2529
-        - name: tmp
-          mountPath: /tmp
         - name: config-volume
           mountPath: /etc/coredns
           readOnly: true

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -214,9 +214,6 @@ spec:
             scheme: HTTP
       dnsPolicy: Default
       volumes:
-        # Workaround for 1.3.1 bug, can be removed after bumping to 1.4+. See: https://github.com/coredns/coredns/pull/2529
-        - name: tmp
-          emptyDir: {}
         - name: config-volume
           configMap:
             name: coredns

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
@@ -64,7 +64,9 @@ data:
   {{- else }}
     .:53 {
         errors
-        health
+        health {
+          lameduck 5s
+        }
         kubernetes {{ KubeDNS.Domain }}. in-addr.arpa ip6.arpa {
           pods insecure
           upstream
@@ -111,7 +113,7 @@ spec:
           beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}k8s.gcr.io/coredns:1.3.1{{ end }}
+        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}k8s.gcr.io/coredns:1.6.6{{ end }}
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -285,7 +285,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 	if kubeDNS.Provider == "CoreDNS" {
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.3.1-kops.5"
+			version := "1.6.6-kops.1"
 
 			{
 				location := key + "/k8s-1.6.yaml"
@@ -304,7 +304,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.3.1-kops.5"
+			version := "1.6.6-kops.1"
 
 			{
 				location := key + "/k8s-1.12.yaml"


### PR DESCRIPTION
Also updates the default Corefile config to make use of the new lameduck functionality for healthcheck: https://coredns.io/plugins/health/ as per kubeADM: https://github.com/kubernetes/kubernetes/pull/86260/file

Builds on top of the work done by @michalschott in #7883 however updates the image for all clusters.

Resolves #8332 
Resolves #8309 