### PR TITLE
Allow changing AZ of masters

### DIFF
--- a/cmd/kops/create_ig.go
+++ b/cmd/kops/create_ig.go
@@ -227,7 +227,7 @@ func RunCreateInstanceGroup(ctx context.Context, f *util.Factory, cmd *cobra.Com
 			return fmt.Errorf("unexpected object type: %T", obj)
 		}
 
-		err = validation.ValidateInstanceGroup(group).ToAggregate()
+		err = validation.CrossValidateInstanceGroup(group, cluster).ToAggregate()
 		if err != nil {
 			return err
 		}

--- a/cmd/kops/edit_instancegroup.go
+++ b/cmd/kops/edit_instancegroup.go
@@ -177,7 +177,7 @@ func RunEditInstanceGroup(ctx context.Context, f *util.Factory, cmd *cobra.Comma
 		return err
 	}
 
-	err = validation.CrossValidateInstanceGroup(fullGroup, fullCluster, true).ToAggregate()
+	err = validation.CrossValidateInstanceGroup(fullGroup, fullCluster).ToAggregate()
 	if err != nil {
 		return err
 	}

--- a/pkg/apis/kops/validation/cluster.go
+++ b/pkg/apis/kops/validation/cluster.go
@@ -92,13 +92,6 @@ func validateEtcdClusterUpdate(fp *field.Path, obj *kops.EtcdClusterSpec, status
 				allErrs = append(allErrs, validateEtcdMemberUpdate(fp, newMember, etcdClusterStatus, oldMember)...)
 			}
 		}
-		for k := range oldMembers {
-			newCluster := newMembers[k]
-			if newCluster == nil {
-				fp := fp.Child("etcdMembers").Key(k)
-				allErrs = append(allErrs, field.Forbidden(fp, "EtcdCluster members cannot be removed"))
-			}
-		}
 	}
 
 	return allErrs

--- a/pkg/apis/kops/validation/cluster_test.go
+++ b/pkg/apis/kops/validation/cluster_test.go
@@ -39,6 +39,54 @@ func TestValidEtcdChanges(t *testing.T) {
 						Name:          "a",
 						InstanceGroup: fi.String("eu-central-1a"),
 					},
+					{
+						Name:          "b",
+						InstanceGroup: fi.String("eu-central-1b"),
+					},
+					{
+						Name:          "c",
+						InstanceGroup: fi.String("eu-central-1c"),
+					},
+				},
+			},
+
+			NewSpec: &kops.EtcdClusterSpec{
+				Name: "main",
+				Members: []*kops.EtcdMemberSpec{
+					{
+						Name:          "a",
+						InstanceGroup: fi.String("eu-central-1a"),
+					},
+					{
+						Name:          "b",
+						InstanceGroup: fi.String("eu-central-1b"),
+					},
+					{
+						Name:          "d",
+						InstanceGroup: fi.String("eu-central-1d"),
+					},
+				},
+			},
+
+			Status: &kops.ClusterStatus{
+				EtcdClusters: []kops.EtcdClusterStatus{
+					{
+						Name: "main",
+					},
+				},
+			},
+
+			Details: "Could not move master from one zone to another",
+		},
+
+		{
+			OldSpec: &kops.EtcdClusterSpec{
+				Name: "main",
+				Members: []*kops.EtcdMemberSpec{
+					{
+						Name:          "a",
+						InstanceGroup: fi.String("eu-central-1a"),
+					},
 				},
 			},
 
@@ -107,7 +155,7 @@ func TestValidEtcdChanges(t *testing.T) {
 	for _, g := range grid {
 		errorList := validateEtcdClusterUpdate(nil, g.NewSpec, g.Status, g.OldSpec)
 		if len(errorList) != 0 {
-			t.Error(g.Details)
+			t.Errorf("%v: %v", g.Details, errorList)
 		}
 	}
 }

--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -225,7 +226,7 @@ func ValidateMasterInstanceGroup(g *kops.InstanceGroup, cluster *kops.Cluster) f
 			}
 		}
 		if !hasEtcd {
-			allErrs = append(allErrs, field.NotFound(field.NewPath("spec", "etcdClusters").Key(etcd.Name), g.ObjectMeta.Name))
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "metadata", "name"), fmt.Sprintf("InstanceGroup \"%s\" with role Master must have a member in etcd cluster \"%s\"", g.ObjectMeta.Name, etcd.Name)))
 		}
 	}
 	return allErrs

