### PR TITLE
Bump k8s versions in alpha and stable channels

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -56,13 +56,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.17.0"
-    recommendedVersion: 1.17.0
+    recommendedVersion: 1.17.2
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
-    recommendedVersion: 1.16.4
+    recommendedVersion: 1.16.6
     requiredVersion: 1.16.0
   - range: ">=1.15.0"
-    recommendedVersion: 1.15.7
+    recommendedVersion: 1.15.9
     requiredVersion: 1.15.0
   - range: ">=1.14.0"
     recommendedVersion: 1.14.10
@@ -83,15 +83,15 @@ spec:
   - range: ">=1.17.0-alpha.1"
     #recommendedVersion: "1.17.0"
     #requiredVersion: 1.17.0
-    kubernetesVersion: 1.17.0
+    kubernetesVersion: 1.17.2
   - range: ">=1.16.0-alpha.1"
     #recommendedVersion: "1.16.0"
     #requiredVersion: 1.16.0
-    kubernetesVersion: 1.16.4
+    kubernetesVersion: 1.16.6
   - range: ">=1.15.0-alpha.1"
     #recommendedVersion: "1.15.0"
     #requiredVersion: 1.15.0
-    kubernetesVersion: 1.15.7
+    kubernetesVersion: 1.15.9
   - range: ">=1.14.0-alpha.1"
     #recommendedVersion: "1.14.0"
     #requiredVersion: 1.14.0

--- a/channels/stable
+++ b/channels/stable
@@ -49,13 +49,13 @@ spec:
     recommendedVersion: 1.17.0
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
-    recommendedVersion: 1.16.3
+    recommendedVersion: 1.16.4
     requiredVersion: 1.16.0
   - range: ">=1.15.0"
-    recommendedVersion: 1.15.6
+    recommendedVersion: 1.15.7
     requiredVersion: 1.15.0
   - range: ">=1.14.0"
-    recommendedVersion: 1.14.9
+    recommendedVersion: 1.14.10
     requiredVersion: 1.14.0
   - range: ">=1.13.0"
     recommendedVersion: 1.13.12
@@ -77,15 +77,15 @@ spec:
   - range: ">=1.16.0-alpha.1"
     #recommendedVersion: "1.16.0"
     #requiredVersion: 1.16.0
-    kubernetesVersion: 1.16.3
+    kubernetesVersion: 1.16.4
   - range: ">=1.15.0-alpha.1"
     #recommendedVersion: "1.15.0"
     #requiredVersion: 1.15.0
-    kubernetesVersion: 1.15.6
+    kubernetesVersion: 1.15.7
   - range: ">=1.14.0-alpha.1"
     #recommendedVersion: "1.14.0"
     #requiredVersion: 1.14.0
-    kubernetesVersion: 1.14.9
+    kubernetesVersion: 1.14.10
   - range: ">=1.13.0-alpha.1"
     #recommendedVersion: "1.13.0"
     #requiredVersion: 1.13.0


### PR DESCRIPTION
Bumping alpha channel k8s versions to stable. They have been sitting in alpha for quite some time now.
Also bumping k8s in the alpha channels to the recently released ones.