### PR TITLE
Remove all versions of a file form the S3 bucket

### DIFF
--- a/upup/models/vfs.go
+++ b/upup/models/vfs.go
@@ -143,3 +143,7 @@ func (p *AssetPath) String() string {
 func (p *AssetPath) Remove() error {
 	return ReadOnlyError
 }
+
+func (p *AssetPath) RemoveAll() error {
+	return p.Remove()
+}

--- a/util/pkg/vfs/fs.go
+++ b/util/pkg/vfs/fs.go
@@ -187,6 +187,10 @@ func (p *FSPath) Remove() error {
 	return os.Remove(p.location)
 }
 
+func (p *FSPath) RemoveAll() error {
+	return p.Remove()
+}
+
 func (p *FSPath) PreferredHash() (*hashing.Hash, error) {
 	return p.Hash(hashing.HashAlgorithmSHA256)
 }

--- a/util/pkg/vfs/gsfs.go
+++ b/util/pkg/vfs/gsfs.go
@@ -132,6 +132,10 @@ func (p *GSPath) Remove() error {
 	}
 }
 
+func (p *GSPath) RemoveAll() error {
+	return p.Remove()
+}
+
 func (p *GSPath) Join(relativePath ...string) Path {
 	args := []string{p.key}
 	args = append(args, relativePath...)

--- a/util/pkg/vfs/k8sfs.go
+++ b/util/pkg/vfs/k8sfs.go
@@ -68,6 +68,10 @@ func (p *KubernetesPath) Remove() error {
 	return fmt.Errorf("KubernetesPath::Remove not supported")
 }
 
+func (p *KubernetesPath) RemoveAll() error {
+	return p.Remove()
+}
+
 func (p *KubernetesPath) Join(relativePath ...string) Path {
 	args := []string{p.key}
 	args = append(args, relativePath...)

--- a/util/pkg/vfs/memfs.go
+++ b/util/pkg/vfs/memfs.go
@@ -169,3 +169,7 @@ func (p *MemFSPath) Remove() error {
 	p.contents = nil
 	return nil
 }
+
+func (p *MemFSPath) RemoveAll() error {
+	return p.Remove()
+}

--- a/util/pkg/vfs/ossfs.go
+++ b/util/pkg/vfs/ossfs.go
@@ -217,6 +217,10 @@ func (p *OSSPath) Remove() error {
 	}
 }
 
+func (p *OSSPath) RemoveAll() error {
+	return p.Remove()
+}
+
 func (p *OSSPath) Base() string {
 	return path.Base(p.key)
 }

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -119,8 +119,6 @@ func (p *S3Path) Remove() error {
 
 		_, err = client.DeleteObject(request)
 		if err != nil {
-			// TODO: Check for not-exists, return os.NotExist
-
 			return fmt.Errorf("error deleting %s version %q: %v", p, aws.StringValue(version.VersionId), err)
 		}
 	}

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -103,7 +103,9 @@ func (p *S3Path) Remove() error {
 	}
 
 	if len(response.Versions) == 0 {
-		return os.ErrNotExist
+		// TODO: Check why cluster teardown fails when files are not found and replace warning with error
+		// return os.ErrNotExist
+		klog.Warningf("error removing file (not found): %s", p)
 	}
 
 	// Sometimes S3 will return paginated results if there are too many versions for an object.
@@ -123,7 +125,7 @@ func (p *S3Path) Remove() error {
 
 		_, err = client.DeleteObject(request)
 		if err != nil {
-			return fmt.Errorf("error deleting %s version %q: %v", p, aws.StringValue(version.VersionId), err)
+			return fmt.Errorf("error removing %s version %q: %v", p, aws.StringValue(version.VersionId), err)
 		}
 	}
 

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -102,6 +102,10 @@ func (p *S3Path) Remove() error {
 		return fmt.Errorf("error listing versions %s: %v", p, err)
 	}
 
+	if len(response.Versions) == 0 {
+		return os.ErrNotExist
+	}
+
 	// Sometimes S3 will return paginated results if there are too many versions for an object.
 	// This is unlikely with current use cases, but a warning should be triggered in case it ever occurs.
 	if aws.BoolValue(response.IsTruncated) {
@@ -113,7 +117,7 @@ func (p *S3Path) Remove() error {
 
 		request := &s3.DeleteObjectInput{
 			Bucket:    aws.String(p.bucket),
-			Key:       aws.String(p.key),
+			Key:       version.Key,
 			VersionId: version.VersionId,
 		}
 

--- a/util/pkg/vfs/sshfs.go
+++ b/util/pkg/vfs/sshfs.go
@@ -111,6 +111,10 @@ func (p *SSHPath) Remove() error {
 	return nil
 }
 
+func (p *SSHPath) RemoveAll() error {
+	return p.Remove()
+}
+
 func (p *SSHPath) Join(relativePath ...string) Path {
 	args := []string{p.path}
 	args = append(args, relativePath...)

--- a/util/pkg/vfs/swiftfs.go
+++ b/util/pkg/vfs/swiftfs.go
@@ -291,6 +291,10 @@ func (p *SwiftPath) Remove() error {
 	}
 }
 
+func (p *SwiftPath) RemoveAll() error {
+	return p.Remove()
+}
+
 func (p *SwiftPath) Join(relativePath ...string) Path {
 	args := []string{p.key}
 	args = append(args, relativePath...)

--- a/util/pkg/vfs/vfs.go
+++ b/util/pkg/vfs/vfs.go
@@ -59,6 +59,9 @@ type Path interface {
 	// Remove deletes the file
 	Remove() error
 
+	// RemoveAll completely deletes the file (with all its versions and markers)
+	RemoveAll() error
+
 	// Base returns the base name (last element)
 	Base() string
 


### PR DESCRIPTION
Kops uses versioned S3 buckets for the state store, which is also used for storing etcd backups.
Currently versions are not deleted and the bucket usage keeps growing over time.

`etcd-manager` should be adjusted to use this change.

The change works for both versioned and unversioned buckets. In the case of unversioned bucket, the version ID is "null" and deletion still works as expected.

This won't fix older versions that were not deleted, but going forward removal should be permanent. 