### PR TITLE
Don't try to configure a bastion DNS name in gossip mode

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -1144,10 +1144,11 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 			bastionGroup.Spec.Image = c.Image
 			instanceGroups = append(instanceGroups, bastionGroup)
 
-			cluster.Spec.Topology.Bastion = &api.BastionSpec{
-				BastionPublicName: "bastion." + clusterName,
+			if !dns.IsGossipHostname(clusterName) {
+				cluster.Spec.Topology.Bastion = &api.BastionSpec{
+					BastionPublicName: "bastion." + clusterName,
+				}
 			}
-
 		}
 
 	default:

--- a/docs/bastion.md
+++ b/docs/bastion.md
@@ -73,6 +73,19 @@ spec:
       bastionPublicName: bastion.mycluster.example.com
 ```
 
+### Access when using gossip (k8s.local)
+
+When using gossip mode, there is no DNS zone where we can configure a
+CNAME for the bastion.  Because bastions are fronted with a load
+balancer, you can instead use the endpoint of the load balancer to
+reach your bastion.
+
+On AWS, an easy way to find this DNS name is with kops toolbox:
+
+```
+kops toolbox dump -ojson | grep 'bastion.*elb.amazonaws.com'
+```
+
 ### Using SSH agent to access your bastion
 
 Verify your local agent is configured correctly


### PR DESCRIPTION
It can't be done anyway; instead we make it work (as far as we can),
and we document the workaround (which is to access it via the ELB DNS
name).

In future we could make it easier to discover this DNS name!

Fix #2881