### PR TITLE
Add support for Ubuntu 20.04 (Focal)

### DIFF
--- a/nodeup/pkg/distros/distribution.go
+++ b/nodeup/pkg/distros/distribution.go
@@ -29,6 +29,7 @@ var (
 	DistributionDebian10     Distribution = "buster"
 	DistributionXenial       Distribution = "xenial"
 	DistributionBionic       Distribution = "bionic"
+	DistributionFocal        Distribution = "focal"
 	DistributionAmazonLinux2 Distribution = "amazonlinux2"
 	DistributionRhel7        Distribution = "rhel7"
 	DistributionCentos7      Distribution = "centos7"
@@ -51,6 +52,8 @@ func (d Distribution) BuildTags() []string {
 		t = []string{"_xenial"}
 	case DistributionBionic:
 		t = []string{"_bionic"}
+	case DistributionFocal:
+		t = []string{"_focal"}
 	case DistributionAmazonLinux2:
 		t = []string{"_amazonlinux2"}
 	case DistributionCentos7:
@@ -89,7 +92,7 @@ func (d Distribution) IsDebianFamily() bool {
 	switch d {
 	case DistributionJessie, DistributionDebian9, DistributionDebian10:
 		return true
-	case DistributionXenial, DistributionBionic:
+	case DistributionXenial, DistributionBionic, DistributionFocal:
 		return true
 	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8, DistributionAmazonLinux2:
 		return false
@@ -105,7 +108,7 @@ func (d Distribution) IsUbuntu() bool {
 	switch d {
 	case DistributionJessie, DistributionDebian9, DistributionDebian10:
 		return false
-	case DistributionXenial, DistributionBionic:
+	case DistributionXenial, DistributionBionic, DistributionFocal:
 		return true
 	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8, DistributionAmazonLinux2:
 		return false
@@ -121,7 +124,7 @@ func (d Distribution) IsRHELFamily() bool {
 	switch d {
 	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8, DistributionAmazonLinux2:
 		return true
-	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9, DistributionDebian10:
+	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionFocal, DistributionDebian9, DistributionDebian10:
 		return false
 	case DistributionCoreOS, DistributionFlatcar, DistributionContainerOS:
 		return false
@@ -133,7 +136,7 @@ func (d Distribution) IsRHELFamily() bool {
 
 func (d Distribution) IsSystemd() bool {
 	switch d {
-	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9, DistributionDebian10:
+	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionFocal, DistributionDebian9, DistributionDebian10:
 		return true
 	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8, DistributionAmazonLinux2:
 		return true

--- a/nodeup/pkg/distros/identify.go
+++ b/nodeup/pkg/distros/identify.go
@@ -37,9 +37,9 @@ func FindDistribution(rootfs string) (Distribution, error) {
 			if line == "DISTRIB_CODENAME=xenial" {
 				return DistributionXenial, nil
 			} else if line == "DISTRIB_CODENAME=bionic" {
-				klog.Warningf("bionic is not fully supported nor tested for Kops and Kubernetes")
-				klog.Warningf("this should only be used for testing purposes.")
 				return DistributionBionic, nil
+			} else if line == "DISTRIB_CODENAME=focal" {
+				return DistributionFocal, nil
 			}
 		}
 	} else if !os.IsNotExist(err) {

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -597,8 +597,10 @@ func (b *KubeletBuilder) buildKubeletConfigSpec() (*kops.KubeletConfigSpec, erro
 
 	// In certain configurations systemd-resolved will put the loopback address 127.0.0.53 as a nameserver into /etc/resolv.conf
 	// https://github.com/coredns/coredns/blob/master/plugin/loop/README.md#troubleshooting-loops-in-kubernetes-clusters
-	if b.Distribution == distros.DistributionBionic && c.ResolverConfig == nil {
-		c.ResolverConfig = s("/run/systemd/resolve/resolv.conf")
+	if c.ResolverConfig == nil {
+		if b.Distribution == distros.DistributionBionic || b.Distribution == distros.DistributionFocal {
+			c.ResolverConfig = s("/run/systemd/resolve/resolv.conf")
+		}
 	}
 
 	// As of 1.16 we can no longer set critical labels.


### PR DESCRIPTION
Ubuntu 20.04 is close to release and will be the next Ubuntu LTS release.
From Kubernetes point of view, this will be the supported distro with the newest Kernel for some time (Debian 10 and RHEL/CentOS 8 were just released).

Once official stable images are released will add an e2e test for it.