### PR TITLE
Add "owned" tag for volumes and instances created with launch templates

### DIFF
--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -183,7 +183,7 @@ func (m *KopsModelContext) NodeInstanceGroups() []*kops.InstanceGroup {
 
 // CloudTagsForInstanceGroup computes the tags to apply to instances in the specified InstanceGroup
 func (m *KopsModelContext) CloudTagsForInstanceGroup(ig *kops.InstanceGroup) (map[string]string, error) {
-	labels := make(map[string]string)
+	labels := m.CloudTags(m.AutoscalingGroupName(ig), false)
 
 	// Apply any user-specified global labels first so they can be overridden by IG-specific labels
 	for k, v := range m.Cluster.Spec.CloudLabels {
@@ -207,10 +207,6 @@ func (m *KopsModelContext) CloudTagsForInstanceGroup(ig *kops.InstanceGroup) (ma
 			labels[clusterAutoscalerNodeTemplateTaint+splits[0]] = splits[1]
 		}
 	}
-
-	// Add cluster and ig names
-	labels[awsup.TagClusterName] = m.ClusterName()
-	labels["Name"] = m.AutoscalingGroupName(ig)
 
 	// The system tags take priority because the cluster likely breaks without them...
 

--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json
@@ -34,6 +34,11 @@
             "Key": "kops.k8s.io/instancegroup",
             "Value": "master-us-test-1b",
             "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/additionalcidr.example.com",
+            "Value": "owned",
+            "PropagateAtLaunch": true
           }
         ],
         "MetricsCollection": [
@@ -86,6 +91,11 @@
           {
             "Key": "kops.k8s.io/instancegroup",
             "Value": "nodes",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/additionalcidr.example.com",
+            "Value": "owned",
             "PropagateAtLaunch": true
           }
         ],

--- a/tests/integration/update_cluster/additional_cidr/kubernetes.tf
+++ b/tests/integration/update_cluster/additional_cidr/kubernetes.tf
@@ -121,6 +121,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-additionalcidr-examp
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/additionalcidr.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -153,6 +159,12 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-additionalcidr-examp
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "master-us-test-1b"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/additionalcidr.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 
@@ -191,6 +203,12 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-additionalcidr-examp
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/additionalcidr.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -223,6 +241,12 @@ resource "aws_autoscaling_group" "nodes-additionalcidr-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/additionalcidr.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json
@@ -34,6 +34,11 @@
             "Key": "kops.k8s.io/instancegroup",
             "Value": "master-us-test-1a",
             "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/additionaluserdata.example.com",
+            "Value": "owned",
+            "PropagateAtLaunch": true
           }
         ],
         "MetricsCollection": [
@@ -86,6 +91,11 @@
           {
             "Key": "kops.k8s.io/instancegroup",
             "Value": "nodes",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/additionaluserdata.example.com",
+            "Value": "owned",
             "PropagateAtLaunch": true
           }
         ],

--- a/tests/integration/update_cluster/api_elb_cross_zone/kubernetes.tf
+++ b/tests/integration/update_cluster/api_elb_cross_zone/kubernetes.tf
@@ -128,6 +128,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-crosszone-example-co
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/crosszone.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -172,6 +178,12 @@ resource "aws_autoscaling_group" "nodes-crosszone-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/crosszone.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -151,6 +151,12 @@ resource "aws_autoscaling_group" "bastion-bastionuserdata-example-com" {
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/bastionuserdata.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -186,6 +192,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-bastionuserdata-exam
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/bastionuserdata.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -218,6 +230,12 @@ resource "aws_autoscaling_group" "nodes-bastionuserdata-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/bastionuserdata.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -44,6 +44,11 @@
             "Key": "kops.k8s.io/instancegroup",
             "Value": "master-us-test-1a",
             "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/complex.example.com",
+            "Value": "owned",
+            "PropagateAtLaunch": true
           }
         ],
         "MetricsCollection": [
@@ -111,6 +116,11 @@
           {
             "Key": "kops.k8s.io/instancegroup",
             "Value": "nodes",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/complex.example.com",
+            "Value": "owned",
             "PropagateAtLaunch": true
           }
         ],

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -128,6 +128,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-complex-example-com"
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/complex.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -172,6 +178,12 @@ resource "aws_autoscaling_group" "nodes-complex-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/complex.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json
@@ -34,6 +34,11 @@
             "Key": "kops.k8s.io/instancegroup",
             "Value": "master-us-test-1a",
             "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/containerd.example.com",
