### PR TITLE
Automated cherry pick of #8462: Tag EBS volumes when using launch templates with AWS API

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -97,6 +97,11 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateTask(c *fi.ModelBuilde
 		return nil, err
 	}
 
+	tags, err := b.CloudTagsForInstanceGroup(ig)
+	if err != nil {
+		return nil, fmt.Errorf("error building cloud tags: %v", err)
+	}
+
 	// @TODO check if there any a better way of doing this .. initially I had a type LaunchTemplate which included
 	// LaunchConfiguration as an anonymous field, bit given up the task dependency walker works this caused issues, due
 	// to the creation of a implicit dependency
@@ -115,6 +120,7 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateTask(c *fi.ModelBuilde
 		RootVolumeType:         lc.RootVolumeType,
 		SSHKey:                 lc.SSHKey,
 		SecurityGroups:         lc.SecurityGroups,
+		Tags:                   tags,
 		Tenancy:                lc.Tenancy,
 		UserData:               lc.UserData,
 	}

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
@@ -62,6 +62,8 @@ type LaunchTemplate struct {
 	SecurityGroups []*SecurityGroup
 	// SpotPrice is set to the spot-price bid if this is a spot pricing request
 	SpotPrice string
+	// Tags are the keypairs to apply to the instance and volume on launch.
+	Tags map[string]string
 	// Tenancy. Can be either default or dedicated.
 	Tenancy *string
 	// UserData is the user data configuration

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -108,6 +108,25 @@ func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, ep, changes *Launch
 	} else {
 		lc.SecurityGroupIds = securityGroups
 	}
+	// @step: add the tags
+	{
+		var list []*ec2.Tag
+		for k, v := range t.Tags {
+			list = append(list, &ec2.Tag{
+				Key:   aws.String(k),
+				Value: aws.String(v),
+			})
+		}
+		instanceTagSpec := ec2.LaunchTemplateTagSpecificationRequest{
+			ResourceType: aws.String("instance"),
+			Tags:         list,
+		}
+		volumeTagSpec := ec2.LaunchTemplateTagSpecificationRequest{
+			ResourceType: aws.String("volume"),
+			Tags:         list,
+		}
+		lc.TagSpecifications = []*ec2.LaunchTemplateTagSpecificationRequest{&instanceTagSpec, &volumeTagSpec}
+	}
 	// @step: add the userdata
 	if t.UserData != nil {
 		d, err := t.UserData.AsBytes()


### PR DESCRIPTION
Cherry pick of #8462 on release-1.17.

#8462: Tag EBS volumes when using launch templates with AWS API

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.