### PR TITLE
Enable configuration of the calico IP_AUTODETECTION_METHOD  and IP6_AUTODETECTION_METHOD

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/zclconf/go-cty v1.3.1
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
+	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9
 	golang.org/x/tools v0.0.0-20191203134012-c197fd4bf371

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2655,6 +2655,22 @@ spec:
                           binary Felix uses Default: Auto (other options: Legacy,
                           NFT)'
                         type: string
+                      ipv4AutoDetectionMethod:
+                        description: 'IPv4AutoDetectionMethod configures how Calico
+                          chooses the IP address used to route between nodes.  This
+                          should be set when the host has multiple interfaces and
+                          it is important to select the interface used. Options: "first-found"
+                          (default), "can-reach=DESTINATION", "interface=INTERFACE-REGEX",
+                          or "skip-interface=INTERFACE-REGEX"'
+                        type: string
+                      ipv6AutoDetectionMethod:
+                        description: 'IPv6AutoDetectionMethod configures how Calico
+                          chooses the IP address used to route between nodes.  This
+                          should be set when the host has multiple interfaces and
+                          it is important to select the interface used. Options: "first-found"
+                          (default), "can-reach=DESTINATION", "interface=INTERFACE-REGEX",
+                          or "skip-interface=INTERFACE-REGEX"'
+                        type: string
                       logSeverityScreen:
                         description: 'LogSeverityScreen lets us set the desired log
                           level. (Default: info)'

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -118,18 +118,18 @@ type CalicoNetworkingSpec struct {
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 	// MajorVersion is the version of Calico to use
 	MajorVersion string `json:"majorVersion,omitempty"`
-	// IPAutoDetectionMethod configures how Calico chooses the IP address used to route
+	// IPv4AutoDetectionMethod configures how Calico chooses the IP address used to route
 	// between nodes.  This should be set when the host has multiple interfaces
 	// and it is important to select the interface used.
 	// Options: "first-found" (default), "can-reach=DESTINATION",
 	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
-	IPAutoDetectionMethod string `json:"ipAutoDetectionMethod,omitempty"`
-	// IP6AutoDetectionMethod configures how Calico chooses the IP address used to route
+	IPv4AutoDetectionMethod string `json:"ipv4AutoDetectionMethod,omitempty"`
+	// IPv6AutoDetectionMethod configures how Calico chooses the IP address used to route
 	// between nodes.  This should be set when the host has multiple interfaces
 	// and it is important to select the interface used.
 	// Options: "first-found" (default), "can-reach=DESTINATION",
 	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
-	IP6AutoDetectionMethod string `json:"ip6AutoDetectionMethod,omitempty"`
+	IPv6AutoDetectionMethod string `json:"ipv6AutoDetectionMethod,omitempty"`
 	// IptablesBackend controls which variant of iptables binary Felix uses
 	// Default: Auto (other options: Legacy, NFT)
 	IptablesBackend string `json:"iptablesBackend,omitempty"`

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -118,6 +118,18 @@ type CalicoNetworkingSpec struct {
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 	// MajorVersion is the version of Calico to use
 	MajorVersion string `json:"majorVersion,omitempty"`
+	// IPAutoDetectionMethod configures how Calico chooses the IP address used to route
+	// between nodes.  This should be set when the host has multiple interfaces
+	// and it is important to select the interface used.
+	// Options: "first-found" (default), "can-reach=DESTINATION",
+	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
+	IPAutoDetectionMethod string `json:"ipAutoDetectionMethod,omitempty"`
+	// IP6AutoDetectionMethod configures how Calico chooses the IP address used to route
+	// between nodes.  This should be set when the host has multiple interfaces
+	// and it is important to select the interface used.
+	// Options: "first-found" (default), "can-reach=DESTINATION",
+	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
+	IP6AutoDetectionMethod string `json:"ip6AutoDetectionMethod,omitempty"`
 	// IptablesBackend controls which variant of iptables binary Felix uses
 	// Default: Auto (other options: Legacy, NFT)
 	IptablesBackend string `json:"iptablesBackend,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -123,6 +123,18 @@ type CalicoNetworkingSpec struct {
 	IptablesBackend string `json:"iptablesBackend,omitempty"`
 	// IPIPMode is mode for CALICO_IPV4POOL_IPIP
 	IPIPMode string `json:"ipipMode,omitempty"`
+	// IPv4AutoDetectionMethod configures how Calico chooses the IP address used to route
+	// between nodes.  This should be set when the host has multiple interfaces
+	// and it is important to select the interface used.
+	// Options: "first-found" (default), "can-reach=DESTINATION",
+	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
+	IPv4AutoDetectionMethod string `json:"ipv4AutoDetectionMethod,omitempty"`
+	// IPv6AutoDetectionMethod configures how Calico chooses the IP address used to route
+	// between nodes.  This should be set when the host has multiple interfaces
+	// and it is important to select the interface used.
+	// Options: "first-found" (default), "can-reach=DESTINATION",
+	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
+	IPv6AutoDetectionMethod string `json:"ipv6AutoDetectionMethod,omitempty"`
 	// TyphaPrometheusMetricsEnabled enables Prometheus metrics collection from Typha
 	// (default: false)
 	TyphaPrometheusMetricsEnabled bool `json:"typhaPrometheusMetricsEnabled,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1292,6 +1292,8 @@ func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.MajorVersion = in.MajorVersion
 	out.IptablesBackend = in.IptablesBackend
 	out.IPIPMode = in.IPIPMode
+	out.IPv4AutoDetectionMethod = in.IPv4AutoDetectionMethod
+	out.IPv6AutoDetectionMethod = in.IPv6AutoDetectionMethod
 	out.TyphaPrometheusMetricsEnabled = in.TyphaPrometheusMetricsEnabled
 	out.TyphaPrometheusMetricsPort = in.TyphaPrometheusMetricsPort
 	out.TyphaReplicas = in.TyphaReplicas
@@ -1313,6 +1315,8 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	out.MajorVersion = in.MajorVersion
+	out.IPv4AutoDetectionMethod = in.IPv4AutoDetectionMethod
+	out.IPv6AutoDetectionMethod = in.IPv6AutoDetectionMethod
 	out.IptablesBackend = in.IptablesBackend
 	out.IPIPMode = in.IPIPMode
 	out.TyphaPrometheusMetricsEnabled = in.TyphaPrometheusMetricsEnabled

--- a/pkg/apis/kops/validation/BUILD.bazel
+++ b/pkg/apis/kops/validation/BUILD.bazel
@@ -24,6 +24,8 @@ go_library(
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/arn:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",
+        "//vendor/golang.org/x/net/ipv4:go_default_library",
+        "//vendor/golang.org/x/net/ipv6:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -642,7 +642,7 @@ func validateCalicoAutoDetectionMethod(fldPath *field.Path, runtime *string, ver
 
 	} else if strings.HasPrefix(*runtime, methodInterface) {
 		ifStr := strings.TrimPrefix(*runtime, methodInterface)
-		ifRegexes := regexp.MustCompile("\\s*,\\s*").Split(ifStr, -1)
+		ifRegexes := regexp.MustCompile(`\s*,\s*`).Split(ifStr, -1)
 		if len(ifRegexes) == 0 || ifRegexes[0] == "" {
 			validationError = append(validationError, field.Invalid(fldPath, runtime, "Expected 'interface=<COMMA-SEPARATED-LIST>'"))
 		}
@@ -656,7 +656,7 @@ func validateCalicoAutoDetectionMethod(fldPath *field.Path, runtime *string, ver
 
 	} else if strings.HasPrefix(*runtime, methodSkipInterface) {
 		ifStr := strings.TrimPrefix(*runtime, methodSkipInterface)
-		ifRegexes := regexp.MustCompile("\\s*,\\s*").Split(ifStr, -1)
+		ifRegexes := regexp.MustCompile(`\s*,\s*`).Split(ifStr, -1)
 		if len(ifRegexes) == 0 || ifRegexes[0] == "" {
 			validationError = append(validationError, field.Invalid(fldPath, runtime, "Expected 'skip-interface=<COMMA-SEPARATED-LIST>'"))
 		}

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
@@ -643,7 +644,7 @@ func validateCalicoAutoDetectionMethod(fldPath *field.Path, runtime string, vers
 			return utilvalidation.IsValidIPv6Address(fldPath, destStr)
 		}
 
-		return field.ErrorList{field.Invalid(fldPath, runtime, "IP version is incorrect")}
+		return field.ErrorList{field.InternalError(fldPath, errors.New("IP version is incorrect"))}
 	case "interface":
 		ifRegexes := regexp.MustCompile(`\s*,\s*`).Split(method[1], -1)
 		if len(ifRegexes) == 0 || ifRegexes[0] == "" {

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -638,13 +638,13 @@ func validateCalicoAutoDetectionMethod(fldPath *field.Path, runtime *string, ver
 			return utilvalidation.IsValidIPv6Address(fldPath, destStr)
 		}
 
-		return field.ErrorList{field.Invalid(fldPath, runtime, "Invalid; IP version in incorrect")}
+		return field.ErrorList{field.InternalError(fldPath, runtime, "IP version is incorrect")}
 
 	} else if strings.HasPrefix(*runtime, methodInterface) {
 		ifStr := strings.TrimPrefix(*runtime, methodInterface)
 		ifRegexes := regexp.MustCompile(`\s*,\s*`).Split(ifStr, -1)
 		if len(ifRegexes) == 0 || ifRegexes[0] == "" {
-			validationError = append(validationError, field.Invalid(fldPath, runtime, "Expected 'interface=<COMMA-SEPARATED-LIST>'"))
+			validationError = append(validationError, field.Invalid(fldPath, runtime, "'interface=' must be followed by a comma separated list of interface regular expressions"))
 		}
 		for _, r := range ifRegexes {
 			_, e := regexp.Compile(r)
@@ -669,7 +669,7 @@ func validateCalicoAutoDetectionMethod(fldPath *field.Path, runtime *string, ver
 
 		return validationError
 	}
-	return field.ErrorList{field.Invalid(fldPath, runtime, "Invalid autodetection method")}
+	return field.ErrorList{field.Invalid(fldPath, runtime, "unsupported autodetection method")}
 }
 
 func validateContainerRuntime(runtime *string, fldPath *field.Path) field.ErrorList {

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -458,7 +458,7 @@ func Test_Validate_Calico(t *testing.T) {
 		{
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
-					IPv4AutoDetectionMethod: "interface=en*,eth0",
+					IPv4AutoDetectionMethod: "interface=en.*,eth0",
 				},
 				Etcd: &kops.EtcdClusterSpec{},
 			},
@@ -466,7 +466,7 @@ func Test_Validate_Calico(t *testing.T) {
 		{
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
-					IPv6AutoDetectionMethod: "skip-interface=en*,eth0",
+					IPv6AutoDetectionMethod: "skip-interface=en.*,eth0",
 				},
 				Etcd: &kops.EtcdClusterSpec{},
 			},

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -396,6 +396,81 @@ func Test_Validate_Calico(t *testing.T) {
 			},
 			ExpectedErrors: []string{"Forbidden::calico.majorVersion"},
 		},
+		{
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					IPv4AutoDetectionMethod: "first-found",
+				},
+				Etcd: &kops.EtcdClusterSpec{},
+			},
+		},
+		{
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					IPv6AutoDetectionMethod: "first-found",
+				},
+				Etcd: &kops.EtcdClusterSpec{},
+			},
+		},
+		{
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					IPv4AutoDetectionMethod: "can-reach=8.8.8.8",
+				},
+				Etcd: &kops.EtcdClusterSpec{},
+			},
+		},
+		{
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					IPv6AutoDetectionMethod: "can-reach=2001:4860:4860::8888",
+				},
+				Etcd: &kops.EtcdClusterSpec{},
+			},
+		},
+		{
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					IPv4AutoDetectionMethod: "bogus",
+				},
+				Etcd: &kops.EtcdClusterSpec{},
+			},
+			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
+		},
+		{
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					IPv6AutoDetectionMethod: "bogus",
+				},
+				Etcd: &kops.EtcdClusterSpec{},
+			},
+			ExpectedErrors: []string{"Invalid value::calico.ipv6AutoDetectionMethod"},
+		},
+		{
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					IPv6AutoDetectionMethod: "interface=",
+				},
+				Etcd: &kops.EtcdClusterSpec{},
+			},
+			ExpectedErrors: []string{"Invalid value::calico.ipv6AutoDetectionMethod"},
+		},
+		{
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					IPv4AutoDetectionMethod: "interface=en*,eth0",
+				},
+				Etcd: &kops.EtcdClusterSpec{},
+			},
+		},
+		{
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					IPv6AutoDetectionMethod: "skip-interface=en*,eth0",
+				},
+				Etcd: &kops.EtcdClusterSpec{},
+			},
+		},
 	}
 	for _, g := range grid {
 		errs := validateNetworkingCalico(g.Input.Calico, g.Input.Etcd, field.NewPath("calico"))

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -471,6 +471,15 @@ func Test_Validate_Calico(t *testing.T) {
 				Etcd: &kops.EtcdClusterSpec{},
 			},
 		},
