### PR TITLE
Kops releases - prefix git tags with v

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -585,10 +585,11 @@ ${CHANNELS}:
 .PHONY: release-tag
 release-tag:
 	git tag ${KOPS_RELEASE_VERSION}
+	git tag v${KOPS_RELEASE_VERSION}
 
 .PHONY: release-github
 release-github:
-	shipbot -tag ${KOPS_RELEASE_VERSION} -config .shipbot.yaml
+	shipbot -tag v${KOPS_RELEASE_VERSION} -config .shipbot.yaml
 
 # --------------------------------------------------
 # API / embedding examples


### PR DESCRIPTION
I noticed this while investigating #8371 and there have been other reports of issues when trying to import kops with go modules (I can't find the GH issues at the moment)

[Go modules require the v prefix](https://github.com/golang/go/wiki/Modules#modules), and [k/k also tags with the v prefix](https://github.com/kubernetes/kubernetes/releases/tag/v1.17.0).

We have some inconsistent tags already, for 1.11.0 we have tags of both `1.11.0` and `v1.11.0` which is the most recent tag with the prefix.
This is also why 1.11.0 is the default version imported by `go get`:

```
go get -v k8s.io/kops
go: downloading k8s.io/kops v1.11.0
```

and the latest version in `go list`:

```
go list -m -versions k8s.io/kops
k8s.io/kops v1.4.0-alpha.1 v1.4.0 v1.4.1 v1.4.2 v1.4.3 v1.4.4 v1.10.0 v1.11.0
```

I'm proposing we switch to only tagging with the v prefix. I'm only updating the actual git tag and not the entire version string used throughout kops due to its larger impact:

* Output by `kops version`
* Public URLs for kops assets
* Protokube tag

I'm hoping this is the least invasive way we can make this change.
If we think advanced notice is required, we could tag with both formats for a number of releases before tagging only with the v prefix.

/hold for Justin's approval
/cc @justinsb