### PR TITLE
Enhancement in Ubuntu or debian apt-get and CI issue fix

### DIFF
--- a/hooks/nvidia-bootstrap/image/Dockerfile
+++ b/hooks/nvidia-bootstrap/image/Dockerfile
@@ -16,7 +16,7 @@ FROM debian:jessie
 # ^ Cannot be Alpine since it does not support systemctl
 # ^ Systemctl is used to restart kubelet upon successful run of run.sh
 
-RUN apt-get update && apt-get -yq install curl jq
+RUN apt-get update && apt-get --no-install-recommends -yq install apt-utils ca-certificates apt-transport-https curl jq
 
 ADD run.sh /run.sh
 


### PR DESCRIPTION
This PR is clean version of #8681  as requested 

Major Changes No 1 : debian package manager tweaks

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Major Changes No 2 : added packages apt-utils ca-certificates

Because Github CI build is 

1.  Slow and in log it is showing because "apt-utils" not installed 

2. to avoid CI build to exits with error without having certificate