### PR TITLE
Validate cilium version

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -673,7 +673,7 @@ func validateNetworkingCilium(cluster *kops.Cluster, v *kops.CiliumNetworkingSpe
 			allErrs = append(allErrs, field.Invalid(versionFld, v.Version, "Only versions 1.6 and 1.7 are supported"))
 		}
 
-		if !cluster.IsKubernetesGTE("1.12.0") && version.GTE(v7) {
+		if !cluster.IsKubernetesGTE("1.12") && version.GTE(v7) {
 			allErrs = append(allErrs, field.Forbidden(versionFld, "Version >= 1.7 requires kubernetesVersion 1.12 or higher"))
 		}
 	}

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -658,6 +658,9 @@ func validateNetworkingCilium(cluster *kops.Cluster, v *kops.CiliumNetworkingSpe
 	if v.Version != "" {
 		versionFld := fldPath.Child("version")
 		version, err := semver.ParseTolerant(v.Version)
+
+		version.Pre = nil
+		version.Build = nil
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(versionFld, v.Version, "Could not parse as semantic version"))
 		}
@@ -671,7 +674,7 @@ func validateNetworkingCilium(cluster *kops.Cluster, v *kops.CiliumNetworkingSpe
 		}
 
 		if !cluster.IsKubernetesGTE("1.12.0") && version.GTE(v7) {
-			allErrs = append(allErrs, field.Invalid(versionFld, v.Version, "Version >= 1.7 requires kubernetesVersion 1.12 or higher"))
+			allErrs = append(allErrs, field.Forbidden(versionFld, "Version >= 1.7 requires kubernetesVersion 1.12 or higher"))
 		}
 	}
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -132,7 +132,7 @@ func validateClusterSpec(spec *kops.ClusterSpec, c *kops.Cluster, fieldPath *fie
 	}
 
 	if spec.Networking != nil {
-		allErrs = append(allErrs, validateNetworking(spec, spec.Networking, fieldPath.Child("networking"))...)
+		allErrs = append(allErrs, validateNetworking(c, spec.Networking, fieldPath.Child("networking"))...)
 		if spec.Networking.Calico != nil {
 			allErrs = append(allErrs, validateNetworkingCalico(spec.Networking.Calico, spec.EtcdClusters[0], fieldPath.Child("networking", "calico"))...)
 		}
@@ -490,7 +490,8 @@ func validateNodeAuthorization(n *kops.NodeAuthorizationSpec, c *kops.Cluster, f
 	return allErrs
 }
 
-func validateNetworking(c *kops.ClusterSpec, v *kops.NetworkingSpec, fldPath *field.Path) field.ErrorList {
+func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *field.Path) field.ErrorList {
+	c := &cluster.Spec
 	allErrs := field.ErrorList{}
 	optionTaken := false
 
@@ -586,7 +587,7 @@ func validateNetworking(c *kops.ClusterSpec, v *kops.NetworkingSpec, fldPath *fi
 		}
 		optionTaken = true
 
-		allErrs = append(allErrs, validateNetworkingCilium(c, v.Cilium, fldPath.Child("cilium"))...)
+		allErrs = append(allErrs, validateNetworkingCilium(cluster, v.Cilium, fldPath.Child("cilium"))...)
 	}
 
 	if v.LyftVPC != nil {
@@ -650,8 +651,29 @@ func validateNetworkingCanal(v *kops.CanalNetworkingSpec, fldPath *field.Path) f
 	return allErrs
 }
 
-func validateNetworkingCilium(c *kops.ClusterSpec, v *kops.CiliumNetworkingSpec, fldPath *field.Path) field.ErrorList {
+func validateNetworkingCilium(cluster *kops.Cluster, v *kops.CiliumNetworkingSpec, fldPath *field.Path) field.ErrorList {
+	c := &cluster.Spec
 	allErrs := field.ErrorList{}
+
+	if v.Version != "" {
+		versionFld := fldPath.Child("version")
+		version, err := semver.ParseTolerant(v.Version)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(versionFld, v.Version, "Could not parse as semantic version"))
+		}
+
+		v8, _ := semver.Parse("1.8.0")
+		v7, _ := semver.Parse("1.7.0")
+		v6, _ := semver.Parse("1.6.0")
+
+		if !(version.GTE(v6) && version.LT(v8)) {
+			allErrs = append(allErrs, field.Invalid(versionFld, v.Version, "Only versions 1.6 and 1.7 are supported"))
+		}
+
+		if !cluster.IsKubernetesGTE("1.12.0") && version.GTE(v7) {
+			allErrs = append(allErrs, field.Invalid(versionFld, v.Version, "Version >= 1.7 requires kubernetesVersion 1.12 or higher"))
+		}
+	}
 
 	if v.EnableNodePort && c.KubeProxy != nil && (c.KubeProxy.Enabled == nil || *c.KubeProxy.Enabled) {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Root().Child("spec", "kubeProxy", "enabled"), "When Cilium NodePort is enabled, kubeProxy must be disabled"))

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -590,12 +590,21 @@ func Test_Validate_Cilium(t *testing.T) {
 		},
 		{
 			Cilium: kops.CiliumNetworkingSpec{
-				Version: "1.7",
+				Version: "1.7.0",
 			},
 			Spec: kops.ClusterSpec{
 				KubernetesVersion: "1.11.0",
 			},
-			ExpectedErrors: []string{"Invalid value::cilium.version"},
+			ExpectedErrors: []string{"Forbidden::cilium.version"},
+		},
+		{
+			Cilium: kops.CiliumNetworkingSpec{
+				Version: "1.7.0-rc1",
+			},
+			Spec: kops.ClusterSpec{
+				KubernetesVersion: "1.11.0",
+			},
+			ExpectedErrors: []string{"Forbidden::cilium.version"},
 		},
 		{
 			Cilium: kops.CiliumNetworkingSpec{

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -292,7 +292,7 @@ func Test_Validate_Networking_Flannel(t *testing.T) {
 		cluster := &kops.Cluster{}
 		cluster.Spec.Networking = networking
 
-		errs := validateNetworking(&cluster.Spec, networking, field.NewPath("networking"))
+		errs := validateNetworking(cluster, networking, field.NewPath("networking"))
 		testErrors(t, g.Input, errs, g.ExpectedErrors)
 	}
 }
@@ -579,12 +579,41 @@ func Test_Validate_Cilium(t *testing.T) {
 			},
 			ExpectedErrors: []string{"Forbidden::cilium.ipam"},
 		},
