### PR TITLE
Automated cherry pick of #8727: Add support for Ubuntu 20.04 (Focal)

### DIFF
--- a/nodeup/pkg/distros/distribution.go
+++ b/nodeup/pkg/distros/distribution.go
@@ -29,6 +29,7 @@ var (
 	DistributionDebian10    Distribution = "buster"
 	DistributionXenial      Distribution = "xenial"
 	DistributionBionic      Distribution = "bionic"
+	DistributionFocal       Distribution = "focal"
 	DistributionRhel7       Distribution = "rhel7"
 	DistributionCentos7     Distribution = "centos7"
 	DistributionRhel8       Distribution = "rhel8"
@@ -50,6 +51,8 @@ func (d Distribution) BuildTags() []string {
 		t = []string{"_xenial"}
 	case DistributionBionic:
 		t = []string{"_bionic"}
+	case DistributionFocal:
+		t = []string{"_focal"}
 	case DistributionCentos7:
 		t = []string{"_centos7"}
 	case DistributionRhel7:
@@ -86,7 +89,7 @@ func (d Distribution) IsDebianFamily() bool {
 	switch d {
 	case DistributionJessie, DistributionDebian9, DistributionDebian10:
 		return true
-	case DistributionXenial, DistributionBionic:
+	case DistributionXenial, DistributionBionic, DistributionFocal:
 		return true
 	case DistributionCentos7, DistributionRhel7:
 		return false
@@ -102,7 +105,7 @@ func (d Distribution) IsUbuntu() bool {
 	switch d {
 	case DistributionJessie, DistributionDebian9, DistributionDebian10:
 		return false
-	case DistributionXenial, DistributionBionic:
+	case DistributionXenial, DistributionBionic, DistributionFocal:
 		return true
 	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8:
 		return false
@@ -118,7 +121,7 @@ func (d Distribution) IsRHELFamily() bool {
 	switch d {
 	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8:
 		return true
-	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9, DistributionDebian10:
+	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionFocal, DistributionDebian9, DistributionDebian10:
 		return false
 	case DistributionCoreOS, DistributionFlatcar, DistributionContainerOS:
 		return false
@@ -130,7 +133,7 @@ func (d Distribution) IsRHELFamily() bool {
 
 func (d Distribution) IsSystemd() bool {
 	switch d {
-	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionDebian9, DistributionDebian10:
+	case DistributionJessie, DistributionXenial, DistributionBionic, DistributionFocal, DistributionDebian9, DistributionDebian10:
 		return true
 	case DistributionCentos7, DistributionRhel7, DistributionCentos8, DistributionRhel8:
 		return true

--- a/nodeup/pkg/distros/identify.go
+++ b/nodeup/pkg/distros/identify.go
@@ -37,9 +37,9 @@ func FindDistribution(rootfs string) (Distribution, error) {
 			if line == "DISTRIB_CODENAME=xenial" {
 				return DistributionXenial, nil
 			} else if line == "DISTRIB_CODENAME=bionic" {
-				klog.Warningf("bionic is not fully supported nor tested for Kops and Kubernetes")
-				klog.Warningf("this should only be used for testing purposes.")
 				return DistributionBionic, nil
+			} else if line == "DISTRIB_CODENAME=focal" {
+				return DistributionFocal, nil
 			}
 		}
 	} else if !os.IsNotExist(err) {

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -591,8 +591,10 @@ func (b *KubeletBuilder) buildKubeletConfigSpec() (*kops.KubeletConfigSpec, erro
 
 	// In certain configurations systemd-resolved will put the loopback address 127.0.0.53 as a nameserver into /etc/resolv.conf
 	// https://github.com/coredns/coredns/blob/master/plugin/loop/README.md#troubleshooting-loops-in-kubernetes-clusters
-	if b.Distribution == distros.DistributionBionic && c.ResolverConfig == nil {
-		c.ResolverConfig = s("/run/systemd/resolve/resolv.conf")
+	if c.ResolverConfig == nil {
+		if b.Distribution == distros.DistributionBionic || b.Distribution == distros.DistributionFocal {
+			c.ResolverConfig = s("/run/systemd/resolve/resolv.conf")
+		}
 	}
 
 	// As of 1.16 we can no longer set critical labels.


### PR DESCRIPTION
Cherry pick of #8727 on release-1.17.

#8727: Add support for Ubuntu 20.04 (Focal)

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.