### PR TITLE
Update coredns to 1.6.7

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -168,7 +168,7 @@ spec:
           beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}k8s.gcr.io/coredns:1.6.6{{ end }}
+        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}k8s.gcr.io/coredns:1.6.7{{ end }}
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
@@ -113,7 +113,7 @@ spec:
           beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}k8s.gcr.io/coredns:1.6.6{{ end }}
+        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}k8s.gcr.io/coredns:1.6.7{{ end }}
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -271,7 +271,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 	if kubeDNS.Provider == "CoreDNS" {
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.6.6-kops.1"
+			version := "1.6.7-kops.1"
 
 			{
 				location := key + "/k8s-1.6.yaml"
@@ -290,7 +290,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.6.6-kops.2"
+			version := "1.6.7-kops.1"
 
 			{
 				location := key + "/k8s-1.12.yaml"


### PR DESCRIPTION
As discussed in #8588 CoreDNS `1.6.7` image has now been published to `k8s.gcr.io`:

https://github.com/kubernetes/kubernetes/issues/88343

```
docker pull k8s.gcr.io/coredns:1.6.7
1.6.7: Pulling from coredns
c6568d217a00: Already exists
ff0415ad7f19: Pull complete
Digest: sha256:2c8d61c46f484d881db43b34d13ca47a269336e576c81cf007ca740fa9ec0800
Status: Downloaded newer image for k8s.gcr.io/coredns:1.6.7
k8s.gcr.io/coredns:1.6.7
```