### PR TITLE
Automated cherry pick of #9053: Allow cluster maintenance when channel is unavailable

### DIFF
--- a/cmd/kops/create_ig.go
+++ b/cmd/kops/create_ig.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 	"k8s.io/kops/cmd/kops/util"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/validation"
@@ -130,7 +131,7 @@ func RunCreateInstanceGroup(f *util.Factory, cmd *cobra.Command, args []string, 
 
 	channel, err := cloudup.ChannelForCluster(cluster)
 	if err != nil {
-		return err
+		klog.Warningf("%v", err)
 	}
 
 	existing, err := clientset.InstanceGroupsFor(cluster).Get(groupName, metav1.GetOptions{})

--- a/cmd/kops/edit_instancegroup.go
+++ b/cmd/kops/edit_instancegroup.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 	"k8s.io/kops/cmd/kops/util"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/validation"
@@ -96,7 +97,7 @@ func RunEditInstanceGroup(f *util.Factory, cmd *cobra.Command, args []string, ou
 
 	channel, err := cloudup.ChannelForCluster(cluster)
 	if err != nil {
-		return err
+		klog.Warningf("%v", err)
 	}
 
 	clientset, err := rootCommand.Clientset()

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -171,7 +171,7 @@ func (c *ApplyClusterCmd) Run() error {
 
 	channel, err := ChannelForCluster(c.Cluster)
 	if err != nil {
-		return err
+		klog.Warningf("%v", err)
 	}
 	c.channel = channel
 

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -116,6 +116,9 @@ func PopulateInstanceGroupSpec(cluster *kops.Cluster, input *kops.InstanceGroup,
 
 	if ig.Spec.Image == "" {
 		ig.Spec.Image = defaultImage(cluster, channel)
+		if ig.Spec.Image == "" {
+			return nil, fmt.Errorf("unable to determine default image for InstanceGroup %s", ig.ObjectMeta.Name)
+		}
 	}
 
 	if ig.Spec.Tenancy != "" && ig.Spec.Tenancy != "default" {


### PR DESCRIPTION
Cherry pick of #9053 on release-1.17.

#9053: Allow cluster maintenance when channel is unavailable

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.