### PR TITLE
Automated cherry pick of #8794: Make cilium operator health check go against localhost IP

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -655,6 +655,7 @@ spec:
 {{ end }}
         livenessProbe:
           httpGet:
+            host: "127.0.0.1"
             path: /healthz
             port: 9234
             scheme: HTTP

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -123,7 +123,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: 02b8d576dfa13fc6256f87309caa21dd2414fc41
+    manifestHash: 6e1abae9d7ae07472288ddca3d8526889e3fd253
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
Cherry pick of #8794 on release-1.16.

#8794: Make cilium operator health check go against localhost IP

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.