### PR TITLE
Automated cherry pick of #9171: Remove all versions of a file form the S3 bucket #9188: Fix nits for removal of S3 file versions

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -421,7 +421,12 @@ func (b *PolicyBuilder) AddS3Permissions(p *Policy) (*Policy, error) {
 
 			p.Statement = append(p.Statement, &Statement{
 				Effect: StatementEffectAllow,
-				Action: stringorslice.Slice([]string{"s3:GetObject", "s3:DeleteObject", "s3:PutObject"}),
+				Action: stringorslice.Slice([]string{
+					"s3:GetObject",
+					"s3:DeleteObject",
+					"s3:DeleteObjectVersion",
+					"s3:PutObject",
+				}),
 				Resource: stringorslice.Of(
 					strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/*"}, ""),
 				),

--- a/upup/models/vfs.go
+++ b/upup/models/vfs.go
@@ -143,3 +143,7 @@ func (p *AssetPath) String() string {
 func (p *AssetPath) Remove() error {
 	return ReadOnlyError
 }
+
+func (p *AssetPath) RemoveAll() error {
+	return p.Remove()
+}

--- a/upup/models/vfs.go
+++ b/upup/models/vfs.go
@@ -144,6 +144,6 @@ func (p *AssetPath) Remove() error {
 	return ReadOnlyError
 }
 
-func (p *AssetPath) RemoveAll() error {
+func (p *AssetPath) RemoveAllVersions() error {
 	return p.Remove()
 }

--- a/util/pkg/vfs/fs.go
+++ b/util/pkg/vfs/fs.go
@@ -187,7 +187,7 @@ func (p *FSPath) Remove() error {
 	return os.Remove(p.location)
 }
 
-func (p *FSPath) RemoveAll() error {
+func (p *FSPath) RemoveAllVersions() error {
 	return p.Remove()
 }
 

--- a/util/pkg/vfs/fs.go
+++ b/util/pkg/vfs/fs.go
@@ -187,6 +187,10 @@ func (p *FSPath) Remove() error {
 	return os.Remove(p.location)
 }
 
+func (p *FSPath) RemoveAll() error {
+	return p.Remove()
+}
+
 func (p *FSPath) PreferredHash() (*hashing.Hash, error) {
 	return p.Hash(hashing.HashAlgorithmSHA256)
 }

--- a/util/pkg/vfs/gsfs.go
+++ b/util/pkg/vfs/gsfs.go
@@ -123,6 +123,10 @@ func (p *GSPath) Remove() error {
 	}
 }
 
+func (p *GSPath) RemoveAll() error {
+	return p.Remove()
+}
+
 func (p *GSPath) Join(relativePath ...string) Path {
 	args := []string{p.key}
 	args = append(args, relativePath...)

--- a/util/pkg/vfs/gsfs.go
+++ b/util/pkg/vfs/gsfs.go
@@ -123,7 +123,7 @@ func (p *GSPath) Remove() error {
 	}
 }
 
-func (p *GSPath) RemoveAll() error {
+func (p *GSPath) RemoveAllVersions() error {
 	return p.Remove()
 }
 

--- a/util/pkg/vfs/k8sfs.go
+++ b/util/pkg/vfs/k8sfs.go
@@ -68,7 +68,7 @@ func (p *KubernetesPath) Remove() error {
 	return fmt.Errorf("KubernetesPath::Remove not supported")
 }
 
-func (p *KubernetesPath) RemoveAll() error {
+func (p *KubernetesPath) RemoveAllVersions() error {
 	return p.Remove()
 }
 

--- a/util/pkg/vfs/k8sfs.go
+++ b/util/pkg/vfs/k8sfs.go
@@ -68,6 +68,10 @@ func (p *KubernetesPath) Remove() error {
 	return fmt.Errorf("KubernetesPath::Remove not supported")
 }
 
+func (p *KubernetesPath) RemoveAll() error {
+	return p.Remove()
+}
+
 func (p *KubernetesPath) Join(relativePath ...string) Path {
 	args := []string{p.key}
 	args = append(args, relativePath...)

--- a/util/pkg/vfs/memfs.go
+++ b/util/pkg/vfs/memfs.go
@@ -170,6 +170,6 @@ func (p *MemFSPath) Remove() error {
 	return nil
 }
 
-func (p *MemFSPath) RemoveAll() error {
+func (p *MemFSPath) RemoveAllVersions() error {
 	return p.Remove()
 }

--- a/util/pkg/vfs/memfs.go
+++ b/util/pkg/vfs/memfs.go
@@ -169,3 +169,7 @@ func (p *MemFSPath) Remove() error {
 	p.contents = nil
 	return nil
 }
+
+func (p *MemFSPath) RemoveAll() error {
+	return p.Remove()
+}

--- a/util/pkg/vfs/ossfs.go
+++ b/util/pkg/vfs/ossfs.go
@@ -217,7 +217,7 @@ func (p *OSSPath) Remove() error {
 	}
 }
 
-func (p *OSSPath) RemoveAll() error {
+func (p *OSSPath) RemoveAllVersions() error {
 	return p.Remove()
 }
 

--- a/util/pkg/vfs/ossfs.go
+++ b/util/pkg/vfs/ossfs.go
@@ -217,6 +217,10 @@ func (p *OSSPath) Remove() error {
 	}
 }
 
+func (p *OSSPath) RemoveAll() error {
+	return p.Remove()
+}
+
 func (p *OSSPath) Base() string {
 	return path.Base(p.key)
 }

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -119,8 +119,6 @@ func (p *S3Path) Remove() error {
 
 		_, err = client.DeleteObject(request)
 		if err != nil {
-			// TODO: Check for not-exists, return os.NotExist
-
 			return fmt.Errorf("error deleting %s version %q: %v", p, aws.StringValue(version.VersionId), err)
 		}
 	}

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -103,7 +103,9 @@ func (p *S3Path) Remove() error {
 	}
 
 	if len(response.Versions) == 0 {
-		return os.ErrNotExist
+		// TODO: Check why cluster teardown fails when files are not found and replace warning with error
+		// return os.ErrNotExist
+		klog.Warningf("error removing file (not found): %s", p)
 	}
 
 	// Sometimes S3 will return paginated results if there are too many versions for an object.
@@ -123,7 +125,7 @@ func (p *S3Path) Remove() error {
 
 		_, err = client.DeleteObject(request)
 		if err != nil {
-			return fmt.Errorf("error deleting %s version %q: %v", p, aws.StringValue(version.VersionId), err)
+			return fmt.Errorf("error removing %s version %q: %v", p, aws.StringValue(version.VersionId), err)
 		}
 	}
 

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -106,13 +106,13 @@ func (p *S3Path) Remove() error {
 	return nil
 }
 
-func (p *S3Path) RemoveAll() error {
+func (p *S3Path) RemoveAllVersions() error {
 	client, err := p.client()
 	if err != nil {
 		return err
 	}
 
-	klog.V(8).Infof("removing file %s", p)
+	klog.V(8).Infof("removing all versions of file %s", p)
 
 	request := &s3.ListObjectVersionsInput{
 		Bucket: aws.String(p.bucket),
@@ -121,7 +121,7 @@ func (p *S3Path) RemoveAll() error {
 
 	response, err := client.ListObjectVersions(request)
 	if err != nil {
-		return fmt.Errorf("error listing versions %s: %v", p, err)
+		return fmt.Errorf("error listing all versions of file %s: %v", p, err)
 	}
 
 	if len(response.Versions) == 0 && len(response.DeleteMarkers) == 0 {

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -102,6 +102,10 @@ func (p *S3Path) Remove() error {
 		return fmt.Errorf("error listing versions %s: %v", p, err)
 	}
 
+	if len(response.Versions) == 0 {
+		return os.ErrNotExist
+	}
+
 	// Sometimes S3 will return paginated results if there are too many versions for an object.
 	// This is unlikely with current use cases, but a warning should be triggered in case it ever occurs.
 	if aws.BoolValue(response.IsTruncated) {
@@ -113,7 +117,7 @@ func (p *S3Path) Remove() error {
 
 		request := &s3.DeleteObjectInput{
 			Bucket:    aws.String(p.bucket),
-			Key:       aws.String(p.key),
+			Key:       version.Key,
 			VersionId: version.VersionId,
 		}
 

--- a/util/pkg/vfs/sshfs.go
+++ b/util/pkg/vfs/sshfs.go
@@ -113,7 +113,7 @@ func (p *SSHPath) Remove() error {
 	return nil
 }
 
-func (p *SSHPath) RemoveAll() error {
+func (p *SSHPath) RemoveAllVersions() error {
 	return p.Remove()
 }
 

--- a/util/pkg/vfs/sshfs.go
+++ b/util/pkg/vfs/sshfs.go
@@ -113,6 +113,10 @@ func (p *SSHPath) Remove() error {
 	return nil
 }
 
+func (p *SSHPath) RemoveAll() error {
+	return p.Remove()
+}
+
 func (p *SSHPath) Join(relativePath ...string) Path {
 	args := []string{p.path}
 	args = append(args, relativePath...)

--- a/util/pkg/vfs/swiftfs.go
+++ b/util/pkg/vfs/swiftfs.go
@@ -291,6 +291,10 @@ func (p *SwiftPath) Remove() error {
 	}
 }
 
+func (p *SwiftPath) RemoveAll() error {
+	return p.Remove()
+}
+
 func (p *SwiftPath) Join(relativePath ...string) Path {
 	args := []string{p.key}
 	args = append(args, relativePath...)

--- a/util/pkg/vfs/swiftfs.go
+++ b/util/pkg/vfs/swiftfs.go
@@ -291,7 +291,7 @@ func (p *SwiftPath) Remove() error {
 	}
 }
 
-func (p *SwiftPath) RemoveAll() error {
+func (p *SwiftPath) RemoveAllVersions() error {
 	return p.Remove()
 }
 

--- a/util/pkg/vfs/vfs.go
+++ b/util/pkg/vfs/vfs.go
@@ -59,8 +59,8 @@ type Path interface {
 	// Remove deletes the file
 	Remove() error
 
-	// RemoveAll completely deletes the file (with all its versions and markers)
-	RemoveAll() error
+	// RemoveAllVersions completely deletes the file (with all its versions and markers).
+	RemoveAllVersions() error
 
 	// Base returns the base name (last element)
 	Base() string

--- a/util/pkg/vfs/vfs.go
+++ b/util/pkg/vfs/vfs.go
@@ -59,6 +59,9 @@ type Path interface {
 	// Remove deletes the file
 	Remove() error
 
+	// RemoveAll completely deletes the file (with all its versions and markers)
+	RemoveAll() error
+
 	// Base returns the base name (last element)
 	Base() string
 


### PR DESCRIPTION
Cherry pick of #9171 #9188 on release-1.16.

#9171: Remove all versions of a file form the S3 bucket
#9188: Fix nits for removal of S3 file versions

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.