### PR TITLE
Adding recent releases to docs site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,6 +145,8 @@ nav:
     - Vendoring: "development/vendoring.md"
     - Ports: "development/ports.md"
   - Releases:
+    - 1.18-beta: releases/1.18-NOTES.md
+    - 1.17: releases/1.17-NOTES.md
     - 1.16: releases/1.16-NOTES.md
     - 1.15: releases/1.15-NOTES.md
     - 1.14: releases/1.14-NOTES.md


### PR DESCRIPTION
I've noticed that we don't have recent releases in the nav pane (the most recent is 1.16).
![image](https://user-images.githubusercontent.com/12524503/83960623-b6760e00-a858-11ea-839f-a9d10ee8fbf1.png)

I added 1.17 release and 1.18 (marked as beta) 