### PR TITLE
Automated cherry pick of #8373: Prefix git tags with `v`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -631,10 +631,11 @@ ${CHANNELS}:
 .PHONY: release-tag
 release-tag:
 	git tag ${KOPS_RELEASE_VERSION}
+	git tag v${KOPS_RELEASE_VERSION}
 
 .PHONY: release-github
 release-github:
-	shipbot -tag ${KOPS_RELEASE_VERSION} -config .shipbot.yaml
+	shipbot -tag v${KOPS_RELEASE_VERSION} -config .shipbot.yaml
 
 # --------------------------------------------------
 # API / embedding examples


### PR DESCRIPTION
Cherry pick of #8373 on release-1.15.

#8373: Prefix git tags with `v`

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.