### PR TITLE
WIP: gce: when setting bucket permissions, respect gce-service-account

### DIFF
--- a/pkg/acls/gce/storage.go
+++ b/pkg/acls/gce/storage.go
@@ -69,7 +69,7 @@ func (s *gcsAclStrategy) GetACL(p vfs.Path, cluster *kops.Cluster) (vfs.ACL, err
 		return nil, err
 	}
 
-	serviceAccount, err := cloud.(gce.GCECloud).ServiceAccount()
+	serviceAccount, err := cloud.(gce.GCECloud).InstanceServiceAccount()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/model/gcemodel/storageacl.go
+++ b/pkg/model/gcemodel/storageacl.go
@@ -41,7 +41,7 @@ var _ fi.ModelBuilder = &NetworkModelBuilder{}
 
 // Build creates the tasks that set up storage acls
 func (b *StorageAclBuilder) Build(c *fi.ModelBuilderContext) error {
-	serviceAccount, err := b.Cloud.ServiceAccount()
+	serviceAccount, err := b.Cloud.InstanceServiceAccount()
 	if err != nil {
 		return fmt.Errorf("error fetching ServiceAccount: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/mock_gce_cloud.go
@@ -137,8 +137,8 @@ func (c *mockGCECloud) Project() string {
 	return c.region
 }
 
-// ServiceAccount implements GCECloud::ServiceAccount
-func (c *mockGCECloud) ServiceAccount() (string, error) {
+// InstanceServiceAccount implements GCECloud::InstanceServiceAccount
+func (c *mockGCECloud) InstanceServiceAccount() (string, error) {
 	return "12345678-compute@developer.gserviceaccount.com", nil
 }
 

--- a/upup/pkg/fi/cloudup/utils.go
+++ b/upup/pkg/fi/cloudup/utils.go
@@ -58,7 +58,12 @@ func BuildCloud(cluster *kops.Cluster) (fi.Cloud, error) {
 
 			labels := map[string]string{gce.GceLabelNameKubernetesCluster: gce.SafeClusterName(cluster.ObjectMeta.Name)}
 
-			gceCloud, err := gce.NewGCECloud(region, project, labels)
+			instanceServiceAccount := ""
+			if cluster.Spec.CloudConfig != nil {
+				instanceServiceAccount = cluster.Spec.CloudConfig.GCEServiceAccount
+			}
+
+			gceCloud, err := gce.NewGCECloud(region, project, labels, instanceServiceAccount)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
When the service-account is specified, that is the service account we
should use when setting up bucket ACLs (not the default project
service account).