### PR TITLE
Update to etcd-manager 3.0.20200429

### DIFF
--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/loader"
 )
 
-const DefaultBackupImage = "kopeio/etcd-backup:3.0.20200307"
+const DefaultBackupImage = "kopeio/etcd-backup:3.0.20200428"
 
 // EtcdOptionsBuilder adds options for etcd to the model
 type EtcdOptionsBuilder struct {

--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/loader"
 )
 
-const DefaultBackupImage = "kopeio/etcd-backup:3.0.20200428"
+const DefaultBackupImage = "kopeio/etcd-backup:3.0.20200429"
 
 // EtcdOptionsBuilder adds options for etcd to the model
 type EtcdOptionsBuilder struct {

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -199,7 +199,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - image: kopeio/etcd-manager:3.0.20200307
+  - image: kopeio/etcd-manager:3.0.20200428
     name: etcd-manager
     resources:
       requests:

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -199,7 +199,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - image: kopeio/etcd-manager:3.0.20200428
+  - image: kopeio/etcd-manager:3.0.20200429
     name: etcd-manager
     resources:
       requests:

--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -79,7 +79,7 @@ func (b *EtcdManagerOptionsBuilder) BuildOptions(o interface{}) error {
 	return nil
 }
 
-var supportedEtcdVersions = []string{"2.2.1", "3.1.12", "3.2.18", "3.2.24", "3.3.10", "3.3.13", "3.4.3"}
+var supportedEtcdVersions = []string{"2.2.1", "3.1.12", "3.2.18", "3.2.24", "3.3.10", "3.3.13", "3.3.17", "3.4.3"}
 
 func etcdVersionIsSupported(version string) bool {
 	version = strings.TrimPrefix(version, "v")

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -89,7 +89,7 @@ Contents:
           --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
           --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
           > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20200428
+        image: kopeio/etcd-manager:3.0.20200429
         name: etcd-manager
         resources:
           requests:
@@ -154,7 +154,7 @@ Contents:
           --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
           --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
           > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20200428
+        image: kopeio/etcd-manager:3.0.20200429
         name: etcd-manager
         resources:
           requests:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -89,7 +89,7 @@ Contents:
           --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
           --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
           > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20200307
+        image: kopeio/etcd-manager:3.0.20200428
         name: etcd-manager
         resources:
           requests:
@@ -154,7 +154,7 @@ Contents:
           --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
           --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
           > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20200307
+        image: kopeio/etcd-manager:3.0.20200428
         name: etcd-manager
         resources:
           requests:

--- a/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
@@ -89,7 +89,7 @@ Contents:
           --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
           --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
           > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20200428
+        image: kopeio/etcd-manager:3.0.20200429
         name: etcd-manager
         resources:
           requests:
@@ -160,7 +160,7 @@ Contents:
           --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
           --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
           > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20200428
+        image: kopeio/etcd-manager:3.0.20200429
         name: etcd-manager
         resources:
           requests:

--- a/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
@@ -89,7 +89,7 @@ Contents:
           --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
           --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
           > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20200307
+        image: kopeio/etcd-manager:3.0.20200428
         name: etcd-manager
         resources:
           requests:
@@ -160,7 +160,7 @@ Contents:
           --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
           --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
           > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20200307
+        image: kopeio/etcd-manager:3.0.20200428
         name: etcd-manager
         resources:
           requests:

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -92,7 +92,7 @@ Contents:
         env:
         - name: ETCD_QUOTA_BACKEND_BYTES
           value: "10737418240"
-        image: kopeio/etcd-manager:3.0.20200307
+        image: kopeio/etcd-manager:3.0.20200428
         name: etcd-manager
         resources:
           requests:
@@ -160,7 +160,7 @@ Contents:
         env:
         - name: ETCD_QUOTA_BACKEND_BYTES
           value: "10737418240"
-        image: kopeio/etcd-manager:3.0.20200307
+        image: kopeio/etcd-manager:3.0.20200428
         name: etcd-manager
         resources:
           requests:

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -92,7 +92,7 @@ Contents:
         env:
         - name: ETCD_QUOTA_BACKEND_BYTES
           value: "10737418240"
-        image: kopeio/etcd-manager:3.0.20200428
+        image: kopeio/etcd-manager:3.0.20200429
         name: etcd-manager
         resources:
           requests:
@@ -160,7 +160,7 @@ Contents:
         env:
         - name: ETCD_QUOTA_BACKEND_BYTES
           value: "10737418240"
-        image: kopeio/etcd-manager:3.0.20200428
+        image: kopeio/etcd-manager:3.0.20200429
         name: etcd-manager
         resources:
           requests:

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -98,7 +98,7 @@ Contents:
           value: http://proxy.example.com
         - name: no_proxy
           value: noproxy.example.com
-        image: kopeio/etcd-manager:3.0.20200428
+        image: kopeio/etcd-manager:3.0.20200429
         name: etcd-manager
         resources:
           requests:
@@ -178,7 +178,7 @@ Contents:
           value: http://proxy.example.com
         - name: no_proxy
           value: noproxy.example.com
-        image: kopeio/etcd-manager:3.0.20200428
+        image: kopeio/etcd-manager:3.0.20200429
         name: etcd-manager
         resources:
           requests:

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -98,7 +98,7 @@ Contents:
           value: http://proxy.example.com
         - name: no_proxy
           value: noproxy.example.com
-        image: kopeio/etcd-manager:3.0.20200307
+        image: kopeio/etcd-manager:3.0.20200428
         name: etcd-manager
         resources:
           requests:
@@ -178,7 +178,7 @@ Contents:
           value: http://proxy.example.com
         - name: no_proxy
           value: noproxy.example.com
-        image: kopeio/etcd-manager:3.0.20200307
+        image: kopeio/etcd-manager:3.0.20200428
         name: etcd-manager
         resources:
           requests:


### PR DESCRIPTION
Contains the workaround for 1-year certificate expiry.

3.0.2020428 changes

* Release notes for 3.0.20200307 [#303](https://github.com/kopeio/etcd-manager/pull/303)
* Add support for etcd 3.3.17 [#304](https://github.com/kopeio/etcd-manager/pull/304)
* Adding client usage extension for server cert (#305) [#306](https://github.com/kopeio/etcd-manager/pull/306)
* Add a check to renew certificates on startup if they expire in 60 days or less [#309](https://github.com/kopeio/etcd-manager/pull/309)
* Try github actions [#310](https://github.com/kopeio/etcd-manager/pull/310)
* Upgrade bazel to 2.2.0 [#311](https://github.com/kopeio/etcd-manager/pull/311)
* Update to go 1.13.10 [#314](https://github.com/kopeio/etcd-manager/pull/314)
* Bazel: update dependency [#316](https://github.com/kopeio/etcd-manager/pull/316)
* e2e tests should wait for cluster readiness [#318](https://github.com/kopeio/etcd-manager/pull/318)
* Remove old bazel versions from travis [#317](https://github.com/kopeio/etcd-manager/pull/317)
* Always renew certificates [#313](https://github.com/kopeio/etcd-manager/pull/313)

3.0.20200429

    * Upgrade aws-sdk-go [#320](https://github.com/kopeio/etcd-manager/pull/320)
    * Release notes for 3.0.20200428 [#319](https://github.com/kopeio/etcd-manager/pull/319)
