### PR TITLE
Automated cherry pick of #9182: Use systemd-timesyncd for Ubuntu 20.04

### DIFF
--- a/nodeup/pkg/model/ntp.go
+++ b/nodeup/pkg/model/ntp.go
@@ -46,7 +46,10 @@ func (b *NTPBuilder) Build(c *fi.ModelBuilderContext) error {
 		return nil
 	}
 
-	if b.Distribution.IsDebianFamily() {
+	if b.Distribution == distros.DistributionFocal {
+		c.AddTask(&nodetasks.Package{Name: "systemd-timesyncd"})
+		c.AddTask((&nodetasks.Service{Name: "systemd-timesyncd"}).InitDefaults())
+	} else if b.Distribution.IsDebianFamily() {
 		c.AddTask(&nodetasks.Package{Name: "ntp"})
 		c.AddTask((&nodetasks.Service{Name: "ntp"}).InitDefaults())
 	} else if b.Distribution.IsRHELFamily() {


### PR DESCRIPTION
Cherry pick of #9182 on release-1.16.

#9182: Use systemd-timesyncd for Ubuntu 20.04

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.