### PR TITLE
Automated cherry pick of #9258: Use Docker 19.03.11 for Kubernetes 1.18+

### DIFF
--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -4,7 +4,7 @@
 
 # Significant changes
 
-* The default Docker version has been changed to 19.03.8.
+* The default Docker version has been changed to 19.03.11.
 
 * Support for [RHEL 8](../operations/images.md#rhel-8) and [CentOS 8](../operations/images.md#centos-8) has been added.
 

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -552,6 +552,15 @@ var dockerVersions = []packageVersion{
 		Hash:           "7f4115dc6a3c19c917f8b9664d7b51c904def1c984e082c4600097433323cf6f",
 	},
 
+	// 19.03.11 - Linux Generic
+	{
+		PackageVersion: "19.03.11",
+		PlainBinary:    true,
+		Architectures:  []Architecture{ArchitectureAmd64},
+		Source:         "https://download.docker.com/linux/static/stable/x86_64/docker-19.03.11.tgz",
+		Hash:           "0f4336378f61ed73ed55a356ac19e46699a995f2aff34323ba5874d131548b9e",
+	},
+
 	// TIP: When adding the next version, copy the previous version, string replace the version and run:
 	//   VERIFY_HASHES=1 go test -v ./nodeup/pkg/model -run TestDockerPackageHashes
 	// (you might want to temporarily comment out older versions on a slower connection and then validate)

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -719,7 +719,7 @@ func validateDockerConfig(config *kops.DockerConfig, fldPath *field.Path) field.
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("version"), config.Version,
 				"version is no longer available: https://www.docker.com/blog/changes-dockerproject-org-apt-yum-repositories/"))
 		} else {
-			valid := []string{"17.03.2", "17.09.0", "18.03.1", "18.06.1", "18.06.2", "18.06.3", "18.09.3", "18.09.9", "19.03.4", "19.03.8"}
+			valid := []string{"17.03.2", "17.09.0", "18.03.1", "18.06.1", "18.06.2", "18.06.3", "18.09.3", "18.09.9", "19.03.4", "19.03.8", "19.03.11"}
 			allErrs = append(allErrs, IsValidValue(fldPath.Child("version"), config.Version, valid)...)
 		}
 	}

--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -90,7 +90,7 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 
 			// Set the containerd version for known Docker versions
 			switch fi.StringValue(clusterSpec.Docker.Version) {
-			case "19.03.8":
+			case "19.03.8", "19.03.11":
 				containerd.Version = fi.String("1.2.13")
 			case "19.03.4":
 				containerd.Version = fi.String("1.2.10")

--- a/pkg/model/components/docker.go
+++ b/pkg/model/components/docker.go
@@ -48,7 +48,7 @@ func (b *DockerOptionsBuilder) BuildOptions(o interface{}) error {
 	// Set the Docker version for known Kubernetes versions
 	if fi.StringValue(clusterSpec.Docker.Version) == "" {
 		if b.IsKubernetesGTE("1.18") {
-			docker.Version = fi.String("19.03.8")
+			docker.Version = fi.String("19.03.11")
 		} else if b.IsKubernetesGTE("1.17") {
 			docker.Version = fi.String("19.03.4")
 		} else if b.IsKubernetesGTE("1.16") {


### PR DESCRIPTION
Cherry pick of #9258 on release-1.18.

#9258: Use Docker 19.03.11 for Kubernetes 1.18+

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.