### PR TITLE
Automated cherry pick of #8423: Update AWS IAM Authenticator to 0.5.0

### DIFF
--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
@@ -1,3 +1,87 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: iamidentitymappings.iamauthenticator.k8s.aws
+spec:
+  group: iamauthenticator.k8s.aws
+  version: v1alpha1
+  scope: Cluster
+  names:
+    plural: iamidentitymappings
+    singular: iamidentitymapping
+    kind: IAMIdentityMapping
+    categories:
+    - all
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+          - arn
+          - username
+          properties:
+            arn:
+              type: string
+            username:
+              type: string
+            groups:
+              type: array
+              items:
+                type: string
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: aws-iam-authenticator
+rules:
+- apiGroups:
+  - iamauthenticator.k8s.aws
+  resources:
+  - iamidentitymappings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - iamauthenticator.k8s.aws
+  resources:
+  - iamidentitymappings/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-iam-authenticator
+  namespace: kube-system
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: aws-iam-authenticator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-iam-authenticator
+subjects:
+- kind: ServiceAccount
+  name: aws-iam-authenticator
+  namespace: kube-system
+
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -19,10 +103,8 @@ spec:
       labels:
         k8s-app: aws-iam-authenticator
     spec:
-      # run on the host network (don't depend on CNI)
+      serviceAccountName: aws-iam-authenticator
       hostNetwork: true
-
-      # run on each master node
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-node-critical
@@ -38,7 +120,7 @@ spec:
       # - output (output kubeconfig to plug into your apiserver configuration, mounted from the host)
       containers:
       - name: aws-iam-authenticator
-        image: {{ or .Authentication.Aws.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.4.0" }}
+        image: {{ or .Authentication.Aws.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.0-scratch" }}
         args:
         - server
         - --config=/etc/aws-iam-authenticator/config.yaml

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -1185,15 +1185,17 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		}
 		if b.cluster.Spec.Authentication.Aws != nil {
 			key := "authentication.aws"
-			version := "0.4.0-kops.2"
-
+			versions := map[string]string{
+				"k8s-1.10": "0.4.0-kops.2",
+				"k8s-1.12": "0.5.0-kops.1",
+			}
 			{
 				location := key + "/k8s-1.10.yaml"
 				id := "k8s-1.10"
 
 				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 					Name:              fi.String(key),
-					Version:           fi.String(version),
+					Version:           fi.String(versions[id]),
 					Selector:          authenticationSelector,
 					Manifest:          fi.String(location),
 					KubernetesVersion: ">=1.10.0 <1.12.0",
@@ -1207,7 +1209,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 				addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 					Name:              fi.String(key),
-					Version:           fi.String(version),
+					Version:           fi.String(versions[id]),
 					Selector:          authenticationSelector,
 					Manifest:          fi.String(location),
 					KubernetesVersion: ">=1.12.0",


### PR DESCRIPTION
Cherry pick of #8423 on release-1.16.

#8423: Update AWS IAM Authenticator to 0.5.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.