### PR TITLE
Revert "Merge pull request #8458 from gjtempleton/automated-cherry-pi…

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -168,7 +168,7 @@ spec:
           beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}k8s.gcr.io/coredns:1.6.7{{ end }}
+        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}k8s.gcr.io/coredns:1.6.6{{ end }}
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
@@ -113,7 +113,7 @@ spec:
           beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}k8s.gcr.io/coredns:1.6.7{{ end }}
+        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}k8s.gcr.io/coredns:1.6.6{{ end }}
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -285,7 +285,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 	if kubeDNS.Provider == "CoreDNS" {
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.6.7-kops.1"
+			version := "1.6.6-kops.1"
 
 			{
 				location := key + "/k8s-1.6.yaml"
@@ -304,7 +304,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.6.7-kops.1"
+			version := "1.6.6-kops.2"
 
 			{
 				location := key + "/k8s-1.12.yaml"


### PR DESCRIPTION
…ck-of-#8452-upstream-release-1.16"

This reverts commit 8760305836762ad55e5fa3a1417f258f89e0ba6d, reversing
changes made to 373955e90787d9e001f28f4de4304b1952cf2a64.

Due to unavailability of the new image `k8s.gcr.io/coredns:1.6.7`.

See https://kubernetes.slack.com/archives/C8MKE2G5P/p1581018949102500 for further discussion.