### PR TITLE
Enable stamping on bazel image builds

### DIFF
--- a/cmd/kops-controller/BUILD.bazel
+++ b/cmd/kops-controller/BUILD.bazel
@@ -46,6 +46,7 @@ container_image(
     files = [
         "//cmd/kops-controller",
     ],
+    stamp = True,
 )
 
 container_push(

--- a/dns-controller/cmd/dns-controller/BUILD.bazel
+++ b/dns-controller/cmd/dns-controller/BUILD.bazel
@@ -52,6 +52,7 @@ container_image(
     files = [
         "dns-controller",
     ],
+    stamp = True,
 )
 
 container_push(

--- a/images/BUILD.bazel
+++ b/images/BUILD.bazel
@@ -87,4 +87,5 @@ container_image(
     files = [
         "//cmd/kops-controller",
     ],
+    stamp = True,
 )


### PR DESCRIPTION
Currently the images have a timestamp of epoch 0:

```
$ docker inspect kope/kops-controller:1.18.0-alpha.2 -f '{{ .Created }}'
1970-01-01T00:00:00Z
```

The `container_image` [bazel rule](https://github.com/bazelbuild/rules_docker#container_image-1) mentions that `creation_time` has a default value of 0 unless `stamp = True`, so this should be enabled on all container_image rules that are pushed to a docker registry.