### PR TITLE
Automated cherry pick of #7730: Add SysctlParameters to ClusterSpec and InstanceGroupSpec

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -859,3 +859,28 @@ spec:
   assets:
     containerProxy: proxy.example.com
 ```
+
+### Setting Custom Kernel Runtime Parameters
+
+To add custom kernel runtime parameters to your all instance groups in the
+cluster, specify the `sysctlParameters` field as an array of strings. Each
+string must take the form of `variable=value` the way it would appear in
+sysctl.conf (see also `sysctl(8)` manpage).
+
+You could also use the `sysctlParameters` field on [the instance group](https://github.com/kubernetes/kops/blob/master/docs/instance_groups.md#setting-custom-kernel-runtime-parameters) to specify different parameters for each instance group.
+
+Unlike a simple file asset, specifying kernel runtime parameters in this manner
+would correctly invoke `sysctl --system` automatically for you to apply said
+parameters.
+
+For example:
+
+```yaml
+spec:
+  sysctlParameters:
+    - fs.pipe-user-pages-soft=524288
+    - net.ipv4.tcp_keepalive_time=200
+```
+
+which would end up in a drop-in file on all masters and nodes of the cluster.
+

--- a/docs/instance_groups.md
+++ b/docs/instance_groups.md
@@ -574,3 +574,31 @@ spec:
 ```
 
 If `openstack.kops.io/osVolumeSize` is not set it will default to the minimum disk specified by the image.
+
+
+## Setting Custom Kernel Runtime Parameters
+
+To add custom kernel runtime parameters to your instance group, specify the
+`sysctlParameters` field as an array of strings. Each string must take the form
+of `variable=value` the way it would appear in sysctl.conf (see also
+`sysctl(8)` manpage).
+
+Unlike a simple file asset, specifying kernel runtime parameters in this manner
+would correctly invoke `sysctl --system` automatically for you to apply said
+parameters.
+
+For example:
+
+```yaml
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  name: nodes
+spec:
+  sysctlParameters:
+    - fs.pipe-user-pages-soft=524288
+    - net.ipv4.tcp_keepalive_time=200
+```
+
+which would end up in a drop-in file on nodes of the instance group in question.
+

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2714,6 +2714,13 @@ spec:
                     type: string
                 type: object
               type: array
+            sysctlParameters:
+              description: SysctlParameters will configure kernel parameters using
+                sysctl(8). When specified, each parameter must follow the form variable=value,
+                the way it would appear in sysctl.conf.
+              items:
+                type: string
+              type: array
             target:
               description: Target allows for us to nest extra config for targets such
                 as terraform

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -664,6 +664,13 @@ spec:
               items:
                 type: string
               type: array
+            sysctlParameters:
+              description: SysctlParameters will configure kernel parameters using
+                sysctl(8). When specified, each parameter must follow the form variable=value,
+                the way it would appear in sysctl.conf.
+              items:
+                type: string
+              type: array
             taints:
               description: Taints indicates the kubernetes taints for nodes in this
                 group

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -179,6 +179,10 @@ type ClusterSpec struct {
 	// UseHostCertificates will mount /etc/ssl/certs to inside needed containers.
 	// This is needed if some APIs do have self-signed certs
 	UseHostCertificates *bool `json:"useHostCertificates,omitempty"`
+	// SysctlParameters will configure kernel parameters using sysctl(8). When
+	// specified, each parameter must follow the form variable=value, the way
+	// it would appear in sysctl.conf.
+	SysctlParameters []string `json:"sysctlParameters,omitempty"`
 }
 
 // NodeAuthorizationSpec is used to node authorization

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -155,6 +155,10 @@ type InstanceGroupSpec struct {
 	SecurityGroupOverride *string `json:"securityGroupOverride,omitempty"`
 	// InstanceProtection makes new instances in an autoscaling group protected from scale in
 	InstanceProtection *bool `json:"instanceProtection,omitempty"`
+	// SysctlParameters will configure kernel parameters using sysctl(8). When
+	// specified, each parameter must follow the form variable=value, the way
+	// it would appear in sysctl.conf.
+	SysctlParameters []string `json:"sysctlParameters,omitempty"`
 }
 
 const (

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -177,6 +177,10 @@ type ClusterSpec struct {
 	// UseHostCertificates will mount /etc/ssl/certs to inside needed containers.
 	// This is needed if some APIs do have self-signed certs
 	UseHostCertificates *bool `json:"useHostCertificates,omitempty"`
+	// SysctlParameters will configure kernel parameters using sysctl(8). When
+	// specified, each parameter must follow the form variable=value, the way
+	// it would appear in sysctl.conf.
+	SysctlParameters []string `json:"sysctlParameters,omitempty"`
 }
 
 // NodeAuthorizationSpec is used to node authorization

--- a/pkg/apis/kops/v1alpha1/instancegroup.go
+++ b/pkg/apis/kops/v1alpha1/instancegroup.go
@@ -142,6 +142,10 @@ type InstanceGroupSpec struct {
 	SecurityGroupOverride *string `json:"securityGroupOverride,omitempty"`
 	// InstanceProtection makes new instances in an autoscaling group protected from scale in
 	InstanceProtection *bool `json:"instanceProtection,omitempty"`
+	// SysctlParameters will configure kernel parameters using sysctl(8). When
+	// specified, each parameter must follow the form variable=value, the way
+	// it would appear in sysctl.conf.
+	SysctlParameters []string `json:"sysctlParameters,omitempty"`
 }
 
 const (

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1861,6 +1861,7 @@ func autoConvert_v1alpha1_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 		out.Target = nil
 	}
 	out.UseHostCertificates = in.UseHostCertificates
+	out.SysctlParameters = in.SysctlParameters
 	return nil
 }
 
