### PR TITLE
Disable static tokens by default as of Kubernetes 1.18

### DIFF
--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -42,7 +42,9 @@
 
 * Lyft CNI plugin default subnet tags changed from from `Type: pod` to `KubernetesCluster: myclustername.mydns.io`. Subnets intended for use by the plugin will need to be tagged with this new tag and [additional tag filters](https://github.com/lyft/cni-ipvlan-vpc-k8s#other-configuration-flags) may need to be added to the cluster spec in order to achieve the desired set of subnets.
 
-* Support for basic authentication has been disabled by default and will be [removed](https://github.com/kubernetes/kubernetes/pull/89069) in Kubernetes 1.19.
+* Support for basic authentication has been disabled by default for Kubernetes 1.18 and will be [removed](https://github.com/kubernetes/kubernetes/pull/89069) in Kubernetes 1.19.
+
+* Support for static tokens has been disabled by default for Kubernetes 1.18 and later. To re-enable, see the [Security Notes for Kubernetes](../security.md). We intend to remove support entirely in a future kops version, so file an issue with your use case if you need this feature. 
 
 * Support for Kubernetes versions prior to 1.9 has been removed.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -51,16 +51,23 @@ spec:
     anonymousAuth: false
 ```
 
+Clusters created with `kops create cluster` using Kubernetes 1.11 or later will have this setting in the generated cluster spec and thus have AnonymousAuth disabled.
+
 **Note** on an existing cluster with 'anonymousAuth' unset you would need to first roll out the masters and then update the node instance groups.
 
 ### API Bearer Token
 
+Static bearer tokens are disabled by default as of Kubernetes 1.18.
+In order to enable them:
+
+```YAML
+# In the cluster spec
+spec:
+  kubeAPIServer:
+    tokenAuthFile: "/srv/kubernetes/known_tokens.csv"
+```
+
 The API bearer token is a secret named 'admin'.
 
-`kops get secrets --type secret admin -oplaintext` will show it
+`kops get secrets --type secret admin -oplaintext` will show it.
 
-### Admin Access
-
-Access to the administrative API is stored in a secret named 'kube':
-
-`kops get secrets kube -oplaintext` or `kubectl config view --minify` to reveal

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -299,11 +299,11 @@ func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 	kubeAPIServer.ClientCAFile = filepath.Join(b.PathSrvKubernetes(), "ca.crt")
 	kubeAPIServer.TLSCertFile = filepath.Join(b.PathSrvKubernetes(), "server.cert")
 	kubeAPIServer.TLSPrivateKeyFile = filepath.Join(b.PathSrvKubernetes(), "server.key")
-	kubeAPIServer.TokenAuthFile = filepath.Join(b.PathSrvKubernetes(), "known_tokens.csv")
 
 	// Support for basic auth was deprecated 1.16 and removed in 1.19
 	// https://github.com/kubernetes/kubernetes/pull/89069
 	if b.IsKubernetesLT("1.18") {
+		kubeAPIServer.TokenAuthFile = filepath.Join(b.PathSrvKubernetes(), "known_tokens.csv")
 		if kubeAPIServer.DisableBasicAuth == nil || !*kubeAPIServer.DisableBasicAuth {
 			kubeAPIServer.BasicAuthFile = filepath.Join(b.PathSrvKubernetes(), "basic_auth.csv")
 		}

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
@@ -42,7 +42,6 @@ contents: |
       - --storage-backend=etcd3
       - --tls-cert-file=/srv/kubernetes/server.cert
       - --tls-private-key-file=/srv/kubernetes/server.key
-      - --token-auth-file=/srv/kubernetes/known_tokens.csv
       - --v=2
       - --logtostderr=false
       - --alsologtostderr


### PR DESCRIPTION
Disables by default in k8s 1.18, can be re-enabled ~~by enabling basic auth. Removed in k8s 1.19~~ using instructions in security.md.