### PR TITLE
OpenStack: possibility to detach instances from the load

### DIFF
--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -152,6 +152,8 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 			Metadata:         igMeta,
 			SecurityGroups:   ig.Spec.AdditionalSecurityGroups,
 			AvailabilityZone: az,
+			ClusterName:      s(b.ClusterName()),
+			GroupName:        s(ig.Name),
 		}
 		if igUserData != nil {
 			instanceTask.UserData = igUserData

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -64,9 +64,13 @@ const (
 	TagClusterName           = "KubernetesCluster"
 	TagRoleMaster            = "master"
 	TagKopsNetwork           = "KopsNetwork"
+	TagNameDetach            = "KopsDetach"
+	TagKopsName              = "KopsName"
 	ResourceTypePort         = "ports"
 	ResourceTypeNetwork      = "networks"
 	ResourceTypeSubnet       = "subnets"
+	FloatingType             = "floating"
+	FixedType                = "fixed"
 )
 
 // ErrNotFound is used to inform that the object is not found
@@ -292,7 +296,7 @@ type OpenstackCloud interface {
 
 	AssociateFloatingIPToInstance(serverID string, opts floatingips.AssociateOpts) (err error)
 
-	ListServerFloatingIPs(id string) ([]*string, error)
+	ListServerIPs(id string, IPType string) ([]*string, error)
 
 	ListFloatingIPs() (fips []floatingips.FloatingIP, err error)
 	ListL3FloatingIPs(opts l3floatingip.ListOpts) (fips []l3floatingip.FloatingIP, err error)
@@ -661,7 +665,7 @@ func (c *openstackCloud) GetApiIngressStatus(cluster *kops.Cluster) ([]kops.ApiI
 			if ok && val == cluster.Name && ok2 {
 				role, success := kops.ParseInstanceGroupRole(val2, false)
 				if success && role == kops.InstanceGroupRoleMaster {
-					ips, err := c.ListServerFloatingIPs(instance.ID)
+					ips, err := c.ListServerIPs(instance.ID, FloatingType)
 					if err != nil {
 						return ingresses, err
 					}

--- a/upup/pkg/fi/cloudup/openstack/instance.go
+++ b/upup/pkg/fi/cloudup/openstack/instance.go
@@ -65,7 +65,7 @@ func (c *openstackCloud) CreateInstance(opt servers.CreateOptsBuilder) (*servers
 	}
 }
 
-func (c *openstackCloud) ListServerFloatingIPs(instanceID string) ([]*string, error) {
+func (c *openstackCloud) ListServerIPs(instanceID string, IPType string) ([]*string, error) {
 	var result []*string
 	_, err := vfs.RetryWithBackoff(floatingBackoff, func() (bool, error) {
 		server, err := c.GetInstance(instanceID)
@@ -82,7 +82,7 @@ func (c *openstackCloud) ListServerFloatingIPs(instanceID string) ([]*string, er
 		for _, addrList := range addresses {
 			for _, props := range addrList {
 				if c.floatingEnabled {
-					if props.IPType == "floating" {
+					if props.IPType == IPType {
 						result = append(result, fi.String(props.Addr))
 					}
 				} else {
@@ -96,7 +96,7 @@ func (c *openstackCloud) ListServerFloatingIPs(instanceID string) ([]*string, er
 		return false, nil
 	})
 	if len(result) == 0 || err != nil {
-		return result, fmt.Errorf("could not find floating ip associated to server (\"%s\") %v", instanceID, err)
+		return result, fmt.Errorf("could not find %s ip associated to server (\"%s\") %v", IPType, instanceID, err)
 	}
 	return result, nil
 }
@@ -112,6 +112,7 @@ func (c *openstackCloud) DeleteInstanceWithID(instanceID string) error {
 
 // DetachInstance is not implemented yet. It needs to cause a cloud instance to no longer be counted against the group's size limits.
 func (c *openstackCloud) DetachInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	// TODO: tag port and instance with detach tag
 	klog.V(8).Info("openstack cloud provider DetachInstance not implemented yet")
 	return fmt.Errorf("openstack cloud provider does not support surging")
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
@@ -71,7 +71,7 @@ func findL3Floating(cloud openstack.OpenstackCloud, opts l3floatingip.ListOpts) 
 }
 
 func (e *FloatingIP) findServerFloatingIP(context *fi.Context, cloud openstack.OpenstackCloud) (*string, error) {
-	ips, err := cloud.ListServerFloatingIPs(fi.StringValue(e.Server.ID))
+	ips, err := cloud.ListServerIPs(fi.StringValue(e.Server.ID), openstack.FloatingType)
 	if err != nil {
 		return nil, err
 	}

--- a/upup/pkg/fi/cloudup/openstacktasks/instance.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance.go
@@ -109,7 +109,7 @@ func (e *Instance) Find(c *fi.Context) (*Instance, error) {
 		return nil, fmt.Errorf("error extracting server page: %v", err)
 	}
 
-	filteredList := []servers.Server{}
+	var filteredList []servers.Server
 	for _, server := range serverList {
 		val, ok := server.Metadata["k8s"]
 		if !ok || val != fi.StringValue(e.ServerGroup.ClusterName) {
@@ -129,7 +129,8 @@ func (e *Instance) Find(c *fi.Context) (*Instance, error) {
 			}
 		}
 	}
-	if len(filteredList) == 0 {
+	serverList = nil
+	if filteredList == nil {
 		return nil, nil
 	}
 	if len(filteredList) > 1 {

--- a/upup/pkg/fi/cloudup/openstacktasks/instance.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance.go
@@ -188,7 +188,7 @@ func makeServerName(e *Instance) (string, error) {
 		return "", err
 	}
 
-	return strings.ToLower(fmt.Sprintf("%s-%s", fi.StringValue(e.NamePrefix), hash[0:5])), nil
+	return strings.ToLower(fmt.Sprintf("%s-%s", fi.StringValue(e.NamePrefix), hash[0:6])), nil
 }
 
 func (_ *Instance) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *Instance) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/port.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port.go
@@ -126,14 +126,14 @@ func (s *Port) Find(context *fi.Context) (*Port, error) {
 	if err != nil {
 		return nil, err
 	}
-	filteredList := []ports.Port{}
+	var filteredList []ports.Port
 	for _, port := range rs {
 		if fi.ArrayContains(port.Tags, openstack.TagNameDetach) {
 			continue
 		}
 		filteredList = append(filteredList, port)
 	}
-	if len(filteredList) == 0 {
+	if filteredList == nil {
 		return nil, nil
 	} else if len(filteredList) != 1 {
 		return nil, fmt.Errorf("found multiple ports with name: %s", fi.StringValue(s.Name))

--- a/upup/pkg/fi/cloudup/openstacktasks/port.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port.go
@@ -126,12 +126,19 @@ func (s *Port) Find(context *fi.Context) (*Port, error) {
 	if err != nil {
 		return nil, err
 	}
-	if rs == nil {
+	filteredList := []ports.Port{}
+	for _, port := range rs {
+		if fi.ArrayContains(port.Tags, openstack.TagNameDetach) {
+			continue
+		}
+		filteredList = append(filteredList, port)
+	}
+	if len(filteredList) == 0 {
 		return nil, nil
-	} else if len(rs) != 1 {
+	} else if len(filteredList) != 1 {
 		return nil, fmt.Errorf("found multiple ports with name: %s", fi.StringValue(s.Name))
 	}
-	return NewPortTaskFromCloud(cloud, s.Lifecycle, &rs[0], s)
+	return NewPortTaskFromCloud(cloud, s.Lifecycle, &filteredList[0], s)
 }
 
 func (s *Port) Run(context *fi.Context) error {

--- a/upup/pkg/fi/utils/hash.go
+++ b/upup/pkg/fi/utils/hash.go
@@ -19,8 +19,6 @@ package utils
 import (
 	"crypto/sha1"
 	"encoding/hex"
-	"math/rand"
-	"time"
 )
 
 // HashString Takes String and returns a sha1 hash represented as a string
@@ -33,32 +31,4 @@ func HashString(s string) (string, error) {
 	sha := h.Sum(nil)                 // "sha" is uint8 type, encoded in base16
 	shaStr := hex.EncodeToString(sha) // String representation
 	return shaStr, nil
-}
-
-const (
-	letterBytes   = "abcdefghijklmnopqrstuvwxyz0123456789"
-	letterIdxBits = 6                    // 6 bits to represent a letter index
-	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
-	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
-)
-
-// RandomString generates a random string of n length
-// source https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-go
-func RandomString(n int) string {
-	src := rand.NewSource(time.Now().UnixNano())
-	b := make([]byte, n)
-	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
-	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
-		if remain == 0 {
-			cache, remain = src.Int63(), letterIdxMax
-		}
-		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
-			b[i] = letterBytes[idx]
-			i--
-		}
-		cache >>= letterIdxBits
-		remain--
-	}
-
-	return string(b)
 }

--- a/upup/pkg/fi/utils/hash.go
+++ b/upup/pkg/fi/utils/hash.go
@@ -19,6 +19,8 @@ package utils
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"math/rand"
+	"time"
 )
 
 // HashString Takes String and returns a sha1 hash represented as a string
@@ -31,4 +33,32 @@ func HashString(s string) (string, error) {
 	sha := h.Sum(nil)                 // "sha" is uint8 type, encoded in base16
 	shaStr := hex.EncodeToString(sha) // String representation
 	return shaStr, nil
+}
+
+const (
+	letterBytes   = "abcdefghijklmnopqrstuvwxyz0123456789"
+	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+)
+
+// RandomString generates a random string of n length
+// source https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-go
+func RandomString(n int) string {
+	src := rand.NewSource(time.Now().UnixNano())
+	b := make([]byte, n)
+	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = src.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return string(b)
 }


### PR DESCRIPTION
what is changed:

1) implement detach things for instance and port.
2) it will modify instance names to be more "cattle" stylish. (it is needed if we want detach instances)

```
% kubectl get nodes
NAME                                  STATUS   ROLES    AGE     VERSION
master-zone-1-1-1-newname-k8s-local   Ready    master   2m31s   v1.17.3
master-zone-1-2-1-newname-k8s-local   Ready    master   2m25s   v1.17.3
master-zone-1-3-1-newname-k8s-local   Ready    master   2m31s   v1.17.3
nodes-1-newname-k8s-local             Ready    node     2m11s   v1.17.3
nodes-2-newname-k8s-local             Ready    node     2m8s    v1.17.3
nodes-3-newname-k8s-local             Ready    node     2m11s   v1.17.3


% kubectl get nodes
NAME                    STATUS   ROLES    AGE   VERSION
master-zone-1-1-fcnlz6  Ready    master   63m   v1.17.4
master-zone-1-2-lynpa3  Ready    master   71m   v1.17.4
master-zone-1-3-ef5w1s  Ready    master   55m   v1.17.4
nodes-3hfjy4            Ready    node     36m   v1.17.4
nodes-7fjtht            Ready    node     43m   v1.17.4
```

