### PR TITLE
Use Ubuntu 18.04 Docker packages for Ubuntu 20.04 setups

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -856,7 +856,7 @@ var dockerVersions = []dockerVersion{
 	{
 		DockerVersion: "18.09.9",
 		Name:          "docker-ce",
-		Distros:       []distros.Distribution{distros.DistributionBionic},
+		Distros:       []distros.Distribution{distros.DistributionBionic, distros.DistributionFocal},
 		Architectures: []Architecture{ArchitectureAmd64},
 		Version:       "18.09.9~3-0~ubuntu-bionic",
 		Source:        "https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce_18.09.9~3-0~ubuntu-bionic_amd64.deb",
@@ -1007,7 +1007,7 @@ var dockerVersions = []dockerVersion{
 	{
 		DockerVersion: "19.03.4",
 		Name:          "docker-ce",
-		Distros:       []distros.Distribution{distros.DistributionBionic},
+		Distros:       []distros.Distribution{distros.DistributionBionic, distros.DistributionFocal},
 		Architectures: []Architecture{ArchitectureAmd64},
 		Version:       "19.03.4~3-0~ubuntu-bionic",
 		Source:        "https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce_19.03.4~3-0~ubuntu-bionic_amd64.deb",


### PR DESCRIPTION
Focal requires a Docker package in older Kops versions. As an official package for Ubuntu 20.04 (Focal) doesn't exist at the moment, the one for Ubuntu 18.04 can be used.
Support for Ubuntu 20.04 is experimental in Kops 1.16 and 1.17.

Related to https://github.com/kubernetes/kops/pull/9044.