### PR TITLE
Automated cherry pick of #8982: Bump cilium to 1.7.2

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -389,7 +389,7 @@ spec:
           value: {{ . }}
         {{ end }}
 {{ with .Networking.Cilium }}
-        image: "docker.io/cilium/cilium:{{- or .Version "v1.7.0" }}"
+        image: "docker.io/cilium/cilium:{{- or .Version "v1.7.2" }}"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -484,7 +484,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: "docker.io/cilium/cilium:{{- or .Version "v1.7.0" }}"
+        image: "docker.io/cilium/cilium:{{- or .Version "v1.7.2" }}"
 ## end of `with .Networking.Cilium`
 #{{ end }}
         imagePullPolicy: IfNotPresent
@@ -664,7 +664,7 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
-        image: "docker.io/cilium/operator:{{- if eq .Version "" -}}v1.7.0{{- else -}}{{ .Version }}{{- end -}}"
+        image: "docker.io/cilium/operator:{{- if eq .Version "" -}}v1.7.2{{- else -}}{{ .Version }}{{- end -}}"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         {{ if .EnablePrometheusMetrics }}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -1178,7 +1178,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 	if b.cluster.Spec.Networking.Cilium != nil {
 		key := "networking.cilium.io"
-		version := "1.7.0-kops.2"
+		version := "1.7.2-kops.1"
 
 		{
 			id := "k8s-1.7"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -119,12 +119,12 @@ spec:
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.7.0-kops.2
+    version: 1.7.2-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: 7b948480cb8939d14717e39f94cfd6df842a1933
+    manifestHash: 712c904ba592ca12e660b9248256a3d329fd6d9c
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.7.0-kops.2
+    version: 1.7.2-kops.1


### PR DESCRIPTION
Cherry pick of #8982 on release-1.17.

#8982: Bump cilium to 1.7.2

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.