### PR TITLE
go-bindata: don't store file metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ kops-gobindata: gobindata-tool ${BINDATA_TARGETS}
 
 UPUP_MODELS_BINDATA_SOURCES:=$(shell find upup/models/ | egrep -v "upup/models/bindata.go")
 upup/models/bindata.go: ${GOBINDATA} ${UPUP_MODELS_BINDATA_SOURCES}
-	cd ${GOPATH_1ST}/src/k8s.io/kops; ${GOBINDATA} -o $@ -pkg models -ignore="\\.DS_Store" -ignore="bindata\\.go" -ignore="vfs\\.go" -prefix upup/models/ upup/models/... && GO111MODULE=on go run golang.org/x/tools/cmd/goimports -w -v upup/models/bindata.go
+	cd ${GOPATH_1ST}/src/k8s.io/kops; ${GOBINDATA} -o $@ -pkg models -nometadata -ignore="\\.DS_Store" -ignore="bindata\\.go" -ignore="vfs\\.go" -prefix upup/models/ upup/models/... && GO111MODULE=on go run golang.org/x/tools/cmd/goimports -w -v upup/models/bindata.go
 
 # Build in a docker container with golang 1.X
 # Used to test we have not broken 1.X

--- a/upup/models/BUILD.bazel
+++ b/upup/models/BUILD.bazel
@@ -23,6 +23,7 @@ genrule(
     cmd = """
 $(location //vendor/github.com/jteeuwen/go-bindata/go-bindata:go-bindata) \
   -o "$(OUTS)" -pkg models \
+  -nometadata \
   -prefix $$(pwd) \
   -prefix upup/models $(SRCS)
 """,


### PR DESCRIPTION
This was a big contributor to the build being non-repeatable.