### PR TITLE
Allow CoreDNS to be specified by create cluster overrides

### DIFF
--- a/pkg/commands/set_cluster.go
+++ b/pkg/commands/set_cluster.go
@@ -95,6 +95,11 @@ func SetClusterFields(fields []string, cluster *api.Cluster, instanceGroups []*a
 			cluster.Spec.KubernetesVersion = kv[1]
 		case "spec.masterPublicName":
 			cluster.Spec.MasterPublicName = kv[1]
+		case "spec.kubeDNS.provider":
+			if cluster.Spec.KubeDNS == nil {
+				cluster.Spec.KubeDNS = &api.KubeDNSConfig{}
+			}
+			cluster.Spec.KubeDNS.Provider = kv[1]
 		case "cluster.spec.etcdClusters[*].enableEtcdTLS":
 			v, err := strconv.ParseBool(kv[1])
 			if err != nil {


### PR DESCRIPTION
This will more easily allow our end-to-end testing to use CoreDNS rather than KubeDNS

`--override spec.kubeDNS.provider=CoreDNS`

Using kubetest's [--kops-overrides flag](https://github.com/kubernetes/test-infra/blob/master/kubetest/kops.go#L74)