### PR TITLE
[WIP] - Update Lyft CNI Default to 0.6.3

### DIFF
--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1208,8 +1208,8 @@ func (c *ApplyClusterCmd) AddFileAssets(assetBuilder *assets.AssetBuilder) error
 
 		urlString := os.Getenv("LYFT_VPC_DOWNLOAD_URL")
 		if urlString == "" {
-			urlString = "https://github.com/lyft/cni-ipvlan-vpc-k8s/releases/download/v0.6.0/cni-ipvlan-vpc-k8s-amd64-v0.6.0.tar.gz"
-			hash, err = hashing.FromString("871757d381035f64020a523e7a3e139b6177b98eb7a61b547813ff25957fc566")
+			urlString = "https://github.com/lyft/cni-ipvlan-vpc-k8s/releases/download/v0.6.3/cni-ipvlan-vpc-k8s-amd64-v0.6.3.tar.gz"
+			hash, err = hashing.FromString("d1cd150cd8bbb65f84710016d3815ffbd381f5754a9c98fcd7086cc23ec0da4b")
 			if err != nil {
 				// Should be impossible
 				return fmt.Errorf("invalid hard-coded hash for lyft url")


### PR DESCRIPTION
Marking as WIP whilst double checking the new version internally.

Brings in a number of Lyft CNI improvements:

* [Handling unavailability of AWS limits](https://github.com/lyft/cni-ipvlan-vpc-k8s/pull/80)
* [Garbage collection of links and IPTables rules](https://github.com/lyft/cni-ipvlan-vpc-k8s/pull/83)
* [Improved bulk allocation](https://github.com/lyft/cni-ipvlan-vpc-k8s/pull/84)