+            "Value": "owned",
+            "PropagateAtLaunch": true
           }
         ],
         "MetricsCollection": [
@@ -86,6 +91,11 @@
           {
             "Key": "kops.k8s.io/instancegroup",
             "Value": "nodes",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/containerd.example.com",
+            "Value": "owned",
             "PropagateAtLaunch": true
           }
         ],

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -101,6 +101,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-existing-iam-example
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/existing-iam.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -133,6 +139,12 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-existing-iam-example
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "master-us-test-1b"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/existing-iam.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 
@@ -171,6 +183,12 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-existing-iam-example
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/existing-iam.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -203,6 +221,12 @@ resource "aws_autoscaling_group" "nodes-existing-iam-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/existing-iam.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json
@@ -34,6 +34,11 @@
             "Key": "kops.k8s.io/instancegroup",
             "Value": "master-us-test-1a",
             "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/minimal.example.com",
+            "Value": "owned",
+            "PropagateAtLaunch": true
           }
         ],
         "MetricsCollection": [
@@ -86,6 +91,11 @@
           {
             "Key": "kops.k8s.io/instancegroup",
             "Value": "nodes",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/minimal.example.com",
+            "Value": "owned",
             "PropagateAtLaunch": true
           }
         ],

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -136,6 +136,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-existingsg-example-c
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/existingsg.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -168,6 +174,12 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-existingsg-example-c
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "master-us-test-1b"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/existingsg.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 
@@ -206,6 +218,12 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-existingsg-example-c
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/existingsg.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -238,6 +256,12 @@ resource "aws_autoscaling_group" "nodes-existingsg-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/existingsg.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/externallb/cloudformation.json
+++ b/tests/integration/update_cluster/externallb/cloudformation.json
@@ -34,6 +34,11 @@
             "Key": "kops.k8s.io/instancegroup",
             "Value": "master-us-test-1a",
             "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/externallb.example.com",
+            "Value": "owned",
+            "PropagateAtLaunch": true
           }
         ],
         "MetricsCollection": [
@@ -92,6 +97,11 @@
           {
             "Key": "kops.k8s.io/instancegroup",
             "Value": "nodes",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/externallb.example.com",
+            "Value": "owned",
             "PropagateAtLaunch": true
           }
         ],

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -126,6 +126,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-externallb-example-c
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/externallb.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -158,6 +164,12 @@ resource "aws_autoscaling_group" "nodes-externallb-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/externallb.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -128,6 +128,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-externalpolicies-exa
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/externalpolicies.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -172,6 +178,12 @@ resource "aws_autoscaling_group" "nodes-externalpolicies-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/externalpolicies.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -121,6 +121,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-ha-example-com" {
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/ha.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -153,6 +159,12 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-ha-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "master-us-test-1b"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/ha.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 
@@ -191,6 +203,12 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-ha-example-com" {
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/ha.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -223,6 +241,12 @@ resource "aws_autoscaling_group" "nodes-ha-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/ha.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/minimal-141/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-141/kubernetes.tf
@@ -111,6 +111,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-141-example-
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/minimal-141.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -143,6 +149,12 @@ resource "aws_autoscaling_group" "nodes-minimal-141-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/minimal-141.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
@@ -34,6 +34,11 @@
             "Key": "kops.k8s.io/instancegroup",
             "Value": "master-us-test-1a",
             "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/minimal.example.com",
+            "Value": "owned",
+            "PropagateAtLaunch": true
           }
         ],
         "MetricsCollection": [
@@ -86,6 +91,11 @@
           {
             "Key": "kops.k8s.io/instancegroup",
             "Value": "nodes",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/minimal.example.com",
+            "Value": "owned",
             "PropagateAtLaunch": true
           }
         ],

--- a/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
+++ b/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
@@ -118,6 +118,11 @@
             "key": "kops.k8s.io/instancegroup",
             "value": "master-us-test-1a",
             "propagate_at_launch": true
+          },
+          {
+            "key": "kubernetes.io/cluster/minimal-json.example.com",
+            "value": "owned",
+            "propagate_at_launch": true
           }
         ],
         "metrics_granularity": "1Minute",
@@ -159,6 +164,11 @@
           {
             "key": "kops.k8s.io/instancegroup",
             "value": "nodes",
+            "propagate_at_launch": true
+          },
+          {
+            "key": "kubernetes.io/cluster/minimal-json.example.com",
+            "value": "owned",
             "propagate_at_launch": true
           }
         ],

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -111,6 +111,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com"
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/minimal.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -143,6 +149,12 @@ resource "aws_autoscaling_group" "nodes-minimal-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/minimal.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json
@@ -34,6 +34,11 @@
             "Key": "kops.k8s.io/instancegroup",
             "Value": "master-us-test-1a",
             "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/mixedinstances.example.com",
