### PR TITLE
Use latest patch release for Calico, Canal and Cilium

### DIFF
--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -154,7 +154,7 @@ type AmazonVPCNetworkingSpec struct {
 	ImageName string `json:"imageName,omitempty"`
 }
 
-const CiliumDefaultVersion = "v1.6.6"
+const CiliumDefaultVersion = "v1.6.7"
 
 // CiliumNetworkingSpec declares that we want Cilium networking
 type CiliumNetworkingSpec struct {

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.12.yaml.template
@@ -1,8 +1,8 @@
-# Canal Version v3.7.4
+# Canal Version v3.7.5
 # https://docs.projectcalico.org/v3.7/release-notes/#v374
 # This manifest includes the following component versions:
-#   calico/node:v3.7.4
-#   calico/cni:v3.7.4
+#   calico/node:v3.7.5
+#   calico/cni:v3.7.5
 #   coreos/flannel:v0.11.0
 
 # Source: calico/templates/calico-config.yaml
@@ -411,7 +411,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.7.4
+          image: calico/cni:v3.7.5
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -447,7 +447,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.7.4
+          image: calico/node:v3.7.5
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -578,7 +578,7 @@ spec:
       serviceAccountName: calico-node
       priorityClassName: system-cluster-critical
       containers:
-      - image: calico/typha:v3.9.3
+      - image: calico/typha:v3.9.5
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -694,7 +694,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.9.3
+          image: calico/cni:v3.9.5
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -714,7 +714,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.9.3
+          image: calico/cni:v3.9.5
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -748,7 +748,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.9.3
+          image: calico/pod2daemon-flexvol:v3.9.5
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -757,7 +757,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.9.3
+          image: calico/node:v3.9.5
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -956,7 +956,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.9.3
+          image: calico/kube-controllers:v3.9.5
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -828,7 +828,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.6":     "2.6.9-kops.1",
 			"k8s-1.7":     "2.6.12-kops.1",
 			"k8s-1.7-v3":  "3.8.0-kops.1",
-			"k8s-1.12":    "3.9.3-kops.1",
+			"k8s-1.12":    "3.9.5-kops.1",
 		}
 
 		{
@@ -911,7 +911,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.6":     "2.4.2-kops.2",
 			"k8s-1.8":     "2.6.7-kops.3",
 			"k8s-1.9":     "3.2.3-kops.1",
-			"k8s-1.12":    "3.7.4",
+			"k8s-1.12":    "3.7.5-kops.1",
 		}
 		{
 			id := "pre-k8s-1.6"
@@ -1132,7 +1132,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 	if b.cluster.Spec.Networking.Cilium != nil {
 		key := "networking.cilium.io"
-		version := "1.6.4-kops.3"
+		version := "1.6.7-kops.1"
 
 		{
 			id := "k8s-1.7"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -115,16 +115,16 @@ spec:
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0 <1.12.0'
     manifest: networking.cilium.io/k8s-1.7.yaml
-    manifestHash: 6928e95ec4b8359075e3dfb069f74e290e2e6eb2
+    manifestHash: 6cdf6ca6ff2109f7a5be614eb0fa46a35d3ab3f1
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.6.4-kops.3
+    version: 1.6.7-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: 84295d293c8a461f7d510721c48b969cd1d99e54
+    manifestHash: 02b8d576dfa13fc6256f87309caa21dd2414fc41
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.6.4-kops.3
+    version: 1.6.7-kops.1


### PR DESCRIPTION
Seems that there will be a Kops 1.16.1 .
This PR is updating some of the network plugins to the latest patch releases:
* Calico - 3.9.5
* Canal - 3.75
* Cilium - 1.6.7