### PR TITLE
Use cluster name as default subnet tag for Lyft CNI

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -545,7 +545,7 @@ You can specify which subnets to use for allocating Pod IPs by specifying
   networking:
     lyftvpc:
       subnetTags:
-        kubernetes_kubelet: true
+        KubernetesCluster: myclustername.mydns.io
 ```
 
 In this example, new interfaces will be attached to subnets tagged with `kubernetes_kubelet = true`.

--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -6,6 +6,8 @@
 
 * Terraform users on AWS may need to rename some resources in their state file in order to prepare for Terraform 0.12 support. See Required Actions below.
 
+* Lyft CNI plugin default subnet tags changed from from `Type: pod` to `KubernetesCluster: myclustername.mydns.io`. Subnets intended for use by the plugin will need to be tagged with this new tag and [additional tag filters](https://github.com/lyft/cni-ipvlan-vpc-k8s#other-configuration-flags) may need to be added to the cluster spec in order to achieve the desired set of subnets.
+
 * Support for Kubernetes versions prior to 1.9 has been removed.
 
 * Kubernetes 1.9 users will need to enable the PodPriority feature gate. See Required Actions below.

--- a/upup/models/nodeup/resources/_lyft_vpc_cni/files/etc/cni/net.d/10-cni-ipvlan-vpc-k8s.conflist.template
+++ b/upup/models/nodeup/resources/_lyft_vpc_cni/files/etc/cni/net.d/10-cni-ipvlan-vpc-k8s.conflist.template
@@ -1,26 +1,26 @@
 {
+  "cniVersion": "0.3.1",
+  "name": "cni-ipvlan-vpc-k8s",
+  "plugins": [
+  {
     "cniVersion": "0.3.1",
-    "name": "cni-ipvlan-vpc-k8s",
-    "plugins": [
-	{
-	    "cniVersion": "0.3.1",
-	    "type": "cni-ipvlan-vpc-k8s-ipam",
-	    "interfaceIndex": 1,
-		"skipDeallocation" : true,
-	    "subnetTags":  {{ SubnetTags }},
-	    "secGroupIds": {{ NodeSecurityGroups }}
-	},
-	{
-	    "cniVersion": "0.3.1",
-	    "type": "cni-ipvlan-vpc-k8s-ipvlan",
-	    "mode": "l2"
-	},
-	{
-	    "cniVersion": "0.3.1",
-	    "type": "cni-ipvlan-vpc-k8s-unnumbered-ptp",
-	    "hostInterface": "eth0",
-	    "containerInterface": "veth0",
-	    "ipMasq": true
-	}
-    ]
+    "type": "cni-ipvlan-vpc-k8s-ipam",
+    "interfaceIndex": 1,
+    "skipDeallocation": true,
+    "subnetTags":  {{ SubnetTags }},
+    "secGroupIds": {{ NodeSecurityGroups }}
+  },
+  {
+    "cniVersion": "0.3.1",
+    "type": "cni-ipvlan-vpc-k8s-ipvlan",
+    "mode": "l2"
+  },
+  {
+    "cniVersion": "0.3.1",
+    "type": "cni-ipvlan-vpc-k8s-unnumbered-ptp",
+    "hostInterface": "eth0",
+    "containerInterface": "veth0",
+    "ipMasq": true
+  }
+  ]
 }

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -261,8 +261,15 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 	if c.cluster.Spec.Networking.LyftVPC != nil {
 
 		loader.TemplateFunctions["SubnetTags"] = func() (string, error) {
-			tags := map[string]string{
-				"Type": "pod",
+			var tags map[string]string
+			if c.cluster.IsKubernetesGTE("1.18") {
+				tags = map[string]string{
+					"KubernetesCluster": c.cluster.Name,
+				}
+			} else {
+				tags = map[string]string{
+					"Type": "pod",
+				}
 			}
 			if len(c.cluster.Spec.Networking.LyftVPC.SubnetTags) > 0 {
 				tags = c.cluster.Spec.Networking.LyftVPC.SubnetTags


### PR DESCRIPTION
The Lyft CNI uses tags to determine which subnets to use when allocating new network adapters.
Current default is not matching anything, so the cluster is broken on startup. Using the cluster name for to determine the cluster subnets seems a better solution.

The the `conflist.template` was misaligned so I reformatted it.