### PR TITLE
Automated cherry pick of #8139: tests: increase timeout in rolling update tests

### DIFF
--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -1003,7 +1003,7 @@ func TestRollingUpdateFlappingValidation(t *testing.T) {
 			Cloud: mockcloud,
 		},
 		FailOnValidate:          true,
-		ValidationTimeout:       20 * time.Millisecond,
+		ValidationTimeout:       200 * time.Second,
 		ValidateTickDuration:    1 * time.Millisecond,
 		ValidateSuccessDuration: 5 * time.Millisecond,
 	}
@@ -1179,7 +1179,7 @@ func TestRollingUpdateValidatesAfterBastion(t *testing.T) {
 		K8sClient:            k8sClient,
 		ClusterValidator:     &failThreeTimesClusterValidator{},
 		FailOnValidate:       true,
-		ValidationTimeout:    10 * time.Millisecond,
+		ValidationTimeout:    1 * time.Second,
 		ValidateTickDuration: 1 * time.Millisecond,
 	}
 

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -1003,7 +1003,7 @@ func TestRollingUpdateFlappingValidation(t *testing.T) {
 			Cloud: mockcloud,
 		},
 		FailOnValidate:          true,
-		ValidationTimeout:       200 * time.Second,
+		ValidationTimeout:       1 * time.Second,
 		ValidateTickDuration:    1 * time.Millisecond,
 		ValidateSuccessDuration: 5 * time.Millisecond,
 	}


### PR DESCRIPTION
Cherry pick of #8139 on release-1.17.

#8139: tests: increase timeout in rolling update tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.