### PR TITLE
Automated cherry pick of #8602: Update coredns to 1.6.7

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -168,7 +168,7 @@ spec:
           beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}k8s.gcr.io/coredns:1.6.6{{ end }}
+        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}k8s.gcr.io/coredns:1.6.7{{ end }}
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.6.yaml.template
@@ -113,7 +113,7 @@ spec:
           beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}k8s.gcr.io/coredns:1.6.6{{ end }}
+        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}k8s.gcr.io/coredns:1.6.7{{ end }}
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -285,7 +285,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 	if kubeDNS.Provider == "CoreDNS" {
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.6.6-kops.1"
+			version := "1.6.7-kops.1"
 
 			{
 				location := key + "/k8s-1.6.yaml"
@@ -304,7 +304,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.6.6-kops.2"
+			version := "1.6.7-kops.1"
 
 			{
 				location := key + "/k8s-1.12.yaml"


### PR DESCRIPTION
Cherry pick of #8602 on release-1.16.

#8602: Update coredns to 1.6.7

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

Only raising with 1.16 for now as the release-note/update was one of the blockers for going to GA with 1.16.