### PR TITLE
Spotinst: Allow users to disable the controller add-on

### DIFF
--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -76,6 +76,8 @@ var (
 	Spotinst = New("Spotinst", Bool(false))
 	// SpotinstOcean toggles the use of Spotinst Ocean instance group implementation.
 	SpotinstOcean = New("SpotinstOcean", Bool(false))
+	// SpotinstController toggles the installation of the Spotinst controller addon.
+	SpotinstController = New("SpotinstController", Bool(true))
 	// VPCSkipEnableDNSSupport if set will make that a VPC does not need DNSSupport enabled.
 	VPCSkipEnableDNSSupport = New("VPCSkipEnableDNSSupport", Bool(false))
 	// VSphereCloudProvider enables the vsphere cloud provider

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -543,7 +543,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		}
 	}
 
-	if featureflag.Spotinst.Enabled() {
+	if featureflag.Spotinst.Enabled() && featureflag.SpotinstController.Enabled() {
 		key := "spotinst-kubernetes-cluster-controller.addons.k8s.io"
 
 		{


### PR DESCRIPTION
This PR adds a new feature flag, named `SpotinstController`, that allows users to toggle the installation of the Spotinst controller off. The feature flag defaults to `true` to maintain backward compatibility.