### PR TITLE
http download: set a timeout to avoid hangs

### DIFF
--- a/upup/pkg/fi/http.go
+++ b/upup/pkg/fi/http.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"time"
 
 	"k8s.io/klog"
 	"k8s.io/kops/util/pkg/hashing"
@@ -76,7 +77,11 @@ func downloadURLAlways(url string, destPath string, dirMode os.FileMode) error {
 
 	klog.Infof("Downloading %q", url)
 
-	response, err := http.Get(url)
+	// Create a client with a shorter timeout
+	httpClient := http.Client{
+		Timeout: 2 * time.Minute,
+	}
+	response, err := httpClient.Get(url)
 	if err != nil {
 		return fmt.Errorf("error doing HTTP fetch of %q: %v", url, err)
 	}


### PR DESCRIPTION
I observed a node failure where we failed to download docker; we need
some timeout just to prevent the hang.

Two minutes should be plenty for our downloads.