### PR TITLE
Fix a bug in UT apis/kops/util/labels_test.go

### DIFF
--- a/pkg/apis/kops/util/labels_test.go
+++ b/pkg/apis/kops/util/labels_test.go
@@ -44,8 +44,7 @@ func TestGetNodeRole(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-2",
 					Labels: map[string]string{
-						"node-role.kubernetes.io/master": "node-role",
-						"node-role.kubernetes.io/node":   "node-role",
+						"node-role.kubernetes.io/node": "node-role",
 					},
 				},
 			},


### PR DESCRIPTION
Go does not keep the order of items when iterate over a map.

Signed-off-by: Dao Cong Tien <tiendc@vn.fujitsu.com>