### PR TITLE
Add root volume tags for CF and TF targets

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -1205,8 +1205,8 @@ func FindAutoScalingLaunchTemplateConfigurations(cloud fi.Cloud, securityGroups 
 		for _, j := range req.LaunchTemplateVersions {
 			// @check if the security group references the security group above
 			var s []*string
-			if len(j.LaunchTemplateData.NetworkInterfaces) > 0 {
-				s = append(s, j.LaunchTemplateData.NetworkInterfaces[0].Groups...)
+			for _, ni := range j.LaunchTemplateData.NetworkInterfaces {
+				s = append(s, ni.Groups...)
 			}
 			s = append(s, j.LaunchTemplateData.SecurityGroupIds...)
 			for _, y := range s {

--- a/tests/integration/update_cluster/launch_templates/cloudformation.json
+++ b/tests/integration/update_cluster/launch_templates/cloudformation.json
@@ -4,6 +4,17 @@
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
         "AutoScalingGroupName": "master-us-test-1a.masters.launchtemplates.example.com",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "AWSEC2LaunchTemplatemasterustest1amasterslaunchtemplatesexamplecom"
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "AWSEC2LaunchTemplatemasterustest1amasterslaunchtemplatesexamplecom",
+              "LatestVersionNumber"
+            ]
+          }
+        },
         "MaxSize": 1,
         "MinSize": 1,
         "VPCZoneIdentifier": [
@@ -59,6 +70,17 @@
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
         "AutoScalingGroupName": "master-us-test-1b.masters.launchtemplates.example.com",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "AWSEC2LaunchTemplatemasterustest1bmasterslaunchtemplatesexamplecom"
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "AWSEC2LaunchTemplatemasterustest1bmasterslaunchtemplatesexamplecom",
+              "LatestVersionNumber"
+            ]
+          }
+        },
         "MaxSize": 1,
         "MinSize": 1,
         "VPCZoneIdentifier": [
@@ -114,6 +136,17 @@
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
         "AutoScalingGroupName": "master-us-test-1c.masters.launchtemplates.example.com",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "AWSEC2LaunchTemplatemasterustest1cmasterslaunchtemplatesexamplecom"
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "AWSEC2LaunchTemplatemasterustest1cmasterslaunchtemplatesexamplecom",
+              "LatestVersionNumber"
+            ]
+          }
+        },
         "MaxSize": 1,
         "MinSize": 1,
         "VPCZoneIdentifier": [
@@ -169,6 +202,17 @@
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
         "AutoScalingGroupName": "nodes.launchtemplates.example.com",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "AWSEC2LaunchTemplatenodeslaunchtemplatesexamplecom"
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "AWSEC2LaunchTemplatenodeslaunchtemplatesexamplecom",
+              "LatestVersionNumber"
+            ]
+          }
+        },
         "MaxSize": 2,
         "MinSize": 2,
         "VPCZoneIdentifier": [
@@ -270,7 +314,7 @@
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/xvda",
-              "EBS": {
+              "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
                 "DeleteOnTermination": true
@@ -288,15 +332,68 @@
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
-              "DeleteOnTermination": true
+              "DeleteOnTermination": true,
+              "DeviceIndex": 0,
+              "Groups": [
+                {
+                  "Ref": "AWSEC2SecurityGroupmasterslaunchtemplatesexamplecom"
+                }
+              ]
             }
           ],
-          "UserData": "extracted",
-          "SecurityGroup": [
+          "TagSpecifications": [
             {
-              "Ref": "AWSEC2SecurityGroupmasterslaunchtemplatesexamplecom"
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "KubernetesCluster",
+                  "Value": "launchtemplates.example.com"
+                },
+                {
+                  "Key": "Name",
+                  "Value": "master-us-test-1a.masters.launchtemplates.example.com"
+                },
+                {
+                  "Key": "k8s.io/role/master",
+                  "Value": "1"
+                },
+                {
+                  "Key": "kops.k8s.io/instancegroup",
+                  "Value": "master-us-test-1a"
+                },
+                {
+                  "Key": "kubernetes.io/cluster/launchtemplates.example.com",
+                  "Value": "owned"
+                }
+              ]
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "KubernetesCluster",
+                  "Value": "launchtemplates.example.com"
+                },
+                {
+                  "Key": "Name",
+                  "Value": "master-us-test-1a.masters.launchtemplates.example.com"
+                },
+                {
+                  "Key": "k8s.io/role/master",
+                  "Value": "1"
+                },
+                {
+                  "Key": "kops.k8s.io/instancegroup",
+                  "Value": "master-us-test-1a"
+                },
+                {
+                  "Key": "kubernetes.io/cluster/launchtemplates.example.com",
+                  "Value": "owned"
+                }
+              ]
             }
-          ]
+          ],
+          "UserData": "extracted"
         }
       }
     },
