### PR TITLE
Bump Calico and Canal version tags for older k8s

### DIFF
--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -682,7 +682,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		versions := map[string]string{
 			"k8s-1.7":    "2.6.12-kops.1",
 			"k8s-1.7-v3": "3.8.0-kops.2",
-			"k8s-1.12":   "3.9.3-kops.2",
+			"k8s-1.12":   "3.9.5-kops.1",
 			"k8s-1.16":   "3.12.0-kops.1",
 		}
 
@@ -749,7 +749,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		key := "networking.projectcalico.org.canal"
 		versions := map[string]string{
 			"k8s-1.9":  "3.2.3-kops.1",
-			"k8s-1.12": "3.7.4-kops.1",
+			"k8s-1.12": "3.7.5-kops.1",
 			"k8s-1.15": "3.12.0-kops.1",
 		}
 		{


### PR DESCRIPTION
This is a small leftover of #8618.