@@ -2148,6 +2149,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha1_ClusterSpec(in *kops.ClusterSpec, 
 		out.Target = nil
 	}
 	out.UseHostCertificates = in.UseHostCertificates
+	out.SysctlParameters = in.SysctlParameters
 	return nil
 }
 
@@ -2997,6 +2999,7 @@ func autoConvert_v1alpha1_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	}
 	out.SecurityGroupOverride = in.SecurityGroupOverride
 	out.InstanceProtection = in.InstanceProtection
+	out.SysctlParameters = in.SysctlParameters
 	return nil
 }
 
@@ -3119,6 +3122,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha1_InstanceGroupSpec(in *kops.I
 	}
 	out.SecurityGroupOverride = in.SecurityGroupOverride
 	out.InstanceProtection = in.InstanceProtection
+	out.SysctlParameters = in.SysctlParameters
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -808,6 +808,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SysctlParameters != nil {
+		in, out := &in.SysctlParameters, &out.SysctlParameters
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -1676,6 +1681,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		in, out := &in.InstanceProtection, &out.InstanceProtection
 		*out = new(bool)
 		**out = **in
+	}
+	if in.SysctlParameters != nil {
+		in, out := &in.SysctlParameters, &out.SysctlParameters
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -177,6 +177,10 @@ type ClusterSpec struct {
 	// UseHostCertificates will mount /etc/ssl/certs to inside needed containers.
 	// This is needed if some APIs do have self-signed certs
 	UseHostCertificates *bool `json:"useHostCertificates,omitempty"`
+	// SysctlParameters will configure kernel parameters using sysctl(8). When
+	// specified, each parameter must follow the form variable=value, the way
+	// it would appear in sysctl.conf.
+	SysctlParameters []string `json:"sysctlParameters,omitempty"`
 }
 
 // NodeAuthorizationSpec is used to node authorization

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -149,6 +149,10 @@ type InstanceGroupSpec struct {
 	SecurityGroupOverride *string `json:"securityGroupOverride,omitempty"`
 	// InstanceProtection makes new instances in an autoscaling group protected from scale in
 	InstanceProtection *bool `json:"instanceProtection,omitempty"`
+	// SysctlParameters will configure kernel parameters using sysctl(8). When
+	// specified, each parameter must follow the form variable=value, the way
+	// it would appear in sysctl.conf.
+	SysctlParameters []string `json:"sysctlParameters,omitempty"`
 }
 
 const (

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1914,6 +1914,7 @@ func autoConvert_v1alpha2_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 		out.Target = nil
 	}
 	out.UseHostCertificates = in.UseHostCertificates
+	out.SysctlParameters = in.SysctlParameters
 	return nil
 }
 
@@ -2216,6 +2217,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, 
 		out.Target = nil
 	}
 	out.UseHostCertificates = in.UseHostCertificates
+	out.SysctlParameters = in.SysctlParameters
 	return nil
 }
 
@@ -3115,6 +3117,7 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	}
 	out.SecurityGroupOverride = in.SecurityGroupOverride
 	out.InstanceProtection = in.InstanceProtection
+	out.SysctlParameters = in.SysctlParameters
 	return nil
 }
 
@@ -3242,6 +3245,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	}
 	out.SecurityGroupOverride = in.SecurityGroupOverride
 	out.InstanceProtection = in.InstanceProtection
+	out.SysctlParameters = in.SysctlParameters
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -781,6 +781,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SysctlParameters != nil {
+		in, out := &in.SysctlParameters, &out.SysctlParameters
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -1638,6 +1643,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		in, out := &in.InstanceProtection, &out.InstanceProtection
 		*out = new(bool)
 		**out = **in
+	}
+	if in.SysctlParameters != nil {
+		in, out := &in.SysctlParameters, &out.SysctlParameters
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -881,6 +881,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SysctlParameters != nil {
+		in, out := &in.SysctlParameters, &out.SysctlParameters
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -1804,6 +1809,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		in, out := &in.InstanceProtection, &out.InstanceProtection
 		*out = new(bool)
 		**out = **in
+	}
+	if in.SysctlParameters != nil {
+		in, out := &in.SysctlParameters, &out.SysctlParameters
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }


### PR DESCRIPTION
Cherry pick of #7730 on release-1.17.

#7730: Add SysctlParameters to ClusterSpec and InstanceGroupSpec

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.