### PR TITLE
Remove WriterTo from VFS interface

### DIFF
--- a/util/pkg/vfs/BUILD.bazel
+++ b/util/pkg/vfs/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
     importpath = "k8s.io/kops/util/pkg/vfs",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/try:go_default_library",
         "//util/pkg/hashing:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/awserr:go_default_library",

--- a/util/pkg/vfs/fs.go
+++ b/util/pkg/vfs/fs.go
@@ -25,7 +25,6 @@ import (
 	"sync"
 
 	"k8s.io/klog"
-	"k8s.io/kops/pkg/try"
 	"k8s.io/kops/util/pkg/hashing"
 )
 
@@ -113,17 +112,6 @@ func (p *FSPath) CreateFile(data io.ReadSeeker, acl ACL) error {
 // ReadFile implements Path::ReadFile
 func (p *FSPath) ReadFile() ([]byte, error) {
 	return ioutil.ReadFile(p.location)
-}
-
-// WriteTo implements io.WriterTo
-func (p *FSPath) WriteTo(out io.Writer) (int64, error) {
-	f, err := os.Open(p.location)
-	if err != nil {
-		return 0, err
-	}
-	defer try.CloseFile(f)
-
-	return io.Copy(out, f)
 }
 
 func (p *FSPath) ReadDir() ([]Path, error) {

--- a/util/pkg/vfs/fs_test.go
+++ b/util/pkg/vfs/fs_test.go
@@ -60,39 +60,3 @@ func TestCreateFile(t *testing.T) {
 		}
 	}
 }
-
-func TestWriteTo(t *testing.T) {
-	var TempDir, _ = ioutil.TempDir("", "test")
-	defer os.Remove(TempDir)
-	tests := []struct {
-		path string
-		data []byte
-	}{
-		{
-			path: path.Join(TempDir, "SubDir", "test1.tmp"),
-			data: []byte("test data\nline 1\r\nline 2"),
-		},
-	}
-	for _, test := range tests {
-		var buf bytes.Buffer
-
-		fspath := NewFSPath(test.path)
-		// Create file
-		err := fspath.CreateFile(bytes.NewReader(test.data), nil)
-		if err != nil {
-			t.Fatalf("Error writing file %s, error: %v", test.path, err)
-		}
-
-		// Write file to buf
-		_, err = fspath.WriteTo(&buf)
-		if err != nil {
-			t.Fatalf("Error reading %s to buf, error: %v", test.path, err)
-		}
-
-		// Check buf content
-		actually_bytes := buf.Bytes()
-		if !bytes.Equal(test.data, actually_bytes) {
-			t.Errorf("Expected %v, actually %v", test.data, actually_bytes)
-		}
-	}
-}

