### PR TITLE
Automated cherry pick of #9205: Allow listing versions for objects in the S3 bucket

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -324,7 +324,12 @@ func (b *PolicyBuilder) AddS3Permissions(p *Policy) (*Policy, error) {
 
 			p.Statement = append(p.Statement, &Statement{
 				Effect: StatementEffectAllow,
-				Action: stringorslice.Of("s3:GetBucketLocation", "s3:GetEncryptionConfiguration", "s3:ListBucket"),
+				Action: stringorslice.Of(
+					"s3:GetBucketLocation",
+					"s3:GetEncryptionConfiguration",
+					"s3:ListBucket",
+					"s3:ListBucketVersions",
+				),
 				Resource: stringorslice.Slice([]string{
 					strings.Join([]string{b.IAMPrefix(), ":s3:::", s3Path.Bucket()}, ""),
 				}),

--- a/pkg/model/iam/tests/iam_builder_master_legacy.json
+++ b/pkg/model/iam/tests/iam_builder_master_legacy.json
@@ -50,7 +50,8 @@
       "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
-        "s3:ListBucket"
+        "s3:ListBucket",
+        "s3:ListBucketVersions"
       ],
       "Resource": [
         "arn:aws:s3:::kops-tests"

--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -142,7 +142,8 @@
       "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
-        "s3:ListBucket"
+        "s3:ListBucket",
+        "s3:ListBucketVersions"
       ],
       "Resource": [
         "arn:aws:s3:::kops-tests"

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -142,7 +142,8 @@
       "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
-        "s3:ListBucket"
+        "s3:ListBucket",
+        "s3:ListBucketVersions"
       ],
       "Resource": [
         "arn:aws:s3:::kops-tests"

--- a/pkg/model/iam/tests/iam_builder_node_legacy.json
+++ b/pkg/model/iam/tests/iam_builder_node_legacy.json
@@ -16,7 +16,8 @@
       "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
-        "s3:ListBucket"
+        "s3:ListBucket",
+        "s3:ListBucketVersions"
       ],
       "Resource": [
         "arn:aws:s3:::kops-tests"

--- a/pkg/model/iam/tests/iam_builder_node_strict.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict.json
@@ -16,7 +16,8 @@
       "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
-        "s3:ListBucket"
+        "s3:ListBucket",
+        "s3:ListBucketVersions"
       ],
       "Resource": [
         "arn:aws:s3:::kops-tests"

--- a/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
@@ -16,7 +16,8 @@
       "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
-        "s3:ListBucket"
+        "s3:ListBucket",
+        "s3:ListBucketVersions"
       ],
       "Resource": [
         "arn:aws:s3:::kops-tests"


### PR DESCRIPTION
Cherry pick of #9205 on release-1.16.

#9205: Allow listing versions for objects in the S3 bucket

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.