### PR TITLE
Automated cherry pick of #8216 #8303: Adding ability to configure resources for weave

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2657,6 +2657,21 @@ spec:
                     connLimit:
                       format: int32
                       type: integer
+                    cpuLimit:
+                      description: CPULimit CPU limit of weave container.
+                      type: string
+                    cpuRequest:
+                      description: CPURequest CPU request of weave container. Default
+                        50m
+                      type: string
+                    memoryLimit:
+                      description: MemoryLimit memory limit of weave container. Default
+                        200Mi
+                      type: string
+                    memoryRequest:
+                      description: MemoryRequest memory request of weave container.
+                        Default 200Mi
+                      type: string
                     mtu:
                       format: int32
                       type: integer
@@ -2665,6 +2680,21 @@ spec:
                     noMasqLocal:
                       format: int32
                       type: integer
+                    npcCPULimit:
+                      description: NPCCPULimit CPU limit of weave npc container
+                      type: string
+                    npcCPURequest:
+                      description: NPCCPURequest CPU request of weave npc container.
+                        Default 50m
+                      type: string
+                    npcMemoryLimit:
+                      description: NPCMemoryLimit memory limit of weave npc container.
+                        Default 200Mi
+                      type: string
+                    npcMemoryRequest:
+                      description: NPCMemoryRequest memory request of weave npc container.
+                        Default 200Mi
+                      type: string
                   type: object
               type: object
             nodeAuthorization:

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package kops
 
