### PR TITLE
Update channel 1.15 k8s recommendation to 1.15.12

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -65,7 +65,7 @@ spec:
     recommendedVersion: 1.16.10
     requiredVersion: 1.16.0
   - range: ">=1.15.0"
-    recommendedVersion: 1.15.11
+    recommendedVersion: 1.15.12
     requiredVersion: 1.15.0
   - range: ">=1.14.0"
     recommendedVersion: 1.14.10
@@ -98,7 +98,7 @@ spec:
   - range: ">=1.15.0-alpha.1"
     #recommendedVersion: "1.15.0"
     #requiredVersion: 1.15.0
-    kubernetesVersion: 1.15.11
+    kubernetesVersion: 1.15.12
   - range: ">=1.14.0-alpha.1"
     #recommendedVersion: "1.14.0"
     #requiredVersion: 1.14.0

--- a/channels/stable
+++ b/channels/stable
@@ -65,7 +65,7 @@ spec:
     recommendedVersion: 1.16.10
     requiredVersion: 1.16.0
   - range: ">=1.15.0"
-    recommendedVersion: 1.15.11
+    recommendedVersion: 1.15.12
     requiredVersion: 1.15.0
   - range: ">=1.14.0"
     recommendedVersion: 1.14.10
@@ -98,7 +98,7 @@ spec:
   - range: ">=1.15.0-alpha.1"
     #recommendedVersion: "1.15.0"
     #requiredVersion: 1.15.0
-    kubernetesVersion: 1.15.11
+    kubernetesVersion: 1.15.12
   - range: ">=1.14.0-alpha.1"
     #recommendedVersion: "1.14.0"
     #requiredVersion: 1.14.0

--- a/channels/stable
+++ b/channels/stable
@@ -65,7 +65,7 @@ spec:
     recommendedVersion: 1.16.10
     requiredVersion: 1.16.0
   - range: ">=1.15.0"
-    recommendedVersion: 1.15.12
+    recommendedVersion: 1.15.11
     requiredVersion: 1.15.0
   - range: ">=1.14.0"
     recommendedVersion: 1.14.10
@@ -98,7 +98,7 @@ spec:
   - range: ">=1.15.0-alpha.1"
     #recommendedVersion: "1.15.0"
     #requiredVersion: 1.15.0
-    kubernetesVersion: 1.15.12
+    kubernetesVersion: 1.15.11
   - range: ">=1.14.0-alpha.1"
     #recommendedVersion: "1.14.0"
     #requiredVersion: 1.14.0


### PR DESCRIPTION
The latest patch release in the 1.15 series is 1.15.12, released 29 days ago, with plenty of bugfixes