### PR TITLE
Add a warning when using file:// state store

### DIFF
--- a/cmd/kops/util/factory.go
+++ b/cmd/kops/util/factory.go
@@ -118,6 +118,9 @@ func (f *Factory) Clientset() (simple.Clientset, error) {
 
 			f.clientset = vfsclientset.NewVFSClientset(basePath, allowVFSList)
 		}
+		if strings.HasPrefix(registryPath, "file://") {
+			klog.Warning("The local filesystem state store is not functional for running clusters")
+		}
 	}
 
 	return f.clientset, nil


### PR DESCRIPTION
As discussed during office hours today. This already requires users to opt-in so they should already know what they're doing, but just in case we print this warning.

```
KOPS_STATE_STORE=file://$(pwd)/state kops update cluster foo.k8s.local
W0117 16:44:05.081437   92040 factory.go:122] The local filesystem state store is not functional for running clusters
I0117 16:44:15.092092   92040 executor.go:103] Tasks: 0 done / 137 total; 55 can run
I0117 16:44:16.268684   92040 executor.go:103] Tasks: 55 done / 137 total; 33 can run
...
```

This warning is printed on all kops commands that utilize the state store (`replace`, `update`, etc.)