### PR TITLE
Validate cluster N times in rolling-update

### DIFF
--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -121,8 +121,8 @@ type RollingUpdateOptions struct {
 	// ValidationTimeout is the timeout for validation to succeed after the drain and pause
 	ValidationTimeout time.Duration
 
-	// ValidateTimes is the amount of time that a cluster needs to be validated after single node update
-	ValidateTimes int32
+	// ValidateCount is the amount of time that a cluster needs to be validated after single node update
+	ValidateCount int32
 
 	// MasterInterval is the minimum time to wait after stopping a master node.  This does not include drain and validate time.
 	MasterInterval time.Duration
@@ -161,7 +161,7 @@ func (o *RollingUpdateOptions) InitDefaults() {
 
 	o.PostDrainDelay = 5 * time.Second
 	o.ValidationTimeout = 15 * time.Minute
-	o.ValidateTimes = 2
+	o.ValidateCount = 2
 }
 
 func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
@@ -181,7 +181,7 @@ func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVar(&options.CloudOnly, "cloudonly", options.CloudOnly, "Perform rolling update without confirming progress with k8s")
 
 	cmd.Flags().DurationVar(&options.ValidationTimeout, "validation-timeout", options.ValidationTimeout, "Maximum time to wait for a cluster to validate")
-	cmd.Flags().Int32Var(&options.ValidateTimes, "validate-times", options.ValidateTimes, "Amount of times that a cluster needs to be validated after single node update")
+	cmd.Flags().Int32Var(&options.ValidateCount, "validate-count", options.ValidateCount, "Amount of times that a cluster needs to be validated after single node update")
 	cmd.Flags().DurationVar(&options.MasterInterval, "master-interval", options.MasterInterval, "Time to wait between restarting masters")
 	cmd.Flags().DurationVar(&options.NodeInterval, "node-interval", options.NodeInterval, "Time to wait between restarting nodes")
 	cmd.Flags().DurationVar(&options.BastionInterval, "bastion-interval", options.BastionInterval, "Time to wait between restarting bastions")
@@ -338,7 +338,7 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 		ClusterName:       options.ClusterName,
 		PostDrainDelay:    options.PostDrainDelay,
 		ValidationTimeout: options.ValidationTimeout,
-		ValidateTimes:     options.ValidateTimes,
+		ValidateCount:     options.ValidateCount,
 		ValidateSucceeded: 0,
 		// TODO should we expose this to the UI?
 		ValidateTickDuration: 30 * time.Second,

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -80,7 +80,7 @@ kops rolling-update cluster [flags]
       --master-interval duration       Time to wait between restarting masters (default 15s)
       --node-interval duration         Time to wait between restarting nodes (default 15s)
       --post-drain-delay duration      Time to wait after draining each node (default 5s)
-      --validate-times int32           Amount of times that a cluster needs to be validated after single node update (default 2)
+      --validate-count int32           Amount of times that a cluster needs to be validated after single node update (default 2)
       --validation-timeout duration    Maximum time to wait for a cluster to validate (default 15m0s)
   -y, --yes                            Perform rolling update immediately, without --yes rolling-update executes a dry-run
 ```

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -80,6 +80,7 @@ kops rolling-update cluster [flags]
       --master-interval duration       Time to wait between restarting masters (default 15s)
       --node-interval duration         Time to wait between restarting nodes (default 15s)
       --post-drain-delay duration      Time to wait after draining each node (default 5s)
+      --validate-times int32           Amount of times that a cluster needs to be validated after single node update (default 2)
       --validation-timeout duration    Maximum time to wait for a cluster to validate (default 15m0s)
   -y, --yes                            Perform rolling update immediately, without --yes rolling-update executes a dry-run
 ```

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -430,10 +430,12 @@ func (c *RollingUpdateCluster) validateClusterWithDuration(duration time.Duratio
 func (c *RollingUpdateCluster) tryValidateCluster(duration time.Duration) bool {
 	result, err := c.ClusterValidator.Validate()
 
-	if err == nil && len(result.Failures) == 0 && c.ValidateSuccessDuration > 0 {
-		klog.Infof("Cluster validated; revalidating in %s to make sure it does not flap.", c.ValidateSuccessDuration)
-		time.Sleep(c.ValidateSuccessDuration)
-		result, err = c.ClusterValidator.Validate()
+	if err == nil && len(result.Failures) == 0 && c.ValidateTimes > 0 {
+		c.ValidateSucceeded++
+		if c.ValidateSucceeded < c.ValidateTimes {
+			klog.Infof("Cluster validated; revalidating %d time(s) to make sure it does not flap.", c.ValidateTimes-c.ValidateSucceeded)
+			return false
+		}
 	}
 
 	if err != nil {

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -430,10 +430,10 @@ func (c *RollingUpdateCluster) validateClusterWithDuration(duration time.Duratio
 func (c *RollingUpdateCluster) tryValidateCluster(duration time.Duration) bool {
 	result, err := c.ClusterValidator.Validate()
 
-	if err == nil && len(result.Failures) == 0 && c.ValidateTimes > 0 {
+	if err == nil && len(result.Failures) == 0 && c.ValidateCount > 0 {
 		c.ValidateSucceeded++
-		if c.ValidateSucceeded < c.ValidateTimes {
-			klog.Infof("Cluster validated; revalidating %d time(s) to make sure it does not flap.", c.ValidateTimes-c.ValidateSucceeded)
+		if c.ValidateSucceeded < c.ValidateCount {
+			klog.Infof("Cluster validated; revalidating %d time(s) to make sure it does not flap.", c.ValidateCount-c.ValidateSucceeded)
 			return false
 		}
 	}

--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -64,8 +64,8 @@ type RollingUpdateCluster struct {
 	// ValidateTickDuration is the amount of time to wait between cluster validation attempts
 	ValidateTickDuration time.Duration
 
-	// ValidateTimes is the amount of time that a cluster needs to be validated after single node update
-	ValidateTimes int32
+	// ValidateCount is the amount of time that a cluster needs to be validated after single node update
+	ValidateCount int32
 
 	// ValidateSucceeded is the amount of times that a cluster validate is succeeded already
 	ValidateSucceeded int32

--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -64,9 +64,11 @@ type RollingUpdateCluster struct {
 	// ValidateTickDuration is the amount of time to wait between cluster validation attempts
 	ValidateTickDuration time.Duration
 
-	// ValidateSuccessDuration is the amount of time a cluster must continue to validate successfully
-	// before updating the next node
-	ValidateSuccessDuration time.Duration
+	// ValidateTimes is the amount of time that a cluster needs to be validated after single node update
+	ValidateTimes int32
+
+	// ValidateSucceeded is the amount of times that a cluster validate is succeeded already
+	ValidateSucceeded int32
 }
 
 // AdjustNeedUpdate adjusts the set of instances that need updating, using factors outside those known by the cloud implementation

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -68,7 +68,7 @@ func getTestSetup() (*RollingUpdateCluster, *awsup.MockAWSCloud, *kopsapi.Cluste
 		ClusterValidator:     &successfulClusterValidator{},
 		FailOnValidate:       true,
 		ValidateTickDuration: 1 * time.Millisecond,
-		ValidateTimes:        1,
+		ValidateCount:        1,
 		ValidateSucceeded:    0,
 	}
 
@@ -512,7 +512,7 @@ func (v *flappingClusterValidator) Validate() (*validation.ValidationCluster, er
 
 func TestRollingUpdateFlappingValidation(t *testing.T) {
 	c, cloud, cluster := getTestSetup()
-	c.ValidateTimes = 3
+	c.ValidateCount = 3
 
 	// This should only take a few milliseconds,
 	// but we have to pad to allow for random delays (e.g. GC)


### PR DESCRIPTION
We are still seeing lots of rolling update errors in case of cluster validation after instance roll. 

Example:
```
I0407 16:41:39.366581 85 instancegroups.go:255] Cluster validated; revalidating in 10s to make sure it does not flap.
I0407 16:42:00.200357 85 instancegroups.go:271] Cluster validated.
master not healthy after update, stopping rolling-update: "cluster \"updateospr-f95a75.k8s.local\" did not pass validation: kube-system pod \"kube-apiserver-master-zone-1-1-1-updateospr-f95a75-k8s-local\" is pending"
I0407 16:42:17.290824 1 batch.go:902] error running kops rolling-update cluster --bastion-interval 2m --instance-group bastions,master-zone-1-1,master-zone-2-1,master-zone-3-1,nodes-z1,nodes-z2,nodes-z3 --validation-timeout 20m --yes
```

Disclaimer: we are running e2e tests quite heavily against kops. We are doing something like 20-50 rolling updates per day for clusters.

cc @hakman @johngmyers could you guys check this.