### PR TITLE
Add support for Kubenet with containerd

### DIFF
--- a/nodeup/pkg/model/BUILD.bazel
+++ b/nodeup/pkg/model/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "//pkg/k8scodecs:go_default_library",
         "//pkg/kubeconfig:go_default_library",
         "//pkg/kubemanifest:go_default_library",
+        "//pkg/model/components:go_default_library",
         "//pkg/nodelabels:go_default_library",
         "//pkg/pki:go_default_library",
         "//pkg/rbac:go_default_library",

--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kops/nodeup/pkg/model/resources"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/flagbuilder"
+	"k8s.io/kops/pkg/model/components"
 	"k8s.io/kops/pkg/systemd"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
@@ -338,7 +339,11 @@ func (b *ContainerdBuilder) Build(c *fi.ModelBuilderContext) error {
 	// Using containerd with Kubenet requires special configuration. This is a temporary backwards-compatible solution
 	// and will be deprecated when Kubenet is deprecated:
 	// https://github.com/containerd/cri/blob/master/docs/config.md#cni-config-template
-	if b.Cluster.Spec.ContainerRuntime == "containerd" && b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.Kubenet != nil {
+	usesKubenet, err := components.UsesKubenet(&b.Cluster.Spec)
+	if err != nil {
+		return err
+	}
+	if b.Cluster.Spec.ContainerRuntime == "containerd" && usesKubenet {
 		b.buildKubenetCNIConfigTemplate(c)
 	}
 

--- a/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
@@ -1,3 +1,27 @@
+contents: |-
+  {
+      "cniVersion": "0.3.1",
+      "name": "kubenet",
+      "plugins": [
+          {
+              "type": "bridge",
+              "bridge": "cbr0",
+              "mtu": 1460,
+              "addIf": "eth0",
+              "isGateway": true,
+              "ipMasq": true,
+              "promiscMode": true,
+              "ipam": {
+                  "type": "host-local",
+                  "subnet": "{{.PodCIDR}}",
+                  "routes": [{ "dst": "0.0.0.0/0" }]
+              }
+          }
+      ]
+  }
+path: /etc/containerd/cni-config.template
+type: file
+---
 contents: ""
 path: /etc/containerd/config-kops.toml
 type: file

--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -63,7 +63,11 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 
 		// Apply defaults for containerd running in container runtime mode
 		containerd.LogLevel = fi.String("info")
-		if clusterSpec.Networking != nil && clusterSpec.Networking.Kubenet != nil {
+		usesKubenet, err := UsesKubenet(clusterSpec)
+		if err != nil {
+			return err
+		}
+		if clusterSpec.Networking != nil && usesKubenet {
 			// Using containerd with Kubenet requires special configuration. This is a temporary backwards-compatible solution
 			// and will be deprecated when Kubenet is deprecated:
 			// https://github.com/containerd/cri/blob/master/docs/config.md#cni-config-template

--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -18,6 +18,7 @@ package components
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/klog"
 	"k8s.io/kops/pkg/apis/kops"
@@ -62,7 +63,22 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 
 		// Apply defaults for containerd running in container runtime mode
 		containerd.LogLevel = fi.String("info")
-		containerd.ConfigOverride = fi.String("")
+		if clusterSpec.Networking != nil && clusterSpec.Networking.Kubenet != nil {
+			// Using containerd with Kubenet requires special configuration. This is a temporary backwards-compatible solution
+			// and will be deprecated when Kubenet is deprecated:
+			// https://github.com/containerd/cri/blob/master/docs/config.md#cni-config-template
+			lines := []string{
+				"version = 2",
+				"[plugins]",
+				"  [plugins.\"io.containerd.grpc.v1.cri\"]",
+				"    [plugins.\"io.containerd.grpc.v1.cri\".cni]",
+				"      conf_template = \"/etc/containerd/cni-config.template\"",
+			}
+			contents := strings.Join(lines, "\n")
+			containerd.ConfigOverride = fi.String(contents)
+		} else {
+			containerd.ConfigOverride = fi.String("")
+		}
 
 	} else if clusterSpec.ContainerRuntime == "docker" {
 		if fi.StringValue(containerd.Version) == "" {

--- a/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
@@ -134,7 +134,12 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscontainerdexampl
   cloudConfig: null
   containerRuntime: containerd
   containerd:
-    configOverride: ""
+    configOverride: |-
+      version = 2
+      [plugins]
+        [plugins."io.containerd.grpc.v1.cri"]
+          [plugins."io.containerd.grpc.v1.cri".cni]
+            conf_template = "/etc/containerd/cni-config.template"
     logLevel: info
     version: 1.2.10
   docker:
@@ -421,7 +426,12 @@ Resources.AWSAutoScalingLaunchConfigurationnodescontainerdexamplecom.Properties.
   cloudConfig: null
   containerRuntime: containerd
   containerd:
-    configOverride: ""
+    configOverride: |-
+      version = 2
+      [plugins]
+        [plugins."io.containerd.grpc.v1.cri"]
+          [plugins."io.containerd.grpc.v1.cri".cni]
+            conf_template = "/etc/containerd/cni-config.template"
     logLevel: info
     version: 1.2.10
   docker:


### PR DESCRIPTION
Docker generates the a conflist file for Kubenet when needed.
containerd has a different approach:
https://github.com/containerd/cri/blob/master/docs/config.md#cni-config-template

At some point, Kubenet will migrate to CNI and this workaround can be removed. Until then, this is the default in Kops and should be added, if possible.
https://github.com/kubernetes/kubernetes/issues/38890

CNI config template is based on:
https://github.com/containerd/cri/blob/master/hack/install/install-cni-config.sh