### PR TITLE
Rename tests to make it easier to search for failing tests

### DIFF
--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53_test.go
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53_test.go
@@ -209,7 +209,7 @@ func TestResourceRecordSetsAdditionVisible(t *testing.T) {
 }
 
 /* TestResourceRecordSetsAddDuplicateFail verifies that addition of a duplicate RRS fails */
-func TestResourceRecordSetsAddDuplicateFail(t *testing.T) {
+func TestResourceRecordSetsAddDuplicateFailure(t *testing.T) {
 	zone := firstZone(t)
 	sets := rrs(t, zone)
 	rrset := getExampleRrs(zone)

--- a/dnsprovider/pkg/dnsprovider/providers/coredns/coredns_test.go
+++ b/dnsprovider/pkg/dnsprovider/providers/coredns/coredns_test.go
@@ -181,7 +181,7 @@ func TestResourceRecordSetsAdditionVisible(t *testing.T) {
 }
 
 /* TestResourceRecordSetsAddDuplicateFail verifies that addition of a duplicate RRS fails */
-func TestResourceRecordSetsAddDuplicateFail(t *testing.T) {
+func TestResourceRecordSetsAddDuplicateFailure(t *testing.T) {
 	zone := firstZone(t)
 	sets := rrs(t, zone)
 	rrset := getExampleRrs(zone)

--- a/dnsprovider/pkg/dnsprovider/providers/google/clouddns/clouddns_test.go
+++ b/dnsprovider/pkg/dnsprovider/providers/google/clouddns/clouddns_test.go
@@ -188,7 +188,7 @@ func TestResourceRecordSetsAdditionVisible(t *testing.T) {
 }
 
 /* TestResourceRecordSetsAddDuplicateFail verifies that addition of a duplicate RRS fails */
-func TestResourceRecordSetsAddDuplicateFail(t *testing.T) {
+func TestResourceRecordSetsAddDuplicateFailure(t *testing.T) {
 	zone := firstZone(t)
 	sets := rrs(t, zone)
 	rrset := getExampleRrs(zone)


### PR DESCRIPTION
This is very minor...

GH Action's search functionality is not case sensitive.
In Travis CI, one could search for `FAIL:` and be taken to relevant test failures.
In GHA, these tests were also in the search results making it harder to find the actual tests that are failing.

This renames the tests so that searching for `FAIL:` (case insensitive) will only return failing tests.

Example:

<img width="1012" alt="Screen Shot 2020-04-30 at 9 09 02 PM" src="https://user-images.githubusercontent.com/1455650/80776009-d95d2600-8b26-11ea-8bbf-3858e570b11d.png">

