### PR TITLE
Create New Default StorageClass: kops-ssd-1-17

### DIFF
--- a/upup/models/cloudup/resources/addons/storage-aws.addons.k8s.io/v1.15.0.yaml
+++ b/upup/models/cloudup/resources/addons/storage-aws.addons.k8s.io/v1.15.0.yaml
@@ -25,7 +25,7 @@ parameters:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: gp2-kops
+  name: kops-ssd-1-17
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
   labels:

--- a/upup/models/cloudup/resources/addons/storage-aws.addons.k8s.io/v1.15.0.yaml
+++ b/upup/models/cloudup/resources/addons/storage-aws.addons.k8s.io/v1.15.0.yaml
@@ -14,6 +14,18 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: gp2
+  labels:
+    k8s-addon: storage-aws.addons.k8s.io
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+
+---
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp2-kops
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
   labels:
@@ -21,6 +33,9 @@ metadata:
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2
+  encrypted: "true"
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
 
 ---
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -73,7 +73,7 @@ spec:
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: 23459f7be52d7c818dc060a8bcf5e3565bd87a7b
+    manifestHash: 5e829e8981470696bef2ed5e96839ea83cb36d24
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -73,7 +73,7 @@ spec:
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: 23459f7be52d7c818dc060a8bcf5e3565bd87a7b
+    manifestHash: 5e829e8981470696bef2ed5e96839ea83cb36d24
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -73,7 +73,7 @@ spec:
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: 23459f7be52d7c818dc060a8bcf5e3565bd87a7b
+    manifestHash: 5e829e8981470696bef2ed5e96839ea83cb36d24
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -73,7 +73,7 @@ spec:
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: 23459f7be52d7c818dc060a8bcf5e3565bd87a7b
+    manifestHash: 5e829e8981470696bef2ed5e96839ea83cb36d24
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io


### PR DESCRIPTION
Since kops manages the default storageclass for AWS, I feel we should add some improvements.

First, we can allow volume expansion now which is handy. https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims

Second, in order to prevent race conditions with Pods, setting the `volumeBindingMode` will only create a PV for a PVC and mount it to a node once the pod is scheduled.

https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode

Third, enable default EBS encryption. This one is debatable but I think for a production-ready kubernetes cluster in AWS this a best practice default.

This PR has the `volumeBindingMode` set as well, but I made a new PR since I am suggesting a few other changes. https://github.com/kubernetes/kops/pull/8416