### PR TITLE
Automated cherry pick of #8589: Bump Cilium to 1.7 for k8s 1.12+ #8591: Fix typo in the cilium default version

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -576,9 +576,6 @@ func (c *Cluster) FillDefaults() error {
 	} else if c.Spec.Networking.AmazonVPC != nil {
 		// OK
 	} else if c.Spec.Networking.Cilium != nil {
-		if c.Spec.Networking.Cilium.Version == "" {
-			c.Spec.Networking.Cilium.Version = CiliumDefaultVersion
-		}
 		// OK
 	} else if c.Spec.Networking.LyftVPC != nil {
 		// OK

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -168,8 +168,6 @@ type AmazonVPCNetworkingSpec struct {
 	ImageName string `json:"imageName,omitempty"`
 }
 
-const CiliumDefaultVersion = "v1.6.6"
-
 // CiliumNetworkingSpec declares that we want Cilium networking
 type CiliumNetworkingSpec struct {
 	Version string `json:"version,omitempty"`

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -155,6 +155,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - namespaces
@@ -207,6 +215,8 @@ rules:
   resources:
   - ciliumnetworkpolicies
   - ciliumnetworkpolicies/status
+  - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/status
   - ciliumendpoints
   - ciliumendpoints/status
   - ciliumnodes
@@ -235,6 +245,14 @@ rules:
   - watch
   - delete
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   # to automatically read from k8s and import the node's pod CIDR to cilium's
@@ -255,6 +273,8 @@ rules:
   resources:
   - ciliumnetworkpolicies
   - ciliumnetworkpolicies/status
+  - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/status
   - ciliumendpoints
   - ciliumendpoints/status
   - ciliumnodes
@@ -316,7 +336,6 @@ spec:
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ""
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"
@@ -368,7 +387,7 @@ spec:
           value: {{ . }}
         {{ end }}
 {{ with .Networking.Cilium }}
-        image: "docker.io/cilium/cilium:{{ .Version }}"
+        image: "docker.io/cilium/cilium:{{- or .Version "v.1.7.0" }}"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -421,6 +440,7 @@ spec:
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
+          mountPropagation: HostToContainer
         - mountPath: /var/run/cilium
           name: cilium-run
         - mountPath: /host/opt/cni/bin
@@ -462,7 +482,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: "docker.io/cilium/cilium:{{ .Version }}"
+        image: "docker.io/cilium/cilium:{{- or .Version "v1.7.0" }}"
 ## end of `with .Networking.Cilium`
 #{{ end }}
         imagePullPolicy: IfNotPresent
@@ -642,7 +662,7 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
-        image: "docker.io/cilium/operator:{{ .Version }}"
+        image: "docker.io/cilium/operator:{{- if eq .Version "" -}}v1.7.0{{- else -}}{{ .Version }}{{- end -}}"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         {{ if .EnablePrometheusMetrics }}

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -387,7 +387,7 @@ spec:
           value: {{ . }}
         {{ end }}
 {{ with .Networking.Cilium }}
-        image: "docker.io/cilium/cilium:{{- or .Version "v.1.7.0" }}"
+        image: "docker.io/cilium/cilium:{{- or .Version "v1.7.0" }}"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
@@ -368,7 +368,7 @@ spec:
           value: {{ . }}
         {{ end }}
 {{ with .Networking.Cilium }}
-        image: "docker.io/cilium/cilium:{{ .Version }}"
+        image: "docker.io/cilium/cilium:{{- or .Version "v1.6.6" }}"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -634,7 +634,7 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
-        image: "docker.io/cilium/operator:{{ .Version }}"
+        image: "docker.io/cilium/operator:{{- or .Version "v1.6.6" }}"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         {{ if .EnablePrometheusMetrics }}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -1161,7 +1161,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 	if b.cluster.Spec.Networking.Cilium != nil {
 		key := "networking.cilium.io"
-		version := "1.6.4-kops.3"
+		version := "1.7.0-kops.1"
 
 		{
 			id := "k8s-1.7"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -115,16 +115,16 @@ spec:
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0 <1.12.0'
     manifest: networking.cilium.io/k8s-1.7.yaml
-    manifestHash: 6928e95ec4b8359075e3dfb069f74e290e2e6eb2
+    manifestHash: 66318e232bf165b6af5da546e711ac3b9444afdc
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.6.4-kops.3
+    version: 1.7.0-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: 84295d293c8a461f7d510721c48b969cd1d99e54
+    manifestHash: e5c3b42382746bb66bc302cd0c162489c8650187
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.6.4-kops.3
+    version: 1.7.0-kops.1

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -123,7 +123,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: e5c3b42382746bb66bc302cd0c162489c8650187
+    manifestHash: c241b96c74983edbe6a7b51f0fb2c7dfe2fb5659
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
Cherry pick of #8589 #8591 on release-1.17.

#8589: Bump Cilium to 1.7 for k8s 1.12+
#8591: Fix typo in the cilium default version

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.