### PR TITLE
Remove support for the legacy etcd provider as of k8s 1.18

### DIFF
--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -26,6 +26,8 @@
 
 * Google API client libraries updated from v0.beta to v1.
 
+* Kops does not support the "Legacy" etcd provider for Kubernetes versions 1.18 and higher. Such clusters will need to use the default "Manager" etcd provider.
+
 # Breaking changes
 
 * Support for Docker versions 1.11, 1.12 and 1.13 has been removed because of the [dockerproject.org shut down](https://www.docker.com/blog/changes-dockerproject-org-apt-yum-repositories/). Those affected must upgrade to a newer Docker version.

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -562,14 +562,14 @@ func validateEtcdClusterSpec(spec *kops.EtcdClusterSpec, c *kops.Cluster, fieldP
 		}
 	}
 	if len(spec.Members) == 0 {
-		allErrs = append(allErrs, field.Required(fieldPath.Child("members"), "No members defined in etcd cluster"))
+		allErrs = append(allErrs, field.Required(fieldPath.Child("etcdMembers"), "No members defined in etcd cluster"))
 	} else if (len(spec.Members) % 2) == 0 {
 		// Not technically a requirement, but doesn't really make sense to allow
-		allErrs = append(allErrs, field.Invalid(fieldPath.Child("members"), len(spec.Members), "Should be an odd number of master-zones for quorum. Use --zones and --master-zones to declare node zones and master zones separately"))
+		allErrs = append(allErrs, field.Invalid(fieldPath.Child("etcdMembers"), len(spec.Members), "Should be an odd number of master-zones for quorum. Use --zones and --master-zones to declare node zones and master zones separately"))
 	}
 	allErrs = append(allErrs, validateEtcdVersion(spec, fieldPath, nil)...)
-	for _, m := range spec.Members {
-		allErrs = append(allErrs, validateEtcdMemberSpec(m, fieldPath)...)
+	for i, m := range spec.Members {
+		allErrs = append(allErrs, validateEtcdMemberSpec(m, fieldPath.Child("etcdMembers").Index(i))...)
 	}
 
 	return allErrs

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -332,12 +332,24 @@ func Test_Validate_AdditionalPolicies(t *testing.T) {
 	}
 	for _, g := range grid {
 		clusterSpec := &kops.ClusterSpec{
+			KubernetesVersion:  "1.17.0",
 			AdditionalPolicies: &g.Input,
 			Subnets: []kops.ClusterSubnetSpec{
 				{Name: "subnet1"},
 			},
+			EtcdClusters: []*kops.EtcdClusterSpec{
+				{
+					Name: "main",
+					Members: []*kops.EtcdMemberSpec{
+						{
+							Name:          "us-test-1a",
+							InstanceGroup: fi.String("master-us-test-1a"),
+						},
+					},
+				},
+			},
 		}
-		errs := validateClusterSpec(clusterSpec, field.NewPath("spec"))
+		errs := validateClusterSpec(clusterSpec, &kops.Cluster{Spec: *clusterSpec}, field.NewPath("spec"))
 		testErrors(t, g.Input, errs, g.ExpectedErrors)
 	}
 }


### PR DESCRIPTION
This proposes to remove support for the legacy etcd provider for clusters running Kubernetes 1.18 or later.