### PR TITLE
Copy "portmap" to /opt/cni/bin for Weave

### DIFF
--- a/nodeup/pkg/model/networking/BUILD.bazel
+++ b/nodeup/pkg/model/networking/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "kube_router.go",
         "kubenet.go",
         "lyft.go",
+        "weave.go",
     ],
     importpath = "k8s.io/kops/nodeup/pkg/model/networking",
     visibility = ["//visibility:public"],

--- a/nodeup/pkg/model/networking/weave.go
+++ b/nodeup/pkg/model/networking/weave.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networking
+
+import (
+	"k8s.io/kops/nodeup/pkg/model"
+	"k8s.io/kops/upup/pkg/fi"
+)
+
+// WeaveBuilder installs weave
+type WeaveBuilder struct {
+	*model.NodeupModelContext
+}
+
+var _ fi.ModelBuilder = &WeaveBuilder{}
+
+// Build is responsible for configuring the weave
+func (b *WeaveBuilder) Build(c *fi.ModelBuilderContext) error {
+	if b.Cluster.Spec.Networking.Weave == nil {
+		return nil
+	}
+
+	b.AddCNIBinAssets(c, []string{"portmap"})
+
+	return nil
+}

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -267,8 +267,9 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 	loader.Builders = append(loader.Builders, &networking.CiliumBuilder{NodeupModelContext: modelContext})
 	// Canal = Flannel + Calico, so use this builder for both CNIs
 	loader.Builders = append(loader.Builders, &networking.FlannelBuilder{NodeupModelContext: modelContext})
-	loader.Builders = append(loader.Builders, &networking.LyftVPCBuilder{NodeupModelContext: modelContext})
 	loader.Builders = append(loader.Builders, &networking.KuberouterBuilder{NodeupModelContext: modelContext})
+	loader.Builders = append(loader.Builders, &networking.LyftVPCBuilder{NodeupModelContext: modelContext})
+	loader.Builders = append(loader.Builders, &networking.WeaveBuilder{NodeupModelContext: modelContext})
 	// Also handles kopeio as kopeio is based on kubenet
 	loader.Builders = append(loader.Builders, &networking.KubenetBuilder{NodeupModelContext: modelContext})
 


### PR DESCRIPTION
Weave requires `portmap` that seems to be missing at the moment:
https://www.weave.works/docs/net/latest/kubernetes/kube-addon/#-installation

e2e tests are failing because of the missing portmap plugin:
https://testgrid.k8s.io/kops-network-plugins#kops-aws-cni-weave

```
E0608 09:35:30.294544    5002 kubelet.go:2187] Container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:docker: network plugin is not ready: cni config uninitialized
I0608 09:35:33.143148    5002 kubelet.go:1952] SyncLoop (PLEG): "weave-net-6v74s_kube-system(14526285-9260-43e3-8c5e-62eb340b2dc1)", event: &pleg.PodLifecycleEvent{ID:"14526285-9260-43e3-8c5e-62eb340b2dc1", Type:"ContainerStarted", Data:"6cea0ffccafd5578fc62e565b78258d4d10bc6fc11be27b5e1990fbc0b40cf2e"}
W0608 09:35:34.281513    5002 cni.go:202] Error validating CNI config list {
    "cniVersion": "0.3.0",
    "name": "weave",
    "plugins": [
        {
            "name": "weave",
            "type": "weave-net",
            "hairpinMode": true
        },
        {
            "type": "portmap",
            "capabilities": {"portMappings": true},
            "snat": true
        }
    ]
}
: [failed to find plugin "portmap" in path [/opt/cni/bin/]]
W0608 09:35:34.282448    5002 cni.go:237] Unable to update cni config: no valid networks found in /etc/cni/net.d/
```