### PR TITLE
Automated cherry pick of #8599: Properly detect that bpffs has been mounted

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 	golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e
 	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
-	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
+	golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9
 	google.golang.org/api v0.0.0-20181220000619-583d854617af
 	gopkg.in/gcfg.v1 v1.2.0
 	gopkg.in/inf.v0 v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -120,6 +120,7 @@ require (
 	golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e
 	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
+	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
 	google.golang.org/api v0.0.0-20181220000619-583d854617af
 	gopkg.in/gcfg.v1 v1.2.0
 	gopkg.in/inf.v0 v0.9.1

--- a/nodeup/pkg/model/BUILD.bazel
+++ b/nodeup/pkg/model/BUILD.bazel
@@ -69,6 +69,7 @@ go_library(
         "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",
+        "//vendor/golang.org/x/sys/unix:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/nodeup/pkg/model/network.go
+++ b/nodeup/pkg/model/network.go
@@ -18,9 +18,9 @@ package model
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
+	"golang.org/x/sys/unix"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 )
@@ -74,15 +74,15 @@ func (b *NetworkBuilder) Build(c *fi.ModelBuilderContext) error {
 	if networking.Cilium != nil {
 		// systemd v238 includes the bpffs mount by default; and gives an error "has a bad unit file setting" if we try to mount it again (see mount_point_is_api)
 		var alreadyMounted bool
-		_, err := os.Stat("/sys/fs/bpf")
+		// bpffs magic number
+		magic := uint32(0xCAFE4A11)
+		var fsdata unix.Statfs_t
+		err := unix.Statfs("/sys/fs/bpf", &fsdata)
+
 		if err != nil {
-			if os.IsNotExist(err) {
-				alreadyMounted = false
-			} else {
-				return fmt.Errorf("error checking for /sys/fs/bpf: %v", err)
-			}
+			alreadyMounted = false
 		} else {
-			alreadyMounted = true
+			alreadyMounted = int32(magic) == int32(fsdata.Type)
 		}
 
 		if !alreadyMounted {

--- a/nodeup/pkg/model/network.go
+++ b/nodeup/pkg/model/network.go
@@ -72,18 +72,19 @@ func (b *NetworkBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 
 	if networking.Cilium != nil {
-		// systemd v238 includes the bpffs mount by default; and gives an error "has a bad unit file setting" if we try to mount it again (see mount_point_is_api)
-		var alreadyMounted bool
-		// bpffs magic number
-		magic := uint32(0xCAFE4A11)
 		var fsdata unix.Statfs_t
 		err := unix.Statfs("/sys/fs/bpf", &fsdata)
 
 		if err != nil {
 			return fmt.Errorf("error checking for /sys/fs/bpf: %v", err)
-		} else {
-			alreadyMounted = int32(magic) == int32(fsdata.Type)
 		}
+
+		// systemd v238 includes the bpffs mount by default; and gives an error "has a bad unit file setting" if we try to mount it again (see mount_point_is_api)
+		var alreadyMounted bool
+		// bpffs magic number. See https://github.com/torvalds/linux/blob/v4.8/include/uapi/linux/magic.h#L80
+		magic := uint32(0xCAFE4A11)
+
+		alreadyMounted = int32(magic) == int32(fsdata.Type)
 
 		if !alreadyMounted {
 			unit := s(`

--- a/nodeup/pkg/model/network.go
+++ b/nodeup/pkg/model/network.go
@@ -80,7 +80,7 @@ func (b *NetworkBuilder) Build(c *fi.ModelBuilderContext) error {
 		err := unix.Statfs("/sys/fs/bpf", &fsdata)
 
 		if err != nil {
-			alreadyMounted = false
+			return fmt.Errorf("error checking for /sys/fs/bpf: %v", err)
 		} else {
 			alreadyMounted = int32(magic) == int32(fsdata.Type)
 		}


### PR DESCRIPTION
Cherry pick of #8599 on release-1.17.

#8599: Properly detect that bpffs has been mounted

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.