### PR TITLE
Fix port conflict on etcd-cilium vs dns-controller memberlist

### DIFF
--- a/pkg/wellknownports/wellknownports.go
+++ b/pkg/wellknownports/wellknownports.go
@@ -30,7 +30,7 @@ const (
 	EtcdEventsGRPC = 3997
 
 	EtcdCiliumQuarantinedClientPort = 3992
-	EtcdCiliumGRPC                  = 3993
+	EtcdCiliumGRPC                  = 3991
 
 	// DNSControllerGossipWeaveMesh is the port where dns-controller listens for the weave-mesh backend gossip
 	DNSControllerGossipWeaveMesh = 3998


### PR DESCRIPTION
Both were allocated port 3993; etcd-cilium is new and so it is less
impactful to renumber that.