### PR TITLE
Automated cherry pick of #8248: Fix issues with older versions of k8s for basic clusters

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 {{- if or (.KubeDNS.UpstreamNameservers) (.KubeDNS.StubDomains) }}
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -28,9 +27,9 @@ data:
   stubDomains: |
     {{ ToJSON .KubeDNS.StubDomains }}
   {{- end }}
-{{- end }}
 
 ---
+{{- end }}
 
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
Cherry pick of #8248 on release-1.17.

#8248: Fix issues with older versions of k8s for basic clusters

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.