+		{
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					IPv4AutoDetectionMethod: "interface=(,en1",
+				},
+				Etcd: &kops.EtcdClusterSpec{},
+			},
+			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
+		},
 	}
 	for _, g := range grid {
 		errs := validateNetworkingCalico(g.Input.Calico, g.Input.Etcd, field.NewPath("calico"))

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -480,6 +480,24 @@ func Test_Validate_Calico(t *testing.T) {
 			},
 			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
 		},
+		{
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					IPv4AutoDetectionMethod: "interface=foo=bar",
+				},
+				Etcd: &kops.EtcdClusterSpec{},
+			},
+			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
+		},
+		{
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					IPv4AutoDetectionMethod: "=en0,eth.*",
+				},
+				Etcd: &kops.EtcdClusterSpec{},
+			},
+			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
+		},
 	}
 	for _, g := range grid {
 		errs := validateNetworkingCalico(g.Input.Calico, g.Input.Etcd, field.NewPath("calico"))

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -7590,9 +7590,9 @@ spec:
             - name: IP
               value: "autodetect"
             - name: IP_AUTODETECTION_METHOD
-              value: "{{- or .Networking.Calico.IPAutoDetectionMethod "first-found" }}"
+              value: "{{- or .Networking.Calico.IPv4AutoDetectionMethod "first-found" }}"
             - name: IP6_AUTODETECTION_METHOD
-              value: "{{- or .Networking.Calico.IP6AutoDetectionMethod "first-found" }}"
+              value: "{{- or .Networking.Calico.IPv6AutoDetectionMethod "first-found" }}"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}CrossSubnet{{- else -}} {{- or .Networking.Calico.IPIPMode "Always" -}} {{- end -}}"
@@ -8709,9 +8709,9 @@ spec:
             - name: IP
               value: "autodetect"
             - name: IP_AUTODETECTION_METHOD