@@ -308,7 +405,7 @@
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/xvda",
-              "EBS": {
+              "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
                 "DeleteOnTermination": true
@@ -326,15 +423,68 @@
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
-              "DeleteOnTermination": true
+              "DeleteOnTermination": true,
+              "DeviceIndex": 0,
+              "Groups": [
+                {
+                  "Ref": "AWSEC2SecurityGroupmasterslaunchtemplatesexamplecom"
+                }
+              ]
             }
           ],
-          "UserData": "extracted",
-          "SecurityGroup": [
+          "TagSpecifications": [
             {
-              "Ref": "AWSEC2SecurityGroupmasterslaunchtemplatesexamplecom"
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "KubernetesCluster",
+                  "Value": "launchtemplates.example.com"
+                },
+                {
+                  "Key": "Name",
+                  "Value": "master-us-test-1b.masters.launchtemplates.example.com"
+                },
+                {
+                  "Key": "k8s.io/role/master",
+                  "Value": "1"
+                },
+                {
+                  "Key": "kops.k8s.io/instancegroup",
+                  "Value": "master-us-test-1b"
+                },
+                {
+                  "Key": "kubernetes.io/cluster/launchtemplates.example.com",
+                  "Value": "owned"
+                }
+              ]
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "KubernetesCluster",
+                  "Value": "launchtemplates.example.com"
+                },
+                {
+                  "Key": "Name",
+                  "Value": "master-us-test-1b.masters.launchtemplates.example.com"
+                },
+                {
+                  "Key": "k8s.io/role/master",
+                  "Value": "1"
+                },
+                {
+                  "Key": "kops.k8s.io/instancegroup",
+                  "Value": "master-us-test-1b"
+                },
+                {
+                  "Key": "kubernetes.io/cluster/launchtemplates.example.com",
+                  "Value": "owned"
+                }
+              ]
             }
-          ]
+          ],
+          "UserData": "extracted"
         }
       }
     },
@@ -346,7 +496,7 @@
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/xvda",
-              "EBS": {
+              "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
                 "DeleteOnTermination": true
@@ -364,15 +514,68 @@
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
-              "DeleteOnTermination": true
+              "DeleteOnTermination": true,
+              "DeviceIndex": 0,
+              "Groups": [
+                {
+                  "Ref": "AWSEC2SecurityGroupmasterslaunchtemplatesexamplecom"
+                }
+              ]
             }
           ],
-          "UserData": "extracted",
-          "SecurityGroup": [
+          "TagSpecifications": [
             {
-              "Ref": "AWSEC2SecurityGroupmasterslaunchtemplatesexamplecom"
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "KubernetesCluster",
+                  "Value": "launchtemplates.example.com"
+                },
+                {
+                  "Key": "Name",
+                  "Value": "master-us-test-1c.masters.launchtemplates.example.com"
+                },
+                {
+                  "Key": "k8s.io/role/master",
+                  "Value": "1"
+                },
+                {
+                  "Key": "kops.k8s.io/instancegroup",
+                  "Value": "master-us-test-1c"
+                },
+                {
+                  "Key": "kubernetes.io/cluster/launchtemplates.example.com",
+                  "Value": "owned"
+                }
+              ]
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "KubernetesCluster",
+                  "Value": "launchtemplates.example.com"
+                },
+                {
+                  "Key": "Name",
+                  "Value": "master-us-test-1c.masters.launchtemplates.example.com"
+                },
+                {
+                  "Key": "k8s.io/role/master",
+                  "Value": "1"
+                },
+                {
+                  "Key": "kops.k8s.io/instancegroup",
+                  "Value": "master-us-test-1c"
+                },
+                {
+                  "Key": "kubernetes.io/cluster/launchtemplates.example.com",
+                  "Value": "owned"
+                }
+              ]
             }
-          ]
+          ],
+          "UserData": "extracted"
         }
       }
     },
@@ -384,7 +587,7 @@
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/xvda",
-              "EBS": {
+              "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 128,
                 "DeleteOnTermination": true
@@ -402,15 +605,68 @@
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
-              "DeleteOnTermination": true
+              "DeleteOnTermination": true,
+              "DeviceIndex": 0,
+              "Groups": [
+                {
+                  "Ref": "AWSEC2SecurityGroupnodeslaunchtemplatesexamplecom"
+                }
+              ]
             }
           ],
