### PR TITLE
Cilium fix bpffs check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,7 @@ require (
 	golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e
 	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
+	golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9
 	golang.org/x/tools v0.0.0-20191203134012-c197fd4bf371
 	google.golang.org/api v0.17.0
 	gopkg.in/gcfg.v1 v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -124,6 +124,7 @@ require (
 	golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e
 	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
 	golang.org/x/tools v0.0.0-20191203134012-c197fd4bf371
 	google.golang.org/api v0.17.0
 	gopkg.in/gcfg.v1 v1.2.0

--- a/nodeup/pkg/model/BUILD.bazel
+++ b/nodeup/pkg/model/BUILD.bazel
@@ -72,6 +72,7 @@ go_library(
         "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",
+        "//vendor/golang.org/x/sys/unix:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/nodeup/pkg/model/network.go
+++ b/nodeup/pkg/model/network.go
@@ -76,7 +76,7 @@ func (b *NetworkBuilder) Build(c *fi.ModelBuilderContext) error {
 		err := unix.Statfs("/sys/fs/bpf", &fsdata)
 
 		if err != nil {
-			alreadyMounted = false
+			return fmt.Errorf("error checking for /sys/fs/bpf: %v", err)
 		} else {
 			alreadyMounted = int32(magic) == int32(fsdata.Type)
 		}

--- a/nodeup/pkg/model/network.go
+++ b/nodeup/pkg/model/network.go
@@ -18,9 +18,9 @@ package model
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
+	"golang.org/x/sys/unix"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 )
@@ -70,15 +70,15 @@ func (b *NetworkBuilder) Build(c *fi.ModelBuilderContext) error {
 	if networking.Cilium != nil {
 		// systemd v238 includes the bpffs mount by default; and gives an error "has a bad unit file setting" if we try to mount it again (see mount_point_is_api)
 		var alreadyMounted bool
-		_, err := os.Stat("/sys/fs/bpf")
+		// bpffs magic number
+		magic := uint32(0xCAFE4A11)
+		var fsdata unix.Statfs_t
+		err := unix.Statfs("/sys/fs/bpf", &fsdata)
+
 		if err != nil {
-			if os.IsNotExist(err) {
-				alreadyMounted = false
-			} else {
-				return fmt.Errorf("error checking for /sys/fs/bpf: %v", err)
-			}
+			alreadyMounted = false
 		} else {
-			alreadyMounted = true
+			alreadyMounted = int32(magic) == int32(fsdata.Type)
 		}
 
 		if !alreadyMounted {

--- a/nodeup/pkg/model/network.go
+++ b/nodeup/pkg/model/network.go
@@ -68,18 +68,19 @@ func (b *NetworkBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 
 	if networking.Cilium != nil {
-		// systemd v238 includes the bpffs mount by default; and gives an error "has a bad unit file setting" if we try to mount it again (see mount_point_is_api)
-		var alreadyMounted bool
-		// bpffs magic number
-		magic := uint32(0xCAFE4A11)
 		var fsdata unix.Statfs_t
 		err := unix.Statfs("/sys/fs/bpf", &fsdata)
 
 		if err != nil {
 			return fmt.Errorf("error checking for /sys/fs/bpf: %v", err)
-		} else {
-			alreadyMounted = int32(magic) == int32(fsdata.Type)
 		}
+
+		// systemd v238 includes the bpffs mount by default; and gives an error "has a bad unit file setting" if we try to mount it again (see mount_point_is_api)
+		var alreadyMounted bool
+		// bpffs magic number. See https://github.com/torvalds/linux/blob/v4.8/include/uapi/linux/magic.h#L80
+		magic := uint32(0xCAFE4A11)
+
+		alreadyMounted = int32(magic) == int32(fsdata.Type)
 
 		if !alreadyMounted {
 			unit := s(`


### PR DESCRIPTION
The check introduced in #7832 is unfortunately too naïve to detect if bpffs has been mounted leading to the unit file never being installed. This is quite disastrous for cilium.

This check in this PR should be more robust.

/kind bug