### PR TITLE
Fix node-authorizer/pkg/server staticcheck failure

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,1 +1,0 @@
-node-authorizer/pkg/server

--- a/node-authorizer/pkg/server/server.go
+++ b/node-authorizer/pkg/server/server.go
@@ -118,7 +118,7 @@ func (n *NodeAuthorizer) Run() error {
 	}()
 
 	go func() {
-		c := make(chan os.Signal)
+		c := make(chan os.Signal, 1)
 		signal.Notify(c, syscall.SIGINT)
 		errs <- fmt.Errorf("received termination signal: %s", <-c)
 	}()


### PR DESCRIPTION
Finally fixes the last exception: #7800. Thanks for doing this @tanjunchen.

```
Errors from staticcheck:
node-authorizer/pkg/server/server.go:122:16: the channel used with signal.Notify should be buffered (SA1017)
```