### PR TITLE
Update DigitalOcean cloud-controller-manager to v0.1.24

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -1767,7 +1767,7 @@ spec:
           operator: Exists
           tolerationSeconds: 300
       containers:
-      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.20
+      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.24
         name: digitalocean-cloud-controller-manager
         command:
           - "/bin/digitalocean-cloud-controller-manager"

--- a/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
@@ -48,7 +48,7 @@ spec:
           operator: Exists
           tolerationSeconds: 300
       containers:
-      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.20
+      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.24
         name: digitalocean-cloud-controller-manager
         command:
           - "/bin/digitalocean-cloud-controller-manager"


### PR DESCRIPTION
This changes bumps DigitalOcean's cloud-controller-manager (CCM) to version 0.1.24 which brings a number of new features and bug fixes.

It seems like there are now two occurrences of the CCM manifest: one as YAML and one in-code. I wasn't entirely sure if the image versions needed to be updated in both places, which I did for now. Please let me know in case that's not needed.

Ideally, the change should be cherry-picked into 1.17 subsequently.