### PR TITLE
Automated cherry pick of #8338: Don't load nonexistent calico-client cert when CNI is Cilium

### DIFF
--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -253,7 +253,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 	} else {
 		loader.Builders = append(loader.Builders, &model.KubeRouterBuilder{NodeupModelContext: modelContext})
 	}
-	if c.cluster.Spec.Networking.Calico != nil || c.cluster.Spec.Networking.Cilium != nil {
+	if c.cluster.Spec.Networking.Calico != nil {
 		loader.Builders = append(loader.Builders, &model.EtcdTLSBuilder{NodeupModelContext: modelContext})
 	}
 


### PR DESCRIPTION
Cherry pick of #8338 on release-1.15.

#8338: Don't load nonexistent calico-client cert when CNI is Cilium

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.