### PR TITLE
Upgrade CUDA from 9.1 to 10.0

### DIFF
--- a/hooks/nvidia-device-plugin/Makefile
+++ b/hooks/nvidia-device-plugin/Makefile
@@ -19,10 +19,10 @@ all: image
 .PHONY: image push
 
 image:  ## Build the image
-	docker build -t dcwangmit01/nvidia-device-plugin:0.1.0 -f image/Dockerfile image/
+	docker build --network host -t fifarzh/nvidia-device-plugin:0.2.0-cuda10.0 -f image/Dockerfile image/
 
 push:   ## Push the image
-	docker push dcwangmit01/nvidia-device-plugin:0.1.0
+	docker push fifarzh/nvidia-device-plugin:0.2.0-cuda10.0
 
 help:   ## Print list of Makefile targets
 	@# Taken from https://github.com/spf13/hugo/blob/master/Makefile

--- a/hooks/nvidia-device-plugin/Makefile
+++ b/hooks/nvidia-device-plugin/Makefile
@@ -16,13 +16,18 @@
 
 all: image
 
-.PHONY: image push
+.PHONY: image push check-docker-registry
 
-image:  ## Build the image
-	docker build --network host -t fifarzh/nvidia-device-plugin:0.2.0-cuda10.0 -f image/Dockerfile image/
+check-docker-registry:
+ifndef DOCKER_REGISTRY
+	$(error DOCKER_REGISTRY is undefined)
+endif
 
-push:   ## Push the image
-	docker push fifarzh/nvidia-device-plugin:0.2.0-cuda10.0
+image: check-docker-registry  ## Build the image
+	docker build --network host -t $(DOCKER_REGISTRY)/nvidia-device-plugin:0.2.0-cuda10.0 -f image/Dockerfile image/
+
+push: check-docker-registry   ## Push the image
+	docker push $(DOCKER_REGISTRY)/nvidia-device-plugin:0.2.0-cuda10.0
 
 help:   ## Print list of Makefile targets
 	@# Taken from https://github.com/spf13/hugo/blob/master/Makefile

