### PR TITLE
Use Ubuntu 18.04 Docker 19.03.8 packages for Ubuntu 20.04

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -1158,7 +1158,7 @@ var dockerVersions = []dockerVersion{
 	{
 		DockerVersion: "19.03.8",
 		Name:          "docker-ce",
-		Distros:       []distros.Distribution{distros.DistributionBionic},
+		Distros:       []distros.Distribution{distros.DistributionBionic, distros.DistributionFocal},
 		Architectures: []Architecture{ArchitectureAmd64},
 		Version:       "19.03.8~3-0~ubuntu-bionic",
 		Source:        "https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce_19.03.8~3-0~ubuntu-bionic_amd64.deb",


### PR DESCRIPTION
Followup of #9047 which did the same for Docker 18.09.9 and 19.03.4.
/cc @rifelpet 