### PR TITLE
Fix repo packages not being installed

### DIFF
--- a/upup/pkg/fi/nodeup/nodetasks/package.go
+++ b/upup/pkg/fi/nodeup/nodetasks/package.go
@@ -297,7 +297,7 @@ func (_ *Package) RenderLocal(t *local.LocalTarget, a, e, changes *Package) erro
 
 	if a == nil || changes.Version != nil {
 		klog.Infof("Installing package %q (dependencies: %v)", e.Name, e.Deps)
-		var localPkgs []string
+		var pkgs []string
 
 		if e.Source != nil {
 			// Install a deb or rpm.
@@ -317,10 +317,10 @@ func (_ *Package) RenderLocal(t *local.LocalTarget, a, e, changes *Package) erro
 			}
 
 			// Download all the debs/rpms.
-			localPkgs = make([]string, 1+len(e.Deps))
+			pkgs = make([]string, 1+len(e.Deps))
 			for i, pkg := range append([]*Package{e}, e.Deps...) {
 				local := path.Join(localPackageDir, pkg.Name+ext)
-				localPkgs[i] = local
+				pkgs[i] = local
 				var hash *hashing.Hash
 				if fi.StringValue(pkg.Hash) != "" {
 					parsed, err := hashing.FromString(fi.StringValue(pkg.Hash))
@@ -334,6 +334,8 @@ func (_ *Package) RenderLocal(t *local.LocalTarget, a, e, changes *Package) erro
 					return err
 				}
 			}
+		} else {
+			pkgs = append(pkgs, e.Name)
 		}
 
 		var args []string
@@ -350,7 +352,7 @@ func (_ *Package) RenderLocal(t *local.LocalTarget, a, e, changes *Package) erro
 		} else {
 			return fmt.Errorf("unsupported package system")
 		}
-		args = append(args, localPkgs...)
+		args = append(args, pkgs...)
 
 		klog.Infof("running command %s", args)
 		cmd := exec.Command(args[0], args[1:]...)


### PR DESCRIPTION
I think the refactoring of `package.go` in https://github.com/kubernetes/kops/commit/6b011c044b3b7d0455bd9815ff29a908eefe3e0c  introduced a bug that keeps repo packages from being installed. 

From https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-k8s-latest/1266103273169883138/artifacts/54.249.221.142/kops-configuration.log
```
I0528 20:27:01.652991     836 package.go:299] Installing package "chrony" (dependencies: [])
I0528 20:27:01.653018     836 package.go:355] running command [apt-get install --yes --no-install-recommends]
```
```
I0528 20:48:51.349091    6615 executor.go:103] Tasks: 64 done / 65 total; 1 can run
I0528 20:48:51.349125    6615 executor.go:174] Executing task "Service/chrony": Service: chrony
I0528 20:48:51.349177    6615 changes.go:81] Field changed "Running" actual="false" expected="true"
I0528 20:48:51.349187    6615 changes.go:81] Field changed "Enabled" actual="<nil>" expected="true"
I0528 20:48:51.349196    6615 changes.go:81] Field changed "ManageState" actual="<nil>" expected="true"
I0528 20:48:51.349205    6615 changes.go:81] Field changed "SmartRestart" actual="<nil>" expected="true"
I0528 20:48:51.349268    6615 service.go:329] Restarting service "chrony"
W0528 20:48:51.353398    6615 executor.go:128] error running task "Service/chrony" (9m58s remaining to succeed): error doing systemd restart chrony: exit status 5
Output: Failed to restart chrony.service: Unit chrony.service not found.
I0528 20:48:51.353418    6615 executor.go:143] No progress made, sleeping before retrying 1 failed task(s)
```