### PR TITLE
Update Calico and Canal to latest patch versions

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -7645,6 +7645,7 @@ spec:
               command:
               - /bin/calico-node
               - -felix-live
+              - -bird-live
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
@@ -8490,7 +8491,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.13.2
+      - image: calico/typha:v3.13.3
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -8602,7 +8603,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.13.2
+          image: calico/cni:v3.13.3
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -8624,7 +8625,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.13.2
+          image: calico/cni:v3.13.3
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -8660,7 +8661,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.13.2
+          image: calico/pod2daemon-flexvol:v3.13.3
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -8671,7 +8672,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.13.2
+          image: calico/node:v3.13.3
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -8875,7 +8876,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.13.2
+          image: calico/kube-controllers:v3.13.3
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS
@@ -11530,7 +11531,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.12.0
+      - image: calico/typha:v3.12.1
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -11647,7 +11648,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.12.0
+          image: calico/cni:v3.12.1
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -11683,7 +11684,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.12.0
+          image: calico/pod2daemon-flexvol:v3.12.1
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -11694,7 +11695,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.12.0
+          image: calico/node:v3.12.1
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -12454,7 +12455,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.13.2
+      - image: calico/typha:v3.13.3
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -12565,7 +12566,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.13.2
+          image: calico/cni:v3.13.3
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -12601,7 +12602,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.13.2
+          image: calico/pod2daemon-flexvol:v3.13.3
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -12612,7 +12613,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.13.2
+          image: calico/node:v3.13.3
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template
@@ -552,7 +552,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.12.0
+      - image: calico/typha:v3.12.1
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -669,7 +669,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.12.0
+          image: calico/cni:v3.12.1
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -705,7 +705,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.12.0
+          image: calico/pod2daemon-flexvol:v3.12.1
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -716,7 +716,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.12.0
+          image: calico/node:v3.12.1
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.16.yaml.template
@@ -549,7 +549,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.13.2
+      - image: calico/typha:v3.13.3
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -660,7 +660,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.13.2
+          image: calico/cni:v3.13.3
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -696,7 +696,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.13.2
+          image: calico/pod2daemon-flexvol:v3.13.3
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -707,7 +707,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.13.2
+          image: calico/node:v3.13.3
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -844,6 +844,7 @@ spec:
               command:
               - /bin/calico-node
               - -felix-live
+              - -bird-live
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -586,7 +586,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.13.2
+      - image: calico/typha:v3.13.3
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -698,7 +698,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.13.2
+          image: calico/cni:v3.13.3
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -720,7 +720,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.13.2
+          image: calico/cni:v3.13.3
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -756,7 +756,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.13.2
+          image: calico/pod2daemon-flexvol:v3.13.3
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -767,7 +767,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.13.2
+          image: calico/node:v3.13.3
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -971,7 +971,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.13.2
+          image: calico/kube-controllers:v3.13.3
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -725,8 +725,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		versions := map[string]string{
 			"k8s-1.7":    "2.6.12-kops.1",
 			"k8s-1.7-v3": "3.8.0-kops.2",
-			"k8s-1.12":   "3.9.5-kops.1",
-			"k8s-1.16":   "3.13.2-kops.1",
+			"k8s-1.12":   "3.9.5-kops.2",
+			"k8s-1.16":   "3.13.3-kops.1",
 		}
 
 		{
@@ -793,8 +793,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		versions := map[string]string{
 			"k8s-1.9":  "3.2.3-kops.1",
 			"k8s-1.12": "3.7.5-kops.1",
-			"k8s-1.15": "3.12.0-kops.1",
-			"k8s-1.16": "3.13.2-kops.1",
+			"k8s-1.15": "3.12.1-kops.1",
+			"k8s-1.16": "3.13.3-kops.1",
 		}
 		{
 			id := "k8s-1.9"


### PR DESCRIPTION
* Calico and Canal `3.13.3` for k8s 1.16+
* Canal `v3.12.1` for k8s 1.15
* Calico liveness probe for k8s 1.12-1.15