### PR TITLE
doc: Typo in docs/state.md

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -121,8 +121,8 @@ Consider the S3 bucket living in Account B and the kops cluster living in Accoun
             "Effect": "Allow",
             "Resource": [
                 "arn:aws:s3:::<state-store-bucket>",
-                "arn:aws:s3:::<state-store-bucket>/*",
-            }
+                "arn:aws:s3:::<state-store-bucket>/*"
+            ],
             "Principal": {
                 "AWS": [
                     "arn:aws:iam::<account-a>:root"


### PR DESCRIPTION
Fix json example for Cross Account State-store.