### PR TITLE
Automated cherry pick of #8789: Make cilium operator health check go against localhost IP

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -677,6 +677,7 @@ spec:
 {{ end }}
         livenessProbe:
           httpGet:
+            host: "127.0.0.1"
             path: /healthz
             port: 9234
             scheme: HTTP

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -123,7 +123,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: 248ca9020966e6d7bcb0fe166e441171acc6147d
+    manifestHash: 7b948480cb8939d14717e39f94cfd6df842a1933
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
Cherry pick of #8789 on release-1.17.

#8789: Make cilium operator health check go against localhost IP

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.