### PR TITLE
Default maxSurge to 1 on AWS

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2947,10 +2947,10 @@ spec:
                     example 10%). The absolute number is calculated from a percentage
                     by rounding up. A value of 0 for both this and MaxUnavailable
                     disables rolling updates. Has no effect on instance groups with
-                    role "Master". Defaults to 0. Example: when this is set to 30%,
-                    the InstanceGroup can be scaled up immediately when the rolling
-                    update starts, such that the total number of old and new nodes
-                    do not exceed 130% of desired nodes.'
+                    role "Master". Defaults to 1 on AWS, 0 otherwise. Example: when
+                    this is set to 30%, the InstanceGroup can be scaled up immediately
+                    when the rolling update starts, such that the total number of
+                    old and new nodes do not exceed 130% of desired nodes.'
                 maxUnavailable:
                   anyOf:
                   - type: string

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -640,10 +640,10 @@ spec:
                     example 10%). The absolute number is calculated from a percentage
                     by rounding up. A value of 0 for both this and MaxUnavailable
                     disables rolling updates. Has no effect on instance groups with
-                    role "Master". Defaults to 0. Example: when this is set to 30%,
-                    the InstanceGroup can be scaled up immediately when the rolling
-                    update starts, such that the total number of old and new nodes
-                    do not exceed 130% of desired nodes.'
+                    role "Master". Defaults to 1 on AWS, 0 otherwise. Example: when
+                    this is set to 30%, the InstanceGroup can be scaled up immediately
+                    when the rolling update starts, such that the total number of
+                    old and new nodes do not exceed 130% of desired nodes.'
                 maxUnavailable:
                   anyOf:
                   - type: string

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -700,7 +700,7 @@ type RollingUpdate struct {
 	// The absolute number is calculated from a percentage by rounding up.
 	// A value of 0 for both this and MaxUnavailable disables rolling updates.
 	// Has no effect on instance groups with role "Master".
-	// Defaults to 0.
+	// Defaults to 1 on AWS, 0 otherwise.
 	// Example: when this is set to 30%, the InstanceGroup can be scaled
 	// up immediately when the rolling update starts, such that the total
 	// number of old and new nodes do not exceed 130% of desired

--- a/pkg/apis/kops/v1alpha1/cluster.go
+++ b/pkg/apis/kops/v1alpha1/cluster.go
@@ -582,7 +582,7 @@ type RollingUpdate struct {
 	// The absolute number is calculated from a percentage by rounding up.
 	// A value of 0 for both this and MaxUnavailable disables rolling updates.
 	// Has no effect on instance groups with role "Master".
-	// Defaults to 0.
+	// Defaults to 1 on AWS, 0 otherwise.
 	// Example: when this is set to 30%, the InstanceGroup can be scaled
 	// up immediately when the rolling update starts, such that the total
 	// number of old and new nodes do not exceed 130% of desired

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -595,7 +595,7 @@ type RollingUpdate struct {
 	// The absolute number is calculated from a percentage by rounding up.
 	// A value of 0 for both this and MaxUnavailable disables rolling updates.
 	// Has no effect on instance groups with role "Master".
-	// Defaults to 0.
+	// Defaults to 1 on AWS, 0 otherwise.
 	// Example: when this is set to 30%, the InstanceGroup can be scaled
 	// up immediately when the rolling update starts, such that the total
 	// number of old and new nodes do not exceed 130% of desired

--- a/pkg/instancegroups/BUILD.bazel
+++ b/pkg/instancegroups/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/client/simple:go_default_library",
         "//pkg/cloudinstances:go_default_library",
         "//pkg/drain:go_default_library",
+        "//pkg/featureflag:go_default_library",
         "//pkg/validation:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/instancegroups/settings_test.go
+++ b/pkg/instancegroups/settings_test.go
@@ -204,3 +204,15 @@ func TestMaxSurge(t *testing.T) {
 		})
 	}
 }
+
+func TestAWSDefault(t *testing.T) {
+	resolved := resolveSettings(&kops.Cluster{
+		Spec: kops.ClusterSpec{
+			CloudProvider: "aws",
+		},
+	}, &kops.InstanceGroup{}, 1000)
+	assert.Equal(t, intstr.Int, resolved.MaxSurge.Type)
+	assert.Equal(t, int32(1), resolved.MaxSurge.IntVal)
+	assert.Equal(t, intstr.Int, resolved.MaxUnavailable.Type)
+	assert.Equal(t, int32(0), resolved.MaxUnavailable.IntVal)
+}


### PR DESCRIPTION
On the cloud provider that supports it, a `maxSurge` of 1 (and thus `maxUnavailable` of 0) is a better default than `maxSurge` of 0 and `maxUnavailable` of 1. Nodes will still be drained one at a time, but the pods evicted from the first node won't have to be replaced on an old node and get evicted again.

The only downside I can think of would require a rather contrived situation: a workload that is deployed with a DaemonSet instead of a Deployment or StatefulSet and which cannot tolerate having the resulting surged pod.

/area rolling-update