### PR TITLE
Automated cherry pick of #7898 8691 8764 8965: Update Weave Net to version 2.6.2

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -168,7 +168,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.1'
+          image: 'weaveworks/weave-kube:2.6.2'
           ports:
             - name: metrics
               containerPort: 6782
@@ -212,7 +212,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.6.1'
+          image: 'weaveworks/weave-npc:2.6.2'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -168,7 +168,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.0'
+          image: 'weaveworks/weave-kube:2.6.1'
           ports:
             - name: metrics
               containerPort: 6782
@@ -203,6 +203,7 @@ spec:
               mountPath: /lib/modules
             - name: xtables-lock
               mountPath: /run/xtables.lock
+              readOnly: false
         - name: weave-npc
           args: []
           env:
@@ -211,7 +212,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.6.0'
+          image: 'weaveworks/weave-npc:2.6.1'
           ports:
             - name: metrics
               containerPort: 6781
@@ -229,7 +230,9 @@ spec:
           volumeMounts:
             - name: xtables-lock
               mountPath: /run/xtables.lock
+              readOnly: false
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       restartPolicy: Always
       securityContext:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -37,6 +37,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - extensions
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - 'networking.k8s.io'
     resources:
       - networkpolicies
@@ -131,7 +139,6 @@ spec:
         role.kubernetes.io/networking: "1"
       annotations:
         prometheus.io/scrape: "true"
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
         - name: weave
@@ -205,7 +212,6 @@ spec:
               mountPath: /run/xtables.lock
               readOnly: false
         - name: weave-npc
-          args: []
           env:
             - name: HOSTNAME
               valueFrom:
@@ -240,6 +246,8 @@ spec:
       serviceAccountName: weave-net
       tolerations:
         - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
           operator: Exists
         - key: CriticalAddonsOnly
           operator: Exists

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -168,7 +168,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.5.2'
+          image: 'weaveworks/weave-kube:2.6.0'
           ports:
             - name: metrics
               containerPort: 6782
@@ -211,7 +211,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.5.2'
+          image: 'weaveworks/weave-npc:2.6.0'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -164,7 +164,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.0'
+          image: 'weaveworks/weave-kube:2.6.1'
           ports:
             - name: metrics
               containerPort: 6782
@@ -199,6 +199,7 @@ spec:
               mountPath: /lib/modules
             - name: xtables-lock
               mountPath: /run/xtables.lock
+              readOnly: false
         - name: weave-npc
           args: []
           env:
@@ -207,7 +208,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.6.0'
+          image: 'weaveworks/weave-npc:2.6.1'
           ports:
             - name: metrics
               containerPort: 6781
@@ -225,6 +226,7 @@ spec:
           volumeMounts:
             - name: xtables-lock
               mountPath: /run/xtables.lock
+              readOnly: false
       hostNetwork: true
       hostPID: true
       restartPolicy: Always

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -37,6 +37,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - extensions
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - 'networking.k8s.io'
     resources:
       - networkpolicies
@@ -201,7 +209,6 @@ spec:
               mountPath: /run/xtables.lock
               readOnly: false
         - name: weave-npc
-          args: []
           env:
             - name: HOSTNAME
               valueFrom:
@@ -235,6 +242,8 @@ spec:
       serviceAccountName: weave-net
       tolerations:
         - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
           operator: Exists
         - key: CriticalAddonsOnly
           operator: Exists

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -164,7 +164,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.5.2'
+          image: 'weaveworks/weave-kube:2.6.0'
           ports:
             - name: metrics
               containerPort: 6782
@@ -207,7 +207,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.5.2'
+          image: 'weaveworks/weave-npc:2.6.0'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -164,7 +164,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.1'
+          image: 'weaveworks/weave-kube:2.6.2'
           ports:
             - name: metrics
               containerPort: 6782
@@ -208,7 +208,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.6.1'
+          image: 'weaveworks/weave-npc:2.6.2'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -695,8 +695,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"pre-k8s-1.6": "2.3.0-kops.4",
 			"k8s-1.6":     "2.3.0-kops.4",
 			"k8s-1.7":     "2.5.2-kops.4",
