### PR TITLE
Update GCB jobs to use bazel 2.2.0

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
 # Start by just pushing the image
-- name: 'gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1'
+- name: 'gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.2.0'
   entrypoint: make
   env:
   # _GIT_TAG is not a valid semver, we use CI=1 instead
@@ -16,7 +16,7 @@ steps:
   - DOCKER_IMAGE_PREFIX=$_DOCKER_IMAGE_PREFIX
   args:
   - kops-controller-push
-- name: 'gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1'
+- name: 'gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.2.0'
   entrypoint: make
   env:
   # _GIT_TAG is not a valid semver, we use CI=1 instead


### PR DESCRIPTION
We upgraded bazel to 2.2.0 in https://github.com/kubernetes/kops/pull/8790 which matches k/k. These cloudbuild jobs were still using an image containing bazel 0.29.1 which [have been failing](https://prow.k8s.io/job-history/kubernetes-jenkins/logs/kops-postsubmit-push-to-staging?buildId=1246516361849475072) since the upgrade.

I added a 2.2.0 image in https://github.com/kubernetes/test-infra/pull/17101 so this updates to use [those new images](https://console.cloud.google.com/gcr/images/k8s-testimages/GLOBAL/bazelbuild?gcrImageListsize=30). 