### PR TITLE
Deprecate support for Kubernetes 1.10

### DIFF
--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -74,7 +74,7 @@
 
 # Deprecations
 
-* Support for Kubernetes version 1.10 is deprecated and will be removed in kops 1.19.
+* Support for Kubernetes versions 1.9 and 1.10 are deprecated and will be removed in kops 1.19.
 
 # Full change list since 1.17.0 release
 

--- a/permalinks/upgrade_k8s.md
+++ b/permalinks/upgrade_k8s.md
@@ -6,7 +6,7 @@ Kops will drop support for Kubernetes versions as follows:
 | kops version | Drops support for Kubernetes version |
 |--------------|--------------------------------------|
 | 1.18         | 1.8 and below                        |
-| 1.19         | 1.9                                  |
+| 1.19         | 1.9 and 1.10                         |
 
 
 You are running a version of kubernetes that we recommend upgrading.

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -94,7 +94,7 @@ var (
 	// OldestSupportedKubernetesVersion is the oldest kubernetes version that is supported in Kops
 	OldestSupportedKubernetesVersion = "1.9.0"
 	// OldestRecommendedKubernetesVersion is the oldest kubernetes version that is not deprecated in Kops
-	OldestRecommendedKubernetesVersion = "1.10.0"
+	OldestRecommendedKubernetesVersion = "1.11.0"
 )
 
 type ApplyClusterCmd struct {


### PR DESCRIPTION
Per our deprecation policy, I had deprecated Kubernetes 1.9 in Kops 1.18, scheduling for removal int Kops 1.19. This is the minimum necessary to avoid increasing the supported range.

This PR proposes to also deprecate Kubernetes 1.10, removing support in Kops 1.19. This narrows the supported range by one version.