### PR TITLE
Update Docker to 19.03.8 for 1.18

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -859,6 +859,15 @@ var dockerVersions = []packageVersion{
 		Hash:           "5f7199aa237cc8fa10b95ee0c06c5e9ca9ad4296",
 	},
 
+	// 19.03.8 - Linux Generic
+	{
+		PackageVersion: "19.03.8",
+		PlainBinary:    true,
+		Architectures:  []Architecture{ArchitectureAmd64},
+		Source:         "https://download.docker.com/linux/static/stable/x86_64/docker-19.03.8.tgz",
+		Hash:           "b1e783804b3436f6153bce9ed7465f4aebe0b8de",
+	},
+
 	// TIP: When adding the next version, copy the previous version, string replace the version and run:
 	//   VERIFY_HASHES=1 go test -v ./nodeup/pkg/model -run TestDockerPackageHashes
 	// (you might want to temporarily comment out older versions on a slower connection and then validate)

--- a/pkg/model/components/docker.go
+++ b/pkg/model/components/docker.go
@@ -49,7 +49,7 @@ func (b *DockerOptionsBuilder) BuildOptions(o interface{}) error {
 	// Set the Docker version for known Kubernetes versions
 	if fi.StringValue(clusterSpec.Docker.Version) == "" {
 		if b.IsKubernetesGTE("1.18") {
-			docker.Version = fi.String("19.03.7")
+			docker.Version = fi.String("19.03.8")
 		} else if b.IsKubernetesGTE("1.17") {
 			docker.Version = fi.String("19.03.4")
 		} else if b.IsKubernetesGTE("1.16") {


### PR DESCRIPTION
Some newer versions of Docker were released since 19.03.4:
https://docs.docker.com/engine/release-notes/#19038