### PR TITLE
Use raw tarfile for AmazonLinux2 + Containerd 1.2.10

### DIFF
--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -93,18 +93,18 @@ var containerdVersions = []packageVersion{
 		Hash:           "f4c941807310e3fa470dddfb068d599174a3daec",
 	},
 
-	// 1.2.10 - CentOS / Rhel 7
+	// 1.2.10 - CentOS7 / Rhel 7
 	{
 		PackageVersion: "1.2.10",
 		Name:           "containerd.io",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7, distros.DistributionAmazonLinux2},
+		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "1.2.10",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.10-3.2.el7.x86_64.rpm",
 		Hash:           "f6447e84479df3a58ce04a3da87ccc384663493b",
 	},
 
-	// 1.2.10 - CentOS / Rhel 8
+	// 1.2.10 - CentOS8 / Rhel 8
 	{
 		PackageVersion: "1.2.10",
 		Name:           "containerd.io",
@@ -113,6 +113,19 @@ var containerdVersions = []packageVersion{
 		Version:        "1.2.10",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.10-3.2.el7.x86_64.rpm",
 		Hash:           "f6447e84479df3a58ce04a3da87ccc384663493b",
+	},
+
+	// 1.2.10 - Linux Generic
+	//
+	// Used only on AmazonLinux2: the Centos7 package pulls in
+	// container-selinux, but selinux isn't used on amazonlinux2
+	{
+		PackageVersion: "1.2.10",
+		PlainBinary:    true,
+		Distros:        []distros.Distribution{distros.DistributionAmazonLinux2},
+		Architectures:  []Architecture{ArchitectureAmd64},
+		Source:         "https://storage.googleapis.com/cri-containerd-release/cri-containerd-1.2.10.linux-amd64.tar.gz",
+		Hash:           "c84c29dcd1867a6ee9899d2106ab4f28854945f6",
 	},
 
 	// 1.2.11 - Linux Generic

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -439,11 +439,11 @@ var dockerVersions = []packageVersion{
 		},
 	},
 
-	// 18.09.9 - CentOS / Rhel7
+	// 18.09.9 - CentOS7 / Rhel7
 	{
 		PackageVersion: "18.09.9",
 		Name:           "docker-ce",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7, distros.DistributionAmazonLinux2},
+		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "18.09.9",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-18.09.9-3.el7.x86_64.rpm",
@@ -475,7 +475,30 @@ var dockerVersions = []packageVersion{
 		},
 	},
 
+	// 18.09.9 - Linux Generic
+	//
+	// Used only on AmazonLinux2: the Centos7 package pulls in
+	// container-selinux, but selinux isn't used on amazonlinux2
+	{
+		PackageVersion: "18.09.9",
+		PlainBinary:    true,
+		Distros:        []distros.Distribution{distros.DistributionAmazonLinux2},
+		Architectures:  []Architecture{ArchitectureAmd64},
+		Source:         "https://download.docker.com/linux/static/stable/x86_64/docker-18.09.9.tgz",
+		Hash:           "1b1516253aa876f77193deb901e53977b3c84476",
+	},
+
 	// 19.03.4 - k8s 1.17 - https://github.com/kubernetes/kubernetes/pull/84476
+
+	// 19.03.4 - Linux Generic used only for Amazon Linux 2
+	{
+		PackageVersion: "19.03.4",
+		PlainBinary:    true,
+		Distros:        []distros.Distribution{distros.DistributionAmazonLinux2},
+		Architectures:  []Architecture{ArchitectureAmd64},
+		Source:         "https://download.docker.com/linux/static/stable/x86_64/docker-19.03.4.tgz",
+		Hash:           "5b9aa113916cfdde3eaf2bd25d2b8c3da49e0268",
+	},
 
 	// 19.03.4 - Debian Stretch
 	{
@@ -553,7 +576,7 @@ var dockerVersions = []packageVersion{
 	{
 		PackageVersion: "19.03.4",
 		Name:           "docker-ce",
-		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7, distros.DistributionAmazonLinux2},
+		Distros:        []distros.Distribution{distros.DistributionRhel7, distros.DistributionCentos7},
 		Architectures:  []Architecture{ArchitectureAmd64},
 		Version:        "19.03.4",
 		Source:         "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-19.03.4-3.el7.x86_64.rpm",


### PR DESCRIPTION
The rpm containerd 1.2.10 package depends on containerd-selinux, which
isn't available on amazonlinux2.  We can't just skip it, because we
can't install the package without its dependencies.

Instead, install from a binary package.