### PR TITLE
Automated cherry pick of #8248: Fix issues with older versions of k8s for basic clusters

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 {{- if or (.KubeDNS.UpstreamNameservers) (.KubeDNS.StubDomains) }}
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -28,9 +27,9 @@ data:
   stubDomains: |
     {{ ToJSON .KubeDNS.StubDomains }}
   {{- end }}
-{{- end }}
 
 ---
+{{- end }}
 
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -21,7 +21,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 14ae2e8c90c7641ea15e871c77516db1d3aed6da
+    manifestHash: c74ca65f461c764fc9682c6d9ec171b241bec335
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/kopeio-vxlan/manifest.yaml
@@ -21,7 +21,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 14ae2e8c90c7641ea15e871c77516db1d3aed6da
+    manifestHash: c74ca65f461c764fc9682c6d9ec171b241bec335
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -21,7 +21,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 14ae2e8c90c7641ea15e871c77516db1d3aed6da
+    manifestHash: c74ca65f461c764fc9682c6d9ec171b241bec335
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -21,7 +21,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 14ae2e8c90c7641ea15e871c77516db1d3aed6da
+    manifestHash: c74ca65f461c764fc9682c6d9ec171b241bec335
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #8248 on release-1.15.

#8248: Fix issues with older versions of k8s for basic clusters

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.