### PR TITLE
Add Ambassador addon to kops

### DIFF
--- a/addons/ambassador/README.md
+++ b/addons/ambassador/README.md
@@ -1,0 +1,57 @@
+# Ambassador
+
+The [Ambassador API Gateway](https://getambassador.io/) provides all the functionality of a traditional ingress
+controller (i.e., path-based routing) while exposing many additional capabilities such as authentication, URL rewriting,
+CORS, rate limiting, and automatic metrics collection.
+
+## Ambassador Addon
+
+[Ambassador Operator](https://github.com/datawire/ambassador-operator) is a Kubernetes Operator that controls the
+complete lifecycle of Ambassador in your cluster. It also automates many of the repeatable tasks you have to perform for
+Ambassador. Once installed, the Operator will automatically complete rapid installations and seamless upgrades to new
+versions of Ambassador.
+
+This addon deploys Ambassador Operator which installs Ambassador in a kops cluster.
+
+##### Note:
+The operator requires widely scoped permissions in order to install and manage Ambassador's lifecycle. Both, the
+operator and Ambassador, are deployed in the `ambassador` namespace. You can review the permissions granted to the
+operator [here](https://github.com/kubernetes/kops/blob/master/addons/ambassador/ambassador-operator.yaml).
+
+### Usage
+
+#### As a kops addon
+
+To deploy the addon, run the following before creating a cluster -
+```console
+kops edit cluster <cluster-name>
+```
+
+Now add the addon specification in the cluster manifest in the section - `spec.addons`
+
+```
+addons:
+- manifest: ambassador
+```
+
+##### Note:
+
+If you've already created the cluster, you'll have to run -
+```console
+kops update cluster <cluster-name> --yes
+```
+followed by -
+```console
+kops rolling-update cluster --yes
+```
+to install the addon.
+
+For more information on how to enable addon during cluster creation refer [Kops Addon guide](https://github.com/kubernetes/kops/blob/master/docs/operations/addons.md#installing-kubernetes-addons).
+
+#### Deploying using `kubectl`
+
+After cluster creation, you can deploy Ambassador using the following command -
+
+```console
+kubectl create -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/ambassador/ambassador-operator.yaml
+```

--- a/addons/ambassador/addon.yaml
+++ b/addons/ambassador/addon.yaml
@@ -1,0 +1,9 @@
+kind: Addons
+metadata:
+  name: ambassador
+spec:
+  addons:
+  - version: 1.1.0
+    selector:
+      k8s-addon: ambassador.addons.k8s.io
+    manifest: ambassador-operator.yaml

--- a/addons/ambassador/ambassador-operator.yaml
+++ b/addons/ambassador/ambassador-operator.yaml
@@ -1,0 +1,445 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ambassador
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ambassadorinstallations.getambassador.io
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .spec.version
+      name: VERSION
+      type: string
+    - JSONPath: .spec.updateWindow
+      name: UPDATE-WINDOW
+      type: integer
+    - JSONPath: .status.lastCheckTime
+      description: Last time checked
+      name: LAST-CHECK
+      type: string
+    - JSONPath: .status.conditions[?(@.type=='Deployed')].status
+      description: Indicates if deployment has completed
+      name: DEPLOYED
+      type: string
+    - JSONPath: .status.conditions[?(@.type=='Deployed')].reason
+      description: Reason for deployment completed
+      name: REASON
+      priority: 1
+      type: string
+    - JSONPath: .status.conditions[?(@.type=='Deployed')].message
+      description: Message for deployment completed
+      name: MESSAGE
+      priority: 1
+      type: string
+    - JSONPath: .status.deployedRelease.appVersion
+      description: Deployed version of Ambassador
+      name: DEPLOYED-VERSION
+      type: string
+    - JSONPath: .status.deployedRelease.flavor
+      description: Deployed flavor of Ambassador (OSS or AES)
+      name: DEPLOYED-FLAVOR
+      type: string
+  group: getambassador.io
+  names:
+    kind: AmbassadorInstallation
+    listKind: AmbassadorInstallationList
+    plural: ambassadorinstallations
+    singular: ambassadorinstallation
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: AmbassadorInstallation is the Schema for the ambassadorinstallations
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: AmbassadorInstallationSpec defines the desired state of AmbassadorInstallation
+          properties:
+            baseImage:
+              description: An (optional) image to use instead of the image specified
+                in the Helm chart.
+              type: string
+            helmRepo:
+              description: An (optional) Helm repository.
+              type: string
+            installOSS:
+              description: 'Installs [Ambassador OSS](https://www.getambassador.io/docs/latest/topics/install/install-ambassador-oss/)
+                instead of [AES](https://www.getambassador.io/docs/latest/topics/install/).
+                Default is false which means it installs AES by default. TODO: 1.
+                AES/AOSS is not installed and the user installs using `installOSS:
+                true`, then we straightaway install AOSS. 2. AOSS is installed via
+                operator and the user sets `installOSS: false`, then we perform the
+                migration as    detailed here - https://www.getambassador.io/docs/latest/topics/install/upgrade-to-edge-stack/
+                3. AES is installed and the user sets `installOSS: true`, then we
+                point users to the docs which gives them    pointers on how to do
+                that themselves.'
+              type: boolean
+            logLevel:
+              description: 'An (optional) log level: debug, info...'
+              enum:
+                - info
+                - debug
+                - warn
+                - warning
+                - error
+                - critical
+                - fatal
+              type: string
+            updateWindow:
+              description: "`updateWindow` is an optional item that will control when
+                the updates can take place. This is used to force system updates to
+                happen late at night if that’s what the sysadmins want. \n  * There
+                can be any number of `updateWindow` entries (separated by commas).
+                \ * `Never` turns off automatic updates even if there are other entries
+                in the    comma-separated list. `Never` is used by sysadmins to disable
+                all updates    during blackout periods by doing a `kubectl apply`
+                or using our Edge Policy    Console to set this. * Each `updateWindow`
+                is in crontab format (see https://crontab.guru/)   Some examples of
+                `updateWindows` are:    - `* 0-6 * * * SUN`: every Sunday, from _0am_
+                to _6am_    - `* 5 1 * * *`: every first day of the month, at _5am_
+                * The Operator cannot guarantee minute time granularity, so specifying
+                \  a minute in the crontab expression can lead to some updates happening
+                \  sooner/later than expected."
+              type: string
+            version:
+              description: "We are using SemVer for the version number and it can
+                be specified with any level of precision and can optionally end in
+                `*`. These are interpreted as: \n * `1.0` = exactly version 1.0 *
+                `1.1` = exactly version 1.1 * `1.1.*` = version 1.1 and any bug fix
+                versions `1.1.1`, `1.1.2`, `1.1.3`, etc. * `2.*` = version 2.0 and
+                any incremental and bug fix versions `2.0`, `2.0.1`,   `2.0.2`, `2.1`,
+                `2.2`, `2.2.1`, etc. * `*` = all versions. * `3.0-ea` = version `3.0-ea1`
+                and any subsequent EA releases on `3.0`.   Also selects the final
+                3.0 once the final GA version is released. * `4.*-ea` = version `4.0-ea1`
+                and any subsequent EA release on `4.0`.   Also selects the final GA
+                `4.0`. Also selects any incremental and bug   fix versions `4.*` and
+                `4.*.*`. Also selects the most recent `4.*` EA release   i.e., if
+                `4.0.5` is the last GA version and there is a `4.1-EA3`, then this
+                \  selects `4.1-EA3` over the `4.0.5` GA. \n   You can find the reference
+                docs about the SemVer syntax accepted   [here](https://github.com/Masterminds/semver#basic-comparisons)."
+              type: string
+          type: object
+        status:
+          description: AmbassadorInstallationStatus defines the observed state of
+            AmbassadorInstallation
+          properties:
+            conditions:
+              description: List of conditions the installation has experienced.
+              items:
+                description: AmbInsCondition defines an Ambassador installation condition,
+                  as well as the last time there was a transition to this condition..
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                  - status
+                  - type
+                type: object
+              type: array
+            deployedRelease:
+              description: the currently deployed Helm chart
+              nullable: true
+              properties:
+                appVersion:
+                  type: string
+                flavor:
+                  type: string
+                manifest:
+                  type: string
+                name:
+                  type: string
+                version:
+                  type: string
+              type: object
+            lastCheckTime:
+              description: Last time a successful update check was performed.
+              format: date-time
+              nullable: true
+              type: string
+          required:
+            - conditions
+          type: object
+      type: object
+  version: v2
+  versions:
+    - name: v2
+      served: true
+      storage: true
+---
+# Source: ambassador-operator/templates/ambassador-operator.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: static-helm-values
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: ambassador-operator
+    app.kubernetes.io/part-of: ambassador
+    helm.sh/chart: ambassador-operator-0.2.0
+    app.kubernetes.io/instance: ambassador
+    app.kubernetes.io/managed-by: Helm
+    getambassador.io/installer: operator
+data:
+  values.yaml: |+
+    deploymentTool: amb-oper-manifest
+---
+# Source: ambassador-operator/templates/ambassador-operator.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ambassador-operator
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: ambassador-operator
+    app.kubernetes.io/part-of: ambassador
+    helm.sh/chart: ambassador-operator-0.2.0
+    app.kubernetes.io/instance: ambassador
+    app.kubernetes.io/managed-by: Helm
+    getambassador.io/installer: operator
+---
+# Source: ambassador-operator/templates/ambassador-operator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ambassador-operator-cluster
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: ambassador-operator
+    app.kubernetes.io/part-of: ambassador
+    helm.sh/chart: ambassador-operator-0.2.0
+    app.kubernetes.io/instance: ambassador
+    app.kubernetes.io/managed-by: Helm
+    getambassador.io/installer: operator
+rules:
+  - apiGroups: ['*']
+    resources: ['*']
+    verbs: ['*']
+  - nonResourceURLs: ['*']
+    verbs: ['*']
+---
+# Source: ambassador-operator/templates/ambassador-operator.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ambassador-operator-cluster
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: ambassador-operator
+    app.kubernetes.io/part-of: ambassador
+    helm.sh/chart: ambassador-operator-0.2.0
+    app.kubernetes.io/instance: ambassador
+    app.kubernetes.io/managed-by: Helm
+    getambassador.io/installer: operator
+subjects:
+  - kind: ServiceAccount
+    name: ambassador-operator
+    namespace: ambassador
+roleRef:
+  kind: ClusterRole
+  name: ambassador-operator-cluster
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: ambassador-operator/templates/ambassador-operator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ambassador-operator
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: ambassador-operator
+    app.kubernetes.io/part-of: ambassador
+    helm.sh/chart: ambassador-operator-0.2.0
+    app.kubernetes.io/instance: ambassador
+    app.kubernetes.io/managed-by: Helm
+    getambassador.io/installer: operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - services/finalizers
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+      - customresourcedefinitions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - apps
+    resourceNames:
+      - ambassador-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+      - deployments
+    verbs:
+      - get
+  - apiGroups:
+      - getambassador.io
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+# Source: ambassador-operator/templates/ambassador-operator.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ambassador-operator
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: ambassador-operator
+    app.kubernetes.io/part-of: ambassador
+    helm.sh/chart: ambassador-operator-0.2.0
+    app.kubernetes.io/instance: ambassador
+    app.kubernetes.io/managed-by: Helm
+    getambassador.io/installer: operator
+subjects:
+  - kind: ServiceAccount
+    name: ambassador-operator
+roleRef:
+  kind: Role
+  name: ambassador-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: ambassador-operator/templates/ambassador-operator.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ambassador-operator
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: ambassador-operator
+    app.kubernetes.io/part-of: ambassador
+    helm.sh/chart: ambassador-operator-0.2.0
+    app.kubernetes.io/instance: ambassador
+    app.kubernetes.io/managed-by: Helm
+    getambassador.io/installer: operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: ambassador-operator
+  template:
+    metadata:
+      labels:
+        name: ambassador-operator
+        app.kubernetes.io/name: ambassador-operator
+        app.kubernetes.io/part-of: ambassador
+        helm.sh/chart: ambassador-operator-0.2.0
+        app.kubernetes.io/instance: ambassador
+        app.kubernetes.io/managed-by: Helm
+        getambassador.io/installer: operator
+    spec:
+      serviceAccountName: ambassador-operator
+      containers:
+        - name: ambassador-operator
+          # Replace this with the built image name
+          image: docker.io/datawire/ambassador-operator:v1.2.6
+          command:
+            - ambassador-operator
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "ambassador-operator"
+          volumeMounts:
+            - name: static-helm-values
+              mountPath: /tmp/helm
+      volumes:
+        - name: static-helm-values
+          configMap:
+            name: static-helm-values
+---
+apiVersion: getambassador.io/v2
+kind: AmbassadorInstallation
+metadata:
+  name: ambassador
+  namespace: ambassador
+spec:
+  installOSS: true
+  helmValues:
+    deploymentTool: amb-oper-kops
+    namespace:
+      name: ambassador


### PR DESCRIPTION
This commit adds Ambassador (https://getambassador.io/) addon to
Kops.

Ambassador is installed via Ambassador Operator which is the
recommended way of installed Ambassador - it makes sure users
always have the latest version of Ambassador installed and takes
care of the update schedule as well.

CC: @brucehorn @inercia