### PR TITLE
Exclude GO 1.14 for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ script:
   - GOPROXY=https://proxy.golang.org make nodeup examples test
 
 jobs:
-  # To exclude a known-bad configuration:
-  #exclude:
-  #  - os: osx
-  #    go: "1.12"
+  # Exclude GO 1.14 for OSX until it becomes the default because of limited availability
+  exclude:
+    - os: osx
+      go: "1.14"
 
   include:
     - name: Verify


### PR DESCRIPTION
Travis OSX test VMs are more rare than linux ones. No need to build on OSX for non-default GO versions.

For reference:
https://github.com/kubernetes/kops/pull/8893#issuecomment-612004667