### PR TITLE
Automated cherry pick of #8386: Fix scheduler policy configmap args

### DIFF
--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -104,7 +104,7 @@ func (b *KubeSchedulerBuilder) buildPod() (*v1.Pod, error) {
 	flags = append(flags, "--kubeconfig="+"/var/lib/kube-scheduler/kubeconfig")
 
 	if c.UsePolicyConfigMap != nil {
-		flags = append(flags, "--policy-configmap=scheduler-policy --policy-configmap-namespace=kube-system")
+		flags = append(flags, "--policy-configmap=scheduler-policy", "--policy-configmap-namespace=kube-system")
 	}
 
 	pod := &v1.Pod{


### PR DESCRIPTION
Cherry pick of #8386 on release-1.16.

#8386: Fix scheduler policy configmap args

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.