### PR TITLE
add s3 region

### DIFF
--- a/util/pkg/env/standard.go
+++ b/util/pkg/env/standard.go
@@ -42,6 +42,7 @@ func BuildSystemComponentEnvVars(spec *kops.ClusterSpec) EnvVars {
 	}
 
 	// Custom S3 endpoint
+	vars.addEnvVariableIfExist("S3_REGION")
 	vars.addEnvVariableIfExist("S3_ENDPOINT")
 	vars.addEnvVariableIfExist("S3_ACCESS_KEY_ID")
 	vars.addEnvVariableIfExist("S3_SECRET_ACCESS_KEY")


### PR DESCRIPTION
we are currently seeing following error in etcd-manager:

```
W0220 12:42:07.934295    8002 controller.go:149] unexpected error running etcd cluster reconciliation loop: error refreshing control store after leadership change: error reading s3://xxxx/bbb.k8s.local/backups/etcd/events/control: error listing s3://xxxx/bbb.k8s.local/backups/etcd/events/control: AuthorizationHeaderMalformed: The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'eu-north-1'
	status code: 400, request id: 9C82F7B26B72D41D, host id: bNWE4d3rO/CnkzlfpTrUcW4LcMdxuBH7M5tY6AmOivMLSvaBqrEc8PpiaOXHDKuBi5jgx6B07Cw=
```

this is because we are using custom s3 credentials and s3 region is not passed to etcd-manager container (so it defaults to us-east-1)