+            "Value": "owned",
+            "PropagateAtLaunch": true
           }
         ],
         "MetricsCollection": [
@@ -86,6 +91,11 @@
           {
             "Key": "kops.k8s.io/instancegroup",
             "Value": "master-us-test-1b",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/mixedinstances.example.com",
+            "Value": "owned",
             "PropagateAtLaunch": true
           }
         ],
@@ -140,6 +150,11 @@
             "Key": "kops.k8s.io/instancegroup",
             "Value": "master-us-test-1c",
             "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/mixedinstances.example.com",
+            "Value": "owned",
+            "PropagateAtLaunch": true
           }
         ],
         "MetricsCollection": [
@@ -189,6 +204,11 @@
           {
             "Key": "kops.k8s.io/instancegroup",
             "Value": "nodes",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/mixedinstances.example.com",
+            "Value": "owned",
             "PropagateAtLaunch": true
           }
         ],

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -121,6 +121,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-mixedinstances-examp
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/mixedinstances.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -156,6 +162,12 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-mixedinstances-examp
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/mixedinstances.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -188,6 +200,12 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-mixedinstances-examp
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "master-us-test-1c"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/mixedinstances.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 
@@ -249,6 +267,12 @@ resource "aws_autoscaling_group" "nodes-mixedinstances-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/mixedinstances.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
@@ -34,6 +34,11 @@
             "Key": "kops.k8s.io/instancegroup",
             "Value": "master-us-test-1a",
             "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/mixedinstances.example.com",
+            "Value": "owned",
+            "PropagateAtLaunch": true
           }
         ],
         "MetricsCollection": [
@@ -86,6 +91,11 @@
           {
             "Key": "kops.k8s.io/instancegroup",
             "Value": "master-us-test-1b",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/mixedinstances.example.com",
+            "Value": "owned",
             "PropagateAtLaunch": true
           }
         ],
@@ -140,6 +150,11 @@
             "Key": "kops.k8s.io/instancegroup",
             "Value": "master-us-test-1c",
             "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/mixedinstances.example.com",
+            "Value": "owned",
+            "PropagateAtLaunch": true
           }
         ],
         "MetricsCollection": [
@@ -189,6 +204,11 @@
           {
             "Key": "kops.k8s.io/instancegroup",
             "Value": "nodes",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/mixedinstances.example.com",
+            "Value": "owned",
             "PropagateAtLaunch": true
           }
         ],

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -121,6 +121,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-mixedinstances-examp
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/mixedinstances.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -156,6 +162,12 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-mixedinstances-examp
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/mixedinstances.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -188,6 +200,12 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-mixedinstances-examp
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "master-us-test-1c"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/mixedinstances.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 
@@ -250,6 +268,12 @@ resource "aws_autoscaling_group" "nodes-mixedinstances-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/mixedinstances.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/nosshkey-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/nosshkey-cloudformation/cloudformation.json
@@ -34,6 +34,11 @@
             "Key": "kops.k8s.io/instancegroup",
             "Value": "master-us-test-1a",
             "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/nosshkey.example.com",
+            "Value": "owned",
+            "PropagateAtLaunch": true
           }
         ],
         "MetricsCollection": [
@@ -86,6 +91,11 @@
           {
             "Key": "kops.k8s.io/instancegroup",
             "Value": "nodes",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/nosshkey.example.com",
+            "Value": "owned",
             "PropagateAtLaunch": true
           }
         ],

--- a/tests/integration/update_cluster/nosshkey/kubernetes.tf
+++ b/tests/integration/update_cluster/nosshkey/kubernetes.tf
@@ -128,6 +128,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-nosshkey-example-com
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/nosshkey.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -172,6 +178,12 @@ resource "aws_autoscaling_group" "nodes-nosshkey-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/nosshkey.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -141,6 +141,12 @@ resource "aws_autoscaling_group" "bastion-private-shared-subnet-example-com" {
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/private-shared-subnet.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -176,6 +182,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-private-shared-subne
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/private-shared-subnet.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -208,6 +220,12 @@ resource "aws_autoscaling_group" "nodes-private-shared-subnet-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/private-shared-subnet.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -34,6 +34,11 @@
             "Key": "kops.k8s.io/instancegroup",
             "Value": "bastion",
             "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/privatecalico.example.com",
