### PR TITLE
kube-apiserver-healthcheck: actually enable on 1.17

### DIFF
--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -233,7 +233,7 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 	// We make sure to disable AnonymousAuth
 	c.AnonymousAuth = fi.Bool(false)
 
-	if b.IsKubernetesGTE("1.18") {
+	if b.IsKubernetesGTE("1.17") {
 		// We query via the kube-apiserver-healthcheck proxy, which listens on port 8080
 		c.InsecurePort = 0
 	} else {

--- a/pkg/model/components/kubeapiserver/model.go
+++ b/pkg/model/components/kubeapiserver/model.go
@@ -41,8 +41,8 @@ func (b *KubeApiserverBuilder) useHealthCheckSidecar(c *fi.ModelBuilderContext) 
 	// Should we use our health-check proxy, which allows us to
 	// query the secure port without enabling anonymous auth?
 	useHealthCheckSidecar := true
-	// We only turn on the proxy in k8s 1.18 and above
-	if b.IsKubernetesLT("1.18") {
+	// We only turn on the proxy in k8s 1.17 and above
+	if b.IsKubernetesLT("1.17") {
 		useHealthCheckSidecar = false
 	}
 


### PR DESCRIPTION
We cherry picked the support to 1.17, but now we need to activate the
feature.

This is itself a (backwards) cherry-pick of #9095