### PR TITLE
Update docs on supported distros and release notes

### DIFF
--- a/docs/operations/images.md
+++ b/docs/operations/images.md
@@ -43,9 +43,29 @@ You can find the name for an image using:
 
 `aws ec2 describe-images --region us-east-1 --image-id ami-00579fbb15b954340`
 
+## Distro Support
+
+The following table provides the support status for various distros with regards to Kops version: 
+
+| Distro | Experimental | Stable | Deprecated | Removed | 
+| ------------ | -----------: | -----: | ---------: | ------: |
+| [Amazon Linux 2](#amazon-linux-2) | 1.10 | 1.18 | - | - |
+| [CentOS 7](#centos-7) | - | 1.5 | - | - |
+| [CentOS 8](#centos-8) | 1.15 | - | - | - |
+| [CoreOS](#coreos) | 1.6 | 1.9 | 1.17 | 1.19 |
+| [Debian 8](#debian-8-jessie) | - | 1.5 | 1.17 | 1.19 |
+| [Debian 9](#debian-9-stretch) | 1.8 | 1.10 | - | - |
+| [Debian 10](#debian-10-buster) | 1.13 | 1.17 | - | - |
+| [Flatcar](#flatcar) | 1.15 | 1.17 | - | - |
+| [RHEL 7](#rhel-7) | - | 1.5 | - | - |
+| [RHEL 8](#rhel-8) | 1.15 | 1.18 | - | - |
+| [Ubuntu 16.04](#ubuntu-1604-xenial) | 1.5.0 | 1.10 | 1.17 | - |
+| [Ubuntu 18.04](#ubuntu-1804-bionic) | 1.10 | 1.16 | - | - |
+| [Ubuntu 20.04](#ubuntu-2004-focal) | 1.16 | 1.18 | - | - |
+
 ## Kope.io
 
-The default imagess from `kope.io` are based on Debian 9 (Stretch). These images include all the necessary files and packages to run Kubernetes, making node startup faster. Other than that, the changes to the official Debian images are (minimal)[https://github.com/kubernetes-sigs/image-builder/tree/master/images/kube-deploy/imagebuilder/templates].
+The default images from `kope.io` are based on Debian 9 (Stretch). These images include all the necessary files and packages to run Kubernetes, making node startup faster. Other than that, the changes to the official Debian images are (minimal)[https://github.com/kubernetes-sigs/image-builder/tree/master/images/kube-deploy/imagebuilder/templates].
 
 The latest image names are kept in the [stable channel manifest](https://github.com/kubernetes/kops/blob/master/channels/stable), but all available images can be listed using:
 
@@ -58,12 +78,12 @@ aws ec2 describe-images --region us-east-1 --output table \
 
 ## Debian 9 (Stretch)
 
-Debian 9 (Stretch) is fully supported and functional.
+Debian 9 (Stretch) is supported and fully functional.
 
 It is based on Kernel version **4.9** which has number of known bugs that affect it and may be noticed with larger clusters:
 
-* https://github.com/kubernetes/kubernetes/issues/56903
-* https://github.com/kubernetes/kubernetes/issues/67577
+* [kubernetes/kubernetes#56903](https://github.com/kubernetes/kubernetes/issues/56903)
+* [kubernetes/kubernetes#67577](https://github.com/kubernetes/kubernetes/issues/67577)
 
 Available images can be listed using:
 
@@ -76,9 +96,7 @@ aws ec2 describe-images --region us-east-1 --output table \
 
 ## Debian 10 (Buster)
 
-Debian 10 support was introduced in **Kops 1.13** and is fully functional as long as `iptables` is in `legacy` mode.
-
-It is based on Kernel version **4.19** which fixes some of the bugs present in Debian 9 and effects are less visible.
+Debian 10 is based on Kernel version **4.19** which fixes some of the bugs present in Debian 9 and effects are less visible.
 
 One notable change is the addition of `iptables` NFT, which is by default. This is not yet supported by most CNI plugins and also seems to be [slower](https://youtu.be/KHMnC3kj3Js?t=771) than the legacy version. It is recommended to switch to `iptables` legacy by using the following script in `additionalUserData` for each instance group:
 
@@ -105,12 +123,10 @@ aws ec2 describe-images --region us-east-1 --output table \
 
 ## Ubuntu 18.04 (Bionic)
 
-Ubuntu 18.04 is fully supported and functional.
+Ubuntu 18.04 is based on Kernel version **4.15** which has number of known bugs that affect it and may be noticed with larger clusters:
 
-It is based on Kernel version **4.15** which has number of known bugs that affect it and may be noticed with larger clusters:
-
-* https://github.com/kubernetes/kubernetes/issues/56903
-* https://github.com/kubernetes/kubernetes/issues/67577
+* [kubernetes/kubernetes#56903](https://github.com/kubernetes/kubernetes/issues/56903)
+* [kubernetes/kubernetes#67577](https://github.com/kubernetes/kubernetes/issues/67577)
 
 Available images can be listed using:
 
@@ -123,9 +139,9 @@ aws ec2 describe-images --region us-east-1 --output table \
 
 ## Ubuntu 20.04 (Focal)
 
-Ubuntu 20.04 support was introduced in **Kops 1.16** and is fully functional. 
+Ubuntu 20.04 support was introduced in **Kops 1.17** and is fully functional.
 
-It is based on Kernel version **5.4** which fixes all the know major Kernel bugs.
+It is based on Kernel version **5.4** which fixes all the known major Kernel bugs.
 
 Available images can be listed using:
 
@@ -138,16 +154,14 @@ aws ec2 describe-images --region us-east-1 --output table \
 
 ## CentOS 7
 
-CentOS 7 is supported and functional. The minimum supported version is **7.4**.
+CentOS 7 is based on Kernel version **3.10** which has a considerable number of known bugs that affect it and may be noticed in production clusters:
 
-It is based on Kernel version **3.10** which has a considerable number of known bugs that affect it and may be noticed in production clusters:
-
-* https://github.com/kubernetes/kubernetes/issues/56903
-* https://github.com/kubernetes/kubernetes/issues/67577
+* [kubernetes/kubernetes#56903](https://github.com/kubernetes/kubernetes/issues/56903)
+* [kubernetes/kubernetes#67577](https://github.com/kubernetes/kubernetes/issues/67577)
 
 Before using CentOS images you must accept the agreement at https://aws.amazon.com/marketplace/pp?sku=aw0evgkw8e5c1q413zgy5pjce.
 
-Available images can be listed using:
+The minimum supported version is **7.4**. Available images can be listed using:
 
 ```bash
 aws ec2 describe-images --region us-east-1 --output table \
@@ -158,14 +172,12 @@ aws ec2 describe-images --region us-east-1 --output table \
 
 ## RHEL 7
 
-RHEL 7 is supported and functional. The minimum supported version is **7.4**.
+RHEL 7 is based on Kernel version **3.10** which has a considerable number of known bugs that affect it and may be noticed in production clusters:
 
-It is based on Kernel version **3.10** which has a considerable number of known bugs that affect it and may be noticed in production clusters:
+* [kubernetes/kubernetes#56903](https://github.com/kubernetes/kubernetes/issues/56903)
+* [kubernetes/kubernetes#67577](https://github.com/kubernetes/kubernetes/issues/67577)
 
-* https://github.com/kubernetes/kubernetes/issues/56903
-* https://github.com/kubernetes/kubernetes/issues/67577
-
-Available images can be listed using:
+The minimum supported version is **7.4**. Available images can be listed using:
 
 ```bash
 aws ec2 describe-images --region us-east-1 --output table \
@@ -174,11 +186,14 @@ aws ec2 describe-images --region us-east-1 --output table \
   --filters "Name=name,Values=RHEL-7.*x86_64*"
 ```
 
+## CentOS 8
+
+The CentOS Project doesn't provide any official images in AWS at the moment.
+Please [report](https://github.com/kubernetes/kops/issues/new/choose) any changes.
+
 ## RHEL 8
 
-RHEL 8 support was introduced in **Kops 1.18** and is experimental. 
-
-It is based on Kernel version **4.18** which fixes some of the bugs present in RHEL/CentOS 7 and effects are less visible.
+RHEL 8 is based on Kernel version **4.18** which fixes some of the bugs present in RHEL/CentOS 7 and effects are less visible.
 
 One notable change is the addition of `iptables` NFT, which is the only iptables backend available. This is not yet supported by most CNI plugins and should be used with care.
 
@@ -193,9 +208,7 @@ aws ec2 describe-images --region us-east-1 --output table \
 
 ## Amazon Linux 2
 
-Amazon Linux 2 support is still experimental, but should work with **Kops 1.18** or newer. Please report any issues.
-
-It is based on Kernel version **4.18** which fixes some of the bugs present in RHEL/CentOS 7 and effects are less visible.
+Amazon Linux 2 is based on Kernel version **4.19** which fixes some of the bugs present in RHEL/CentOS 7 and effects are less visible.
 
 Available images can be listed using:
 
@@ -209,8 +222,6 @@ aws ec2 describe-images --region us-east-1 --output table \
 ## Flatcar
 
 Flatcar is a friendly fork of CoreOS and as such, compatible with it.
-
-Support was introduced in **Kops 1.15** and it is both supported and functional.
 
 Available images can be listed using:
 
@@ -233,5 +244,4 @@ Support for Ubuntu 16.04 (Xenial) is deprecated and will be removed in future ve
 
 Support for CoreOS is deprecated and will be removed in future versions of Kops.
 
-You should consider using Flatcar as a replacement.
-
+You should consider using [Flatcar](#flatcar) as a replacement.

--- a/docs/releases/1.17-NOTES.md
+++ b/docs/releases/1.17-NOTES.md
@@ -5,9 +5,17 @@ the notes prior to the release).
 
 # Significant changes
 
-* The default Docker version was changed to 19.03.4. Optional support for Docker 19.03.8 was added and will be the default in future versions. Enable by setting `spec.docker.version: 19.03.8`.
+* The default Docker version has been changed to 19.03.4. Optional support for Docker 19.03.8 has been added and will be the default in future versions. Enable by setting `spec.docker.version: 19.03.8`.
 
-* The default instance type for AWS was changed to t3.medium. This should provide better performance and reduced costs in clusters where the average CPU usage is low.
+* The default instance type for AWS has been changed to t3.medium. This should provide better performance and reduced costs in clusters where the average CPU usage is low.
+
+* Support for [Ubuntu 20.04 (Focal)](../operations/images.md#ubuntu-2004-focal) has been added.
+
+* Support for Ubuntu 16.04 (Xenial) has been deprecated and will be removed in future versions of Kops.
+
+* Support for Debian 8 (Jessie) has been deprecated and will be removed in future versions of Kops. 
+ 
+* Support for CoreOS has been deprecated and will be removed in future versions of Kops. Those affected should consider using [Flatcar](../operations/images.md#flatcar) as a replacement.
 
 # Breaking changes
 

--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -4,13 +4,13 @@
 
 # Significant changes
 
-* The default Docker version was changed to 19.03.8.
+* The default Docker version has been changed to 19.03.8.
 
-* Support for Ubuntu 20.04 and RHEL/CentOS 8 was added.
+* Support for [RHEL 8](../operations/images.md#rhel-8) and [CentOS 8](../operations/images.md#centos-8) has been added.
 
-* Support for Amazon Linux 2 was improved and will work with the default Docker version. 
+* Support for Amazon Linux 2 has been improved and will work with the default Docker version.
 
-* [containerd](https://github.com/containerd/containerd/blob/master/README.md) was added and can be selected as an alternate container runtime for Kubernetes. Enable by using the `--container-runtime containerd` flag when creating a cluster or by setting `spec.containerRuntime: containerd`.
+* [containerd](https://github.com/containerd/containerd/blob/master/README.md) has been added and can be selected as an alternate container runtime for Kubernetes. Enable by using the `--container-runtime containerd` flag when creating a cluster or by setting `spec.containerRuntime: containerd`.
 
 * Rolling updates now support surging and parallelism within an instance group. For details see [the documentation](../operations/rolling-update.md).
 
@@ -29,14 +29,14 @@
 # Breaking changes
 
 * Support for Docker versions 1.11, 1.12 and 1.13 has been removed because of the [dockerproject.org shut down](https://www.docker.com/blog/changes-dockerproject-org-apt-yum-repositories/). Those affected must upgrade to a newer Docker version.
- 
+
 * Terraform users on AWS may need to rename some resources in their state file in order to prepare for Terraform 0.12 support. See Required Actions below.
 
 * The Docker `health-check` service is now disabled by default. It shouldn't be needed anymore, but it can still be enabled by setting `spec.docker.healthCheck: true`. It is recommended to also check [node-problem-detector](https://github.com/kubernetes/node-problem-detector) and [draino](https://github.com/planetlabs/draino) as replacements. See Required Actions below.
 
 * Lyft CNI plugin default subnet tags changed from from `Type: pod` to `KubernetesCluster: myclustername.mydns.io`. Subnets intended for use by the plugin will need to be tagged with this new tag and [additional tag filters](https://github.com/lyft/cni-ipvlan-vpc-k8s#other-configuration-flags) may need to be added to the cluster spec in order to achieve the desired set of subnets.
 
-* Support for basic authentication has been disabled by default and will be [removed](https://github.com/kubernetes/kubernetes/pull/89069) in Kubernetes 1.19. 
+* Support for basic authentication has been disabled by default and will be [removed](https://github.com/kubernetes/kubernetes/pull/89069) in Kubernetes 1.19.
 
 * Support for Kubernetes versions prior to 1.9 has been removed.
 
@@ -83,7 +83,7 @@
     docker:
       healthCheck: true
   ```
- 
+
 * Kubernetes 1.9 users will need to enable the PodPriority feature gate. This is required for newer versions of Kops.
 
   To enable the Pod priority feature, follow these steps:


### PR DESCRIPTION
Added a few more tweaks to the supported distros and release notes.
Decided to advertise Ubuntu 20.04 only for Kops 1.17+. For those that want to test, they will be able to use also Kops 1.16.2.

No action was done to remove the deprecated distros, but we need to start announcing the reduced support for them.

/cc @rifelpet @johngmyers 