### PR TITLE
Add healthcheck to aws-iam-authenticator

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -413,6 +413,12 @@ spec:
           limits:
             memory: {{ or .Authentication.Aws.MemoryLimit "20Mi" }}
             cpu: {{ or .Authentication.Aws.CPULimit "100m" }}
+        livenessProbe:
+          httpGet:
+            host: 127.0.0.1
+            path: /healthz
+            port: 21362
+            scheme: HTTPS
         volumeMounts:
         - name: config
           mountPath: /etc/aws-iam-authenticator/

--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
@@ -138,6 +138,12 @@ spec:
           limits:
             memory: {{ or .Authentication.Aws.MemoryLimit "20Mi" }}
             cpu: {{ or .Authentication.Aws.CPULimit "100m" }}
+        livenessProbe:
+          httpGet:
+            host: 127.0.0.1
+            path: /healthz
+            port: 21362
+            scheme: HTTPS
         volumeMounts:
         - name: config
           mountPath: /etc/aws-iam-authenticator/


### PR DESCRIPTION
This builds on PR #8423 by @rifelpet 

A 5.0.1 version of aws-iam-authenticator has not been released as of the creation of this PR, however I had the need to create internal version with the health check and decided to create the PR as a reminder to merger it in the future.
