### PR TITLE
Cilium - Add missing Identity Allocation Mode to Operator Template

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -542,9 +542,16 @@ spec:
       containers:
       - args:
         - --debug=$(CILIUM_DEBUG)
+        - --identity-allocation-mode=$(CILIUM_IDENTITY_ALLOCATION_MODE)
         command:
         - cilium-operator
         env:
+        - name: CILIUM_IDENTITY_ALLOCATION_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: identity-allocation-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_K8S_NAMESPACE
           valueFrom:
             fieldRef:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -97,7 +97,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: b36181e5522a41b1726362e138ad87df87839a68
+    manifestHash: 47d2613d2d7380172350417e1cd282ea7cf893c3
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
In the course of debugging [this Cilium Garbage Collection Issue](https://github.com/cilium/cilium/issues/9805) it was noted that the default templates used for the `cilium-operator` `Deployment` were missing the `--identity-allocation-mode` argument.

The default configuration assumes that the Cilium version is > `1.6` with CRD backed identity management and as such the operator deployment should launch with the correct arguments for CRD-backed identity management.