### PR TITLE
Install packages updates during bootstrap

### DIFF
--- a/docs/getting_started/arguments.md
+++ b/docs/getting_started/arguments.md
@@ -62,6 +62,8 @@ Values:
 
 * unset means to use the default policy, which is currently to apply OS security updates unless they require a reboot
 
+Required packages are also updated during bootstrapping if the value is not set. 
+
 ## out
 
 `out` determines the directory into which Kops will write the target output for Terraform and CloudFormation.  It defaults to `out/terraform` and `out/cloudformation` respectively.

--- a/upup/pkg/fi/nodeup/nodetasks/package.go
+++ b/upup/pkg/fi/nodeup/nodetasks/package.go
@@ -216,7 +216,9 @@ func (e *Package) findDpkg(c *fi.Context) (*Package, error) {
 		}
 	}
 
-	if !installed {
+	target := c.Target.(*local.LocalTarget)
+	updates := target.HasTag(tags.TagUpdatePolicyAuto)
+	if !updates && !installed {
 		return nil, nil
 	}
 
@@ -264,7 +266,9 @@ func (e *Package) findYum(c *fi.Context) (*Package, error) {
 		healthy = fi.Bool(true)
 	}
 
-	if !installed {
+	target := c.Target.(*local.LocalTarget)
+	updates := target.HasTag(tags.TagUpdatePolicyAuto)
+	if !updates && !installed {
 		return nil, nil
 	}
 

--- a/upup/pkg/fi/nodeup/tags/tags.go
+++ b/upup/pkg/fi/nodeup/tags/tags.go
@@ -25,6 +25,12 @@ const (
 	TagOSRHEL8        = "_rhel8"
 
 	TagSystemd = "_systemd"
+
+	// Nodes with the "_automatic_upgrade" tag automatically update installed packages
+	// during bootstrapping and daily for security updates (unless this update would require
+	// a node reboot). To disable automatic node package updates, set:
+	// `Cluster.Spec.UpdatePolicy = external`
+	TagUpdatePolicyAuto = "_automatic_upgrades"
 )
 
 type HasTags interface {


### PR DESCRIPTION
During bootstrap packages that are already installed are skipped. They are later installed by the automatic updater.

The PR checks if automatic updates are enabled and tries to install the updated version.
The package managed decides if there is an update to be installed or not, so the only thing that has to be done is try to install it again. The newer the base image, the less updates will be installed.

This is a followup of #8020 and after discussing about the issue during office hours.