### PR TITLE
Use latest patch version for GO in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - osx
 go:
   # 1.12 is no longer supported by apimachinery; we recommend 1.13
-  - "1.13"
-  - "1.14"
+  - 1.13.x
+  - 1.14.x
 
 go_import_path: k8s.io/kops
 
@@ -16,11 +16,11 @@ jobs:
   # Exclude GO 1.14 for OSX until it becomes the default because of limited availability
   exclude:
     - os: osx
-      go: "1.14"
+      go: 1.14.x
 
   include:
     - name: Verify
       os: linux
-      go: "1.13"
+      go: 1.13.x
       script:
         - GOPROXY=https://proxy.golang.org make travis-ci


### PR DESCRIPTION
At the moment, Travis runs tests using the `.0` version of GO.
Would be better if Travis would use the latest patch version of GO, which is closer to what is used in official builds.
https://docs.travis-ci.com/user/languages/go/#specifying-a-go-version-to-use