### PR TITLE
Fix containerd image side-loading

### DIFF
--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -193,7 +193,7 @@ func (t *ProtokubeBuilder) ProtokubeImagePullCommand() (string, error) {
 	if t.Cluster.Spec.ContainerRuntime == "docker" {
 		protokubeImagePullCommand = "-/usr/bin/docker pull " + sources[0]
 	} else if t.Cluster.Spec.ContainerRuntime == "containerd" {
-		protokubeImagePullCommand = "-/usr/bin/ctr images pull docker.io/" + sources[0]
+		protokubeImagePullCommand = "-/usr/bin/ctr --namespace k8s.io images pull docker.io/" + sources[0]
 	} else {
 		return "", fmt.Errorf("unable to create protokube image pull command for unsupported runtime %q", t.Cluster.Spec.ContainerRuntime)
 	}
@@ -219,7 +219,7 @@ func (t *ProtokubeBuilder) ProtokubeContainerRemoveCommand() (string, error) {
 	if t.Cluster.Spec.ContainerRuntime == "docker" {
 		containerRemoveCommand = "-/usr/bin/docker rm protokube"
 	} else if t.Cluster.Spec.ContainerRuntime == "containerd" {
-		containerRemoveCommand = "-/usr/bin/ctr container rm protokube"
+		containerRemoveCommand = "-/usr/bin/ctr --namespace k8s.io container rm protokube"
 	} else {
 		return "", fmt.Errorf("unable to create protokube remove command for unsupported runtime %q", t.Cluster.Spec.ContainerRuntime)
 	}
@@ -272,7 +272,7 @@ func (t *ProtokubeBuilder) ProtokubeContainerRunCommand() (string, error) {
 
 	} else if t.Cluster.Spec.ContainerRuntime == "containerd" {
 		containerRunArgs = append(containerRunArgs, []string{
-			"/usr/bin/ctr run",
+			"/usr/bin/ctr --namespace k8s.io run",
 			"--net-host",
 			"--with-ns pid:/proc/1/ns/pid",
 			"--privileged",

--- a/nodeup/pkg/model/tests/protokube/containerd/tasks.yaml
+++ b/nodeup/pkg/model/tests/protokube/containerd/tasks.yaml
@@ -6,9 +6,9 @@ definition: |
 
   [Service]
   ExecStartPre=/bin/true
-  ExecStartPre=-/usr/bin/ctr container rm protokube
+  ExecStartPre=-/usr/bin/ctr --namespace k8s.io container rm protokube
   ExecStartPre=/bin/true
-  ExecStart=/usr/bin/ctr run --net-host --with-ns pid:/proc/1/ns/pid --privileged --mount type=bind,src=/,dst=/rootfs,options=rbind:rslave --mount type=bind,src=/var/run/dbus,dst=/var/run/dbus,options=rbind:rprivate --mount type=bind,src=/run/systemd,dst=/run/systemd,options=rbind:rprivate --env KUBECONFIG=/rootfs/var/lib/kops/kubeconfig --mount type=bind,src=/usr/local/bin,dst=/opt/kops/bin,options=rbind:ro:rprivate --env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/kops/bin docker.io/library/protokube:test protokube /usr/bin/protokube --bootstrap-master-node-labels=true --cloud=aws --containerized=true --dns-internal-suffix=.internal.minimal.example.com --dns=aws-route53 --initialize-rbac=true --manage-etcd=false --master=true --node-name=example-hostname --remove-dns-names=etcd-master-us-test-1a.internal.minimal.example.com,etcd-events-master-us-test-1a.internal.minimal.example.com --v=4
+  ExecStart=/usr/bin/ctr --namespace k8s.io run --net-host --with-ns pid:/proc/1/ns/pid --privileged --mount type=bind,src=/,dst=/rootfs,options=rbind:rslave --mount type=bind,src=/var/run/dbus,dst=/var/run/dbus,options=rbind:rprivate --mount type=bind,src=/run/systemd,dst=/run/systemd,options=rbind:rprivate --env KUBECONFIG=/rootfs/var/lib/kops/kubeconfig --mount type=bind,src=/usr/local/bin,dst=/opt/kops/bin,options=rbind:ro:rprivate --env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/kops/bin docker.io/library/protokube:test protokube /usr/bin/protokube --bootstrap-master-node-labels=true --cloud=aws --containerized=true --dns-internal-suffix=.internal.minimal.example.com --dns=aws-route53 --initialize-rbac=true --manage-etcd=false --master=true --node-name=example-hostname --remove-dns-names=etcd-master-us-test-1a.internal.minimal.example.com,etcd-events-master-us-test-1a.internal.minimal.example.com --v=4
   Restart=always
   RestartSec=2s
   StartLimitInterval=0

--- a/upup/pkg/fi/nodeup/nodetasks/load_image.go
+++ b/upup/pkg/fi/nodeup/nodetasks/load_image.go
@@ -159,7 +159,7 @@ func (_ *LoadImageTask) RenderLocal(t *local.LocalTarget, a, e, changes *LoadIma
 	case "docker":
 		args = []string{"docker", "load", "-i", tarFile}
 	case "containerd":
-		args = []string{"ctr", "images", "import", tarFile}
+		args = []string{"ctr", "--namespace", "k8s.io", "images", "import", tarFile}
 	default:
 		return fmt.Errorf("unknown container runtime: %s", runtime)
 	}


### PR DESCRIPTION
Imported container images have to be put into the `k8s.io` namespace to be accessible to Kubernetes. Initially I thought side-loading was just for Protokube and could be kept in a different namespace, but the mechanism is used for more than this.

In short, beginner level mistake. This fix mostly reverts an old commit of mine from https://github.com/kubernetes/kops/pull/8217.

Fixes https://github.com/kubernetes/kops/issues/9099