--- a/hooks/nvidia-device-plugin/README.md
+++ b/hooks/nvidia-device-plugin/README.md
@@ -8,13 +8,13 @@ types](https://aws.amazon.com/ec2/instance-types/).
 
 It installs the following from web sources.
 
-1. [Nvidia Device Drivers](http://www.nvidia.com/Download/index.aspx)
-2. [Cuda Libraries v9.1](https://developer.nvidia.com/cuda-downloads)
+1. [NVIDIA Device Drivers](http://www.nvidia.com/Download/index.aspx)
+2. [CUDA Libraries](https://developer.nvidia.com/cuda-downloads)
 3. [nvidia-docker](https://github.com/NVIDIA/nvidia-docker)
 4. [docker-ce](https://www.docker.com/community-edition)
 
-Using this hook indicates that you agree to the Nvidia
-[licenses](http://www.nvidia.com/content/DriverDownload-March2009/licence.php?lang=us).
+Using this hook indicates that you agree to the NVIDIA
+[license](http://www.nvidia.com/content/DriverDownload-March2009/licence.php?lang=us).
 
 ## How it works
 
@@ -23,7 +23,7 @@ Using this hook indicates that you agree to the Nvidia
   `nvidia-device-plugin.service` along with setup scripts.
 * The systemd unit `nvidia-device-plugin.service` runs and executes the setup
   scripts in the host directory `/nvidia-device-plugin`.
-* The scripts install the Nvidia device drivers, Cuda libs, Nvidia docker along
+* The scripts install the NVIDIA device drivers, CUDA libs, nvidia-docker along
   with the matching version of docker-ce.
 * The scheduling of work in a separate systemd unit outside of this kops hook
   is required because it is not possible to upgrade docker-ce on the host from
@@ -34,9 +34,9 @@ Using this hook indicates that you agree to the Nvidia
 Although this hook *may* work among many combinatorial versions of software and
 images, it has only been tested with the following:
 
-* kops: **1.9**
-* kubernetes: 1.10, **1.11**
-* OS Image: **`kope.io/k8s-1.10-debian-stretch-amd64-hvm-ebs-2018-05-27`**
+* kops: **1.9**, **1.15.0**
+* kubernetes: 1.10, **1.11**, **1.15.5**
+* OS Image: **`kope.io/k8s-1.10-debian-stretch-amd64-hvm-ebs-2018-05-27`**, **`kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17`**
   * This is most certainly not the default image for kops.  The OS image must
     be explicitly overridden in the cluster or instancegroup spec.
   * Debian stretch is needed because `nvidia-docker` requires a newer version
@@ -56,6 +56,7 @@ This kops hook was developed against the following version combinations.
 
 | Kops Version  | Kubernetes Version | GPU Mode     | OS Image |
 | ------------- | ------------------ | ------------ | -------- |
+| 1.15.0        | 1.15.5             | deviceplugin | kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
 | 1.10-beta.1   | 1.10               | deviceplugin | kope.io/k8s-1.10-debian-stretch-amd64-hvm-ebs-2018-05-27
 | 1.9.1         | 1.11               | deviceplugin | kope.io/k8s-1.10-debian-stretch-amd64-hvm-ebs-2018-05-27
 | 1.9.1         | 1.10               | legacy       | kope.io/k8s-1.10-debian-stretch-amd64-hvm-ebs-2018-05-27
@@ -65,18 +66,19 @@ This kops hook was developed against the following version combinations.
 ### Create a Cluster with GPU Nodes
 
 ```bash
-kops create cluster gpu.example.com \
+kops create cluster \
+  --name gpu.example.k8s.local \
   --zones us-east-1c \
   --node-size p2.xlarge \
   --node-count 1 \
-  --image kope.io/k8s-1.10-debian-stretch-amd64-hvm-ebs-2018-05-27 \
-  --kubernetes-version 1.11.0
+  --image kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17 \
+  --kubernetes-version 1.15.5
 ```
 
 ### Enable the Kops Installation Hook and DevicePlugins
 
 This should be safe to do for all machines, because the hook auto-detects if
-the machine is an AWS GPU instancetype and will NO-OP otherwise.  Choose
+the machine is an AWS GPU instancetype and will NO-OP otherwise. Choose
 between the DevicePlugin GPU Mode or Legacy Accelerators GPU Mode.
 
 #### (Preferred) DevicePlugin GPU Mode
@@ -90,7 +92,14 @@ For Kubernetes >= 1.11.0 or clusters supporting DevicePlugins
 
 ```yaml
 # > kops edit instancegroup nodes
+# CUDA 10.0
+spec:
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
+  hooks:
+  - execContainer:
+      image: fifarzh/nvidia-device-plugin:0.2.0-cuda10.0
 
+# CUDA 9.1
 spec:
   image: kope.io/k8s-1.10-debian-stretch-amd64-hvm-ebs-2018-05-27
   hooks:
@@ -134,22 +143,18 @@ spec:
 ### Update the cluster
 
 ```bash
-kops update cluster gpu.example.com --yes
-kops rolling-update cluster gpu.example.com --yes
+kops update cluster gpu.example.k8s.local --yes
+kops rolling-update cluster gpu.example.k8s.local --yes
 ```
 
-### Deploy the Daemonset for the Nvidia DevicePlugin
+### Deploy the Daemonset for the NVIDIA DevicePlugin
 
 Only for DevicePlugin GPU Mode, load the deviceplugin daemonset for your
-specific environment.  This is not required for the Legacy Accelerators GPU
+specific environment. This is not required for the Legacy Accelerators GPU
 Mode.
 
 ```bash
-# For kubernetes 1.10
-kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v1.10/nvidia-device-plugin.yml
-
-# For kubernetes 1.11
-kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v1.11/nvidia-device-plugin.yml
+kubectl apply -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/master/nvidia-device-plugin.yml
 
 # (Optional) Set permissive toleration to allow daemonset to run anywhere.
 #   By default this is permissive in case you have tainted your GPU nodes.
@@ -162,6 +167,26 @@ kubectl patch daemonset nvidia-device-plugin-daemonset --namespace kube-system \
 #### Deploy a Test Pod
 
 ```bash
+# CUDA 10.0
+cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tf-gpu
+spec:
+  containers:
+  - name: gpu
+    image: tensorflow/tensorflow:2.0.1-gpu
+    command: [ "/bin/bash", "-ce", "tail -f /dev/null" ]
+    # ^ From 2.0.0 onwards, CMD is not set
+    imagePullPolicy: IfNotPresent
+    resources:
+      limits:
+        memory: 1024Mi
+        nvidia.com/gpu: 1 # requesting 1 GPU
+EOF
+
+# CUDA 9.1
 cat << EOF | kubectl create -f -
 apiVersion: v1
 kind: Pod
@@ -198,10 +223,10 @@ EOF
 
 ```bash
 # Check that nodes are detected to have GPUs
-kubectl describe nodes|grep -E 'gpu:\s.*[1-9]'
+kubectl describe nodes | grep -E 'gpu:\s.*[1-9]'
 
 # Check the logs of the Tensorflow Container to ensure that it ran
-kubectl logs tf-gpu
+kubectl logs tf-gpu # no output since 2.0.0
 
 # Show GPU info from within the pod
 #   Only works in DevicePlugin mode
@@ -211,4 +236,12 @@ kubectl exec -it tf-gpu nvidia-smi
 #   Only works in DevicePlugin mode
 kubectl exec -it tf-gpu -- \
   python -c 'from tensorflow.python.client import device_lib; print(device_lib.list_local_devices())'
+```
+
+### Teardown the Test Cluster
+
+```yaml
+kubectl delete pod/tf-gpu
+kubectl delete -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/master/nvidia-device-plugin.yml
+kops delete cluster --name gpu.example.k8s.local --yes
 ```

--- a/hooks/nvidia-device-plugin/README.md
+++ b/hooks/nvidia-device-plugin/README.md
@@ -97,7 +97,7 @@ spec:
   image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
   hooks:
   - execContainer:
-      image: fifarzh/nvidia-device-plugin:0.2.0-cuda10.0
+      image: DOCKER_REGISTRY/nvidia-device-plugin:0.2.0-cuda10.0 # Replace DOCKER_REGISTRY with the registry used to host the image
 
 # CUDA 9.1
 spec:
@@ -154,7 +154,7 @@ specific environment. This is not required for the Legacy Accelerators GPU
 Mode.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/master/nvidia-device-plugin.yml
+kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/1.0.0-beta5/nvidia-device-plugin.yml
 
 # (Optional) Set permissive toleration to allow daemonset to run anywhere.
 #   By default this is permissive in case you have tainted your GPU nodes.
@@ -242,6 +242,6 @@ kubectl exec -it tf-gpu -- \
 
 ```yaml
 kubectl delete pod/tf-gpu
-kubectl delete -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/master/nvidia-device-plugin.yml
+kubectl delete -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/1.0.0-beta5/nvidia-device-plugin.yml
 kops delete cluster --name gpu.example.k8s.local --yes
 ```

--- a/hooks/nvidia-device-plugin/README.md
+++ b/hooks/nvidia-device-plugin/README.md
@@ -61,6 +61,11 @@ This kops hook was developed against the following version combinations.
 | 1.9.1         | 1.11               | deviceplugin | kope.io/k8s-1.10-debian-stretch-amd64-hvm-ebs-2018-05-27
 | 1.9.1         | 1.10               | legacy       | kope.io/k8s-1.10-debian-stretch-amd64-hvm-ebs-2018-05-27
 
+### About the Docker Image
+
+- For CUDA 10.0, run `DOCKER_REGISTRY= make image push` with the desired registry to self-host the docker image.
+- For CUDA 9.1, the image is already hosted according to the InstanceGroup spec example but can be mirrored elsewhere.
+
 ## Using this DevicePlugin
 
 ### Create a Cluster with GPU Nodes

--- a/hooks/nvidia-device-plugin/image/files/01-aws-nvidia-driver.sh
+++ b/hooks/nvidia-device-plugin/image/files/01-aws-nvidia-driver.sh
@@ -36,13 +36,13 @@ CACHE_DIR=/nvidia-device-plugin
 # http://www.nvidia.com/Download/index.aspx
 declare -A class_to_driver_file
 class_to_driver_file=( \
-    ["g2"]="http://us.download.nvidia.com/XFree86/Linux-x86_64/440.82/NVIDIA-Linux-x86_64-440.82.run" \
-    ["g3"]="http://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
-    ["g3s"]="http://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
-    ["g4dn"]="http://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
-    ["p2"]="http://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
-    ["p3"]="http://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
-    ["p3dn"]="http://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
+    ["g2"]="https://us.download.nvidia.com/XFree86/Linux-x86_64/440.82/NVIDIA-Linux-x86_64-440.82.run" \
+    ["g3"]="https://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
+    ["g3s"]="https://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
+    ["g4dn"]="https://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
+    ["p2"]="https://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
+    ["p3"]="https://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
+    ["p3dn"]="https://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
 )
 declare -A class_to_driver_checksum
 class_to_driver_checksum=( \

--- a/hooks/nvidia-device-plugin/image/files/01-aws-nvidia-driver.sh
+++ b/hooks/nvidia-device-plugin/image/files/01-aws-nvidia-driver.sh
@@ -29,24 +29,30 @@ CACHE_DIR=/nvidia-device-plugin
 #   G2         GRID          GRID Series     GRID K520 (deprecated)
 #   G3         Tesla         M-Series        M-60
 #   G3S        Tesla         M-Series        M-60
+#   G4DN       Tesla         T-Series        T4
 #   P2         Tesla         K-Series        K-80
 #   P3         Tesla         V-Series        V100
+#   P3DN       Tesla         V-Series        V100
 # http://www.nvidia.com/Download/index.aspx
 declare -A class_to_driver_file
 class_to_driver_file=( \
-    ["g2"]="http://us.download.nvidia.com/XFree86/Linux-x86_64/367.124/NVIDIA-Linux-x86_64-367.124.run" \
-    ["g3"]="http://us.download.nvidia.com/tesla/390.46/NVIDIA-Linux-x86_64-390.46.run" \
-    ["g3s"]="http://us.download.nvidia.com/tesla/390.46/NVIDIA-Linux-x86_64-390.46.run" \
-    ["p2"]="http://us.download.nvidia.com/tesla/390.46/NVIDIA-Linux-x86_64-390.46.run" \
-    ["p3"]="http://us.download.nvidia.com/tesla/390.46/NVIDIA-Linux-x86_64-390.46.run" \
+    ["g2"]="http://us.download.nvidia.com/XFree86/Linux-x86_64/440.82/NVIDIA-Linux-x86_64-440.82.run" \
+    ["g3"]="http://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
+    ["g3s"]="http://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
+    ["g4dn"]="http://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
+    ["p2"]="http://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
+    ["p3"]="http://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
+    ["p3dn"]="http://us.download.nvidia.com/tesla/410.129/NVIDIA-Linux-x86_64-410.129-diagnostic.run" \
 )
 declare -A class_to_driver_checksum
 class_to_driver_checksum=( \
-    ["g2"]="77f37939efeea4b6505842bed50445971992e303" \
-    ["g3"]="57569ecb6f6d839ecc77fa10a2c573cc069990cc" \
-    ["g3s"]="57569ecb6f6d839ecc77fa10a2c573cc069990cc" \
-    ["p2"]="57569ecb6f6d839ecc77fa10a2c573cc069990cc" \
-    ["p3"]="57569ecb6f6d839ecc77fa10a2c573cc069990cc" \
+    ["g2"]="1552d4cc8b3c7317b80e96268fbf685224022021" \
+    ["g3"]="e5d234cc8acb35f425f60e1923e07e7e50272d9c" \
+    ["g3s"]="e5d234cc8acb35f425f60e1923e07e7e50272d9c" \
+    ["g4dn"]="e5d234cc8acb35f425f60e1923e07e7e50272d9c" \
+    ["p2"]="e5d234cc8acb35f425f60e1923e07e7e50272d9c" \
+    ["p3"]="e5d234cc8acb35f425f60e1923e07e7e50272d9c" \
+    ["p3dn"]="e5d234cc8acb35f425f60e1923e07e7e50272d9c" \
 )
 
 # CUDA Files that need to be installed ~1.4GB
@@ -55,16 +61,12 @@ class_to_driver_checksum=( \
 #   Order in the arrays below matters
 # https://developer.nvidia.com/cuda-downloads
 cuda_files=( \
-  "https://developer.nvidia.com/compute/cuda/9.1/Prod/local_installers/cuda_9.1.85_387.26_linux" \
-  "https://developer.nvidia.com/compute/cuda/9.1/Prod/patches/1/cuda_9.1.85.1_linux" \
-  "https://developer.nvidia.com/compute/cuda/9.1/Prod/patches/2/cuda_9.1.85.2_linux" \
-  "https://developer.nvidia.com/compute/cuda/9.1/Prod/patches/3/cuda_9.1.85.3_linux" \
+  "https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/cuda_10.0.130_410.48_linux" \
+  "http://developer.download.nvidia.com/compute/cuda/10.0/Prod/patches/1/cuda_10.0.130.1_linux.run" \
 )
 cuda_files_checksums=( \
-  "1540658f4fe657dddd8b0899555b7468727d4aa8" \
-  "7ec6970ecd81163b0d02ef30d35599e7fd6e97d8" \
-  "cfa3b029b58fc117d8ce510a70efc848924dd565" \
-  "6269a2c5784b08997edb97ea0020fb4e6c8769ed" \
+  "009cb0b6d3a81a97eb529e2301ff613e23c6edd3" \
+  "659814268e2712942c58fcc415168c9a23190d4f" \
 )
 
 containsElement () { for e in "${@:2}"; do [[ "$e" = "$1" ]] && return 0; done; return 1; }

--- a/hooks/nvidia-device-plugin/image/files/01-aws-nvidia-driver.sh
+++ b/hooks/nvidia-device-plugin/image/files/01-aws-nvidia-driver.sh
@@ -55,14 +55,14 @@ class_to_driver_checksum=( \
     ["p3dn"]="e5d234cc8acb35f425f60e1923e07e7e50272d9c" \
 )
 
-# CUDA Files that need to be installed ~1.4GB
+# CUDA Files that need to be installed ~1.9GB
 #   First one is main installation
 #   Subsequent files are patches which need to be applied in order
 #   Order in the arrays below matters
 # https://developer.nvidia.com/cuda-downloads
 cuda_files=( \
   "https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/cuda_10.0.130_410.48_linux" \
-  "http://developer.download.nvidia.com/compute/cuda/10.0/Prod/patches/1/cuda_10.0.130.1_linux.run" \
+  "https://developer.download.nvidia.com/compute/cuda/10.0/Prod/patches/1/cuda_10.0.130.1_linux.run" \
 )
 cuda_files_checksums=( \
   "009cb0b6d3a81a97eb529e2301ff613e23c6edd3" \

--- a/hooks/nvidia-device-plugin/image/files/02-nvidia-docker.sh
+++ b/hooks/nvidia-device-plugin/image/files/02-nvidia-docker.sh
@@ -87,3 +87,5 @@ systemctl mask kops-configuration.service
 
 # Restore protokube and protokube will bring up kubelet
 systemctl start protokube
+# Seems protokube won't bring up kubelet, so start kubelet separately
+systemctl start kubelet


### PR DESCRIPTION
Recent deep learning frameworks like TensorFlow and PyTorch require at least CUDA 10.0.

TensorFlow: https://www.tensorflow.org/install/gpu#software_requirements
PyTorch: https://pytorch.org/get-started/locally/