### PR TITLE
Profiling and protect kernel defaults flags

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -480,6 +480,16 @@ spec:
     volumePluginDirectory: /provide/a/writable/path/here
 ```
 
+### Protect Kernel Defaults
+
+Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults. (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.)
+
+```yaml
+spec:
+  kubelet:
+    protectKernelDefaults: true
+```
+
 ## kubeScheduler
 
 This block contains configurations for `kube-scheduler`.  See https://kubernetes.io/docs/admin/kube-scheduler/

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -315,9 +315,9 @@ spec:
   kubeAPIServer:
     maxMutatingRequestsInflight: 450
 ```
-### profiling
+### Profiling
 
-Disable profiling via web interface (enabled by default):
+Profiling via web interface `host:port/debug/pprof/`. (default: true)
 
 ```yaml
 spec:
@@ -482,7 +482,7 @@ spec:
 
 ### Protect Kernel Defaults
 
-Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults. (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.)
+Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.
 
 ```yaml
 spec:

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -315,6 +315,15 @@ spec:
   kubeAPIServer:
     maxMutatingRequestsInflight: 450
 ```
+### profiling
+
+Disable profiling via web interface (enabled by default):
+
+```yaml
+spec:
+  kubeAPIServer:
+    enableProfiling: false
+```
 
 ### runtimeConfig
 
@@ -475,10 +484,11 @@ spec:
 
 This block contains configurations for `kube-scheduler`.  See https://kubernetes.io/docs/admin/kube-scheduler/
 
- ```yaml
- spec:
-   kubeScheduler:
-     usePolicyConfigMap: true
+```yaml
+spec:
+  kubeScheduler:
+    usePolicyConfigMap: true
+    enableProfiling: false
 ```
 
 Will make kube-scheduler use the scheduler policy from configmap "scheduler-policy" in namespace kube-system.
@@ -577,6 +587,7 @@ spec:
     horizontalPodAutoscalerUpscaleDelay: 3m0s
     horizontalPodAutoscalerTolerance: 0.1
     experimentalClusterSigningDuration: 8760h0m0s
