### PR TITLE
Add cilium option tofqdns-dns-reject-response-code

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2917,6 +2917,11 @@ spec:
                       description: StateDir is not implemented and may be removed
                         in the future. Setting this has no effect.
                       type: string
+                    toFqdnsDnsRejectResponseCode:
+                      description: 'ToFqdnsDNSRejectResponseCode sets the DNS response
+                        code for rejecting DNS requests. Possible values are "nameError"
+                        or "refused". Default: refused'
+                      type: string
                     toFqdnsEnablePoller:
                       description: 'ToFqdnsEnablePoller replaces the DNS proxy-based
                         implementation of FQDN policies with the less powerful legacy

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -376,6 +376,10 @@ type CiliumNetworkingSpec struct {
 	SidecarIstioProxyImage string `json:"sidecarIstioProxyImage"`
 	// ClusterName is the name of the cluster. It is only relevant when building a mesh of clusters.
 	ClusterName string `json:"clusterName"`
+	// ToFqdnsDNSRejectResponseCode sets the DNS response code for rejecting DNS requests.
+	// Possible values are "nameError" or "refused".
+	// Default: refused
+	ToFqdnsDNSRejectResponseCode string `json:"toFqdnsDnsRejectResponseCode,omitempty"`
 	// ToFqdnsEnablePoller replaces the DNS proxy-based implementation of FQDN policies
 	// with the less powerful legacy implementation.
 	// Default: false

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -374,6 +374,10 @@ type CiliumNetworkingSpec struct {
 	SidecarIstioProxyImage string `json:"sidecarIstioProxyImage"`
 	// ClusterName is the name of the cluster. It is only relevant when building a mesh of clusters.
 	ClusterName string `json:"clusterName"`
+	// ToFqdnsDNSRejectResponseCode sets the DNS response code for rejecting DNS requests.
+	// Possible values are "nameError" or "refused".
+	// Default: refused
+	ToFqdnsDNSRejectResponseCode string `json:"toFqdnsDnsRejectResponseCode,omitempty"`
 	// ToFqdnsEnablePoller replaces the DNS proxy-based implementation of FQDN policies
 	// with the less powerful legacy implementation.
 	// Default: false

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1328,6 +1328,7 @@ func autoConvert_v1alpha1_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.PreallocateBPFMaps = in.PreallocateBPFMaps
 	out.SidecarIstioProxyImage = in.SidecarIstioProxyImage
 	out.ClusterName = in.ClusterName
+	out.ToFqdnsDNSRejectResponseCode = in.ToFqdnsDNSRejectResponseCode
 	out.ToFqdnsEnablePoller = in.ToFqdnsEnablePoller
 	out.ContainerRuntimeLabels = in.ContainerRuntimeLabels
 	out.Ipam = in.Ipam
@@ -1409,6 +1410,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha1_CiliumNetworkingSpec(in *
 	out.PreallocateBPFMaps = in.PreallocateBPFMaps
 	out.SidecarIstioProxyImage = in.SidecarIstioProxyImage
 	out.ClusterName = in.ClusterName
+	out.ToFqdnsDNSRejectResponseCode = in.ToFqdnsDNSRejectResponseCode
 	out.ToFqdnsEnablePoller = in.ToFqdnsEnablePoller
 	out.ContainerRuntimeLabels = in.ContainerRuntimeLabels
 	out.Ipam = in.Ipam

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -374,6 +374,10 @@ type CiliumNetworkingSpec struct {
 	SidecarIstioProxyImage string `json:"sidecarIstioProxyImage"`
 	// ClusterName is the name of the cluster. It is only relevant when building a mesh of clusters.
 	ClusterName string `json:"clusterName"`
+	// ToFqdnsDNSRejectResponseCode sets the DNS response code for rejecting DNS requests.
+	// Possible values are "nameError" or "refused".
+	// Default: refused
+	ToFqdnsDNSRejectResponseCode string `json:"toFqdnsDnsRejectResponseCode,omitempty"`
 	// ToFqdnsEnablePoller replaces the DNS proxy-based implementation of FQDN policies
 	// with the less powerful legacy implementation.
 	// Default: false

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1370,6 +1370,7 @@ func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.PreallocateBPFMaps = in.PreallocateBPFMaps
 	out.SidecarIstioProxyImage = in.SidecarIstioProxyImage
 	out.ClusterName = in.ClusterName
+	out.ToFqdnsDNSRejectResponseCode = in.ToFqdnsDNSRejectResponseCode
 	out.ToFqdnsEnablePoller = in.ToFqdnsEnablePoller
 	out.ContainerRuntimeLabels = in.ContainerRuntimeLabels
 	out.Ipam = in.Ipam
@@ -1451,6 +1452,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha2_CiliumNetworkingSpec(in *
 	out.PreallocateBPFMaps = in.PreallocateBPFMaps
 	out.SidecarIstioProxyImage = in.SidecarIstioProxyImage
 	out.ClusterName = in.ClusterName
+	out.ToFqdnsDNSRejectResponseCode = in.ToFqdnsDNSRejectResponseCode
 	out.ToFqdnsEnablePoller = in.ToFqdnsEnablePoller
 	out.ContainerRuntimeLabels = in.ContainerRuntimeLabels
 	out.Ipam = in.Ipam

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -98,6 +98,9 @@ data:
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: "{{- if eq .ClusterName "" -}}default{{- else -}}{{ .ClusterName}}{{- end -}}"
 
+  # DNS response code for rejecting DNS requests,
+  # available options are "nameError" and "refused"
+  tofqdns-dns-reject-response-code: "{{- if eq .ToFqdnsDNSRejectResponseCode  "" -}}refused{{- else -}}{{ .ToFqdnsDNSRejectResponseCode }}{{- end -}}"
   # This option is disabled by default starting from version 1.4.x in favor
   # of a more powerful DNS proxy-based implementation, see [0] for details.
   # Enable this option if you want to use FQDN policies but do not want to use

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -97,7 +97,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: a897a4b5d8f69f704c33c90487016f87b3737ffd
+    manifestHash: e48ec2946be06a6e324cb19853381bcd2bf78ea2
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
This PR adds the possibility to set the cilium option `--tofqdns-dns-reject-response-code`
https://docs.cilium.io/en/v1.6/cmdref/cilium-agent/#options

Thanks a lot :+1: :cat: 