-          "UserData": "extracted",
-          "SecurityGroup": [
+          "TagSpecifications": [
             {
-              "Ref": "AWSEC2SecurityGroupnodeslaunchtemplatesexamplecom"
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "KubernetesCluster",
+                  "Value": "launchtemplates.example.com"
+                },
+                {
+                  "Key": "Name",
+                  "Value": "nodes.launchtemplates.example.com"
+                },
+                {
+                  "Key": "k8s.io/role/node",
+                  "Value": "1"
+                },
+                {
+                  "Key": "kops.k8s.io/instancegroup",
+                  "Value": "nodes"
+                },
+                {
+                  "Key": "kubernetes.io/cluster/launchtemplates.example.com",
+                  "Value": "owned"
+                }
+              ]
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "KubernetesCluster",
+                  "Value": "launchtemplates.example.com"
+                },
+                {
+                  "Key": "Name",
+                  "Value": "nodes.launchtemplates.example.com"
+                },
+                {
+                  "Key": "k8s.io/role/node",
+                  "Value": "1"
+                },
+                {
+                  "Key": "kops.k8s.io/instancegroup",
+                  "Value": "nodes"
+                },
+                {
+                  "Key": "kubernetes.io/cluster/launchtemplates.example.com",
+                  "Value": "owned"
+                }
+              ]
             }
-          ]
+          ],
+          "UserData": "extracted"
         }
       }
     },

--- a/tests/integration/update_cluster/launch_templates/kubernetes.tf
+++ b/tests/integration/update_cluster/launch_templates/kubernetes.tf
@@ -91,7 +91,13 @@ provider "aws" {
 }
 
 resource "aws_autoscaling_group" "master-us-test-1a-masters-launchtemplates-example-com" {
-  name                = "master-us-test-1a.masters.launchtemplates.example.com"
+  name = "master-us-test-1a.masters.launchtemplates.example.com"
+
+  launch_template = {
+    id      = "${aws_launch_template.master-us-test-1a-masters-launchtemplates-example-com.id}"
+    version = "${aws_launch_template.master-us-test-1a-masters-launchtemplates-example-com.latest_version}"
+  }
+
   max_size            = 1
   min_size            = 1
   vpc_zone_identifier = ["${aws_subnet.us-test-1a-launchtemplates-example-com.id}"]
@@ -131,7 +137,13 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-launchtemplates-exam
 }
 
 resource "aws_autoscaling_group" "master-us-test-1b-masters-launchtemplates-example-com" {
-  name                = "master-us-test-1b.masters.launchtemplates.example.com"
+  name = "master-us-test-1b.masters.launchtemplates.example.com"
+
+  launch_template = {
+    id      = "${aws_launch_template.master-us-test-1b-masters-launchtemplates-example-com.id}"
+    version = "${aws_launch_template.master-us-test-1b-masters-launchtemplates-example-com.latest_version}"
+  }
+
   max_size            = 1
   min_size            = 1
   vpc_zone_identifier = ["${aws_subnet.us-test-1b-launchtemplates-example-com.id}"]
@@ -171,7 +183,13 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-launchtemplates-exam
 }
 
 resource "aws_autoscaling_group" "master-us-test-1c-masters-launchtemplates-example-com" {
-  name                = "master-us-test-1c.masters.launchtemplates.example.com"
+  name = "master-us-test-1c.masters.launchtemplates.example.com"
+
+  launch_template = {
+    id      = "${aws_launch_template.master-us-test-1c-masters-launchtemplates-example-com.id}"
+    version = "${aws_launch_template.master-us-test-1c-masters-launchtemplates-example-com.latest_version}"
+  }
+
   max_size            = 1
   min_size            = 1
   vpc_zone_identifier = ["${aws_subnet.us-test-1c-launchtemplates-example-com.id}"]
@@ -211,7 +229,13 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-launchtemplates-exam
 }
 
 resource "aws_autoscaling_group" "nodes-launchtemplates-example-com" {
-  name                = "nodes.launchtemplates.example.com"
+  name = "nodes.launchtemplates.example.com"
+
+  launch_template = {
+    id      = "${aws_launch_template.nodes-launchtemplates-example-com.id}"
+    version = "${aws_launch_template.nodes-launchtemplates-example-com.latest_version}"
+  }
+
   max_size            = 2
   min_size            = 2
   vpc_zone_identifier = ["${aws_subnet.us-test-1b-launchtemplates-example-com.id}"]
@@ -419,6 +443,30 @@ resource "aws_launch_template" "master-us-test-1a-masters-launchtemplates-exampl
     security_groups             = ["${aws_security_group.masters-launchtemplates-example-com.id}"]
   }
 
+  tag_specifications = {
+    resource_type = "instance"
+
+    tags = {
+      KubernetesCluster                                   = "launchtemplates.example.com"
+      Name                                                = "master-us-test-1a.masters.launchtemplates.example.com"
+      "k8s.io/role/master"                                = "1"
+      "kops.k8s.io/instancegroup"                         = "master-us-test-1a"
+      "kubernetes.io/cluster/launchtemplates.example.com" = "owned"
+    }
+  }
+
+  tag_specifications = {
+    resource_type = "volume"
+
+    tags = {
+      KubernetesCluster                                   = "launchtemplates.example.com"
+      Name                                                = "master-us-test-1a.masters.launchtemplates.example.com"
+      "k8s.io/role/master"                                = "1"
+      "kops.k8s.io/instancegroup"                         = "master-us-test-1a"
+      "kubernetes.io/cluster/launchtemplates.example.com" = "owned"
+    }
+  }
+
   user_data = "${file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.launchtemplates.example.com_user_data")}"
 }
 
