### PR TITLE
Automated cherry pick of #8903: Add CloudLabels tags to additional AWS resources

### DIFF
--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -264,6 +264,9 @@ func (m *KopsModelContext) CloudTags(name string, shared bool) map[string]string
 			tags["kubernetes.io/cluster/"+m.Cluster.ObjectMeta.Name] = "shared"
 		} else {
 			tags["kubernetes.io/cluster/"+m.Cluster.ObjectMeta.Name] = "owned"
+			for k, v := range m.Cluster.Spec.CloudLabels {
+				tags[k] = v
+			}
 		}
 
 	}

--- a/tests/integration/update_cluster/api_elb_cross_zone/kubernetes.tf
+++ b/tests/integration/update_cluster/api_elb_cross_zone/kubernetes.tf
@@ -285,6 +285,8 @@ resource "aws_internet_gateway" "crosszone-example-com" {
   tags = {
     KubernetesCluster                             = "crosszone.example.com"
     Name                                          = "crosszone.example.com"
+    Owner                                         = "John Doe"
+    "foo/bar"                                     = "fib+baz"
     "kubernetes.io/cluster/crosszone.example.com" = "owned"
   }
 }
@@ -370,6 +372,8 @@ resource "aws_route_table" "crosszone-example-com" {
   tags = {
     KubernetesCluster                             = "crosszone.example.com"
     Name                                          = "crosszone.example.com"
+    Owner                                         = "John Doe"
+    "foo/bar"                                     = "fib+baz"
     "kubernetes.io/cluster/crosszone.example.com" = "owned"
     "kubernetes.io/kops/role"                     = "public"
   }
@@ -388,6 +392,8 @@ resource "aws_security_group" "api-elb-crosszone-example-com" {
   tags = {
     KubernetesCluster                             = "crosszone.example.com"
     Name                                          = "api-elb.crosszone.example.com"
+    Owner                                         = "John Doe"
+    "foo/bar"                                     = "fib+baz"
     "kubernetes.io/cluster/crosszone.example.com" = "owned"
   }
 }
@@ -400,6 +406,8 @@ resource "aws_security_group" "masters-crosszone-example-com" {
   tags = {
     KubernetesCluster                             = "crosszone.example.com"
     Name                                          = "masters.crosszone.example.com"
+    Owner                                         = "John Doe"
+    "foo/bar"                                     = "fib+baz"
     "kubernetes.io/cluster/crosszone.example.com" = "owned"
   }
 }
@@ -412,6 +420,8 @@ resource "aws_security_group" "nodes-crosszone-example-com" {
   tags = {
     KubernetesCluster                             = "crosszone.example.com"
     Name                                          = "nodes.crosszone.example.com"
+    Owner                                         = "John Doe"
+    "foo/bar"                                     = "fib+baz"
     "kubernetes.io/cluster/crosszone.example.com" = "owned"
   }
 }
@@ -595,7 +605,9 @@ resource "aws_subnet" "us-test-1a-crosszone-example-com" {
   tags = {
     KubernetesCluster                             = "crosszone.example.com"
     Name                                          = "us-test-1a.crosszone.example.com"
+    Owner                                         = "John Doe"
     SubnetType                                    = "Public"
+    "foo/bar"                                     = "fib+baz"
     "kubernetes.io/cluster/crosszone.example.com" = "owned"
     "kubernetes.io/role/elb"                      = "1"
   }
@@ -609,6 +621,8 @@ resource "aws_vpc" "crosszone-example-com" {
   tags = {
     KubernetesCluster                             = "crosszone.example.com"
     Name                                          = "crosszone.example.com"
+    Owner                                         = "John Doe"
+    "foo/bar"                                     = "fib+baz"
     "kubernetes.io/cluster/crosszone.example.com" = "owned"
   }
 }
@@ -620,6 +634,8 @@ resource "aws_vpc_dhcp_options" "crosszone-example-com" {
   tags = {
     KubernetesCluster                             = "crosszone.example.com"
     Name                                          = "crosszone.example.com"
+    Owner                                         = "John Doe"
+    "foo/bar"                                     = "fib+baz"
     "kubernetes.io/cluster/crosszone.example.com" = "owned"
   }
 }

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -220,6 +220,14 @@
             "Value": "complex.example.com"
           },
           {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
+          },
+          {
             "Key": "kubernetes.io/cluster/complex.example.com",
             "Value": "owned"
           }
@@ -237,6 +245,14 @@
           {
             "Key": "Name",
             "Value": "complex.example.com"
+          },
+          {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
           },
           {
             "Key": "kubernetes.io/cluster/complex.example.com",
@@ -271,6 +287,14 @@
           {
             "Key": "Name",
             "Value": "complex.example.com"
+          },
+          {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
           },
           {
             "Key": "kubernetes.io/cluster/complex.example.com",
@@ -544,6 +568,14 @@
             "Value": "api-elb.complex.example.com"
           },
           {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
+          },
+          {
             "Key": "kubernetes.io/cluster/complex.example.com",
             "Value": "owned"
           }
@@ -567,6 +599,14 @@
             "Value": "masters.complex.example.com"
           },
           {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
+          },
+          {
             "Key": "kubernetes.io/cluster/complex.example.com",
             "Value": "owned"
           }
@@ -588,6 +628,14 @@
           {
             "Key": "Name",
             "Value": "nodes.complex.example.com"
+          },
+          {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
           },
           {
             "Key": "kubernetes.io/cluster/complex.example.com",
@@ -625,8 +673,16 @@
             "Value": "us-test-1a.complex.example.com"
           },
           {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
             "Key": "SubnetType",
             "Value": "Public"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
           },
           {
             "Key": "kubernetes.io/cluster/complex.example.com",
@@ -675,6 +731,14 @@
           {
             "Key": "Name",
             "Value": "complex.example.com"
+          },
+          {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
           },
           {
             "Key": "kubernetes.io/cluster/complex.example.com",

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -285,6 +285,8 @@ resource "aws_internet_gateway" "complex-example-com" {
   tags = {
     KubernetesCluster                           = "complex.example.com"
     Name                                        = "complex.example.com"
+    Owner                                       = "John Doe"
+    "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
 }
@@ -377,6 +379,8 @@ resource "aws_route_table" "complex-example-com" {
   tags = {
     KubernetesCluster                           = "complex.example.com"
     Name                                        = "complex.example.com"
+    Owner                                       = "John Doe"
+    "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
     "kubernetes.io/kops/role"                   = "public"
   }
@@ -395,6 +399,8 @@ resource "aws_security_group" "api-elb-complex-example-com" {
   tags = {
     KubernetesCluster                           = "complex.example.com"
     Name                                        = "api-elb.complex.example.com"
+    Owner                                       = "John Doe"
+    "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
 }
@@ -407,6 +413,8 @@ resource "aws_security_group" "masters-complex-example-com" {
   tags = {
     KubernetesCluster                           = "complex.example.com"
     Name                                        = "masters.complex.example.com"
+    Owner                                       = "John Doe"
+    "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
 }
@@ -419,6 +427,8 @@ resource "aws_security_group" "nodes-complex-example-com" {
   tags = {
     KubernetesCluster                           = "complex.example.com"
     Name                                        = "nodes.complex.example.com"
+    Owner                                       = "John Doe"
+    "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
 }
@@ -602,7 +612,9 @@ resource "aws_subnet" "us-test-1a-complex-example-com" {
   tags = {
     KubernetesCluster                           = "complex.example.com"
     Name                                        = "us-test-1a.complex.example.com"
+    Owner                                       = "John Doe"
     SubnetType                                  = "Public"
+    "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
     "kubernetes.io/role/elb"                    = "1"
   }
@@ -616,6 +628,8 @@ resource "aws_vpc" "complex-example-com" {
   tags = {
     KubernetesCluster                           = "complex.example.com"
     Name                                        = "complex.example.com"
+    Owner                                       = "John Doe"
+    "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
 }
@@ -627,6 +641,8 @@ resource "aws_vpc_dhcp_options" "complex-example-com" {
   tags = {
     KubernetesCluster                           = "complex.example.com"
     Name                                        = "complex.example.com"
+    Owner                                       = "John Doe"
+    "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
 }

--- a/tests/integration/update_cluster/nosshkey/kubernetes.tf
+++ b/tests/integration/update_cluster/nosshkey/kubernetes.tf
@@ -285,6 +285,8 @@ resource "aws_internet_gateway" "nosshkey-example-com" {
   tags = {
     KubernetesCluster                            = "nosshkey.example.com"
     Name                                         = "nosshkey.example.com"
+    Owner                                        = "John Doe"
+    "foo/bar"                                    = "fib+baz"
     "kubernetes.io/cluster/nosshkey.example.com" = "owned"
   }
 }
@@ -363,6 +365,8 @@ resource "aws_route_table" "nosshkey-example-com" {
   tags = {
     KubernetesCluster                            = "nosshkey.example.com"
     Name                                         = "nosshkey.example.com"
+    Owner                                        = "John Doe"
+    "foo/bar"                                    = "fib+baz"
     "kubernetes.io/cluster/nosshkey.example.com" = "owned"
     "kubernetes.io/kops/role"                    = "public"
   }
@@ -381,6 +385,8 @@ resource "aws_security_group" "api-elb-nosshkey-example-com" {
   tags = {
     KubernetesCluster                            = "nosshkey.example.com"
     Name                                         = "api-elb.nosshkey.example.com"
+    Owner                                        = "John Doe"
+    "foo/bar"                                    = "fib+baz"
     "kubernetes.io/cluster/nosshkey.example.com" = "owned"
   }
 }
@@ -393,6 +399,8 @@ resource "aws_security_group" "masters-nosshkey-example-com" {
   tags = {
     KubernetesCluster                            = "nosshkey.example.com"
     Name                                         = "masters.nosshkey.example.com"
+    Owner                                        = "John Doe"
+    "foo/bar"                                    = "fib+baz"
     "kubernetes.io/cluster/nosshkey.example.com" = "owned"
   }
 }
@@ -405,6 +413,8 @@ resource "aws_security_group" "nodes-nosshkey-example-com" {
   tags = {
     KubernetesCluster                            = "nosshkey.example.com"
     Name                                         = "nodes.nosshkey.example.com"
+    Owner                                        = "John Doe"
+    "foo/bar"                                    = "fib+baz"
     "kubernetes.io/cluster/nosshkey.example.com" = "owned"
   }
 }
@@ -588,7 +598,9 @@ resource "aws_subnet" "us-test-1a-nosshkey-example-com" {
   tags = {
     KubernetesCluster                            = "nosshkey.example.com"
     Name                                         = "us-test-1a.nosshkey.example.com"
+    Owner                                        = "John Doe"
     SubnetType                                   = "Public"
+    "foo/bar"                                    = "fib+baz"
     "kubernetes.io/cluster/nosshkey.example.com" = "owned"
     "kubernetes.io/role/elb"                     = "1"
   }
@@ -602,6 +614,8 @@ resource "aws_vpc" "nosshkey-example-com" {
   tags = {
     KubernetesCluster                            = "nosshkey.example.com"
     Name                                         = "nosshkey.example.com"
+    Owner                                        = "John Doe"
+    "foo/bar"                                    = "fib+baz"
     "kubernetes.io/cluster/nosshkey.example.com" = "owned"
   }
 }
@@ -613,6 +627,8 @@ resource "aws_vpc_dhcp_options" "nosshkey-example-com" {
   tags = {
     KubernetesCluster                            = "nosshkey.example.com"
     Name                                         = "nosshkey.example.com"
+    Owner                                        = "John Doe"
+    "foo/bar"                                    = "fib+baz"
     "kubernetes.io/cluster/nosshkey.example.com" = "owned"
   }
 }

--- a/tests/integration/update_cluster/privatedns1/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatedns1/in-v1alpha2.yaml
@@ -7,6 +7,9 @@ spec:
   kubernetesApiAccess:
   - 0.0.0.0/0
   channel: stable
+  cloudLabels:
+    Owner: John Doe
+    foo/bar: fib+baz
   cloudProvider: aws
   configBase: memfs://clusters.example.com/privatedns1.example.com
   dnsZone: internal.example.com

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -140,6 +140,18 @@ resource "aws_autoscaling_group" "bastion-privatedns1-example-com" {
   }
 
   tag = {
+    key                 = "Owner"
+    value               = "John Doe"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "foo/bar"
+    value               = "fib+baz"
+    propagate_at_launch = true
+  }
+
+  tag = {
     key                 = "k8s.io/role/bastion"
     value               = "1"
     propagate_at_launch = true
@@ -171,6 +183,18 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatedns1-example-
   tag = {
     key                 = "Name"
     value               = "master-us-test-1a.masters.privatedns1.example.com"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "Owner"
+    value               = "John Doe"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "foo/bar"
+    value               = "fib+baz"
     propagate_at_launch = true
   }
 
@@ -210,6 +234,18 @@ resource "aws_autoscaling_group" "nodes-privatedns1-example-com" {
   }
 
   tag = {
+    key                 = "Owner"
+    value               = "John Doe"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "foo/bar"
+    value               = "fib+baz"
+    propagate_at_launch = true
+  }
+
+  tag = {
     key                 = "k8s.io/role/node"
     value               = "1"
     propagate_at_launch = true
@@ -234,6 +270,8 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "us-test-1a.etcd-events.privatedns1.example.com"
+    Owner                                           = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "k8s.io/etcd/events"                            = "us-test-1a/us-test-1a"
     "k8s.io/role/master"                            = "1"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
@@ -249,6 +287,8 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "us-test-1a.etcd-main.privatedns1.example.com"
+    Owner                                           = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "k8s.io/etcd/main"                              = "us-test-1a/us-test-1a"
     "k8s.io/role/master"                            = "1"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
@@ -261,6 +301,8 @@ resource "aws_eip" "us-test-1a-privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "us-test-1a.privatedns1.example.com"
+    Owner                                           = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
@@ -292,6 +334,8 @@ resource "aws_elb" "api-privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "api.privatedns1.example.com"
+    Owner                                           = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
@@ -322,6 +366,8 @@ resource "aws_elb" "bastion-privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "bastion.privatedns1.example.com"
+    Owner                                           = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
@@ -380,6 +426,8 @@ resource "aws_internet_gateway" "privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "privatedns1.example.com"
+    Owner                                           = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
@@ -469,6 +517,8 @@ resource "aws_nat_gateway" "us-test-1a-privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "us-test-1a.privatedns1.example.com"
+    Owner                                           = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
@@ -509,6 +559,8 @@ resource "aws_route_table" "private-us-test-1a-privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "private-us-test-1a.privatedns1.example.com"
+    Owner                                           = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
     "kubernetes.io/kops/role"                       = "private-us-test-1a"
   }
@@ -520,6 +572,8 @@ resource "aws_route_table" "privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "privatedns1.example.com"
+    Owner                                           = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
     "kubernetes.io/kops/role"                       = "public"
   }
@@ -543,6 +597,8 @@ resource "aws_security_group" "api-elb-privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "api-elb.privatedns1.example.com"
+    Owner                                           = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
@@ -555,6 +611,8 @@ resource "aws_security_group" "bastion-elb-privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "bastion-elb.privatedns1.example.com"
+    Owner                                           = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
@@ -567,6 +625,8 @@ resource "aws_security_group" "bastion-privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "bastion.privatedns1.example.com"
+    Owner                                           = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
@@ -579,6 +639,8 @@ resource "aws_security_group" "masters-privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "masters.privatedns1.example.com"
+    Owner                                           = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
@@ -591,6 +653,8 @@ resource "aws_security_group" "nodes-privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "nodes.privatedns1.example.com"
+    Owner                                           = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
@@ -774,7 +838,9 @@ resource "aws_subnet" "us-test-1a-privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "us-test-1a.privatedns1.example.com"
+    Owner                                           = "John Doe"
     SubnetType                                      = "Private"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
     "kubernetes.io/role/internal-elb"               = "1"
   }
@@ -788,7 +854,9 @@ resource "aws_subnet" "utility-us-test-1a-privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "utility-us-test-1a.privatedns1.example.com"
+    Owner                                           = "John Doe"
     SubnetType                                      = "Utility"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
     "kubernetes.io/role/elb"                        = "1"
   }
@@ -802,6 +870,8 @@ resource "aws_vpc" "privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "privatedns1.example.com"
+    Owner                                           = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }
@@ -813,6 +883,8 @@ resource "aws_vpc_dhcp_options" "privatedns1-example-com" {
   tags = {
     KubernetesCluster                               = "privatedns1.example.com"
     Name                                            = "privatedns1.example.com"
+    Owner                                           = "John Doe"
+    "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
 }


### PR DESCRIPTION
Cherry pick of #8903 on release-1.17.

#8903: Add CloudLabels tags to additional AWS resources

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.