### PR TITLE
Automated cherry pick of #8378: Backport the k8s 1.9 required action release note

### DIFF
--- a/docs/releases/1.15-NOTES.md
+++ b/docs/releases/1.15-NOTES.md
@@ -22,5 +22,17 @@
   apiGroup will now be kops.k8s.io, not kops.  If performing strict string
   comparison you will need to update your expected values.
 
+* Kubernetes 1.9 users will need to enable the PodPriority feature gate. This is required for newer versions of Kops.
+
+  To enable the Pod priority feature, follow these steps:
+  ```
+  kops edit cluster
+  # Add the following section
+  spec:
+    kubelet:
+      featureGates:
+        PodPriority: "true"
+  ```
+ 
 # Full change list since 1.14.0 release
 


### PR DESCRIPTION
Cherry pick of #8378 on release-1.15.

#8378: Backport the k8s 1.9 required action release note

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.