### PR TITLE
Fail cluster validation if too few nodes for ig's target size

### DIFF
--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -369,6 +369,9 @@ func RunRollingUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer
 		t.AddColumn("MIN", func(r *cloudinstances.CloudInstanceGroup) string {
 			return strconv.Itoa(r.MinSize)
 		})
+		t.AddColumn("TARGET", func(r *cloudinstances.CloudInstanceGroup) string {
+			return strconv.Itoa(r.TargetSize)
+		})
 		t.AddColumn("MAX", func(r *cloudinstances.CloudInstanceGroup) string {
 			return strconv.Itoa(r.MaxSize)
 		})
@@ -391,7 +394,7 @@ func RunRollingUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer
 			l = append(l, v)
 		}
 
-		columns := []string{"NAME", "STATUS", "NEEDUPDATE", "READY", "MIN", "MAX"}
+		columns := []string{"NAME", "STATUS", "NEEDUPDATE", "READY", "MIN", "TARGET", "MAX"}
 		if !options.CloudOnly {
 			columns = append(columns, "NODES")
 		}

--- a/pkg/cloudinstances/cloud_instance_group.go
+++ b/pkg/cloudinstances/cloud_instance_group.go
@@ -33,6 +33,7 @@ type CloudInstanceGroup struct {
 	Ready         []*CloudInstanceGroupMember
 	NeedUpdate    []*CloudInstanceGroupMember
 	MinSize       int
+	TargetSize    int
 	MaxSize       int
 
 	// Raw allows for the implementer to attach an object, for tracking additional state

--- a/pkg/resources/spotinst/resources.go
+++ b/pkg/resources/spotinst/resources.go
@@ -279,6 +279,7 @@ func buildCloudInstanceGroupFromInstanceGroup(cloud Cloud, ig *kops.InstanceGrou
 		HumanName:     group.Name(),
 		InstanceGroup: ig,
 		MinSize:       group.MinSize(),
+		TargetSize:    group.MinSize(), // TODO: Retrieve the target size from the cloud provider
 		MaxSize:       group.MaxSize(),
 		Raw:           group,
 	}

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -299,14 +299,14 @@ func (v *ValidationCluster) validateNodes(cloudGroups map[string]*cloudinstances
 				numNodes++
 			}
 		}
-		if numNodes < cloudGroup.MinSize {
+		if numNodes < cloudGroup.TargetSize {
 			v.addError(&ValidationError{
 				Kind: "InstanceGroup",
 				Name: cloudGroup.InstanceGroup.Name,
 				Message: fmt.Sprintf("InstanceGroup %q did not have enough nodes %d vs %d",
 					cloudGroup.InstanceGroup.Name,
 					numNodes,
-					cloudGroup.MinSize),
+					cloudGroup.TargetSize),
 			})
 		}
 

--- a/pkg/validation/validate_cluster_test.go
+++ b/pkg/validation/validate_cluster_test.go
@@ -124,7 +124,8 @@ func Test_ValidateNodesNotEnough(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleNode,
 			},
 		},
-		MinSize: 3,
+		MinSize:    2,
+		TargetSize: 3,
 		Ready: []*cloudinstances.CloudInstanceGroupMember{
 			{
 				ID: "i-00001",
@@ -176,7 +177,8 @@ func Test_ValidateDetachedNodesDontCount(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleNode,
 			},
 		},
-		MinSize: 2,
+		MinSize:    2,
+		TargetSize: 2,
 		Ready: []*cloudinstances.CloudInstanceGroupMember{
 			{
 				ID: "i-00001",
@@ -229,7 +231,8 @@ func Test_ValidateNodeNotReady(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleNode,
 			},
 		},
-		MinSize: 2,
+		MinSize:    2,
+		TargetSize: 2,
 		Ready: []*cloudinstances.CloudInstanceGroupMember{
 			{
 				ID: "i-00001",
@@ -281,7 +284,8 @@ func Test_ValidateMastersNotEnough(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleMaster,
 			},
 		},
-		MinSize: 3,
+		MinSize:    2,
+		TargetSize: 3,
 		Ready: []*cloudinstances.CloudInstanceGroupMember{
 			{
 				ID: "i-00001",
@@ -333,7 +337,8 @@ func Test_ValidateMasterNotReady(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleMaster,
 			},
 		},
-		MinSize: 2,
+		MinSize:    2,
+		TargetSize: 2,
 		Ready: []*cloudinstances.CloudInstanceGroupMember{
 			{
 				ID: "i-00001",
@@ -385,7 +390,8 @@ func Test_ValidateMasterStaticPods(t *testing.T) {
 				Role: kopsapi.InstanceGroupRoleMaster,
 			},
 		},
-		MinSize: 1,
+		MinSize:    1,
+		TargetSize: 1,
 		Ready: []*cloudinstances.CloudInstanceGroupMember{
 			{
 				ID: "i-00001",

--- a/upup/pkg/fi/cloudup/aliup/status.go
+++ b/upup/pkg/fi/cloudup/aliup/status.go
@@ -246,6 +246,7 @@ func buildCloudInstanceGroup(c ALICloud, ig *kops.InstanceGroup, g ess.ScalingGr
 		HumanName:     g.ScalingGroupName,
 		InstanceGroup: ig,
 		MinSize:       g.MinSize,
+		TargetSize:    g.MinSize, // TODO: Which is the appropriate field? Need to add DesiredCapacity field to ScalingGroupItemType?
 		MaxSize:       g.MaxSize,
 		Raw:           g,
 	}

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -713,6 +713,7 @@ func awsBuildCloudInstanceGroup(c AWSCloud, cluster *kops.Cluster, ig *kops.Inst
 		HumanName:     aws.StringValue(g.AutoScalingGroupName),
 		InstanceGroup: ig,
 		MinSize:       int(aws.Int64Value(g.MinSize)),
+		TargetSize:    int(aws.Int64Value(g.DesiredCapacity)),
 		MaxSize:       int(aws.Int64Value(g.MaxSize)),
 		Raw:           g,
 	}

--- a/upup/pkg/fi/cloudup/gce/instancegroups.go
+++ b/upup/pkg/fi/cloudup/gce/instancegroups.go
@@ -169,6 +169,7 @@ func getCloudGroups(c GCECloud, cluster *kops.Cluster, instancegroups []*kops.In
 					HumanName:     mig.Name,
 					InstanceGroup: ig,
 					MinSize:       int(mig.TargetSize),
+					TargetSize:    int(mig.TargetSize),
 					MaxSize:       int(mig.TargetSize),
 					Raw:           mig,
 				}

--- a/upup/pkg/fi/cloudup/openstack/server_group.go
+++ b/upup/pkg/fi/cloudup/openstack/server_group.go
@@ -107,6 +107,7 @@ func (c *openstackCloud) osBuildCloudInstanceGroup(cluster *kops.Cluster, ig *ko
 		HumanName:     newLaunchConfigName,
 		InstanceGroup: ig,
 		MinSize:       int(fi.Int32Value(ig.Spec.MinSize)),
+		TargetSize:    int(fi.Int32Value(ig.Spec.MinSize)), // TODO: Retrieve the target size from OpenStack?
 		MaxSize:       int(fi.Int32Value(ig.Spec.MaxSize)),
 		Raw:           g,
 	}


### PR DESCRIPTION
If the ASG has scaled above the min, rolling updates can start draining the next node before the ASG replaces a terminated one.
