### PR TITLE
Automated cherry pick of #8445: Cilium - Add missing Identity Allocation Mode to Operator

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -537,9 +537,16 @@ spec:
       containers:
       - args:
         - --debug=$(CILIUM_DEBUG)
+        - --identity-allocation-mode=$(CILIUM_IDENTITY_ALLOCATION_MODE)
         command:
         - cilium-operator
         env:
+        - name: CILIUM_IDENTITY_ALLOCATION_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: identity-allocation-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_K8S_NAMESPACE
           valueFrom:
             fieldRef:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -115,7 +115,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: 2d40b9ab7453b4a0a413196fae4c8bdcd62c69ce
+    manifestHash: 21275a967e302c5030ec0392d363453f904ea845
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
Cherry pick of #8445 on release-1.15.

#8445: Cilium - Add missing Identity Allocation Mode to Operator

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.