### PR TITLE
Update Weave Net to version 2.6.1

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -168,7 +168,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.0'
+          image: 'weaveworks/weave-kube:2.6.1'
           ports:
             - name: metrics
               containerPort: 6782
@@ -203,6 +203,7 @@ spec:
               mountPath: /lib/modules
             - name: xtables-lock
               mountPath: /run/xtables.lock
+              readOnly: false
         - name: weave-npc
           args: []
           env:
@@ -215,7 +216,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.0'
+          image: 'weaveworks/weave-npc:2.6.1'
           ports:
             - name: metrics
               containerPort: 6781
@@ -233,7 +234,9 @@ spec:
           volumeMounts:
             - name: xtables-lock
               mountPath: /run/xtables.lock
+              readOnly: false
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       restartPolicy: Always
       securityContext:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -164,7 +164,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.0'
+          image: 'weaveworks/weave-kube:2.6.1'
           ports:
             - name: metrics
               containerPort: 6782
@@ -199,6 +199,7 @@ spec:
               mountPath: /lib/modules
             - name: xtables-lock
               mountPath: /run/xtables.lock
+              readOnly: false
         - name: weave-npc
           args: []
           env:
@@ -211,7 +212,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.0'
+          image: 'weaveworks/weave-npc:2.6.1'
           ports:
             - name: metrics
               containerPort: 6781
@@ -229,6 +230,7 @@ spec:
           volumeMounts:
             - name: xtables-lock
               mountPath: /run/xtables.lock
+              readOnly: false
       hostNetwork: true
       hostPID: true
       restartPolicy: Always

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -608,8 +608,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 	if b.cluster.Spec.Networking.Weave != nil {
 		key := "networking.weave"
 		versions := map[string]string{
-			"k8s-1.8":  "2.6.0-kops.2",
-			"k8s-1.12": "2.6.0-kops.3",
+			"k8s-1.8":  "2.6.1-kops.1",
+			"k8s-1.12": "2.6.1-kops.1",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -89,16 +89,16 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: <1.12.0
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: 50a20409003956b7c31a479408ca42ec97774854
+    manifestHash: 7aa5336ec05aef46b185cb660fc02bb2ac201852
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.0-kops.2
+    version: 2.6.1-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: d2df87d90f8877a201f5cad93de296697191d4ae
+    manifestHash: 6f12295454fef72234205b7e6c62cdac656eab52
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.0-kops.3
+    version: 2.6.1-kops.1


### PR DESCRIPTION
Weave 2.6.1 was (released)[https://github.com/weaveworks/weave/releases/v2.6.1] with support for Debian 10 (Buster).

Changes are based on:
https://github.com/weaveworks/weave/releases/download/v2.6.1/weave-daemonset-k8s-1.11.yaml
https://github.com/weaveworks/weave/releases/download/v2.6.1/weave-daemonset-k8s-1.8.yaml

This should be a good addition to the 1.17 release.