+import "k8s.io/apimachinery/pkg/api/resource"
+
 // NetworkingSpec allows selection and configuration of a networking plugin
 type NetworkingSpec struct {
 	Classic    *ClassicNetworkingSpec    `json:"classic,omitempty"`
@@ -65,6 +67,23 @@ type WeaveNetworkingSpec struct {
 	ConnLimit    *int32 `json:"connLimit,omitempty"`
 	NoMasqLocal  *int32 `json:"noMasqLocal,omitempty"`
 	NetExtraArgs string `json:"netExtraArgs,omitempty"`
+
+	// MemoryRequest memory request of weave container. Default 200Mi
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest CPU request of weave container. Default 50m
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// MemoryLimit memory limit of weave container. Default 200Mi
+	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
+	// CPULimit CPU limit of weave container.
+	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
+	// NPCMemoryRequest memory request of weave npc container. Default 200Mi
+	NPCMemoryRequest *resource.Quantity `json:"npcMemoryRequest,omitempty"`
+	// NPCCPURequest CPU request of weave npc container. Default 50m
+	NPCCPURequest *resource.Quantity `json:"npcCPURequest,omitempty"`
+	// NPCMemoryLimit memory limit of weave npc container. Default 200Mi
+	NPCMemoryLimit *resource.Quantity `json:"npcMemoryLimit,omitempty"`
+	// NPCCPULimit CPU limit of weave npc container
+	NPCCPULimit *resource.Quantity `json:"npcCPULimit,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/parse_test.go
+++ b/pkg/apis/kops/parse_test.go
@@ -121,3 +121,48 @@ func TestParseConfigYAML(t *testing.T) {
 		})
 	}
 }
+
+func TestWeaveParseConfigYAML(t *testing.T) {
+	grid := []struct {
+		Config        string
+		ExpectedValue string
+	}{
+		{
+			Config:        "networking: {  weave: { memoryRequest: 500Mi, cpuRequest: 100m, npcMemoryRequest: 100Mi, npcCPURequest: 50m} }",
+			ExpectedValue: "50m",
+		},
+		{
+			Config:        "networking: {}",
+			ExpectedValue: "",
+		},
+	}
+	for i := range grid {
+		g := grid[i]
+		t.Run(fmt.Sprintf("%q", g.Config), func(t *testing.T) {
+			config := ClusterSpec{}
+			err := utils.YamlUnmarshal([]byte(g.Config), &config)
+			if err != nil {
+				t.Errorf("error parsing configuration %q: %v", g.Config, err)
+				return
+			}
+			var actual string
+			if nil != config.Networking.Weave {
+				actual = config.Networking.Weave.NPCCPURequest.String()
+			}
+			if g.ExpectedValue == "" {
+				if actual != "" {
+					t.Errorf("expected empty value for Networking.Weave.NPCCPURequest.String(), got %v", actual)
+					return
+				}
+			} else {
+				if actual == "" {
+					t.Errorf("expected %v value for Networking.Weave.NPCCPURequest.String(), got empty string", g.ExpectedValue)
+					return
+				} else if actual != g.ExpectedValue {
+					t.Errorf("expected %v value for Networking.Weave.NPCCPURequest.String(), got %v", g.ExpectedValue, actual)
+					return
+				}
+			}
+		})
+	}
+}

--- a/pkg/apis/kops/v1alpha1/networking.go
+++ b/pkg/apis/kops/v1alpha1/networking.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package v1alpha1
 
+import "k8s.io/apimachinery/pkg/api/resource"
+
 // NetworkingSpec allows selection and configuration of a networking plugin
 type NetworkingSpec struct {
 	Classic    *ClassicNetworkingSpec    `json:"classic,omitempty"`
@@ -65,6 +67,23 @@ type WeaveNetworkingSpec struct {
 	ConnLimit    *int32 `json:"connLimit,omitempty"`
 	NoMasqLocal  *int32 `json:"noMasqLocal,omitempty"`
 	NetExtraArgs string `json:"netExtraArgs,omitempty"`
+
+	// MemoryRequest memory request of weave container. Default 200Mi
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest CPU request of weave container. Default 50m
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// MemoryLimit memory limit of weave container. Default 200Mi
+	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
+	// CPULimit CPU limit of weave container.
+	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
+	// NPCMemoryRequest memory request of weave npc container. Default 200Mi
+	NPCMemoryRequest *resource.Quantity `json:"npcMemoryRequest,omitempty"`
+	// NPCCPURequest CPU request of weave npc container. Default 50m
+	NPCCPURequest *resource.Quantity `json:"npcCPURequest,omitempty"`
+	// NPCMemoryLimit memory limit of weave npc container. Default 200Mi
+	NPCMemoryLimit *resource.Quantity `json:"npcMemoryLimit,omitempty"`
+	// NPCCPULimit CPU limit of weave npc container
+	NPCCPULimit *resource.Quantity `json:"npcCPULimit,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -4833,6 +4833,14 @@ func autoConvert_v1alpha1_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *We
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
 	out.NetExtraArgs = in.NetExtraArgs
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
+	out.MemoryLimit = in.MemoryLimit
+	out.CPULimit = in.CPULimit
+	out.NPCMemoryRequest = in.NPCMemoryRequest
+	out.NPCCPURequest = in.NPCCPURequest
+	out.NPCMemoryLimit = in.NPCMemoryLimit
+	out.NPCCPULimit = in.NPCCPULimit
 	return nil
 }
 
@@ -4846,6 +4854,14 @@ func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha1_WeaveNetworkingSpec(in *ko
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
 	out.NetExtraArgs = in.NetExtraArgs
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
+	out.MemoryLimit = in.MemoryLimit
+	out.CPULimit = in.CPULimit
+	out.NPCMemoryRequest = in.NPCMemoryRequest
+	out.NPCCPURequest = in.NPCCPURequest
+	out.NPCMemoryLimit = in.NPCMemoryLimit
+	out.NPCCPULimit = in.NPCCPULimit
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -3411,6 +3411,46 @@ func (in *WeaveNetworkingSpec) DeepCopyInto(out *WeaveNetworkingSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPULimit != nil {
+		in, out := &in.CPULimit, &out.CPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCMemoryRequest != nil {
+		in, out := &in.NPCMemoryRequest, &out.NPCMemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCCPURequest != nil {
+		in, out := &in.NPCCPURequest, &out.NPCCPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCMemoryLimit != nil {
+		in, out := &in.NPCMemoryLimit, &out.NPCMemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCCPULimit != nil {
+		in, out := &in.NPCCPULimit, &out.NPCCPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package v1alpha2
 
+import "k8s.io/apimachinery/pkg/api/resource"
+
 // NetworkingSpec allows selection and configuration of a networking plugin
 type NetworkingSpec struct {
 	Classic    *ClassicNetworkingSpec    `json:"classic,omitempty"`
@@ -65,6 +67,23 @@ type WeaveNetworkingSpec struct {
 	ConnLimit    *int32 `json:"connLimit,omitempty"`
 	NoMasqLocal  *int32 `json:"noMasqLocal,omitempty"`
 	NetExtraArgs string `json:"netExtraArgs,omitempty"`
+
+	// MemoryRequest memory request of weave container. Default 200Mi
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest CPU request of weave container. Default 50m
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// MemoryLimit memory limit of weave container. Default 200Mi
+	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
+	// CPULimit CPU limit of weave container.
+	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
+	// NPCMemoryRequest memory request of weave npc container. Default 200Mi
+	NPCMemoryRequest *resource.Quantity `json:"npcMemoryRequest,omitempty"`
+	// NPCCPURequest CPU request of weave npc container. Default 50m
+	NPCCPURequest *resource.Quantity `json:"npcCPURequest,omitempty"`
+	// NPCMemoryLimit memory limit of weave npc container. Default 200Mi
+	NPCMemoryLimit *resource.Quantity `json:"npcMemoryLimit,omitempty"`
+	// NPCCPULimit CPU limit of weave npc container
+	NPCCPULimit *resource.Quantity `json:"npcCPULimit,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5161,6 +5161,14 @@ func autoConvert_v1alpha2_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *We
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
 	out.NetExtraArgs = in.NetExtraArgs
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
+	out.MemoryLimit = in.MemoryLimit
+	out.CPULimit = in.CPULimit
+	out.NPCMemoryRequest = in.NPCMemoryRequest
+	out.NPCCPURequest = in.NPCCPURequest
+	out.NPCMemoryLimit = in.NPCMemoryLimit
+	out.NPCCPULimit = in.NPCCPULimit
 	return nil
 }
 
@@ -5174,6 +5182,14 @@ func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha2_WeaveNetworkingSpec(in *ko
 	out.ConnLimit = in.ConnLimit
 	out.NoMasqLocal = in.NoMasqLocal
 	out.NetExtraArgs = in.NetExtraArgs
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
+	out.MemoryLimit = in.MemoryLimit
+	out.CPULimit = in.CPULimit
+	out.NPCMemoryRequest = in.NPCMemoryRequest
+	out.NPCCPURequest = in.NPCCPURequest
+	out.NPCMemoryLimit = in.NPCMemoryLimit
+	out.NPCCPULimit = in.NPCCPULimit
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3482,6 +3482,46 @@ func (in *WeaveNetworkingSpec) DeepCopyInto(out *WeaveNetworkingSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPULimit != nil {
+		in, out := &in.CPULimit, &out.CPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCMemoryRequest != nil {
+		in, out := &in.NPCMemoryRequest, &out.NPCMemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCCPURequest != nil {
+		in, out := &in.NPCCPURequest, &out.NPCCPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCMemoryLimit != nil {
+		in, out := &in.NPCMemoryLimit, &out.NPCMemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCCPULimit != nil {
+		in, out := &in.NPCCPULimit, &out.NPCCPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3696,6 +3696,46 @@ func (in *WeaveNetworkingSpec) DeepCopyInto(out *WeaveNetworkingSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPULimit != nil {
+		in, out := &in.CPULimit, &out.CPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCMemoryRequest != nil {
+		in, out := &in.NPCMemoryRequest, &out.NPCMemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCCPURequest != nil {
+		in, out := &in.NPCCPURequest, &out.NPCCPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCMemoryLimit != nil {
+		in, out := &in.NPCMemoryLimit, &out.NPCMemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.NPCCPULimit != nil {
+		in, out := &in.NPCCPULimit, &out.NPCCPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -180,12 +180,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.CPURequest "50m" }}
-              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.CPULimit }}
               cpu: {{ .Networking.Weave.CPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200Mi" }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -218,12 +218,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.NPCCPURequest "50m" }}
-              memory: {{ or .Networking.Weave.NPCMemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.NPCMemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.NPCCPULimit }}
               cpu: {{ .Networking.Weave.NPCCPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.NPCMemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.NPCMemoryLimit "200Mi" }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -179,10 +179,13 @@ spec:
               port: 6784
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.CPURequest "50m" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.CPULimit }}
+              cpu: {{ .Networking.Weave.CPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -214,10 +217,13 @@ spec:
               containerPort: 6781
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.NPCCPURequest "50m" }}
+              memory: {{ or .Networking.Weave.NPCMemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.NPCCPULimit }}
+              cpu: {{ .Networking.Weave.NPCCPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.NPCMemoryLimit "200mi" }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
@@ -161,10 +161,13 @@ spec:
               port: 6784
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.CPURequest "50m" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.CPULimit }}
+              cpu: {{ .Networking.Weave.CPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -195,10 +198,13 @@ spec:
               containerPort: 6781
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.NPCCPURequest "50m" }}
+              memory: {{ or .Networking.Weave.NPCMemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.NPCCPULimit }}
+              cpu: {{ .Networking.Weave.NPCCPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.NPCMemoryLimit "200mi" }}
           securityContext:
             privileged: true
       hostNetwork: true

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.6.yaml.template
@@ -162,12 +162,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.CPURequest "50m" }}
-              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.CPULimit }}
               cpu: {{ .Networking.Weave.CPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200Mi" }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -199,12 +199,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.NPCCPURequest "50m" }}
-              memory: {{ or .Networking.Weave.NPCMemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.NPCMemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.NPCCPULimit }}
               cpu: {{ .Networking.Weave.NPCCPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.NPCMemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.NPCMemoryLimit "200Mi" }}
           securityContext:
             privileged: true
       hostNetwork: true

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -172,12 +172,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.CPURequest "50m" }}
-              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.CPULimit }}
               cpu: {{ .Networking.Weave.CPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200Mi" }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -210,12 +210,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.NPCCPURequest "50m" }}
-              memory: {{ or .Networking.Weave.NPCMemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.NPCMemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.NPCCPULimit }}
               cpu: {{ .Networking.Weave.NPCCPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.NPCMemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.NPCMemoryLimit "200Mi" }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.7.yaml.template
@@ -171,10 +171,13 @@ spec:
               port: 6784
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.CPURequest "50m" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.CPULimit }}
+              cpu: {{ .Networking.Weave.CPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -206,10 +209,13 @@ spec:
               containerPort: 6781
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.NPCCPURequest "50m" }}
+              memory: {{ or .Networking.Weave.NPCMemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.NPCCPULimit }}
+              cpu: {{ .Networking.Weave.NPCCPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.NPCMemoryLimit "200mi" }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -175,10 +175,13 @@ spec:
               port: 6784
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.CPURequest "50m" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.CPULimit }}
+              cpu: {{ .Networking.Weave.CPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -210,10 +213,13 @@ spec:
               containerPort: 6781
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.NPCCPURequest "50m" }}
+              memory: {{ or .Networking.Weave.NPCMemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.NPCCPULimit }}
+              cpu: {{ .Networking.Weave.NPCCPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.NPCMemoryLimit "200mi" }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -176,12 +176,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.CPURequest "50m" }}
-              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.CPULimit }}
               cpu: {{ .Networking.Weave.CPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200Mi" }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -214,12 +214,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.NPCCPURequest "50m" }}
-              memory: {{ or .Networking.Weave.NPCMemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.NPCMemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.NPCCPULimit }}
               cpu: {{ .Networking.Weave.NPCCPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.NPCMemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.NPCMemoryLimit "200Mi" }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
@@ -59,10 +59,13 @@ spec:
             initialDelaySeconds: 30
           resources:
             requests:
-              cpu: 50m
-              memory: 200Mi
+              cpu: {{ or .Networking.Weave.CPURequest "50m" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
             limits:
-              memory: 200Mi
+              {{- if .Networking.Weave.CPULimit }}
+              cpu: {{ .Networking.Weave.CPULimit }}
+              {{- end }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/pre-k8s-1.6.yaml.template
@@ -60,12 +60,12 @@ spec:
           resources:
             requests:
               cpu: {{ or .Networking.Weave.CPURequest "50m" }}
-              memory: {{ or .Networking.Weave.MemoryRequest "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryRequest "200Mi" }}
             limits:
               {{- if .Networking.Weave.CPULimit }}
               cpu: {{ .Networking.Weave.CPULimit }}
               {{- end }}
-              memory: {{ or .Networking.Weave.MemoryLimit "200mi" }}
+              memory: {{ or .Networking.Weave.MemoryLimit "200Mi" }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -692,11 +692,11 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 	if b.cluster.Spec.Networking.Weave != nil {
 		key := "networking.weave"
 		versions := map[string]string{
-			"pre-k8s-1.6": "2.3.0-kops.3",
-			"k8s-1.6":     "2.3.0-kops.3",
-			"k8s-1.7":     "2.5.2-kops.2",
-			"k8s-1.8":     "2.5.2-kops.2",
-			"k8s-1.12":    "2.5.2-kops.3",
+			"pre-k8s-1.6": "2.3.0-kops.4",
+			"k8s-1.6":     "2.3.0-kops.4",
+			"k8s-1.7":     "2.5.2-kops.4",
+			"k8s-1.8":     "2.5.2-kops.4",
+			"k8s-1.12":    "2.5.2-kops.4",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/cluster.yaml
@@ -23,7 +23,15 @@ spec:
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16
   networking:
-    weave: {}
+    weave:
+      memoryRequest: 300Mi
+      cpuRequest: 100m
+      memoryLimit: 300Mi
+      cpuLimit: 200m
+      npcMemoryRequest: 300Mi
+      npcCPURequest: 100m
+      npcMemoryLimit: 300Mi
+      npcCPULimit: 200m
   nonMasqueradeCIDR: 100.64.0.0/10
   sshAccess:
     - 0.0.0.0/0

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -115,7 +115,7 @@ spec:
   - id: pre-k8s-1.6
     kubernetesVersion: <1.6.0
     manifest: networking.weave/pre-k8s-1.6.yaml
-    manifestHash: 564f5bea5d9eee61af636dba48c4092a0bedef7f
+    manifestHash: 8e7a361fff381e0ed84e0011506ff3bfdc7bc202
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
@@ -123,7 +123,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.7.0'
     manifest: networking.weave/k8s-1.6.yaml
-    manifestHash: 6897c214a84d8ba960f7c92e237e1f9d8edea394
+    manifestHash: 6dcb06c0178143b534dac093fcad00c331b12319
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
@@ -131,7 +131,7 @@ spec:
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0 <1.8.0'
     manifest: networking.weave/k8s-1.7.yaml
-    manifestHash: 258ad76c3ef165f216980c96367df13a8bffb1d8
+    manifestHash: 600d89f6a75a02082c21b06e8aca519f5123c997
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
@@ -139,7 +139,7 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: 748a1526515a719058b99c203cd943a740675e21
+    manifestHash: 2015055c3bac44104be0a56907cc87df0138e397
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
@@ -147,7 +147,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: 96334bfcfa6a3ec9791b50c94674a8821cb6ad67
+    manifestHash: 7608d945590987fa7548a85081f591b716bf2106
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -119,7 +119,7 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.3.0-kops.3
+    version: 2.3.0-kops.4
   - id: k8s-1.6
     kubernetesVersion: '>=1.6.0 <1.7.0'
     manifest: networking.weave/k8s-1.6.yaml
@@ -127,7 +127,7 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.3.0-kops.3
+    version: 2.3.0-kops.4
   - id: k8s-1.7
     kubernetesVersion: '>=1.7.0 <1.8.0'
     manifest: networking.weave/k8s-1.7.yaml
@@ -135,7 +135,7 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.2-kops.2
+    version: 2.5.2-kops.4
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
@@ -143,7 +143,7 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.2-kops.2
+    version: 2.5.2-kops.4
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
@@ -151,4 +151,4 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.2-kops.3
+    version: 2.5.2-kops.4


### PR DESCRIPTION
Cherry pick of #8216 #8303 on release-1.17.

#8216: Adding ability to configure resources for weave (#8113)
#8303: Fix unit name for memory request for weave

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.