### PR TITLE
Include secondary protocol flag always

### DIFF
--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -361,7 +361,7 @@ type ProtokubeFlags struct {
 	GossipListen   *string `json:"gossip-listen" flag:"gossip-listen"`
 	GossipSecret   *string `json:"gossip-secret" flag:"gossip-secret"`
 
-	GossipProtocolSecondary *string `json:"gossip-protocol-secondary" flag:"gossip-protocol-secondary"`
+	GossipProtocolSecondary *string `json:"gossip-protocol-secondary" flag:"gossip-protocol-secondary" flag-include-empty:"true"`
 	GossipListenSecondary   *string `json:"gossip-listen-secondary" flag:"gossip-listen-secondary"`
 	GossipSecretSecondary   *string `json:"gossip-secret-secondary" flag:"gossip-secret-secondary"`
 }


### PR DESCRIPTION
This way if you have the value set in config (even as "") it'll get
passed down to allow you to override the default config

Related to #9006


More detailed explanation: https://github.com/kubernetes/kops/issues/9006#issuecomment-620298643