### PR TITLE
Automated cherry pick of #9237: Update etcd-manager to 3.0.20200531

### DIFF
--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/loader"
 )
 
-const DefaultBackupImage = "kopeio/etcd-backup:3.0.20200429"
+const DefaultBackupImage = "kopeio/etcd-backup:3.0.20200531"
 
 // EtcdOptionsBuilder adds options for etcd to the model
 type EtcdOptionsBuilder struct {

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -189,7 +189,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - image: kopeio/etcd-manager:3.0.20200429
+  - image: kopeio/etcd-manager:3.0.20200531
     name: etcd-manager
     resources:
       requests:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -89,7 +89,7 @@ Contents:
           --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
           --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
           > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20200429
+        image: kopeio/etcd-manager:3.0.20200531
         name: etcd-manager
         resources:
           requests:
@@ -160,7 +160,7 @@ Contents:
           --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
           --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
           > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20200429
+        image: kopeio/etcd-manager:3.0.20200531
         name: etcd-manager
         resources:
           requests:

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -98,7 +98,7 @@ Contents:
           value: http://proxy.example.com
         - name: no_proxy
           value: noproxy.example.com
-        image: kopeio/etcd-manager:3.0.20200429
+        image: kopeio/etcd-manager:3.0.20200531
         name: etcd-manager
         resources:
           requests:
@@ -178,7 +178,7 @@ Contents:
           value: http://proxy.example.com
         - name: no_proxy
           value: noproxy.example.com
-        image: kopeio/etcd-manager:3.0.20200429
+        image: kopeio/etcd-manager:3.0.20200531
         name: etcd-manager
         resources:
           requests:


### PR DESCRIPTION
Cherry pick of #9237 on release-1.16.

#9237: Update etcd-manager to 3.0.20200531

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.