### PR TITLE
Support S3 Virtual Hosted Style

### DIFF
--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -42,7 +42,7 @@ var (
 	// https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 	// TODO: perhaps make region regex more specific, i.e. (us|eu|ap|cn|ca|sa), to prevent matching bucket names that match region format?
 	//       but that will mean updating this list when AWS introduces new regions
-	s3UrlRegexp = regexp.MustCompile(`s3([-.](?P<region>\w{2}-\w+-\d{1})|[-.](?P<bucket>[\w.\-\_]+)|)?.amazonaws.com(.cn)?(?P<path>.*)?`)
+	s3UrlRegexp = regexp.MustCompile(`(s3([-.](?P<region>\w{2}-\w+-\d{1})|[-.](?P<bucket>[\w.\-\_]+)|)?|(?P<bucket>[\w.\-\_]+).s3.(?P<region>\w{2}-\w+-\d{1})).amazonaws.com(.cn)?(?P<path>.*)?`)
 )
 
 type S3BucketDetails struct {
@@ -385,7 +385,9 @@ func VFSPath(url string) (string, error) {
 
 	captured := map[string]string{}
 	for i, value := range result {
-		captured[groupNames[i]] = value
+		if value != "" {
+			captured[groupNames[i]] = value
+		}
 	}
 	bucket := captured["bucket"]
 	path := captured["path"]

--- a/util/pkg/vfs/s3context_test.go
+++ b/util/pkg/vfs/s3context_test.go
@@ -80,6 +80,11 @@ func Test_VFSPath(t *testing.T) {
 			ExpectError:    false,
 		},
 		{
+			Input:          "https://bucket-name.s3.us-east-1.amazonaws.com/path",
+			ExpectedResult: "s3://bucket-name/path",
+			ExpectError:    false,
+		},
+		{
 			Input:          "example.com/bucket",
 			ExpectedResult: "",
 			ExpectError:    true,


### PR DESCRIPTION
Support S3 URLs written in Virtual Hosted Style, which seems to be only recommended notation nowadays, but isn't supported in kops.

https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#virtual-host-style-url-ex

All the other options are more or less deprecated path style https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#path-style-access, old virtual styles https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#VirtualHostingBackwardsCompatibility