### PR TITLE
Automated cherry pick of #8064: Announce removal of kops/v1alpha1 in kops 1.18

### DIFF
--- a/docs/releases/1.16-NOTES.md
+++ b/docs/releases/1.16-NOTES.md
@@ -39,6 +39,10 @@ the notes prior to the release).
         PodPriority: "true"
   ```
  
+# Deprecations
+
+* The `kops/v1alpha1` API is deprecated and will be removed in kops 1.18. Users of `kops replace` will need to supply v1alpha2 resources.
+
 # Full change list since 1.15.0 release
 
 ## 1.15.0-alpha.1 to 1.16.0-alpha.1


### PR DESCRIPTION
Cherry pick of #8064 on release-1.16.

#8064: Announce removal of kops/v1alpha1 in kops 1.18

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.