### PR TITLE
kubelet: map rotate-certificates options

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1973,6 +1973,9 @@ spec:
                   description: RootDir is the directory path for managing kubelet
                     files (volume mounts,etc)
                   type: string
+                rotateCertificates:
+                  description: rotateCertificates enables client certificate rotation.
+                  type: boolean
                 runtimeCgroups:
                   description: Cgroups that container runtime is expected to be isolated
                     in.
@@ -2328,6 +2331,9 @@ spec:
                   description: RootDir is the directory path for managing kubelet
                     files (volume mounts,etc)
                   type: string
+                rotateCertificates:
+                  description: rotateCertificates enables client certificate rotation.
+                  type: boolean
                 runtimeCgroups:
                   description: Cgroups that container runtime is expected to be isolated
                     in.

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -492,6 +492,9 @@ spec:
                   description: RootDir is the directory path for managing kubelet
                     files (volume mounts,etc)
                   type: string
+                rotateCertificates:
+                  description: rotateCertificates enables client certificate rotation.
+                  type: boolean
                 runtimeCgroups:
                   description: Cgroups that container runtime is expected to be isolated
                     in.

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -196,6 +196,9 @@ type KubeletConfigSpec struct {
 	RegistryPullQPS *int32 `json:"registryPullQPS,omitempty" flag:"registry-qps"`
 	//RegistryBurst Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry-qps. Only used if --registry-qps > 0 (default 10)
 	RegistryBurst *int32 `json:"registryBurst,omitempty" flag:"registry-burst"`
+
+	// rotateCertificates enables client certificate rotation.
+	RotateCertificates *bool `json:"rotateCertificates,omitempty" flag:"rotate-certificates"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -196,6 +196,9 @@ type KubeletConfigSpec struct {
 	RegistryPullQPS *int32 `json:"registryPullQPS,omitempty" flag:"registry-qps"`
 	//RegistryBurst Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry-qps. Only used if --registry-qps > 0 (default 10)
 	RegistryBurst *int32 `json:"registryBurst,omitempty" flag:"registry-burst"`
+
+	// rotateCertificates enables client certificate rotation.
+	RotateCertificates *bool `json:"rotateCertificates,omitempty" flag:"rotate-certificates"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -3854,6 +3854,7 @@ func autoConvert_v1alpha1_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.CpuManagerPolicy = in.CpuManagerPolicy
 	out.RegistryPullQPS = in.RegistryPullQPS
 	out.RegistryBurst = in.RegistryBurst
+	out.RotateCertificates = in.RotateCertificates
 	return nil
 }
 
@@ -3938,6 +3939,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha1_KubeletConfigSpec(in *kops.K
 	out.CpuManagerPolicy = in.CpuManagerPolicy
 	out.RegistryPullQPS = in.RegistryPullQPS
 	out.RegistryBurst = in.RegistryBurst
+	out.RotateCertificates = in.RotateCertificates
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2700,6 +2700,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.RotateCertificates != nil {
+		in, out := &in.RotateCertificates, &out.RotateCertificates
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -196,6 +196,9 @@ type KubeletConfigSpec struct {
 	RegistryPullQPS *int32 `json:"registryPullQPS,omitempty" flag:"registry-qps"`
 	//RegistryBurst Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry-qps. Only used if --registry-qps > 0 (default 10)
 	RegistryBurst *int32 `json:"registryBurst,omitempty" flag:"registry-burst"`
+
+	// rotateCertificates enables client certificate rotation.
+	RotateCertificates *bool `json:"rotateCertificates,omitempty" flag:"rotate-certificates"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4124,6 +4124,7 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.CpuManagerPolicy = in.CpuManagerPolicy
 	out.RegistryPullQPS = in.RegistryPullQPS
 	out.RegistryBurst = in.RegistryBurst
+	out.RotateCertificates = in.RotateCertificates
 	return nil
 }
 
@@ -4208,6 +4209,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.CpuManagerPolicy = in.CpuManagerPolicy
 	out.RegistryPullQPS = in.RegistryPullQPS
 	out.RegistryBurst = in.RegistryBurst
+	out.RotateCertificates = in.RotateCertificates
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2771,6 +2771,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.RotateCertificates != nil {
+		in, out := &in.RotateCertificates, &out.RotateCertificates
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2953,6 +2953,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.RotateCertificates != nil {
+		in, out := &in.RotateCertificates, &out.RotateCertificates
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Additive flag mapping, may be useful for kubelet bootstrap.