+		{
+			Cilium: kops.CiliumNetworkingSpec{
+				Version: "1.0",
+			},
+			Spec: kops.ClusterSpec{
+				KubernetesVersion: "1.11.0",
+			},
+			ExpectedErrors: []string{"Invalid value::cilium.version"},
+		},
+		{
+			Cilium: kops.CiliumNetworkingSpec{
+				Version: "1.7",
+			},
+			Spec: kops.ClusterSpec{
+				KubernetesVersion: "1.11.0",
+			},
+			ExpectedErrors: []string{"Invalid value::cilium.version"},
+		},
+		{
+			Cilium: kops.CiliumNetworkingSpec{
+				Version: "1.7",
+			},
+			Spec: kops.ClusterSpec{
+				KubernetesVersion: "1.12.0",
+			},
+		},
 	}
 	for _, g := range grid {
 		g.Spec.Networking = &kops.NetworkingSpec{
 			Cilium: &g.Cilium,
 		}
-		errs := validateNetworkingCilium(&g.Spec, g.Spec.Networking.Cilium, field.NewPath("cilium"))
+		cluster := &kops.Cluster{
+			Spec: g.Spec,
+		}
+		errs := validateNetworkingCilium(cluster, g.Spec.Networking.Cilium, field.NewPath("cilium"))
 		testErrors(t, g.Spec, errs, g.ExpectedErrors)
 	}
 }

--- a/pkg/model/components/BUILD.bazel
+++ b/pkg/model/components/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "apiserver.go",
+        "cilium.go",
         "containerd.go",
         "context.go",
         "defaults.go",