-              value: "{{- or .Networking.Calico.IPAutoDetectionMethod "first-found" }}"
+              value: "{{- or .Networking.Calico.IPv4AutoDetectionMethod "first-found" }}"
             - name: IP6_AUTODETECTION_METHOD
-              value: "{{- or .Networking.Calico.IP6AutoDetectionMethod "first-found" }}"
+              value: "{{- or .Networking.Calico.IPv6AutoDetectionMethod "first-found" }}"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}CrossSubnet{{- else -}} {{- or .Networking.Calico.IPIPMode "Always" -}} {{- end -}}"

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -7589,6 +7589,10 @@ spec:
             # Auto-detect the BGP IP address.
             - name: IP
               value: "autodetect"
+            - name: IP_AUTODETECTION_METHOD
+              value: "{{- or .Networking.Calico.IPAutoDetectionMethod "first-found" }}"
+            - name: IP6_AUTODETECTION_METHOD
+              value: "{{- or .Networking.Calico.IP6AutoDetectionMethod "first-found" }}"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}CrossSubnet{{- else -}} {{- or .Networking.Calico.IPIPMode "Always" -}} {{- end -}}"
@@ -8704,6 +8708,10 @@ spec:
             # Auto-detect the BGP IP address.
             - name: IP
               value: "autodetect"
