### PR TITLE
Update 1.18 release notes now that Terraform 0.12 is supported

### DIFF
--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -10,6 +10,8 @@
 
 * Cilium CNI can now use AWS networking natively through the AWS ENI IPAM mode. Kops can also run a Kubernetes cluster entirely without kube-proxy using Cilium's BPF NodePort implementation
 
+* The Terraform target now supports Terraform 0.12 syntax (HCL2) by default. See the Required Actions item below.
+
 * New clusters in GCE are configured to run the [metadata-proxy](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/metadata-proxy) by default. The proxy runs as a DaemonSet and lands on nodes with the nodeLabel `cloud.google.com/metadata-proxy-ready: "true"`. If you want to enable metadata-proxy on an existing cluster/instance group, add that nodeLabel to your instancegroup specs (`kops edit ig ...`) and run `kops update cluster`. When the changes are applied, the proxy will roll out to those targeted nodes.
 
 * GCE has a new flag: `--gce-service-account`. This takes the email of an existing GCP service account and launches the instances with it. This setting applies to the whole cluster (ie: it is not currently designed to support Instance Groups with different service accounts). If you do not specify a service account during cluster creation, the default compute service account will be used which matches the prior behavior.
@@ -38,14 +40,15 @@
 
 # Required Actions
 
-* Terraform users on AWS may need to rename resources in their terraform state file in order to prepare for future Terraform 0.12 support.
+* Terraform users on AWS may need to rename resources in their terraform state file in order to support Terraform 0.12.
   Terraform 0.12 [no longer supports resource names starting with digits](https://www.terraform.io/upgrade-guides/0-12.html#pre-upgrade-checklist). In Kops, both the default route and additional VPC CIDR associations are affected. See [#7957](https://github.com/kubernetes/kops/pull/7957) for more information.
   * The default route was named `aws_route.0-0-0-0--0` and will now be named `aws_route.route-0-0-0-0--0`.
   * Additional CIDR blocks associated with a VPC were similarly named the hyphenated CIDR block with two hyphens for the `/`, for example `aws_vpc_ipv4_cidr_block_association.10-1-0-0--16`. These will now be prefixed with `cidr-`, for example `aws_vpc_ipv4_cidr_block_association.cidr-10-1-0-0--16`.
 
   To prevent downtime, follow these steps with the new version of Kops:
   ```
-  kops update cluster --target terraform ...
+  KOPS_FEATURE_FLAG=-Terraform-0.12 kops update cluster --target terraform ...
+  # Use Terraform <0.12
   terraform plan
   # Observe any aws_route or aws_vpc_ipv4_cidr_block_association resources being destroyed and recreated
   # Run these commands as necessary. The exact names may differ; use what is outputted by terraform plan
@@ -54,6 +57,12 @@
   terraform plan
   # Ensure these resources are no longer being destroyed and recreated
   terraform apply
+  ```
+  Kops will now output Terraform 0.12 syntax with the normal workflow:
+  ```
+  kops update cluster --target terraform ...
+  # Use Terraform 0.12. This plan should be a no-op
+  terraform plan
   ```
 
 * Users that need the Docker `health-check` service will need to explicitly enable it:


### PR DESCRIPTION
With #8825 and #8878 merged and targeting Kops 1.18, this updates the release notes with updated migration instructions.