### PR TITLE
Update Calico and Canal for CVE-2020-13597

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -7385,7 +7385,7 @@ spec:
       serviceAccountName: calico-node
       priorityClassName: system-cluster-critical
       containers:
-      - image: calico/typha:v3.9.5
+      - image: calico/typha:v3.9.6
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -7501,7 +7501,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.9.5
+          image: calico/cni:v3.9.6
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -7521,7 +7521,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.9.5
+          image: calico/cni:v3.9.6
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -7555,7 +7555,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.9.5
+          image: calico/pod2daemon-flexvol:v3.9.6
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -7564,7 +7564,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.9.5
+          image: calico/node:v3.9.6
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -7771,7 +7771,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.9.5
+          image: calico/kube-controllers:v3.9.6
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS
@@ -8501,7 +8501,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.13.3
+      - image: calico/typha:v3.13.4
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -8613,7 +8613,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.13.3
+          image: calico/cni:v3.13.4
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -8635,7 +8635,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.13.3
+          image: calico/cni:v3.13.4
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -8671,7 +8671,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.13.3
+          image: calico/pod2daemon-flexvol:v3.13.4
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -8682,7 +8682,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.13.3
+          image: calico/node:v3.13.4
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -8890,7 +8890,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.13.3
+          image: calico/kube-controllers:v3.13.4
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS
@@ -11545,7 +11545,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.12.1
+      - image: calico/typha:v3.12.2
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -11662,7 +11662,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.12.1
+          image: calico/cni:v3.12.2
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -11698,7 +11698,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.12.1
+          image: calico/pod2daemon-flexvol:v3.12.2
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -11709,7 +11709,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.12.1
+          image: calico/node:v3.12.2
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -12469,7 +12469,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.13.3
+      - image: calico/typha:v3.13.4
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -12580,7 +12580,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.13.3
+          image: calico/cni:v3.13.4
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -12616,7 +12616,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.13.3
+          image: calico/pod2daemon-flexvol:v3.13.4
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -12627,7 +12627,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.13.3
+          image: calico/node:v3.13.4
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.15.yaml.template
@@ -552,7 +552,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.12.1
+      - image: calico/typha:v3.12.2
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -669,7 +669,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.12.1
+          image: calico/cni:v3.12.2
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -705,7 +705,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.12.1
+          image: calico/pod2daemon-flexvol:v3.12.2
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -716,7 +716,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.12.1
+          image: calico/node:v3.12.2
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.16.yaml.template
@@ -549,7 +549,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.13.3
+      - image: calico/typha:v3.13.4
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -660,7 +660,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.13.3
+          image: calico/cni:v3.13.4
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -696,7 +696,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.13.3
+          image: calico/pod2daemon-flexvol:v3.13.4
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -707,7 +707,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.13.3
+          image: calico/node:v3.13.4
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -578,7 +578,7 @@ spec:
       serviceAccountName: calico-node
       priorityClassName: system-cluster-critical
       containers:
-      - image: calico/typha:v3.9.5
+      - image: calico/typha:v3.9.6
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -694,7 +694,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.9.5
+          image: calico/cni:v3.9.6
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -714,7 +714,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.9.5
+          image: calico/cni:v3.9.6
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -748,7 +748,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.9.5
+          image: calico/pod2daemon-flexvol:v3.9.6
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -757,7 +757,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.9.5
+          image: calico/node:v3.9.6
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -964,7 +964,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.9.5
+          image: calico/kube-controllers:v3.9.6
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -586,7 +586,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.13.3
+      - image: calico/typha:v3.13.4
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -698,7 +698,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.13.3
+          image: calico/cni:v3.13.4
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -720,7 +720,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.13.3
+          image: calico/cni:v3.13.4
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -756,7 +756,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.13.3
+          image: calico/pod2daemon-flexvol:v3.13.4
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -767,7 +767,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.13.3
+          image: calico/node:v3.13.4
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -975,7 +975,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.13.3
+          image: calico/kube-controllers:v3.13.4
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -725,8 +725,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		versions := map[string]string{
 			"k8s-1.7":    "2.6.12-kops.1",
 			"k8s-1.7-v3": "3.8.0-kops.2",
-			"k8s-1.12":   "3.9.5-kops.4",
-			"k8s-1.16":   "3.13.3-kops.3",
+			"k8s-1.12":   "3.9.6-kops.1",
+			"k8s-1.16":   "3.13.4-kops.1",
 		}
 
 		{
@@ -793,8 +793,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		versions := map[string]string{
 			"k8s-1.9":  "3.2.3-kops.1",
 			"k8s-1.12": "3.7.5-kops.2",
-			"k8s-1.15": "3.12.1-kops.2",
-			"k8s-1.16": "3.13.3-kops.2",
+			"k8s-1.15": "3.12.2-kops.1",
+			"k8s-1.16": "3.13.4-kops.1",
 		}
 		{
 			id := "k8s-1.9"


### PR DESCRIPTION
Due to security advisory kubernetes/kubernetes#91507, new versions of Calico were released.

Ref: https://www.projectcalico.org/security-bulletins/

/assign @KashifSaadat 