### PR TITLE
Automated cherry pick of #8855: Remove support for Docker 1.11, 1.12 and 1.13

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -422,7 +422,7 @@ func validateDockerConfig(config *kops.DockerConfig, fldPath *field.Path) field.
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("version"), config.Version,
 				"version is no longer available: https://www.docker.com/blog/changes-dockerproject-org-apt-yum-repositories/"))
 		} else {
-			valid := []string{"17.03.2", "17.09.0", "18.03.1", "18.06.1", "18.06.2", "18.06.3", "18.09.3", "18.09.9", "19.03.4", "19.03.8"}
+			valid := []string{"17.03.2", "17.09.0", "18.03.1", "18.06.1", "18.06.2", "18.06.3", "18.09.3", "18.09.9", "19.03.4"}
 			allErrs = append(allErrs, IsValidValue(fldPath.Child("version"), config.Version, valid)...)
 		}
 	}

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -32,14 +32,6 @@ import (
 	"k8s.io/kops/pkg/model/iam"
 )
 
-var validDockerConfigStorageValues = []string{"aufs", "btrfs", "devicemapper", "overlay", "overlay2", "zfs"}
-
-func ValidateDockerConfig(config *kops.DockerConfig, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, IsValidValue(fldPath.Child("storage"), config.Storage, validDockerConfigStorageValues)...)
-	return allErrs
-}
-
 func newValidateCluster(cluster *kops.Cluster) field.ErrorList {
 	allErrs := validation.ValidateObjectMeta(&cluster.ObjectMeta, false, validation.NameIsDNSSubdomain, field.NewPath("metadata"))
 	allErrs = append(allErrs, validateClusterSpec(&cluster.Spec, field.NewPath("spec"))...)
@@ -114,6 +106,10 @@ func validateClusterSpec(spec *kops.ClusterSpec, fieldPath *field.Path) field.Er
 		for i, etcdCluster := range spec.EtcdClusters {
 			allErrs = append(allErrs, validateEtcdClusterSpec(etcdCluster, fieldPath.Child("etcdClusters").Index(i))...)
 		}
+	}
+
+	if spec.Docker != nil {
+		allErrs = append(allErrs, validateDockerConfig(spec.Docker, fieldPath.Child("docker"))...)
 	}
 
 	return allErrs
@@ -413,6 +409,30 @@ func validateNetworkingCalico(v *kops.CalicoNetworkingSpec, e *kops.EtcdClusterS
 		allErrs = append(allErrs, ValidateEtcdVersionForCalicoV3(e, v.MajorVersion, fldPath)...)
 	default:
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("MajorVersion"), v.MajorVersion, []string{"v3"}))
+	}
+
+	return allErrs
+}
+
+func validateDockerConfig(config *kops.DockerConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if config.Version != nil {
+		if strings.HasPrefix(*config.Version, "1.1") {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("version"), config.Version,
+				"version is no longer available: https://www.docker.com/blog/changes-dockerproject-org-apt-yum-repositories/"))
+		} else {
+			valid := []string{"17.03.2", "17.09.0", "18.03.1", "18.06.1", "18.06.2", "18.06.3", "18.09.3", "18.09.9", "19.03.4", "19.03.8"}
+			allErrs = append(allErrs, IsValidValue(fldPath.Child("version"), config.Version, valid)...)
+		}
+	}
+
+	if config.Storage != nil {
+		valid := []string{"aufs", "btrfs", "devicemapper", "overlay", "overlay2", "zfs"}
+		values := strings.Split(*config.Storage, ",")
+		for _, value := range values {
+			allErrs = append(allErrs, IsValidValue(fldPath.Child("storage"), &value, valid)...)
+		}
 	}
 
 	return allErrs

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -215,7 +215,7 @@ func TestValidateKubeAPIServer(t *testing.T) {
 func Test_Validate_DockerConfig_Storage(t *testing.T) {
 	for _, name := range []string{"aufs", "zfs", "overlay"} {
 		config := &kops.DockerConfig{Storage: &name}
-		errs := ValidateDockerConfig(config, field.NewPath("docker"))
+		errs := validateDockerConfig(config, field.NewPath("docker"))
 		if len(errs) != 0 {
 			t.Fatalf("Unexpected errors validating DockerConfig %q", errs)
 		}
@@ -223,7 +223,7 @@ func Test_Validate_DockerConfig_Storage(t *testing.T) {
 
 	for _, name := range []string{"overlayfs", "", "au"} {
 		config := &kops.DockerConfig{Storage: &name}
-		errs := ValidateDockerConfig(config, field.NewPath("docker"))
+		errs := validateDockerConfig(config, field.NewPath("docker"))
 		if len(errs) != 1 {
 			t.Fatalf("Expected errors validating DockerConfig %+v", config)
 		}


### PR DESCRIPTION
Cherry pick of #8855 on release-1.16.

#8855: Remove support for Docker 1.11, 1.12 and 1.13

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.