### PR TITLE
Validate more static pods on masters

### DIFF
--- a/pkg/validation/validate_cluster_test.go
+++ b/pkg/validation/validate_cluster_test.go
@@ -427,11 +427,36 @@ func Test_ValidateMasterStaticPods(t *testing.T) {
 					},
 				},
 			},
+			{
+				ID: "i-00003",
+				Node: &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "master-1c",
+						Labels: map[string]string{"kubernetes.io/role": "master"},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: "Ready", Status: v1.ConditionFalse},
+						},
+						Addresses: []v1.NodeAddress{
+							{
+								Address: "9.10.11.12",
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 
 	var podList []map[string]string
-	var expectedFailures []*ValidationError
+	expectedFailures := []*ValidationError{
+		{
+			Kind:    "Node",
+			Name:    "master-1c",
+			Message: "master \"master-1c\" is not ready",
+		},
+	}
 
 	for i, pod := range []string{
 		"kube-apiserver",


### PR DESCRIPTION
This should cut down on cluster validation flapping.

Not testing the etcd pods as their `k8s-app` annotation depends on whether or not the cluster is configured to use etcd-manager. (It's also unlikely kube-apiserver would be ready without them.) Not testing kube-proxy pods because whether or not they're supposed to be there depends on the cluster spec.

Suppressing the static pod checks on non-ready nodes to cut down on redundant failure messages.
/area rolling-update