### PR TITLE
Add table of networking providers and their status

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -6,19 +6,18 @@ The following table provides the support status for various networking providers
 
 | Network provider | Experimental | Stable | Deprecated | Removed | 
 | ------------ | -----------: | -----: | ---------: | ------: |
-| AWS VPC | ? | ? | - | - |
+| AWS VPC | 1.9 | - | - | - |
 | Calico | 1.6 | 1.11 | - | - |
 | Canal  | 1.12 | - | - | - |
 | Cilium | 1.9 | 1.15 | - | - |
-| Classic | ? | ? | 1.17 | 1.18 |
-| Flannel udp | ? | - | - | - |
-| Flannel vxlan | ? | - | - | - |
-| Kopeio | ? | - | 1.17 | 1.18 |
+| Flannel udp | 1.5.2 | - | - | - |
+| Flannel vxlan | 1.8.0 | - | - | - |
+| Kopeio | 1.5 | - | 1.17 | 1.18 |
 | Kube-router | 1.6.2 | - | - | - |
-| Kubenet | ? | ? | - | - |
+| Kubenet | 1.5 | 1.5 | - | - |
 | Lyft VPC | 1.11 | - | - | - |
-| Romana | ? | - | 1.17 | 1.18 |
-| Weave | ? | ? | - | - |
+| Romana | 1.8 | - | 1.17 | 1.18 |
+| Weave | 1.5 | - | - | - |
 
 
 The networking options determines how the pod and service networking is implemented and managed.

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,4 +1,25 @@
-## Kubernetes Networking Options
+# Kubernetes Networking Options
+
+## Supported networking options
+
+The following table provides the support status for various networking providers with regards to Kops version: 
+
+| Network provider | Experimental | Stable | Deprecated | Removed | 
+| ------------ | -----------: | -----: | ---------: | ------: |
+| AWS VPC | ? | ? | - | - |
+| Calico | 1.6 | 1.11 | - | - |
+| Canal  | 1.12 | - | - | - |
+| Cilium | 1.9 | 1.15 | - | - |
+| Classic | ? | ? | 1.17 | 1.18 |
+| Flannel udp | ? | - | - | - |
+| Flannel vxlan | ? | - | - | - |
+| Kopeio | ? | - | 1.17 | 1.18 |
+| Kube-router | 1.6.2 | - | - | - |
+| Kubenet | ? | ? | - | - |
+| Lyft VPC | 1.11 | - | - | - |
+| Romana | ? | - | 1.17 | 1.18 |
+| Weave | ? | ? | - | - |
+
 
 The networking options determines how the pod and service networking is implemented and managed.
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -12,11 +12,11 @@ The following table provides the support status for various networking providers
 | Cilium | 1.9 | 1.15 | - | - |
 | Flannel udp | 1.5.2 | - | - | - |
 | Flannel vxlan | 1.8.0 | - | - | - |
-| Kopeio | 1.5 | - | 1.17 | 1.18 |
+| Kopeio | 1.5 | - | - | - |
 | Kube-router | 1.6.2 | - | - | - |
 | Kubenet | 1.5 | 1.5 | - | - |
 | Lyft VPC | 1.11 | - | - | - |
-| Romana | 1.8 | - | 1.17 | 1.18 |
+| Romana | 1.8 | - | 1.18 | 1.19 |
 | Weave | 1.5 | - | - | - |
 
 

--- a/docs/networking/romana.md
+++ b/docs/networking/romana.md
@@ -1,5 +1,7 @@
 # Romana
 
+Support for Romana is deprecated as of kops 1.18 and removed in kops 1.19.
+
 ## Installing
 
 To use Romana, specify the following in the cluster spec:

--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -113,6 +113,8 @@
 
 * Support for Ubuntu 16.04 (Xenial) has been deprecated and will be removed in future versions of Kops.
 
+* Support for the Romana networking provider is deprecated and will be removed in kops 1.19.
+
 # Full change list since 1.17.0 release
 
 ## 1.17.0-alpha.1 to 1.18.0-alpha.1

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -3202,7 +3202,8 @@ spec:
                     type: object
                   romana:
                     description: RomanaNetworkingSpec declares that we want Romana
-                      networking
+                      networking Romana is deprecated as of kops 1.18 and removed
+                      as of kops 1.19
                     properties:
                       daemonServiceIP:
                         description: DaemonServiceIP is the Kubernetes Service IP

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -181,6 +181,7 @@ type KuberouterNetworkingSpec struct {
 }
 
 // RomanaNetworkingSpec declares that we want Romana networking
+// Romana is deprecated as of kops 1.18 and removed as of kops 1.19
 type RomanaNetworkingSpec struct {
 	// DaemonServiceIP is the Kubernetes Service IP for the romana-daemon pod
 	DaemonServiceIP string `json:"daemonServiceIP,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -181,6 +181,7 @@ type KuberouterNetworkingSpec struct {
 }
 
 // RomanaNetworkingSpec declares that we want Romana networking
+// Romana is deprecated as of kops 1.18 and removed as of kops 1.19
 type RomanaNetworkingSpec struct {
 	// DaemonServiceIP is the Kubernetes Service IP for the romana-daemon pod
 	DaemonServiceIP string `json:"daemonServiceIP,omitempty"`


### PR DESCRIPTION
As discussed on slack, we should have a table here to guide users at what kind of support one can expect.

There is a quite a bit to debate here.
The question marks is where I believe they have this status, but no idea since when. Predates the release logs so we can just default to 1.6 here if no one minds.

Romana is dead and I think this one is a no-brainer. Starting a new cluster with Romana hasn't worked since the introduction of etcd-manager.
Classic doesn't work. If you try to create the cluster, you get a validation error about classic not being a valid provider.
Kopeio is undocumented and not frequently modify. We could keep it at experimental. It seems to work when I install it.
Flannel has had its issues lately, but I am not too familiar with the status. My guess is experimental.