+            - name: IP_AUTODETECTION_METHOD
+              value: "{{- or .Networking.Calico.IPAutoDetectionMethod "first-found" }}"
+            - name: IP6_AUTODETECTION_METHOD
+              value: "{{- or .Networking.Calico.IP6AutoDetectionMethod "first-found" }}"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}CrossSubnet{{- else -}} {{- or .Networking.Calico.IPIPMode "Always" -}} {{- end -}}"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -790,9 +790,9 @@ spec:
             - name: IP
               value: "autodetect"
             - name: IP_AUTODETECTION_METHOD
-              value: "{{- or .Networking.Calico.IPAutoDetectionMethod "first-found" }}"
+              value: "{{- or .Networking.Calico.IPv4AutoDetectionMethod "first-found" }}"
             - name: IP6_AUTODETECTION_METHOD
-              value: "{{- or .Networking.Calico.IP6AutoDetectionMethod "first-found" }}"
+              value: "{{- or .Networking.Calico.IPv6AutoDetectionMethod "first-found" }}"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}CrossSubnet{{- else -}} {{- or .Networking.Calico.IPIPMode "Always" -}} {{- end -}}"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -789,6 +789,10 @@ spec:
             # Auto-detect the BGP IP address.
             - name: IP
               value: "autodetect"
