### PR TITLE
Add the aws iam authenticator known issue to the 1.17 release notes

### DIFF
--- a/docs/releases/1.17-NOTES.md
+++ b/docs/releases/1.17-NOTES.md
@@ -61,6 +61,13 @@ the notes prior to the release).
 
 * The `kops/v1alpha1` API is deprecated and will be removed in kops 1.18. Users of `kops replace` will need to supply v1alpha2 resources.
 
+# Known Issues
+
+* Kops 1.17.0-beta.1 included an update for AWS IAM Authenticator to 0.5.0.
+  This version fails to use the volume mounted ConfigMap causing API authentication issues for clients with aws-iam-authenticator credentials.
+  Any cluster with `spec.authentication.aws` defined according to the [docs](../authentication.md#aws-iam-authenticator) without overriding the `spec.authentication.aws.image` is affected.
+  The workaround is to specify the old 0.4.0 image with `spec.authentication.aws.image=602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.4.0`.
+ 
 # Full change list since 1.16.0 release
 
 ## 1.16.0-alpha.1 to 1.17.0-alpha.1


### PR DESCRIPTION
This issue was discussed during office hours. I'll revert the upgrade in release-1.17 while we address the issue itself.