### PR TITLE
GCS: Log ACLs if we're writing them

### DIFF
--- a/util/pkg/vfs/gsfs.go
+++ b/util/pkg/vfs/gsfs.go
@@ -60,6 +60,15 @@ type GSAcl struct {
 	Acl []*storage.ObjectAccessControl
 }
 
+func (a *GSAcl) String() string {
+	var s []string
+	for _, acl := range a.Acl {
+		s = append(s, fmt.Sprintf("%+v", acl))
+	}
+
+	return "{" + strings.Join(s, ", ") + "}"
+}
+
 var _ ACL = &GSAcl{}
 
 // gcsWriteBackoff is the backoff strategy for GCS write retries
@@ -154,6 +163,9 @@ func (p *GSPath) WriteFile(data io.ReadSeeker, acl ACL) error {
 				return true, fmt.Errorf("write to %s with ACL of unexpected type %T", p, acl)
 			}
 			obj.Acl = gsACL.Acl
+			klog.V(4).Infof("Writing file %q with ACL %v", p, gsACL)
+		} else {
+			klog.V(4).Infof("Writing file %q", p)
 		}
 
 		if _, err := data.Seek(0, 0); err != nil {


### PR DESCRIPTION
We log at V(4) because they are fairly verbose.