### PR TITLE
Backport from master: Set the default instance type to t3.medium for AWS

### DIFF
--- a/docs/releases/1.16-NOTES.md
+++ b/docs/releases/1.16-NOTES.md
@@ -21,6 +21,9 @@ the notes prior to the release).
   kops-controller currently labels nodes, but will likely perform additional
   functionality in future releases.
 
+* The default instance type for AWS is now t3.medium. This should provide better
+  performance and reduced costs in clusters where the average CPU usage is low.
+
 # Required Actions
 
 * If either a Kops 1.16 alpha release or a custom Kops build was used on a cluster,

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -1368,17 +1368,13 @@ func (c *awsCloudImplementation) DefaultInstanceType(cluster *kops.Cluster, ig *
 	var candidates []string
 
 	switch ig.Spec.Role {
-	case kops.InstanceGroupRoleMaster:
-		// Some regions do not (currently) support the m3 family; the c4 large is the cheapest non-burstable instance
-		// (us-east-2, ca-central-1, eu-west-2, ap-northeast-2).
-		// Also some accounts are no longer supporting m3 in us-east-1 zones
-		candidates = []string{"m3.medium", "c4.large"}
-
-	case kops.InstanceGroupRoleNode:
-		candidates = []string{"t2.medium"}
+	case kops.InstanceGroupRoleMaster, kops.InstanceGroupRoleNode:
+		// t3.medium is the cheapest instance with 4GB of mem, unlimited by default, fast and has decent network
+		// c5.large and c4.large are a good second option in case t3.medium is not available in the AZ
+		candidates = []string{"t3.medium", "c5.large", "c4.large"}
 
 	case kops.InstanceGroupRoleBastion:
-		candidates = []string{"t2.micro"}
+		candidates = []string{"t3.micro", "t2.micro"}
 
 	default:
 		return "", fmt.Errorf("unhandled role %q", ig.Spec.Role)


### PR DESCRIPTION
This changeset backports 7a42cf42cdcba2c81c0003d49fd2a50bd0d3606b from master into the 1.16 release branch.

Reasons:
- this change is very low impact
- 1.17 is still in beta
- this change didn't make it into 1.17 anyway
- it would make my govcloud deployments immensely easier, for reasons

I don't know the kops policy on backporting, I'll understand if it doesn't meet criteria to go into 1.16.1 .