### PR TITLE
Image Pushing - Remove .git dependency from get_workspace_status.sh

### DIFF
--- a/tools/get_workspace_status.sh
+++ b/tools/get_workspace_status.sh
@@ -25,15 +25,11 @@
 # and the output will be discarded.
 
 # The code below presents an implementation that works for git repository
-git_rev=$(git rev-parse HEAD)
-if [[ $? != 0 ]];
-then
-    exit 1
-fi
+git_rev=$(git rev-parse HEAD 2>/dev/null)
 echo "BUILD_SCM_REVISION ${git_rev}"
 
 # Check whether there are any uncommited changes
-git diff-index --quiet HEAD --
+git diff-index --quiet HEAD -- 2>/dev/null
 if [[ $? == 0 ]];
 then
     tree_status="Clean"
@@ -43,7 +39,7 @@ fi
 echo "BUILD_SCM_STATUS ${tree_status}"
 
 # Compute KOPS_VERSION.  Keep in sync with logic in Makefile
-GITSHA=$(git describe --always)
+GITSHA=$(git describe --always 2>/dev/null)
 
 # These variables need to match the values in our Makefile
 # When we cut a new release we need to increment these accordingly


### PR DESCRIPTION
The [image pushing postsubmit job](https://testgrid.k8s.io/sig-cluster-lifecycle-kops#kops-postsubmit-push-to-staging) is one step closer to succeeding! It recognizes the cloudbuild.yaml file in the repo root and is able to call `make kops-controller-push`

It currently fails because when the builder image uploads the kops directory to GCS for to be consumed by GCB, it [excludes the .git directory](https://github.com/kubernetes/test-infra/blob/18391d89866518581e4b6de2546e16ba2b08a3be/images/builder/main.go#L87).

This causes the job to fail because `make kops-controller-push` [uses bazel which runs get_workspace_status.sh](https://github.com/kubernetes/kops/blob/b1276ac8353279c2d1de7beea4e6ec3713d83f6c/tools/bazel.rc#L10) which aborts if the git commands fail.

The prow job doesnt contain much output but the GCB logs can be seen in GCS at `gs://k8s-staging-kops-gcb/logs/log-a7dc3a24-97cd-42fe-bec3-971dc78a0e3a.txt`and heres the relevant snippet:

```
...
Analyzing: target //cmd/kops-controller:push-image (35 packages loaded, 1478 targets configured)
Analyzing: target //cmd/kops-controller:push-image (47 packages loaded, 6667 targets configured)
INFO: Analyzed target //cmd/kops-controller:push-image (498 packages loaded, 9482 targets configured).
INFO: Found 1 target...
[0 / 1] [Prepa] BazelWorkspaceStatusAction stable-status.txt
ERROR: Process exited with status 1
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
Target //cmd/kops-controller:push-image failed to build
INFO: Elapsed time: 92.554s, Critical Path: 0.03s
INFO: 0 processes.
FAILED: Build did NOT complete successfully
ERROR: Build failed. Not running target
FAILED: Build did NOT complete successfully
Makefile:889: recipe for target 'kops-controller-push' failed
```

This error can be reproduced locally by temporarily renaming the .git directory to something else and running `make kops-controller-push`. With this PR, the command succeeds (at least until the permission denied error from the docker registry when actually pushing the image)

This PR removes the dependency on git commands.
I dont think any of the logic in the script will change because [we already set VERSION](https://github.com/kubernetes/kops/blob/b1276ac8353279c2d1de7beea4e6ec3713d83f6c/cloudbuild.yaml#L10) which is the only variable in get_workspace_status.sh that depends on git commands and is [used to build and push the kops controller image](https://github.com/kubernetes/kops/blob/b1276ac8353279c2d1de7beea4e6ec3713d83f6c/cmd/kops-controller/BUILD.bazel#L51-L65).

/cc @justinsb