### PR TITLE
Initial validation durring rolling update does single try.

### DIFF
--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -91,7 +91,7 @@ func (c *RollingUpdateCluster) rollingUpdateInstanceGroup(ctx context.Context, c
 	} else if c.CloudOnly {
 		klog.V(3).Info("Not validating cluster as validation is turned off via the cloud-only flag.")
 	} else {
-		if err = c.validateClusterWithDuration(c.validationTimeout); err != nil {
+		if err = c.validateClusterWithDuration(c.ValidationTimeout); err != nil {
 			if c.FailOnValidate {
 				return err
 			}

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -91,7 +91,7 @@ func (c *RollingUpdateCluster) rollingUpdateInstanceGroup(ctx context.Context, c
 	} else if c.CloudOnly {
 		klog.V(3).Info("Not validating cluster as validation is turned off via the cloud-only flag.")
 	} else {
-		if err = c.validateClusterWithDuration(validationTimeout); err != nil {
+		if err = c.validateClusterWithDuration(c.validationTimeout); err != nil {
 			if c.FailOnValidate {
 				return err
 			}

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -465,23 +465,6 @@ func (c *RollingUpdateCluster) tryValidateCluster(ctx context.Context) bool {
 	}
 }
 
-// validateCluster runs our validation methods on the K8s Cluster.
-func (c *RollingUpdateCluster) validateCluster() error {
-	result, err := c.ClusterValidator.Validate()
-	if err != nil {
-		return fmt.Errorf("cluster %q did not validate: %v", c.ClusterName, err)
-	}
-	if len(result.Failures) > 0 {
-		messages := []string{}
-		for _, failure := range result.Failures {
-			messages = append(messages, failure.Message)
-		}
-		return fmt.Errorf("cluster %q did not pass validation: %s", c.ClusterName, strings.Join(messages, ", "))
-	}
-
-	return nil
-}
-
 // detachInstance detaches a Cloud Instance
 func (c *RollingUpdateCluster) detachInstance(u *cloudinstances.CloudInstanceGroupMember) error {
 	id := u.ID

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -91,7 +91,7 @@ func (c *RollingUpdateCluster) rollingUpdateInstanceGroup(ctx context.Context, c
 	} else if c.CloudOnly {
 		klog.V(3).Info("Not validating cluster as validation is turned off via the cloud-only flag.")
 	} else {
-		if err = c.validateCluster(); err != nil {
+		if err = c.validateClusterWithDuration(validationTimeout); err != nil {
 			if c.FailOnValidate {
 				return err
 			}


### PR DESCRIPTION
When doing a rolling update, the initial validation of the cluster only does a single check. This can cause failures if pods are pending, nodes coming up, etc.. 

This MR switches the initial  validation to do multiple checks, like the rest of rolling update.