### PR TITLE
Automated cherry pick of #9121: Add EC2 instance lifecycle label to nodes

### DIFF
--- a/cmd/kops-controller/controllers/node_controller.go
+++ b/cmd/kops-controller/controllers/node_controller.go
@@ -118,6 +118,15 @@ func (r *NodeReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, fmt.Errorf("unable to build config for node %s: %v", node.Name, err)
 	}
 
+	lifecycle, err := r.getInstanceLifecycle(ctx, node)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to get instance lifecycle %s: %v", node.Name, err)
+	}
+
+	if len(lifecycle) > 0 {
+		labels[fmt.Sprintf("node-role.kubernetes.io/%s-worker", lifecycle)] = "true"
+	}
+
 	updateLabels := make(map[string]string)
 	for k, v := range labels {
 		actual, found := node.Labels[k]
@@ -185,6 +194,17 @@ func (r *NodeReconciler) getClusterForNode(node *corev1.Node) (*kops.Cluster, er
 		return nil, err
 	}
 	return cluster, nil
+}
+
+// getInstanceLifecycle returns InstanceLifecycle string object
+func (r *NodeReconciler) getInstanceLifecycle(ctx context.Context, node *corev1.Node) (string, error) {
+
+	identity, err := r.identifier.IdentifyNode(ctx, node)
+	if err != nil {
+		return "", fmt.Errorf("error identifying node %q: %v", node.Name, err)
+	}
+
+	return identity.InstanceLifecycle, nil
 }
 
 // getInstanceGroupForNode returns the kops.InstanceGroup object for the node

--- a/pkg/nodeidentity/aws/identify.go
+++ b/pkg/nodeidentity/aws/identify.go
@@ -102,6 +102,11 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 		return nil, fmt.Errorf("found instance %q, but state is %q", instanceID, instanceState)
 	}
 
+	lifecycle := ""
+	if instance.InstanceLifecycle != nil {
+		lifecycle = *instance.InstanceLifecycle
+	}
+
 	// TODO: Should we traverse to the ASG to confirm the tags there?
 	igName := getTag(instance.Tags, CloudTagInstanceGroupName)
 	if igName == "" {
@@ -110,6 +115,7 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 
 	info := &nodeidentity.Info{}
 	info.InstanceGroup = igName
+	info.InstanceLifecycle = lifecycle
 
 	return info, nil
 }

--- a/pkg/nodeidentity/interfaces.go
+++ b/pkg/nodeidentity/interfaces.go
@@ -27,5 +27,6 @@ type Identifier interface {
 }
 
 type Info struct {
-	InstanceGroup string
+	InstanceGroup     string
+	InstanceLifecycle string
 }


### PR DESCRIPTION
Cherry pick of #9121 on release-1.17.

#9121: Add EC2 instance lifecycle label to nodes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.