### PR TITLE
Automated cherry pick of #9181: Use debian as default image for DO images

### DIFF
--- a/docs/getting_started/digitalocean.md
+++ b/docs/getting_started/digitalocean.md
@@ -28,13 +28,13 @@ export S3_SECRET_ACCESS_KEY=<secret-key>  # where <secret-key> is the Spaces API
 export KOPS_FEATURE_FLAGS="AlphaAllowDO"
 ```
 
-## Creating a Cluster
+## Creating a Single Master Cluster
 
 In the following examples, `example.com` should be replaced with the DigitalOcean domain you created when going through the [Requirements](#requirements).
 Note that you kops will only be able to successfully provision clusters in regions that support block storage (AMS3, BLR1, FRA1, LON1, NYC1, NYC3, SFO2, SGP1 and TOR1).
 
 ```bash
-# coreos (the default) + flannel overlay cluster in tor1
+# debian (the default) + flannel overlay cluster in tor1
 kops create cluster --cloud=digitalocean --name=my-cluster.example.com --networking=flannel --zones=tor1 --ssh-public-key=~/.ssh/id_rsa.pub
 kops update cluster my-cluster.example.com --yes
 
@@ -50,9 +50,21 @@ kops update cluster my-cluster.example.com --yes
 kops delete cluster my-cluster.example.com --yes
 ```
 
+## Creating a Multi-Master HA Cluster
+
+In the below example, `dev5.k8s.local` should be replaced with any cluster name that ends with `.k8s.local` such that a gossip based cluster is created.
+Ensure the master-count is odd-numbered. A load balancer is created dynamically front-facing the master instances.
+
+```bash
+# debian (the default) + flannel overlay cluster in tor1 with 3 master setup and a public load balancer.
+kops create cluster --cloud=digitalocean --name=dev5.k8s.local --networking=cilium --api-loadbalancer-type=public --master-count=3 --zones=tor1 --ssh-public-key=~/.ssh/id_rsa.pub --yes
+
+# to delete a cluster - this will also delete the load balancer associated with the cluster.
+kops delete cluster dev5.k8s.local --yes
+```
+
 ## Features Still in Development
 
 kops for DigitalOcean currently does not support these features:
-* multi master kubernetes clusters
+
 * rolling update for instance groups
-* multi-region clusters

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -43,11 +43,11 @@ const (
 
 	defaultMasterMachineTypeGCE     = "n1-standard-1"
 	defaultMasterMachineTypeVSphere = "vsphere_master"
-	defaultMasterMachineTypeDO      = "s-2vcpu-2gb"
+	defaultMasterMachineTypeDO      = "s-2vcpu-4gb"
 	defaultMasterMachineTypeALI     = "ecs.n2.medium"
 
 	defaultVSphereNodeImage = "kops_ubuntu_16_04.ova"
-	defaultDONodeImage      = "coreos-stable"
+	defaultDONodeImage      = "debian-9-x64"
 	defaultALINodeImage     = "centos_7_04_64_20G_alibase_201701015.vhd"
 )
 


### PR DESCRIPTION
Cherry pick of #9181 on release-1.17.

#9181: Use debian as default image for DO images

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.