### PR TITLE
Update apiVersion to resolve 'no matches for kind "Deployment" in ver…

### DIFF
--- a/addons/route53-mapper/v1.3.0.yml
+++ b/addons/route53-mapper/v1.3.0.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: app/v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: route53-mapper

--- a/addons/route53-mapper/v1.3.0.yml
+++ b/addons/route53-mapper/v1.3.0.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: app/v1
 kind: Deployment
 metadata:
   name: route53-mapper


### PR DESCRIPTION
…sion "extensions/v1beta"' message.

I am running kubectl version:
```
Client Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.3", GitCommit:"06ad960bfd03b39c8310aaf92d1e7c12ce618213", GitTreeState:"clean", BuildDate:"2020-02-11T18:14:22Z", GoVersion:"go1.13.6", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.7", GitCommit:"be3d344ed06bff7a4fc60656200a93c74f31f9a4", GitTreeState:"clean", BuildDate:"2020-02-11T19:24:46Z", GoVersion:"go1.13.6", Compiler:"gc", Platform:"linux/amd64"}
```