### PR TITLE
Reduce the number of TravisCI jobs for release branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ os:
   - linux
   - osx
 go:
-  # 1.12 is now best-effort; we recommend 1.13
-  - "1.12"
   - "1.13"
 
 go_import_path: k8s.io/kops


### PR DESCRIPTION
For release branches we only need Linux and macOS with the default GO version.
This should help reduce the load on macOS jobs and, in general, before releases. 