### PR TITLE
Fix addon/ing/nginx v1.6.0 deployment apiVersion and selector

### DIFF
--- a/addons/ingress-nginx/v1.6.0.yaml
+++ b/addons/ingress-nginx/v1.6.0.yaml
@@ -174,7 +174,7 @@ spec:
 ---
 
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: nginx-default-backend
   namespace: kube-ingress
@@ -255,7 +255,7 @@ spec:
 ---
 
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: ingress-nginx
   namespace: kube-ingress

--- a/addons/ingress-nginx/v1.6.0.yaml
+++ b/addons/ingress-nginx/v1.6.0.yaml
@@ -184,6 +184,9 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: nginx-default-backend
   template:
     metadata:
       labels:
@@ -264,6 +267,9 @@ metadata:
     k8s-addon: ingress-nginx.addons.k8s.io
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: ingress-nginx
   template:
     metadata:
       labels:


### PR DESCRIPTION
Deployments with `extensions/v1beta1` apiVersions are deprecated, according to [this](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/).

`spec.selector` is also required for deployment.