### PR TITLE
Migrates GCE sdk from v0.beta to v1

### DIFF
--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -24,6 +24,8 @@
 
 * GCE has a new flag: `--gce-service-account`. This takes the email of an existing GCP service account and launches the instances with it. This setting applies to the whole cluster (ie: it is not currently designed to support Instance Groups with different service accounts). If you do not specify a service account during cluster creation, the default compute service account will be used which matches the prior behavior.
 
+* Google API client libraries updated from v0.beta to v1.
+
 # Breaking changes
 
 * Support for Docker versions 1.11, 1.12 and 1.13 has been removed because of the [dockerproject.org shut down](https://www.docker.com/blog/changes-dockerproject-org-apt-yum-repositories/). Those affected must upgrade to a newer Docker version.

--- a/pkg/nodeidentity/gce/BUILD.bazel
+++ b/pkg/nodeidentity/gce/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     deps = [
         "//pkg/nodeidentity:go_default_library",
         "//vendor/cloud.google.com/go/compute/metadata:go_default_library",
-        "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
+        "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/pkg/nodeidentity/gce/identify.go
+++ b/pkg/nodeidentity/gce/identify.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/compute/metadata"
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/nodeidentity"

--- a/pkg/resources/gce/BUILD.bazel
+++ b/pkg/resources/gce/BUILD.bazel
@@ -13,7 +13,7 @@ go_library(
         "//pkg/resources:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/gce:go_default_library",
-        "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
+        "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/google.golang.org/api/dns/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/pkg/resources/gce/dump.go
+++ b/pkg/resources/gce/dump.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"sync"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/resources"
 	gce "k8s.io/kops/upup/pkg/fi/cloudup/gce"

--- a/pkg/resources/gce/gce.go
+++ b/pkg/resources/gce/gce.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	clouddns "google.golang.org/api/dns/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"

--- a/protokube/pkg/gossip/gce/BUILD.bazel
+++ b/protokube/pkg/gossip/gce/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//protokube/pkg/gossip:go_default_library",
-        "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
+        "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/protokube/pkg/gossip/gce/seeds.go
+++ b/protokube/pkg/gossip/gce/seeds.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/protokube/pkg/gossip"
 )

--- a/protokube/pkg/protokube/BUILD.bazel
+++ b/protokube/pkg/protokube/BUILD.bazel
@@ -61,7 +61,7 @@ go_library(
         "//vendor/github.com/digitalocean/godo:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach:go_default_library",
-        "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
+        "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/protokube/pkg/protokube/gce_volume.go
+++ b/protokube/pkg/protokube/gce_volume.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/compute/metadata"
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/protokube/pkg/etcd"
 	"k8s.io/kops/protokube/pkg/gossip"

--- a/upup/pkg/fi/cloudup/gce/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/gce/BUILD.bazel
@@ -25,7 +25,7 @@ go_library(
         "//protokube/pkg/etcd:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//vendor/golang.org/x/oauth2/google:go_default_library",
-        "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
+        "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/google.golang.org/api/dns/v1:go_default_library",
         "//vendor/google.golang.org/api/googleapi:go_default_library",
         "//vendor/google.golang.org/api/iam/v1:go_default_library",

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"golang.org/x/oauth2/google"
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/dns/v1"
 	"google.golang.org/api/iam/v1"
 	oauth2 "google.golang.org/api/oauth2/v2"

--- a/upup/pkg/fi/cloudup/gce/instancegroups.go
+++ b/upup/pkg/fi/cloudup/gce/instancegroups.go
@@ -23,7 +23,7 @@ import (
 	"hash/fnv"
 	"strings"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/apis/kops"

--- a/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
@@ -19,7 +19,7 @@ package gce
 import (
 	"fmt"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/dns/v1"
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/storage/v1"

--- a/upup/pkg/fi/cloudup/gce/network.go
+++ b/upup/pkg/fi/cloudup/gce/network.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"net"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"

--- a/upup/pkg/fi/cloudup/gce/op.go
+++ b/upup/pkg/fi/cloudup/gce/op.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"time"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"

--- a/upup/pkg/fi/cloudup/gce/status.go
+++ b/upup/pkg/fi/cloudup/gce/status.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/protokube/pkg/etcd"

--- a/upup/pkg/fi/cloudup/gce/wrappers.go
+++ b/upup/pkg/fi/cloudup/gce/wrappers.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 )
 

--- a/upup/pkg/fi/cloudup/gcetasks/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/gcetasks/BUILD.bazel
@@ -38,7 +38,7 @@ go_library(
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/gce:go_default_library",
         "//upup/pkg/fi/cloudup/terraform:go_default_library",
-        "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
+        "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/google.golang.org/api/storage/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/upup/pkg/fi/cloudup/gcetasks/address.go
+++ b/upup/pkg/fi/cloudup/gcetasks/address.go
@@ -19,7 +19,7 @@ package gcetasks
 import (
 	"fmt"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"

--- a/upup/pkg/fi/cloudup/gcetasks/disk.go
+++ b/upup/pkg/fi/cloudup/gcetasks/disk.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"

--- a/upup/pkg/fi/cloudup/gcetasks/firewallrule.go
+++ b/upup/pkg/fi/cloudup/gcetasks/firewallrule.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"

--- a/upup/pkg/fi/cloudup/gcetasks/forwardingrule.go
+++ b/upup/pkg/fi/cloudup/gcetasks/forwardingrule.go
@@ -19,7 +19,7 @@ package gcetasks
 import (
 	"fmt"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"

--- a/upup/pkg/fi/cloudup/gcetasks/instance.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instance.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"strings"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"

--- a/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
@@ -151,13 +151,11 @@ func (_ *InstanceGroupManager) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Ins
 		}
 
 		if changes.TargetSize != nil {
-			request := &compute.InstanceGroupManagersResizeAdvancedRequest{
-				TargetSize: i.TargetSize,
+			newSize := int64(0)
+			if i.TargetSize != 0 {
+				newSize = int64(i.TargetSize)
 			}
-			if i.TargetSize == 0 {
-				request.ForceSendFields = append(request.ForceSendFields, "TargetSize")
-			}
-			op, err := t.Cloud.Compute().InstanceGroupManagers.ResizeAdvanced(t.Cloud.Project(), *e.Zone, i.Name, request).Do()
+			op, err := t.Cloud.Compute().InstanceGroupManagers.Resize(t.Cloud.Project(), *e.Zone, i.Name, newSize).Do()
 			if err != nil {
 				return fmt.Errorf("error resizing InstanceGroupManager: %v", err)
 			}

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/diff"
 	"k8s.io/kops/upup/pkg/fi"

--- a/upup/pkg/fi/cloudup/gcetasks/network.go
+++ b/upup/pkg/fi/cloudup/gcetasks/network.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"

--- a/upup/pkg/fi/cloudup/gcetasks/subnet.go
+++ b/upup/pkg/fi/cloudup/gcetasks/subnet.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"

--- a/upup/pkg/fi/cloudup/gcetasks/targetpool.go
+++ b/upup/pkg/fi/cloudup/gcetasks/targetpool.go
@@ -19,7 +19,7 @@ package gcetasks
 import (
 	"fmt"
 
-	compute "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"


### PR DESCRIPTION
Waiting on #8969 

Bumps the gcp libraries from v0beta to v1! 
`&compute.InstanceGroupManagersResizeAdvancedRequest` is only available in the beta libraries. I've updated the IGM resize method to reflect the [docs](https://cloud.google.com/compute/docs/reference/rest/v1/instanceGroupManagers/resize#go)

