### PR TITLE
Automated cherry pick of #8484: Update cilium to 1.6.6

### DIFF
--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -169,7 +169,7 @@ type AmazonVPCNetworkingSpec struct {
 	ImageName string `json:"imageName,omitempty"`
 }
 
-const CiliumDefaultVersion = "v1.6.4"
+const CiliumDefaultVersion = "v1.6.6"
 
 // CiliumNetworkingSpec declares that we want Cilium networking
 type CiliumNetworkingSpec struct {

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -115,7 +115,7 @@ spec:
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0 <1.12.0'
     manifest: networking.cilium.io/k8s-1.7.yaml
-    manifestHash: 2d40b9ab7453b4a0a413196fae4c8bdcd62c69ce
+    manifestHash: 6928e95ec4b8359075e3dfb069f74e290e2e6eb2
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
@@ -123,7 +123,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: 47d2613d2d7380172350417e1cd282ea7cf893c3
+    manifestHash: 84295d293c8a461f7d510721c48b969cd1d99e54
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
Cherry pick of #8484 on release-1.17.

#8484: Update cilium to 1.6.6

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.