@@ -451,6 +499,30 @@ resource "aws_launch_template" "master-us-test-1b-masters-launchtemplates-exampl
     associate_public_ip_address = true
     delete_on_termination       = true
     security_groups             = ["${aws_security_group.masters-launchtemplates-example-com.id}"]
+  }
+
+  tag_specifications = {
+    resource_type = "instance"
+
+    tags = {
+      KubernetesCluster                                   = "launchtemplates.example.com"
+      Name                                                = "master-us-test-1b.masters.launchtemplates.example.com"
+      "k8s.io/role/master"                                = "1"
+      "kops.k8s.io/instancegroup"                         = "master-us-test-1b"
+      "kubernetes.io/cluster/launchtemplates.example.com" = "owned"
+    }
+  }
+
+  tag_specifications = {
+    resource_type = "volume"
+
+    tags = {
+      KubernetesCluster                                   = "launchtemplates.example.com"
+      Name                                                = "master-us-test-1b.masters.launchtemplates.example.com"
+      "k8s.io/role/master"                                = "1"
+      "kops.k8s.io/instancegroup"                         = "master-us-test-1b"
+      "kubernetes.io/cluster/launchtemplates.example.com" = "owned"
+    }
   }
 
   user_data = "${file("${path.module}/data/aws_launch_template_master-us-test-1b.masters.launchtemplates.example.com_user_data")}"
@@ -487,6 +559,30 @@ resource "aws_launch_template" "master-us-test-1c-masters-launchtemplates-exampl
     security_groups             = ["${aws_security_group.masters-launchtemplates-example-com.id}"]
   }
 
+  tag_specifications = {
+    resource_type = "instance"
+
+    tags = {
+      KubernetesCluster                                   = "launchtemplates.example.com"
+      Name                                                = "master-us-test-1c.masters.launchtemplates.example.com"
+      "k8s.io/role/master"                                = "1"
+      "kops.k8s.io/instancegroup"                         = "master-us-test-1c"
+      "kubernetes.io/cluster/launchtemplates.example.com" = "owned"
+    }
+  }
+
+  tag_specifications = {
+    resource_type = "volume"
+
+    tags = {
+      KubernetesCluster                                   = "launchtemplates.example.com"
+      Name                                                = "master-us-test-1c.masters.launchtemplates.example.com"
+      "k8s.io/role/master"                                = "1"
+      "kops.k8s.io/instancegroup"                         = "master-us-test-1c"
+      "kubernetes.io/cluster/launchtemplates.example.com" = "owned"
+    }
+  }
+
   user_data = "${file("${path.module}/data/aws_launch_template_master-us-test-1c.masters.launchtemplates.example.com_user_data")}"
 }
 
