### PR TITLE
Update lyft CNI to v0.5.3

### DIFF
--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1175,8 +1175,8 @@ func (c *ApplyClusterCmd) AddFileAssets(assetBuilder *assets.AssetBuilder) error
 
 		urlString := os.Getenv("LYFT_VPC_DOWNLOAD_URL")
 		if urlString == "" {
-			urlString = "https://github.com/lyft/cni-ipvlan-vpc-k8s/releases/download/v0.5.1/cni-ipvlan-vpc-k8s-v0.5.1.tar.gz"
-			hash, err = hashing.FromString("6e8308bc3205a9f88998df5ba5f0d3845a84ec8ff207a698277dd51eb7e3fb52")
+			urlString = "https://github.com/lyft/cni-ipvlan-vpc-k8s/releases/download/v0.5.3/cni-ipvlan-vpc-k8s-amd64-v0.5.3.tar.gz"
+			hash, err = hashing.FromString("5e42bb70b48a9c5b4bd0d95e13a2352860575c9ba87fe58342d3d19b14f36d72")
 			if err != nil {
 				// Should be impossible
 				return fmt.Errorf("invalid hard-coded hash for lyft url")


### PR DESCRIPTION
Bump the Lyft CNI to the latest v.0.5.3. This adds support for more instance families and types.

