### PR TITLE
Automated cherry pick of #7957: Update terraform resource names to be 0.12 compatible.

### DIFF
--- a/tests/integration/update_cluster/additional_cidr/kubernetes.tf
+++ b/tests/integration/update_cluster/additional_cidr/kubernetes.tf
@@ -474,7 +474,7 @@ resource "aws_launch_configuration" "nodes-additionalcidr-example-com" {
   enable_monitoring = false
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.additionalcidr-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.additionalcidr-example-com.id}"
@@ -708,7 +708,7 @@ resource "aws_vpc_dhcp_options_association" "additionalcidr-example-com" {
   dhcp_options_id = "${aws_vpc_dhcp_options.additionalcidr-example-com.id}"
 }
 
-resource "aws_vpc_ipv4_cidr_block_association" "10-1-0-0--16" {
+resource "aws_vpc_ipv4_cidr_block_association" "cidr-10-1-0-0--16" {
   vpc_id     = "${aws_vpc.additionalcidr-example-com.id}"
   cidr_block = "10.1.0.0/16"
 }

--- a/tests/integration/update_cluster/api_elb_cross_zone/kubernetes.tf
+++ b/tests/integration/update_cluster/api_elb_cross_zone/kubernetes.tf
@@ -345,7 +345,7 @@ resource "aws_launch_configuration" "nodes-crosszone-example-com" {
   enable_monitoring = true
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.crosszone-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.crosszone-example-com.id}"

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -474,13 +474,13 @@ resource "aws_nat_gateway" "us-test-1a-bastionuserdata-example-com" {
   }
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.bastionuserdata-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.bastionuserdata-example-com.id}"
 }
 
-resource "aws_route" "private-us-test-1a-0-0-0-0--0" {
+resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.private-us-test-1a-bastionuserdata-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "${aws_nat_gateway.us-test-1a-bastionuserdata-example-com.id}"

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -345,7 +345,7 @@ resource "aws_launch_configuration" "nodes-complex-example-com" {
   enable_monitoring = true
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.complex-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.complex-example-com.id}"

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -362,7 +362,7 @@ resource "aws_launch_configuration" "nodes-existing-iam-example-com" {
   enable_monitoring = false
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.existing-iam-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.existing-iam-example-com.id}"

--- a/tests/integration/update_cluster/existing_iam_cloudformation/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/kubernetes.tf
@@ -311,25 +311,25 @@ resource "aws_nat_gateway" "us-west-2c-k8s-iam-us-west-2-td-priv" {
   subnet_id     = "${aws_subnet.utility-us-west-2c-k8s-iam-us-west-2-td-priv.id}"
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.k8s-iam-us-west-2-td-priv.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.k8s-iam-us-west-2-td-priv.id}"
 }
 
-resource "aws_route" "private-us-west-2a-0-0-0-0--0" {
+resource "aws_route" "route-private-us-west-2a-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.private-us-west-2a-k8s-iam-us-west-2-td-priv.id}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "${aws_nat_gateway.us-west-2a-k8s-iam-us-west-2-td-priv.id}"
 }
 
-resource "aws_route" "private-us-west-2b-0-0-0-0--0" {
+resource "aws_route" "route-private-us-west-2b-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.private-us-west-2b-k8s-iam-us-west-2-td-priv.id}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "${aws_nat_gateway.us-west-2b-k8s-iam-us-west-2-td-priv.id}"
 }
 
-resource "aws_route" "private-us-west-2c-0-0-0-0--0" {
+resource "aws_route" "route-private-us-west-2c-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.private-us-west-2c-k8s-iam-us-west-2-td-priv.id}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "${aws_nat_gateway.us-west-2c-k8s-iam-us-west-2-td-priv.id}"

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -520,7 +520,7 @@ resource "aws_launch_configuration" "nodes-existingsg-example-com" {
   enable_monitoring = false
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.existingsg-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.existingsg-example-com.id}"

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -293,7 +293,7 @@ resource "aws_launch_configuration" "nodes-externallb-example-com" {
   enable_monitoring = false
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.externallb-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.externallb-example-com.id}"

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -474,7 +474,7 @@ resource "aws_launch_configuration" "nodes-ha-example-com" {
   enable_monitoring = false
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.ha-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.ha-example-com.id}"

--- a/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
+++ b/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
@@ -76,13 +76,13 @@ resource "aws_nat_gateway" "us-test-1a-lifecyclephases-example-com" {
   }
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.lifecyclephases-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.lifecyclephases-example-com.id}"
 }
 
-resource "aws_route" "private-us-test-1a-0-0-0-0--0" {
+resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.private-us-test-1a-lifecyclephases-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "${aws_nat_gateway.us-test-1a-lifecyclephases-example-com.id}"

--- a/tests/integration/update_cluster/minimal-141/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-141/kubernetes.tf
@@ -278,7 +278,7 @@ resource "aws_launch_configuration" "nodes-minimal-141-example-com" {
   enable_monitoring = false
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.minimal-141-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.minimal-141-example-com.id}"

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -278,7 +278,7 @@ resource "aws_launch_configuration" "nodes-minimal-example-com" {
   enable_monitoring = false
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.minimal-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.minimal-example-com.id}"

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -512,7 +512,7 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
   user_data = "${file("${path.module}/data/aws_launch_template_nodes.mixedinstances.example.com_user_data")}"
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.mixedinstances-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.mixedinstances-example-com.id}"

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -512,7 +512,7 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
   user_data = "${file("${path.module}/data/aws_launch_template_nodes.mixedinstances.example.com_user_data")}"
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.mixedinstances-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.mixedinstances-example-com.id}"

