### PR TITLE
1.16 Release Notes - Add Known CoreDNS metrics regression

### DIFF
--- a/docs/releases/1.16-NOTES.md
+++ b/docs/releases/1.16-NOTES.md
@@ -38,12 +38,19 @@ the notes prior to the release).
       featureGates:
         PodPriority: "true"
   ```
- 
+
 # Deprecations
 
 * Support for Kubernetes releases prior to 1.9 is deprecated and will be removed in kops 1.18.
 
 * The `kops/v1alpha1` API is deprecated and will be removed in kops 1.18. Users of `kops replace` will need to supply v1alpha2 resources.
+
+# Known Issues
+
+* There is a known issue [coredns/coredns#3577](https://github.com/coredns/coredns/issues/3577) in CoreDNS 1.6.6
+  where an existing metric, coredns_cache_misses_total, is removed. If you require this metric you can choose to
+  override the CoreDNS image and registry used as this is resolved in CoreDNS 1.6.7 in
+  [coredns/coredns#3578](https://github.com/coredns/coredns/pull/3578).
 
 # Full change list since 1.15.0 release
 


### PR DESCRIPTION
Replacement for #8587 

As per discussion at office hours.

I've followed the style and syntax as much as possible from upstream k/k given we haven't had known issues blocks since 1.6, open to feedback especially as it doesn't actually apply to all releases in the 1.16 train.