### PR TITLE
Delete launch templates when using EnableLaunchTemplates

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -1204,7 +1204,10 @@ func FindAutoScalingLaunchTemplateConfigurations(cloud fi.Cloud, securityGroups 
 		}
 		for _, j := range req.LaunchTemplateVersions {
 			// @check if the security group references the security group above
-			for _, y := range j.LaunchTemplateData.SecurityGroupIds {
+			var s []*string
+			s = append(s, j.LaunchTemplateData.NetworkInterfaces[0].Groups...)
+			s = append(s, j.LaunchTemplateData.SecurityGroupIds...)
+			for _, y := range s {
 				if securityGroups.Has(fi.StringValue(y)) {
 					list = append(list, &resources.Resource{
 						Name:    aws.StringValue(x.LaunchTemplateName),


### PR DESCRIPTION
Setting the feature flag `EnableLaunchTemplates=true` make kops use Launch Templates instead of Launch Configurations to create the ASGs.

Launch Templates implementation in Kops is derived from the Mixed Instance Policy feature, but requires a few tweaks. One of it is that security groups are declared for the primary network interface instead of the SecurityGroups field. For this reason, the delete mechanism is not finding these launch templates.