### PR TITLE
Spotinst: Add OWNERS file to Spotinst specific packages

### DIFF
--- a/pkg/model/spotinstmodel/OWNERS
+++ b/pkg/model/spotinstmodel/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- liranp
+reviewers:
+- liranp

--- a/pkg/resources/spotinst/OWNERS
+++ b/pkg/resources/spotinst/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- liranp
+reviewers:
+- liranp

--- a/upup/pkg/fi/cloudup/spotinsttasks/OWNERS
+++ b/upup/pkg/fi/cloudup/spotinsttasks/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- liranp
+reviewers:
+- liranp


### PR DESCRIPTION
We propose that we add OWNERS file to Spotinst specific packages in order to decrease the time of development lifecycle (for example, please see the following PRs: #7040, #7252 and #8294), so we can review and approve things ourselves. For now, these files contain only one approver (me), but we will add more contributors later.