### PR TITLE
Don't set terraform user_data if it is empty 

### DIFF
--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -61,6 +61,7 @@ type integrationTest struct {
 	lifecycleOverrides []string
 	sshKey             bool
 	jsonOutput         bool
+	bastionUserData    bool
 }
 
 func newIntegrationTest(clusterName, srcDir string) *integrationTest {
@@ -111,6 +112,11 @@ func (i *integrationTest) withPrivate() *integrationTest {
 
 func (i *integrationTest) withLaunchTemplate() *integrationTest {
 	i.launchTemplate = true
+	return i
+}
+
+func (i *integrationTest) withBastionUserData() *integrationTest {
+	i.bastionUserData = true
 	return i
 }
 
@@ -185,7 +191,7 @@ func TestAdditionalUserData(t *testing.T) {
 
 // TestBastionAdditionalUserData runs the test on passing additional user-data to a bastion instance group
 func TestBastionAdditionalUserData(t *testing.T) {
-	newIntegrationTest("bastionuserdata.example.com", "bastionadditional_user-data").withPrivate().runTestTerraformAWS(t)
+	newIntegrationTest("bastionuserdata.example.com", "bastionadditional_user-data").withPrivate().withBastionUserData().runTestTerraformAWS(t)
 }
 
 // TestMinimal_JSON runs the test on a minimal data set and outputs JSON
@@ -519,8 +525,10 @@ func (i *integrationTest) runTestTerraformAWS(t *testing.T) {
 			expectedFilenames = append(expectedFilenames, []string{
 				"aws_iam_role_bastions." + i.clusterName + "_policy",
 				"aws_iam_role_policy_bastions." + i.clusterName + "_policy",
-				"aws_launch_configuration_bastion." + i.clusterName + "_user_data",
 			}...)
+			if i.bastionUserData {
+				expectedFilenames = append(expectedFilenames, "aws_launch_configuration_bastion."+i.clusterName+"_user_data")
+			}
 		}
 	}
 	i.runTest(t, h, expectedFilenames, tfFileName, tfFileName, nil)

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -385,7 +385,6 @@ resource "aws_launch_configuration" "bastion-private-shared-subnet-example-com" 
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-private-shared-subnet-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-private-shared-subnet-example-com.id}"]
   associate_public_ip_address = true
-  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.private-shared-subnet.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -415,7 +415,6 @@ resource "aws_launch_configuration" "bastion-privatecalico-example-com" {
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-privatecalico-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-privatecalico-example-com.id}"]
   associate_public_ip_address = true
-  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.privatecalico.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -415,7 +415,6 @@ resource "aws_launch_configuration" "bastion-privatecanal-example-com" {
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-privatecanal-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-privatecanal-example-com.id}"]
   associate_public_ip_address = true
-  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.privatecanal.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -415,7 +415,6 @@ resource "aws_launch_configuration" "bastion-privatedns1-example-com" {
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-privatedns1-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-privatedns1-example-com.id}"]
   associate_public_ip_address = true
-  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.privatedns1.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -400,7 +400,6 @@ resource "aws_launch_configuration" "bastion-privatedns2-example-com" {
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-privatedns2-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-privatedns2-example-com.id}"]
   associate_public_ip_address = true
-  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.privatedns2.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -415,7 +415,6 @@ resource "aws_launch_configuration" "bastion-privateflannel-example-com" {
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-privateflannel-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-privateflannel-example-com.id}"]
   associate_public_ip_address = true
-  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.privateflannel.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -420,7 +420,6 @@ resource "aws_launch_configuration" "bastion-privatekopeio-example-com" {
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-privatekopeio-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-privatekopeio-example-com.id}"]
   associate_public_ip_address = true
-  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.privatekopeio.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -415,7 +415,6 @@ resource "aws_launch_configuration" "bastion-privateweave-example-com" {
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-privateweave-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-privateweave-example-com.id}"]
   associate_public_ip_address = true
-  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.privateweave.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -390,7 +390,6 @@ resource "aws_launch_configuration" "bastion-unmanaged-example-com" {
   iam_instance_profile        = "${aws_iam_instance_profile.bastions-unmanaged-example-com.id}"
   security_groups             = ["${aws_security_group.bastion-unmanaged-example-com.id}"]
   associate_public_ip_address = true
-  user_data                   = "${file("${path.module}/data/aws_launch_configuration_bastion.unmanaged.example.com_user_data")}"
 
   root_block_device = {
     volume_type           = "gp2"

--- a/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
@@ -538,9 +538,15 @@ func (_ *LaunchConfiguration) RenderTerraform(t *terraform.TerraformTarget, a, e
 	}
 
 	if e.UserData != nil {
-		tf.UserData, err = t.AddFile("aws_launch_configuration", *e.Name, "user_data", e.UserData)
+		userData, err := fi.ResourceAsString(e.UserData)
 		if err != nil {
 			return err
+		}
+		if userData != "" {
+			tf.UserData, err = t.AddFile("aws_launch_configuration", *e.Name, "user_data", e.UserData)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if e.IAMInstanceProfile != nil {

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -206,11 +206,13 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 			return err
 		}
 		b64d := base64.StdEncoding.EncodeToString(d)
-		b64UserDataResource := fi.WrapResource(fi.NewStringResource(b64d))
+		if b64d != "" {
+			b64UserDataResource := fi.WrapResource(fi.NewStringResource(b64d))
 
-		tf.UserData, err = target.AddFile("aws_launch_template", fi.StringValue(e.Name), "user_data", b64UserDataResource)
-		if err != nil {
-			return err
+			tf.UserData, err = target.AddFile("aws_launch_template", fi.StringValue(e.Name), "user_data", b64UserDataResource)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	devices, err := e.buildRootDevice(cloud)


### PR DESCRIPTION
Bastion hosts have no user_data by default. This is not valid in terraform, evidenced by the error messages reported [here](https://travis-ci.org/github/kubernetes/kops/jobs/662472020#L606).

The Terraform provider code says user_data is optional for both [LaunchConfigurations](https://github.com/terraform-providers/terraform-provider-aws/blob/04d24f80f3b740d0c9d74d97e818b7da15cb96c5/aws/resource_aws_launch_configuration.go#L74-L76) and [LaunchTemplates](https://github.com/terraform-providers/terraform-provider-aws/blob/04d24f80f3b740d0c9d74d97e818b7da15cb96c5/aws/resource_aws_launch_template.go#L510-L512).

This change prevents the user_data property from being added to `aws_launch_configuration` and `aws_launch_template` resources if the string is empty.