### PR TITLE
Update release notes for the default instance type change

### DIFF
--- a/docs/releases/1.17-NOTES.md
+++ b/docs/releases/1.17-NOTES.md
@@ -3,6 +3,10 @@
 (The kops 1.17 release has not been released yet, this is a document to gather
 the notes prior to the release).
 
+# Significant changes
+
+* The default instance type for AWS is now t3.medium. This should provide better performance and reduced costs in clusters where the average CPU usage is low.
+
 # Breaking changes
 
 * Terraform users on AWS may need to rename some resources in their state file in order to prepare for future Terraform 0.12 support. See Required Actions below.
@@ -13,11 +17,6 @@ the notes prior to the release).
 * Since 1.16, a controller is now used to apply labels to nodes.  If
   you are not using AWS, GCE or OpenStack your (non-master) nodes may
   not have labels applied correctly.
-
-# Significant changes
-
-* If upgrading from 1.11 or earlier, please see the notes in previous releases
-  about upgrading through kubernetes 1.12, with the etcd3 upgrade.
 
 # Required Actions
 

--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -6,8 +6,6 @@
 
 * [containerd](https://github.com/containerd/containerd/blob/master/README.md) can now be selected as an alternate container runtime for Kubernetes. Use the `--container-runtime containerd` flag to create such a cluster.
 
-* The default instance type for AWS is now t3.medium. This should provide better performance and reduced costs in clusters where the average CPU usage is low.
-
 # Breaking changes
 
 * Terraform users on AWS may need to rename some resources in their state file in order to prepare for Terraform 0.12 support. See Required Actions below.


### PR DESCRIPTION
#8282 was cherry-picked to 1.17 in #8656. It makes sense that the release notes are updated also.