### PR TITLE
Add packages hashes verification for containerd and Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -553,6 +553,10 @@ verify-terraform:
 verify-bindata:
 	./hack/verify-bindata.sh
 
+.PHONY: verify-hashes
+verify-hashes:
+	./hack/verify-hashes.sh
+
 # ci target is for developers, it aims to cover all the CI jobs
 # verify-gendocs will call kops target
 # verify-package has to be after verify-gendocs, because with .gitignore for federation bindata

--- a/hack/verify-hashes.sh
+++ b/hack/verify-hashes.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+cd "${KOPS_ROOT}"
+
+# Verify package hashes for Containerd and Docker
+VERIFY_HASHES=1 go test -v ./nodeup/pkg/model -run PackageHashes


### PR DESCRIPTION
Prow should verify package hashes for containerd and Docker.
Reference: https://github.com/kubernetes/kops/pull/9215#issuecomment-636327311

/cc @rifelpet 