### PR TITLE
GCE: don't rely on hostname being correct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ push: crossbuild-nodeup
 
 .PHONY: push-gce-dry
 push-gce-dry: push
-	ssh ${TARGET} sudo /tmp/nodeup --conf=metadata://gce/config --dryrun --v=8
+	ssh ${TARGET} sudo /tmp/nodeup --conf=metadata://gce/instance/attributes/config --dryrun --v=8
 
 .PHONY: push-gce-dry
 push-aws-dry: push

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -153,6 +153,12 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		}
 		clusterSpec.CloudConfig.Multizone = fi.Bool(true)
 		clusterSpec.CloudConfig.NodeTags = fi.String(GCETagForRole(b.Context.ClusterName, kops.InstanceGroupRoleNode))
+
+		// Use the hostname from the GCE metadata service
+		// if hostnameOverride is not set.
+		if clusterSpec.Kubelet.HostnameOverride == "" {
+			clusterSpec.Kubelet.HostnameOverride = "@gce"
+		}
 	}
 
 	if cloudProvider == kops.CloudProviderVSphere {

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_startup-script
@@ -226,6 +226,7 @@ kubelet:
   featureGates:
     ExperimentalCriticalPodAnnotation: "true"
   hairpinMode: promiscuous-bridge
+  hostnameOverride: '@gce'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
   networkPluginMTU: 9001
@@ -244,6 +245,7 @@ masterKubelet:
   featureGates:
     ExperimentalCriticalPodAnnotation: "true"
   hairpinMode: promiscuous-bridge
+  hostnameOverride: '@gce'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
   networkPluginMTU: 9001

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_startup-script
@@ -226,6 +226,7 @@ kubelet:
   featureGates:
     ExperimentalCriticalPodAnnotation: "true"
   hairpinMode: promiscuous-bridge
+  hostnameOverride: '@gce'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
   networkPluginMTU: 9001
@@ -244,6 +245,7 @@ masterKubelet:
   featureGates:
     ExperimentalCriticalPodAnnotation: "true"
   hairpinMode: promiscuous-bridge
+  hostnameOverride: '@gce'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
   networkPluginMTU: 9001

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_startup-script
@@ -226,6 +226,7 @@ kubelet:
   featureGates:
     ExperimentalCriticalPodAnnotation: "true"
   hairpinMode: promiscuous-bridge
+  hostnameOverride: '@gce'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
   networkPluginMTU: 9001
@@ -244,6 +245,7 @@ masterKubelet:
   featureGates:
     ExperimentalCriticalPodAnnotation: "true"
   hairpinMode: promiscuous-bridge
+  hostnameOverride: '@gce'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
   networkPluginMTU: 9001

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_startup-script
@@ -162,6 +162,7 @@ kubelet:
   featureGates:
     ExperimentalCriticalPodAnnotation: "true"
   hairpinMode: promiscuous-bridge
+  hostnameOverride: '@gce'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
   networkPluginMTU: 9001

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
@@ -226,6 +226,7 @@ kubelet:
   featureGates:
     ExperimentalCriticalPodAnnotation: "true"
   hairpinMode: promiscuous-bridge
+  hostnameOverride: '@gce'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
   networkPluginMTU: 9001
@@ -244,6 +245,7 @@ masterKubelet:
   featureGates:
     ExperimentalCriticalPodAnnotation: "true"
   hairpinMode: promiscuous-bridge
+  hostnameOverride: '@gce'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
   networkPluginMTU: 9001

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
@@ -162,6 +162,7 @@ kubelet:
   featureGates:
     ExperimentalCriticalPodAnnotation: "true"
   hairpinMode: promiscuous-bridge
+  hostnameOverride: '@gce'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
   networkPluginMTU: 9001

--- a/util/pkg/vfs/context.go
+++ b/util/pkg/vfs/context.go
@@ -97,7 +97,7 @@ func (c *VFSContext) ReadFile(location string, options ...VFSOption) ([]byte, er
 		case "metadata":
 			switch u.Host {
 			case "gce":
-				httpURL := "http://169.254.169.254/computeMetadata/v1/instance/attributes/" + u.Path
+				httpURL := "http://169.254.169.254/computeMetadata/v1/" + u.Path
 				httpHeaders := make(map[string]string)
 				httpHeaders["Metadata-Flavor"] = "Google"
 				return c.readHTTPLocation(httpURL, httpHeaders, opts)


### PR DESCRIPTION
Distros that use systemd for DHCP often don't have the hostname
correct, due to e.g. the requirement for policy kit.

We don't rely on it being set correctly on other clouds; no real
reason to require it on GCP either!

Example issue: https://github.com/systemd/systemd/issues/13501