### PR TITLE
Some debian package manager tweaks

### DIFF
--- a/hooks/nvidia-bootstrap/image/Dockerfile
+++ b/hooks/nvidia-bootstrap/image/Dockerfile
@@ -16,7 +16,7 @@ FROM debian:jessie
 # ^ Cannot be Alpine since it does not support systemctl
 # ^ Systemctl is used to restart kubelet upon successful run of run.sh
 
-RUN apt-get update && apt-get -yq install curl jq
+RUN apt-get update && apt-get --no-install-recommends -yq install curl jq
 
 ADD run.sh /run.sh
 

--- a/hooks/nvidia-bootstrap/image/Dockerfile
+++ b/hooks/nvidia-bootstrap/image/Dockerfile
@@ -16,7 +16,7 @@ FROM debian:jessie
 # ^ Cannot be Alpine since it does not support systemctl
 # ^ Systemctl is used to restart kubelet upon successful run of run.sh
 
-RUN apt-get update && apt-get --no-install-recommends -yq install curl jq
+RUN apt-get update && apt-get --no-install-recommends -yq install apt-utils ca-certificates apt-transport-https curl jq
 
 ADD run.sh /run.sh
 

--- a/images/dns-controller-builder/Dockerfile
+++ b/images/dns-controller-builder/Dockerfile
@@ -19,7 +19,7 @@ FROM k8s.gcr.io/debian-base-amd64:0.3
 #  git (for getting the current head)
 #  gcc make (for compilation)
 RUN apt-get update && apt-get --no-install-recommends install --yes --reinstall lsb-base \
-  && apt-get --no-install-recommends install --yes curl git gcc make bash \
+  && apt-get --no-install-recommends install --yes curl git gcc make bash apt-utils ca-certificates apt-transport-https \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/images/dns-controller-builder/Dockerfile
+++ b/images/dns-controller-builder/Dockerfile
@@ -18,8 +18,8 @@ FROM k8s.gcr.io/debian-base-amd64:0.3
 #  curl (to download golang)
 #  git (for getting the current head)
 #  gcc make (for compilation)
-RUN apt-get update && apt-get install --yes --reinstall lsb-base \
-  && apt-get install --yes curl git gcc make bash \
+RUN apt-get update && apt-get --no-install-recommends install --yes --reinstall lsb-base \
+  && apt-get --no-install-recommends install --yes curl git gcc make bash \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/images/dns-controller/Dockerfile
+++ b/images/dns-controller/Dockerfile
@@ -15,7 +15,7 @@
 FROM k8s.gcr.io/debian-base-amd64:0.3
 
 # ca-certificates: Needed to talk to EC2 API
-RUN apt-get update && apt-get --no-install-recommends install --yes ca-certificates \
+RUN apt-get update && apt-get --no-install-recommends install --yes apt-utils ca-certificates apt-transport-https \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/images/dns-controller/Dockerfile
+++ b/images/dns-controller/Dockerfile
@@ -15,7 +15,7 @@
 FROM k8s.gcr.io/debian-base-amd64:0.3
 
 # ca-certificates: Needed to talk to EC2 API
-RUN apt-get update && apt-get install --yes ca-certificates \
+RUN apt-get update && apt-get --no-install-recommends install --yes ca-certificates \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/images/protokube-builder/Dockerfile
+++ b/images/protokube-builder/Dockerfile
@@ -18,8 +18,8 @@ FROM k8s.gcr.io/debian-base-amd64:0.3
 #  curl (to download golang)
 #  git (for getting the current head)
 #  gcc make (for compilation)
-RUN apt-get update && apt-get install --yes --reinstall lsb-base \
-  && apt-get install --yes curl git gcc make bash \
+RUN apt-get update && apt-get --no-install-recommends install --yes --reinstall lsb-base \
+  && apt-get --no-install-recommends install --yes curl git gcc make bash \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/images/protokube-builder/Dockerfile
+++ b/images/protokube-builder/Dockerfile
@@ -19,7 +19,7 @@ FROM k8s.gcr.io/debian-base-amd64:0.3
 #  git (for getting the current head)
 #  gcc make (for compilation)
 RUN apt-get update && apt-get --no-install-recommends install --yes --reinstall lsb-base \
-  && apt-get --no-install-recommends install --yes curl git gcc make bash \
+  && apt-get --no-install-recommends install --yes apt-utils ca-certificates apt-transport-https curl git gcc make bash \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/images/protokube/Dockerfile
+++ b/images/protokube/Dockerfile
@@ -16,7 +16,7 @@ FROM k8s.gcr.io/debian-base-amd64:0.3
 
 # ca-certificates: Needed to talk to EC2 API
 # e2fsprogs: Needed to mount / format ext4 filesytems
-RUN apt-get update && apt-get install --yes \
+RUN apt-get update && apt-get --no-install-recommends install --yes \
   bash ca-certificates e2fsprogs systemd \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*

--- a/images/protokube/Dockerfile
+++ b/images/protokube/Dockerfile
@@ -17,7 +17,7 @@ FROM k8s.gcr.io/debian-base-amd64:0.3
 # ca-certificates: Needed to talk to EC2 API
 # e2fsprogs: Needed to mount / format ext4 filesytems
 RUN apt-get update && apt-get --no-install-recommends install --yes \
-  bash ca-certificates e2fsprogs systemd \
+  bash apt-utils ca-certificates apt-transport-https e2fsprogs systemd \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/images/utils-builder/Dockerfile
+++ b/images/utils-builder/Dockerfile
@@ -22,7 +22,7 @@ deb http://security.debian.org jessie/updates main\n \
 deb-src http://security.debian.org jessie/updates main\n \
 deb-src http://ftp.us.debian.org/debian/ jessie main" > /etc/apt/sources.list
 
-RUN apt-get update && apt-get install --yes dpkg-dev bash \
+RUN apt-get update && apt-get --no-install-recommends install --yes dpkg-dev bash \
   && apt-get build-dep --yes socat conntrack \
   && apt-get clean
 

--- a/images/utils-builder/Dockerfile
+++ b/images/utils-builder/Dockerfile
@@ -22,7 +22,7 @@ deb http://security.debian.org jessie/updates main\n \
 deb-src http://security.debian.org jessie/updates main\n \
 deb-src http://ftp.us.debian.org/debian/ jessie main" > /etc/apt/sources.list
 
-RUN apt-get update && apt-get --no-install-recommends install --yes dpkg-dev bash \
+RUN apt-get update && apt-get --no-install-recommends install --yes apt-utils ca-certificates apt-transport-https dpkg-dev bash \
   && apt-get build-dep --yes socat conntrack \
   && apt-get clean
 


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .