### PR TITLE
Don't restrict GitHub Actions to master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,8 @@
 name: build
 
 'on':
-  push:
-    branches:
-      - master
-  pull_request:
-    branches: ["*"]
+  - push
+  - pull_request
 
 env:
   GOPROXY: https://proxy.golang.org


### PR DESCRIPTION
A significant benefit of Travis/GitHub Actions is getting test and verification results before making a pull request. Restricting push triggers to master branch significantly impedes this.

Remove the restriction to master branch, bringing it into alignment with the current Travis settings.