### PR TITLE
Updating stable channel to use latest k8s versions

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -56,13 +56,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.17.0"
-    recommendedVersion: 1.17.4
+    recommendedVersion: 1.17.5
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
-    recommendedVersion: 1.16.8
+    recommendedVersion: 1.16.9
     requiredVersion: 1.16.0
   - range: ">=1.15.0"
-    recommendedVersion: 1.15.10
+    recommendedVersion: 1.15.11
     requiredVersion: 1.15.0
   - range: ">=1.14.0"
     recommendedVersion: 1.14.10
@@ -83,15 +83,15 @@ spec:
   - range: ">=1.17.0-alpha.1"
     #recommendedVersion: "1.17.0"
     #requiredVersion: 1.17.0
-    kubernetesVersion: 1.17.4
+    kubernetesVersion: 1.17.5
   - range: ">=1.16.0-alpha.1"
     #recommendedVersion: "1.16.0"
     #requiredVersion: 1.16.0
-    kubernetesVersion: 1.16.8
+    kubernetesVersion: 1.16.9
   - range: ">=1.15.0-alpha.1"
     #recommendedVersion: "1.15.0"
     #requiredVersion: 1.15.0
-    kubernetesVersion: 1.15.10
+    kubernetesVersion: 1.15.11
   - range: ">=1.14.0-alpha.1"
     #recommendedVersion: "1.14.0"
     #requiredVersion: 1.14.0


### PR DESCRIPTION
It's been a week since we updated these versions and things seem stable, Looks like we should be good bumping the versions up to reflect the latest patch versions of k8s.