### PR TITLE
Switch AWS NAT Gateway creation to use tags on create

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -307,7 +307,9 @@ func (_ *NatGateway) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *NatGateway)
 
 		klog.V(2).Infof("Creating Nat Gateway")
 
-		request := &ec2.CreateNatGatewayInput{}
+		request := &ec2.CreateNatGatewayInput{
+			TagSpecifications: awsup.EC2TagSpecification(ec2.ResourceTypeNatgateway, e.Tags),
+		}
 		request.AllocationId = e.ElasticIP.ID
 		request.SubnetId = e.Subnet.ID
 		response, err := t.Cloud.EC2().CreateNatGateway(request)


### PR DESCRIPTION
AWS has been adding support for "tag on create" to many services. Typically this support also includes referencing tags in IAM policies involving these resources.

This means kops could use a more locked-down IAM policy that only allows creating NAT Gateways if they include cluster-specific tags, for example. Ideally we could use this for as many resource types as possible and have a much more locked down example IAM policy for kops users.

Marking WIP until I get a chance to test this locally since none of our e2e jobs create NAT gateways.