### PR TITLE
Upgrde amazon vpc cni to 1.6.2

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -3926,15 +3926,15 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: "beta.kubernetes.io/os"
+              - key: "kubernetes.io/os"
                 operator: In
                 values:
                 - linux
-              - key: "beta.kubernetes.io/arch"
+              - key: "kubernetes.io/arch"
                 operator: In
                 values:
                 - amd64
-              - key: eks.amazonaws.com/compute-type
+              - key: "eks.amazonaws.com/compute-type"
                 operator: NotIn
                 values:
                 - fargate
@@ -3943,7 +3943,7 @@ spec:
       tolerations:
       - operator: Exists
       containers:
-      - image: "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.1" }}"
+      - image: "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.2" }}"
         imagePullPolicy: Always
         ports:
         - containerPort: 61678

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -71,15 +71,15 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: "beta.kubernetes.io/os"
+              - key: "kubernetes.io/os"
                 operator: In
                 values:
                 - linux
-              - key: "beta.kubernetes.io/arch"
+              - key: "kubernetes.io/arch"
                 operator: In
                 values:
                 - amd64
-              - key: eks.amazonaws.com/compute-type
+              - key: "eks.amazonaws.com/compute-type"
                 operator: NotIn
                 values:
                 - fargate
@@ -88,7 +88,7 @@ spec:
       tolerations:
       - operator: Exists
       containers:
-      - image: "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.1" }}"
+      - image: "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.2" }}"
         imagePullPolicy: Always
         ports:
         - containerPort: 61678

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -113,7 +113,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0'
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: bcd0b0d5d79a33a5f9d6d226f0c6c1ba18ec848f
+    manifestHash: 92f1b119fe4732fe00ea4bf2e8846a2579e39dc9
     name: networking.amazon-vpc-routed-eni
     selector:
       role.kubernetes.io/networking: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -73,11 +73,11 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/os
+              - key: kubernetes.io/os
                 operator: In
                 values:
                 - linux
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
@@ -103,7 +103,7 @@ spec:
           value: "10"
         - name: AWS_VPC_K8S_CNI_LOGLEVEL
           value: debug
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.2
         imagePullPolicy: Always
         livenessProbe:
           exec:


### PR DESCRIPTION
Two changes in this PR:
1. Upgrading image to version 1.6.2 following [release](https://github.com/aws/amazon-vpc-cni-k8s/releases/tag/v1.6.2)
2. Applying changes to node selectors, following [this update](https://github.com/aws/amazon-vpc-cni-k8s/pull/937) to the upstream manifest