### PR TITLE
Update Calico and Canal to v3.12.0

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2460,7 +2460,7 @@ spec:
                       type: string
                     iptablesBackend:
                       description: 'IptablesBackend controls which variant of iptables
-                        binary Felix uses Default: Legacy (other options: NFT)'
+                        binary Felix uses Default: Auto (other options: Legacy, NFT)'
                       type: string
                     logSeverityScreen:
                       description: 'LogSeverityScreen lets us set the desired log
@@ -2529,7 +2529,7 @@ spec:
                       type: boolean
                     iptablesBackend:
                       description: 'IptablesBackend controls which variant of iptables
-                        binary Felix uses Default: Legacy (other options: NFT)'
+                        binary Felix uses Default: Auto (other options: Legacy, NFT)'
                       type: string
                     logSeveritySys:
                       description: 'LogSeveritySys the severity to set for logs which

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -118,7 +118,7 @@ type CalicoNetworkingSpec struct {
 	// MajorVersion is the version of Calico to use
 	MajorVersion string `json:"majorVersion,omitempty"`
 	// IptablesBackend controls which variant of iptables binary Felix uses
-	// Default: Legacy (other options: NFT)
+	// Default: Auto (other options: Legacy, NFT)
 	IptablesBackend string `json:"iptablesBackend,omitempty"`
 	// IPIPMode is mode for CALICO_IPV4POOL_IPIP
 	IPIPMode string `json:"ipipMode,omitempty"`
@@ -146,7 +146,7 @@ type CanalNetworkingSpec struct {
 	// default ACCEPT traffic rules to the iptables FORWARD chain
 	DisableFlannelForwardRules bool `json:"disableFlannelForwardRules,omitempty"`
 	// IptablesBackend controls which variant of iptables binary Felix uses
-	// Default: Legacy (other options: NFT)
+	// Default: Auto (other options: Legacy, NFT)
 	IptablesBackend string `json:"iptablesBackend,omitempty"`
 	// LogSeveritySys the severity to set for logs which are sent to syslog
 	// Default: INFO (other options: DEBUG, WARNING, ERROR, CRITICAL, NONE)

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -118,7 +118,7 @@ type CalicoNetworkingSpec struct {
 	// MajorVersion is the version of Calico to use
 	MajorVersion string `json:"majorVersion,omitempty"`
 	// IptablesBackend controls which variant of iptables binary Felix uses
-	// Default: Legacy (other options: NFT)
+	// Default: Auto (other options: Legacy, NFT)
 	IptablesBackend string `json:"iptablesBackend,omitempty"`
 	// IPIPMode is mode for CALICO_IPV4POOL_IPIP
 	IPIPMode string `json:"ipipMode,omitempty"`
@@ -146,7 +146,7 @@ type CanalNetworkingSpec struct {
 	// default ACCEPT traffic rules to the iptables FORWARD chain
 	DisableFlannelForwardRules bool `json:"disableFlannelForwardRules,omitempty"`
 	// IptablesBackend controls which variant of iptables binary Felix uses
-	// Default: Legacy (other options: NFT)
+	// Default: Auto (other options: Legacy, NFT)
 	IptablesBackend string `json:"iptablesBackend,omitempty"`
 	// LogSeveritySys the severity to set for logs which are sent to syslog
 	// Default: INFO (other options: DEBUG, WARNING, ERROR, CRITICAL, NONE)

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -118,7 +118,7 @@ type CalicoNetworkingSpec struct {
 	// MajorVersion is the version of Calico to use
 	MajorVersion string `json:"majorVersion,omitempty"`
 	// IptablesBackend controls which variant of iptables binary Felix uses
-	// Default: Legacy (other options: NFT)
+	// Default: Auto (other options: Legacy, NFT)
 	IptablesBackend string `json:"iptablesBackend,omitempty"`
 	// IPIPMode is mode for CALICO_IPV4POOL_IPIP
 	IPIPMode string `json:"ipipMode,omitempty"`
@@ -146,7 +146,7 @@ type CanalNetworkingSpec struct {
 	// default ACCEPT traffic rules to the iptables FORWARD chain
 	DisableFlannelForwardRules bool `json:"disableFlannelForwardRules,omitempty"`
 	// IptablesBackend controls which variant of iptables binary Felix uses
-	// Default: Legacy (other options: NFT)
+	// Default: Auto (other options: Legacy, NFT)
 	IptablesBackend string `json:"iptablesBackend,omitempty"`
 	// LogSeveritySys the severity to set for logs which are sent to syslog
 	// Default: INFO (other options: DEBUG, WARNING, ERROR, CRITICAL, NONE)

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -430,25 +430,24 @@ func validateNetworkingFlannel(v *kops.FlannelNetworkingSpec, fldPath *field.Pat
 func validateNetworkingCanal(v *kops.CanalNetworkingSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	action := v.DefaultEndpointToHostAction
-	switch action {
-	case "", "ACCEPT", "DROP", "RETURN":
-	default:
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("defaultEndpointToHostAction"), action, []string{"ACCEPT", "DROP", "RETURN"}))
+	if v.DefaultEndpointToHostAction != "" {
+		valid := []string{"ACCEPT", "DROP", "RETURN"}
+		allErrs = append(allErrs, IsValidValue(fldPath, &v.DefaultEndpointToHostAction, valid)...)
 	}
 
-	chainInsertMode := v.ChainInsertMode
-	switch chainInsertMode {
-	case "", "insert", "append":
-	default:
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("chainInsertMode"), chainInsertMode, []string{"insert", "append"}))
+	if v.ChainInsertMode != "" {
+		valid := []string{"insert", "append"}
+		allErrs = append(allErrs, IsValidValue(fldPath, &v.ChainInsertMode, valid)...)
 	}
 
-	logSeveritySys := v.LogSeveritySys
-	switch logSeveritySys {
-	case "", "INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL", "NONE":
-	default:
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("logSeveritySys"), logSeveritySys, []string{"INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL", "NONE"}))
+	if v.LogSeveritySys != "" {
+		valid := []string{"INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL", "NONE"}
+		allErrs = append(allErrs, IsValidValue(fldPath, &v.LogSeveritySys, valid)...)
+	}
+
+	if v.IptablesBackend != "" {
+		valid := []string{"Auto", "Legacy", "NFT"}
+		allErrs = append(allErrs, IsValidValue(fldPath, &v.IptablesBackend, valid)...)
 	}
 
 	return allErrs
@@ -566,18 +565,22 @@ func ValidateEtcdVersionForCalicoV3(e *kops.EtcdClusterSpec, majorVersion string
 
 func validateNetworkingCalico(v *kops.CalicoNetworkingSpec, e *kops.EtcdClusterSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+
 	if v.TyphaReplicas < 0 {
 		allErrs = append(allErrs,
 			field.Invalid(fldPath.Child("typhaReplicas"), v.TyphaReplicas,
 				fmt.Sprintf("Unable to set number of Typha replicas to less than 0, you've specified %d", v.TyphaReplicas)))
 	}
-	switch v.MajorVersion {
-	case "":
-		// OK:
-	case "v3":
+
+	if v.MajorVersion != "" {
+		valid := []string{"v3"}
+		allErrs = append(allErrs, IsValidValue(fldPath, &v.MajorVersion, valid)...)
 		allErrs = append(allErrs, ValidateEtcdVersionForCalicoV3(e, v.MajorVersion, fldPath)...)
-	default:
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("majorVersion"), v.MajorVersion, []string{"v3"}))
+	}
+
+	if v.IptablesBackend != "" {
+		valid := []string{"Auto", "Legacy", "NFT"}
+		allErrs = append(allErrs, IsValidValue(fldPath, &v.IptablesBackend, valid)...)
 	}
 
 	return allErrs

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -432,22 +432,22 @@ func validateNetworkingCanal(v *kops.CanalNetworkingSpec, fldPath *field.Path) f
 
 	if v.DefaultEndpointToHostAction != "" {
 		valid := []string{"ACCEPT", "DROP", "RETURN"}
-		allErrs = append(allErrs, IsValidValue(fldPath, &v.DefaultEndpointToHostAction, valid)...)
+		allErrs = append(allErrs, IsValidValue(fldPath.Child("defaultEndpointToHostAction"), &v.DefaultEndpointToHostAction, valid)...)
 	}
 
 	if v.ChainInsertMode != "" {
 		valid := []string{"insert", "append"}
-		allErrs = append(allErrs, IsValidValue(fldPath, &v.ChainInsertMode, valid)...)
+		allErrs = append(allErrs, IsValidValue(fldPath.Child("chainInsertMode"), &v.ChainInsertMode, valid)...)
 	}
 
 	if v.LogSeveritySys != "" {
 		valid := []string{"INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL", "NONE"}
-		allErrs = append(allErrs, IsValidValue(fldPath, &v.LogSeveritySys, valid)...)
+		allErrs = append(allErrs, IsValidValue(fldPath.Child("logSeveritySys"), &v.LogSeveritySys, valid)...)
 	}
 
 	if v.IptablesBackend != "" {
 		valid := []string{"Auto", "Legacy", "NFT"}
-		allErrs = append(allErrs, IsValidValue(fldPath, &v.IptablesBackend, valid)...)
+		allErrs = append(allErrs, IsValidValue(fldPath.Child("iptablesBackend"), &v.IptablesBackend, valid)...)
 	}
 
 	return allErrs
@@ -574,13 +574,15 @@ func validateNetworkingCalico(v *kops.CalicoNetworkingSpec, e *kops.EtcdClusterS
 
 	if v.MajorVersion != "" {
 		valid := []string{"v3"}
-		allErrs = append(allErrs, IsValidValue(fldPath, &v.MajorVersion, valid)...)
-		allErrs = append(allErrs, ValidateEtcdVersionForCalicoV3(e, v.MajorVersion, fldPath)...)
+		allErrs = append(allErrs, IsValidValue(fldPath.Child("majorVersion"), &v.MajorVersion, valid)...)
+		if v.MajorVersion == "v3" {
+			allErrs = append(allErrs, ValidateEtcdVersionForCalicoV3(e, v.MajorVersion, fldPath)...)
+		}
 	}
 
 	if v.IptablesBackend != "" {
 		valid := []string{"Auto", "Legacy", "NFT"}
-		allErrs = append(allErrs, IsValidValue(fldPath, &v.IptablesBackend, valid)...)
+		allErrs = append(allErrs, IsValidValue(fldPath.Child("iptablesBackend"), &v.IptablesBackend, valid)...)
 	}
 
 	return allErrs

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.12.yaml.template
@@ -1,10 +1,6 @@
-# Canal Version v3.7.4
-# https://docs.projectcalico.org/v3.7/release-notes/#v374
-# This manifest includes the following component versions:
-#   calico/node:v3.7.4
-#   calico/cni:v3.7.4
-#   coreos/flannel:v0.11.0
+# Pulled and modified from: https://docs.projectcalico.org/v3.7/manifests/canal.yaml
 
+---
 # Source: calico/templates/calico-config.yaml
 # This ConfigMap is used to configure a self-hosted Canal installation.
 kind: ConfigMap
@@ -411,7 +407,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.7.4
+          image: calico/cni:v3.7.5
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -447,7 +443,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.7.4
+          image: calico/node:v3.7.5
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template
@@ -1,4 +1,4 @@
-{{- /* Pulled and modified from: https://docs.projectcalico.org/v3.10/manifests/canal.yaml */ -}}
+# Pulled and modified from: https://docs.projectcalico.org/v3.12/manifests/canal.yaml
 
 ---
 # Source: calico/templates/calico-config.yaml
@@ -57,6 +57,10 @@ data:
           "type": "portmap",
           "snat": true,
           "capabilities": {"portMappings": true}
+        },
+        {
+          "type": "bandwidth",
+          "capabilities": {"bandwidth": true}
         }
       ]
     }
@@ -531,7 +535,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         kubernetes.io/role: master
       hostNetwork: true
       tolerations:
@@ -548,7 +552,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.10.2
+      - image: calico/typha:v3.12.0
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -645,7 +649,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
         # Make sure canal gets scheduled on all nodes.
@@ -665,7 +669,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.10.2
+          image: calico/cni:v3.12.0
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -696,19 +700,23 @@ spec:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+          securityContext:
+            privileged: true
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.10.2
+          image: calico/pod2daemon-flexvol:v3.12.0
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
+          securityContext:
+            privileged: true
       containers:
         # Runs canal container on each Kubernetes node.  This
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.10.2
+          image: calico/node:v3.12.0
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -739,6 +747,9 @@ spec:
             - name: CLUSTER_TYPE
               # was value: "k8s,bgp"
               value: "k8s,canal"
+            # Period, in seconds, at which felix re-applies all iptables state
+            - name: FELIX_IPTABLESREFRESHINTERVAL
+              value: "60"
             # No IP address needed.
             - name: IP
               value: ""
@@ -769,10 +780,7 @@ spec:
               value: "{{- or .Networking.Canal.ChainInsertMode "insert" }}"
             # Set Felix iptables binary variant, Legacy or NFT
             - name: FELIX_IPTABLESBACKEND
-              value: "{{- or .Networking.Canal.IptablesBackend "Legacy" }}"
-            # Period, in seconds, at which felix re-applies all iptables state
-            - name: FELIX_IPTABLESREFRESHINTERVAL
-              value: "60"
+              value: "{{- or .Networking.Canal.IptablesBackend "Auto" }}"
             # Set to enable the experimental Prometheus metrics server
             - name: FELIX_PROMETHEUSMETRICSENABLED
               value: "{{- or .Networking.Canal.PrometheusMetricsEnabled "false" }}"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -1,6 +1,6 @@
----
 # Pulled and modified from: https://docs.projectcalico.org/v3.9/manifests/calico-typha.yaml
 
+---
 # Source: calico/templates/calico-config.yaml
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
@@ -578,7 +578,7 @@ spec:
       serviceAccountName: calico-node
       priorityClassName: system-cluster-critical
       containers:
-      - image: calico/typha:v3.9.3
+      - image: calico/typha:v3.9.5
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -694,7 +694,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.9.3
+          image: calico/cni:v3.9.5
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -714,7 +714,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.9.3
+          image: calico/cni:v3.9.5
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -748,7 +748,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.9.3
+          image: calico/pod2daemon-flexvol:v3.9.5
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -757,7 +757,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.9.3
+          image: calico/node:v3.9.5
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -959,7 +959,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.9.3
+          image: calico/kube-controllers:v3.9.5
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -1,4 +1,4 @@
-{{- /* Pulled and modified from: https://docs.projectcalico.org/v3.10/manifests/calico-typha.yaml */ -}}
+# Pulled and modified from: https://docs.projectcalico.org/v3.12/manifests/calico-typha.yaml
 
 ---
 # Source: calico/templates/calico-config.yaml
@@ -50,6 +50,10 @@ data:
           "type": "portmap",
           "snat": true,
           "capabilities": {"portMappings": true}
+        },
+        {
+          "type": "bandwidth",
+          "capabilities": {"bandwidth": true}
         }
       ]
     }
@@ -567,7 +571,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         kubernetes.io/role: master
       hostNetwork: true
       tolerations:
@@ -584,7 +588,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.10.2
+      - image: calico/typha:v3.12.0
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -681,7 +685,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
         # Make sure calico-node gets scheduled on all nodes.
@@ -702,7 +706,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.10.2
+          image: calico/cni:v3.12.0
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -719,10 +723,12 @@ spec:
               name: host-local-net-dir
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir
+          securityContext:
+            privileged: true
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.10.2
+          image: calico/cni:v3.12.0
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -753,19 +759,23 @@ spec:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+          securityContext:
+            privileged: true
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.10.2
+          image: calico/pod2daemon-flexvol:v3.12.0
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
+          securityContext:
+            privileged: true
       containers:
         # Runs calico-node container on each Kubernetes node.  This
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.10.2
+          image: calico/node:v3.12.0
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -831,7 +841,7 @@ spec:
             # kops additions
             # Set Felix iptables binary variant, Legacy or NFT
             - name: FELIX_IPTABLESBACKEND
-              value: "{{- or .Networking.Calico.IptablesBackend "Legacy" }}"
+              value: "{{- or .Networking.Calico.IptablesBackend "Auto" }}"
             # Set to enable the experimental Prometheus metrics server
             - name: FELIX_PROMETHEUSMETRICSENABLED
               value: "{{- or .Networking.Calico.PrometheusMetricsEnabled "false" }}"
@@ -959,7 +969,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
@@ -970,7 +980,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.10.2
+          image: calico/kube-controllers:v3.12.0
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -683,7 +683,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.7":    "2.6.12-kops.1",
 			"k8s-1.7-v3": "3.8.0-kops.2",
 			"k8s-1.12":   "3.9.3-kops.2",
-			"k8s-1.16":   "3.10.2-kops.1",
+			"k8s-1.16":   "3.12.0-kops.1",
 		}
 
 		{
@@ -750,7 +750,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		versions := map[string]string{
 			"k8s-1.9":  "3.2.3-kops.1",
 			"k8s-1.12": "3.7.4-kops.1",
-			"k8s-1.15": "3.10.2-kops.1",
+			"k8s-1.15": "3.12.0-kops.1",
 		}
 		{
 			id := "k8s-1.9"


### PR DESCRIPTION
Calico 3.12 add support for autodetecting the iptables backend, quite useful for the people using Debian Buster, very soon the default base image in Kops.
https://docs.projectcalico.org/v3.12/release-notes/

This PR moves Calico and Canal to 3.12.0 and bumps the patch version for some of the previous releases.