### PR TITLE
Automated cherry pick of #8452: Update coredns to 1.6.7

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -167,7 +167,7 @@ spec:
           beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.6
+        image: k8s.gcr.io/coredns:1.6.7
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
@@ -113,7 +113,7 @@ spec:
           beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.6
+        image: k8s.gcr.io/coredns:1.6.7
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -264,7 +264,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 	if kubeDNS.Provider == "CoreDNS" {
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.6.6-kops.1"
+			version := "1.6.7-kops.1"
 
 			{
 				location := key + "/k8s-1.6.yaml"
@@ -283,7 +283,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.6.6-kops.1"
+			version := "1.6.7-kops.1"
 
 			{
 				location := key + "/k8s-1.12.yaml"


### PR DESCRIPTION
Only worry about cherry-picking back this far is the lack of cherry-picking #7794 back this far which means we can't advise anyone potentially affected by the removal of the long deprecated DNS support (https://github.com/coredns/coredns/pull/3554) to override the image as discussed at office hours today.

Cherry pick of #8452 on release-1.15.

#8452: Update coredns to 1.6.7

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.