+            - name: IP_AUTODETECTION_METHOD
+              value: "{{- or .Networking.Calico.IPAutoDetectionMethod "first-found" }}"
+            - name: IP6_AUTODETECTION_METHOD
+              value: "{{- or .Networking.Calico.IP6AutoDetectionMethod "first-found" }}"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}CrossSubnet{{- else -}} {{- or .Networking.Calico.IPIPMode "Always" -}} {{- end -}}"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -801,9 +801,9 @@ spec:
             - name: IP
               value: "autodetect"
             - name: IP_AUTODETECTION_METHOD
-              value: "{{- or .Networking.Calico.IPAutoDetectionMethod "first-found" }}"
+              value: "{{- or .Networking.Calico.IPv4AutoDetectionMethod "first-found" }}"
             - name: IP6_AUTODETECTION_METHOD
-              value: "{{- or .Networking.Calico.IP6AutoDetectionMethod "first-found" }}"
+              value: "{{- or .Networking.Calico.IPv6AutoDetectionMethod "first-found" }}"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}CrossSubnet{{- else -}} {{- or .Networking.Calico.IPIPMode "Always" -}} {{- end -}}"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -800,6 +800,10 @@ spec:
             # Auto-detect the BGP IP address.
             - name: IP
               value: "autodetect"
+            - name: IP_AUTODETECTION_METHOD
+              value: "{{- or .Networking.Calico.IPAutoDetectionMethod "first-found" }}"
+            - name: IP6_AUTODETECTION_METHOD
+              value: "{{- or .Networking.Calico.IP6AutoDetectionMethod "first-found" }}"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}CrossSubnet{{- else -}} {{- or .Networking.Calico.IPIPMode "Always" -}} {{- end -}}"

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -725,8 +725,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		versions := map[string]string{
 			"k8s-1.7":    "2.6.12-kops.1",
 			"k8s-1.7-v3": "3.8.0-kops.2",
-			"k8s-1.12":   "3.9.5-kops.3",
-			"k8s-1.16":   "3.13.3-kops.2",
+			"k8s-1.12":   "3.9.5-kops.4",
+			"k8s-1.16":   "3.13.3-kops.3",
 		}
 
 		{


### PR DESCRIPTION
By default, Calico auto-detects the IP address to bind to from the IP addresses available on the host using a "first-found" policy.  This works, except when it doesn't.  This will sometimes fail on hosts that have multiple interfaces.  To work around this, Calico allows setting the IP_AUTODETECTION_METHOD environment variable and customizing how it selects the right IP address.

This PR adds the environment variables IP_AUTODETECTION_METHOD and IP6_AUTODETECTION_METHOD to the DaemonSet config and adds some api variables for this so they can be customized in the cluster yaml.

I'm not a kops expert by any means, so if there is a better way to do this please let me know.