### PR TITLE
Use kubescheduler.config.k8s.io/v1alpha2 for Kubernetes 1.18+

### DIFF
--- a/nodeup/pkg/model/kube_scheduler_test.go
+++ b/nodeup/pkg/model/kube_scheduler_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestParseDefault(t *testing.T) {
 	expect := []byte(
-		`apiVersion: kubescheduler.config.k8s.io/v1alpha1
+		`apiVersion: kubescheduler.config.k8s.io/v1alpha2
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: /var/lib/kube-scheduler/kubeconfig
@@ -35,7 +35,7 @@ clientConnection:
 
 	s := &kops.KubeSchedulerConfig{}
 
-	yaml, err := configbuilder.BuildConfigYaml(s, NewSchedulerConfig())
+	yaml, err := configbuilder.BuildConfigYaml(s, NewSchedulerConfig("kubescheduler.config.k8s.io/v1alpha2"))
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
@@ -47,7 +47,7 @@ clientConnection:
 
 func TestParse(t *testing.T) {
 	expect := []byte(
-		`apiVersion: kubescheduler.config.k8s.io/v1alpha1
+		`apiVersion: kubescheduler.config.k8s.io/v1alpha2
 kind: KubeSchedulerConfiguration
 clientConnection:
   burst: 100
@@ -58,7 +58,7 @@ clientConnection:
 
 	s := &kops.KubeSchedulerConfig{Qps: &qps, Burst: 100}
 
-	yaml, err := configbuilder.BuildConfigYaml(s, NewSchedulerConfig())
+	yaml, err := configbuilder.BuildConfigYaml(s, NewSchedulerConfig("kubescheduler.config.k8s.io/v1alpha2"))
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}


### PR DESCRIPTION
kubescheduler.config.k8s.io/v1alpha2 was removed in 1.19 by https://github.com/kubernetes/kubernetes/pull/89298.
kubescheduler.config.k8s.io/v1alpha2 was added in 1.18 by https://github.com/kubernetes/kubernetes/pull/87628.

Fixes #8871