### PR TITLE
Add Docker version and new distros to release notes

### DIFF
--- a/docs/releases/1.17-NOTES.md
+++ b/docs/releases/1.17-NOTES.md
@@ -5,7 +5,9 @@ the notes prior to the release).
 
 # Significant changes
 
-* The default instance type for AWS is now t3.medium. This should provide better performance and reduced costs in clusters where the average CPU usage is low.
+* The default Docker version was changed to 19.03.4. Optional support for Docker 19.03.8 was added and will be the default in future versions. Enable by setting `spec.docker.version: 19.03.8`.
+
+* The default instance type for AWS was changed to t3.medium. This should provide better performance and reduced costs in clusters where the average CPU usage is low.
 
 # Breaking changes
 

--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -4,9 +4,15 @@
 
 # Significant changes
 
-* Rolling updates now support surging and parallelism within an instance group. For details see [the documentation](../operations/rolling-update.md).
+* The default Docker version was changed to 19.03.8.
 
-* [containerd](https://github.com/containerd/containerd/blob/master/README.md) can now be selected as an alternate container runtime for Kubernetes. Use the `--container-runtime containerd` flag to create such a cluster.
+* Support for Ubuntu 20.04 and RHEL/CentOS 8 was added.
+
+* Support for Amazon Linux 2 was improved and will work with the default Docker version. 
+
+* [containerd](https://github.com/containerd/containerd/blob/master/README.md) was added and can be selected as an alternate container runtime for Kubernetes. Enable by using the `--container-runtime containerd` flag when creating a cluster or by setting `spec.containerRuntime: containerd`.
+
+* Rolling updates now support surging and parallelism within an instance group. For details see [the documentation](../operations/rolling-update.md).
 
 * Cilium CNI can now use AWS networking natively through the AWS ENI IPAM mode. Kops can also run a Kubernetes cluster entirely without kube-proxy using Cilium's BPF NodePort implementation
 


### PR DESCRIPTION
Release notes for 1.18 and 1.17 should have info about:
* default Docker version
* new distros supported by Kops