-			"k8s-1.8":     "2.5.2-kops.4",
-			"k8s-1.12":    "2.5.2-kops.4",
+			"k8s-1.8":     "2.6.0-kops.2",
+			"k8s-1.12":    "2.6.0-kops.3",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -695,8 +695,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"pre-k8s-1.6": "2.3.0-kops.4",
 			"k8s-1.6":     "2.3.0-kops.4",
 			"k8s-1.7":     "2.5.2-kops.4",
-			"k8s-1.8":     "2.6.2-kops.1",
-			"k8s-1.12":    "2.6.2-kops.1",
+			"k8s-1.8":     "2.6.2-kops.2",
+			"k8s-1.12":    "2.6.2-kops.2",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -695,8 +695,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"pre-k8s-1.6": "2.3.0-kops.4",
 			"k8s-1.6":     "2.3.0-kops.4",
 			"k8s-1.7":     "2.5.2-kops.4",
-			"k8s-1.8":     "2.6.1-kops.1",
-			"k8s-1.12":    "2.6.1-kops.1",
+			"k8s-1.8":     "2.6.2-kops.1",
+			"k8s-1.12":    "2.6.2-kops.1",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -695,8 +695,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"pre-k8s-1.6": "2.3.0-kops.4",
 			"k8s-1.6":     "2.3.0-kops.4",
 			"k8s-1.7":     "2.5.2-kops.4",
-			"k8s-1.8":     "2.6.0-kops.2",
-			"k8s-1.12":    "2.6.0-kops.3",
+			"k8s-1.8":     "2.6.1-kops.1",
+			"k8s-1.12":    "2.6.1-kops.1",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -139,16 +139,16 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: 23511c3485517049f5b90ce365a3e329509194ee
+    manifestHash: c155a287ba70947925da304dd81e50f159c541bc
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.2-kops.1
+    version: 2.6.2-kops.2
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: 5c6202bc41043a72cb78ade6c761ccaf183bd36c
+    manifestHash: d472c3e0dd7c71148dc5eae96bea50eba4e17807
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.2-kops.1
+    version: 2.6.2-kops.2

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -139,16 +139,16 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: f9d056a15c55dd906fb0d41583d457542f7136e2
+    manifestHash: 7aa5336ec05aef46b185cb660fc02bb2ac201852
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.0-kops.2
+    version: 2.6.1-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: c6614394aa5efaf6d12dedd8df66b5ee3e63aa46
+    manifestHash: 6f12295454fef72234205b7e6c62cdac656eab52
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.0-kops.3
+    version: 2.6.1-kops.1

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -139,16 +139,16 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: 2015055c3bac44104be0a56907cc87df0138e397
+    manifestHash: f9d056a15c55dd906fb0d41583d457542f7136e2
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.2-kops.4
+    version: 2.6.0-kops.2
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: 7608d945590987fa7548a85081f591b716bf2106
+    manifestHash: c6614394aa5efaf6d12dedd8df66b5ee3e63aa46
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.2-kops.4
+    version: 2.6.0-kops.3

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -139,16 +139,16 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: 7aa5336ec05aef46b185cb660fc02bb2ac201852
+    manifestHash: 23511c3485517049f5b90ce365a3e329509194ee
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.1-kops.1
+    version: 2.6.2-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: 6f12295454fef72234205b7e6c62cdac656eab52
+    manifestHash: 5c6202bc41043a72cb78ade6c761ccaf183bd36c
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.1-kops.1
+    version: 2.6.2-kops.1


### PR DESCRIPTION
Cherry pick of #7898 #8691 #8764 #8965 on release-1.17.

#7898: Update Weave Net to version 2.6.0
#8691: Update Weave Net to version 2.6.1
#8764: Update Weave Net to version 2.6.2
#8965: Fix missing changes in Weave manifest

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.