### PR TITLE
Update base images for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: go
+dist: bionic
+osx_image: xcode11.4
 os:
   - linux
   - osx


### PR DESCRIPTION
Travis uses pretty old distro images by default. An update may be useful.
https://docs.travis-ci.com/user/reference/linux#default
https://docs.travis-ci.com/user/reference/osx#macos-version