### PR TITLE
Automated cherry pick of #8835: Enable stamping on bazel image builds

### DIFF
--- a/cmd/kops-controller/BUILD.bazel
+++ b/cmd/kops-controller/BUILD.bazel
@@ -45,6 +45,7 @@ container_image(
     files = [
         "//cmd/kops-controller",
     ],
+    stamp = True,
 )
 
 container_push(

--- a/dns-controller/cmd/dns-controller/BUILD.bazel
+++ b/dns-controller/cmd/dns-controller/BUILD.bazel
@@ -51,6 +51,7 @@ container_image(
     files = [
         "dns-controller",
     ],
+    stamp = True,
 )
 
 container_push(

--- a/images/BUILD.bazel
+++ b/images/BUILD.bazel
@@ -98,4 +98,5 @@ container_image(
     files = [
         "//cmd/kops-controller",
     ],
+    stamp = True,
 )


### PR DESCRIPTION
Cherry pick of #8835 on release-1.17.

#8835: Enable stamping on bazel image builds

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.