### PR TITLE
Fix condition for innstall packages updates during bootstrap

### DIFF
--- a/upup/pkg/fi/nodeup/nodetasks/package.go
+++ b/upup/pkg/fi/nodeup/nodetasks/package.go
@@ -218,7 +218,7 @@ func (e *Package) findDpkg(c *fi.Context) (*Package, error) {
 
 	target := c.Target.(*local.LocalTarget)
 	updates := target.HasTag(tags.TagUpdatePolicyAuto)
-	if !updates && !installed {
+	if updates || !installed {
 		return nil, nil
 	}
 
@@ -268,7 +268,7 @@ func (e *Package) findYum(c *fi.Context) (*Package, error) {
 
 	target := c.Target.(*local.LocalTarget)
 	updates := target.HasTag(tags.TagUpdatePolicyAuto)
-	if !updates && !installed {
+	if updates || !installed {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Due to a mistake in #8635, the condition for installing updated packages was not working correct.
This update should fix it to work as intended.