### PR TITLE
Add custom route53 endpoint for aws china region

### DIFF
--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53.go
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53.go
@@ -19,6 +19,8 @@ package route53
 
 import (
 	"io"
+	"strings"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -58,7 +60,10 @@ func newRoute53(config io.Reader) (*Interface, error) {
 	// Connect to AWS Route53 - TODO: Do more sophisticated auth
 
 	awsConfig := aws.NewConfig()
-
+	
+	if strings.HasPrefix(os.Getenv("AWS_REGION"), "cn-") {
+		awsConfig = awsConfig.WithEndpoint("https://api.route53.cn")
+	}
 	// This avoids a confusing error message when we fail to get credentials
 	// e.g. https://github.com/kubernetes/kops/issues/605
 	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true)

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -268,6 +268,10 @@ func NewAWSCloud(region string, tags map[string]string) (AWSCloud, error) {
 		c.autoscaling.Handlers.Send.PushFront(requestLogger)
 		c.addHandlers(region, &c.autoscaling.Handlers)
 
+		if strings.HasPrefix(region, "cn-") {
+			config = config.WithEndpoint("https://api.route53.cn")
+		}
+		
 		sess, err = session.NewSession(config)
 		if err != nil {
 			return c, err


### PR DESCRIPTION
AWS CN supports route53 service however endpoint is slightly differnet from what is provided by aws-sdk-go. Instead of `https://route53.cn-northwest-1.amazonaws.com.cn`  url we should use `https://api.route53.cn`. Since this is not implemented in aws-sdk-go, my proposition is to add exception in kops for china regions to use custom route53 endpoint. This will solve #7871 
 