### PR TITLE
Use larger machine type for cloudbuild jobs

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,6 +2,7 @@
 timeout: 1200s
 options:
   substitution_option: ALLOW_LOOSE
+  machineType: 'N1_HIGHCPU_8'
 steps:
 # Start by just pushing the image
 - name: 'gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1'


### PR DESCRIPTION
Using [this reference](https://cloud.google.com/cloud-build/docs/build-config#options)

As mentioned here: https://github.com/kubernetes/kops/pull/8518#issuecomment-584356896  our postsubmit builds are now timing out because we're building more artifacts: https://storage.googleapis.com/kubernetes-jenkins/logs/kops-postsubmit-push-to-staging/1226925957785325568/artifacts/build.log

We'll see if increasing the CPU resources available will be enough to avoid the timeout.  Otherwise it looks like there are [timeout fields](https://cloud.google.com/cloud-build/docs/build-config#timeout_2) available both at the build and step levels that we could try increasing too.