### PR TITLE
Spotinst: Allow a user specifiable node draining timeout

### DIFF
--- a/docs/getting_started/spot-ocean.md
+++ b/docs/getting_started/spot-ocean.md
@@ -152,6 +152,7 @@ metadata:
 | `spotinst.io/spot-percentage` | Specify the percentage of Spot instances that should spin up from the target capacity. | `100` |
 | `spotinst.io/utilize-reserved-instances` | Specify whether reserved instances should be utilized. | `true` |
 | `spotinst.io/fallback-to-ondemand` | Specify whether fallback to on-demand instances should be enabled. | `true` |
+| `spotinst.io/draining-timeout` | Specify a period of time, in seconds, after a node is marked for termination during which on running pods remains active. | none |
 | `spotinst.io/grace-period` | Specify a period of time, in seconds, that Ocean should wait before applying instance health checks. | none |
 | `spotinst.io/ocean-default-launchspec` | Specify whether to use the InstanceGroup's spec as the default Launch Spec for the Ocean cluster. | none |
 | `spotinst.io/ocean-instance-types-whitelist` | Specify whether to whitelist specific instance types. | none |

--- a/pkg/model/spotinstmodel/instance_group.go
+++ b/pkg/model/spotinstmodel/instance_group.go
@@ -57,6 +57,11 @@ const (
 	// be enabled.
 	InstanceGroupLabelFallbackToOnDemand = "spotinst.io/fallback-to-ondemand"
 
+	// InstanceGroupLabelDrainingTimeout is the metadata label used on the
+	// instance group to specify a period of time, in seconds, after a node
+	// is marked for termination during which on running pods remains active.
+	InstanceGroupLabelDrainingTimeout = "spotinst.io/draining-timeout"
+
 	// InstanceGroupLabelGracePeriod is the metadata label used on the
 	// instance group to specify a period of time, in seconds, that Ocean
 	// should wait before applying instance health checks.
@@ -198,6 +203,12 @@ func (b *InstanceGroupModelBuilder) buildElastigroup(c *fi.ModelBuilderContext, 
 
 		case InstanceGroupLabelFallbackToOnDemand:
 			group.FallbackToOnDemand, err = parseBool(v)
+			if err != nil {
+				return err
+			}
+
+		case InstanceGroupLabelDrainingTimeout:
+			group.DrainingTimeout, err = parseInt(v)
 			if err != nil {
 				return err
 			}
@@ -374,6 +385,12 @@ func (b *InstanceGroupModelBuilder) buildOcean(c *fi.ModelBuilderContext, igs ..
 
 		case InstanceGroupLabelGracePeriod:
 			ocean.GracePeriod, err = parseInt(v)
+			if err != nil {
+				return err
+			}
+
+		case InstanceGroupLabelDrainingTimeout:
+			ocean.DrainingTimeout, err = parseInt(v)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR adds support for node draining timeout for both Elastigroup and Ocean.