### PR TITLE
Don't load nonexistent calico-client cert when CNI is Cilium

### DIFF
--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -254,7 +254,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 	} else {
 		loader.Builders = append(loader.Builders, &model.KubeRouterBuilder{NodeupModelContext: modelContext})
 	}
-	if c.cluster.Spec.Networking.Calico != nil || c.cluster.Spec.Networking.Cilium != nil {
+	if c.cluster.Spec.Networking.Calico != nil {
 		loader.Builders = append(loader.Builders, &model.EtcdTLSBuilder{NodeupModelContext: modelContext})
 	}
 


### PR DESCRIPTION
/kind bug

6d0133698d82f578b1a0e78f1dca444ed77cb4d5 stopped generating the "calico-client" keypair and certificate when the CNI was set to Cilium, as the new version of Cilium no longer needed to use the apiserver's etcd cluster. Unfortunately, it failed to stop adding the EtcdTLSBuilder in that case. The result of this is that if the cluster is not using etcd-manager and has etcd TLS enabled, masters will fail to come up looking for "calico-client" certificates that don't exist.