### PR TITLE
Automated cherry pick of #6465: Allow local filesystem state stores

### DIFF
--- a/util/pkg/vfs/vfs.go
+++ b/util/pkg/vfs/vfs.go
@@ -102,16 +102,13 @@ func IsClusterReadable(p Path) bool {
 	}
 
 	switch p.(type) {
-	case *S3Path, *GSPath, *SwiftPath, *OSSPath:
+	case *S3Path, *GSPath, *SwiftPath, *OSSPath, *FSPath:
 		return true
 
 	case *KubernetesPath:
 		return true
 
 	case *SSHPath:
-		return false
-
-	case *FSPath:
 		return false
 
 	case *MemFSPath:


### PR DESCRIPTION
Cherry pick of #6465 on release-1.17.

#6465: Allow local filesystem state stores

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.