@@ -519,6 +615,30 @@ resource "aws_launch_template" "nodes-launchtemplates-example-com" {
     associate_public_ip_address = true
     delete_on_termination       = true
     security_groups             = ["${aws_security_group.nodes-launchtemplates-example-com.id}"]
+  }
+
+  tag_specifications = {
+    resource_type = "instance"
+
+    tags = {
+      KubernetesCluster                                   = "launchtemplates.example.com"
+      Name                                                = "nodes.launchtemplates.example.com"
+      "k8s.io/role/node"                                  = "1"
+      "kops.k8s.io/instancegroup"                         = "nodes"
+      "kubernetes.io/cluster/launchtemplates.example.com" = "owned"
+    }
+  }
+
+  tag_specifications = {
+    resource_type = "volume"
+
+    tags = {
+      KubernetesCluster                                   = "launchtemplates.example.com"
+      Name                                                = "nodes.launchtemplates.example.com"
+      "k8s.io/role/node"                                  = "1"
+      "kops.k8s.io/instancegroup"                         = "nodes"
+      "kubernetes.io/cluster/launchtemplates.example.com" = "owned"
+    }
   }
 
   user_data = "${file("${path.module}/data/aws_launch_template_nodes.launchtemplates.example.com_user_data")}"

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json
@@ -230,7 +230,15 @@
         "MixedInstancesPolicy": {
           "LaunchTemplate": {
             "LaunchTemplateSpecification": {
-              "LaunchTemplateName": "nodes.mixedinstances.example.com"
+              "LaunchTemplateId": {
+                "Ref": "AWSEC2LaunchTemplatenodesmixedinstancesexamplecom"
+              },
+              "Version": {
+                "Fn::GetAtt": [
+                  "AWSEC2LaunchTemplatenodesmixedinstancesexamplecom",
+                  "LatestVersionNumber"
+                ]
+              }
             },
             "Overrides": [
               {
@@ -400,7 +408,7 @@
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/xvda",
-              "EBS": {
+              "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 128,
                 "DeleteOnTermination": true
@@ -418,15 +426,68 @@
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
-              "DeleteOnTermination": true
+              "DeleteOnTermination": true,
+              "DeviceIndex": 0,
+              "Groups": [
+                {
+                  "Ref": "AWSEC2SecurityGroupnodesmixedinstancesexamplecom"
+                }
+              ]
             }
           ],
-          "UserData": "extracted",
-          "SecurityGroup": [
+          "TagSpecifications": [
             {
-              "Ref": "AWSEC2SecurityGroupnodesmixedinstancesexamplecom"
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "KubernetesCluster",
+                  "Value": "mixedinstances.example.com"
+                },
+                {
+                  "Key": "Name",
+                  "Value": "nodes.mixedinstances.example.com"
+                },
+                {
+                  "Key": "k8s.io/role/node",
+                  "Value": "1"
+                },
+                {
+                  "Key": "kops.k8s.io/instancegroup",
+                  "Value": "nodes"
+                },
+                {
+                  "Key": "kubernetes.io/cluster/mixedinstances.example.com",
+                  "Value": "owned"
+                }
+              ]
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "KubernetesCluster",
+                  "Value": "mixedinstances.example.com"
+                },
+                {
+                  "Key": "Name",
+                  "Value": "nodes.mixedinstances.example.com"
+                },
+                {
+                  "Key": "k8s.io/role/node",
+                  "Value": "1"
+                },
+                {
+                  "Key": "kops.k8s.io/instancegroup",
+                  "Value": "nodes"
+                },
+                {
+                  "Key": "kubernetes.io/cluster/mixedinstances.example.com",
+                  "Value": "owned"
+                }
+              ]
             }
-          ]
+          ],
+          "UserData": "extracted"
         }
       }
     },

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -533,6 +533,30 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
     security_groups             = ["${aws_security_group.nodes-mixedinstances-example-com.id}"]
   }
 
+  tag_specifications = {
+    resource_type = "instance"
+
+    tags = {
+      KubernetesCluster                                  = "mixedinstances.example.com"
+      Name                                               = "nodes.mixedinstances.example.com"
+      "k8s.io/role/node"                                 = "1"
+      "kops.k8s.io/instancegroup"                        = "nodes"
+      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+    }
+  }
+
+  tag_specifications = {
+    resource_type = "volume"
+
+    tags = {
+      KubernetesCluster                                  = "mixedinstances.example.com"
+      Name                                               = "nodes.mixedinstances.example.com"
+      "k8s.io/role/node"                                 = "1"
+      "kops.k8s.io/instancegroup"                        = "nodes"
+      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+    }
+  }
+
   user_data = "${file("${path.module}/data/aws_launch_template_nodes.mixedinstances.example.com_user_data")}"
 }
 

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
@@ -230,7 +230,15 @@
         "MixedInstancesPolicy": {
           "LaunchTemplate": {
             "LaunchTemplateSpecification": {
-              "LaunchTemplateName": "nodes.mixedinstances.example.com"
+              "LaunchTemplateId": {
+                "Ref": "AWSEC2LaunchTemplatenodesmixedinstancesexamplecom"
+              },
+              "Version": {
+                "Fn::GetAtt": [
+                  "AWSEC2LaunchTemplatenodesmixedinstancesexamplecom",
+                  "LatestVersionNumber"
+                ]
+              }
             },
             "Overrides": [
               {
@@ -401,7 +409,7 @@
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/xvda",
-              "EBS": {
+              "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 128,
                 "DeleteOnTermination": true
@@ -419,15 +427,68 @@
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
-              "DeleteOnTermination": true
+              "DeleteOnTermination": true,
+              "DeviceIndex": 0,
+              "Groups": [
+                {
+                  "Ref": "AWSEC2SecurityGroupnodesmixedinstancesexamplecom"
+                }
+              ]
             }
           ],
-          "UserData": "extracted",
-          "SecurityGroup": [
+          "TagSpecifications": [
             {
-              "Ref": "AWSEC2SecurityGroupnodesmixedinstancesexamplecom"
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "KubernetesCluster",
+                  "Value": "mixedinstances.example.com"
+                },
+                {
+                  "Key": "Name",
+                  "Value": "nodes.mixedinstances.example.com"
+                },
+                {
+                  "Key": "k8s.io/role/node",
+                  "Value": "1"
+                },
+                {
+                  "Key": "kops.k8s.io/instancegroup",
+                  "Value": "nodes"
+                },
+                {
+                  "Key": "kubernetes.io/cluster/mixedinstances.example.com",
+                  "Value": "owned"
+                }
+              ]
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "KubernetesCluster",
+                  "Value": "mixedinstances.example.com"
+                },
+                {
+                  "Key": "Name",
+                  "Value": "nodes.mixedinstances.example.com"
+                },
+                {
+                  "Key": "k8s.io/role/node",
+                  "Value": "1"
+                },
+                {
+                  "Key": "kops.k8s.io/instancegroup",
+                  "Value": "nodes"
+                },
+                {
+                  "Key": "kubernetes.io/cluster/mixedinstances.example.com",
+                  "Value": "owned"
+                }
+              ]
             }
-          ]
+          ],
+          "UserData": "extracted"
         }
       }
     },

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -533,6 +533,30 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
     security_groups             = ["${aws_security_group.nodes-mixedinstances-example-com.id}"]
   }
 
