### PR TITLE
Automated cherry pick of #8038: Fix Handling of LaunchTemplate Versions for #8261: Fix RollingUpdate behaviour when using LaunchTemplates for #8567: Treat nil of LaunchTemplateSpecification.Version as $Default

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -596,7 +596,7 @@ func findAutoscalingGroupLaunchConfiguration(c AWSCloud, g *autoscaling.Group) (
 				//See what version the ASG is set to use
 				mixedVersion := aws.StringValue(g.MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.Version)
 				//Correctly Handle Default and Latest Versions
-				if mixedVersion == "$Default" || mixedVersion == "$Latest" {
+				if mixedVersion == "" || mixedVersion == "$Default" || mixedVersion == "$Latest" {
 					request := &ec2.DescribeLaunchTemplatesInput{
 						LaunchTemplateNames: []*string{&name},
 					}
@@ -605,7 +605,7 @@ func findAutoscalingGroupLaunchConfiguration(c AWSCloud, g *autoscaling.Group) (
 						return "", fmt.Errorf("error describing launch templates: %v", err)
 					}
 					launchTemplate := dltResponse.LaunchTemplates[0]
-					if mixedVersion == "$Default" {
+					if mixedVersion == "" || mixedVersion == "$Default" {
 						version = strconv.FormatInt(*launchTemplate.DefaultVersionNumber, 10)
 					} else {
 						version = strconv.FormatInt(*launchTemplate.LatestVersionNumber, 10)

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -614,7 +614,7 @@ func findAutoscalingGroupLaunchConfiguration(c AWSCloud, g *autoscaling.Group) (
 					version = mixedVersion
 				}
 				klog.V(4).Infof("Launch Template Version Specified By ASG: %v", mixedVersion)
-				klog.V(4).Infof("Luanch Template Version we are using for compare: %v", version)
+				klog.V(4).Infof("Launch Template Version we are using for compare: %v", version)
 				if name != "" {
 					launchTemplate := name + ":" + version
 					return launchTemplate, nil


### PR DESCRIPTION
Cherry pick of #8038 #8261 #8567 on release-1.17.

#8038: Fix Handling of LaunchTemplate Versions for
#8261: Fix RollingUpdate behaviour when using LaunchTemplates for
#8567: Treat nil of LaunchTemplateSpecification.Version as $Default

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.