### PR TITLE
Automated cherry pick of #9179: Update DigitalOcean cloud-controller-manager to v0.1.24

### DIFF
--- a/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
@@ -48,7 +48,7 @@ spec:
           operator: Exists
           tolerationSeconds: 300
       containers:
-      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.20
+      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.24
         name: digitalocean-cloud-controller-manager
         command:
           - "/bin/digitalocean-cloud-controller-manager"


### PR DESCRIPTION
Cherry pick of #9179 on release-1.17.

#9179: Update DigitalOcean cloud-controller-manager to v0.1.24

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.