### PR TITLE
Use CNI 0.8.5 for Kubernetes 1.18+

### DIFF
--- a/upup/pkg/fi/cloudup/networking.go
+++ b/upup/pkg/fi/cloudup/networking.go
@@ -125,6 +125,10 @@ const (
 	defaultCNIAssetSHA1StringK8s1_11   = "52e9d2de8a5f927307d9397308735658ee44ab8d"
 	defaultCNIAssetSHA256StringK8s1_11 = "3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64"
 
+	// defaultCNIAssetK8s1_18 is the CNI tarball for k8s >= 1.18
+	defaultCNIAssetK8s1_18             = "https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz"
+	defaultCNIAssetSHA256StringK8s1_18 = "bd682ffcf701e8f83283cdff7281aad0c83b02a56084d6e601216210732833f9"
+
 	// Environment variable for overriding CNI url
 	ENV_VAR_CNI_VERSION_URL       = "CNI_VERSION_URL"
 	ENV_VAR_CNI_ASSET_HASH_STRING = "CNI_ASSET_HASH_STRING"
@@ -160,19 +164,23 @@ func findCNIAssets(c *api.Cluster, assetBuilder *assets.AssetBuilder) (*url.URL,
 	}
 
 	var cniAsset, cniAssetHash string
-	if util.IsKubernetesGTE("1.15", *sv) {
+	if util.IsKubernetesGTE("1.18", *sv) {
+		cniAsset = defaultCNIAssetK8s1_18
+		cniAssetHash = defaultCNIAssetSHA256StringK8s1_18
+		klog.V(2).Infof("Adding default CNI asset for k8s >= 1.18: %s", cniAsset)
+	} else if util.IsKubernetesGTE("1.15", *sv) {
 		// We're still on the same asset, but we use sha256
 		cniAsset = defaultCNIAssetK8s1_11
 		cniAssetHash = defaultCNIAssetSHA256StringK8s1_11
-		klog.V(2).Infof("Adding default CNI asset for k8s >= 1.11: %s", defaultCNIAssetK8s1_9)
+		klog.V(2).Infof("Adding default CNI asset for 1.18 > k8s >= 1.11: %s", cniAsset)
 	} else if util.IsKubernetesGTE("1.11", *sv) {
 		cniAsset = defaultCNIAssetK8s1_11
 		cniAssetHash = defaultCNIAssetSHA1StringK8s1_11
-		klog.V(2).Infof("Adding default CNI asset for k8s >= 1.11: %s", defaultCNIAssetK8s1_9)
+		klog.V(2).Infof("Adding default CNI asset for 1.18 > k8s >= 1.11: %s", cniAsset)
 	} else {
 		cniAsset = defaultCNIAssetK8s1_9
 		cniAssetHash = defaultCNIAssetHashStringK8s1_9
-		klog.V(2).Infof("Adding default CNI asset for 1.11 > k8s >= 1.9: %s", defaultCNIAssetK8s1_9)
+		klog.V(2).Infof("Adding default CNI asset for 1.11 > k8s >= 1.9: %s", cniAsset)
 	}
 
 	u, err := url.Parse(cniAsset)


### PR DESCRIPTION
Equivalent of https://github.com/kubernetes/kubernetes/pull/78819.