### PR TITLE
Automated cherry pick of #8462: Tag EBS volumes when using launch templates with AWS API #8466: Update tags support for LaunchTemplates

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -97,6 +97,11 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateTask(c *fi.ModelBuilde
 		return nil, err
 	}
 
+	tags, err := b.CloudTagsForInstanceGroup(ig)
+	if err != nil {
+		return nil, fmt.Errorf("error building cloud tags: %v", err)
+	}
+
 	// @TODO check if there any a better way of doing this .. initially I had a type LaunchTemplate which included
 	// LaunchConfiguration as an anonymous field, bit given up the task dependency walker works this caused issues, due
 	// to the creation of a implicit dependency
@@ -115,6 +120,7 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateTask(c *fi.ModelBuilde
 		RootVolumeType:         lc.RootVolumeType,
 		SSHKey:                 lc.SSHKey,
 		SecurityGroups:         lc.SecurityGroups,
+		Tags:                   tags,
 		Tenancy:                lc.Tenancy,
 		UserData:               lc.UserData,
 	}

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -208,6 +208,10 @@ func (m *KopsModelContext) CloudTagsForInstanceGroup(ig *kops.InstanceGroup) (ma
 		}
 	}
 
+	// Add cluster and ig names
+	labels[awsup.TagClusterName] = m.ClusterName()
+	labels["Name"] = m.AutoscalingGroupName(ig)
+
 	// The system tags take priority because the cluster likely breaks without them...
 
 	if ig.Spec.Role == kops.InstanceGroupRoleMaster {

--- a/pkg/model/spotinstmodel/BUILD.bazel
+++ b/pkg/model/spotinstmodel/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//pkg/model/defaults:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awstasks:go_default_library",
-        "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//upup/pkg/fi/cloudup/spotinsttasks:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/pkg/model/spotinstmodel/instance_group.go
+++ b/pkg/model/spotinstmodel/instance_group.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/kops/pkg/model/defaults"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
-	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/spotinsttasks"
 )
 
@@ -605,8 +604,6 @@ func (b *InstanceGroupModelBuilder) buildTags(ig *kops.InstanceGroup) (map[strin
 	if err != nil {
 		return nil, err
 	}
-	tags[awsup.TagClusterName] = b.ClusterName()
-	tags["Name"] = b.AutoscalingGroupName(ig)
 	return tags, nil
 }
 

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
@@ -62,6 +62,8 @@ type LaunchTemplate struct {
 	SecurityGroups []*SecurityGroup
 	// SpotPrice is set to the spot-price bid if this is a spot pricing request
 	SpotPrice string
+	// Tags are the keypairs to apply to the instance and volume on launch.
+	Tags map[string]string
 	// Tenancy. Can be either default or dedicated.
 	Tenancy *string
 	// UserData is the user data configuration

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -108,6 +108,25 @@ func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, ep, changes *Launch
 	} else {
 		lc.SecurityGroupIds = securityGroups
 	}
+	// @step: add the tags
+	{
+		var list []*ec2.Tag
+		for k, v := range t.Tags {
+			list = append(list, &ec2.Tag{
+				Key:   aws.String(k),
+				Value: aws.String(v),
+			})
+		}
+		instanceTagSpec := ec2.LaunchTemplateTagSpecificationRequest{
+			ResourceType: aws.String("instance"),
+			Tags:         list,
+		}
+		volumeTagSpec := ec2.LaunchTemplateTagSpecificationRequest{
+			ResourceType: aws.String("volume"),
+			Tags:         list,
+		}
+		lc.TagSpecifications = []*ec2.LaunchTemplateTagSpecificationRequest{&instanceTagSpec, &volumeTagSpec}
+	}
 	// @step: add the userdata
 	if t.UserData != nil {
 		d, err := t.UserData.AsBytes()


### PR DESCRIPTION
Cherry pick of #8462 #8466 on release-1.17.

#8462: Tag EBS volumes when using launch templates with AWS API
#8466: Update tags support for LaunchTemplates

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.