### PR TITLE
Ensure we have IAM bucket permissions to other S3 buckets

### DIFF
--- a/pkg/model/iam/BUILD.bazel
+++ b/pkg/model/iam/BUILD.bazel
@@ -26,7 +26,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/kops:go_default_library",
-        "//pkg/diff:go_default_library",
+        "//pkg/testutils/golden:go_default_library",
         "//pkg/util/stringorslice:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
     ],

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -18,14 +18,12 @@ package iam
 
 import (
 	"encoding/json"
-	"io/ioutil"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 
 	"k8s.io/kops/pkg/apis/kops"
-	"k8s.io/kops/pkg/diff"
+	"k8s.io/kops/pkg/testutils/golden"
 	"k8s.io/kops/pkg/util/stringorslice"
 )
 
@@ -185,19 +183,7 @@ func TestPolicyGeneration(t *testing.T) {
 			t.Errorf("case %d failed to convert generated IAM Policy to JSON. Error: %v", i, err)
 			continue
 		}
-		actualPolicy = strings.TrimSpace(actualPolicy)
 
-		expectedPolicyBytes, err := ioutil.ReadFile(x.Policy)
-		if err != nil {
-			t.Fatalf("unexpected error reading IAM Policy from file %q: %v", x.Policy, err)
-		}
-		expectedPolicy := strings.TrimSpace(string(expectedPolicyBytes))
-
-		if expectedPolicy != actualPolicy {
-			diffString := diff.FormatDiff(expectedPolicy, actualPolicy)
-			t.Logf("diff:\n%s\n", diffString)
-			t.Errorf("case %d failed, policy output differed from expected (%s).", i, x.Policy)
-			continue
-		}
+		golden.AssertMatchesFile(t, actualPolicy, x.Policy)
 	}
 }

--- a/pkg/model/iam/tests/iam_builder_master_legacy.json
+++ b/pkg/model/iam/tests/iam_builder_master_legacy.json
@@ -48,6 +48,13 @@
     {
       "Effect": "Allow",
       "Action": [
+        "s3:*"
+      ],
+      "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
         "s3:ListBucket",
@@ -56,13 +63,6 @@
       "Resource": [
         "arn:aws:s3:::kops-tests"
       ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:*"
-      ],
-      "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
     },
     {
       "Effect": "Allow",

--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -140,6 +140,13 @@
     {
       "Effect": "Allow",
       "Action": [
+        "s3:Get*"
+      ],
+      "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
         "s3:ListBucket",
@@ -148,13 +155,6 @@
       "Resource": [
         "arn:aws:s3:::kops-tests"
       ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:Get*"
-      ],
-      "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
     },
     {
       "Effect": "Allow",

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -1,4 +1,4 @@
-  {
+{
   "Version": "2012-10-17",
   "Statement": [
     {
@@ -140,6 +140,13 @@
     {
       "Effect": "Allow",
       "Action": [
+        "s3:Get*"
+      ],
+      "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
         "s3:ListBucket",
@@ -148,13 +155,6 @@
       "Resource": [
         "arn:aws:s3:::kops-tests"
       ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:Get*"
-      ],
-      "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
     },
     {
       "Effect": "Allow",

--- a/pkg/model/iam/tests/iam_builder_node_legacy.json
+++ b/pkg/model/iam/tests/iam_builder_node_legacy.json
@@ -14,6 +14,13 @@
     {
       "Effect": "Allow",
       "Action": [
+        "s3:*"
+      ],
+      "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
         "s3:ListBucket",
@@ -22,13 +29,6 @@
       "Resource": [
         "arn:aws:s3:::kops-tests"
       ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:*"
-      ],
-      "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
     },
     {
       "Effect": "Allow",

--- a/pkg/model/iam/tests/iam_builder_node_strict.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict.json
@@ -14,18 +14,6 @@
     {
       "Effect": "Allow",
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Resource": [
-        "arn:aws:s3:::kops-tests"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
         "s3:Get*"
       ],
       "Resource": [
@@ -38,6 +26,18 @@
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kubelet/*",
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/ssh/*",
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/secrets/dockerconfig"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:GetEncryptionConfiguration",
+        "s3:ListBucket",
+        "s3:ListBucketVersions"
+      ],
+      "Resource": [
+        "arn:aws:s3:::kops-tests"
       ]
     }
   ]

--- a/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
@@ -14,18 +14,6 @@
     {
       "Effect": "Allow",
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Resource": [
-        "arn:aws:s3:::kops-tests"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
         "s3:Get*"
       ],
       "Resource": [
@@ -38,6 +26,18 @@
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kubelet/*",
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/ssh/*",
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/secrets/dockerconfig"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:GetEncryptionConfiguration",
+        "s3:ListBucket",
+        "s3:ListBucketVersions"
+      ],
+      "Resource": [
+        "arn:aws:s3:::kops-tests"
       ]
     },
     {


### PR DESCRIPTION
If we are expected to write to other buckets, we need to have suitable
permissions to e.g. determine their location.