### PR TITLE
Automated cherry pick of #9020: Upgrade amazon vpc cni to 1.6.1

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -10,7 +10,6 @@ rules:
   - crd.k8s.amazonaws.com
   resources:
   - "*"
-  - namespaces
   verbs:
   - "*"
 - apiGroups: [""]
@@ -89,7 +88,7 @@ spec:
       tolerations:
       - operator: Exists
       containers:
-      - image: "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.0" }}"
+      - image: "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.1" }}"
         imagePullPolicy: Always
         ports:
         - containerPort: 61678

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -147,7 +147,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0'
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: ff9687c4431781c50257b44a9610765e52d0f137
+    manifestHash: 18baa1b3ce4ef0775a86bde2d983a3d84f27caa4
     name: networking.amazon-vpc-routed-eni
     selector:
       role.kubernetes.io/networking: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -7,7 +7,6 @@ rules:
   - crd.k8s.amazonaws.com
   resources:
   - '*'
-  - namespaces
   verbs:
   - '*'
 - apiGroups:
@@ -100,7 +99,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.1
         imagePullPolicy: Always
         livenessProbe:
           exec:


### PR DESCRIPTION
Cherry pick of #9020 on release-1.16.

#9020: Upgrade amazon vpc cni to 1.6.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.