### PR TITLE
Add CloudLabels tags to additional AWS resources

### DIFF
--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -258,6 +258,9 @@ func (m *KopsModelContext) CloudTags(name string, shared bool) map[string]string
 			tags["kubernetes.io/cluster/"+m.Cluster.ObjectMeta.Name] = "shared"
 		} else {
 			tags["kubernetes.io/cluster/"+m.Cluster.ObjectMeta.Name] = "owned"
+			for k, v := range m.Cluster.Spec.CloudLabels {
+				tags[k] = v
+			}
 		}
 
 	}

--- a/tests/integration/update_cluster/api_elb_cross_zone/kubernetes.tf
+++ b/tests/integration/update_cluster/api_elb_cross_zone/kubernetes.tf
@@ -273,6 +273,8 @@ resource "aws_internet_gateway" "crosszone-example-com" {
   tags = {
     "KubernetesCluster"                           = "crosszone.example.com"
     "Name"                                        = "crosszone.example.com"
+    "Owner"                                       = "John Doe"
+    "foo/bar"                                     = "fib+baz"
     "kubernetes.io/cluster/crosszone.example.com" = "owned"
   }
   vpc_id = aws_vpc.crosszone-example-com.id
@@ -347,6 +349,8 @@ resource "aws_route_table" "crosszone-example-com" {
   tags = {
     "KubernetesCluster"                           = "crosszone.example.com"
     "Name"                                        = "crosszone.example.com"
+    "Owner"                                       = "John Doe"
+    "foo/bar"                                     = "fib+baz"
     "kubernetes.io/cluster/crosszone.example.com" = "owned"
     "kubernetes.io/kops/role"                     = "public"
   }
@@ -536,6 +540,8 @@ resource "aws_security_group" "api-elb-crosszone-example-com" {
   tags = {
     "KubernetesCluster"                           = "crosszone.example.com"
     "Name"                                        = "api-elb.crosszone.example.com"
+    "Owner"                                       = "John Doe"
+    "foo/bar"                                     = "fib+baz"
     "kubernetes.io/cluster/crosszone.example.com" = "owned"
   }
   vpc_id = aws_vpc.crosszone-example-com.id
@@ -547,6 +553,8 @@ resource "aws_security_group" "masters-crosszone-example-com" {
   tags = {
     "KubernetesCluster"                           = "crosszone.example.com"
     "Name"                                        = "masters.crosszone.example.com"
+    "Owner"                                       = "John Doe"
+    "foo/bar"                                     = "fib+baz"
     "kubernetes.io/cluster/crosszone.example.com" = "owned"
   }
   vpc_id = aws_vpc.crosszone-example-com.id
@@ -558,6 +566,8 @@ resource "aws_security_group" "nodes-crosszone-example-com" {
   tags = {
     "KubernetesCluster"                           = "crosszone.example.com"
     "Name"                                        = "nodes.crosszone.example.com"
+    "Owner"                                       = "John Doe"
+    "foo/bar"                                     = "fib+baz"
     "kubernetes.io/cluster/crosszone.example.com" = "owned"
   }
   vpc_id = aws_vpc.crosszone-example-com.id
@@ -569,7 +579,9 @@ resource "aws_subnet" "us-test-1a-crosszone-example-com" {
   tags = {
     "KubernetesCluster"                           = "crosszone.example.com"
     "Name"                                        = "us-test-1a.crosszone.example.com"
+    "Owner"                                       = "John Doe"
     "SubnetType"                                  = "Public"
+    "foo/bar"                                     = "fib+baz"
     "kubernetes.io/cluster/crosszone.example.com" = "owned"
     "kubernetes.io/role/elb"                      = "1"
   }
@@ -587,6 +599,8 @@ resource "aws_vpc_dhcp_options" "crosszone-example-com" {
   tags = {
     "KubernetesCluster"                           = "crosszone.example.com"
     "Name"                                        = "crosszone.example.com"
+    "Owner"                                       = "John Doe"
+    "foo/bar"                                     = "fib+baz"
     "kubernetes.io/cluster/crosszone.example.com" = "owned"
   }
 }
@@ -598,6 +612,8 @@ resource "aws_vpc" "crosszone-example-com" {
   tags = {
     "KubernetesCluster"                           = "crosszone.example.com"
     "Name"                                        = "crosszone.example.com"
+    "Owner"                                       = "John Doe"
+    "foo/bar"                                     = "fib+baz"
     "kubernetes.io/cluster/crosszone.example.com" = "owned"
   }
 }

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -230,6 +230,14 @@
             "Value": "complex.example.com"
           },
           {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
+          },
+          {
             "Key": "kubernetes.io/cluster/complex.example.com",
             "Value": "owned"
           }
@@ -247,6 +255,14 @@
           {
             "Key": "Name",
             "Value": "complex.example.com"
+          },
+          {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
           },
           {
             "Key": "kubernetes.io/cluster/complex.example.com",
@@ -281,6 +297,14 @@
           {
             "Key": "Name",
             "Value": "complex.example.com"
+          },
+          {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
           },
           {
             "Key": "kubernetes.io/cluster/complex.example.com",
@@ -554,6 +578,14 @@
             "Value": "api-elb.complex.example.com"
           },
           {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
+          },
+          {
             "Key": "kubernetes.io/cluster/complex.example.com",
             "Value": "owned"
           }
@@ -577,6 +609,14 @@
             "Value": "masters.complex.example.com"
           },
           {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
+          },
+          {
             "Key": "kubernetes.io/cluster/complex.example.com",
             "Value": "owned"
           }
@@ -598,6 +638,14 @@
           {
             "Key": "Name",
             "Value": "nodes.complex.example.com"
+          },
+          {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
           },
           {
             "Key": "kubernetes.io/cluster/complex.example.com",
@@ -635,8 +683,16 @@
             "Value": "us-test-1a.complex.example.com"
           },
           {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
             "Key": "SubnetType",
             "Value": "Public"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
           },
           {
             "Key": "kubernetes.io/cluster/complex.example.com",
@@ -685,6 +741,14 @@
           {
             "Key": "Name",
             "Value": "complex.example.com"
+          },
+          {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
           },
           {
             "Key": "kubernetes.io/cluster/complex.example.com",

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -273,6 +273,8 @@ resource "aws_internet_gateway" "complex-example-com" {
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "complex.example.com"
+    "Owner"                                     = "John Doe"
+    "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
   vpc_id = aws_vpc.complex-example-com.id
@@ -353,6 +355,8 @@ resource "aws_route_table" "complex-example-com" {
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "complex.example.com"
+    "Owner"                                     = "John Doe"
+    "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
     "kubernetes.io/kops/role"                   = "public"
   }
@@ -542,6 +546,8 @@ resource "aws_security_group" "api-elb-complex-example-com" {
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "api-elb.complex.example.com"
+    "Owner"                                     = "John Doe"
+    "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
   vpc_id = aws_vpc.complex-example-com.id
@@ -553,6 +559,8 @@ resource "aws_security_group" "masters-complex-example-com" {
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "masters.complex.example.com"
+    "Owner"                                     = "John Doe"
+    "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
   vpc_id = aws_vpc.complex-example-com.id
@@ -564,6 +572,8 @@ resource "aws_security_group" "nodes-complex-example-com" {
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "nodes.complex.example.com"
+    "Owner"                                     = "John Doe"
+    "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
   vpc_id = aws_vpc.complex-example-com.id
@@ -575,7 +585,9 @@ resource "aws_subnet" "us-test-1a-complex-example-com" {
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "us-test-1a.complex.example.com"
+    "Owner"                                     = "John Doe"
     "SubnetType"                                = "Public"
+    "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
     "kubernetes.io/role/elb"                    = "1"
   }
@@ -593,6 +605,8 @@ resource "aws_vpc_dhcp_options" "complex-example-com" {
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "complex.example.com"
+    "Owner"                                     = "John Doe"
+    "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
 }
@@ -604,6 +618,8 @@ resource "aws_vpc" "complex-example-com" {
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "complex.example.com"
+    "Owner"                                     = "John Doe"
+    "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
 }

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -283,6 +283,8 @@ resource "aws_internet_gateway" "externalpolicies-example-com" {
   tags = {
     "KubernetesCluster"                                  = "externalpolicies.example.com"
     "Name"                                               = "externalpolicies.example.com"
+    "Owner"                                              = "John Doe"
+    "foo/bar"                                            = "fib+baz"
     "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
   }
   vpc_id = aws_vpc.externalpolicies-example-com.id
@@ -357,6 +359,8 @@ resource "aws_route_table" "externalpolicies-example-com" {
   tags = {
     "KubernetesCluster"                                  = "externalpolicies.example.com"
     "Name"                                               = "externalpolicies.example.com"
+    "Owner"                                              = "John Doe"
+    "foo/bar"                                            = "fib+baz"
     "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
     "kubernetes.io/kops/role"                            = "public"
   }
@@ -546,6 +550,8 @@ resource "aws_security_group" "api-elb-externalpolicies-example-com" {
   tags = {
     "KubernetesCluster"                                  = "externalpolicies.example.com"
     "Name"                                               = "api-elb.externalpolicies.example.com"
+    "Owner"                                              = "John Doe"
+    "foo/bar"                                            = "fib+baz"
     "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
   }
   vpc_id = aws_vpc.externalpolicies-example-com.id
@@ -557,6 +563,8 @@ resource "aws_security_group" "masters-externalpolicies-example-com" {
   tags = {
     "KubernetesCluster"                                  = "externalpolicies.example.com"
     "Name"                                               = "masters.externalpolicies.example.com"
+    "Owner"                                              = "John Doe"
+    "foo/bar"                                            = "fib+baz"
     "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
   }
   vpc_id = aws_vpc.externalpolicies-example-com.id
@@ -568,6 +576,8 @@ resource "aws_security_group" "nodes-externalpolicies-example-com" {
   tags = {
     "KubernetesCluster"                                  = "externalpolicies.example.com"
     "Name"                                               = "nodes.externalpolicies.example.com"
+    "Owner"                                              = "John Doe"
+    "foo/bar"                                            = "fib+baz"
     "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
   }
   vpc_id = aws_vpc.externalpolicies-example-com.id
@@ -579,7 +589,9 @@ resource "aws_subnet" "us-test-1a-externalpolicies-example-com" {
   tags = {
     "KubernetesCluster"                                  = "externalpolicies.example.com"
     "Name"                                               = "us-test-1a.externalpolicies.example.com"
+    "Owner"                                              = "John Doe"
     "SubnetType"                                         = "Public"
+    "foo/bar"                                            = "fib+baz"
     "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
     "kubernetes.io/role/elb"                             = "1"
   }
@@ -597,6 +609,8 @@ resource "aws_vpc_dhcp_options" "externalpolicies-example-com" {
   tags = {
     "KubernetesCluster"                                  = "externalpolicies.example.com"
     "Name"                                               = "externalpolicies.example.com"
+    "Owner"                                              = "John Doe"
+    "foo/bar"                                            = "fib+baz"
     "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
   }
 }
@@ -608,6 +622,8 @@ resource "aws_vpc" "externalpolicies-example-com" {
   tags = {
     "KubernetesCluster"                                  = "externalpolicies.example.com"
     "Name"                                               = "externalpolicies.example.com"
+    "Owner"                                              = "John Doe"
+    "foo/bar"                                            = "fib+baz"
     "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
   }
 }

--- a/tests/integration/update_cluster/nosshkey/kubernetes.tf
+++ b/tests/integration/update_cluster/nosshkey/kubernetes.tf
@@ -273,6 +273,8 @@ resource "aws_internet_gateway" "nosshkey-example-com" {
   tags = {
     "KubernetesCluster"                          = "nosshkey.example.com"
     "Name"                                       = "nosshkey.example.com"
+    "Owner"                                      = "John Doe"
+    "foo/bar"                                    = "fib+baz"
     "kubernetes.io/cluster/nosshkey.example.com" = "owned"
   }
   vpc_id = aws_vpc.nosshkey-example-com.id
@@ -340,6 +342,8 @@ resource "aws_route_table" "nosshkey-example-com" {
   tags = {
     "KubernetesCluster"                          = "nosshkey.example.com"
     "Name"                                       = "nosshkey.example.com"
+    "Owner"                                      = "John Doe"
+    "foo/bar"                                    = "fib+baz"
     "kubernetes.io/cluster/nosshkey.example.com" = "owned"
     "kubernetes.io/kops/role"                    = "public"
   }
@@ -529,6 +533,8 @@ resource "aws_security_group" "api-elb-nosshkey-example-com" {
   tags = {
     "KubernetesCluster"                          = "nosshkey.example.com"
     "Name"                                       = "api-elb.nosshkey.example.com"
+    "Owner"                                      = "John Doe"
+    "foo/bar"                                    = "fib+baz"
     "kubernetes.io/cluster/nosshkey.example.com" = "owned"
   }
   vpc_id = aws_vpc.nosshkey-example-com.id
@@ -540,6 +546,8 @@ resource "aws_security_group" "masters-nosshkey-example-com" {
   tags = {
     "KubernetesCluster"                          = "nosshkey.example.com"
     "Name"                                       = "masters.nosshkey.example.com"
+    "Owner"                                      = "John Doe"
+    "foo/bar"                                    = "fib+baz"
     "kubernetes.io/cluster/nosshkey.example.com" = "owned"
   }
   vpc_id = aws_vpc.nosshkey-example-com.id
@@ -551,6 +559,8 @@ resource "aws_security_group" "nodes-nosshkey-example-com" {
   tags = {
     "KubernetesCluster"                          = "nosshkey.example.com"
     "Name"                                       = "nodes.nosshkey.example.com"
+    "Owner"                                      = "John Doe"
+    "foo/bar"                                    = "fib+baz"
     "kubernetes.io/cluster/nosshkey.example.com" = "owned"
   }
   vpc_id = aws_vpc.nosshkey-example-com.id
@@ -562,7 +572,9 @@ resource "aws_subnet" "us-test-1a-nosshkey-example-com" {
   tags = {
     "KubernetesCluster"                          = "nosshkey.example.com"
     "Name"                                       = "us-test-1a.nosshkey.example.com"
+    "Owner"                                      = "John Doe"
     "SubnetType"                                 = "Public"
+    "foo/bar"                                    = "fib+baz"
     "kubernetes.io/cluster/nosshkey.example.com" = "owned"
     "kubernetes.io/role/elb"                     = "1"
   }
@@ -580,6 +592,8 @@ resource "aws_vpc_dhcp_options" "nosshkey-example-com" {
   tags = {
     "KubernetesCluster"                          = "nosshkey.example.com"
     "Name"                                       = "nosshkey.example.com"
+    "Owner"                                      = "John Doe"
+    "foo/bar"                                    = "fib+baz"
     "kubernetes.io/cluster/nosshkey.example.com" = "owned"
   }
 }
@@ -591,6 +605,8 @@ resource "aws_vpc" "nosshkey-example-com" {
   tags = {
     "KubernetesCluster"                          = "nosshkey.example.com"
     "Name"                                       = "nosshkey.example.com"
+    "Owner"                                      = "John Doe"
+    "foo/bar"                                    = "fib+baz"
     "kubernetes.io/cluster/nosshkey.example.com" = "owned"
   }
 }

--- a/tests/integration/update_cluster/privatedns1/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatedns1/in-v1alpha2.yaml
@@ -7,6 +7,9 @@ spec:
   kubernetesApiAccess:
   - 0.0.0.0/0
   channel: stable
+  cloudLabels:
+    Owner: John Doe
+    foo/bar: fib+baz
   cloudProvider: aws
   configBase: memfs://clusters.example.com/privatedns1.example.com
   dnsZone: internal.example.com

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -138,6 +138,16 @@ resource "aws_autoscaling_group" "bastion-privatedns1-example-com" {
     value               = "bastion.privatedns1.example.com"
   }
   tag {
+    key                 = "Owner"
+    propagate_at_launch = true
+    value               = "John Doe"
+  }
+  tag {
+    key                 = "foo/bar"
+    propagate_at_launch = true
+    value               = "fib+baz"
+  }
+  tag {
     key                 = "k8s.io/role/bastion"
     propagate_at_launch = true
     value               = "1"
@@ -171,6 +181,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatedns1-example-
     key                 = "Name"
     propagate_at_launch = true
     value               = "master-us-test-1a.masters.privatedns1.example.com"
+  }
+  tag {
+    key                 = "Owner"
+    propagate_at_launch = true
+    value               = "John Doe"
+  }
+  tag {
+    key                 = "foo/bar"
+    propagate_at_launch = true
+    value               = "fib+baz"
   }
   tag {
     key                 = "k8s.io/role/master"
@@ -208,6 +228,16 @@ resource "aws_autoscaling_group" "nodes-privatedns1-example-com" {
     value               = "nodes.privatedns1.example.com"
   }
   tag {
+    key                 = "Owner"
+    propagate_at_launch = true
+    value               = "John Doe"
+  }
+  tag {
+    key                 = "foo/bar"
+    propagate_at_launch = true
+    value               = "fib+baz"
+  }
+  tag {
     key                 = "k8s.io/role/node"
     propagate_at_launch = true
     value               = "1"
@@ -232,6 +262,8 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "us-test-1a.etcd-events.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "k8s.io/etcd/events"                            = "us-test-1a/us-test-1a"
     "k8s.io/role/master"                            = "1"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
@@ -246,6 +278,8 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "us-test-1a.etcd-main.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "k8s.io/etcd/main"                              = "us-test-1a/us-test-1a"
     "k8s.io/role/master"                            = "1"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
@@ -257,6 +291,8 @@ resource "aws_eip" "us-test-1a-privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "us-test-1a.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
   vpc = true
@@ -285,6 +321,8 @@ resource "aws_elb" "api-privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "api.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
@@ -311,6 +349,8 @@ resource "aws_elb" "bastion-privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "bastion.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
@@ -367,6 +407,8 @@ resource "aws_internet_gateway" "privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
   vpc_id = aws_vpc.privatedns1-example-com.id
@@ -446,6 +488,8 @@ resource "aws_nat_gateway" "us-test-1a-privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "us-test-1a.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
@@ -480,6 +524,8 @@ resource "aws_route_table" "private-us-test-1a-privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "private-us-test-1a.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
     "kubernetes.io/kops/role"                       = "private-us-test-1a"
   }
@@ -490,6 +536,8 @@ resource "aws_route_table" "privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
     "kubernetes.io/kops/role"                       = "public"
   }
@@ -685,6 +733,8 @@ resource "aws_security_group" "api-elb-privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "api-elb.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
   vpc_id = aws_vpc.privatedns1-example-com.id
@@ -696,6 +746,8 @@ resource "aws_security_group" "bastion-elb-privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "bastion-elb.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
   vpc_id = aws_vpc.privatedns1-example-com.id
@@ -707,6 +759,8 @@ resource "aws_security_group" "bastion-privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "bastion.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
   vpc_id = aws_vpc.privatedns1-example-com.id
@@ -718,6 +772,8 @@ resource "aws_security_group" "masters-privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "masters.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
   vpc_id = aws_vpc.privatedns1-example-com.id
@@ -729,6 +785,8 @@ resource "aws_security_group" "nodes-privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "nodes.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
   vpc_id = aws_vpc.privatedns1-example-com.id
@@ -740,7 +798,9 @@ resource "aws_subnet" "us-test-1a-privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "us-test-1a.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
     "SubnetType"                                    = "Private"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
     "kubernetes.io/role/internal-elb"               = "1"
   }
@@ -753,7 +813,9 @@ resource "aws_subnet" "utility-us-test-1a-privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "utility-us-test-1a.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
     "SubnetType"                                    = "Utility"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
     "kubernetes.io/role/elb"                        = "1"
   }
@@ -771,6 +833,8 @@ resource "aws_vpc_dhcp_options" "privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
@@ -782,6 +846,8 @@ resource "aws_vpc" "privatedns1-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }


### PR DESCRIPTION
This adds any labels defined in the Cluster spec's CloudLabels to the tags of the following AWS resource types:

- Elastic IP
- Internet Gateway
- NAT Gateway
- Route Table
- Security Group
- Subnet
- VPC DHCP Options
- VPC

I debated between priority if they ever conflict with a tag key already being set by Kops. Currently this PR has CloudLabels taking priority over any built-in tags. If there is concern about users overwriting an important tag key with a value that kops won't handle properly then I could switch it to have the built-in tags take priority over the CloudLabels.

Fixes #8792