### PR TITLE
Update alpha and stable channels with April updates

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -56,10 +56,10 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.17.0"
-    recommendedVersion: 1.17.4
+    recommendedVersion: 1.17.5
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
-    recommendedVersion: 1.16.8
+    recommendedVersion: 1.16.9
     requiredVersion: 1.16.0
   - range: ">=1.15.0"
     recommendedVersion: 1.15.11
@@ -83,11 +83,11 @@ spec:
   - range: ">=1.17.0-alpha.1"
     #recommendedVersion: "1.17.0"
     #requiredVersion: 1.17.0
-    kubernetesVersion: 1.17.4
+    kubernetesVersion: 1.17.5
   - range: ">=1.16.0-alpha.1"
     #recommendedVersion: "1.16.0"
     #requiredVersion: 1.16.0
-    kubernetesVersion: 1.16.8
+    kubernetesVersion: 1.16.9
   - range: ">=1.15.0-alpha.1"
     #recommendedVersion: "1.15.0"
     #requiredVersion: 1.15.0

--- a/channels/stable
+++ b/channels/stable
@@ -56,10 +56,10 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.17.0"
-    recommendedVersion: 1.17.3
+    recommendedVersion: 1.17.4
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
-    recommendedVersion: 1.16.7
+    recommendedVersion: 1.16.8
     requiredVersion: 1.16.0
   - range: ">=1.15.0"
     recommendedVersion: 1.15.10
@@ -83,11 +83,11 @@ spec:
   - range: ">=1.17.0-alpha.1"
     #recommendedVersion: "1.17.0"
     #requiredVersion: 1.17.0
-    kubernetesVersion: 1.17.3
+    kubernetesVersion: 1.17.4
   - range: ">=1.16.0-alpha.1"
     #recommendedVersion: "1.16.0"
     #requiredVersion: 1.16.0
-    kubernetesVersion: 1.16.7
+    kubernetesVersion: 1.16.8
   - range: ">=1.15.0-alpha.1"
     #recommendedVersion: "1.15.0"
     #requiredVersion: 1.15.0


### PR DESCRIPTION
The versions going to `stable` have been running in `alpha` for just over a month now, looks like it's safe to move to `stable`.