### PR TITLE
Fix Terraform 0.12 support for GCE

### DIFF
--- a/hack/verify-terraform.sh
+++ b/hack/verify-terraform.sh
@@ -41,9 +41,7 @@ done 3< <(find "${KOPS_ROOT}/tests/integration/update_cluster" -type d -maxdepth
 
 if [ $RC != 0 ]; then
   echo -e "\nTerraform validation failed\n"
-  # TODO(rifelpet): make this script blocking in PRs by exiting non-zero on failure
-  # exit $RC
-  exit 0
+  exit $RC
 else
   echo -e "\nTerraform validation succeeded\n"
 fi

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -332,19 +332,163 @@ resource "google_compute_instance_group_manager" "c-nodes-ha-gce-example-com" {
 }
 
 resource "google_compute_instance_template" "master-us-test1-a-ha-gce-example-com" {
+  can_ip_forward = true
+  disk {
+    auto_delete  = true
+    boot         = true
+    device_name  = "persistent-disks-0"
+    disk_name    = ""
+    disk_size_gb = 64
+    disk_type    = "pd-standard"
+    interface    = ""
+    mode         = "READ_WRITE"
+    source       = ""
+    source_image = "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-57-9202-64-0"
+    type         = "PERSISTENT"
+  }
+  machine_type = "n1-standard-1"
+  metadata = {
+    "cluster-name"                    = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_cluster-name")
+    "kops-k8s-io-instance-group-name" = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_kops-k8s-io-instance-group-name")
+    "ssh-keys"                        = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_ssh-keys")
+    "startup-script"                  = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_startup-script")
+  }
   name_prefix = "master-us-test1-a-ha-gce--ke5ah6-"
+  network_interface {
+    access_config {
+    }
+    network = google_compute_network.default.name
+  }
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    preemptible         = false
+  }
+  service_account {
+    email  = "default"
+    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
+  }
+  tags = ["ha-gce-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_instance_template" "master-us-test1-b-ha-gce-example-com" {
+  can_ip_forward = true
+  disk {
+    auto_delete  = true
+    boot         = true
+    device_name  = "persistent-disks-0"
+    disk_name    = ""
+    disk_size_gb = 64
+    disk_type    = "pd-standard"
+    interface    = ""
+    mode         = "READ_WRITE"
+    source       = ""
+    source_image = "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-57-9202-64-0"
+    type         = "PERSISTENT"
+  }
+  machine_type = "n1-standard-1"
+  metadata = {
+    "cluster-name"                    = file("${path.module}/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_cluster-name")
+    "kops-k8s-io-instance-group-name" = file("${path.module}/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_kops-k8s-io-instance-group-name")
+    "ssh-keys"                        = file("${path.module}/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_ssh-keys")
+    "startup-script"                  = file("${path.module}/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_startup-script")
+  }
   name_prefix = "master-us-test1-b-ha-gce--c8u7qq-"
+  network_interface {
+    access_config {
+    }
+    network = google_compute_network.default.name
+  }
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    preemptible         = false
+  }
+  service_account {
+    email  = "default"
+    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
+  }
+  tags = ["ha-gce-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_instance_template" "master-us-test1-c-ha-gce-example-com" {
+  can_ip_forward = true
+  disk {
+    auto_delete  = true
+    boot         = true
+    device_name  = "persistent-disks-0"
+    disk_name    = ""
+    disk_size_gb = 64
+    disk_type    = "pd-standard"
+    interface    = ""
+    mode         = "READ_WRITE"
+    source       = ""
+    source_image = "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-57-9202-64-0"
+    type         = "PERSISTENT"
+  }
+  machine_type = "n1-standard-1"
+  metadata = {
+    "cluster-name"                    = file("${path.module}/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_cluster-name")
+    "kops-k8s-io-instance-group-name" = file("${path.module}/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_kops-k8s-io-instance-group-name")
+    "ssh-keys"                        = file("${path.module}/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_ssh-keys")
+    "startup-script"                  = file("${path.module}/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_startup-script")
+  }
   name_prefix = "master-us-test1-c-ha-gce--3unp7l-"
+  network_interface {
+    access_config {
+    }
+    network = google_compute_network.default.name
+  }
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    preemptible         = false
+  }
+  service_account {
+    email  = "default"
+    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
+  }
+  tags = ["ha-gce-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_instance_template" "nodes-ha-gce-example-com" {
+  can_ip_forward = true
+  disk {
+    auto_delete  = true
+    boot         = true
+    device_name  = "persistent-disks-0"
+    disk_name    = ""
+    disk_size_gb = 128
+    disk_type    = "pd-standard"
+    interface    = ""
+    mode         = "READ_WRITE"
+    source       = ""
+    source_image = "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-57-9202-64-0"
+    type         = "PERSISTENT"
+  }
+  machine_type = "n1-standard-2"
+  metadata = {
+    "cluster-name"                    = file("${path.module}/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_cluster-name")
+    "kops-k8s-io-instance-group-name" = file("${path.module}/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_kops-k8s-io-instance-group-name")
+    "ssh-keys"                        = file("${path.module}/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_ssh-keys")
+    "startup-script"                  = file("${path.module}/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_startup-script")
+  }
   name_prefix = "nodes-ha-gce-example-com-"
+  network_interface {
+    access_config {
+    }
+    network = google_compute_network.default.name
+  }
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    preemptible         = false
+  }
+  service_account {
+    email  = "default"
+    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_only"]
+  }
+  tags = ["ha-gce-example-com-k8s-io-role-node"]
 }
 
 resource "google_compute_network" "default" {

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -244,11 +244,83 @@ resource "google_compute_instance_group_manager" "a-nodes-minimal-gce-example-co
 }
 
 resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-example-com" {
+  can_ip_forward = true
+  disk {
+    auto_delete  = true
+    boot         = true
+    device_name  = "persistent-disks-0"
+    disk_name    = ""
+    disk_size_gb = 64
+    disk_type    = "pd-standard"
+    interface    = ""
+    mode         = "READ_WRITE"
+    source       = ""
+    source_image = "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-57-9202-64-0"
+    type         = "PERSISTENT"
+  }
+  machine_type = "n1-standard-1"
+  metadata = {
+    "cluster-name"                    = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_cluster-name")
+    "kops-k8s-io-instance-group-name" = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_kops-k8s-io-instance-group-name")
+    "ssh-keys"                        = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_ssh-keys")
+    "startup-script"                  = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script")
+  }
   name_prefix = "master-us-test1-a-minimal-do16cp-"
+  network_interface {
+    access_config {
+    }
+    network = google_compute_network.default.name
+  }
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    preemptible         = false
+  }
+  service_account {
+    email  = "default"
+    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
+  }
+  tags = ["minimal-gce-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_instance_template" "nodes-minimal-gce-example-com" {
+  can_ip_forward = true
+  disk {
+    auto_delete  = true
+    boot         = true
+    device_name  = "persistent-disks-0"
+    disk_name    = ""
+    disk_size_gb = 128
+    disk_type    = "pd-standard"
+    interface    = ""
+    mode         = "READ_WRITE"
+    source       = ""
+    source_image = "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-57-9202-64-0"
+    type         = "PERSISTENT"
+  }
+  machine_type = "n1-standard-2"
+  metadata = {
+    "cluster-name"                    = file("${path.module}/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_cluster-name")
+    "kops-k8s-io-instance-group-name" = file("${path.module}/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_kops-k8s-io-instance-group-name")
+    "ssh-keys"                        = file("${path.module}/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_ssh-keys")
+    "startup-script"                  = file("${path.module}/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script")
+  }
   name_prefix = "nodes-minimal-gce-example-com-"
+  network_interface {
+    access_config {
+    }
+    network = google_compute_network.default.name
+  }
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    preemptible         = false
+  }
+  service_account {
+    email  = "default"
+    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_only"]
+  }
+  tags = ["minimal-gce-example-com-k8s-io-role-node"]
 }
 
 resource "google_compute_network" "default" {

--- a/upup/pkg/fi/cloudup/gcetasks/instance.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instance.go
@@ -394,28 +394,25 @@ func ShortenImageURL(defaultProject string, imageURL string) (string, error) {
 }
 
 type terraformInstance struct {
-	Name                  string                        `json:"name" cty:"name"`
-	CanIPForward          bool                          `json:"can_ip_forward" cty:"can_ip_forward"`
-	MachineType           string                        `json:"machine_type,omitempty" cty:"machine_type"`
-	ServiceAccount        *terraformServiceAccount      `json:"service_account,omitempty" cty:"service_account"`
-	Scheduling            *terraformScheduling          `json:"scheduling,omitempty" cty:"scheduling"`
-	Disks                 []*terraformInstanceAttachedDisk      `json:"disk,omitempty" cty:"disk"`
-	NetworkInterfaces     []*terraformNetworkInterface  `json:"network_interface,omitempty" cty:"network_interface"`
-	Metadata              map[string]*terraform.Literal `json:"metadata,omitempty" cty:"metadata"`
-	MetadataStartupScript *terraform.Literal            `json:"metadata_startup_script,omitempty" cty:"metadata_startup_script"`
-	Tags                  []string                      `json:"tags,omitempty" cty:"tags"`
-	Zone                  string                        `json:"zone,omitempty" cty:"zone"`
+	Name                  string                           `json:"name" cty:"name"`
+	CanIPForward          bool                             `json:"can_ip_forward" cty:"can_ip_forward"`
+	MachineType           string                           `json:"machine_type,omitempty" cty:"machine_type"`
+	ServiceAccount        *terraformServiceAccount         `json:"service_account,omitempty" cty:"service_account"`
+	Scheduling            *terraformScheduling             `json:"scheduling,omitempty" cty:"scheduling"`
+	Disks                 []*terraformInstanceAttachedDisk `json:"disk,omitempty" cty:"disk"`
+	NetworkInterfaces     []*terraformNetworkInterface     `json:"network_interface,omitempty" cty:"network_interface"`
+	Metadata              map[string]*terraform.Literal    `json:"metadata,omitempty" cty:"metadata"`
+	MetadataStartupScript *terraform.Literal               `json:"metadata_startup_script,omitempty" cty:"metadata_startup_script"`
+	Tags                  []string                         `json:"tags,omitempty" cty:"tags"`
+	Zone                  string                           `json:"zone,omitempty" cty:"zone"`
 }
-
 
 type terraformInstanceAttachedDisk struct {
 	AutoDelete bool   `json:"auto_delete,omitempty" cty:"auto_delete"`
 	DeviceName string `json:"device_name,omitempty" cty:"device_name"`
 
-	// DANGER - common but different meaning:
-	//   for an instance template this is scratch vs persistent
-	//   for an instance this is 'pd-standard', 'pd-ssd', 'local-ssd' etc
-	Type string `json:"type,omitempty" cty:"type"`
+	// 'pd-standard', 'pd-ssd', 'local-ssd' etc
+	Type    string `json:"type,omitempty" cty:"type"`
 	Disk    string `json:"disk,omitempty" cty:"disk"`
 	Image   string `json:"image,omitempty" cty:"image"`
 	Scratch bool   `json:"scratch,omitempty" cty:"scratch"`

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -417,16 +417,16 @@ func (_ *InstanceTemplate) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Instanc
 }
 
 type terraformInstanceTemplate struct {
-	NamePrefix            string                        `json:"name_prefix" cty:"name_prefix"`
-	CanIPForward          bool                          `json:"can_ip_forward" cty:"can_ip_forward"`
-	MachineType           string                        `json:"machine_type,omitempty" cty:"machine_type"`
-	ServiceAccount        *terraformServiceAccount      `json:"service_account,omitempty" cty:"service_account"`
-	Scheduling            *terraformScheduling          `json:"scheduling,omitempty" cty:"scheduling"`
-	Disks                 []*terraformInstanceTemplateAttachedDisk      `json:"disk,omitempty" cty:"disk"`
-	NetworkInterfaces     []*terraformNetworkInterface  `json:"network_interface,omitempty" cty:"network_interface"`
-	Metadata              map[string]*terraform.Literal `json:"metadata,omitempty" cty:"metadata"`
-	MetadataStartupScript *terraform.Literal            `json:"metadata_startup_script,omitempty" cty:"metadata_startup_script"`
-	Tags                  []string                      `json:"tags,omitempty" cty:"tags"`
+	NamePrefix            string                                   `json:"name_prefix" cty:"name_prefix"`
+	CanIPForward          bool                                     `json:"can_ip_forward" cty:"can_ip_forward"`
+	MachineType           string                                   `json:"machine_type,omitempty" cty:"machine_type"`
+	ServiceAccount        *terraformServiceAccount                 `json:"service_account,omitempty" cty:"service_account"`
+	Scheduling            *terraformScheduling                     `json:"scheduling,omitempty" cty:"scheduling"`
+	Disks                 []*terraformInstanceTemplateAttachedDisk `json:"disk,omitempty" cty:"disk"`
+	NetworkInterfaces     []*terraformNetworkInterface             `json:"network_interface,omitempty" cty:"network_interface"`
+	Metadata              map[string]*terraform.Literal            `json:"metadata,omitempty" cty:"metadata"`
+	MetadataStartupScript *terraform.Literal                       `json:"metadata_startup_script,omitempty" cty:"metadata_startup_script"`
+	Tags                  []string                                 `json:"tags,omitempty" cty:"tags"`
 }
 
 type terraformServiceAccount struct {
@@ -444,12 +444,8 @@ type terraformInstanceTemplateAttachedDisk struct {
 	AutoDelete bool   `json:"auto_delete,omitempty" cty:"auto_delete"`
 	DeviceName string `json:"device_name,omitempty" cty:"device_name"`
 
-	// DANGER - common but different meaning:
-	//   for an instance template this is scratch vs persistent
-	//   for an instance this is 'pd-standard', 'pd-ssd', 'local-ssd' etc
-	Type string `json:"type,omitempty" cty:"type"`
-
-	// These values are only for instance templates:
+	// scratch vs persistent
+	Type        string `json:"type,omitempty" cty:"type"`
 	Boot        bool   `json:"boot,omitempty" cty:"boot"`
 	DiskName    string `json:"disk_name,omitempty" cty:"disk_name"`
 	SourceImage string `json:"source_image,omitempty" cty:"source_image"`

--- a/upup/pkg/fi/cloudup/terraform/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/terraform/BUILD.bazel
@@ -40,5 +40,6 @@ go_test(
         "//pkg/diff:go_default_library",
         "//vendor/github.com/hashicorp/hcl/v2/hclwrite:go_default_library",
         "//vendor/github.com/zclconf/go-cty/cty:go_default_library",
+        "//vendor/github.com/zclconf/go-cty/cty/gocty:go_default_library",
     ],
 )


### PR DESCRIPTION
The HCL2 library used for Terraform 0.12 support does not handle embedded types easily. The `google_compute_instance` and `google_compute_instance_template` terraform types used embedded types for common fields. Rather than detecting embedded types with reflection I figured it was easier to just copy the shared fields directly into the two types which included creating distinct AttachedDisk types as well. This also updates the `Add*` receiver functions for the defunct InstanceCommon type to instead return the value for the field that was being modified for both `google_compute_instance` and `google_compute_instance_template`.

This also adds support for writing maps of strings to `file()` references which is used in GCE's metadata fields.

Lastly, this updates the verify-terraform script to exit non-zero on failure now that it is successfully passing for all integration test clusters.

There is a larger question of whether the `google_compute_instance` resource type is actually used. It seems synonymous with having AWS resources for both LaunchConfigurations (for use by an ASG) and individual EC2 instances, which doesn't make much sense. I'm not a GCE user but perhaps @geojaz can chime in? If we don't need to generate `google_compute_instance` resources (which the integration test outputs currently do not) then we could delete `instance.go` altogether. Thoughts?