### PR TITLE
Disable anonymous auth in integration test clusters

### DIFF
--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
@@ -219,6 +219,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
       leaderElect: true
     logLevel: 2
   kubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -236,6 +237,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
     podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -449,6 +451,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
     image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10

--- a/tests/integration/update_cluster/additional_cidr/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/additional_cidr/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1b
       name: us-test-1b
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.additionalcidr.example.com
   masterPublicName: api.additionalcidr.example.com

--- a/tests/integration/update_cluster/additional_cidr/in-v1alpha3.yaml
+++ b/tests/integration/update_cluster/additional_cidr/in-v1alpha3.yaml
@@ -26,6 +26,8 @@ spec:
     - instanceGroup: master-us-test-1c
       name: us-test-1c
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.additionalcidr.example.com
   masterPublicName: api.additionalcidr.example.com

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -228,6 +228,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
       leaderElect: true
     logLevel: 2
   kubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -245,6 +246,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
     podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -478,6 +480,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
     image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10

--- a/tests/integration/update_cluster/additional_user-data/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/additional_user-data/in-v1alpha2.yaml
@@ -27,6 +27,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.additionaluserdata.example.com
   masterPublicName: api.additionaluserdata.example.com

--- a/tests/integration/update_cluster/api_elb_cross_zone/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/api_elb_cross_zone/in-v1alpha2.yaml
@@ -30,6 +30,8 @@ spec:
     name: events
   kubeAPIServer:
     serviceNodePortRange: 28000-32767
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.crosszone.example.com
   masterPublicName: api.crosszone.example.com

--- a/tests/integration/update_cluster/bastionadditional_user-data/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/bastionadditional_user-data/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.bastionuserdata.example.com
   masterPublicName: api.bastionuserdata.example.com

--- a/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
@@ -221,6 +221,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscomplexexampleco
       leaderElect: true
     logLevel: 2
   kubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -238,6 +239,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscomplexexampleco
     podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -451,6 +453,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodescomplexexamplecom.Properties.Use
     image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -30,6 +30,8 @@ spec:
   kubeAPIServer:
     serviceNodePortRange: 28000-32767
     auditWebhookBatchThrottleQps: 3.14
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.complex.example.com
   masterPublicName: api.complex.example.com

--- a/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
@@ -213,6 +213,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscontainerdexampl
       leaderElect: true
     logLevel: 2
   kubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -230,6 +231,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscontainerdexampl
     podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -437,6 +439,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodescontainerdexamplecom.Properties.
     image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10

--- a/tests/integration/update_cluster/containerd-cloudformation/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/containerd-cloudformation/in-v1alpha2.yaml
@@ -21,6 +21,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.containerd.example.com
   masterPublicName: api.containerd.example.com

--- a/tests/integration/update_cluster/existing_iam/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/existing_iam/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: v1.14.0

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -219,6 +219,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
       leaderElect: true
     logLevel: 2
   kubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -236,6 +237,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -449,6 +451,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
     image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10

--- a/tests/integration/update_cluster/existing_iam_cloudformation/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com

--- a/tests/integration/update_cluster/existing_sg/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/existing_sg/in-v1alpha2.yaml
@@ -29,6 +29,8 @@ spec:
     - instanceGroup: master-us-test-1c
       name: c
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.existingsg.example.com
   masterPublicName: api.existingsg.example.com

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -219,6 +219,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
       leaderElect: true
     logLevel: 2
   kubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -236,6 +237,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
     podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -449,6 +451,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
     image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10

--- a/tests/integration/update_cluster/externallb/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/externallb/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.externallb.example.com
   masterPublicName: api.externallb.example.com

--- a/tests/integration/update_cluster/externalpolicies/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/externalpolicies/in-v1alpha2.yaml
@@ -30,6 +30,8 @@ spec:
   kubeAPIServer:
     serviceNodePortRange: 28000-32767
     auditWebhookBatchThrottleQps: 3.14
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.externalpolicies.example.com
   masterPublicName: api.externalpolicies.example.com

