### PR TITLE
kube-apiserver-healthcheck: actually enable on 1.17

### DIFF
--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -296,7 +296,7 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 		c.AnonymousAuth = fi.Bool(false)
 	}
 
-	if b.IsKubernetesGTE("1.18") {
+	if b.IsKubernetesGTE("1.17") {
 		// We query via the kube-apiserver-healthcheck proxy, which listens on port 8080
 		c.InsecurePort = 0
 	} else {

--- a/pkg/model/components/kubeapiserver/model.go
+++ b/pkg/model/components/kubeapiserver/model.go
@@ -41,8 +41,8 @@ func (b *KubeApiserverBuilder) useHealthCheckSidecar(c *fi.ModelBuilderContext) 
 	// Should we use our health-check proxy, which allows us to
 	// query the secure port without enabling anonymous auth?
 	useHealthCheckSidecar := true
-	// We only turn on the proxy in k8s 1.18 and above
-	if b.IsKubernetesLT("1.18") {
+	// We only turn on the proxy in k8s 1.17 and above
+	if b.IsKubernetesLT("1.17") {
 		useHealthCheckSidecar = false
 	}
 
@@ -94,7 +94,7 @@ kind: Pod
 spec:
   containers:
   - name: healthcheck
-    image: kope/kube-apiserver-healthcheck:1.18.0-alpha.3
+    image: kope/kube-apiserver-healthcheck:1.17.0-beta.2
     livenessProbe:
       httpGet:
         # The sidecar serves a healthcheck on the same port,

--- a/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
+++ b/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
@@ -13,7 +13,7 @@ Contents:
         - --client-key=/secrets/client.key
         command:
         - /usr/bin/kube-apiserver-healthcheck
-        image: kope/kube-apiserver-healthcheck:1.18.0-alpha.3
+        image: kope/kube-apiserver-healthcheck:1.17.0-beta.2
         livenessProbe:
           httpGet:
             host: 127.0.0.1


### PR DESCRIPTION
We cherry picked, but now we need to activate the feature.