### PR TITLE
Use BPF_FS_MAGIC from go sys lib instead of hardcode

### DIFF
--- a/nodeup/pkg/model/network.go
+++ b/nodeup/pkg/model/network.go
@@ -75,12 +75,11 @@ func (b *NetworkBuilder) Build(c *fi.ModelBuilderContext) error {
 			return fmt.Errorf("error checking for /sys/fs/bpf: %v", err)
 		}
 
-		// systemd v238 includes the bpffs mount by default; and gives an error "has a bad unit file setting" if we try to mount it again (see mount_point_is_api)
-		var alreadyMounted bool
-		// bpffs magic number. See https://github.com/torvalds/linux/blob/v4.8/include/uapi/linux/magic.h#L80
-		magic := uint32(0xCAFE4A11)
+		// equivalent to unix.BPF_FS_MAGIC in golang.org/x/sys/unix
+		BPF_FS_MAGIC := uint32(0xcafe4a11)
 
-		alreadyMounted = int32(magic) == int32(fsdata.Type)
+		// systemd v238 includes the bpffs mount by default; and gives an error "has a bad unit file setting" if we try to mount it again (see mount_point_is_api)
+		alreadyMounted := uint32(fsdata.Type) == BPF_FS_MAGIC
 
 		if !alreadyMounted {
 			unit := s(`


### PR DESCRIPTION
This also avoids overflow during conversion. 0xCAFE4A11 is bigger than
the max of int32, so doing int32(uint32(0xCAFE4A11)) (will not compile
directly unless done over two lines) will result in -0x3501b5ef.

Due to some strange errors[0] in the types in "unix.Statfs_t" for 32 bits
systems, we have to explicitly convert to uint to support those (eg.
armv7). If we only need support for 64 bit systems, we can remove the
uint conversion as well.

[0]: For 32bits systems "fsdata.Type" should be uint32 instead of the
current int32, as it is in the linux kernel. This is due to the types in
glibc that the go types are generated from. For 64 bit systems the type
is correctly set to int64.