### PR TITLE
Default to Debian 9 (Stretch) for Kubernetes 1.8, 1.9 and 1.10

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -13,13 +13,13 @@ spec:
     - name: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2018-08-17
       providerID: aws
       kubernetesVersion: ">=1.7.0 <1.8.0"
-    - name: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-08-17
+    - name: kope.io/k8s-1.8-debian-stretch-amd64-hvm-ebs-2018-08-17
       providerID: aws
       kubernetesVersion: ">=1.8.0 <1.9.0"
-    - name: kope.io/k8s-1.9-debian-jessie-amd64-hvm-ebs-2018-08-17
+    - name: kope.io/k8s-1.9-debian-stretch-amd64-hvm-ebs-2018-08-17
       providerID: aws
       kubernetesVersion: ">=1.9.0 <1.10.0"
-    - name: kope.io/k8s-1.10-debian-jessie-amd64-hvm-ebs-2018-08-17
+    - name: kope.io/k8s-1.10-debian-stretch-amd64-hvm-ebs-2018-08-17
       providerID: aws
       kubernetesVersion: ">=1.10.0 <1.11.0"
     # Stretch is the default for 1.11 (for nvme)

--- a/channels/stable
+++ b/channels/stable
@@ -13,13 +13,13 @@ spec:
     - name: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2018-08-17
       providerID: aws
       kubernetesVersion: ">=1.7.0 <1.8.0"
-    - name: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-08-17
+    - name: kope.io/k8s-1.8-debian-stretch-amd64-hvm-ebs-2018-08-17
       providerID: aws
       kubernetesVersion: ">=1.8.0 <1.9.0"
-    - name: kope.io/k8s-1.9-debian-jessie-amd64-hvm-ebs-2018-08-17
+    - name: kope.io/k8s-1.9-debian-stretch-amd64-hvm-ebs-2018-08-17
       providerID: aws
       kubernetesVersion: ">=1.9.0 <1.10.0"
-    - name: kope.io/k8s-1.10-debian-jessie-amd64-hvm-ebs-2018-08-17
+    - name: kope.io/k8s-1.10-debian-stretch-amd64-hvm-ebs-2018-08-17
       providerID: aws
       kubernetesVersion: ">=1.10.0 <1.11.0"
     # Stretch is the default for 1.11 (for nvme)


### PR DESCRIPTION
Debian 8 (Jessie) are shutting down ahead of its soon to be EOL. As Kops still officially supports older versions of Kubernetes and images are already built it should use them by default.

Failing periodic e2e for 1.10:
https://testgrid.k8s.io/sig-cluster-lifecycle-kops#kops-aws-k8s-1.10

/cc @justinsb @rifelpet