### PR TITLE
Switch AWS IAM Authenticator to use non-scratch image

### DIFF
--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
@@ -120,7 +120,7 @@ spec:
       # - output (output kubeconfig to plug into your apiserver configuration, mounted from the host)
       containers:
       - name: aws-iam-authenticator
-        image: {{ or .Authentication.Aws.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.0-scratch" }}
+        image: {{ or .Authentication.Aws.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.0-debian-stretch" }}
         args:
         - server
         - --config=/etc/aws-iam-authenticator/config.yaml


### PR DESCRIPTION
The authenticator binary uses glog which requires write access to the filesystem under /tmp.
On the scratch image /tmp doesnt exist which caused a crash loop:

```
time="2020-02-14T02:06:00Z" level=info msg="creating event broadcaster"
time="2020-02-14T02:06:00Z" level=info msg="setting up event handlers"
W0214 02:06:00.358119       1 client_config.go:539] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
log: exiting because of error: log: cannot create log: open /tmp/aws-iam-authenticator.ip-X-X-X-X.aws-iam-authenticator.log.WARNING.20200214-020600.1: no such file or directory
```

Switching to debian-stretch fixed the issue although we could realistically use any of the other images in the release [0]

This will need cherry-picking back to 1.16 to match #8423 and its cherry-picks.

[0] https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/tag/v0.5.0

Side note: I'd like this us to use authenticator in an e2e job but i believe it requires either a configmap or CRD so in additional to adding [--override plumbing](https://github.com/kubernetes/kops/blob/f68a2235966440ed1fd012f2be7cd644ef0f7bcb/pkg/commands/set_cluster.go#L75) we'd need a way for the test to apply an arbitrary manifest. I'm not sure if thats supported by our prow jobs and kubetest, but I can look into it.