### PR TITLE
Automated cherry pick of #8731: Allow configuration of enable-remote-node-identity

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2437,6 +2437,8 @@ spec:
                       type: string
                     enablePrometheusMetrics:
                       type: boolean
+                    enableRemoteNodeIdentity:
+                      type: boolean
                     enableTracing:
                       type: boolean
                     enableipv4:
@@ -2541,6 +2543,7 @@ spec:
                   - clusterName
                   - cniBinPath
                   - enableNodePort
+                  - enableRemoteNodeIdentity
                   - enableipv4
                   - enableipv6
                   - monitorAggregation

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -225,19 +225,20 @@ type CiliumNetworkingSpec struct {
 	TracePayloadLen          int               `json:"tracePayloadlen,omitempty"`
 	Tunnel                   string            `json:"tunnel,omitempty"`
 
-	EnableIpv6             bool   `json:"enableipv6"`
-	EnableIpv4             bool   `json:"enableipv4"`
-	MonitorAggregation     string `json:"monitorAggregation"`
-	BPFCTGlobalTCPMax      int    `json:"bpfCTGlobalTCPMax"`
-	BPFCTGlobalAnyMax      int    `json:"bpfCTGlobalAnyMax"`
-	PreallocateBPFMaps     bool   `json:"preallocateBPFMaps"`
-	SidecarIstioProxyImage string `json:"sidecarIstioProxyImage"`
-	ClusterName            string `json:"clusterName"`
-	ToFqdnsEnablePoller    bool   `json:"toFqdnsEnablePoller"`
-	ContainerRuntimeLabels string `json:"containerRuntimeLabels,omitempty"`
-	IPTablesRulesNoinstall bool   `json:"IPTablesRulesNoinstall"`
-	AutoDirectNodeRoutes   bool   `json:"autoDirectNodeRoutes"`
-	EnableNodePort         bool   `json:"enableNodePort"`
+	EnableIpv6               bool   `json:"enableipv6"`
+	EnableIpv4               bool   `json:"enableipv4"`
+	MonitorAggregation       string `json:"monitorAggregation"`
+	BPFCTGlobalTCPMax        int    `json:"bpfCTGlobalTCPMax"`
+	BPFCTGlobalAnyMax        int    `json:"bpfCTGlobalAnyMax"`
+	PreallocateBPFMaps       bool   `json:"preallocateBPFMaps"`
+	SidecarIstioProxyImage   string `json:"sidecarIstioProxyImage"`
+	ClusterName              string `json:"clusterName"`
+	ToFqdnsEnablePoller      bool   `json:"toFqdnsEnablePoller"`
+	ContainerRuntimeLabels   string `json:"containerRuntimeLabels,omitempty"`
+	IPTablesRulesNoinstall   bool   `json:"IPTablesRulesNoinstall"`
+	AutoDirectNodeRoutes     bool   `json:"autoDirectNodeRoutes"`
+	EnableNodePort           bool   `json:"enableNodePort"`
+	EnableRemoteNodeIdentity bool   `json:"enableRemoteNodeIdentity"`
 
 	//node init options
 	RemoveCbrBridge       bool   `json:"removeCbrBridge"`

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -224,19 +224,20 @@ type CiliumNetworkingSpec struct {
 	TracePayloadLen          int               `json:"tracePayloadlen,omitempty"`
 	Tunnel                   string            `json:"tunnel,omitempty"`
 
-	EnableIpv6             bool   `json:"enableipv6"`
-	EnableIpv4             bool   `json:"enableipv4"`
-	MonitorAggregation     string `json:"monitorAggregation"`
-	BPFCTGlobalTCPMax      int    `json:"bpfCTGlobalTCPMax"`
-	BPFCTGlobalAnyMax      int    `json:"bpfCTGlobalAnyMax"`
-	PreallocateBPFMaps     bool   `json:"preallocateBPFMaps"`
-	SidecarIstioProxyImage string `json:"sidecarIstioProxyImage"`
-	ClusterName            string `json:"clusterName"`
-	ToFqdnsEnablePoller    bool   `json:"toFqdnsEnablePoller"`
-	ContainerRuntimeLabels string `json:"containerRuntimeLabels,omitempty"`
-	IPTablesRulesNoinstall bool   `json:"IPTablesRulesNoinstall"`
-	AutoDirectNodeRoutes   bool   `json:"autoDirectNodeRoutes"`
-	EnableNodePort         bool   `json:"enableNodePort"`
+	EnableIpv6               bool   `json:"enableipv6"`
+	EnableIpv4               bool   `json:"enableipv4"`
+	MonitorAggregation       string `json:"monitorAggregation"`
+	BPFCTGlobalTCPMax        int    `json:"bpfCTGlobalTCPMax"`
+	BPFCTGlobalAnyMax        int    `json:"bpfCTGlobalAnyMax"`
+	PreallocateBPFMaps       bool   `json:"preallocateBPFMaps"`
+	SidecarIstioProxyImage   string `json:"sidecarIstioProxyImage"`
+	ClusterName              string `json:"clusterName"`
+	ToFqdnsEnablePoller      bool   `json:"toFqdnsEnablePoller"`
+	ContainerRuntimeLabels   string `json:"containerRuntimeLabels,omitempty"`
+	IPTablesRulesNoinstall   bool   `json:"IPTablesRulesNoinstall"`
+	AutoDirectNodeRoutes     bool   `json:"autoDirectNodeRoutes"`
+	EnableNodePort           bool   `json:"enableNodePort"`
+	EnableRemoteNodeIdentity bool   `json:"enableRemoteNodeIdentity"`
 
 	//node init options
 	RemoveCbrBridge       bool   `json:"removeCbrBridge"`

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1313,6 +1313,7 @@ func autoConvert_v1alpha1_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.IPTablesRulesNoinstall = in.IPTablesRulesNoinstall
 	out.AutoDirectNodeRoutes = in.AutoDirectNodeRoutes
 	out.EnableNodePort = in.EnableNodePort
+	out.EnableRemoteNodeIdentity = in.EnableRemoteNodeIdentity
 	out.RemoveCbrBridge = in.RemoveCbrBridge
 	out.RestartPods = in.RestartPods
 	out.ReconfigureKubelet = in.ReconfigureKubelet
@@ -1391,6 +1392,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha1_CiliumNetworkingSpec(in *
 	out.IPTablesRulesNoinstall = in.IPTablesRulesNoinstall
 	out.AutoDirectNodeRoutes = in.AutoDirectNodeRoutes
 	out.EnableNodePort = in.EnableNodePort
+	out.EnableRemoteNodeIdentity = in.EnableRemoteNodeIdentity
 	out.RemoveCbrBridge = in.RemoveCbrBridge
 	out.RestartPods = in.RestartPods
 	out.ReconfigureKubelet = in.ReconfigureKubelet

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -225,19 +225,20 @@ type CiliumNetworkingSpec struct {
 	TracePayloadLen          int               `json:"tracePayloadlen,omitempty"`
 	Tunnel                   string            `json:"tunnel,omitempty"`
 
-	EnableIpv6             bool   `json:"enableipv6"`
-	EnableIpv4             bool   `json:"enableipv4"`
-	MonitorAggregation     string `json:"monitorAggregation"`
-	BPFCTGlobalTCPMax      int    `json:"bpfCTGlobalTCPMax"`
-	BPFCTGlobalAnyMax      int    `json:"bpfCTGlobalAnyMax"`
-	PreallocateBPFMaps     bool   `json:"preallocateBPFMaps"`
-	SidecarIstioProxyImage string `json:"sidecarIstioProxyImage"`
-	ClusterName            string `json:"clusterName"`
-	ToFqdnsEnablePoller    bool   `json:"toFqdnsEnablePoller"`
-	ContainerRuntimeLabels string `json:"containerRuntimeLabels,omitempty"`
-	IPTablesRulesNoinstall bool   `json:"IPTablesRulesNoinstall"`
-	AutoDirectNodeRoutes   bool   `json:"autoDirectNodeRoutes"`
-	EnableNodePort         bool   `json:"enableNodePort"`
+	EnableIpv6               bool   `json:"enableipv6"`
+	EnableIpv4               bool   `json:"enableipv4"`
+	MonitorAggregation       string `json:"monitorAggregation"`
+	BPFCTGlobalTCPMax        int    `json:"bpfCTGlobalTCPMax"`
+	BPFCTGlobalAnyMax        int    `json:"bpfCTGlobalAnyMax"`
+	PreallocateBPFMaps       bool   `json:"preallocateBPFMaps"`
+	SidecarIstioProxyImage   string `json:"sidecarIstioProxyImage"`
+	ClusterName              string `json:"clusterName"`
+	ToFqdnsEnablePoller      bool   `json:"toFqdnsEnablePoller"`
+	ContainerRuntimeLabels   string `json:"containerRuntimeLabels,omitempty"`
+	IPTablesRulesNoinstall   bool   `json:"IPTablesRulesNoinstall"`
+	AutoDirectNodeRoutes     bool   `json:"autoDirectNodeRoutes"`
+	EnableNodePort           bool   `json:"enableNodePort"`
+	EnableRemoteNodeIdentity bool   `json:"enableRemoteNodeIdentity"`
 
 	//node init options
 	RemoveCbrBridge       bool   `json:"removeCbrBridge"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1355,6 +1355,7 @@ func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.IPTablesRulesNoinstall = in.IPTablesRulesNoinstall
 	out.AutoDirectNodeRoutes = in.AutoDirectNodeRoutes
 	out.EnableNodePort = in.EnableNodePort
+	out.EnableRemoteNodeIdentity = in.EnableRemoteNodeIdentity
 	out.RemoveCbrBridge = in.RemoveCbrBridge
 	out.RestartPods = in.RestartPods
 	out.ReconfigureKubelet = in.ReconfigureKubelet
@@ -1433,6 +1434,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha2_CiliumNetworkingSpec(in *
 	out.IPTablesRulesNoinstall = in.IPTablesRulesNoinstall
 	out.AutoDirectNodeRoutes = in.AutoDirectNodeRoutes
 	out.EnableNodePort = in.EnableNodePort
+	out.EnableRemoteNodeIdentity = in.EnableRemoteNodeIdentity
 	out.RemoveCbrBridge = in.RemoveCbrBridge
 	out.RestartPods = in.RestartPods
 	out.ReconfigureKubelet = in.ReconfigureKubelet

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -122,6 +122,7 @@ data:
   install-iptables-rules: "{{- if .IPTablesRulesNoinstall -}}false{{- else -}}true{{- end -}}"
   auto-direct-node-routes: "{{- if .AutoDirectNodeRoutes -}}true{{- else -}}false{{- end -}}"
   enable-node-port: "{{- if .EnableNodePort -}}true{{- else -}}false{{- end -}}"
+  enable-remote-node-identity: "{{- if .EnableRemoteNodeIdentity -}}true{{- else -}}false{{- end -}}"
 {{ end }} # With .Networking.Cilium end
 ---
 apiVersion: v1

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -1161,7 +1161,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 	if b.cluster.Spec.Networking.Cilium != nil {
 		key := "networking.cilium.io"
-		version := "1.7.0-kops.1"
+		version := "1.7.0-kops.2"
 
 		{
 			id := "k8s-1.7"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -119,12 +119,12 @@ spec:
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.7.0-kops.1
+    version: 1.7.0-kops.2
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: 4803f1392f0ec3abf3dc73b240897d4a9464f627
+    manifestHash: 248ca9020966e6d7bcb0fe166e441171acc6147d
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.7.0-kops.1
+    version: 1.7.0-kops.2


### PR DESCRIPTION
Cherry pick of #8731 on release-1.17.

#8731: Allow configuration of enable-remote-node-identity

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.