### PR TITLE
Automated cherry pick of #8366: use IAMPrefix() for hostedzone

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -539,9 +539,6 @@ func addECRPermissions(p *Policy) {
 func (b *PolicyBuilder) addRoute53Permissions(p *Policy, hostedZoneID string) {
 
 	// TODO: Route53 currently not supported in China, need to check and fail/return
-	//if b.IAMPrefix() == "arn:aws-cn" {
-	//
-	//}
 	// Remove /hostedzone/ prefix (if present)
 	hostedZoneID = strings.TrimPrefix(hostedZoneID, "/")
 	hostedZoneID = strings.TrimPrefix(hostedZoneID, "hostedzone/")


### PR DESCRIPTION
Cherry pick of #8366 on release-1.16.

#8366: use IAMPrefix() for hostedzone

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.