### PR TITLE
Only create git tags with the v prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -584,7 +584,6 @@ ${CHANNELS}:
 
 .PHONY: release-tag
 release-tag:
-	git tag ${KOPS_RELEASE_VERSION}
 	git tag v${KOPS_RELEASE_VERSION}
 
 .PHONY: release-github


### PR DESCRIPTION
[The tagging of both formats](https://github.com/kubernetes/kops/pull/8373) was cherry-picked back to 1.15 and will be used in 1.16.0 stable.

I think having all 1.16.X and 1.17.X releases tagged with both formats is long enough, so I'm removing the non-prefixed tag for 1.18.0