### PR TITLE
When building to staging, split out the marker files by branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,6 +335,12 @@ gcs-upload: bazel-version-dist
 	@echo "== Uploading kops =="
 	gsutil -h "Cache-Control:private, max-age=0, no-transform" -m cp -n -r ${BAZELUPLOAD}/kops/* ${GCS_LOCATION}
 
+# gcs-upload-tag runs gcs-upload to upload, then uploads a version-marker to LATEST_FILE
+.PHONY: gcs-upload-and-tag
+gcs-upload-and-tag: gcs-upload
+	echo "${GCS_URL}${VERSION}" > ${BAZELUPLOAD}/latest.txt
+	gsutil -h "Cache-Control:private, max-age=0, no-transform" cp ${BAZELUPLOAD}/latest.txt ${GCS_LOCATION}${LATEST_FILE}
+
 # gcs-publish-ci is the entry point for CI testing
 # In CI testing, always upload the CI version.
 .PHONY: gcs-publish-ci

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -26,8 +26,9 @@ steps:
   - DOCKER_REGISTRY=$_DOCKER_REGISTRY
   - DOCKER_IMAGE_PREFIX=$_DOCKER_IMAGE_PREFIX
   - GCS_LOCATION=$_GCS_LOCATION
+  - LATEST_FILE=markers/${_PULL_BASE_REF}/latest-ci.txt
   args:
-  - gcs-upload
+  - gcs-upload-and-tag
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution


### PR DESCRIPTION
This will let us start to have separate CI pipelines per branch.