### PR TITLE
Update set-version script to bump tag in Makefile

### DIFF
--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -80,6 +80,8 @@ make ci
 # For versions prior to 1.18: make dns-controller-push DOCKER_REGISTRY=kope
 make dns-controller-push DOCKER_IMAGE_PREFIX=kope/  DOCKER_REGISTRY=index.docker.io
 
+make kube-apiserver-healthcheck-push DOCKER_IMAGE_PREFIX=kope/  DOCKER_REGISTRY=index.docker.io
+
 make kops-controller-push DOCKER_IMAGE_PREFIX=kope/  DOCKER_REGISTRY=index.docker.io
 ```
 

--- a/hack/set-version
+++ b/hack/set-version
@@ -49,6 +49,7 @@ echo "KOPS_CI_VERSION ${KOPS_CI_VERSION} -> ${NEW_CI_VERSION}"
 
 sed -i -e "s@DNS_CONTROLLER_TAG=${KOPS_RELEASE_VERSION}@DNS_CONTROLLER_TAG=${NEW_RELEASE_VERSION}@g" Makefile
 sed -i -e "s@KOPS_CONTROLLER_TAG=${KOPS_RELEASE_VERSION}@KOPS_CONTROLLER_TAG=${NEW_RELEASE_VERSION}@g" Makefile
+sed -i -e "s@KUBE_APISERVER_HEALTHCHECK_TAG=${KOPS_RELEASE_VERSION}@KUBE_APISERVER_HEALTHCHECK_TAG=${NEW_RELEASE_VERSION}@g" Makefile
 sed -i -e "s@\"${KOPS_RELEASE_VERSION}\"@\"${NEW_RELEASE_VERSION}\"@g" upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
 
 git grep -l kope/dns-controller | xargs -I {} sed -i -e "s@dns-controller:${KOPS_RELEASE_VERSION}@dns-controller:${NEW_RELEASE_VERSION}@g" {}


### PR DESCRIPTION
I had forgotten to automatically bump the
KUBE_APISERVER_HEALTHCHECK_TAG in the Makefile.

Also add pushing the image to the release procedure.