### PR TITLE
Automated cherry pick of #8248: Fix issues with older versions of k8s for basic clusters

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 {{- if or (.KubeDNS.UpstreamNameservers) (.KubeDNS.StubDomains) }}
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -28,9 +27,9 @@ data:
   stubDomains: |
     {{ ToJSON .KubeDNS.StubDomains }}
   {{- end }}
-{{- end }}
 
 ---
+{{- end }}
 
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: efb1399217d403fa5207e2bc8cf1fbef58c7f8b2
+    manifestHash: eb8989571b15af1f02677a0eb4e0dfd1442feda5
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
@@ -29,7 +29,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 191685ca6fe009302e55512b0eefc5a676433f10
+    manifestHash: 555f952a8b955ce7a5dd0bcd06a5be9e72bd2895
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #8248 on release-1.16.

#8248: Fix issues with older versions of k8s for basic clusters

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.