### PR TITLE
GCE: needs to use v1 network resources, not beta

### DIFF
--- a/upup/pkg/fi/cloudup/gcetasks/network.go
+++ b/upup/pkg/fi/cloudup/gcetasks/network.go
@@ -76,7 +76,7 @@ func (e *Network) Find(c *fi.Context) (*Network, error) {
 
 func (e *Network) URL(project string) string {
 	u := gce.GoogleCloudURL{
-		Version: "beta",
+		Version: "v1",
 		Project: project,
 		Name:    *e.Name,
 		Type:    "networks",

--- a/upup/pkg/fi/cloudup/gcetasks/subnet.go
+++ b/upup/pkg/fi/cloudup/gcetasks/subnet.go
@@ -193,7 +193,7 @@ func (_ *Subnet) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Subnet) error {
 
 func (e *Subnet) URL(project string, region string) string {
 	u := gce.GoogleCloudURL{
-		Version: "beta",
+		Version: "v1",
 		Project: project,
 		Name:    *e.GCEName,
 		Type:    "subnetworks",


### PR DESCRIPTION
closes #9003 

~~I don't think this impacts existing clusters, but am checking...~~
Looks like this is a no-op for existing clusters, we're good to go.