### PR TITLE
Use BindMount task for /home/kubernetes/bin

### DIFF
--- a/nodeup/pkg/model/directories.go
+++ b/nodeup/pkg/model/directories.go
@@ -40,11 +40,12 @@ func (b *DirectoryBuilder) Build(c *fi.ModelBuilderContext) error {
 			Path: dirname,
 			Type: nodetasks.FileType_Directory,
 			Mode: s("0755"),
+		})
 
-			OnChangeExecute: [][]string{
-				{"/bin/mount", "--bind", dirname, dirname},
-				{"/bin/mount", "-o", "remount,exec", dirname},
-			},
+		c.AddTask(&nodetasks.BindMount{
+			Source:     dirname,
+			Mountpoint: dirname,
+			Options:    []string{"exec"},
 		})
 	}
 


### PR DESCRIPTION
Without this, a reboot on COS does not remount /home/kubernetes/bin with exec permission.