### PR TITLE
Automated cherry pick of #8353: Fix DNS loop on Ubuntu 18.04 (Bionic)

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -589,6 +589,12 @@ func (b *KubeletBuilder) buildKubeletConfigSpec() (*kops.KubeletConfigSpec, erro
 		}
 	}
 
+	// In certain configurations systemd-resolved will put the loopback address 127.0.0.53 as a nameserver into /etc/resolv.conf
+	// https://github.com/coredns/coredns/blob/master/plugin/loop/README.md#troubleshooting-loops-in-kubernetes-clusters
+	if b.Distribution == distros.DistributionBionic && c.ResolverConfig == nil {
+		c.ResolverConfig = s("/run/systemd/resolve/resolv.conf")
+	}
+
 	// As of 1.16 we can no longer set critical labels.
 	// kops-controller will set these labels.
 	// For bootstrapping reasons, protokube sets the critical labels for kops-controller to run.


### PR DESCRIPTION
Cherry pick of #8353 on release-1.16.

#8353: Fix DNS loop on Ubuntu 18.04 (Bionic)

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.