### PR TITLE
Remove redundant ValidateInstanceGroup call

### DIFF
--- a/cmd/kops/edit_instancegroup.go
+++ b/cmd/kops/edit_instancegroup.go
@@ -155,11 +155,6 @@ func RunEditInstanceGroup(ctx context.Context, f *util.Factory, cmd *cobra.Comma
 		return fmt.Errorf("object was not of expected type: %T", newObj)
 	}
 
-	err = validation.ValidateInstanceGroup(newGroup).ToAggregate()
-	if err != nil {
-		return err
-	}
-
 	fullGroup, err := cloudup.PopulateInstanceGroupSpec(cluster, newGroup, channel)
 	if err != nil {
 		return err


### PR DESCRIPTION
The `cloudup.PopulateInstanceGroupSpec` directly after this calls `ValidateInstanceGroup` so this first call is redundant.

https://github.com/kubernetes/kops/blob/7b067983dfab5e78148dc9906242bed29efed455/upup/pkg/fi/cloudup/populate_instancegroup_spec.go#L61-L66

This is minor cleanup to help simplify the aws instance type validation PR