+  tag_specifications = {
+    resource_type = "instance"
+
+    tags = {
+      KubernetesCluster                                  = "mixedinstances.example.com"
+      Name                                               = "nodes.mixedinstances.example.com"
+      "k8s.io/role/node"                                 = "1"
+      "kops.k8s.io/instancegroup"                        = "nodes"
+      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+    }
+  }
+
+  tag_specifications = {
+    resource_type = "volume"
+
+    tags = {
+      KubernetesCluster                                  = "mixedinstances.example.com"
+      Name                                               = "nodes.mixedinstances.example.com"
+      "k8s.io/role/node"                                 = "1"
+      "kops.k8s.io/instancegroup"                        = "nodes"
+      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+    }
+  }
+
   user_data = "${file("${path.module}/data/aws_launch_template_nodes.mixedinstances.example.com_user_data")}"
 }
 

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -263,7 +263,7 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 			VPCZoneIdentifier:    fi.String(strings.Join(e.AutoscalingGroupSubnets(), ",")),
 		}
 
-		// @check are we using a launch configuation or mixed instance policies or launch template
+		// @check are we using a launch configuration, mixed instances policy, or launch template
 		if e.LaunchConfiguration != nil {
 			request.LaunchConfigurationName = e.LaunchConfiguration.ID
 		} else if e.UseMixedInstancesPolicy() {
@@ -294,7 +294,7 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 				Version:            aws.String("1"),
 			}
 		} else {
-			return fmt.Errorf("could not find on of launch configuation, mixed instance policies or launch template")
+			return fmt.Errorf("could not find one of launch configuration, mixed instances policy, or launch template")
 		}
 
 		// @step: attempt to create the autoscaling group for us
@@ -611,9 +611,9 @@ type terraformASGTag struct {
 }
 
 type terraformAutoscalingLaunchTemplateSpecification struct {
-	// LaunchTemplateID is the ID of the template to use
+	// LaunchTemplateID is the ID of the template to use.
 	LaunchTemplateID *terraform.Literal `json:"id,omitempty"`
-	// Version is the version of the Launch Template to use
+	// Version is the version of the Launch Template to use.
 	Version *terraform.Literal `json:"version,omitempty"`
 }
 
@@ -739,7 +739,7 @@ func (_ *AutoscalingGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, c
 			Version:          e.LaunchTemplate.VersionLink(),
 		}
 	} else {
-		return fmt.Errorf("could not find on of launch configuation, mixed instance policies or launch template")
+		return fmt.Errorf("could not find one of launch configuration, mixed instances policy, or launch template")
 	}
 
 	role := ""
@@ -811,9 +811,9 @@ type cloudformationASGMetricsCollection struct {
 }
 
 type cloudformationAutoscalingLaunchTemplateSpecification struct {
-	// LaunchTemplateId is the IDx of the template to use
+	// LaunchTemplateId is the IDx of the template to use.
 	LaunchTemplateId *cloudformation.Literal `json:"LaunchTemplateId,omitempty"`
-	// Version is the version number of the template to use
+	// Version is the version number of the template to use.
 	Version *cloudformation.Literal `json:"Version,omitempty"`
 }
 
