### PR TITLE
Update CentOS 7 AMI

### DIFF
--- a/docs/operations/images.md
+++ b/docs/operations/images.md
@@ -74,8 +74,8 @@ CentOS7 support is still experimental, but should work. Please report any issues
 The following steps are known:
 
 * You must accept the agreement at http://aws.amazon.com/marketplace/pp?sku=aw0evgkw8e5c1q413zgy5pjce
-* Specify the AMI by id (there are no tags): us-east-1: `ami-6d1c2007`
-* You may find images from the [CentOS AWS page](https://wiki.centos.org/Cloud/AWS)
+* Specify the AMI by id (there are no tags): us-east-1: `ami-01ed306a12b7d1c96`
+* You may find public images from the [CentOS AWS page](https://wiki.centos.org/Cloud/AWS) but the table may not be up to date.
 * You can also query by product-code: `aws ec2 describe-images --region=us-west-2 --filters Name=product-code,Values=aw0evgkw8e5c1q413zgy5pjce Name=architecture,Values=x86_64 'Name=name,Values=CentOS*' --query 'sort_by(Images,&Name)'`
 
 Be aware of the following limitations:


### PR DESCRIPTION
Our CentOS 7 e2e job has been failing for a long time: https://testgrid.k8s.io/sig-cluster-lifecycle-kops#kops-aws-centos-7

due to the AMI's lack of ENA/NVMe support and our tests defaulting to m5.large for the masters. This caused the masters to never launch, which means prow couldn't even get job artifacts from the master instances.

[I updated the AMI in the e2e job](https://github.com/kubernetes/test-infra/pull/15928) and it appears to be successfully launching the cluster (still experiencing aws volume flakes though).

This updates our docs to match the new AMI ID. While the centos website is not up to date, this AMI ID can be found with the documented aws cli query.