### PR TITLE
Migrates cloudup/gce from v0.beta => v1

### DIFF
--- a/pkg/resources/gce/BUILD.bazel
+++ b/pkg/resources/gce/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
         "//pkg/resources:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/gce:go_default_library",
-        "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
+        "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/pkg/resources/gce/dump.go
+++ b/pkg/resources/gce/dump.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"sync"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/resources"
 	gce "k8s.io/kops/upup/pkg/fi/cloudup/gce"

--- a/pkg/resources/gce/gce.go
+++ b/pkg/resources/gce/gce.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/resources"

--- a/protokube/pkg/gossip/gce/BUILD.bazel
+++ b/protokube/pkg/gossip/gce/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//protokube/pkg/gossip:go_default_library",
-        "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
+        "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/protokube/pkg/gossip/gce/seeds.go
+++ b/protokube/pkg/gossip/gce/seeds.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/protokube/pkg/gossip"
 )

--- a/protokube/pkg/protokube/BUILD.bazel
+++ b/protokube/pkg/protokube/BUILD.bazel
@@ -62,7 +62,7 @@ go_library(
         "//vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",
-        "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
+        "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/protokube/pkg/protokube/gce_volume.go
+++ b/protokube/pkg/protokube/gce_volume.go
@@ -24,7 +24,7 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"golang.org/x/net/context"
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/protokube/pkg/etcd"
 	"k8s.io/kops/protokube/pkg/gossip"

--- a/upup/pkg/fi/cloudup/gce/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/gce/BUILD.bazel
@@ -26,7 +26,7 @@ go_library(
         "//upup/pkg/fi:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",
         "//vendor/golang.org/x/oauth2/google:go_default_library",
-        "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
+        "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/google.golang.org/api/googleapi:go_default_library",
         "//vendor/google.golang.org/api/iam/v1:go_default_library",
         "//vendor/google.golang.org/api/oauth2/v2:go_default_library",

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -25,7 +25,7 @@ import (
 
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/iam/v1"
 	oauth2 "google.golang.org/api/oauth2/v2"
 	"google.golang.org/api/storage/v1"

--- a/upup/pkg/fi/cloudup/gce/instancegroups.go
+++ b/upup/pkg/fi/cloudup/gce/instancegroups.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	context "golang.org/x/net/context"
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/apis/kops"

--- a/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
@@ -19,7 +19,7 @@ package gce
 import (
 	"fmt"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/storage/v1"
 	v1 "k8s.io/api/core/v1"

--- a/upup/pkg/fi/cloudup/gce/network.go
+++ b/upup/pkg/fi/cloudup/gce/network.go
@@ -22,7 +22,7 @@ import (
 	"net"
 
 	context "golang.org/x/net/context"
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"

--- a/upup/pkg/fi/cloudup/gce/op.go
+++ b/upup/pkg/fi/cloudup/gce/op.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"time"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"

--- a/upup/pkg/fi/cloudup/gce/status.go
+++ b/upup/pkg/fi/cloudup/gce/status.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/protokube/pkg/etcd"

--- a/upup/pkg/fi/cloudup/gcetasks/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/gcetasks/BUILD.bazel
@@ -38,7 +38,7 @@ go_library(
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/gce:go_default_library",
         "//upup/pkg/fi/cloudup/terraform:go_default_library",
-        "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
+        "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/google.golang.org/api/storage/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/upup/pkg/fi/cloudup/gcetasks/address.go
+++ b/upup/pkg/fi/cloudup/gcetasks/address.go
@@ -19,7 +19,7 @@ package gcetasks
 import (
 	"fmt"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"

--- a/upup/pkg/fi/cloudup/gcetasks/disk.go
+++ b/upup/pkg/fi/cloudup/gcetasks/disk.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"

--- a/upup/pkg/fi/cloudup/gcetasks/firewallrule.go
+++ b/upup/pkg/fi/cloudup/gcetasks/firewallrule.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"

--- a/upup/pkg/fi/cloudup/gcetasks/forwardingrule.go
+++ b/upup/pkg/fi/cloudup/gcetasks/forwardingrule.go
@@ -19,7 +19,7 @@ package gcetasks
 import (
 	"fmt"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"

--- a/upup/pkg/fi/cloudup/gcetasks/instance.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instance.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"strings"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/diff"
 	"k8s.io/kops/upup/pkg/fi"

--- a/upup/pkg/fi/cloudup/gcetasks/network.go
+++ b/upup/pkg/fi/cloudup/gcetasks/network.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"

--- a/upup/pkg/fi/cloudup/gcetasks/subnet.go
+++ b/upup/pkg/fi/cloudup/gcetasks/subnet.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"

--- a/upup/pkg/fi/cloudup/gcetasks/targetpool.go
+++ b/upup/pkg/fi/cloudup/gcetasks/targetpool.go
@@ -19,7 +19,7 @@ package gcetasks
 import (
 	"fmt"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"


### PR DESCRIPTION
This relates to #8516 and is a first pass at modernizing our GCE integration. 

~#8516 needs to go first to get this green...~
We got the vendoring updated so when the tests are green, we can go on this one