@@ -908,7 +908,7 @@ func (_ *AutoscalingGroup) RenderCloudformation(t *cloudformation.Cloudformation
 			Version:          e.LaunchTemplate.CloudformationVersion(),
 		}
 	} else {
-		return fmt.Errorf("could not find on of launch configuation, mixed instance policies or launch template")
+		return fmt.Errorf("could not find one of launch configuration, mixed instances policy, or launch template")
 	}
 
 	for _, s := range e.Subnets {

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
@@ -390,7 +390,15 @@ func TestAutoscalingGroupCloudformationRender(t *testing.T) {
         "MixedInstancesPolicy": {
           "LaunchTemplate": {
             "LaunchTemplateSpecification": {
-              "LaunchTemplateName": "test_lt"
+              "LaunchTemplateId": {
+                "Ref": "AWSEC2LaunchTemplatetest_lt"
+              },
+              "Version": {
+                "Fn::GetAtt": [
+                  "AWSEC2LaunchTemplatetest_lt",
+                  "LatestVersionNumber"
+                ]
+              }
             },
             "Overrides": [
               {

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation.go
@@ -100,9 +100,9 @@ type cloudformationLaunchTemplateBlockDevice struct {
 }
 
 type cloudformationLaunchTemplateTagSpecification struct {
-	// The type of resource to tag
+	// ResourceType is the type of resource to tag.
 	ResourceType *string `json:"ResourceType,omitempty"`
-	// The tags to apply to the resource.
+	// Tags are the tags to apply to the resource.
 	Tags []cloudformationTag `json:"Tags,omitempty"`
 }
 
@@ -127,7 +127,7 @@ type cloudformationLaunchTemplateData struct {
 	NetworkInterfaces []*cloudformationLaunchTemplateNetworkInterface `json:"NetworkInterfaces,omitempty"`
 	// Placement are the tenancy options
 	Placement []*cloudformationLaunchTemplatePlacement `json:"Placement,omitempty"`
-	// TagSpecifications specifies tags to apply to a resource when the resource is created
+	// TagSpecifications are the tags to apply to a resource when it is created.
 	TagSpecifications []*cloudformationLaunchTemplateTagSpecification `json:"TagSpecifications,omitempty"`
 	// UserData is the user data for the instances
 	UserData *string `json:"UserData,omitempty"`
@@ -145,7 +145,7 @@ func (t *LaunchTemplate) CloudformationLink() *cloudformation.Literal {
 	return cloudformation.Ref("AWS::EC2::LaunchTemplate", fi.StringValue(t.Name))
 }
 
-// CloudformationLink returns the cloudformation version for us
+// CloudformationLink returns the cloudformation version.
 func (t *LaunchTemplate) CloudformationVersion() *cloudformation.Literal {
 	return cloudformation.GetAtt("AWS::EC2::LaunchTemplate", fi.StringValue(t.Name), "LatestVersionNumber")
 }

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation_test.go
@@ -64,20 +64,21 @@ func TestLaunchTemplateCloudformationRender(t *testing.T) {
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
-              "DeleteOnTermination": true
+              "DeleteOnTermination": true,
+              "DeviceIndex": 0,
+              "Groups": [
+                {
+                  "Ref": "AWSEC2SecurityGroupnodes1"
+                },
+                {
+                  "Ref": "AWSEC2SecurityGroupnodes2"
+                }
+              ]
             }
           ],
           "Placement": [
             {
               "Tenancy": "dedicated"
-            }
-          ],
-          "SecurityGroup": [
-            {
-              "Ref": "AWSEC2SecurityGroupnodes1"
-            },
-            {
-              "Ref": "AWSEC2SecurityGroupnodes2"
             }
           ]
         }
@@ -127,7 +128,7 @@ func TestLaunchTemplateCloudformationRender(t *testing.T) {
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/xvdd",
-              "EBS": {
+              "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 100,
                 "DeleteOnTermination": true,
@@ -146,20 +147,21 @@ func TestLaunchTemplateCloudformationRender(t *testing.T) {
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
-              "DeleteOnTermination": true
+              "DeleteOnTermination": true,
+              "DeviceIndex": 0,
+              "Groups": [
+                {
+                  "Ref": "AWSEC2SecurityGroupnodes1"
+                },
+                {
+                  "Ref": "AWSEC2SecurityGroupnodes2"
+                }
+              ]
             }
           ],
           "Placement": [
             {
               "Tenancy": "dedicated"
-            }
-          ],
-          "SecurityGroup": [
-            {
-              "Ref": "AWSEC2SecurityGroupnodes1"
-            },
-            {
-              "Ref": "AWSEC2SecurityGroupnodes2"
             }
           ]
         }

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -101,9 +101,9 @@ type terraformLaunchTemplateBlockDevice struct {
 }
 
 type terraformLaunchTemplateTagSpecification struct {
-	// The type of resource to tag
+	// ResourceType is the type of resource to tag.
 	ResourceType *string `json:"resource_type,omitempty"`
-	// The tags to apply to the resource.
+	// Tags are the tags to apply to the resource.
 	Tags map[string]string `json:"tags,omitempty"`
 }
 
@@ -133,7 +133,7 @@ type terraformLaunchTemplate struct {
 	NetworkInterfaces []*terraformLaunchTemplateNetworkInterface `json:"network_interfaces,omitempty"`
 	// Placement are the tenancy options
 	Placement []*terraformLaunchTemplatePlacement `json:"placement,omitempty"`
-	// TagSpecifications specifies tags to apply to a resource when the resource is created
+	// TagSpecifications are the tags to apply to a resource when it is created.
 	TagSpecifications []*terraformLaunchTemplateTagSpecification `json:"tag_specifications,omitempty"`
 	// UserData is the user data for the instances
 	UserData *terraform.Literal `json:"user_data,omitempty"`

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -24,12 +24,12 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
 )
 
-type terraformLaunchTemplateNetworkInterfaces struct {
+type terraformLaunchTemplateNetworkInterface struct {
 	// AssociatePublicIPAddress associates a public ip address with the network interface. Boolean value.
 	AssociatePublicIPAddress *bool `json:"associate_public_ip_address,omitempty"`
 	// DeleteOnTermination indicates whether the network interface should be destroyed on instance termination.
 	DeleteOnTermination *bool `json:"delete_on_termination,omitempty"`
-	// SecurityGroups is a list of security group ids
+	// SecurityGroups is a list of security group ids.
 	SecurityGroups []*terraform.Literal `json:"security_groups,omitempty"`
 }
 
@@ -100,6 +100,13 @@ type terraformLaunchTemplateBlockDevice struct {
 	EBS []*terraformLaunchTemplateBlockDeviceEBS `json:"ebs,omitempty"`
 }
 
+type terraformLaunchTemplateTagSpecification struct {
+	// The type of resource to tag
+	ResourceType *string `json:"resource_type,omitempty"`
+	// The tags to apply to the resource.
+	Tags map[string]string `json:"tags,omitempty"`
+}
+
 type terraformLaunchTemplate struct {
 	// NamePrefix is the name of the launch template
 	NamePrefix *string `json:"name_prefix,omitempty"`
@@ -123,9 +130,11 @@ type terraformLaunchTemplate struct {
 	// Monitoring are the instance monitoring options
 	Monitoring []*terraformLaunchTemplateMonitoring `json:"monitoring,omitempty"`
 	// NetworkInterfaces are the networking options
-	NetworkInterfaces []*terraformLaunchTemplateNetworkInterfaces `json:"network_interfaces,omitempty"`
+	NetworkInterfaces []*terraformLaunchTemplateNetworkInterface `json:"network_interfaces,omitempty"`
 	// Placement are the tenancy options
 	Placement []*terraformLaunchTemplatePlacement `json:"placement,omitempty"`
+	// TagSpecifications specifies tags to apply to a resource when the resource is created
+	TagSpecifications []*terraformLaunchTemplateTagSpecification `json:"tag_specifications,omitempty"`
 	// UserData is the user data for the instances
 	UserData *terraform.Literal `json:"user_data,omitempty"`
 }
@@ -161,9 +170,11 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 		ImageID:      image,
 		InstanceType: e.InstanceType,
 		Lifecycle:    &terraform.Lifecycle{CreateBeforeDestroy: fi.Bool(true)},
-		NetworkInterfaces: []*terraformLaunchTemplateNetworkInterfaces{
-			{AssociatePublicIPAddress: e.AssociatePublicIP,
-				DeleteOnTermination: fi.Bool(true)},
+		NetworkInterfaces: []*terraformLaunchTemplateNetworkInterface{
+			{
+				AssociatePublicIPAddress: e.AssociatePublicIP,
+				DeleteOnTermination:      fi.Bool(true),
+			},
 		},
 	}
 
@@ -246,6 +257,17 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 		tf.BlockDeviceMappings = append(tf.BlockDeviceMappings, &terraformLaunchTemplateBlockDevice{
 			VirtualName: x.VirtualName,
 			DeviceName:  fi.String(n),
+		})
+	}
+
+	if e.Tags != nil {
+		tf.TagSpecifications = append(tf.TagSpecifications, &terraformLaunchTemplateTagSpecification{
+			ResourceType: fi.String("instance"),
+			Tags:         e.Tags,
+		})
+		tf.TagSpecifications = append(tf.TagSpecifications, &terraformLaunchTemplateTagSpecification{
+			ResourceType: fi.String("volume"),
+			Tags:         e.Tags,
 		})
 	}
 


### PR DESCRIPTION
Adding root volume tags has been requested for a long time #3358 and was implemented in #8462 and #8466, but only for the `direct` target.

This PR adds root volume tags for `terraform` and `cloudformation` targets when using launch templates or mixed instances policies.

Notes:
* launch templates were not working at all
* an autoscaling group should [use only one](https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html) of launch configuration, launch template or mixed instances policy
* security groups should be specified for each network interface, instead of globally (global was meant for EC2 Classic and Default VPC)
* to enable the launch templates feature, the `EnableLaunchTemplates` [feature flag](https://github.com/kubernetes/kops/blob/master/docs/advanced/experimental.md) must be specified