### PR TITLE
Remove support for Docker 1.11, 1.12 and 1.13

### DIFF
--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -232,7 +232,7 @@ func TestValidateKubeAPIServer(t *testing.T) {
 func Test_Validate_DockerConfig_Storage(t *testing.T) {
 	for _, name := range []string{"aufs", "zfs", "overlay"} {
 		config := &kops.DockerConfig{Storage: &name}
-		errs := ValidateDockerConfig(config, field.NewPath("docker"))
+		errs := validateDockerConfig(config, field.NewPath("docker"))
 		if len(errs) != 0 {
 			t.Fatalf("Unexpected errors validating DockerConfig %q", errs)
 		}
@@ -240,7 +240,7 @@ func Test_Validate_DockerConfig_Storage(t *testing.T) {
 
 	for _, name := range []string{"overlayfs", "", "au"} {
 		config := &kops.DockerConfig{Storage: &name}
-		errs := ValidateDockerConfig(config, field.NewPath("docker"))
+		errs := validateDockerConfig(config, field.NewPath("docker"))
 		if len(errs) != 1 {
 			t.Fatalf("Expected errors validating DockerConfig %+v", config)
 		}


### PR DESCRIPTION
The repo containing the binaries for Docker 1.11, 1.12 and 1.13 was shut down on March 31. This means support for older docker versions cannot be maintained.
https://www.docker.com/blog/changes-dockerproject-org-apt-yum-repositories/
> On the 31st of March 2020, we will be shutting down the legacy APT and YUM repositories hosted at dockerproject.org and dockerproject.com. These repositories haven’t been updated with the latest releases of Docker and so the packages hosted there contain security vulnerabilities. Removing these repositories will make sure that people download the latest version of Docker ensuring their security and providing the best experience possible

This PR will need to be cherry-picked to 1.16+.