### PR TITLE
Update Weave Net to version 2.6.2

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -168,7 +168,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.1'
+          image: 'weaveworks/weave-kube:2.6.2'
           ports:
             - name: metrics
               containerPort: 6782
@@ -216,7 +216,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.1'
+          image: 'weaveworks/weave-npc:2.6.2'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -164,7 +164,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.1'
+          image: 'weaveworks/weave-kube:2.6.2'
           ports:
             - name: metrics
               containerPort: 6782
@@ -212,7 +212,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.1'
+          image: 'weaveworks/weave-npc:2.6.2'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -628,8 +628,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 	if b.cluster.Spec.Networking.Weave != nil {
 		key := "networking.weave"
 		versions := map[string]string{
-			"k8s-1.8":  "2.6.1-kops.1",
-			"k8s-1.12": "2.6.1-kops.1",
+			"k8s-1.8":  "2.6.2-kops.1",
+			"k8s-1.12": "2.6.2-kops.1",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -89,16 +89,16 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: <1.12.0
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: 7aa5336ec05aef46b185cb660fc02bb2ac201852
+    manifestHash: 23511c3485517049f5b90ce365a3e329509194ee
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.1-kops.1
+    version: 2.6.2-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: 6f12295454fef72234205b7e6c62cdac656eab52
+    manifestHash: 5c6202bc41043a72cb78ade6c761ccaf183bd36c
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.1-kops.1
+    version: 2.6.2-kops.1


### PR DESCRIPTION
Weave v2.6.1 contains a regression that is fixed in v2.6.2: https://github.com/kubernetes/kops/pull/8691#issuecomment-598111201