### PR TITLE
Fix tests for obsolete Docker versions in 1.17

### DIFF
--- a/pkg/model/components/docker.go
+++ b/pkg/model/components/docker.go
@@ -59,16 +59,8 @@ func (b *DockerOptionsBuilder) BuildOptions(o interface{}) error {
 			dockerVersion = "18.09.9"
 		} else if sv.Major == 1 && sv.Minor >= 12 {
 			dockerVersion = "18.06.3"
-		} else if sv.Major == 1 && sv.Minor >= 9 {
+		} else {
 			dockerVersion = "17.03.2"
-		} else if sv.Major == 1 && sv.Minor >= 8 {
-			dockerVersion = "1.13.1"
-		} else if sv.Major == 1 && sv.Minor >= 6 {
-			dockerVersion = "1.12.6"
-		} else if sv.Major == 1 && sv.Minor >= 5 {
-			dockerVersion = "1.12.3"
-		} else if sv.Major == 1 && sv.Minor <= 4 {
-			dockerVersion = "1.11.2"
 		}
 
 		if dockerVersion == "" {

--- a/upup/pkg/fi/cloudup/populatecluster_test.go
+++ b/upup/pkg/fi/cloudup/populatecluster_test.go
@@ -469,11 +469,11 @@ func TestPopulateCluster_DockerVersion(t *testing.T) {
 	}{
 		{
 			KubernetesVersion: "1.4.6",
-			DockerVersion:     "1.11.2",
+			DockerVersion:     "17.03.2",
 		},
 		{
 			KubernetesVersion: "1.5.1",
-			DockerVersion:     "1.12.3",
+			DockerVersion:     "17.03.2",
 		},
 	}
 


### PR DESCRIPTION
#8860 broke one of the tests. This should fix it.