### PR TITLE
Automated cherry pick of #8936: Remove irrelevant TODO comment from userdata

### DIFF
--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -119,9 +119,6 @@ function split-commas() {
 }
 
 function try-download-release() {
-  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-  # optimization.
-
   local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
   if [[ -n "${NODEUP_HASH:-}" ]]; then
     local -r nodeup_hash="${NODEUP_HASH}"

--- a/pkg/model/tests/data/bootstrapscript_0.txt
+++ b/pkg/model/tests/data/bootstrapscript_0.txt
@@ -108,9 +108,6 @@ function split-commas() {
 }
 
 function try-download-release() {
-  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-  # optimization.
-
   local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
   if [[ -n "${NODEUP_HASH:-}" ]]; then
     local -r nodeup_hash="${NODEUP_HASH}"

--- a/pkg/model/tests/data/bootstrapscript_1.txt
+++ b/pkg/model/tests/data/bootstrapscript_1.txt
@@ -108,9 +108,6 @@ function split-commas() {
 }
 
 function try-download-release() {
-  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-  # optimization.
-
   local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
   if [[ -n "${NODEUP_HASH:-}" ]]; then
     local -r nodeup_hash="${NODEUP_HASH}"

--- a/pkg/model/tests/data/bootstrapscript_2.txt
+++ b/pkg/model/tests/data/bootstrapscript_2.txt
@@ -108,9 +108,6 @@ function split-commas() {
 }
 
 function try-download-release() {
-  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-  # optimization.
-
   local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
   if [[ -n "${NODEUP_HASH:-}" ]]; then
     local -r nodeup_hash="${NODEUP_HASH}"

--- a/pkg/model/tests/data/bootstrapscript_3.txt
+++ b/pkg/model/tests/data/bootstrapscript_3.txt
@@ -108,9 +108,6 @@ function split-commas() {
 }
 
 function try-download-release() {
-  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-  # optimization.
-
   local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
   if [[ -n "${NODEUP_HASH:-}" ]]; then
     local -r nodeup_hash="${NODEUP_HASH}"

--- a/pkg/model/tests/data/bootstrapscript_4.txt
+++ b/pkg/model/tests/data/bootstrapscript_4.txt
@@ -108,9 +108,6 @@ function split-commas() {
 }
 
 function try-download-release() {
-  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-  # optimization.
-
   local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
   if [[ -n "${NODEUP_HASH:-}" ]]; then
     local -r nodeup_hash="${NODEUP_HASH}"

--- a/pkg/model/tests/data/bootstrapscript_5.txt
+++ b/pkg/model/tests/data/bootstrapscript_5.txt
@@ -108,9 +108,6 @@ function split-commas() {
 }
 
 function try-download-release() {
-  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-  # optimization.
-
   local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
   if [[ -n "${NODEUP_HASH:-}" ]]; then
     local -r nodeup_hash="${NODEUP_HASH}"

--- a/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_cidr/cloudformation.json.extracted.yaml
@@ -93,9 +93,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersadditionalcidrex
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
@@ -382,9 +379,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionalcidrexamplecom.Propert
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"

--- a/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/additional_user-data/cloudformation.json.extracted.yaml
@@ -102,9 +102,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersadditionaluserda
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
@@ -411,9 +408,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesadditionaluserdataexamplecom.Pro
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"

--- a/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
@@ -93,9 +93,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscomplexexampleco
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
@@ -384,9 +381,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodescomplexexamplecom.Properties.Use
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -93,9 +93,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
@@ -382,9 +379,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"

--- a/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_master-us-west-2a.masters.k8s-iam.us-west-2.td.priv_user_data
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/data/aws_launch_configuration_master-us-west-2a.masters.k8s-iam.us-west-2.td.priv_user_data
@@ -99,9 +99,6 @@ function split-commas() {
 }
 
 function try-download-release() {
-  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-  # optimization.
-
   local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
   local -r nodeup_filename="${nodeup_urls[0]##*/}"
   if [[ -n "${NODEUP_HASH:-}" ]]; then

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -93,9 +93,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersexternallbexampl
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
@@ -382,9 +379,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesexternallbexamplecom.Properties.
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -93,9 +93,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersminimalexampleco
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
@@ -382,9 +379,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesminimalexamplecom.Properties.Use
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
@@ -93,9 +93,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
@@ -384,9 +381,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
@@ -675,9 +669,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
@@ -966,9 +957,6 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
@@ -93,9 +93,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersmixedinstancesex
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
@@ -384,9 +381,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmastersmixedinstancesex
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
@@ -675,9 +669,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmastersmixedinstancesex
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
@@ -966,9 +957,6 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"

--- a/tests/integration/update_cluster/nosshkey-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/nosshkey-cloudformation/cloudformation.json.extracted.yaml
@@ -93,9 +93,6 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amastersnosshkeyexamplec
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"
@@ -385,9 +382,6 @@ Resources.AWSAutoScalingLaunchConfigurationnodesnosshkeyexamplecom.Properties.Us
   }
 
   function try-download-release() {
-    # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot
-    # optimization.
-
     local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )
     if [[ -n "${NODEUP_HASH:-}" ]]; then
       local -r nodeup_hash="${NODEUP_HASH}"


### PR DESCRIPTION
Cherry pick of #8936 on release-1.17.

#8936: Remove irrelevant TODO comment from userdata

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.