### PR TITLE
Automated cherry pick of #8025: Alicloud: allow use RAM role for OSS client

### DIFF
--- a/util/pkg/vfs/BUILD.bazel
+++ b/util/pkg/vfs/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/s3:go_default_library",
+        "//vendor/github.com/denverdino/aliyungo/metadata:go_default_library",
         "//vendor/github.com/denverdino/aliyungo/oss:go_default_library",
         "//vendor/github.com/go-ini/ini:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud:go_default_library",

--- a/util/pkg/vfs/osscontext.go
+++ b/util/pkg/vfs/osscontext.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/denverdino/aliyungo/metadata"
 	"github.com/denverdino/aliyungo/oss"
 )
 
@@ -29,6 +30,7 @@ type aliyunOSSConfig struct {
 	internal        bool
 	accessKeyId     string
 	accessKeySecret string
+	securityToken   string
 	secure          bool
 }
 
@@ -50,23 +52,46 @@ func NewAliOSSClient() (*oss.Client, error) {
 		return nil, fmt.Errorf("error building aliyun oss client: %v", err)
 	}
 
+	if c.securityToken != "" {
+		return oss.NewOSSClientForAssumeRole(c.region, c.internal, c.accessKeyId, c.accessKeySecret, c.securityToken, c.secure), nil
+	}
+
 	return oss.NewOSSClient(c.region, c.internal, c.accessKeyId, c.accessKeySecret, c.secure), nil
 }
 
 func (c *aliyunOSSConfig) loadConfig() error {
+	meta := metadata.NewMetaData(nil)
+
 	c.region = oss.Region(os.Getenv("OSS_REGION"))
 	if c.region == "" {
-		// TODO: can we use default region?
-		return fmt.Errorf("OSS_REGION cannot be empty")
+		region, err := meta.Region()
+		if err != nil {
+			return fmt.Errorf("can't get region-id from ECS metadata")
+		}
+		c.region = oss.Region(fmt.Sprintf("oss-%s", region))
 	}
+
 	c.accessKeyId = os.Getenv("ALIYUN_ACCESS_KEY_ID")
-	if c.accessKeyId == "" {
-		return fmt.Errorf("ALIYUN_ACCESS_KEY_ID cannot be empty")
+	if c.accessKeyId != "" {
+		c.accessKeySecret = os.Getenv("ALIYUN_ACCESS_KEY_SECRET")
+		if c.accessKeySecret == "" {
+			return fmt.Errorf("ALIYUN_ACCESS_KEY_SECRET cannot be empty")
+		}
+	} else {
+		role, err := meta.RoleName()
+		if err != nil {
+			return fmt.Errorf("Can't find role from ECS metadata: %s", err)
+		}
+
+		roleAuth, err := meta.RamRoleToken(role)
+		if err != nil {
+			return fmt.Errorf("Can't get role token: %s", err)
+		}
+		c.accessKeyId = roleAuth.AccessKeyId
+		c.accessKeySecret = roleAuth.AccessKeySecret
+		c.securityToken = roleAuth.SecurityToken
 	}
-	c.accessKeySecret = os.Getenv("ALIYUN_ACCESS_KEY_SECRET")
-	if c.accessKeySecret == "" {
-		return fmt.Errorf("ALIYUN_ACCESS_KEY_SECRET cannot be empty")
-	}
+
 	ossInternal := os.Getenv("ALIYUN_OSS_INTERNAL")
 	if ossInternal != "" {
 		c.internal = true


### PR DESCRIPTION
Cherry pick of #8025 on release-1.17.

#8025: Alicloud: allow use RAM role for OSS client

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.