### PR TITLE
Allow failure of the ARM64 job in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ os:
   - linux
   - osx
 go:
-  # 1.12 is no longer supported by apimachinery; we recommend 1.13
   - 1.13.x
   - 1.14.x
 
@@ -16,7 +15,9 @@ script:
   - GOPROXY=https://proxy.golang.org travis_wait 30 make nodeup examples test
 
 jobs:
-  # Exclude GO 1.14 for OSX until it becomes the default because of limited availability
+  allow_failures:
+    - arch: arm64
+
   exclude:
     - os: osx
       go: 1.13.x


### PR DESCRIPTION
The ARM64 test in TravisCI seems flaky and should be allowed to fail for now until we have a chance to see if anything can be improved.