### PR TITLE
Update OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,17 +1,23 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+emeritus_approvers:
+  - chrislovecnm
+  - chrisz100
+  - gambol99
+  - granular-ryanbonham
 approvers:
   - justinsb
-  - chrislovecnm
   - geojaz
   - kashifsaadat
-  - gambol99
   - mikesplain
-  - chrisz100
   - rdrgmnzs
-  - granular-ryanbonham
   - rifelpet
   - zetaab
 reviewers:
+  - hakman
+  - johngmyers
   - joshbranham
-  - robinpercy
+  - kashifsaadat
+  - mikesplain
+  - rdrgmnzs
+  - zetaab


### PR DESCRIPTION
I ran some stats: looking at pull requests with `updated:2019-05-01..2020-05-01` I counted the number of PRs that each of the existing approvers approved (either by commenting `/approve` or by authoring the PR) and the number of PRs that each person left a `/lgtm` comment on.

```
approvers:
   407 rifelpet
   301 justinsb
    86 mikesplain
    33 zetaab
    22 geojaz
    18 rdrgmnzs
    12 KashifSaadat
    10 granular-ryanbonham
     3 chrisz100
reviewers:
   334 rifelpet
   167 justinsb
   117 hakman
    70 johngmyers
    59 mikesplain
    23 joshbranham
    19 zetaab
    14 KashifSaadat
    14 rdrgmnzs
    13 gjtempleton
    13 olemarkus
    12 geojaz
     6 tanjunchen
     3 chrisz100
     3 granular-ryanbonham
     3 hwdef
     2 gambol99
     1 idealhack
     1 prksu
```

Based on that, I propose moving some approvers to emeritus status.

The remaining approvers I added to the reviewers list, excepting @justinsb and @rifelpet. I'd like to reserve @justinsb's time for things that require his expertise and don't think we need to ask more of @rifelpet.

I then propose adding myself and @hakman to the reviewers list and removing @robinpercy.

