### PR TITLE
Fixes regression in e2e tests

### DIFF
--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -63,7 +63,7 @@ func (b *KubeSchedulerBuilder) Build(c *fi.ModelBuilderContext) error {
 	if !b.IsMaster {
 		return nil
 	}
-	useConfigFile := b.IsKubernetesGTE("1.11")
+	useConfigFile := b.IsKubernetesGTE("1.12")
 	{
 		pod, err := b.buildPod(useConfigFile)
 		if err != nil {


### PR DESCRIPTION
As mentioned in https://github.com/kubernetes/kops/pull/8407, this change makes the feature available from kubernetes 1.12 and newer due to incompatibility with 1.11