### PR TITLE
Update support for Amazon Linux 2

### DIFF
--- a/nodeup/pkg/distros/distribution.go
+++ b/nodeup/pkg/distros/distribution.go
@@ -24,18 +24,19 @@ import (
 type Distribution string
 
 var (
-	DistributionJessie      Distribution = "jessie"
-	DistributionDebian9     Distribution = "debian9"
-	DistributionDebian10    Distribution = "buster"
-	DistributionXenial      Distribution = "xenial"
-	DistributionBionic      Distribution = "bionic"
-	DistributionRhel7       Distribution = "rhel7"
-	DistributionCentos7     Distribution = "centos7"
-	DistributionRhel8       Distribution = "rhel8"
-	DistributionCentos8     Distribution = "centos8"
-	DistributionCoreOS      Distribution = "coreos"
-	DistributionFlatcar     Distribution = "flatcar"
-	DistributionContainerOS Distribution = "containeros"
+	DistributionJessie       Distribution = "jessie"
+	DistributionDebian9      Distribution = "debian9"
+	DistributionDebian10     Distribution = "buster"
+	DistributionXenial       Distribution = "xenial"
+	DistributionBionic       Distribution = "bionic"
+	DistributionAmazonLinux2 Distribution = "amazonlinux2"
+	DistributionRhel7        Distribution = "rhel7"
+	DistributionCentos7      Distribution = "centos7"
+	DistributionRhel8        Distribution = "rhel8"
+	DistributionCentos8      Distribution = "centos8"
+	DistributionCoreOS       Distribution = "coreos"
+	DistributionFlatcar      Distribution = "flatcar"
+	DistributionContainerOS  Distribution = "containeros"
 )
 
 func (d Distribution) BuildTags() []string {
@@ -50,6 +51,8 @@ func (d Distribution) BuildTags() []string {
 		t = []string{"_xenial"}
 	case DistributionBionic:
 		t = []string{"_bionic"}
+	case DistributionAmazonLinux2:
+		t = []string{"_amazonlinux2"}
 	case DistributionCentos7:
 		t = []string{"_centos7"}
 	case DistributionRhel7:
@@ -88,7 +91,7 @@ func (d Distribution) IsDebianFamily() bool {
 		return true
 	case DistributionXenial, DistributionBionic:
 		return true
-	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8:
+	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8, DistributionAmazonLinux2:
 		return false
 	case DistributionCoreOS, DistributionFlatcar, DistributionContainerOS:
 		return false
@@ -104,7 +107,7 @@ func (d Distribution) IsUbuntu() bool {
 		return false
 	case DistributionXenial, DistributionBionic:
 		return true
-	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8:
+	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8, DistributionAmazonLinux2:
 		return false
 	case DistributionCoreOS, DistributionFlatcar, DistributionContainerOS:
 		return false
@@ -116,7 +119,7 @@ func (d Distribution) IsUbuntu() bool {
 
 func (d Distribution) IsRHELFamily() bool {
 	switch d {
-	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8:
+	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8, DistributionAmazonLinux2:
 		return true
 	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9, DistributionDebian10:
 		return false
@@ -132,7 +135,7 @@ func (d Distribution) IsSystemd() bool {
 	switch d {
 	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9, DistributionDebian10:
 		return true
-	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8:
+	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8, DistributionAmazonLinux2:
 		return true
 	case DistributionCoreOS, DistributionFlatcar:
 		return true

--- a/nodeup/pkg/distros/identify.go
+++ b/nodeup/pkg/distros/identify.go
@@ -113,8 +113,7 @@ func FindDistribution(rootfs string) (Distribution, error) {
 				return DistributionContainerOS, nil
 			}
 			if strings.HasPrefix(line, "PRETTY_NAME=\"Amazon Linux 2") {
-				// TODO: This is a hack. Amazon Linux is "special" and should get its own distro entry
-				return DistributionRhel7, nil
+				return DistributionAmazonLinux2, nil
 			}
 		}
 		klog.Warningf("unhandled /etc/os-release info %q", string(osRelease))

--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -97,7 +97,7 @@ var containerdVersions = []packageVersion{
 	{
 		PackageVersion: "1.2.10",
 		Name:           "containerd.io",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7, distros.DistributionAmazonLinux2},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "1.2.10",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.10-3.2.el7.x86_64.rpm",

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -74,7 +74,7 @@ var dockerVersions = []packageVersion{
 	{
 		PackageVersion: "1.11.2",
 		Name:           "docker-engine",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7, distros.DistributionAmazonLinux2},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "1.11.2",
 		Source:         "https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-1.11.2-1.el7.centos.x86_64.rpm",
@@ -117,7 +117,7 @@ var dockerVersions = []packageVersion{
 	{
 		PackageVersion: "1.12.1",
 		Name:           "docker-engine",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7, distros.DistributionAmazonLinux2},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "1.12.1",
 		Source:         "https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-1.12.1-1.el7.centos.x86_64.rpm",
@@ -176,7 +176,7 @@ var dockerVersions = []packageVersion{
 	{
 		PackageVersion: "1.12.3",
 		Name:           "docker-engine",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7, distros.DistributionAmazonLinux2},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "1.12.3",
 		Source:         "https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-1.12.3-1.el7.centos.x86_64.rpm",
@@ -250,7 +250,7 @@ var dockerVersions = []packageVersion{
 	{
 		PackageVersion: "1.12.6",
 		Name:           "docker-engine",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7, distros.DistributionAmazonLinux2},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "1.12.6",
 		Source:         "https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-1.12.6-1.el7.centos.x86_64.rpm",
@@ -324,7 +324,7 @@ var dockerVersions = []packageVersion{
 	{
 		PackageVersion: "1.13.1",
 		Name:           "docker-engine",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7, distros.DistributionAmazonLinux2},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "1.13.1",
 		Source:         "https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-1.13.1-1.el7.centos.x86_64.rpm",
@@ -409,7 +409,7 @@ var dockerVersions = []packageVersion{
 	{
 		PackageVersion: "17.03.2",
 		Name:           "docker-ce",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7, distros.DistributionAmazonLinux2},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "17.03.2.ce",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-17.03.2.ce-1.el7.centos.x86_64.rpm",
@@ -508,7 +508,7 @@ var dockerVersions = []packageVersion{
 	{
 		PackageVersion: "17.09.0",
 		Name:           "docker-ce",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7, distros.DistributionAmazonLinux2},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "17.09.0.ce",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-17.09.0.ce-1.el7.centos.x86_64.rpm",
@@ -598,7 +598,7 @@ var dockerVersions = []packageVersion{
 	{
 		PackageVersion: "18.06.1",
 		Name:           "docker-ce",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7, distros.DistributionAmazonLinux2},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "18.06.1.ce",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-18.06.1.ce-3.el7.x86_64.rpm",
@@ -628,7 +628,7 @@ var dockerVersions = []packageVersion{
 	{
 		PackageVersion: "18.06.2",
 		Name:           "docker-ce",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7, distros.DistributionAmazonLinux2},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "18.06.2.ce",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-18.06.2.ce-3.el7.x86_64.rpm",
@@ -681,7 +681,7 @@ var dockerVersions = []packageVersion{
 	{
 		PackageVersion: "18.06.3",
 		Name:           "docker-ce",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7, distros.DistributionAmazonLinux2},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "18.06.3.ce",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-18.06.3.ce-3.el7.x86_64.rpm",
@@ -782,7 +782,7 @@ var dockerVersions = []packageVersion{
 	{
 		PackageVersion: "18.09.9",
 		Name:           "docker-ce",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7, distros.DistributionAmazonLinux2},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "18.09.9",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-18.09.9-3.el7.x86_64.rpm",
@@ -898,7 +898,7 @@ var dockerVersions = []packageVersion{
 	{
 		PackageVersion: "19.03.4",
 		Name:           "docker-ce",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
+		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7, distros.DistributionAmazonLinux2},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "19.03.4",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-19.03.4-3.el7.x86_64.rpm",

--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -56,17 +56,20 @@ func (b *PackagesBuilder) Build(c *fi.ModelBuilderContext) error {
 		c.AddTask(&nodetasks.Package{Name: "libseccomp"})
 		c.AddTask(&nodetasks.Package{Name: "socat"})
 		c.AddTask(&nodetasks.Package{Name: "util-linux"})
-
-		// Handle RHEL 7 and Amazon Linux 2 differently when installing "extras"
-		if b.Distribution != distros.DistributionRhel7 {
-			c.AddTask(&nodetasks.Package{Name: "container-selinux"})
-			c.AddTask(&nodetasks.Package{Name: "pigz"})
-		} else {
+		// Handle some packages differently for each distro
+		switch b.Distribution {
+		case distros.DistributionRhel7:
+			// Easier to install container-selinux from CentOS than extras
 			c.AddTask(&nodetasks.Package{
 				Name:   "container-selinux",
 				Source: s("http://vault.centos.org/7.6.1810/extras/x86_64/Packages/container-selinux-2.107-1.el7_6.noarch.rpm"),
 				Hash:   s("7de4211fa0dfd240d8827b93763e1eb5f0d56411"),
 			})
+		case distros.DistributionAmazonLinux2:
+			// Amazon Linux 2 doesn't have SELinux enabled by default
+		default:
+			c.AddTask(&nodetasks.Package{Name: "container-selinux"})
+			c.AddTask(&nodetasks.Package{Name: "pigz"})
 		}
 	} else {
 		// Hopefully they are already installed

--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -54,7 +54,7 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 		// Set containerd based on Kubernetes version
 		if fi.StringValue(containerd.Version) == "" {
 			if b.IsKubernetesGTE("1.17") {
-				containerd.Version = fi.String("1.2.10")
+				containerd.Version = fi.String("1.3.2")
 			} else if b.IsKubernetesGTE("1.11") {
 				return fmt.Errorf("containerd version is required")
 			}

--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -502,16 +502,16 @@ func (s *dumpState) getImageInfo(imageID string) (*imageInfo, error) {
 func guessSSHUser(image *ec2.Image) string {
 	owner := aws.StringValue(image.OwnerId)
 	switch owner {
-	case awsup.WellKnownAccountAmazonSystemLinux2:
+	case awsup.WellKnownAccountAmazonLinux2, awsup.WellKnownAccountRedhat:
 		return "ec2-user"
-	case awsup.WellKnownAccountRedhat:
-		return "ec2-user"
-	case awsup.WellKnownAccountCoreOS:
-		return "core"
-	case awsup.WellKnownAccountKopeio:
+	case awsup.WellKnownAccountCentOS:
+		return "centos"
+	case awsup.WellKnownAccountDebian9, awsup.WellKnownAccountDebian10, awsup.WellKnownAccountKopeio:
 		return "admin"
 	case awsup.WellKnownAccountUbuntu:
 		return "ubuntu"
+	case awsup.WellKnownAccountCoreOS, awsup.WellKnownAccountFlatcar:
+		return "core"
 	}
 
 	name := aws.StringValue(image.Name)

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -86,11 +86,15 @@ const TagNameKopsRole = "kubernetes.io/kops/role"
 const TagNameClusterOwnershipPrefix = "kubernetes.io/cluster/"
 
 const (
-	WellKnownAccountKopeio             = "383156758163"
-	WellKnownAccountRedhat             = "309956199498"
-	WellKnownAccountCoreOS             = "595879546273"
-	WellKnownAccountAmazonSystemLinux2 = "137112412989"
-	WellKnownAccountUbuntu             = "099720109477"
+	WellKnownAccountAmazonLinux2 = "137112412989"
+	WellKnownAccountCentOS       = "679593333241"
+	WellKnownAccountCoreOS       = "595879546273"
+	WellKnownAccountDebian9      = "379101102735"
+	WellKnownAccountDebian10     = "136693071363"
+	WellKnownAccountFlatcar      = "075585003325"
+	WellKnownAccountKopeio       = "383156758163"
+	WellKnownAccountRedhat       = "309956199498"
+	WellKnownAccountUbuntu       = "099720109477"
 )
 
 type AWSCloud interface {
@@ -1165,14 +1169,24 @@ func resolveImage(ec2Client ec2iface.EC2API, name string) (*ec2.Image, error) {
 
 			// Check for well known owner aliases
 			switch owner {
-			case "kope.io":
-				owner = WellKnownAccountKopeio
-			case "coreos.com":
+			case "amazon", "amazon.com":
+				owner = WellKnownAccountAmazonLinux2
+			case "centos":
+				owner = WellKnownAccountCentOS
+			case "coreos", "coreos.com":
 				owner = WellKnownAccountCoreOS
-			case "redhat.com":
+			case "debian9":
+				owner = WellKnownAccountDebian9
+			case "debian10":
+				owner = WellKnownAccountDebian10
+			case "flatcar":
+				owner = WellKnownAccountFlatcar
+			case "kopeio", "kope.io":
+				owner = WellKnownAccountKopeio
+			case "redhat", "redhat.com":
 				owner = WellKnownAccountRedhat
-			case "amazon.com":
-				owner = WellKnownAccountAmazonSystemLinux2
+			case "ubuntu":
+				owner = WellKnownAccountUbuntu
 			}
 
 			request.Owners = []*string{&owner}


### PR DESCRIPTION
Amazon Linux 2 support is broken with Docker packages for CentOS, because of the missing `container-selinux` dependency. Even if this is added from the CentOS repo, it is missing its own dependencies. Sadly, this is not something that can be easily fixed.

The good news is that Amazon Linux 2 has SELinux disabled by default, so the `container-selinux` package is not needed. Static binaries for containerd or Docker should run just fine.

#8199 adds support for static binaries for latest containerd and can be used to setup a Kubernetes cluster on Amazon Linux 2 with minor changes.

This PR adds the following changes:
* separates Amazon Linux from CentOS and RHEL to not require installing `container-selinux`
* updates default containerd version to 1.3.2 (noting to worry, this is targeted for 1.18)
* adds simpler aliases for well known accounts