### PR TITLE
Update Weave for CVE-2020-13597

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -13185,18 +13185,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 rules:
   - apiGroups:
       - ''
@@ -13236,10 +13236,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: weave-net
@@ -13293,17 +13293,17 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 spec:
   # Wait 5 seconds to let pod connect before rolling next pod
-  minReadySeconds: 5
   selector:
     matchLabels:
       name: weave-net
       role.kubernetes.io/networking: "1"
+  minReadySeconds: 5
   template:
     metadata:
       labels:
@@ -13347,7 +13347,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.2'
+          image: 'weaveworks/weave-kube:2.6.4'
           ports:
             - name: metrics
               containerPort: 6782
@@ -13394,7 +13394,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.2'
+          image: 'weaveworks/weave-npc:2.6.4'
           ports:
             - name: metrics
               containerPort: 6781
@@ -13485,18 +13485,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
+  namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 rules:
   - apiGroups:
       - ''
@@ -13532,14 +13532,14 @@ rules:
       - patch
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: weave-net
@@ -13549,7 +13549,7 @@ subjects:
     name: weave-net
     namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: weave-net
@@ -13573,7 +13573,7 @@ rules:
     verbs:
       - create
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: weave-net
@@ -13593,10 +13593,10 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 spec:
   # Wait 5 seconds to let pod connect before rolling next pod
   minReadySeconds: 5
@@ -13644,7 +13644,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.2'
+          image: 'weaveworks/weave-kube:2.6.4'
           ports:
             - name: metrics
               containerPort: 6782
@@ -13691,7 +13691,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.2'
+          image: 'weaveworks/weave-npc:2.6.4'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -13,18 +13,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 rules:
   - apiGroups:
       - ''
@@ -64,10 +64,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: weave-net
@@ -121,17 +121,17 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 spec:
   # Wait 5 seconds to let pod connect before rolling next pod
-  minReadySeconds: 5
   selector:
     matchLabels:
       name: weave-net
       role.kubernetes.io/networking: "1"
+  minReadySeconds: 5
   template:
     metadata:
       labels:
@@ -175,7 +175,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.2'
+          image: 'weaveworks/weave-kube:2.6.4'
           ports:
             - name: metrics
               containerPort: 6782
@@ -222,7 +222,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.2'
+          image: 'weaveworks/weave-npc:2.6.4'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -13,18 +13,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
+  namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 rules:
   - apiGroups:
       - ''
@@ -60,14 +60,14 @@ rules:
       - patch
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: weave-net
@@ -77,7 +77,7 @@ subjects:
     name: weave-net
     namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: weave-net
@@ -101,7 +101,7 @@ rules:
     verbs:
       - create
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: weave-net
@@ -121,10 +121,10 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 spec:
   # Wait 5 seconds to let pod connect before rolling next pod
   minReadySeconds: 5
@@ -172,7 +172,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.2'
+          image: 'weaveworks/weave-kube:2.6.4'
           ports:
             - name: metrics
               containerPort: 6782
@@ -219,7 +219,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.2'
+          image: 'weaveworks/weave-npc:2.6.4'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -636,8 +636,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 	if b.cluster.Spec.Networking.Weave != nil {
 		key := "networking.weave"
 		versions := map[string]string{
-			"k8s-1.8":  "2.6.2-kops.2",
-			"k8s-1.12": "2.6.2-kops.2",
+			"k8s-1.8":  "2.6.4-kops.1",
+			"k8s-1.12": "2.6.4-kops.1",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -89,16 +89,16 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: <1.12.0
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: 6d1820c37afaee6423b9d16cfbc45fcca281b18f
+    manifestHash: f8b6cd9ce602b4c812cb6a60b8a5d7639bab75d5
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.2-kops.2
+    version: 2.6.4-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: 103cd60b880d9bab489b80c81a307a60a8328c69
+    manifestHash: 9274099876041660ea8a7048a43a3512f7339021
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.2-kops.2
+    version: 2.6.4-kops.1


### PR DESCRIPTION
Due to security advisory kubernetes/kubernetes#91507, new versions of Weave was released.

Ref: https://github.com/weaveworks/weave/releases/tag/v2.6.3