+    enableProfiling: false
 ```
 
 For more details on `horizontalPodAutoscaler` flags see the [official HPA docs](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) and the [Kops guides on how to set it up](horizontal_pod_autoscaling.md).

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1073,7 +1073,8 @@ spec:
                       authentication
                     type: boolean
                   enableProfiling:
-                    description: Enable profiling via web interface
+                    description: EnableProfiling enables profiling via web interface
+                      host:port/debug/pprof/
                     type: boolean
                   encryptionProviderConfig:
                     description: EncryptionProviderConfig enables encryption at rest
@@ -1395,7 +1396,8 @@ spec:
                       type: string
                     type: array
                   enableProfiling:
-                    description: Enable profiling via web interface
+                    description: EnableProfiling enables profiling via web interface
+                      host:port/debug/pprof/
                     type: boolean
                   experimentalClusterSigningDuration:
                     description: ExperimentalClusterSigningDuration is the duration
@@ -1752,7 +1754,8 @@ spec:
                     format: int32
                     type: integer
                   enableProfiling:
-                    description: Enable profiling via web interface
+                    description: EnableProfiling enables profiling via web interface
+                      host:port/debug/pprof/
                     type: boolean
                   featureGates:
                     additionalProperties:
@@ -2075,9 +2078,7 @@ spec:
                     description: 'Default kubelet behaviour for kernel tuning. If
                       set, kubelet errors if any of kernel tunables is different than
                       kubelet defaults. (DEPRECATED: This parameter should be set
-                      via the config file specified by the Kubelet''s --config flag.
-                      See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
-                      for more information.)'
+                      via the config file specified by the Kubelet''s --config flag.'
                     type: boolean
                   readOnlyPort:
                     description: ReadOnlyPort is the port used by the kubelet api
@@ -2450,9 +2451,7 @@ spec:
                     description: 'Default kubelet behaviour for kernel tuning. If
                       set, kubelet errors if any of kernel tunables is different than
                       kubelet defaults. (DEPRECATED: This parameter should be set
-                      via the config file specified by the Kubelet''s --config flag.
-                      See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
-                      for more information.)'
+                      via the config file specified by the Kubelet''s --config flag.'
                     type: boolean
                   readOnlyPort:
                     description: ReadOnlyPort is the port used by the kubelet api

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1315,8 +1315,6 @@ spec:
                   tokenAuthFile:
                     description: 'TODO: Remove unused TokenAuthFile'
                     type: string
-                required:
-                - enableProfiling
                 type: object
               kubeControllerManager:
                 description: KubeControllerManagerConfig is the configuration for
@@ -1568,8 +1566,6 @@ spec:
                     description: UseServiceAccountCredentials controls whether we
                       use individual service account credentials for each controller.
                     type: boolean
-                required:
-                - enableProfiling
                 type: object
               kubeDNS:
                 description: KubeDNSConfig defines the kube dns configuration
@@ -1839,8 +1835,6 @@ spec:
                     description: UsePolicyConfigMap enable setting the scheduler policy
                       from a configmap
                     type: boolean
-                required:
-                - enableProfiling
                 type: object
               kubelet:
                 description: KubeletConfigSpec defines the kubelet configuration

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1072,6 +1072,9 @@ spec:
                       in the 'kube-system' namespace to be used for TLS bootstrapping
                       authentication
                     type: boolean
+                  enableProfiling:
+                    description: Enable profiling via web interface
+                    type: boolean
                   encryptionProviderConfig:
                     description: EncryptionProviderConfig enables encryption at rest
                       for secrets.
@@ -1312,6 +1315,8 @@ spec:
                   tokenAuthFile:
                     description: 'TODO: Remove unused TokenAuthFile'
                     type: string
+                required:
+                - enableProfiling
                 type: object
               kubeControllerManager:
                 description: KubeControllerManagerConfig is the configuration for
@@ -1391,6 +1396,9 @@ spec:
                     items:
                       type: string
                     type: array
+                  enableProfiling:
+                    description: Enable profiling via web interface
+                    type: boolean
                   experimentalClusterSigningDuration:
                     description: ExperimentalClusterSigningDuration is the duration
                       that determines the length of duration that the signed certificates
@@ -1560,6 +1568,8 @@ spec:
                     description: UseServiceAccountCredentials controls whether we
                       use individual service account credentials for each controller.
                     type: boolean
+                required:
+                - enableProfiling
                 type: object
               kubeDNS:
                 description: KubeDNSConfig defines the kube dns configuration
@@ -1745,6 +1755,9 @@ spec:
                       the burst quota is exhausted
                     format: int32
                     type: integer
+                  enableProfiling:
+                    description: Enable profiling via web interface
+                    type: boolean
                   featureGates:
                     additionalProperties:
                       type: string
@@ -1826,6 +1839,8 @@ spec:
                     description: UsePolicyConfigMap enable setting the scheduler policy
                       from a configmap
                     type: boolean
+                required:
+                - enableProfiling
                 type: object
               kubelet:
                 description: KubeletConfigSpec defines the kubelet configuration
@@ -2062,6 +2077,14 @@ spec:
                     description: config is the path to the config file or directory
                       of files
                     type: string
+                  protectKernelDefaults:
+                    description: 'Default kubelet behaviour for kernel tuning. If
+                      set, kubelet errors if any of kernel tunables is different than
+                      kubelet defaults. (DEPRECATED: This parameter should be set
+                      via the config file specified by the Kubelet''s --config flag.
+                      See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
+                      for more information.)'
+                    type: boolean
                   readOnlyPort:
                     description: ReadOnlyPort is the port used by the kubelet api
                       for read-only access (default 10255)
@@ -2429,6 +2452,14 @@ spec:
                     description: config is the path to the config file or directory
                       of files
                     type: string
+                  protectKernelDefaults:
+                    description: 'Default kubelet behaviour for kernel tuning. If
+                      set, kubelet errors if any of kernel tunables is different than
+                      kubelet defaults. (DEPRECATED: This parameter should be set
+                      via the config file specified by the Kubelet''s --config flag.
+                      See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
+                      for more information.)'
+                    type: boolean
                   readOnlyPort:
                     description: ReadOnlyPort is the port used by the kubelet api
                       for read-only access (default 10255)

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -460,9 +460,7 @@ spec:
                     description: 'Default kubelet behaviour for kernel tuning. If
                       set, kubelet errors if any of kernel tunables is different than
                       kubelet defaults. (DEPRECATED: This parameter should be set
-                      via the config file specified by the Kubelet''s --config flag.
-                      See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
-                      for more information.)'
+                      via the config file specified by the Kubelet''s --config flag.'
                     type: boolean
                   readOnlyPort:
                     description: ReadOnlyPort is the port used by the kubelet api

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -456,6 +456,14 @@ spec:
                     description: config is the path to the config file or directory
                       of files
                     type: string
+                  protectKernelDefaults:
+                    description: 'Default kubelet behaviour for kernel tuning. If
+                      set, kubelet errors if any of kernel tunables is different than
+                      kubelet defaults. (DEPRECATED: This parameter should be set
+                      via the config file specified by the Kubelet''s --config flag.
+                      See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
+                      for more information.)'
+                    type: boolean
                   readOnlyPort:
                     description: ReadOnlyPort is the port used by the kubelet api
                       for read-only access (default 10255)

--- a/nodeup/pkg/model/kube_apiserver_test.go
+++ b/nodeup/pkg/model/kube_apiserver_test.go
@@ -223,6 +223,12 @@ func Test_KubeAPIServer_BuildFlags(t *testing.T) {
 			},
 			"--audit-dynamic-configuration=true --insecure-port=0 --secure-port=0",
 		},
+		{
+			kops.KubeAPIServerConfig{
+				EnableProfiling: &[]bool{false}[0],
+			},
+			"--insecure-port=0 --profiling=false --secure-port=0",
+		},
 	}
 
 	for _, g := range grid {

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -203,7 +203,7 @@ type KubeletConfigSpec struct {
 	RotateCertificates *bool `json:"rotateCertificates,omitempty" flag:"rotate-certificates"`
 
 	// Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.
-	// (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.)
+	// (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag.
 	ProtectKernelDefaults *bool `json:"protectKernelDefaults,omitempty" flag:"protect-kernel-defaults"`
 }
 
@@ -470,7 +470,7 @@ type KubeAPIServerConfig struct {
 	// AuditDynamicConfiguration enables dynamic audit configuration via AuditSinks
 	AuditDynamicConfiguration *bool `json:"auditDynamicConfiguration,omitempty" flag:"audit-dynamic-configuration"`
 
-	// Enable profiling via web interface
+	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
 }
 
@@ -576,7 +576,7 @@ type KubeControllerManagerConfig struct {
 	// The number of replicationcontroller objects that are allowed to sync concurrently.
 	ConcurrentRcSyncs *int32 `json:"concurrentRcSyncs,omitempty" flag:"concurrent-rc-syncs"`
 
-	// Enable profiling via web interface
+	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
 }
 
@@ -631,7 +631,7 @@ type KubeSchedulerConfig struct {
 	// Burst sets the maximum qps to send to apiserver after the burst quota is exhausted
 	Burst int32 `json:"burst,omitempty" configfile:"ClientConnection.Burst"`
 
-	// Enable profiling via web interface
+	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
 }
 

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -201,6 +201,10 @@ type KubeletConfigSpec struct {
 
 	// rotateCertificates enables client certificate rotation.
 	RotateCertificates *bool `json:"rotateCertificates,omitempty" flag:"rotate-certificates"`
+
+	// Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.
+	// (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.)
+	ProtectKernelDefaults *bool `json:"protectKernelDefaults,omitempty" flag:"protect-kernel-defaults"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -465,6 +465,9 @@ type KubeAPIServerConfig struct {
 
 	// AuditDynamicConfiguration enables dynamic audit configuration via AuditSinks
 	AuditDynamicConfiguration *bool `json:"auditDynamicConfiguration,omitempty" flag:"audit-dynamic-configuration"`
+
+	// Enable profiling via web interface
+	EnableProfiling *bool `json:"enableProfiling,imitempty" flag:"profiling"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller
@@ -568,6 +571,9 @@ type KubeControllerManagerConfig struct {
 	ConcurrentServiceaccountTokenSyncs *int32 `json:"concurrentServiceaccountTokenSyncs,omitempty" flag:"concurrent-serviceaccount-token-syncs"`
 	// The number of replicationcontroller objects that are allowed to sync concurrently.
 	ConcurrentRcSyncs *int32 `json:"concurrentRcSyncs,omitempty" flag:"concurrent-rc-syncs"`
+
+	// Enable profiling via web interface
+	EnableProfiling *bool `json:"enableProfiling,imitempty" flag:"profiling"`
 }
 
 // CloudControllerManagerConfig is the configuration of the cloud controller
@@ -620,6 +626,9 @@ type KubeSchedulerConfig struct {
 	Qps *resource.Quantity `json:"qps,omitempty" configfile:"ClientConnection.QPS"`
 	// Burst sets the maximum qps to send to apiserver after the burst quota is exhausted
 	Burst int32 `json:"burst,omitempty" configfile:"ClientConnection.Burst"`
+
+	// Enable profiling via web interface
+	EnableProfiling *bool `json:"enableProfiling,imitempty" flag:"profiling"`
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -471,7 +471,7 @@ type KubeAPIServerConfig struct {
 	AuditDynamicConfiguration *bool `json:"auditDynamicConfiguration,omitempty" flag:"audit-dynamic-configuration"`
 
 	// Enable profiling via web interface
-	EnableProfiling *bool `json:"enableProfiling,imitempty" flag:"profiling"`
+	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller
@@ -577,7 +577,7 @@ type KubeControllerManagerConfig struct {
 	ConcurrentRcSyncs *int32 `json:"concurrentRcSyncs,omitempty" flag:"concurrent-rc-syncs"`
 
 	// Enable profiling via web interface
-	EnableProfiling *bool `json:"enableProfiling,imitempty" flag:"profiling"`
+	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
 }
 
 // CloudControllerManagerConfig is the configuration of the cloud controller
@@ -632,7 +632,7 @@ type KubeSchedulerConfig struct {
 	Burst int32 `json:"burst,omitempty" configfile:"ClientConnection.Burst"`
 
 	// Enable profiling via web interface
-	EnableProfiling *bool `json:"enableProfiling,imitempty" flag:"profiling"`
+	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -201,6 +201,10 @@ type KubeletConfigSpec struct {
 
 	// rotateCertificates enables client certificate rotation.
 	RotateCertificates *bool `json:"rotateCertificates,omitempty" flag:"rotate-certificates"`
+
+	// Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.
+	// (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.)
+	ProtectKernelDefaults *bool `json:"protectKernelDefaults,omitempty" flag:"protect-kernel-defaults"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -465,6 +465,9 @@ type KubeAPIServerConfig struct {
 
 	// AuditDynamicConfiguration enables dynamic audit configuration via AuditSinks
 	AuditDynamicConfiguration *bool `json:"auditDynamicConfiguration,omitempty" flag:"audit-dynamic-configuration"`
+
+	// Enable profiling via web interface
+	EnableProfiling *bool `json:"enableProfiling,imitempty" flag:"profiling"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller
@@ -569,6 +572,9 @@ type KubeControllerManagerConfig struct {
 	// The number of replicationcontroller objects that are allowed to sync concurrently.
 	// This only works on kubernetes >= 1.14
 	ConcurrentRcSyncs *int32 `json:"concurrentRcSyncs,omitempty" flag:"concurrent-rc-syncs"`
+
+	// Enable profiling via web interface
+	EnableProfiling *bool `json:"enableProfiling,imitempty" flag:"profiling"`
 }
 
 // CloudControllerManagerConfig is the configuration of the cloud controller
@@ -621,6 +627,9 @@ type KubeSchedulerConfig struct {
 	Qps *resource.Quantity `json:"qps,omitempty"`
 	// Burst sets the maximum qps to send to apiserver after the burst quota is exhausted
 	Burst int32 `json:"burst,omitempty"`
+
+	// Enable profiling via web interface
+	EnableProfiling *bool `json:"enableProfiling,imitempty" flag:"profiling"`
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -471,7 +471,7 @@ type KubeAPIServerConfig struct {
 	AuditDynamicConfiguration *bool `json:"auditDynamicConfiguration,omitempty" flag:"audit-dynamic-configuration"`
 
 	// Enable profiling via web interface
-	EnableProfiling *bool `json:"enableProfiling,imitempty" flag:"profiling"`
+	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller
@@ -578,7 +578,7 @@ type KubeControllerManagerConfig struct {
 	ConcurrentRcSyncs *int32 `json:"concurrentRcSyncs,omitempty" flag:"concurrent-rc-syncs"`
 
 	// Enable profiling via web interface
-	EnableProfiling *bool `json:"enableProfiling,imitempty" flag:"profiling"`
+	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
 }
 
 // CloudControllerManagerConfig is the configuration of the cloud controller
@@ -633,7 +633,7 @@ type KubeSchedulerConfig struct {
 	Burst int32 `json:"burst,omitempty"`
 
 	// Enable profiling via web interface
-	EnableProfiling *bool `json:"enableProfiling,imitempty" flag:"profiling"`
+	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -203,7 +203,7 @@ type KubeletConfigSpec struct {
 	RotateCertificates *bool `json:"rotateCertificates,omitempty" flag:"rotate-certificates"`
 
 	// Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.
-	// (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.)
+	// (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag.
 	ProtectKernelDefaults *bool `json:"protectKernelDefaults,omitempty" flag:"protect-kernel-defaults"`
 }
 
@@ -470,7 +470,7 @@ type KubeAPIServerConfig struct {
 	// AuditDynamicConfiguration enables dynamic audit configuration via AuditSinks
 	AuditDynamicConfiguration *bool `json:"auditDynamicConfiguration,omitempty" flag:"audit-dynamic-configuration"`
 
-	// Enable profiling via web interface
+	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
 }
 
@@ -577,7 +577,7 @@ type KubeControllerManagerConfig struct {
 	// This only works on kubernetes >= 1.14
 	ConcurrentRcSyncs *int32 `json:"concurrentRcSyncs,omitempty" flag:"concurrent-rc-syncs"`
 
-	// Enable profiling via web interface
+	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
 }
 
@@ -632,7 +632,7 @@ type KubeSchedulerConfig struct {
 	// Burst sets the maximum qps to send to apiserver after the burst quota is exhausted
 	Burst int32 `json:"burst,omitempty"`
 
-	// Enable profiling via web interface
+	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3783,6 +3783,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.CPURequest = in.CPURequest
 	out.EventTTL = in.EventTTL
 	out.AuditDynamicConfiguration = in.AuditDynamicConfiguration
+	out.EnableProfiling = in.EnableProfiling
 	return nil
 }
 
@@ -3884,6 +3885,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.CPURequest = in.CPURequest
 	out.EventTTL = in.EventTTL
 	out.AuditDynamicConfiguration = in.AuditDynamicConfiguration
+	out.EnableProfiling = in.EnableProfiling
 	return nil
 }
 
@@ -3942,6 +3944,7 @@ func autoConvert_v1alpha2_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.ConcurrentResourceQuotaSyncs = in.ConcurrentResourceQuotaSyncs
 	out.ConcurrentServiceaccountTokenSyncs = in.ConcurrentServiceaccountTokenSyncs
 	out.ConcurrentRcSyncs = in.ConcurrentRcSyncs
+	out.EnableProfiling = in.EnableProfiling
 	return nil
 }
 
@@ -4000,6 +4003,7 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha2_KubeControllerMana
 	out.ConcurrentResourceQuotaSyncs = in.ConcurrentResourceQuotaSyncs
 	out.ConcurrentServiceaccountTokenSyncs = in.ConcurrentServiceaccountTokenSyncs
 	out.ConcurrentRcSyncs = in.ConcurrentRcSyncs
+	out.EnableProfiling = in.EnableProfiling
 	return nil
 }
 
@@ -4148,6 +4152,7 @@ func autoConvert_v1alpha2_KubeSchedulerConfig_To_kops_KubeSchedulerConfig(in *Ku
 	out.MaxPersistentVolumes = in.MaxPersistentVolumes
 	out.Qps = in.Qps
 	out.Burst = in.Burst
+	out.EnableProfiling = in.EnableProfiling
 	return nil
 }
 
@@ -4174,6 +4179,7 @@ func autoConvert_kops_KubeSchedulerConfig_To_v1alpha2_KubeSchedulerConfig(in *ko
 	out.MaxPersistentVolumes = in.MaxPersistentVolumes
 	out.Qps = in.Qps
 	out.Burst = in.Burst
+	out.EnableProfiling = in.EnableProfiling
 	return nil
 }
 
@@ -4260,6 +4266,7 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.RegistryBurst = in.RegistryBurst
 	out.TopologyManagerPolicy = in.TopologyManagerPolicy
 	out.RotateCertificates = in.RotateCertificates
+	out.ProtectKernelDefaults = in.ProtectKernelDefaults
 	return nil
 }
 
@@ -4346,6 +4353,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.RegistryBurst = in.RegistryBurst
 	out.TopologyManagerPolicy = in.TopologyManagerPolicy
 	out.RotateCertificates = in.RotateCertificates
+	out.ProtectKernelDefaults = in.ProtectKernelDefaults
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2253,6 +2253,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableProfiling != nil {
+		in, out := &in.EnableProfiling, &out.EnableProfiling
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 
@@ -2426,6 +2431,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(int32)
 		**out = **in
 	}
+	if in.EnableProfiling != nil {
+		in, out := &in.EnableProfiling, &out.EnableProfiling
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 
@@ -2587,6 +2597,11 @@ func (in *KubeSchedulerConfig) DeepCopyInto(out *KubeSchedulerConfig) {
 		in, out := &in.Qps, &out.Qps
 		x := (*in).DeepCopy()
 		*out = &x
+	}
+	if in.EnableProfiling != nil {
+		in, out := &in.EnableProfiling, &out.EnableProfiling
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -2824,6 +2839,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 	}
 	if in.RotateCertificates != nil {
 		in, out := &in.RotateCertificates, &out.RotateCertificates
+		*out = new(bool)
+		**out = **in
+	}
+	if in.ProtectKernelDefaults != nil {
+		in, out := &in.ProtectKernelDefaults, &out.ProtectKernelDefaults
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2435,6 +2435,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableProfiling != nil {
+		in, out := &in.EnableProfiling, &out.EnableProfiling
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 
@@ -2608,6 +2613,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(int32)
 		**out = **in
 	}
+	if in.EnableProfiling != nil {
+		in, out := &in.EnableProfiling, &out.EnableProfiling
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 
@@ -2769,6 +2779,11 @@ func (in *KubeSchedulerConfig) DeepCopyInto(out *KubeSchedulerConfig) {
 		in, out := &in.Qps, &out.Qps
 		x := (*in).DeepCopy()
 		*out = &x
+	}
+	if in.EnableProfiling != nil {
+		in, out := &in.EnableProfiling, &out.EnableProfiling
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -3006,6 +3021,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 	}
 	if in.RotateCertificates != nil {
 		in, out := &in.RotateCertificates, &out.RotateCertificates
+		*out = new(bool)
+		**out = **in
+	}
+	if in.ProtectKernelDefaults != nil {
+		in, out := &in.ProtectKernelDefaults, &out.ProtectKernelDefaults
 		*out = new(bool)
 		**out = **in
 	}


### PR DESCRIPTION
Adding support for two flags required by CIS / aquasecurity/kube-bench.

Work on this started previously [here](https://github.com/kubernetes/kops/pull/4799).