--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -103,7 +103,7 @@ func TestValidMasterInstanceGroup(t *testing.T) {
 			Cluster: &kops.Cluster{
 				Spec: kops.ClusterSpec{
 					EtcdClusters: []*kops.EtcdClusterSpec{
-						&kops.EtcdClusterSpec{
+						{
 							Name: "main",
 							Members: []*kops.EtcdMemberSpec{
 								{
@@ -138,7 +138,7 @@ func TestValidMasterInstanceGroup(t *testing.T) {
 			Cluster: &kops.Cluster{
 				Spec: kops.ClusterSpec{
 					EtcdClusters: []*kops.EtcdClusterSpec{
-						&kops.EtcdClusterSpec{
+						{
 							Name: "main",
 							Members: []*kops.EtcdMemberSpec{
 								{

--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -19,6 +19,7 @@ package validation
 import (
 	"testing"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
@@ -89,4 +90,92 @@ func TestValidateInstanceProfile(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestValidMasterInstanceGroup(t *testing.T) {
+	grid := []struct {
+		Cluster        *kops.Cluster
+		IG             *kops.InstanceGroup
+		ExpectedErrors int
+		Description    string
+	}{
+		{
+			Cluster: &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					EtcdClusters: []*kops.EtcdClusterSpec{
+						&kops.EtcdClusterSpec{
+							Name: "main",
+							Members: []*kops.EtcdMemberSpec{
+								{
+									Name:          "a",
+									InstanceGroup: fi.String("eu-central-1a"),
+								},
+								{
+									Name:          "b",
+									InstanceGroup: fi.String("eu-central-1b"),
+								},
+								{
+									Name:          "c",
+									InstanceGroup: fi.String("eu-central-1c"),
+								},
+							},
+						},
+					},
+				},
+			},
+			IG: &kops.InstanceGroup{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "eu-central-1a",
+				},
+				Spec: kops.InstanceGroupSpec{
+					Role: kops.InstanceGroupRoleMaster,
+				},
+			},
+			ExpectedErrors: 0,
+			Description:    "Valid instance group failed to validate",
+		},
+		{
+			Cluster: &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					EtcdClusters: []*kops.EtcdClusterSpec{
+						&kops.EtcdClusterSpec{
+							Name: "main",
+							Members: []*kops.EtcdMemberSpec{
+								{
+									Name:          "a",
+									InstanceGroup: fi.String("eu-central-1a"),
+								},
+								{
+									Name:          "b",
+									InstanceGroup: fi.String("eu-central-1b"),
+								},
+								{
+									Name:          "c",
+									InstanceGroup: fi.String("eu-central-1c"),
+								},
+							},
+						},
+					},
+				},
+			},
+			IG: &kops.InstanceGroup{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "eu-central-1d",
+				},
+				Spec: kops.InstanceGroupSpec{
+					Role: kops.InstanceGroupRoleMaster,
+				},
+			},
+			ExpectedErrors: 1,
+			Description:    "Master IG without etcd member validated",
+		},
+	}
+
+	for _, g := range grid {
+		errList := ValidateMasterInstanceGroup(g.IG, g.Cluster)
+		if len(errList) != g.ExpectedErrors {
+			t.Error(g.Description)
+		}
+	}
+
 }

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -654,7 +654,7 @@ func DeepValidate(c *kops.Cluster, groups []*kops.InstanceGroup, strict bool) er
 	}
 
 	for _, g := range groups {
-		errs := CrossValidateInstanceGroup(g, c, strict)
+		errs := CrossValidateInstanceGroup(g, c)
 
 		// Additional cloud-specific validation rules,
 		// such as making sure that identifiers match the expected formats for the given cloud

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_configuration_master-us-test-1a.masters.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_configuration_master-us-test-1a.masters.existing-iam.example.com_user_data
@@ -153,7 +153,7 @@ etcdClusters:
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false
-  apiServerCount: 1
+  apiServerCount: 3
   authorizationMode: AlwaysAllow
   bindAddress: 0.0.0.0
   cloudProvider: aws

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_configuration_master-us-test-1b.masters.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_configuration_master-us-test-1b.masters.existing-iam.example.com_user_data
@@ -153,7 +153,7 @@ etcdClusters:
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false
-  apiServerCount: 1
+  apiServerCount: 3
   authorizationMode: AlwaysAllow
   bindAddress: 0.0.0.0
   cloudProvider: aws

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_configuration_master-us-test-1c.masters.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_configuration_master-us-test-1c.masters.existing-iam.example.com_user_data
@@ -153,7 +153,7 @@ etcdClusters:
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false
-  apiServerCount: 1
+  apiServerCount: 3
   authorizationMode: AlwaysAllow
   bindAddress: 0.0.0.0
   cloudProvider: aws

--- a/tests/integration/update_cluster/existing_iam/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/existing_iam/in-v1alpha2.yaml
@@ -13,10 +13,18 @@ spec:
   - etcdMembers:
     - instanceGroup: master-us-test-1a
       name: a
+    - instanceGroup: master-us-test-1b
+      name: b
+    - instanceGroup: master-us-test-1c
+      name: c
     name: main
   - etcdMembers:
     - instanceGroup: master-us-test-1a
       name: a
+    - instanceGroup: master-us-test-1b
+      name: b
+    - instanceGroup: master-us-test-1c
+      name: c
     name: events
   kubelet:
     anonymousAuth: false

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -217,7 +217,7 @@ resource "aws_ebs_volume" "a-etcd-events-existing-iam-example-com" {
   tags = {
     "KubernetesCluster"                              = "existing-iam.example.com"
     "Name"                                           = "a.etcd-events.existing-iam.example.com"
-    "k8s.io/etcd/events"                             = "a/a"
+    "k8s.io/etcd/events"                             = "a/a,b,c"
     "k8s.io/role/master"                             = "1"
     "kubernetes.io/cluster/existing-iam.example.com" = "owned"
   }
@@ -231,7 +231,63 @@ resource "aws_ebs_volume" "a-etcd-main-existing-iam-example-com" {
   tags = {
     "KubernetesCluster"                              = "existing-iam.example.com"
     "Name"                                           = "a.etcd-main.existing-iam.example.com"
-    "k8s.io/etcd/main"                               = "a/a"
+    "k8s.io/etcd/main"                               = "a/a,b,c"
+    "k8s.io/role/master"                             = "1"
+    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+  }
+  type = "gp2"
+}
+
+resource "aws_ebs_volume" "b-etcd-events-existing-iam-example-com" {
+  availability_zone = "us-test-1b"
+  encrypted         = false
+  size              = 20
+  tags = {
+    "KubernetesCluster"                              = "existing-iam.example.com"
+    "Name"                                           = "b.etcd-events.existing-iam.example.com"
+    "k8s.io/etcd/events"                             = "b/a,b,c"
+    "k8s.io/role/master"                             = "1"
+    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+  }
+  type = "gp2"
+}
+
+resource "aws_ebs_volume" "b-etcd-main-existing-iam-example-com" {
+  availability_zone = "us-test-1b"
+  encrypted         = false
+  size              = 20
+  tags = {
+    "KubernetesCluster"                              = "existing-iam.example.com"
+    "Name"                                           = "b.etcd-main.existing-iam.example.com"
+    "k8s.io/etcd/main"                               = "b/a,b,c"
+    "k8s.io/role/master"                             = "1"
+    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+  }
+  type = "gp2"
+}
+
+resource "aws_ebs_volume" "c-etcd-events-existing-iam-example-com" {
+  availability_zone = "us-test-1c"
+  encrypted         = false
+  size              = 20
+  tags = {
+    "KubernetesCluster"                              = "existing-iam.example.com"
+    "Name"                                           = "c.etcd-events.existing-iam.example.com"
+    "k8s.io/etcd/events"                             = "c/a,b,c"
+    "k8s.io/role/master"                             = "1"
+    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+  }
+  type = "gp2"
+}
+
+resource "aws_ebs_volume" "c-etcd-main-existing-iam-example-com" {
+  availability_zone = "us-test-1c"
+  encrypted         = false
+  size              = 20
+  tags = {
+    "KubernetesCluster"                              = "existing-iam.example.com"
+    "Name"                                           = "c.etcd-main.existing-iam.example.com"
+    "k8s.io/etcd/main"                               = "c/a,b,c"
     "k8s.io/role/master"                             = "1"
     "kubernetes.io/cluster/existing-iam.example.com" = "owned"
   }

--- a/upup/pkg/fi/cloudup/populateinstancegroup_test.go
+++ b/upup/pkg/fi/cloudup/populateinstancegroup_test.go
@@ -33,11 +33,11 @@ func buildMinimalNodeInstanceGroup(subnets ...string) *kopsapi.InstanceGroup {
 	return g
 }
 
-func buildMinimalMasterInstanceGroup(subnets ...string) *kopsapi.InstanceGroup {
+func buildMinimalMasterInstanceGroup(subnet string) *kopsapi.InstanceGroup {
 	g := &kopsapi.InstanceGroup{}
-	g.ObjectMeta.Name = "master"
+	g.ObjectMeta.Name = "master-" + subnet
 	g.Spec.Role = kopsapi.InstanceGroupRoleMaster
-	g.Spec.Subnets = subnets
+	g.Spec.Subnets = []string{subnet}
 
 	return g
 }

--- a/upup/pkg/fi/cloudup/validation_test.go
+++ b/upup/pkg/fi/cloudup/validation_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/validation"
@@ -39,23 +38,20 @@ func buildDefaultCluster(t *testing.T) *api.Cluster {
 	}
 
 	if len(c.Spec.EtcdClusters) == 0 {
-		zones := sets.NewString()
-		for _, z := range c.Spec.Subnets {
-			zones.Insert(z.Zone)
-		}
-		etcdZones := zones.List()
 
 		for _, etcdCluster := range EtcdClusters {
+
 			etcd := &api.EtcdClusterSpec{}
 			etcd.Name = etcdCluster
-			for _, zone := range etcdZones {
+			for _, subnet := range c.Spec.Subnets {
 				m := &api.EtcdMemberSpec{}
-				m.Name = zone
-				m.InstanceGroup = fi.String(zone)
+				m.Name = subnet.Zone
+				m.InstanceGroup = fi.String("master-" + subnet.Name)
 				etcd.Members = append(etcd.Members, m)
 			}
 			c.Spec.EtcdClusters = append(c.Spec.EtcdClusters, etcd)
 		}
+
 	}
 
 	fullSpec, err := mockedPopulateClusterSpec(c)


### PR DESCRIPTION
Fixes #8817 

I have not done any testing on terraform though.
Care still needs to be taken when deleting master IGs. If you break quorum you need to restore etcd from backup. Preventing master IGs in an unsafe way is already possible though, so I didn't do anything to prevent this here.