### PR TITLE
use v0.29 in prometheus operator

### DIFF
--- a/addons/prometheus-operator/addon.yaml
+++ b/addons/prometheus-operator/addon.yaml
@@ -13,3 +13,8 @@ spec:
       k8s-addon: prometheus-operator.addons.k8s.io
     manifest: v0.26.0.yaml
     kubernetesVersion: ">=1.8.0"
+  - version: 0.29.0
+    selector:
+      k8s-addon: prometheus-operator.addons.k8s.io
+    manifest: v0.29.0.yaml
+    kubernetesVersion: ">=1.8.0"


### PR DESCRIPTION
there are problems without this already described in v0.29.yaml. Is there any reason v0.29 is not included in addons.yaml here?