### PR TITLE
Automated cherry pick of #8379: Add Cilium.EnablePolicy back into templates

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -354,6 +354,10 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
+        {{ with .Networking.Cilium.EnablePolicy }}
+        - name: CILIUM_ENABLE_POLICY
+          value: {{ . }}
+        {{ end }}
 {{ with .Networking.Cilium }}
         image: "docker.io/cilium/cilium:{{ .Version }}"
         imagePullPolicy: IfNotPresent

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
@@ -354,6 +354,10 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
+        {{ with .Networking.Cilium.EnablePolicy }}
+        - name: CILIUM_ENABLE_POLICY
+          value: {{ . }}
+        {{ end }}
 {{ with .Networking.Cilium }}
         image: "docker.io/cilium/cilium:{{ .Version }}"
         imagePullPolicy: IfNotPresent

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -1146,7 +1146,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 	if b.cluster.Spec.Networking.Cilium != nil {
 		key := "networking.cilium.io"
-		version := "1.6.4-kops.1"
+		version := "1.6.4-kops.2"
 
 		{
 			id := "k8s-1.7"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -119,7 +119,7 @@ spec:
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.6.4-kops.1
+    version: 1.6.4-kops.2
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
@@ -127,4 +127,4 @@ spec:
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.6.4-kops.1
+    version: 1.6.4-kops.2


### PR DESCRIPTION
Cherry pick of #8379 on release-1.17.

#8379: Add Cilium.EnablePolicy back into templates

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.