### PR TITLE
docs: getting started - commands - fix formatting

### DIFF
--- a/docs/getting_started/commands.md
+++ b/docs/getting_started/commands.md
@@ -2,7 +2,7 @@
 This page lists the most common kops commands.
 Please refer to the kops [cli reference](../cli/kops.md) for full documentation.
 
-## `kops create
+## `kops create`
 
 `kops create` registers a cluster. There are two ways of registering a cluster: using a cluster spec file or using cli arguments.
 


### PR DESCRIPTION
missing backtick in markdown resulted in document heading appearing as '`kops create'