### PR TITLE
Automated cherry pick of #8467: Stop logging to /var/log/kops-controller.log

### DIFF
--- a/hack/.packages
+++ b/hack/.packages
@@ -143,6 +143,7 @@ k8s.io/kops/pkg/util/templater
 k8s.io/kops/pkg/validation
 k8s.io/kops/pkg/values
 k8s.io/kops/pkg/wellknownports
+k8s.io/kops/pkg/wellknownusers
 k8s.io/kops/protokube/cmd/protokube
 k8s.io/kops/protokube/pkg/etcd
 k8s.io/kops/protokube/pkg/gossip

--- a/nodeup/pkg/model/BUILD.bazel
+++ b/nodeup/pkg/model/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
         "//pkg/systemd:go_default_library",
         "//pkg/tokens:go_default_library",
         "//pkg/try:go_default_library",
+        "//pkg/wellknownusers:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//upup/pkg/fi/nodeup/nodetasks:go_default_library",

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kops/pkg/k8scodecs"
 	"k8s.io/kops/pkg/kubeconfig"
 	"k8s.io/kops/pkg/kubemanifest"
+	"k8s.io/kops/pkg/wellknownusers"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 	"k8s.io/kops/util/pkg/exec"
@@ -218,7 +219,7 @@ func (b *KubeAPIServerBuilder) writeAuthenticationConfig(c *fi.ModelBuilderConte
 		{
 			c.AddTask(&nodetasks.UserTask{
 				Name:  "aws-iam-authenticator",
-				UID:   10000,
+				UID:   wellknownusers.AWSAuthenticator,
 				Shell: "/sbin/nologin",
 				Home:  "/srv/kubernetes/aws-iam-authenticator",
 			})

--- a/pkg/wellknownusers/BUILD.bazel
+++ b/pkg/wellknownusers/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["wellknownusers.go"],
+    importpath = "k8s.io/kops/pkg/wellknownusers",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/wellknownusers/wellknownusers.go
+++ b/pkg/wellknownusers/wellknownusers.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wellknownusers
+
+// We define some user ids that we use for non-root containers.
+// We base at 10000 because some distros (COS) have pre-defined users around 1000
+
+const (
+	// Generic is the user id we use for non-privileged containers, where we don't need extra permissions
+	// Used by e.g. dns-controller, kops-controller
+	Generic = 10001
+
+	// AWSAuthenticator is the user-id for the aws-iam-authenticator (built externally)
+	AWSAuthenticator = 10000
+)


### PR DESCRIPTION
Cherry pick of #8467 on release-1.17.

#8467: Stop logging to /var/log/kops-controller.log

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.