### PR TITLE
Update security_groups.md

### DIFF
--- a/docs/security_groups.md
+++ b/docs/security_groups.md
@@ -11,7 +11,7 @@ This is convenient for determining policy changes that need to be made when upgr
 NOTE: 
 - *Currently Kops only supports using existing Security Groups for every instance group and Load Balancer in the Cluster, not a mix of existing and managed Security Groups.
 This is due to the lifecycle overrides being used to prevent creation of the Security Groups related resources.*
-- *Kops will still try to add necessary security group rules to the specified existing security group, despite that the name of field is "securityGroupOverride".*
+- *Kops will add necessary rules to the security group specified in `securityGroupOverride`.*
 
 To do this first specify the Security Groups for the ELB (if you are using a LB) and Instance Groups
 Example:

--- a/docs/security_groups.md
+++ b/docs/security_groups.md
@@ -8,8 +8,10 @@ Kops will still output any differences in the managed and your own Security Grou
 This is convenient for determining policy changes that need to be made when upgrading Kops.
 **Using Managed Security Groups will not output these differences, it is up to the user to track expected changes to policies.**
 
-*NOTE: Currently Kops only supports using existing Security Groups for every instance group and Load Balancer in the Cluster, not a mix of existing and managed Security Groups.
+NOTE: 
+- *Currently Kops only supports using existing Security Groups for every instance group and Load Balancer in the Cluster, not a mix of existing and managed Security Groups.
 This is due to the lifecycle overrides being used to prevent creation of the Security Groups related resources.*
+- *Kops will still try to add necessary security group rules to the specified existing security group, despite that the name of field is "securityGroupOverride".*
 
 To do this first specify the Security Groups for the ELB (if you are using a LB) and Instance Groups
 Example:

--- a/docs/security_groups.md
+++ b/docs/security_groups.md
@@ -9,6 +9,7 @@ This is convenient for determining policy changes that need to be made when upgr
 **Using Managed Security Groups will not output these differences, it is up to the user to track expected changes to policies.**
 
 NOTE: 
+
 - *Currently Kops only supports using existing Security Groups for every instance group and Load Balancer in the Cluster, not a mix of existing and managed Security Groups.
 This is due to the lifecycle overrides being used to prevent creation of the Security Groups related resources.*
 - *Kops will add necessary rules to the security group specified in `securityGroupOverride`.*


### PR DESCRIPTION
This PR updates `security_groups.md` in order to clear some confusions that developers might encounter when they see the name of "securityGroupOverride".

Specifically, `Override` implies that the passed in security group will be the source of truth, but in reality the passed in security group will be modified.
The awareness of this tiny detail will potentially prevent unwanted changes to some shared security groups.  
