### PR TITLE
Use containerd 1.2.13 with Docker 19.03.8

### DIFF
--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -73,7 +73,7 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 
 			// Set the containerd version for known Docker versions
 			switch fi.StringValue(clusterSpec.Docker.Version) {
-			case "19.03.7":
+			case "19.03.7", "19.03.8":
 				containerd.Version = fi.String("1.2.13")
 			case "19.03.4":
 				containerd.Version = fi.String("1.2.10")


### PR DESCRIPTION
Corresponding containerd needs to be specified at the moment for each version of Docker.
This should fix the failing periodic e2e tests.