--- a/tests/integration/update_cluster/ha/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/ha/in-v1alpha2.yaml
@@ -26,6 +26,8 @@ spec:
     - instanceGroup: master-us-test-1c
       name: c
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: v1.14.0

--- a/tests/integration/update_cluster/ha_gce/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/ha_gce/in-v1alpha2.yaml
@@ -30,6 +30,8 @@ spec:
     name: events
   iam:
     legacy: false
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: v1.14.0

--- a/tests/integration/update_cluster/launch_templates/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/launch_templates/cloudformation.json.extracted.yaml
@@ -220,6 +220,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterslaunchtemplatesexamplecom.Pro
     logLevel: 2
   kubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -238,6 +239,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterslaunchtemplatesexamplecom.Pro
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -516,6 +518,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1bmasterslaunchtemplatesexamplecom.Pro
     logLevel: 2
   kubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -534,6 +537,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1bmasterslaunchtemplatesexamplecom.Pro
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -812,6 +816,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1cmasterslaunchtemplatesexamplecom.Pro
     logLevel: 2
   kubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -830,6 +835,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1cmasterslaunchtemplatesexamplecom.Pro
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -1044,6 +1050,7 @@ Resources.AWSEC2LaunchTemplatenodeslaunchtemplatesexamplecom.Properties.LaunchTe
     logLevel: 2
   kubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10

--- a/tests/integration/update_cluster/launch_templates/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/launch_templates/in-v1alpha2.yaml
@@ -26,6 +26,8 @@ spec:
     - instanceGroup: master-us-test-1c
       name: us-test-1c
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.12.9
   masterInternalName: api.internal.launchtemplates.example.com
   masterPublicName: api.launchtemplates.example.com

--- a/tests/integration/update_cluster/lifecycle_phases/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/lifecycle_phases/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.lifecyclephases.example.com
   masterPublicName: api.lifecyclephases.example.com

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -219,6 +219,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
       leaderElect: true
     logLevel: 2
   kubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -236,6 +237,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
     podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -449,6 +451,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
     image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10

--- a/tests/integration/update_cluster/minimal-cloudformation/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com

--- a/tests/integration/update_cluster/minimal-json/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal-json/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.minimal-json.example.com
   masterPublicName: api.minimal-json.example.com

--- a/tests/integration/update_cluster/minimal/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com

--- a/tests/integration/update_cluster/minimal_gce/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal_gce/in-v1alpha2.yaml
@@ -22,6 +22,8 @@ spec:
     name: events
   iam:
     legacy: false
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: v1.14.0

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
@@ -220,6 +220,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
     logLevel: 2
   kubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -238,6 +239,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -516,6 +518,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
     logLevel: 2
   kubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -534,6 +537,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -812,6 +816,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
     logLevel: 2
   kubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -830,6 +835,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -1044,6 +1050,7 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
     logLevel: 2
   kubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10

--- a/tests/integration/update_cluster/mixed_instances/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/mixed_instances/in-v1alpha2.yaml
@@ -26,6 +26,8 @@ spec:
     - instanceGroup: master-us-test-1c
       name: us-test-1c
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.12.9
   masterInternalName: api.internal.mixedinstances.example.com
   masterPublicName: api.mixedinstances.example.com

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
@@ -220,6 +220,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
     logLevel: 2
   kubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -238,6 +239,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -516,6 +518,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
     logLevel: 2
   kubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -534,6 +537,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -812,6 +816,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
     logLevel: 2
   kubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -830,6 +835,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -1044,6 +1050,7 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
     logLevel: 2
   kubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10

--- a/tests/integration/update_cluster/mixed_instances_spot/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/mixed_instances_spot/in-v1alpha2.yaml
@@ -26,6 +26,8 @@ spec:
     - instanceGroup: master-us-test-1c
       name: us-test-1c
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.12.9
   masterInternalName: api.internal.mixedinstances.example.com
   masterPublicName: api.mixedinstances.example.com

