### PR TITLE
Automated cherry pick of #8016: Alicloud: etcd-manager support

### DIFF
--- a/pkg/model/components/etcdmanager/BUILD.bazel
+++ b/pkg/model/components/etcdmanager/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/urls:go_default_library",
         "//pkg/wellknownports:go_default_library",
         "//upup/pkg/fi:go_default_library",
+        "//upup/pkg/fi/cloudup/aliup:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//upup/pkg/fi/cloudup/do:go_default_library",
         "//upup/pkg/fi/cloudup/gce:go_default_library",

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kops/pkg/model"
 	"k8s.io/kops/pkg/wellknownports"
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/aliup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/do"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
@@ -370,6 +371,16 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster *kops.EtcdClusterSpec) (*v1.Po
 				awsup.TagNameRolePrefix + "master=1",
 			}
 			config.VolumeNameTag = awsup.TagNameEtcdClusterPrefix + etcdCluster.Name
+
+		case kops.CloudProviderALI:
+			config.VolumeProvider = "alicloud"
+
+			config.VolumeTag = []string{
+				fmt.Sprintf("kubernetes.io/cluster/%s=owned", b.Cluster.Name),
+				aliup.TagNameEtcdClusterPrefix + etcdCluster.Name,
+				aliup.TagNameRolePrefix + "master=1",
+			}
+			config.VolumeNameTag = aliup.TagNameEtcdClusterPrefix + etcdCluster.Name
 
 		case kops.CloudProviderGCE:
 			config.VolumeProvider = "gce"

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -308,6 +308,8 @@ func (b *MasterVolumeBuilder) addALIVolume(c *fi.ModelBuilderContext, name strin
 	tags[aliup.TagNameEtcdClusterPrefix+etcd.Name] = m.Name + "/" + strings.Join(allMembers, ",")
 	// This says "only mount on a master"
 	tags[aliup.TagNameRolePrefix+"master"] = "1"
+	// We always add an owned tags (these can't be shared)
+	tags["kubernetes.io/cluster/"+b.Cluster.ObjectMeta.Name] = "owned"
 
 	encrypted := fi.BoolValue(m.EncryptedVolume)
 


### PR DESCRIPTION
Cherry pick of #8016 on release-1.17.

#8016: Alicloud: etcd-manager support

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.