### PR TITLE
Update instance_groups.md

### DIFF
--- a/docs/instance_groups.md
+++ b/docs/instance_groups.md
@@ -143,9 +143,45 @@ which would end up in a drop-in file on nodes of the instance group in question.
 
 ## mixedInstancePolicy (AWS Only)
 
+### Example
+
+```
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  generation: 2
+  labels:
+    kops.k8s.io/cluster: <clustername>
+  name: spot-4vcpu-16gb
+spec:
+  cloudLabels:
+    autoscaler: enabled
+    cluster: kops-cluster
+  image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17
+  maxSize: 5
+  minSize: 1
+  machineType: m5.xlarge
+  mixedInstancesPolicy:
+    instances:
+    - m5.xlarge
+    - m5d.xlarge
+    - m4.xlarge
+    - t3.xlarge
+    - t3a.xlarge
+    - m5a.xlarge
+    - m5ad.xlarge
+    - m5n.xlarge    
+    - m5dn.xlarge
+    onDemandBase: 0
+    onDemandAboveBase: 0
+    spotAllocationStrategy: capacity-optimized
+  nodeLabels:
+    lifecycle: Ec2Spot
+```
+
 ### Instances
 
-Instances is a list of instance types which we are willing to run in the EC2 fleet
+Instances is a list of instance types which we are willing to run in the EC2 Auto Scaling group
 
 ### onDemandAllocationStrategy
 

--- a/docs/instance_groups.md
+++ b/docs/instance_groups.md
@@ -164,12 +164,11 @@ leave this parameter set to 100, the percentages are 100% for On-Demand Instance
 Spot Instances.
 
 ### spotAllocationStrategy
+SpotAllocationStrategy Indicates how to allocate instances across Spot Instance pools.
 
-SpotAllocationStrategy diversifies your Spot capacity across multiple instance types to
-find the best pricing. Higher Spot availability may result from a larger number of
-instance types to choose from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet.html#spot-fleet-allocation-strategy
+If the allocation strategy is lowest-price, the Auto Scaling group launches instances using the Spot pools with the lowest price, and evenly allocates your instances across the number of Spot pools that you specify in spotInstancePools. If the allocation strategy is [capacity-optimized](https://aws.amazon.com/blogs/compute/introducing-the-capacity-optimized-allocation-strategy-for-amazon-ec2-spot-instances/), the Auto Scaling group launches instances using Spot pools that are optimally chosen based on the available Spot capacity.
+https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstancesDistribution.html
 
 ### spotInstancePools
-
-SpotInstancePools is the number of Spot pools to use to allocate your Spot capacity (defaults to 2)
-pools are determined from the different instance types in the Overrides array of LaunchTemplate
+Used only when the Spot allocation strategy is lowest-price.
+The number of Spot Instance pools across which to allocate your Spot Instances. The Spot pools are determined from the different instance types in the Overrides array of LaunchTemplate. Default if not set is 2.


### PR DESCRIPTION
the description and link for spotAllocationStrategy are currently taken from the Spot Fleet documentation, while kops uses EC2 Auto Scaling groups. these are two different tools/APIs, so I am proposing a fix to the readme file that would correct spotAllocationStrategy to point to the ASG documentation instead.