### PR TITLE
Back-port well known owner aliases and SSH users to 1.17

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -504,16 +504,16 @@ func (s *dumpState) getImageInfo(imageID string) (*imageInfo, error) {
 func guessSSHUser(image *ec2.Image) string {
 	owner := aws.StringValue(image.OwnerId)
 	switch owner {
-	case awsup.WellKnownAccountAmazonSystemLinux2:
+	case awsup.WellKnownAccountAmazonLinux2, awsup.WellKnownAccountRedhat:
 		return "ec2-user"
-	case awsup.WellKnownAccountRedhat:
-		return "ec2-user"
-	case awsup.WellKnownAccountCoreOS:
-		return "core"
-	case awsup.WellKnownAccountKopeio:
+	case awsup.WellKnownAccountCentOS:
+		return "centos"
+	case awsup.WellKnownAccountDebian9, awsup.WellKnownAccountDebian10, awsup.WellKnownAccountKopeio:
 		return "admin"
 	case awsup.WellKnownAccountUbuntu:
 		return "ubuntu"
+	case awsup.WellKnownAccountCoreOS, awsup.WellKnownAccountFlatcar:
+		return "core"
 	}
 
 	name := aws.StringValue(image.Name)

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -86,11 +86,15 @@ const TagNameKopsRole = "kubernetes.io/kops/role"
 const TagNameClusterOwnershipPrefix = "kubernetes.io/cluster/"
 
 const (
-	WellKnownAccountKopeio             = "383156758163"
-	WellKnownAccountRedhat             = "309956199498"
-	WellKnownAccountCoreOS             = "595879546273"
-	WellKnownAccountAmazonSystemLinux2 = "137112412989"
-	WellKnownAccountUbuntu             = "099720109477"
+	WellKnownAccountAmazonLinux2 = "137112412989"
+	WellKnownAccountCentOS       = "679593333241"
+	WellKnownAccountCoreOS       = "595879546273"
+	WellKnownAccountDebian9      = "379101102735"
+	WellKnownAccountDebian10     = "136693071363"
+	WellKnownAccountFlatcar      = "075585003325"
+	WellKnownAccountKopeio       = "383156758163"
+	WellKnownAccountRedhat       = "309956199498"
+	WellKnownAccountUbuntu       = "099720109477"
 )
 
 type AWSCloud interface {
@@ -1192,14 +1196,24 @@ func resolveImage(ec2Client ec2iface.EC2API, name string) (*ec2.Image, error) {
 
 			// Check for well known owner aliases
 			switch owner {
-			case "kope.io":
-				owner = WellKnownAccountKopeio
-			case "coreos.com":
+			case "amazon", "amazon.com":
+				owner = WellKnownAccountAmazonLinux2
+			case "centos":
+				owner = WellKnownAccountCentOS
+			case "coreos", "coreos.com":
 				owner = WellKnownAccountCoreOS
-			case "redhat.com":
+			case "debian9":
+				owner = WellKnownAccountDebian9
+			case "debian10":
+				owner = WellKnownAccountDebian10
+			case "flatcar":
+				owner = WellKnownAccountFlatcar
+			case "kopeio", "kope.io":
+				owner = WellKnownAccountKopeio
+			case "redhat", "redhat.com":
 				owner = WellKnownAccountRedhat
-			case "amazon.com":
-				owner = WellKnownAccountAmazonSystemLinux2
+			case "ubuntu":
+				owner = WellKnownAccountUbuntu
 			}
 
 			request.Owners = []*string{&owner}


### PR DESCRIPTION
Well known owner aliases and SSH users were updated on master via multiple PR, but never back-ported.
These are important, considering they are listed in https://kops.sigs.k8s.io/operations/images/.