### PR TITLE
gce: log bucket-policy-only message at a level that always appears

### DIFF
--- a/pkg/acls/gce/storage.go
+++ b/pkg/acls/gce/storage.go
@@ -59,7 +59,7 @@ func (s *gcsAclStrategy) GetACL(p vfs.Path, cluster *kops.Cluster) (vfs.ACL, err
 	}
 
 	if bucketPolicyOnly {
-		klog.V(2).Infof("bucket gs://%s has bucket-policy only; won't try to set ACLs", bucketName)
+		klog.Infof("bucket gs://%s has bucket-policy only; won't try to set ACLs", bucketName)
 		return nil, nil
 	}
 


### PR DESCRIPTION
It's a pretty important message when permissions aren't set correctly;
let's re-enable it and then figure out more accurate conditions for
if it matters.