### PR TITLE
Fix uploading of file assets

### DIFF
--- a/upup/pkg/fi/assettasks/copyfile.go
+++ b/upup/pkg/fi/assettasks/copyfile.go
@@ -172,15 +172,15 @@ func transferFile(c *fi.Context, source string, target string, sha string) error
 		return fmt.Errorf("error building path %q: %v", shaTarget, err)
 	}
 
-	in := bytes.NewReader(data)
-	dataHash, err := hashing.HashAlgorithmSHA1.Hash(in)
-	if err != nil {
-		return fmt.Errorf("unable to parse sha from file %q downloaded: %v", sha, err)
-	}
-
 	shaHash, err := hashing.FromString(strings.TrimSpace(sha))
 	if err != nil {
-		return fmt.Errorf("unable to hash sha: %q, %v", sha, err)
+		return fmt.Errorf("unable to parse sha: %q, %v", sha, err)
+	}
+
+	in := bytes.NewReader(data)
+	dataHash, err := shaHash.Algorithm.Hash(in)
+	if err != nil {
+		return fmt.Errorf("unable to hash file %q downloaded: %v", source, err)
 	}
 
 	if !shaHash.Equal(dataHash) {

--- a/util/pkg/hashing/hash.go
+++ b/util/pkg/hashing/hash.go
@@ -138,30 +138,6 @@ func (ha HashAlgorithm) HashFile(p string) (*Hash, error) {
 	return ha.Hash(f)
 }
 
-func HashesForResource(r io.Reader, hashAlgorithms []HashAlgorithm) ([]*Hash, error) {
-	var hashers []hash.Hash
-	var writers []io.Writer
-	for _, hashAlgorithm := range hashAlgorithms {
-		hasher := hashAlgorithm.NewHasher()
-		hashers = append(hashers, hasher)
-		writers = append(writers, hasher)
-	}
-
-	w := io.MultiWriter(writers...)
-
-	_, err := copyToHasher(w, r)
-	if err != nil {
-		return nil, fmt.Errorf("error while hashing resource: %v", err)
-	}
-
-	var hashes []*Hash
-	for i, hasher := range hashers {
-		hashes = append(hashes, &Hash{Algorithm: hashAlgorithms[i], HashValue: hasher.Sum(nil)})
-	}
-
-	return hashes, nil
-}
-
 func copyToHasher(dest io.Writer, src io.Reader) (int64, error) {
 	n, err := io.Copy(dest, src)
 	if err != nil {


### PR DESCRIPTION
Attempts to run the assets phase to copy file assets results in errors such as:

```
W0307 21:31:28.450047    2220 executor.go:130] error running task "CopyFile/https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz" (8m57s remaining to succeed): unable to transfer "https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz" to "https://REDACTED.s3.amazonaws.com/file-assets/kops/1.15.0/linux/amd64/utils.tar.gz": the sha value in "s3://file-assets/kops/1.15.0/linux/amd64/utils.tar.gz.sha256" does not match "https://kubeupv2.s3.amazonaws.com/kops/1.15.0/linux/amd64/utils.tar.gz" calculated value "sha1:ec8a939a80c3ba408a8be2d96528ac14f18aea8f"W0307 
```

/kind bug