### PR TITLE
Use systemd-timesyncd for Ubuntu 20.04

### DIFF
--- a/nodeup/pkg/model/ntp.go
+++ b/nodeup/pkg/model/ntp.go
@@ -46,7 +46,10 @@ func (b *NTPBuilder) Build(c *fi.ModelBuilderContext) error {
 		return nil
 	}
 
-	if b.Distribution.IsDebianFamily() {
+	if b.Distribution == distros.DistributionFocal {
+		c.AddTask(&nodetasks.Package{Name: "systemd-timesyncd"})
+		c.AddTask((&nodetasks.Service{Name: "systemd-timesyncd"}).InitDefaults())
+	} else if b.Distribution.IsDebianFamily() {
 		c.AddTask(&nodetasks.Package{Name: "ntp"})
 		c.AddTask((&nodetasks.Service{Name: "ntp"}).InitDefaults())
 	} else if b.Distribution.IsRHELFamily() {


### PR DESCRIPTION
`systemd-timesyncd` is the default service for clock synchronisation in Ubuntu 20.04. Installing `ntp` seems to make `kops-configuration` crash as reported in #9180.

We already use `systemd-timesyncd` for Ubuntu in 1.18 and this issue is not noticeable. Using it  in 1.17 and 1.16 instead of `ntp` seems the best way to go.

https://github.com/kubernetes/kops/blob/82257362184894e882bdbba79e79840c2b89b340/nodeup/pkg/model/ntp.go#L60-L64