### PR TITLE
Change the deleted user to ghost

### DIFF
--- a/docs/releases/1.13-NOTES.md
+++ b/docs/releases/1.13-NOTES.md
@@ -95,7 +95,7 @@
 * Instance protection [@mikesplain](https://github.com/mikesplain) [#7179](https://github.com/kubernetes/kops/pull/7179)
 * update instances list with make update-machine-types [@rekcah78](https://github.com/rekcah78) [#7196](https://github.com/kubernetes/kops/pull/7196)
 * update instances list with make update-machine-types [@rekcah78](https://github.com/rekcah78) [#7198](https://github.com/kubernetes/kops/pull/7198)
-* Add helpers to set the built-in pod priorities [@vainu-arto](https://github.com/vainu-arto) [#7191](https://github.com/kubernetes/kops/pull/7191)
+* Add helpers to set the built-in pod priorities [@vainu-arto](https://github.com/ghost) [#7191](https://github.com/kubernetes/kops/pull/7191)
 * Allow user to set the --kube-api-qps and --kube-api-burst flags on KubeControllerManager [@rdrgmnzs](https://github.com/rdrgmnzs) [#7153](https://github.com/kubernetes/kops/pull/7153)
 * Bumping calico for bugfixes. [@michalschott](https://github.com/michalschott) [#7225](https://github.com/kubernetes/kops/pull/7225)
 * Make an actual deep-copy of the state [@jacksontj](https://github.com/jacksontj) [#7230](https://github.com/kubernetes/kops/pull/7230)

--- a/docs/releases/1.14-NOTES.md
+++ b/docs/releases/1.14-NOTES.md
@@ -62,7 +62,7 @@
 * Instance protection [@mikesplain](https://github.com/mikesplain) [#7177](https://github.com/kubernetes/kops/pull/7177)
 * update instances list with make update-machine-types [@rekcah78](https://github.com/rekcah78) [#7195](https://github.com/kubernetes/kops/pull/7195)
 * add c5.12xlarge, c5.24xlarge, c5.metal, i3en.metal [@rekcah78](https://github.com/rekcah78) [#7166](https://github.com/kubernetes/kops/pull/7166)
-* Set priority for static pods [@vainu-arto](https://github.com/vainu-arto) [#6897](https://github.com/kubernetes/kops/pull/6897)
+* Set priority for static pods [@vainu-arto](https://github.com/ghost) [#6897](https://github.com/kubernetes/kops/pull/6897)
 * Allow user to set the --kube-api-qps and --kube-api-burst flags on KubeControllerManager [@rdrgmnzs](https://github.com/rdrgmnzs) [#7153](https://github.com/kubernetes/kops/pull/7153)
 * Bumping calico for bugfixes. [@michalschott](https://github.com/michalschott) [#7223](https://github.com/kubernetes/kops/pull/7223)
 * Make an actual deep-copy of the state [@jacksontj](https://github.com/jacksontj) [#7219](https://github.com/kubernetes/kops/pull/7219)

--- a/docs/releases/1.15-NOTES.md
+++ b/docs/releases/1.15-NOTES.md
@@ -171,7 +171,7 @@ is safer.
 * doc: support to debug kops-apiserver [@Sn0rt](https://github.com/Sn0rt) [#7151](https://github.com/kubernetes/kops/pull/7151)
 * GCE tutorial markdown formatting [@flaviamissi](https://github.com/flaviamissi) [#7188](https://github.com/kubernetes/kops/pull/7188)
 * Make an actual deep-copy of the state [@jacksontj](https://github.com/jacksontj) [#7219](https://github.com/kubernetes/kops/pull/7219)
-* Set priority for static pods [@vainu-arto](https://github.com/vainu-arto) [#6897](https://github.com/kubernetes/kops/pull/6897)
+* Set priority for static pods [@vainu-arto](https://github.com/ghost) [#6897](https://github.com/kubernetes/kops/pull/6897)
 * Allow setting Limit & Request for aws-iam-authenticator [@rdrgmnzs](https://github.com/rdrgmnzs) [#7260](https://github.com/kubernetes/kops/pull/7260)
 * Delete the function keyword to prevent shellcheck from failing [@xichengliudui](https://github.com/xichengliudui) [#6811](https://github.com/kubernetes/kops/pull/6811)
 * Bumping calico to 3.7.4. [@michalschott](https://github.com/michalschott) [#7249](https://github.com/kubernetes/kops/pull/7249)

--- a/docs/releases/1.9-NOTES.md
+++ b/docs/releases/1.9-NOTES.md
@@ -28,7 +28,7 @@ None known at this time
 * SSH keys - be lazier about keystore creation [@justinsb](https://github.com/justinsb) [#3933](https://github.com/kubernetes/kops/pull/3933)
 * Update aws-sdk-go to v1.10.34 [@rdrgmnzs](https://github.com/rdrgmnzs) [#3885](https://github.com/kubernetes/kops/pull/3885)
 * Update bazel / gazelle [@justinsb](https://github.com/justinsb) [#4000](https://github.com/kubernetes/kops/pull/4000)
-* When using private DNS add ELB name to the api certificate [@vainu-arto](https://github.com/vainu-arto) [#3941](https://github.com/kubernetes/kops/pull/3941)
+* When using private DNS add ELB name to the api certificate [@vainu-arto](https://github.com/ghost) [#3941](https://github.com/kubernetes/kops/pull/3941)
 * Fixed minor typo in 1.8-NOTES.md file [@sellers](https://github.com/sellers) [#4013](https://github.com/kubernetes/kops/pull/4013)
 * Minor update to docs/getting_started/aws.md [@ysim](https://github.com/ysim) [#4008](https://github.com/kubernetes/kops/pull/4008)
 * Fix libcgroup dependency typo [@wannabesrevenge](https://github.com/wannabesrevenge) [#4030](https://github.com/kubernetes/kops/pull/4030)


### PR DESCRIPTION
View these four documents : docs/releases/1.13-NOTES.md，docs/releases/1.14-NOTES.md，docs/releases/1.15-NOTES.md，docs/releases/1.9-NOTES.md，which contain 4 pr :  https://github.com/kubernetes/kops/pull/7191,https://github.com/kubernetes/kops/pull/6897,https://github.com/kubernetes/kops/pull/6897,https://github.com/kubernetes/kops/pull/3941, these 4 pr  contains one deleted user：vainu-arto，whose link is ready to use ghost instead. This can improve the user experience