### PR TITLE
Enabling the ability to drain daemon set pods, with priority

### DIFF
--- a/pkg/drain/drain_test.go
+++ b/pkg/drain/drain_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func getTestSetup(objects []runtime.Object) *fake.Clientset {
+	k8sClient := fake.NewSimpleClientset(objects...)
+	return k8sClient
+}
+
+func dummyDaemonSet(name string) appsv1.DaemonSet {
+	return appsv1.DaemonSet{
+		ObjectMeta: v1meta.ObjectMeta{
+			Name:      name,
+			Namespace: "kube-system",
+		},
+	}
+}
+
+func dummyPod(podMap map[string]string) v1.Pod {
+	pod := v1.Pod{
+		ObjectMeta: v1meta.ObjectMeta{
+			Name:      podMap["name"],
+			Namespace: "kube-system",
+		},
+		Spec: v1.PodSpec{
+			NodeName: "node1",
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodPhase(podMap["phase"]),
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:  "container1",
+					Ready: podMap["ready"] == "true",
+				},
+			},
+		},
+	}
+	if podMap["controller"] == "DaemonSet" {
+		pod.SetOwnerReferences([]v1meta.OwnerReference{
+			{
+				Name:       podMap["controllerName"],
+				Kind:       appsv1.SchemeGroupVersion.WithKind("DaemonSet").Kind,
+				Controller: &[]bool{true}[0],
+			},
+		})
+	}
+	return pod
+}
+
+// MakePodList constructs api.PodList from a list of pod attributes
+func makePodList(pods []map[string]string) []runtime.Object {
+	var list []runtime.Object
+	for _, pod := range pods {
+		p := dummyPod(pod)
+		list = append(list, &p)
+	}
+	return list
+}
+
+func TestRollingUpdateDaemonSetMixedPods(t *testing.T) {
+	objects := makePodList(
+		[]map[string]string{
+			{
+				"name":           "pod1",
+				"ready":          "true",
+				"phase":          string(v1.PodRunning),
+				"controller":     "DaemonSet",
+				"controllerName": "ds1",
+			},
+			{
+				"name":  "pod2",
+				"ready": "true",
+				"phase": string(v1.PodRunning),
+			},
+		},
+	)
+	ds := dummyDaemonSet("ds1")
+	objects = append(objects, &ds)
+	k8sClient := getTestSetup(objects)
+	helper := Helper{
+		Client:              k8sClient,
+		Force:               true,
+		IgnoreAllDaemonSets: false,
+		DeleteLocalData:     true,
+	}
+
+	podList, _ := helper.GetPodsForDeletion("node1")
+	assert.True(t, podList.Warnings() != "")
+	assert.True(t, len(podList.errors()) == 0)
+	assert.True(t, podList.items[0].status.priority == podDeletionPriorityHighest)
+	assert.True(t, podList.items[1].status.priority == podDeletionPriorityLowest)
+	assert.NotNil(t, podList)
+}
+
+func TestRollingUpdateNoDaemonSets(t *testing.T) {
+	objects := makePodList(
+		[]map[string]string{
+			{
+				"name":  "pod1",
+				"ready": "true",
+				"phase": string(v1.PodRunning),
+			},
+			{
+				"name":  "pod2",
+				"ready": "true",
+				"phase": string(v1.PodRunning),
+			},
+		},
+	)
+	k8sClient := getTestSetup(objects)
+	helper := Helper{
+		Client:              k8sClient,
+		Force:               true,
+		IgnoreAllDaemonSets: false,
+		DeleteLocalData:     true,
+	}
+
+	podList, _ := helper.GetPodsForDeletion("node1")
+	assert.True(t, podList.Warnings() != "")
+	assert.True(t, len(podList.errors()) == 0)
+	assert.True(t, podList.items[0].status.priority == podDeletionPriorityHighest)
+	assert.True(t, podList.items[1].status.priority == podDeletionPriorityHighest)
+	assert.NotNil(t, podList)
+}
+
+func TestRollingUpdateAllDaemonSetPods(t *testing.T) {
+	objects := makePodList(
+		[]map[string]string{
+			{
+				"name":           "pod1",
+				"ready":          "true",
+				"phase":          string(v1.PodRunning),
+				"controller":     "DaemonSet",
+				"controllerName": "ds1",
+			},
+			{
+				"name":           "pod2",
+				"ready":          "true",
+				"phase":          string(v1.PodRunning),
+				"controller":     "DaemonSet",
+				"controllerName": "ds1",
+			},
+		},
+	)
+	ds := dummyDaemonSet("ds1")
+	objects = append(objects, &ds)
+	k8sClient := getTestSetup(objects)
+	helper := Helper{
+		Client:              k8sClient,
+		Force:               true,
+		IgnoreAllDaemonSets: false,
+		DeleteLocalData:     true,
+	}
+
+	podList, _ := helper.GetPodsForDeletion("node1")
+	assert.True(t, podList.Warnings() == "")
+	assert.True(t, len(podList.errors()) == 0)
+	assert.True(t, podList.items[0].status.priority == podDeletionPriorityLowest)
+	assert.True(t, podList.items[1].status.priority == podDeletionPriorityLowest)
+	assert.NotNil(t, podList)
+}

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -493,7 +493,7 @@ func (r *RollingUpdateInstanceGroup) DrainNode(u *cloudinstances.CloudInstanceGr
 		Client:              rollingUpdateData.K8sClient,
 		Force:               true,
 		GracePeriodSeconds:  -1,
-		IgnoreAllDaemonSets: true,
+		IgnoreAllDaemonSets: rollingUpdateData.IgnoreDaemonsets,
 		Out:                 os.Stdout,
 		ErrOut:              os.Stderr,
 

--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -67,6 +67,9 @@ type RollingUpdateCluster struct {
 	// ValidateSuccessDuration is the amount of time a cluster must continue to validate successfully
 	// before updating the next node
 	ValidateSuccessDuration time.Duration
+
+	// IgnoreDaemonsets when a node is drained, daemon set pods will also be drained if false.  Default is true.
+	IgnoreDaemonsets bool
 }
 
 // RollingUpdate performs a rolling update on a K8s Cluster.

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -850,6 +850,15 @@ func TestRollingUpdateMaxUnavailableAllNeedUpdateMaster(t *testing.T) {
 	concurrentTest.AssertComplete()
 }
 
+func TestRollingUpdateAllNeedUpdateDoNotIgnoreDaemonsets(t *testing.T) {
+	c, cloud, cluster := getTestSetup()
+	c.IgnoreDaemonsets = false
+	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
+	makeGroup(groups, c.K8sClient, cloud, "node-1", kopsapi.InstanceGroupRoleNode, 1, 1)
+	err := c.RollingUpdate(groups, cluster, &kopsapi.InstanceGroupList{})
+	assert.NoError(t, err, "rolling update")
+}
+
 func assertCordon(t *testing.T, action testingclient.PatchAction) {
 	assert.Equal(t, "nodes", action.GetResource().Resource)
 	assert.Equal(t, cordonPatch, string(action.GetPatch()))


### PR DESCRIPTION
This PR gives the ability to drain daemon set pods during a rolling update.  Daemon set pods will be deleted last.  This is to address issue (#8391) 

Signed-off-by: mmerrill3 <michael.merrill@vonage.com>