### PR TITLE
Automated cherry pick of #9068: Added support for configuring disable-attach-detach-reconcile-sync

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1197,6 +1197,11 @@ spec:
                   items:
                     type: string
                   type: array
+                disableAttachDetachReconcileSync:
+                  description: DisableAttachDetachReconcileSync disables the reconcile
+                    sync loop in the attach-detach controller. This can cause volumes
+                    to become mismatched with pods
+                  type: boolean
                 enableProfiling:
                   description: EnableProfiling enables profiling via web interface
                     host:port/debug/pprof/

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -500,6 +500,9 @@ type KubeControllerManagerConfig struct {
 	// AttachDetachReconcileSyncPeriod is the amount of time the reconciler sync states loop
 	// wait between successive executions. Is set to 1 min by kops by default
 	AttachDetachReconcileSyncPeriod *metav1.Duration `json:"attachDetachReconcileSyncPeriod,omitempty" flag:"attach-detach-reconcile-sync-period"`
+	// DisableAttachDetachReconcileSync disables the reconcile sync loop in the attach-detach controller.
+	// This can cause volumes to become mismatched with pods
+	DisableAttachDetachReconcileSync *bool `json:"disableAttachDetachReconcileSync,omitempty" flag:"disable-attach-detach-reconcile-sync"`
 	// TerminatedPodGCThreshold is the number of terminated pods that can exist
 	// before the terminated pod garbage collector starts deleting terminated pods.
 	// If <= 0, the terminated pod garbage collector is disabled.

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -500,6 +500,9 @@ type KubeControllerManagerConfig struct {
 	// ReconcilerSyncLoopPeriod is the amount of time the reconciler sync states loop
 	// wait between successive executions. Is set to 1 min by kops by default
 	AttachDetachReconcileSyncPeriod *metav1.Duration `json:"attachDetachReconcileSyncPeriod,omitempty" flag:"attach-detach-reconcile-sync-period"`
+	// DisableAttachDetachReconcileSync disables the reconcile sync loop in the attach-detach controller.
+	// This can cause volumes to become mismatched with pods
+	DisableAttachDetachReconcileSync *bool `json:"disableAttachDetachReconcileSync,omitempty" flag:"disable-attach-detach-reconcile-sync"`
 	// TerminatedPodGCThreshold is the number of terminated pods that can exist
 	// before the terminated pod garbage collector starts deleting terminated pods.
 	// If <= 0, the terminated pod garbage collector is disabled.

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -3444,6 +3444,7 @@ func autoConvert_v1alpha1_KubeControllerManagerConfig_To_kops_KubeControllerMana
 		out.LeaderElection = nil
 	}
 	out.AttachDetachReconcileSyncPeriod = in.AttachDetachReconcileSyncPeriod
+	out.DisableAttachDetachReconcileSync = in.DisableAttachDetachReconcileSync
 	out.TerminatedPodGCThreshold = in.TerminatedPodGCThreshold
 	out.NodeMonitorPeriod = in.NodeMonitorPeriod
 	out.NodeMonitorGracePeriod = in.NodeMonitorGracePeriod
@@ -3495,6 +3496,7 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha1_KubeControllerMana
 		out.LeaderElection = nil
 	}
 	out.AttachDetachReconcileSyncPeriod = in.AttachDetachReconcileSyncPeriod
+	out.DisableAttachDetachReconcileSync = in.DisableAttachDetachReconcileSync
 	out.TerminatedPodGCThreshold = in.TerminatedPodGCThreshold
 	out.NodeMonitorPeriod = in.NodeMonitorPeriod
 	out.NodeMonitorGracePeriod = in.NodeMonitorGracePeriod

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -2116,6 +2116,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.DisableAttachDetachReconcileSync != nil {
+		in, out := &in.DisableAttachDetachReconcileSync, &out.DisableAttachDetachReconcileSync
+		*out = new(bool)
+		**out = **in
+	}
 	if in.TerminatedPodGCThreshold != nil {
 		in, out := &in.TerminatedPodGCThreshold, &out.TerminatedPodGCThreshold
 		*out = new(int32)

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -500,6 +500,9 @@ type KubeControllerManagerConfig struct {
 	// ReconcilerSyncLoopPeriod is the amount of time the reconciler sync states loop
 	// wait between successive executions. Is set to 1 min by kops by default
 	AttachDetachReconcileSyncPeriod *metav1.Duration `json:"attachDetachReconcileSyncPeriod,omitempty" flag:"attach-detach-reconcile-sync-period"`
+	// DisableAttachDetachReconcileSync disables the reconcile sync loop in the attach-detach controller.
+	// This can cause volumes to become mismatched with pods
+	DisableAttachDetachReconcileSync *bool `json:"disableAttachDetachReconcileSync,omitempty" flag:"disable-attach-detach-reconcile-sync"`
 	// TerminatedPodGCThreshold is the number of terminated pods that can exist
 	// before the terminated pod garbage collector starts deleting terminated pods.
 	// If <= 0, the terminated pod garbage collector is disabled.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3714,6 +3714,7 @@ func autoConvert_v1alpha2_KubeControllerManagerConfig_To_kops_KubeControllerMana
 		out.LeaderElection = nil
 	}
 	out.AttachDetachReconcileSyncPeriod = in.AttachDetachReconcileSyncPeriod
+	out.DisableAttachDetachReconcileSync = in.DisableAttachDetachReconcileSync
 	out.TerminatedPodGCThreshold = in.TerminatedPodGCThreshold
 	out.NodeMonitorPeriod = in.NodeMonitorPeriod
 	out.NodeMonitorGracePeriod = in.NodeMonitorGracePeriod
@@ -3765,6 +3766,7 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha2_KubeControllerMana
 		out.LeaderElection = nil
 	}
 	out.AttachDetachReconcileSyncPeriod = in.AttachDetachReconcileSyncPeriod
+	out.DisableAttachDetachReconcileSync = in.DisableAttachDetachReconcileSync
 	out.TerminatedPodGCThreshold = in.TerminatedPodGCThreshold
 	out.NodeMonitorPeriod = in.NodeMonitorPeriod
 	out.NodeMonitorGracePeriod = in.NodeMonitorGracePeriod

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2187,6 +2187,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.DisableAttachDetachReconcileSync != nil {
+		in, out := &in.DisableAttachDetachReconcileSync, &out.DisableAttachDetachReconcileSync
+		*out = new(bool)
+		**out = **in
+	}
 	if in.TerminatedPodGCThreshold != nil {
 		in, out := &in.TerminatedPodGCThreshold, &out.TerminatedPodGCThreshold
 		*out = new(int32)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2369,6 +2369,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.DisableAttachDetachReconcileSync != nil {
+		in, out := &in.DisableAttachDetachReconcileSync, &out.DisableAttachDetachReconcileSync
+		*out = new(bool)
+		**out = **in
+	}
 	if in.TerminatedPodGCThreshold != nil {
 		in, out := &in.TerminatedPodGCThreshold, &out.TerminatedPodGCThreshold
 		*out = new(int32)


### PR DESCRIPTION
Cherry pick of #9068 on release-1.17.

#9068: Added support for configuring disable-attach-detach-reconcile-sync

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.