### PR TITLE
Use IAMPrefix() for hostedzone

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -539,9 +539,6 @@ func addECRPermissions(p *Policy) {
 func (b *PolicyBuilder) addRoute53Permissions(p *Policy, hostedZoneID string) {
 
 	// TODO: Route53 currently not supported in China, need to check and fail/return
-	//if b.IAMPrefix() == "arn:aws-cn" {
-	//
-	//}
 	// Remove /hostedzone/ prefix (if present)
 	hostedZoneID = strings.TrimPrefix(hostedZoneID, "/")
 	hostedZoneID = strings.TrimPrefix(hostedZoneID, "hostedzone/")


### PR DESCRIPTION
fixes #8359 upstream

Tested in us-gov-west-1 zone with the following

```
$ ./kops create cluster --image=${AMI_NAME} --dns=private --zones=us-gov-west-1a --name=${CLUSTER_NAME}
$ ./kops update cluster ${CLUSTER_NAME} --yes
I0117 13:59:21.485847   14570 dns.go:94] Private DNS: skipping DNS validation
I0117 13:59:22.071985   14570 executor.go:103] Tasks: 0 done / 87 total; 44 can run
I0117 13:59:22.751585   14570 vfs_castore.go:675] Issuing new certificate: "apiserver-aggregator-ca"
I0117 13:59:22.828018   14570 vfs_castore.go:675] Issuing new certificate: "etcd-peers-ca-main"
I0117 13:59:22.830881   14570 vfs_castore.go:675] Issuing new certificate: "ca"
I0117 13:59:22.835241   14570 vfs_castore.go:675] Issuing new certificate: "etcd-manager-ca-main"
I0117 13:59:22.911223   14570 vfs_castore.go:675] Issuing new certificate: "etcd-manager-ca-events"
I0117 13:59:22.958590   14570 vfs_castore.go:675] Issuing new certificate: "etcd-peers-ca-events"
I0117 13:59:22.986829   14570 vfs_castore.go:675] Issuing new certificate: "etcd-clients-ca"
I0117 13:59:23.555176   14570 executor.go:103] Tasks: 44 done / 87 total; 23 can run
I0117 13:59:24.182575   14570 vfs_castore.go:675] Issuing new certificate: "apiserver-aggregator"
I0117 13:59:24.419804   14570 vfs_castore.go:675] Issuing new certificate: "kube-controller-manager"
I0117 13:59:24.429200   14570 vfs_castore.go:675] Issuing new certificate: "kube-scheduler"
I0117 13:59:24.435082   14570 vfs_castore.go:675] Issuing new certificate: "kubecfg"
I0117 13:59:24.459443   14570 vfs_castore.go:675] Issuing new certificate: "kops"
I0117 13:59:24.605755   14570 vfs_castore.go:675] Issuing new certificate: "apiserver-proxy-client"
I0117 13:59:24.744055   14570 vfs_castore.go:675] Issuing new certificate: "master"
I0117 13:59:24.783516   14570 vfs_castore.go:675] Issuing new certificate: "kubelet"
I0117 13:59:24.788647   14570 vfs_castore.go:675] Issuing new certificate: "kube-proxy"
I0117 13:59:24.800117   14570 vfs_castore.go:675] Issuing new certificate: "kubelet-api"
I0117 13:59:25.224904   14570 executor.go:103] Tasks: 67 done / 87 total; 18 can run
I0117 13:59:25.622946   14570 launchconfiguration.go:375] waiting for IAM instance profile "nodes.mission.control" to be ready
I0117 13:59:25.643104   14570 launchconfiguration.go:375] waiting for IAM instance profile "masters.mission.control" to be ready
I0117 13:59:36.227543   14570 executor.go:103] Tasks: 85 done / 87 total; 2 can run
I0117 13:59:37.000449   14570 executor.go:103] Tasks: 87 done / 87 total; 0 can run
I0117 13:59:37.000531   14570 dns.go:155] Pre-creating DNS records
I0117 13:59:37.603519   14570 update_cluster.go:305] Exporting kubecfg for cluster
W0117 13:59:37.843630   14570 create_kubecfg.go:76] Did not find API endpoint for gossip hostname; may not be able to reach cluster
kops has set your kubectl context to mission.control

Cluster is starting.  It should be ready in a few minutes.

Suggestions:
 * validate cluster: kops validate cluster
 * list nodes: kubectl get nodes --show-labels
 * ssh to the master: ssh -i ~/.ssh/id_rsa admin@api.mission.control
 * the admin user is specific to Debian. If not using Debian please use the appropriate user based on your OS.
 * read about installing addons at: https://kops.sigs.k8s.io/operations/addons.
```