### PR TITLE
Validation: MixedInstancePolicy need not override instance types

### DIFF
--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -125,9 +125,6 @@ func ValidateInstanceGroup(g *kops.InstanceGroup) field.ErrorList {
 func validatedMixedInstancesPolicy(path *field.Path, spec *kops.MixedInstancesPolicySpec, ig *kops.InstanceGroup) field.ErrorList {
 	var errs field.ErrorList
 
-	if len(spec.Instances) < 2 {
-		errs = append(errs, field.Invalid(path.Child("instances"), spec.Instances, "must be 2 or more instance types"))
-	}
 	// @step: check the instances are validate
 	for i, x := range spec.Instances {
 		errs = append(errs, awsValidateMachineType(path.Child("instances").Index(i).Child("instanceType"), x)...)


### PR DESCRIPTION
The mixed instance policy is also useful for spot instances, and
generally overriding the instances doesn't seem to be required.

Also both 0 and 1 instance type overrides appear to be supported by
AWS.