--- a/tests/integration/update_cluster/nosshkey/kubernetes.tf
+++ b/tests/integration/update_cluster/nosshkey/kubernetes.tf
@@ -338,7 +338,7 @@ resource "aws_launch_configuration" "nodes-nosshkey-example-com" {
   enable_monitoring = true
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.nosshkey-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.nosshkey-example-com.id}"

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -473,13 +473,13 @@ resource "aws_nat_gateway" "us-test-1a-privatecalico-example-com" {
   }
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.privatecalico-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.privatecalico-example-com.id}"
 }
 
-resource "aws_route" "private-us-test-1a-0-0-0-0--0" {
+resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.private-us-test-1a-privatecalico-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "${aws_nat_gateway.us-test-1a-privatecalico-example-com.id}"

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -473,13 +473,13 @@ resource "aws_nat_gateway" "us-test-1a-privatecanal-example-com" {
   }
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.privatecanal-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.privatecanal-example-com.id}"
 }
 
-resource "aws_route" "private-us-test-1a-0-0-0-0--0" {
+resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.private-us-test-1a-privatecanal-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "${aws_nat_gateway.us-test-1a-privatecanal-example-com.id}"

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -473,13 +473,13 @@ resource "aws_nat_gateway" "us-test-1a-privatedns1-example-com" {
   }
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.privatedns1-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.privatedns1-example-com.id}"
 }
 
-resource "aws_route" "private-us-test-1a-0-0-0-0--0" {
+resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.private-us-test-1a-privatedns1-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "${aws_nat_gateway.us-test-1a-privatedns1-example-com.id}"

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -458,13 +458,13 @@ resource "aws_nat_gateway" "us-test-1a-privatedns2-example-com" {
   }
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.privatedns2-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "igw-1"
 }
 
-resource "aws_route" "private-us-test-1a-0-0-0-0--0" {
+resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.private-us-test-1a-privatedns2-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "${aws_nat_gateway.us-test-1a-privatedns2-example-com.id}"

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -473,13 +473,13 @@ resource "aws_nat_gateway" "us-test-1a-privateflannel-example-com" {
   }
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.privateflannel-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.privateflannel-example-com.id}"
 }
 
-resource "aws_route" "private-us-test-1a-0-0-0-0--0" {
+resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.private-us-test-1a-privateflannel-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "${aws_nat_gateway.us-test-1a-privateflannel-example-com.id}"

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -467,19 +467,19 @@ resource "aws_launch_configuration" "nodes-privatekopeio-example-com" {
   enable_monitoring = false
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.privatekopeio-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.privatekopeio-example-com.id}"
 }
 
-resource "aws_route" "private-us-test-1a-0-0-0-0--0" {
+resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.private-us-test-1a-privatekopeio-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "nat-a2345678"
 }
 
-resource "aws_route" "private-us-test-1b-0-0-0-0--0" {
+resource "aws_route" "route-private-us-test-1b-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.private-us-test-1b-privatekopeio-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "nat-b2345678"

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -473,13 +473,13 @@ resource "aws_nat_gateway" "us-test-1a-privateweave-example-com" {
   }
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.privateweave-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.privateweave-example-com.id}"
 }
 
-resource "aws_route" "private-us-test-1a-0-0-0-0--0" {
+resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.private-us-test-1a-privateweave-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "${aws_nat_gateway.us-test-1a-privateweave-example-com.id}"

--- a/tests/integration/update_cluster/restrict_access/kubernetes.tf
+++ b/tests/integration/update_cluster/restrict_access/kubernetes.tf
@@ -278,7 +278,7 @@ resource "aws_launch_configuration" "nodes-restrictaccess-example-com" {
   enable_monitoring = false
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.restrictaccess-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.restrictaccess-example-com.id}"

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -263,7 +263,7 @@ resource "aws_launch_configuration" "nodes-sharedvpc-example-com" {
   enable_monitoring = false
 }
 
-resource "aws_route" "0-0-0-0--0" {
+resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = "${aws_route_table.sharedvpc-example-com.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "igw-1"

--- a/upup/pkg/fi/cloudup/awstasks/route.go
+++ b/upup/pkg/fi/cloudup/awstasks/route.go
@@ -246,7 +246,10 @@ func (_ *Route) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Rou
 		tf.InstanceID = e.Instance.TerraformLink()
 	}
 
-	return t.RenderResource("aws_route", *e.Name, tf)
+	// Terraform 0.12 doesn't support resource names that start with digits. See #7052
+	// and https://www.terraform.io/upgrade-guides/0-12.html#pre-upgrade-checklist
+	name := fmt.Sprintf("route-%v", *e.Name)
+	return t.RenderResource("aws_route", name, tf)
 }
 
 type cloudformationRoute struct {

--- a/upup/pkg/fi/cloudup/awstasks/vpccidrblock.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpccidrblock.go
@@ -124,7 +124,10 @@ func (_ *VPCCIDRBlock) RenderTerraform(t *terraform.TerraformTarget, a, e, chang
 		CIDRBlock: e.CIDRBlock,
 	}
 
-	return t.RenderResource("aws_vpc_ipv4_cidr_block_association", *e.Name, tf)
+	// Terraform 0.12 doesn't support resource names that start with digits. See #7052
+	// and https://www.terraform.io/upgrade-guides/0-12.html#pre-upgrade-checklist
+	name := fmt.Sprintf("cidr-%v", *e.Name)
+	return t.RenderResource("aws_vpc_ipv4_cidr_block_association", name, tf)
 }
 
 type cloudformationVPCCIDRBlock struct {


### PR DESCRIPTION
Cherry pick of #7957 on release-1.17.

#7957: Update terraform resource names to be 0.12 compatible.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.


[as discussed](https://github.com/kubernetes/kops/pull/7957#issuecomment-575598054) this will target 1.17.