+            "Value": "owned",
+            "PropagateAtLaunch": true
           }
         ],
         "MetricsCollection": [
@@ -92,6 +97,11 @@
             "Key": "kops.k8s.io/instancegroup",
             "Value": "master-us-test-1a",
             "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/privatecalico.example.com",
+            "Value": "owned",
+            "PropagateAtLaunch": true
           }
         ],
         "MetricsCollection": [
@@ -149,6 +159,11 @@
           {
             "Key": "kops.k8s.io/instancegroup",
             "Value": "nodes",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "kubernetes.io/cluster/privatecalico.example.com",
+            "Value": "owned",
             "PropagateAtLaunch": true
           }
         ],

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -151,6 +151,12 @@ resource "aws_autoscaling_group" "bastion-privatecalico-example-com" {
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/privatecalico.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -186,6 +192,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatecalico-exampl
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/privatecalico.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -218,6 +230,12 @@ resource "aws_autoscaling_group" "nodes-privatecalico-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/privatecalico.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -151,6 +151,12 @@ resource "aws_autoscaling_group" "bastion-privatecanal-example-com" {
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/privatecanal.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -186,6 +192,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatecanal-example
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/privatecanal.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -218,6 +230,12 @@ resource "aws_autoscaling_group" "nodes-privatecanal-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/privatecanal.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -151,6 +151,12 @@ resource "aws_autoscaling_group" "bastion-privatedns1-example-com" {
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/privatedns1.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -186,6 +192,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatedns1-example-
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/privatedns1.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -218,6 +230,12 @@ resource "aws_autoscaling_group" "nodes-privatedns1-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/privatedns1.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -146,6 +146,12 @@ resource "aws_autoscaling_group" "bastion-privatedns2-example-com" {
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/privatedns2.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -181,6 +187,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatedns2-example-
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/privatedns2.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -213,6 +225,12 @@ resource "aws_autoscaling_group" "nodes-privatedns2-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/privatedns2.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -151,6 +151,12 @@ resource "aws_autoscaling_group" "bastion-privateflannel-example-com" {
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/privateflannel.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -186,6 +192,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privateflannel-examp
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/privateflannel.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -218,6 +230,12 @@ resource "aws_autoscaling_group" "nodes-privateflannel-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/privateflannel.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -166,6 +166,12 @@ resource "aws_autoscaling_group" "bastion-privatekopeio-example-com" {
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/privatekopeio.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -201,6 +207,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatekopeio-exampl
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/privatekopeio.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -233,6 +245,12 @@ resource "aws_autoscaling_group" "nodes-privatekopeio-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/privatekopeio.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -151,6 +151,12 @@ resource "aws_autoscaling_group" "bastion-privateweave-example-com" {
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/privateweave.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -186,6 +192,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privateweave-example
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/privateweave.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -218,6 +230,12 @@ resource "aws_autoscaling_group" "nodes-privateweave-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/privateweave.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/restrict_access/kubernetes.tf
+++ b/tests/integration/update_cluster/restrict_access/kubernetes.tf
@@ -111,6 +111,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-restrictaccess-examp
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/restrictaccess.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -143,6 +149,12 @@ resource "aws_autoscaling_group" "nodes-restrictaccess-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/restrictaccess.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -106,6 +106,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-sharedsubnet-example
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/sharedsubnet.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -138,6 +144,12 @@ resource "aws_autoscaling_group" "nodes-sharedsubnet-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/sharedsubnet.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -106,6 +106,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-sharedvpc-example-co
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/sharedvpc.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -138,6 +144,12 @@ resource "aws_autoscaling_group" "nodes-sharedvpc-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/sharedvpc.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -146,6 +146,12 @@ resource "aws_autoscaling_group" "bastion-unmanaged-example-com" {
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/unmanaged.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -181,6 +187,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-unmanaged-example-co
     propagate_at_launch = true
   }
 
+  tag = {
+    key                 = "kubernetes.io/cluster/unmanaged.example.com"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
   metrics_granularity = "1Minute"
   enabled_metrics     = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
 }
@@ -213,6 +225,12 @@ resource "aws_autoscaling_group" "nodes-unmanaged-example-com" {
   tag = {
     key                 = "kops.k8s.io/instancegroup"
     value               = "nodes"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "kubernetes.io/cluster/unmanaged.example.com"
+    value               = "owned"
     propagate_at_launch = true
   }
 


### PR DESCRIPTION
Using launch templates for instance groups make adds the kops & k8s tags to instances and root volumes.

For volumes, the cluster delete function checks if the resource is "shared" or "owned", otherwise it displays the following warning:
```
W0229 23:33:33.176831    8549 aws.go:2148] (new) cluster tag not found on volume:vol-038ab86f6fcd93336
```

https://github.com/kubernetes/kops/blob/632b426bdfc2bd3566c6bc5a690fa1c4022d736d/pkg/resources/aws/aws.go#L2134-L2136