--- a/tests/integration/update_cluster/nosshkey-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/nosshkey-cloudformation/cloudformation.json.extracted.yaml
@@ -224,6 +224,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersnosshkeyexamplec
     logLevel: 2
   kubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -242,6 +243,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersnosshkeyexamplec
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -453,6 +455,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesnosshkeyexamplecom.Properties.Us
     logLevel: 2
   kubelet:
     allowPrivileged: true
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10

--- a/tests/integration/update_cluster/nosshkey-cloudformation/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/nosshkey-cloudformation/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.11.10
   masterInternalName: api.internal.nosshkey.example.com
   masterPublicName: api.nosshkey.example.com

--- a/tests/integration/update_cluster/nosshkey/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/nosshkey/in-v1alpha2.yaml
@@ -27,6 +27,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubeAPIServer:
     serviceNodePortRange: 28000-32767
   kubernetesVersion: v1.11.10

--- a/tests/integration/update_cluster/private-shared-subnet/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/private-shared-subnet/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.private-shared-subnet.example.com
   masterPublicName: api.private-shared-subnet.example.com

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
@@ -220,6 +220,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersprivatecalicoexa
       leaderElect: true
     logLevel: 2
   kubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -236,6 +237,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersprivatecalicoexa
     podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10
@@ -448,6 +450,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodesprivatecalicoexamplecom.Properti
     image: k8s.gcr.io/kube-proxy:v1.14.0
     logLevel: 2
   kubelet:
+    anonymousAuth: false
     cgroupRoot: /
     cloudProvider: aws
     clusterDNS: 100.64.0.10

--- a/tests/integration/update_cluster/privatecalico/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatecalico/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privatecalico.example.com
   masterPublicName: api.privatecalico.example.com

--- a/tests/integration/update_cluster/privatecanal/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatecanal/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privatecanal.example.com
   masterPublicName: api.privatecanal.example.com

--- a/tests/integration/update_cluster/privatedns1/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatedns1/in-v1alpha2.yaml
@@ -19,6 +19,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privatedns1.example.com
   masterPublicName: api.privatedns1.example.com

--- a/tests/integration/update_cluster/privatedns2/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatedns2/in-v1alpha2.yaml
@@ -19,6 +19,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privatedns2.example.com
   masterPublicName: api.privatedns2.example.com

--- a/tests/integration/update_cluster/privateflannel/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privateflannel/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privateflannel.example.com
   masterPublicName: api.privateflannel.example.com

--- a/tests/integration/update_cluster/privatekopeio/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatekopeio/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privatekopeio.example.com
   masterPublicName: api.privatekopeio.example.com

--- a/tests/integration/update_cluster/privateweave/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privateweave/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.privateweave.example.com
   masterPublicName: api.privateweave.example.com

--- a/tests/integration/update_cluster/restrict_access/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/restrict_access/in-v1alpha2.yaml
@@ -19,6 +19,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.restrictaccess.example.com
   masterPublicName: api.restrictaccess.example.com

--- a/tests/integration/update_cluster/shared_subnet/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/shared_subnet/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.sharedsubnet.example.com
   masterPublicName: api.sharedsubnet.example.com

--- a/tests/integration/update_cluster/shared_vpc/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/shared_vpc/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.sharedvpc.example.com
   masterPublicName: api.sharedvpc.example.com

--- a/tests/integration/update_cluster/unmanaged/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/unmanaged/in-v1alpha2.yaml
@@ -18,6 +18,8 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
+  kubelet:
+    anonymousAuth: false
   kubernetesVersion: v1.14.0
   masterInternalName: api.internal.unmanaged.example.com
   masterPublicName: api.unmanaged.example.com


### PR DESCRIPTION
This silences the anonymousAuth warning printed during `update cluster`, reducing the integration test output by >500 lines.

```
*********************************************************************************

Kubelet anonymousAuth is currently turned on. This allows RBAC escalation and remote code execution possibilities.
It is highly recommended you turn it off by setting 'spec.kubelet.anonymousAuth' to 'false' via 'kops edit cluster'

See https://kops.sigs.k8s.io/security/#kubelet-api

*********************************************************************************
```