### PR TITLE
Automated cherry pick of #8945: Load the correct certificate before deleting

### DIFF
--- a/upup/pkg/fi/BUILD.bazel
+++ b/upup/pkg/fi/BUILD.bazel
@@ -72,6 +72,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/apis/kops:go_default_library",
         "//pkg/pki:go_default_library",
         "//util/pkg/vfs:go_default_library",
     ],

--- a/upup/pkg/fi/vfs_castore.go
+++ b/upup/pkg/fi/vfs_castore.go
@@ -1063,7 +1063,7 @@ func (c *VFSCAStore) deletePrivateKey(name string, id string) (bool, error) {
 func (c *VFSCAStore) deleteCertificate(name string, id string) (bool, error) {
 	// Update the bundle
 	{
-		p := c.buildPrivateKeyPoolPath(name)
+		p := c.buildCertificatePoolPath(name)
 		ks, err := c.loadCertificates(p, false)
 		if err != nil {
 			return false, err

--- a/upup/pkg/fi/vfs_castore_test.go
+++ b/upup/pkg/fi/vfs_castore_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/pki"
 	"k8s.io/kops/util/pkg/vfs"
 )
@@ -212,6 +213,22 @@ spec:
 		if string(roundTrip) != privateKeyData {
 			t.Fatalf("unexpected round-tripped private key data: %q", string(roundTrip))
 		}
+	}
+
+	// Check that keyset gets deleted
+	{
+		keyset := &kops.Keyset{}
+		keyset.Name = "ca"
+		keyset.Spec.Type = kops.SecretTypeKeypair
+
+		s.DeleteKeysetItem(keyset, "237054359138908419352140518924933177492")
+
+		_, err := pathMap["memfs://tests/private/ca/237054359138908419352140518924933177492.key"].ReadFile()
+		pathMap["memfs://tests/private/ca/237054359138908419352140518924933177492.key"].ReadFile()
+		if err == nil {
+			t.Fatalf("File memfs://tests/private/ca/237054359138908419352140518924933177492.key still exists")
+		}
+
 	}
 
 }


### PR DESCRIPTION
Cherry pick of #8945 on release-1.16.

#8945: Load the correct certificate before deleting

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.