### PR TITLE
Set default log level to "info" for containerd

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -378,7 +378,7 @@ spec:
                   type: string
                 logLevel:
                   description: Logging level [trace, debug, info, warn, error, fatal,
-                    panic] (default "warn")
+                    panic] (default "info")
                   type: string
                 root:
                   description: Directory for persistent data (default "/var/lib/containerd")

--- a/pkg/apis/kops/containerdconfig.go
+++ b/pkg/apis/kops/containerdconfig.go
@@ -22,7 +22,7 @@ type ContainerdConfig struct {
 	Address *string `json:"address,omitempty" flag:"address"`
 	// Complete containerd config file provided by the user
 	ConfigOverride *string `json:"configOverride,omitempty"`
-	// Logging level [trace, debug, info, warn, error, fatal, panic] (default "warn")
+	// Logging level [trace, debug, info, warn, error, fatal, panic] (default "info")
 	LogLevel *string `json:"logLevel,omitempty" flag:"log-level"`
 	// Directory for persistent data (default "/var/lib/containerd")
 	Root *string `json:"root,omitempty" flag:"root"`

--- a/pkg/apis/kops/v1alpha1/containerdconfig.go
+++ b/pkg/apis/kops/v1alpha1/containerdconfig.go
@@ -22,7 +22,7 @@ type ContainerdConfig struct {
 	Address *string `json:"address,omitempty" flag:"address"`
 	// Complete containerd config file provided by the user
 	ConfigOverride *string `json:"configOverride,omitempty"`
-	// Logging level [trace, debug, info, warn, error, fatal, panic] (default "warn")
+	// Logging level [trace, debug, info, warn, error, fatal, panic] (default "info")
 	LogLevel *string `json:"logLevel,omitempty" flag:"log-level"`
 	// Directory for persistent data (default "/var/lib/containerd")
 	Root *string `json:"root,omitempty" flag:"root"`

--- a/pkg/apis/kops/v1alpha2/containerdconfig.go
+++ b/pkg/apis/kops/v1alpha2/containerdconfig.go
@@ -22,7 +22,7 @@ type ContainerdConfig struct {
 	Address *string `json:"address,omitempty" flag:"address"`
 	// Complete containerd config file provided by the user
 	ConfigOverride *string `json:"configOverride,omitempty"`
-	// Logging level [trace, debug, info, warn, error, fatal, panic] (default "warn")
+	// Logging level [trace, debug, info, warn, error, fatal, panic] (default "info")
 	LogLevel *string `json:"logLevel,omitempty" flag:"log-level"`
 	// Directory for persistent data (default "/var/lib/containerd")
 	Root *string `json:"root,omitempty" flag:"root"`

--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -61,7 +61,7 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 		}
 
 		// Apply defaults for containerd running in container runtime mode
-		containerd.LogLevel = fi.String("warn")
+		containerd.LogLevel = fi.String("info")
 		containerd.ConfigOverride = fi.String("")
 
 	} else if clusterSpec.ContainerRuntime == "docker" {
@@ -89,7 +89,7 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 		}
 
 		// Apply defaults for containerd running in Docker mode
-		containerd.LogLevel = fi.String("warn")
+		containerd.LogLevel = fi.String("info")
 		containerd.ConfigOverride = fi.String("disabled_plugins = [\"cri\"]\n")
 
 	} else {

--- a/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
@@ -138,7 +138,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscontainerdexampl
   containerRuntime: containerd
   containerd:
     configOverride: ""
-    logLevel: warn
+    logLevel: info
     version: 1.2.10
   docker:
     skipInstall: true
@@ -426,7 +426,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodescontainerdexamplecom.Properties.
   containerRuntime: containerd
   containerd:
     configOverride: ""
-    logLevel: warn
+    logLevel: info
     version: 1.2.10
   docker:
     skipInstall: true


### PR DESCRIPTION
"info" is the default log level for containerd and also very useful compared to "warn", but still doesn't create a huge log file.