### PR TITLE
Use UTC when calculating copyright year

### DIFF
--- a/hack/update-header.sh
+++ b/hack/update-header.sh
@@ -19,7 +19,7 @@
 BAD_HEADERS=$((${KUBE_ROOT}/hack/verify-boilerplate.sh || true) | awk '{ print $7}')
 FORMATS="sh go Makefile Dockerfile"
 
-YEAR=`date +%Y`
+YEAR=`date -u +%Y`
 
 for i in ${FORMATS}
 do


### PR DESCRIPTION
Avoids discrepancies between developer's laptop and CI verification in the evening of Dec 31.