### PR TITLE
Update tags support for LaunchTemplates

### DIFF
--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -208,6 +208,10 @@ func (m *KopsModelContext) CloudTagsForInstanceGroup(ig *kops.InstanceGroup) (ma
 		}
 	}
 
+	// Add cluster and ig names
+	labels[awsup.TagClusterName] = m.ClusterName()
+	labels["Name"] = m.AutoscalingGroupName(ig)
+
 	// The system tags take priority because the cluster likely breaks without them...
 
 	if ig.Spec.Role == kops.InstanceGroupRoleMaster {

--- a/pkg/model/spotinstmodel/BUILD.bazel
+++ b/pkg/model/spotinstmodel/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//pkg/model/defaults:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awstasks:go_default_library",
-        "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//upup/pkg/fi/cloudup/spotinsttasks:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/pkg/model/spotinstmodel/instance_group.go
+++ b/pkg/model/spotinstmodel/instance_group.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/kops/pkg/model/defaults"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
-	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/spotinsttasks"
 )
 
@@ -605,8 +604,6 @@ func (b *InstanceGroupModelBuilder) buildTags(ig *kops.InstanceGroup) (map[strin
 	if err != nil {
 		return nil, err
 	}
-	tags[awsup.TagClusterName] = b.ClusterName()
-	tags["Name"] = b.AutoscalingGroupName(ig)
 	return tags, nil
 }
 


### PR DESCRIPTION
Launch Templates are the recommended way of creating an ASG in AWS and allows specifying various options that are not possible with Launch Configurations.
https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchTemplates.html

This is a followup of #8462 with the following improvements:
* adds remaining cloud tags
* checks for changes before applying new tags

This is a bit more complicated as it has to account Launch Configurations, Mixed Instance Policies and Launch Templates at same time.
A lot of testing is also required to avoid breaking existing features.

@johngmyers as I said during office hours, I am looking into this for some time. If you plan to do any other changes in this area, we should sync so that we don't duplicate the effort.