### PR TITLE
Set kube-proxy-replacement to partial

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -116,6 +116,7 @@ data:
   # - none
   # - auto (automatically detect the container runtime)
   #
+  kube-proxy-replacement: partial
   container-runtime: "{{- if eq .ContainerRuntimeLabels "" -}}none{{- else -}}{{ .ContainerRuntimeLabels }}{{- end -}}"
   masquerade: "{{- if .DisableMasquerade -}}false{{- else -}}true{{- end -}}"
   install-iptables-rules: "{{- if .IPTablesRulesNoinstall -}}false{{- else -}}true{{- end -}}"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -123,7 +123,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: c241b96c74983edbe6a7b51f0fb2c7dfe2fb5659
+    manifestHash: 4803f1392f0ec3abf3dc73b240897d4a9464f627
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
Probing for bpf-features doesn't work properly on buster images. Setting it to partial works better. Same setting is the default in the master branch already (implicitly configured by the bpf nodeport flag)