### PR TITLE
Add support for installing ec2-instance-connect

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -20,6 +20,18 @@ To change the SSH public key on an existing cluster:
 * `kops update cluster --yes` to reconfigure the auto-scaling groups
 * `kops rolling-update cluster --name <clustername> --yes` to immediately roll all the machines so they have the new key (optional)
 
+### EC2 Instance Connect
+
+Kops clusters on AWS can configure make use of [EC2 Instance Connect](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Connect-using-EC2-Instance-Connect.html).
+
+To enable this, add the following to the Instance Group spec.
+
+```
+spec:
+    ec2InstanceConnect: true
+```
+
+
 ## Docker Configuration
 
 If you are using a private registry such as quay.io, you may be familiar with the inconvenience of managing the `imagePullSecrets` for each namespace. It can also be a pain to use [Kops Hooks](cluster_spec.md#hooks) with private images. To configure docker on all nodes with access to one or more private registries:

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -97,6 +97,10 @@ spec:
                 description: DetailedInstanceMonitoring defines if detailed-monitoring
                   is enabled (AWS only)
                 type: boolean
+              ec2InstanceConnect:
+                description: EC2InstanceConnect installs the ec2-instance-connect
+                  package.
+                type: boolean
               externalLoadBalancers:
                 description: ExternalLoadBalancers define loadbalancers that should
                   be attached to the instancegroup

--- a/nodeup/pkg/model/BUILD.bazel
+++ b/nodeup/pkg/model/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "convenience.go",
         "directories.go",
         "docker.go",
+        "ec2instanceconnect.go",
         "etcd.go",
         "etcd_manager_tls.go",
         "etcd_tls.go",

--- a/nodeup/pkg/model/ec2instanceconnect.go
+++ b/nodeup/pkg/model/ec2instanceconnect.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"k8s.io/klog"
+	"k8s.io/kops/nodeup/pkg/distros"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
+)
+
+// DockerBuilder install docker (just the packages at the moment)
+type EC2InstanceConnectBuilder struct {
+	*NodeupModelContext
+}
+
+var _ fi.ModelBuilder = &EC2InstanceConnectBuilder{}
+
+// Build is responsible for installing packages
+func (b *EC2InstanceConnectBuilder) Build(c *fi.ModelBuilderContext) error {
+	if !b.InstanceGroup.Spec.EC2InstanceConnect {
+		return nil
+	}
+
+	if b.Distribution.IsUbuntu() || b.Distribution == distros.DistributionAmazonLinux2 {
+		c.AddTask(&nodetasks.Package{Name: "ec2-instance-connect"})
+	} else if b.Distribution.IsDebianFamily() {
+		c.AddTask(&nodetasks.Package{
+			Name:   "ec2-instance-connect",
+			Source: s("http://archive.ubuntu.com/ubuntu/pool/universe/e/ec2-instance-connect/ec2-instance-connect_1.1.12+dfsg1-0ubuntu3~19.10.0_all.deb"),
+			Hash:   s("52768695e6b9bac9e55bf6324026c240"),
+		})
+	} else {
+		klog.Warningf("unsupported distribution, skipping installation on: %v", b.Distribution)
+	}
+
+	return nil
+
+}

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -161,6 +161,8 @@ type InstanceGroupSpec struct {
 	SysctlParameters []string `json:"sysctlParameters,omitempty"`
 	// RollingUpdate defines the rolling-update behavior
 	RollingUpdate *RollingUpdate `json:"rollingUpdate,omitempty"`
+	// EC2InstanceConnect installs the ec2-instance-connect package.
+	EC2InstanceConnect bool `json:"ec2InstanceConnect,omitempty"`
 }
 
 const (

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -157,6 +157,8 @@ type InstanceGroupSpec struct {
 	SysctlParameters []string `json:"sysctlParameters,omitempty"`
 	// RollingUpdate defines the rolling-update behavior
 	RollingUpdate *RollingUpdate `json:"rollingUpdate,omitempty"`
+	// EC2InstanceConnect installs the ec2-instance-connect package.
+	EC2InstanceConnect bool `json:"ec2InstanceConnect,omitempty"`
 }
 
 const (

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3366,6 +3366,7 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	} else {
 		out.RollingUpdate = nil
 	}
+	out.EC2InstanceConnect = in.EC2InstanceConnect
 	return nil
 }
 
@@ -3504,6 +3505,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	} else {
 		out.RollingUpdate = nil
 	}
+	out.EC2InstanceConnect = in.EC2InstanceConnect
 	return nil
 }
 

--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -207,6 +207,12 @@ func CrossValidateInstanceGroup(g *kops.InstanceGroup, cluster *kops.Cluster, st
 		}
 	}
 
+	if g.Spec.EC2InstanceConnect {
+		if kops.CloudProviderID(cluster.Spec.CloudProvider) != kops.CloudProviderAWS {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "ec2InstanceConnect"), "ec2-instance-connect is only available on AWS"))
+		}
+	}
+
 	return allErrs
 }
 

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -249,6 +249,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 	loader.Builders = append(loader.Builders, &model.KubeControllerManagerBuilder{NodeupModelContext: modelContext})
 	loader.Builders = append(loader.Builders, &model.KubeSchedulerBuilder{NodeupModelContext: modelContext})
 	loader.Builders = append(loader.Builders, &model.EtcdManagerTLSBuilder{NodeupModelContext: modelContext})
+	loader.Builders = append(loader.Builders, &model.EC2InstanceConnectBuilder{NodeupModelContext: modelContext})
 
 	if c.cluster.Spec.Networking.Cilium != nil {
 		loader.Builders = append(loader.Builders, &model.CiliumBuilder{NodeupModelContext: modelContext})


### PR DESCRIPTION
Adds a field to the instance group spec that installs the ec2-instance-connect package on supported distros.
Installing the package is the only thing needed for ec2-instance-connect to work.