### PR TITLE
Automated cherry pick of #8855: Remove support for Docker 1.11, 1.12 and 1.13

### DIFF
--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -215,7 +215,7 @@ func TestValidateKubeAPIServer(t *testing.T) {
 func Test_Validate_DockerConfig_Storage(t *testing.T) {
 	for _, name := range []string{"aufs", "zfs", "overlay"} {
 		config := &kops.DockerConfig{Storage: &name}
-		errs := ValidateDockerConfig(config, field.NewPath("docker"))
+		errs := validateDockerConfig(config, field.NewPath("docker"))
 		if len(errs) != 0 {
 			t.Fatalf("Unexpected errors validating DockerConfig %q", errs)
 		}
@@ -223,7 +223,7 @@ func Test_Validate_DockerConfig_Storage(t *testing.T) {
 
 	for _, name := range []string{"overlayfs", "", "au"} {
 		config := &kops.DockerConfig{Storage: &name}
-		errs := ValidateDockerConfig(config, field.NewPath("docker"))
+		errs := validateDockerConfig(config, field.NewPath("docker"))
 		if len(errs) != 1 {
 			t.Fatalf("Expected errors validating DockerConfig %+v", config)
 		}


### PR DESCRIPTION
Cherry pick of #8855 on release-1.17.

#8855: Remove support for Docker 1.11, 1.12 and 1.13

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.