### PR TITLE
Add release notes for terraform resource renaming

### DIFF
--- a/docs/releases/1.17-NOTES.md
+++ b/docs/releases/1.17-NOTES.md
@@ -5,6 +5,8 @@ the notes prior to the release).
 
 # Breaking changes
 
+* Terraform users on AWS may need to rename some resources in their state file in order to prepare for future Terraform 0.12 support. See Required Actions below.
+
 * Please see the notes in the 1.15 release about the apiGroup changing from kops
   to kops.k8s.io
 
@@ -18,6 +20,24 @@ the notes prior to the release).
   about upgrading through kubernetes 1.12, with the etcd3 upgrade.
 
 # Required Actions
+
+* Terraform users on AWS may need to rename resources in their terraform state file in order to prepare for future Terraform 0.12 support.
+  Terraform 0.12 [no longer supports resource names starting with digits](https://www.terraform.io/upgrade-guides/0-12.html#pre-upgrade-checklist). In Kops, both the default route and additional VPC CIDR associations are affected. See [#7957](https://github.com/kubernetes/kops/pull/7957) for more information.
+  * The default route was named `aws_route.0-0-0-0--0` and will now be named `aws_route.route-0-0-0-0--0`.
+  * Additional CIDR blocks associated with a VPC were similarly named the hyphenated CIDR block with two hyphens for the `/`, for example `aws_vpc_ipv4_cidr_block_association.10-1-0-0--16`. These will now be prefixed with `cidr-`, for example `aws_vpc_ipv4_cidr_block_association.cidr-10-1-0-0--16`.
+  
+  To prevent downtime, follow these steps with the new version of Kops:
+  ```
+  kops update cluster --target terraform ...
+  terraform plan
+  # Observe any aws_route or aws_vpc_ipv4_cidr_block_association resources being destroyed and recreated
+  # Run these commands as necessary. The exact names may differ; use what is outputted by terraform plan
+  terraform state mv aws_route.0-0-0-0--0 aws_route.route-0-0-0-0--0
+  terraform state mv aws_vpc_ipv4_cidr_block_association.10-1-0-0--16 aws_vpc_ipv4_cidr_block_association.cidr-10-1-0-0--16
+  terraform plan
+  # Ensure these resources are no longer being destroyed and recreated
+  terraform apply
+  ```
 
 * If either a Kops 1.17 alpha release or a custom Kops build was used on a cluster,
   a kops-controller Deployment may have been created that should get deleted because it has been replaced with a DaemonSet.

--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -5,6 +5,8 @@ the notes prior to the release).
 
 # Breaking changes
 
+* Terraform users on AWS may need to rename some resources in their state file in order to prepare for Terraform 0.12 support. See Required Actions below.
+
 * Please see the notes in the 1.15 release about the apiGroup changing from kops
   to kops.k8s.io
 
@@ -15,6 +17,24 @@ the notes prior to the release).
 # Significant changes
 
 # Required Actions
+
+* Terraform users on AWS may need to rename resources in their terraform state file in order to prepare for future Terraform 0.12 support.
+  Terraform 0.12 [no longer supports resource names starting with digits](https://www.terraform.io/upgrade-guides/0-12.html#pre-upgrade-checklist). In Kops, both the default route and additional VPC CIDR associations are affected. See [#7957](https://github.com/kubernetes/kops/pull/7957) for more information.
+  * The default route was named `aws_route.0-0-0-0--0` and will now be named `aws_route.route-0-0-0-0--0`.
+  * Additional CIDR blocks associated with a VPC were similarly named the hyphenated CIDR block with two hyphens for the `/`, for example `aws_vpc_ipv4_cidr_block_association.10-1-0-0--16`. These will now be prefixed with `cidr-`, for example `aws_vpc_ipv4_cidr_block_association.cidr-10-1-0-0--16`.
+  
+  To prevent downtime, follow these steps with the new version of Kops:
+  ```
+  kops update cluster --target terraform ...
+  terraform plan
+  # Observe any aws_route or aws_vpc_ipv4_cidr_block_association resources being destroyed and recreated
+  # Run these commands as necessary. The exact names may differ; use what is outputted by terraform plan
+  terraform state mv aws_route.0-0-0-0--0 aws_route.route-0-0-0-0--0
+  terraform state mv aws_vpc_ipv4_cidr_block_association.10-1-0-0--16 aws_vpc_ipv4_cidr_block_association.cidr-10-1-0-0--16
+  terraform plan
+  # Ensure these resources are no longer being destroyed and recreated
+  terraform apply
+  ```
 
 * If a custom Kops build was used on a cluster, a kops-controller Deployment may have been created that should get deleted.
   Run `kubectl -n kube-system delete deployment kops-controller` after upgrading to Kops 1.16.0-beta.1 or later.


### PR DESCRIPTION
Followup to https://github.com/kubernetes/kops/pull/7957

/cc @mccare since you're involved with the terraform 0.12 upgrade work as well.

/area documentation