--- a/util/pkg/vfs/gsfs.go
+++ b/util/pkg/vfs/gsfs.go
@@ -219,7 +219,7 @@ func (p *GSPath) ReadFile() ([]byte, error) {
 	var b bytes.Buffer
 	done, err := RetryWithBackoff(gcsReadBackoff, func() (bool, error) {
 		b.Reset()
-		_, err := p.WriteTo(&b)
+		_, err := p.writeTo(&b)
 		if err != nil {
 			if os.IsNotExist(err) {
 				// Not recoverable
@@ -240,8 +240,7 @@ func (p *GSPath) ReadFile() ([]byte, error) {
 	}
 }
 
-// WriteTo implements io.WriterTo::WriteTo
-func (p *GSPath) WriteTo(out io.Writer) (int64, error) {
+func (p *GSPath) writeTo(out io.Writer) (int64, error) {
 	klog.V(4).Infof("Reading file %q", p)
 
 	response, err := p.client.Objects.Get(p.bucket, p.key).Download()

--- a/util/pkg/vfs/k8sfs.go
+++ b/util/pkg/vfs/k8sfs.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vfs
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"path"
@@ -93,17 +92,7 @@ func (p *KubernetesPath) CreateFile(data io.ReadSeeker, acl ACL) error {
 
 // ReadFile implements Path::ReadFile
 func (p *KubernetesPath) ReadFile() ([]byte, error) {
-	var b bytes.Buffer
-	_, err := p.WriteTo(&b)
-	if err != nil {
-		return nil, err
-	}
-	return b.Bytes(), nil
-}
-
-// WriteTo implements io.WriterTo
-func (p *KubernetesPath) WriteTo(out io.Writer) (int64, error) {
-	return 0, fmt.Errorf("KubernetesPath::WriteTo not supported")
+	return nil, fmt.Errorf("KubernetesPath::ReadFile not supported")
 }
 
 func (p *KubernetesPath) ReadDir() ([]Path, error) {

--- a/util/pkg/vfs/memfs.go
+++ b/util/pkg/vfs/memfs.go
@@ -121,15 +121,6 @@ func (p *MemFSPath) ReadFile() ([]byte, error) {
 	return p.contents, nil
 }
 
-// WriteTo implements io.WriterTo
-func (p *MemFSPath) WriteTo(out io.Writer) (int64, error) {
-	if p.contents == nil {
-		return 0, os.ErrNotExist
-	}
-	n, err := out.Write(p.contents)
-	return int64(n), err
-}
-
 func (p *MemFSPath) ReadDir() ([]Path, error) {
 	var paths []Path
 	for _, f := range p.children {

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -267,15 +267,14 @@ func (p *S3Path) CreateFile(data io.ReadSeeker, acl ACL) error {
 // ReadFile implements Path::ReadFile
 func (p *S3Path) ReadFile() ([]byte, error) {
 	var b bytes.Buffer
-	_, err := p.WriteTo(&b)
+	_, err := p.writeTo(&b)
 	if err != nil {
 		return nil, err
 	}
 	return b.Bytes(), nil
 }
 
-// WriteTo implements io.WriterTo
-func (p *S3Path) WriteTo(out io.Writer) (int64, error) {
+func (p *S3Path) writeTo(out io.Writer) (int64, error) {
 	client, err := p.client()
 	if err != nil {
 		return 0, err

--- a/util/pkg/vfs/sshfs.go
+++ b/util/pkg/vfs/sshfs.go
@@ -250,15 +250,14 @@ func (p *SSHPath) CreateFile(data io.ReadSeeker, acl ACL) error {
 // ReadFile implements Path::ReadFile
 func (p *SSHPath) ReadFile() ([]byte, error) {
 	var b bytes.Buffer
-	_, err := p.WriteTo(&b)
+	_, err := p.writeTo(&b)
 	if err != nil {
 		return nil, err
 	}
 	return b.Bytes(), nil
 }
 
-// WriteTo implements io.WriterTo
-func (p *SSHPath) WriteTo(out io.Writer) (int64, error) {
+func (p *SSHPath) writeTo(out io.Writer) (int64, error) {
 	sftpClient, err := p.newClient()
 	if err != nil {
 		return 0, err

--- a/util/pkg/vfs/swiftfs.go
+++ b/util/pkg/vfs/swiftfs.go
@@ -396,7 +396,7 @@ func (p *SwiftPath) ReadFile() ([]byte, error) {
 	var b bytes.Buffer
 	done, err := RetryWithBackoff(swiftReadBackoff, func() (bool, error) {
 		b.Reset()
-		_, err := p.WriteTo(&b)
+		_, err := p.writeTo(&b)
 		if err != nil {
 			if os.IsNotExist(err) {
 				// Not recoverable
@@ -417,8 +417,7 @@ func (p *SwiftPath) ReadFile() ([]byte, error) {
 	}
 }
 
-// WriteTo implements io.WriterTo
-func (p *SwiftPath) WriteTo(out io.Writer) (int64, error) {
+func (p *SwiftPath) writeTo(out io.Writer) (int64, error) {
 	klog.V(4).Infof("Reading file %q", p)
 
 	opt := swiftobject.DownloadOpts{}

--- a/util/pkg/vfs/vfs.go
+++ b/util/pkg/vfs/vfs.go
@@ -43,8 +43,6 @@ type ACLOracle func(Path) (ACL, error)
 
 // Path is a path in the VFS space, which we can read, write, list etc
 type Path interface {
-	io.WriterTo
-
 	Join(relativePath ...string) Path
 
 	// ReadFile returns the contents of the file, or an error if the file could not be read.


### PR DESCRIPTION
And remove/don't export WriteTo in VFS implementations

With  #9174 merged, the WriterTo interface is no longer used in VFS.