### PR TITLE
Update default users for kubeconfig with supported distros

### DIFF
--- a/nodeup/pkg/model/kubectl.go
+++ b/nodeup/pkg/model/kubectl.go
@@ -106,8 +106,12 @@ func (b *KubectlBuilder) findKubeconfigUser() (*fi.User, *fi.Group, error) {
 	switch b.Distribution {
 	case distros.DistributionJessie, distros.DistributionDebian9, distros.DistributionDebian10:
 		users = []string{"admin", "root"}
-	case distros.DistributionCentos7:
+	case distros.DistributionXenial, distros.DistributionBionic, distros.DistributionFocal:
+		users = []string{"ubuntu"}
+	case distros.DistributionCentos7, distros.DistributionCentos8:
 		users = []string{"centos"}
+	case distros.DistributionAmazonLinux2, distros.DistributionRhel7, distros.DistributionRhel8:
+		users = []string{"ec2-user"}
 	default:
 		klog.Warningf("Unknown distro; won't write kubeconfig to homedir %s", b.Distribution)
 		return nil, nil, nil


### PR DESCRIPTION
Kubernetes 1.19 stoped defaulting kubeconfig to http://localhost:8080 and needs a kubeconf in the home dir for kubectl to work by default.
https://github.com/kubernetes/kubernetes/pull/86173