### PR TITLE
Don't put bastions in the utility subnets

### DIFF
--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -110,7 +110,7 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 		var subnets []*openstacktasks.Subnet
 		if len(ig.Spec.Subnets) > 0 {
 			subnet := ig.Spec.Subnets[int(i)%len(ig.Spec.Subnets)]
-			// bastion subnet name is not actual zone name, it contains "utility-" prefix
+			// bastion subnet name might contain a "utility-" prefix
 			if ig.Spec.Role == kops.InstanceGroupRoleBastion {
 				az = fi.String(strings.Replace(subnet, "utility-", "", 1))
 			} else {

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -77,7 +77,7 @@ spec:
     kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
-  - utility-us-test-1a
+  - us-test-1a
 
 ---
 

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -77,7 +77,7 @@ spec:
     kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
-  - utility-us-test-1a
+  - us-test-1a
 
 ---
 

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -80,7 +80,7 @@ spec:
     kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
-  - utility-us-test-1a
+  - us-test-1a
 
 ---
 

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -137,14 +137,6 @@ func PopulateInstanceGroupSpec(cluster *kops.Cluster, input *kops.InstanceGroup,
 		if len(ig.Spec.Subnets) == 0 {
 			return nil, fmt.Errorf("Master InstanceGroup %s did not specify any Subnets", ig.ObjectMeta.Name)
 		}
-	} else if ig.Spec.Role == kops.InstanceGroupRoleBastion {
-		if len(ig.Spec.Subnets) == 0 {
-			for _, subnet := range cluster.Spec.Subnets {
-				if subnet.Type == kops.SubnetTypeUtility {
-					ig.Spec.Subnets = append(ig.Spec.Subnets, subnet.Name)
-				}
-			}
-		}
 	} else {
 		if len(ig.Spec.Subnets) == 0 {
 			for _, subnet := range cluster.Spec.Subnets {


### PR DESCRIPTION
There's no reason to put bastions in utility subnets as their securitygroup only allows incoming traffic from the load balancer.
