### PR TITLE
Update godoc.org references to use pkg.go.dev

### DIFF
--- a/README-ES.md
+++ b/README-ES.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/kubernetes/kops.svg?branch=master)](https://travis-ci.org/kubernetes/kops) [![Go Report Card](https://goreportcard.com/badge/k8s.io/kops)](https://goreportcard.com/report/k8s.io/kops)  [![GoDoc Widget]][GoDoc]
 
-[GoDoc]: https://godoc.org/k8s.io/kops
+[GoDoc]: https://pkg.go.dev/k8s.io/kops
 [GoDoc Widget]: https://godoc.org/k8s.io/kops?status.svg
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Build Status](https://travis-ci.org/kubernetes/kops.svg?branch=master)](https://travis-ci.org/kubernetes/kops) [![Go Report Card](https://goreportcard.com/badge/k8s.io/kops)](https://goreportcard.com/report/k8s.io/kops)  [![GoDoc Widget]][GoDoc]
 
-[GoDoc]: https://godoc.org/k8s.io/kops
+[GoDoc]: https://pkg.go.dev/k8s.io/kops
 [GoDoc Widget]: https://godoc.org/k8s.io/kops?status.svg
 
 

--- a/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/clouddns.go
+++ b/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/clouddns.go
@@ -17,7 +17,7 @@ limitations under the License.
 package internal
 
 // Implementation of internal/interfaces/* on top of Google Cloud DNS API.
-// See https://godoc.org/google.golang.org/api/dns/v1 for details
+// See https://pkg.go.dev/google.golang.org/api/dns/v1 for details
 // This facilitates stubbing out Google Cloud DNS for unit testing.
 // Only the parts of the API that we use are included.
 // Others can be added as needed.

--- a/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/interfaces/interfaces.go
+++ b/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/interfaces/interfaces.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Interfaces to directly mirror the Google Cloud DNS API structures.
-// See https://godoc.org/google.golang.org/api/dns/v1 for details
+// See https://pkg.go.dev/google.golang.org/api/dns/v1 for details
 // This facilitates stubbing out Google Cloud DNS for unit testing.
 // Only the parts of the API that we use are included.
 // Others can be added as needed.

--- a/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/clouddns.go
+++ b/dnsprovider/pkg/dnsprovider/providers/google/clouddns/internal/stubs/clouddns.go
@@ -17,7 +17,7 @@ limitations under the License.
 package stubs
 
 // Implementation of internal/interfaces/* on top of Google Cloud DNS API.
-// See https://godoc.org/google.golang.org/api/dns/v1 for details
+// See https://pkg.go.dev/google.golang.org/api/dns/v1 for details
 // This facilitates stubbing out Google Cloud DNS for unit testing.
 // Only the parts of the API that we use are included.
 // Others can be added as needed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,8 +37,8 @@
 ## Advanced / Detailed List of Configurations
 
 ### API / Configuration References
-* [Godocs for Cluster - `ClusterSpec`](https://godoc.org/k8s.io/kops/pkg/apis/kops#ClusterSpec).
-* [Godocs for Instance Group - `InstanceGroupSpec`](https://godoc.org/k8s.io/kops/pkg/apis/kops#InstanceGroupSpec).
+* [Godocs for Cluster - `ClusterSpec`](https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#ClusterSpec).
+* [Godocs for Instance Group - `InstanceGroupSpec`](https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#InstanceGroupSpec).
 
 ### API Usage Guides
 * [`kops` cluster API definitions](cluster_spec.md)

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -1,6 +1,6 @@
 # Description of Keys in `config` and `cluster.spec`
 
-This list is not complete but aims to document any keys that are less than self-explanatory. Our [godoc](https://godoc.org/k8s.io/kops/pkg/apis/kops) reference provides a more detailed list of API values. [ClusterSpec](https://godoc.org/k8s.io/kops/pkg/apis/kops#ClusterSpec), defined as `kind: Cluster` in YAML, and [InstanceGroup](https://godoc.org/k8s.io/kops/pkg/apis/kops#InstanceGroup), defined as `kind: InstanceGroup` in YAML, are the two top-level API values used to describe a cluster.
+This list is not complete but aims to document any keys that are less than self-explanatory. Our [go.dev](https://pkg.go.dev/k8s.io/kops/pkg/apis/kops) reference provides a more detailed list of API values. [ClusterSpec](https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#ClusterSpec), defined as `kind: Cluster` in YAML, and [InstanceGroupSpec](https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#InstanceGroupSpec), defined as `kind: InstanceGroup` in YAML, are the two top-level API values used to describe a cluster.
 
 ## spec
 
@@ -745,7 +745,7 @@ spec:
 
 ### docker
 
-It is possible to override Docker daemon options for all masters and nodes in the cluster. See the [API docs](https://godoc.org/k8s.io/kops/pkg/apis/kops#DockerConfig) for the full list of options.
+It is possible to override Docker daemon options for all masters and nodes in the cluster. See the [API docs](https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#DockerConfig) for the full list of options.
 
 #### registryMirrors
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # kops - Kubernetes Operations
 
-[GoDoc]: https://godoc.org/k8s.io/kops
+[GoDoc]: https://pkg.go.dev/k8s.io/kops
 [GoDoc Widget]: https://godoc.org/k8s.io/kops?status.svg
 
 The easiest way to get a production grade Kubernetes cluster up and running.

--- a/docs/manifests_and_customizing_via_api.md
+++ b/docs/manifests_and_customizing_via_api.md
@@ -19,7 +19,7 @@ This document also applies to using the `kops` API to customize a Kubernetes clu
 
 Because of the above statement `kops` includes an API which provides a feature for users to utilize YAML or JSON manifests for managing their `kops` created Kubernetes installations. In the same way that you can use a YAML manifest to deploy a Job, you can deploy and manage a `kops` Kubernetes instance with a manifest. All of these values are also usable via the interactive editor with `kops edit`.
 
-> You can see all the options that are currently supported in Kops [here](https://github.com/kubernetes/kops/blob/master/pkg/apis/kops/componentconfig.go) or [more prettily here](https://godoc.org/k8s.io/kops/pkg/apis/kops#ClusterSpec)
+> You can see all the options that are currently supported in Kops [here](https://github.com/kubernetes/kops/blob/master/pkg/apis/kops/componentconfig.go) or [more prettily here](https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#ClusterSpec)
 
 The following is a list of the benefits of using a file to manage instances.
 
@@ -298,7 +298,7 @@ spec:
   api:
 ```
 
-Full documentation is accessible via [godoc](https://godoc.org/k8s.io/kops/pkg/apis/kops#ClusterSpec).
+Full documentation is accessible via [godoc](https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#ClusterSpec).
 
 The `ClusterSpec` allows a user to set configurations for such values as Docker log driver, Kubernetes API server log level, VPC for reusing a VPC (`NetworkID`), and the Kubernetes version.
 
@@ -330,7 +330,7 @@ metadata:
 spec:
 ```
 
-Full documentation is accessible via [godocs](https://godoc.org/k8s.io/kops/pkg/apis/kops#InstanceGroupSpec).
+Full documentation is accessible via [godocs](https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#InstanceGroupSpec).
 
 Instance Groups map to Auto Scaling Groups in AWS, and Instance Groups in GCE. They are an API level description of a group of compute instances used as Masters or Nodes.
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -162,7 +162,7 @@ The swift store can be configured by providing your OpenStack credentials and co
 - `OS_APPLICATION_CREDENTIAL_NAME`: application credential name
 - `OS_APPLICATION_CREDENTIAL_SECRET`: application secret
 
-The mechanism used to retrieve the credentials is derived from the [gophercloud OpenStack SDK](https://godoc.org/github.com/gophercloud/gophercloud).
+The mechanism used to retrieve the credentials is derived from the [gophercloud OpenStack SDK](https://pkg.go.dev/github.com/gophercloud/gophercloud).
 
 A credentials file with `OPENSTACK_CREDENTIAL_FILE` or a config derived from your personal credentials living in `$HOME/.openstack/config` can also be used to configure your store.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,8 +64,8 @@ nav:
     - Cluster Spec: "cluster_spec.md"
     - Instance Group API: "instance_groups.md"
     - Using Manifests and Customizing: "manifests_and_customizing_via_api.md"
-    - Godocs for Cluster - ClusterSpec: "https://godoc.org/k8s.io/kops/pkg/apis/kops#ClusterSpec"
-    - Godocs for Instance Group - InstanceGroupSpec: "https://godoc.org/k8s.io/kops/pkg/apis/kops#InstanceGroupSpec"
+    - Godocs for Cluster - ClusterSpec: "https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#ClusterSpec"
+    - Godocs for Instance Group - InstanceGroupSpec: "https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#InstanceGroupSpec"
 
   - Operations:
     - Updates & Upgrades: "operations/updates_and_upgrades.md"

--- a/nodeup/pkg/model/kube_proxy_test.go
+++ b/nodeup/pkg/model/kube_proxy_test.go
@@ -33,8 +33,8 @@ import (
 
 func TestKubeProxyBuilder_buildPod(t *testing.T) {
 	// kube proxy spec can be found here.
-	// https://godoc.org/k8s.io/kops/pkg/apis/kops#ClusterSpec
-	// https://godoc.org/k8s.io/kops/pkg/apis/kops#KubeProxyConfig
+	// https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#ClusterSpec
+	// https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#KubeProxyConfig
 
 	var cluster = &kops.Cluster{}
 	cluster.Spec.MasterInternalName = "dev-cluster"


### PR DESCRIPTION
[pkg.go.dev will soon replace godoc.org](https://blog.golang.org/pkg.go.dev-2020). The main advantage of pkg.go.dev is that it is module-aware and version-aware, so one can view documentation for previous kops versions.

The only remaining references to godoc.org are these status widgets, which I dont believe are yet supported on pkg.go.dev:
```
grep -r godoc.org . | grep -v vendor
./docs/index.md:[GoDoc Widget]: https://godoc.org/k8s.io/kops?status.svg
./README.md:[GoDoc Widget]: https://godoc.org/k8s.io/kops?status.svg
./README-ES.md:[GoDoc Widget]: https://godoc.org/k8s.io/kops?status.svg
``` 

/area documentation

fixes #8371