--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -38,7 +38,7 @@ func (b *CiliumOptionsBuilder) BuildOptions(o interface{}) error {
 	if c.Version == "" {
 		if b.Context.IsKubernetesLT("1.12.0") {
 			c.Version = "v1.6.9"
-		} else if b.Context.IsKubernetesLT("1.18.0") {
+		} else {
 			c.Version = "v1.7.4"
 		}
 	}
@@ -69,6 +69,14 @@ func (b *CiliumOptionsBuilder) BuildOptions(o interface{}) error {
 
 	if c.ToFqdnsDNSRejectResponseCode == "" {
 		c.ToFqdnsDNSRejectResponseCode = "refused"
+	}
+
+	if c.ContainerRuntimeLabels == "" {
+		c.ContainerRuntimeLabels = "none"
+	}
+
+	if c.AgentPrometheusPort == 0 {
+		c.AgentPrometheusPort = 9090
 	}
 
 	return nil

--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+import (
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/upup/pkg/fi/loader"
+)
+
+// CiliumOptionsBuilder adds options for the cilium to the model
+type CiliumOptionsBuilder struct {
+	Context *OptionsContext
+}
+
+var _ loader.OptionsBuilder = &CiliumOptionsBuilder{}
+
+func (b *CiliumOptionsBuilder) BuildOptions(o interface{}) error {
+	clusterSpec := o.(*kops.ClusterSpec)
+	c := clusterSpec.Networking.Cilium
+	if c == nil {
+		return nil
+	}
+
+	if c.Version == "" {
+		if b.Context.IsKubernetesLT("1.12.0") {
+			c.Version = "v1.6.9"
+		} else if b.Context.IsKubernetesLT("1.18.0") {
+			c.Version = "v1.7.4"
+		}
+	}
+
+	if c.BPFCTGlobalAnyMax == 0 {
+		c.BPFCTGlobalAnyMax = 262144
+
+	}
+	if c.BPFCTGlobalTCPMax == 0 {
+		c.BPFCTGlobalTCPMax = 524288
+	}
+
+	if c.ClusterName == "" {
+		c.ClusterName = "default"
+	}
+
+	if c.MonitorAggregation == "" {
+		c.MonitorAggregation = "medium"
+	}
+
+	if c.SidecarIstioProxyImage == "" {
+		c.SidecarIstioProxyImage = "cilium/istio_proxy"
+	}
+
+	if c.Tunnel == "" {
+		c.Tunnel = "vxlan"
+	}
+
+	if c.ToFqdnsDNSRejectResponseCode == "" {
+		c.ToFqdnsDNSRejectResponseCode = "refused"
+	}
+
+	return nil
+
+}

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -4091,7 +4091,7 @@ data:
   #   setting it to "kvstore".
   identity-allocation-mode: crd
   # If you want to run cilium in debug mode change this value to true
-  debug: "{{- if .Debug -}}true{{- else -}}false{{- end -}}"
+  debug: "{{ .Debug }}"
   {{ if .EnablePrometheusMetrics }}
   # If you want metrics enabled in all of your Cilium agents, set the port for
   # which the Cilium agents will have their metrics exposed.
@@ -4099,7 +4099,7 @@ data:
   # "cilium-metrics-config" ConfigMap
   # NOTE that this will open the port on ALL nodes where Cilium pods are
   # scheduled.
-  prometheus-serve-addr: ":{{- or .AgentPrometheusPort "9090" }}"
+  prometheus-serve-addr: ":{{ .AgentPrometheusPort }}"
   {{ end }}
   {{ if .EnableEncryption }}
   enable-ipsec: "true"
@@ -4114,7 +4114,7 @@ data:
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets
   # that will be seen in monitor output.
-  monitor-aggregation: "{{- if eq .MonitorAggregation "" -}}medium{{- else -}}{{ .MonitorAggregation }}{{- end -}}"
+  monitor-aggregation: "{{ .MonitorAggregation }}"
   # ct-global-max-entries-* specifies the maximum number of connections
   # supported across all endpoints, split by protocol: tcp or other. One pair
   # of maps uses these values for IPv4 connections, and another pair of maps
@@ -4126,8 +4126,8 @@ data:
   #
   # For users upgrading from Cilium 1.2 or earlier, to minimize disruption
   # during the upgrade process, comment out these options.
-  bpf-ct-global-tcp-max: "{{- if eq .BPFCTGlobalTCPMax 0 -}}524288{{- else -}}{{ .BPFCTGlobalTCPMax}}{{- end -}}"
-  bpf-ct-global-any-max: "{{- if eq .BPFCTGlobalAnyMax 0 -}}262144{{- else -}}{{ .BPFCTGlobalAnyMax}}{{- end -}}"
+  bpf-ct-global-tcp-max: "{{ .BPFCTGlobalTCPMax }}"
+  bpf-ct-global-any-max: "{{ .BPFCTGlobalAnyMax }}"
 
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The
@@ -4148,7 +4148,7 @@ data:
   preallocate-bpf-maps: "{{- if .PreallocateBPFMaps -}}true{{- else -}}false{{- end -}}"
   # Regular expression matching compatible Istio sidecar istio-proxy
   # container image names
-  sidecar-istio-proxy-image: "{{- if eq .SidecarIstioProxyImage "" -}}cilium/istio_proxy{{- else -}}{{ .SidecarIstioProxyImage }}{{- end -}}"
+  sidecar-istio-proxy-image: "{{ .SidecarIstioProxyImage }}"
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
@@ -4195,11 +4195,11 @@ data:
   # - none
   # - auto (automatically detect the container runtime)
   #
-  container-runtime: "{{- if eq .ContainerRuntimeLabels "" -}}none{{- else -}}{{ .ContainerRuntimeLabels }}{{- end -}}"
+  container-runtime: "{{ .ContainerRuntimeLabels }}"
   masquerade: "{{- if .DisableMasquerade -}}false{{- else -}}true{{- end -}}"
   install-iptables-rules: "{{- if .IPTablesRulesNoinstall -}}false{{- else -}}true{{- end -}}"
-  auto-direct-node-routes: "{{- if .AutoDirectNodeRoutes -}}true{{- else -}}false{{- end -}}"
-  enable-node-port: "{{- if .EnableNodePort -}}true{{- else -}}false{{- end -}}"
+  auto-direct-node-routes: "{{ .AutoDirectNodeRoutes }}"
+  enable-node-port: "{{ .EnableNodePort }}"
   kube-proxy-replacement: "{{- if .EnableNodePort -}}strict{{- else -}}partial{{- end -}}"
   enable-remote-node-identity: "{{- if .EnableRemoteNodeIdentity -}}true{{- else -}}false{{- end -}}"
   {{ with .Ipam }}
@@ -4480,7 +4480,7 @@ spec:
           value: {{ . }}
         {{ end }}
 {{ with .Networking.Cilium }}
-        image: "docker.io/cilium/cilium:{{- or .Version "v1.7.3" }}"
+        image: "docker.io/cilium/cilium:{{ .Version  }}"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -4508,8 +4508,8 @@ spec:
         name: cilium-agent
         {{ if .EnablePrometheusMetrics }}
         ports:
-        - containerPort: {{ or .AgentPrometheusPort "9090" }}
-          hostPort: {{ or .AgentPrometheusPort "9090" }}
+        - containerPort: {{ .AgentPrometheusPort }}
+          hostPort: {{ .AgentPrometheusPort }}
           name: prometheus
           protocol: TCP
         {{ end }}
@@ -4587,7 +4587,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: "docker.io/cilium/cilium:{{- or .Version "v1.7.3" }}"
+        image: "docker.io/cilium/cilium:{{ "v1.7.3" }}"
 ## end of ` + "`" + `with .Networking.Cilium` + "`" + `
 #{{ end }}
         imagePullPolicy: IfNotPresent
@@ -4793,7 +4793,7 @@ spec:
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
 {{ with .Networking.Cilium }}
-        image: "docker.io/cilium/operator:{{- if eq .Version "" -}}v1.7.3{{- else -}}{{ .Version }}{{- end -}}"
+        image: "docker.io/cilium/operator:{{ .Version }}"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         {{ if .EnablePrometheusMetrics }}
@@ -4928,8 +4928,8 @@ data:
   #
   # For users upgrading from Cilium 1.2 or earlier, to minimize disruption
   # during the upgrade process, comment out these options.
-  bpf-ct-global-tcp-max: "{{- if eq .BPFCTGlobalTCPMax 0 -}}524288{{- else -}}{{ .BPFCTGlobalTCPMax}}{{- end -}}"
-  bpf-ct-global-any-max: "{{- if eq .BPFCTGlobalAnyMax 0 -}}262144{{- else -}}{{ .BPFCTGlobalAnyMax}}{{- end -}}"
+  bpf-ct-global-tcp-max: "{{ .BPFCTGlobalTCPMax }}"
+  bpf-ct-global-any-max: "{{ .BPFCTGlobalAnyMax }}"
 
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The
@@ -4947,19 +4947,19 @@ data:
   #
   # If this option is set to "false" during an upgrade from 1.3 or earlier to
   # 1.4 or later, then it may cause one-time disruptions during the upgrade.
-  preallocate-bpf-maps: "{{- if .PreallocateBPFMaps -}}true{{- else -}}false{{- end -}}"
+  preallocate-bpf-maps: "{{ .PreallocateBPFMaps }}"
   # Regular expression matching compatible Istio sidecar istio-proxy
   # container image names
-  sidecar-istio-proxy-image: "{{- if eq .SidecarIstioProxyImage "" -}}cilium/istio_proxy{{- else -}}{{ .SidecarIstioProxyImage }}{{- end -}}"
+  sidecar-istio-proxy-image: "{{ .SidecarIstioProxyImage }}"
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
   #   - vxlan (default)
   #   - geneve
-  tunnel: "{{- if eq .Tunnel "" -}}vxlan{{- else -}}{{ .Tunnel }}{{- end -}}"
+  tunnel: "{{ .Tunnel }}"
 
   # Name of the cluster. Only relevant when building a mesh of clusters.
-  cluster-name: "{{- if eq .ClusterName "" -}}default{{- else -}}{{ .ClusterName}}{{- end -}}"
+  cluster-name: "{{ .ClusterName }}"
 
   # This option is disabled by default starting from version 1.4.x in favor
   # of a more powerful DNS proxy-based implementation, see [0] for details.
@@ -4972,7 +4972,7 @@ data:
   #
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
-  tofqdns-enable-poller: "{{- if .ToFqdnsEnablePoller -}}true{{- else -}}false{{- end -}}"
+  tofqdns-enable-poller: "{{ .ToFqdnsEnablePoller }}"
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
   # Enable fetching of container-runtime specific metadata
@@ -4994,11 +4994,11 @@ data:
   # - none
   # - auto (automatically detect the container runtime)
   #
-  container-runtime: "{{- if eq .ContainerRuntimeLabels "" -}}none{{- else -}}{{ .ContainerRuntimeLabels }}{{- end -}}"
+  container-runtime: "{{ .ContainerRuntimeLabels }}"
   masquerade: "{{- if .DisableMasquerade -}}false{{- else -}}true{{- end -}}"
   install-iptables-rules: "{{- if .IPTablesRulesNoinstall -}}false{{- else -}}true{{- end -}}"
   auto-direct-node-routes: "{{- if .AutoDirectNodeRoutes -}}true{{- else -}}false{{- end -}}"
-  enable-node-port: "{{- if .EnableNodePort -}}true{{- else -}}false{{- end -}}"
+  enable-node-port: "{{ .EnableNodePort }}"
   {{ with .Ipam }}
   ipam: {{ . }}
   {{ if eq . "eni" }}
@@ -5258,7 +5258,7 @@ spec:
           value: {{ . }}
         {{ end }}
 {{ with .Networking.Cilium }}
-        image: "docker.io/cilium/cilium:{{- or .Version "v1.6.6" }}"
+        image: "docker.io/cilium/cilium:{{ .Version  }}"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -5286,8 +5286,8 @@ spec:
         name: cilium-agent
         {{ if .EnablePrometheusMetrics }}
         ports:
-        - containerPort: {{ or .AgentPrometheusPort "9090" }}
-          hostPort: {{ or .AgentPrometheusPort "9090" }}
+        - containerPort: {{ .AgentPrometheusPort }}
+          hostPort: {{ .AgentPrometheusPort }}
           name: prometheus
           protocol: TCP
         {{ end }}
@@ -5530,7 +5530,7 @@ spec:
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
 {{ with .Networking.Cilium }}
-        image: "docker.io/cilium/operator:{{- or .Version "v1.6.6" }}"
+        image: "docker.io/cilium/operator:{{ .Version }}"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         {{ if .EnablePrometheusMetrics }}

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -4154,14 +4154,14 @@ data:
   #   - disabled
   #   - vxlan (default)
   #   - geneve
-  tunnel: "{{- if eq .Tunnel "" -}}vxlan{{- else -}}{{ .Tunnel }}{{- end -}}"
+  tunnel: "{{ .Tunnel }}"
 
   # Name of the cluster. Only relevant when building a mesh of clusters.
-  cluster-name: "{{- if eq .ClusterName "" -}}default{{- else -}}{{ .ClusterName}}{{- end -}}"
+  cluster-name: "{{ .ClusterName }}"
 
   # DNS response code for rejecting DNS requests,
   # available options are "nameError" and "refused"
-  tofqdns-dns-reject-response-code: "{{- if eq .ToFqdnsDNSRejectResponseCode  "" -}}refused{{- else -}}{{ .ToFqdnsDNSRejectResponseCode }}{{- end -}}"
+  tofqdns-dns-reject-response-code: "{{ .ToFqdnsDNSRejectResponseCode }}"
   # This option is disabled by default starting from version 1.4.x in favor
   # of a more powerful DNS proxy-based implementation, see [0] for details.
   # Enable this option if you want to use FQDN policies but do not want to use

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -44,7 +44,7 @@ data:
   #   setting it to "kvstore".
   identity-allocation-mode: crd
   # If you want to run cilium in debug mode change this value to true
-  debug: "{{- if .Debug -}}true{{- else -}}false{{- end -}}"
+  debug: "{{ .Debug }}"
   {{ if .EnablePrometheusMetrics }}
   # If you want metrics enabled in all of your Cilium agents, set the port for
   # which the Cilium agents will have their metrics exposed.
@@ -52,7 +52,7 @@ data:
   # "cilium-metrics-config" ConfigMap
   # NOTE that this will open the port on ALL nodes where Cilium pods are
   # scheduled.
-  prometheus-serve-addr: ":{{- or .AgentPrometheusPort "9090" }}"
+  prometheus-serve-addr: ":{{ .AgentPrometheusPort }}"
   {{ end }}
   {{ if .EnableEncryption }}
   enable-ipsec: "true"
@@ -67,7 +67,7 @@ data:
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets
   # that will be seen in monitor output.
-  monitor-aggregation: "{{- if eq .MonitorAggregation "" -}}medium{{- else -}}{{ .MonitorAggregation }}{{- end -}}"
+  monitor-aggregation: "{{ .MonitorAggregation }}"
   # ct-global-max-entries-* specifies the maximum number of connections
   # supported across all endpoints, split by protocol: tcp or other. One pair
   # of maps uses these values for IPv4 connections, and another pair of maps
@@ -79,8 +79,8 @@ data:
   #
   # For users upgrading from Cilium 1.2 or earlier, to minimize disruption
   # during the upgrade process, comment out these options.
-  bpf-ct-global-tcp-max: "{{- if eq .BPFCTGlobalTCPMax 0 -}}524288{{- else -}}{{ .BPFCTGlobalTCPMax}}{{- end -}}"
-  bpf-ct-global-any-max: "{{- if eq .BPFCTGlobalAnyMax 0 -}}262144{{- else -}}{{ .BPFCTGlobalAnyMax}}{{- end -}}"
+  bpf-ct-global-tcp-max: "{{ .BPFCTGlobalTCPMax }}"
+  bpf-ct-global-any-max: "{{ .BPFCTGlobalAnyMax }}"
 
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The
@@ -101,7 +101,7 @@ data:
   preallocate-bpf-maps: "{{- if .PreallocateBPFMaps -}}true{{- else -}}false{{- end -}}"
   # Regular expression matching compatible Istio sidecar istio-proxy
   # container image names
-  sidecar-istio-proxy-image: "{{- if eq .SidecarIstioProxyImage "" -}}cilium/istio_proxy{{- else -}}{{ .SidecarIstioProxyImage }}{{- end -}}"
+  sidecar-istio-proxy-image: "{{ .SidecarIstioProxyImage }}"
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
@@ -148,11 +148,11 @@ data:
   # - none
   # - auto (automatically detect the container runtime)
   #
-  container-runtime: "{{- if eq .ContainerRuntimeLabels "" -}}none{{- else -}}{{ .ContainerRuntimeLabels }}{{- end -}}"
+  container-runtime: "{{ .ContainerRuntimeLabels }}"
   masquerade: "{{- if .DisableMasquerade -}}false{{- else -}}true{{- end -}}"
   install-iptables-rules: "{{- if .IPTablesRulesNoinstall -}}false{{- else -}}true{{- end -}}"
-  auto-direct-node-routes: "{{- if .AutoDirectNodeRoutes -}}true{{- else -}}false{{- end -}}"
-  enable-node-port: "{{- if .EnableNodePort -}}true{{- else -}}false{{- end -}}"
+  auto-direct-node-routes: "{{ .AutoDirectNodeRoutes }}"
+  enable-node-port: "{{ .EnableNodePort }}"
   kube-proxy-replacement: "{{- if .EnableNodePort -}}strict{{- else -}}partial{{- end -}}"
   enable-remote-node-identity: "{{- if .EnableRemoteNodeIdentity -}}true{{- else -}}false{{- end -}}"
   {{ with .Ipam }}
@@ -433,7 +433,7 @@ spec:
           value: {{ . }}
         {{ end }}
 {{ with .Networking.Cilium }}
-        image: "docker.io/cilium/cilium:{{- or .Version "v1.7.3" }}"
+        image: "docker.io/cilium/cilium:{{ .Version  }}"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -461,8 +461,8 @@ spec:
         name: cilium-agent
         {{ if .EnablePrometheusMetrics }}
         ports:
-        - containerPort: {{ or .AgentPrometheusPort "9090" }}
-          hostPort: {{ or .AgentPrometheusPort "9090" }}
+        - containerPort: {{ .AgentPrometheusPort }}
+          hostPort: {{ .AgentPrometheusPort }}
           name: prometheus
           protocol: TCP
         {{ end }}
@@ -540,7 +540,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: "docker.io/cilium/cilium:{{- or .Version "v1.7.3" }}"
+        image: "docker.io/cilium/cilium:{{ "v1.7.3" }}"
 ## end of `with .Networking.Cilium`
 #{{ end }}
         imagePullPolicy: IfNotPresent
@@ -746,7 +746,7 @@ spec:
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
 {{ with .Networking.Cilium }}
-        image: "docker.io/cilium/operator:{{- if eq .Version "" -}}v1.7.3{{- else -}}{{ .Version }}{{- end -}}"
+        image: "docker.io/cilium/operator:{{ .Version }}"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         {{ if .EnablePrometheusMetrics }}

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -107,14 +107,14 @@ data:
   #   - disabled
   #   - vxlan (default)
   #   - geneve
-  tunnel: "{{- if eq .Tunnel "" -}}vxlan{{- else -}}{{ .Tunnel }}{{- end -}}"
+  tunnel: "{{ .Tunnel }}"
 
   # Name of the cluster. Only relevant when building a mesh of clusters.
-  cluster-name: "{{- if eq .ClusterName "" -}}default{{- else -}}{{ .ClusterName}}{{- end -}}"
+  cluster-name: "{{ .ClusterName }}"
 
   # DNS response code for rejecting DNS requests,
   # available options are "nameError" and "refused"
-  tofqdns-dns-reject-response-code: "{{- if eq .ToFqdnsDNSRejectResponseCode  "" -}}refused{{- else -}}{{ .ToFqdnsDNSRejectResponseCode }}{{- end -}}"
+  tofqdns-dns-reject-response-code: "{{ .ToFqdnsDNSRejectResponseCode }}"
   # This option is disabled by default starting from version 1.4.x in favor
   # of a more powerful DNS proxy-based implementation, see [0] for details.
   # Enable this option if you want to use FQDN policies but do not want to use

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.7.yaml.template
@@ -50,8 +50,8 @@ data:
   #
   # For users upgrading from Cilium 1.2 or earlier, to minimize disruption
   # during the upgrade process, comment out these options.
-  bpf-ct-global-tcp-max: "{{- if eq .BPFCTGlobalTCPMax 0 -}}524288{{- else -}}{{ .BPFCTGlobalTCPMax}}{{- end -}}"
-  bpf-ct-global-any-max: "{{- if eq .BPFCTGlobalAnyMax 0 -}}262144{{- else -}}{{ .BPFCTGlobalAnyMax}}{{- end -}}"
+  bpf-ct-global-tcp-max: "{{ .BPFCTGlobalTCPMax }}"
+  bpf-ct-global-any-max: "{{ .BPFCTGlobalAnyMax }}"
 
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The
@@ -69,19 +69,19 @@ data:
   #
   # If this option is set to "false" during an upgrade from 1.3 or earlier to
   # 1.4 or later, then it may cause one-time disruptions during the upgrade.
-  preallocate-bpf-maps: "{{- if .PreallocateBPFMaps -}}true{{- else -}}false{{- end -}}"
+  preallocate-bpf-maps: "{{ .PreallocateBPFMaps }}"
   # Regular expression matching compatible Istio sidecar istio-proxy
   # container image names
-  sidecar-istio-proxy-image: "{{- if eq .SidecarIstioProxyImage "" -}}cilium/istio_proxy{{- else -}}{{ .SidecarIstioProxyImage }}{{- end -}}"
+  sidecar-istio-proxy-image: "{{ .SidecarIstioProxyImage }}"
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
   #   - vxlan (default)
   #   - geneve
-  tunnel: "{{- if eq .Tunnel "" -}}vxlan{{- else -}}{{ .Tunnel }}{{- end -}}"
+  tunnel: "{{ .Tunnel }}"
 
   # Name of the cluster. Only relevant when building a mesh of clusters.
-  cluster-name: "{{- if eq .ClusterName "" -}}default{{- else -}}{{ .ClusterName}}{{- end -}}"
+  cluster-name: "{{ .ClusterName }}"
 
   # This option is disabled by default starting from version 1.4.x in favor
   # of a more powerful DNS proxy-based implementation, see [0] for details.
@@ -94,7 +94,7 @@ data:
   #
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
-  tofqdns-enable-poller: "{{- if .ToFqdnsEnablePoller -}}true{{- else -}}false{{- end -}}"
+  tofqdns-enable-poller: "{{ .ToFqdnsEnablePoller }}"
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
   # Enable fetching of container-runtime specific metadata
@@ -116,11 +116,11 @@ data:
   # - none
   # - auto (automatically detect the container runtime)
   #
-  container-runtime: "{{- if eq .ContainerRuntimeLabels "" -}}none{{- else -}}{{ .ContainerRuntimeLabels }}{{- end -}}"
+  container-runtime: "{{ .ContainerRuntimeLabels }}"
   masquerade: "{{- if .DisableMasquerade -}}false{{- else -}}true{{- end -}}"
   install-iptables-rules: "{{- if .IPTablesRulesNoinstall -}}false{{- else -}}true{{- end -}}"
   auto-direct-node-routes: "{{- if .AutoDirectNodeRoutes -}}true{{- else -}}false{{- end -}}"
-  enable-node-port: "{{- if .EnableNodePort -}}true{{- else -}}false{{- end -}}"
+  enable-node-port: "{{ .EnableNodePort }}"
   {{ with .Ipam }}
   ipam: {{ . }}
   {{ if eq . "eni" }}
@@ -380,7 +380,7 @@ spec:
           value: {{ . }}
         {{ end }}
 {{ with .Networking.Cilium }}
-        image: "docker.io/cilium/cilium:{{- or .Version "v1.6.6" }}"
+        image: "docker.io/cilium/cilium:{{ .Version  }}"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -408,8 +408,8 @@ spec:
         name: cilium-agent
         {{ if .EnablePrometheusMetrics }}
         ports:
-        - containerPort: {{ or .AgentPrometheusPort "9090" }}
-          hostPort: {{ or .AgentPrometheusPort "9090" }}
+        - containerPort: {{ .AgentPrometheusPort }}
+          hostPort: {{ .AgentPrometheusPort }}
           name: prometheus
           protocol: TCP
         {{ end }}
@@ -652,7 +652,7 @@ spec:
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
 {{ with .Networking.Cilium }}
-        image: "docker.io/cilium/operator:{{- or .Version "v1.6.6" }}"
+        image: "docker.io/cilium/operator:{{ .Version }}"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         {{ if .EnablePrometheusMetrics }}

--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -305,6 +305,7 @@ func (c *populateClusterSpec) run(clientset simple.Clientset) error {
 			codeModels = append(codeModels, &components.KubeControllerManagerOptionsBuilder{Context: optionsContext})
 			codeModels = append(codeModels, &components.KubeSchedulerOptionsBuilder{OptionsContext: optionsContext})
 			codeModels = append(codeModels, &components.KubeProxyOptionsBuilder{Context: optionsContext})
+			codeModels = append(codeModels, &components.CiliumOptionsBuilder{Context: optionsContext})
 		}
 	}
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -89,7 +89,7 @@ spec:
   - id: k8s-1.7
     kubernetesVersion: <1.12.0
     manifest: networking.cilium.io/k8s-1.7.yaml
-    manifestHash: e6670d455bcd03c5b85ccb6ff6bbe6e068aa7674
+    manifestHash: 590dd7dc770d721f15d63e8983aa253010757ddd
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"
@@ -97,7 +97,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: 2cac1ca4c0db3b48bb066d1477e6cdfe4f3080d5
+    manifestHash: 61f05c6e376a570b3f1e53d6b0b2ed9e63cf4c50
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
It is a bit too easy for Cilium users to configure unsupported combinations of cilium version and features. This PR ensures that users only set a supported version. Plan on follow-ups that will validate various features as well.