### PR TITLE
Disable disk based evictions for Kubernetes 1.19

### DIFF
--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -105,7 +105,7 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 			// Disk based evictions are not detecting the correct disk capacity in Kubernetes 1.19 and are
 			// blocking scheduling by tainting worker nodes with "node.kubernetes.io/disk-pressure:NoSchedule"
 			// TODO: Re-enable once the Kubelet issue is fixed
-			if b.Context.IsKubernetesGTE("1.19") {
+			if b.Context.IsKubernetesLT("1.19") {
 				// Disk based eviction (evict old images)
 				// We don't need to specify both, but it seems harmless / safer
 				evictionHard = append(evictionHard, "nodefs.available<10%")

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -101,13 +101,17 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 			evictionHard := []string{
 				// TODO: Some people recommend 250Mi, but this would hurt small machines
 				"memory.available<100Mi",
-
-				// Disk eviction (evict old images)
+			}
+			// Disk based evictions are not detecting the correct disk capacity in Kubernetes 1.19 and are
+			// blocking scheduling by tainting worker nodes with "node.kubernetes.io/disk-pressure:NoSchedule"
+			// TODO: Re-enable once the Kubelet issue is fixed
+			if b.Context.IsKubernetesGTE("1.19") {
+				// Disk based eviction (evict old images)
 				// We don't need to specify both, but it seems harmless / safer
-				"nodefs.available<10%",
-				"nodefs.inodesFree<5%",
-				"imagefs.available<10%",
-				"imagefs.inodesFree<5%",
+				evictionHard = append(evictionHard, "nodefs.available<10%")
+				evictionHard = append(evictionHard, "nodefs.inodesFree<5%")
+				evictionHard = append(evictionHard, "imagefs.available<10%")
+				evictionHard = append(evictionHard, "imagefs.inodesFree<5%")
 			}
 			clusterSpec.Kubelet.EvictionHard = fi.String(strings.Join(evictionHard, ","))
 		}


### PR DESCRIPTION
e2e pre-submits and periodic e2e for 1.19. Logs indicate it is related to the eviction manager that cannot correctly retrieve the disk stats:
https://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/e2e-kops-aws-k8s-latest/1269848278476787712/
```
W0608 04:40:31.222453    4996 eviction_manager.go:339] eviction manager: attempting to reclaim ephemeral-storage
I0608 04:40:31.222488    4996 container_gc.go:85] attempting to delete unused containers
I0608 04:40:31.225274    4996 image_gc_manager.go:322] attempting to delete unused images
I0608 04:40:31.231317    4996 eviction_manager.go:350] eviction manager: must evict pod(s) to reclaim ephemeral-storage
I0608 04:40:31.231341    4996 eviction_manager.go:368] eviction manager: pods ranked for eviction: kube-proxy-ip-172-20-42-239.ap-northeast-2.compute.internal_kube-system(98b80b03aaa21bd38ed134d9616a3730)
E0608 04:40:31.231362    4996 eviction_manager.go:569] eviction manager: cannot evict a critical pod kube-proxy-ip-172-20-42-239.ap-northeast-2.compute.internal_kube-system(98b80b03aaa21bd38ed134d9616a3730)
I0608 04:40:31.231370    4996 eviction_manager.go:391] eviction manager: unable to evict any pods from the node
I0608 04:40:40.627941    4996 image_gc_manager.go:305] [imageGCManager]: Disk usage on image filesystem is at 100% which is over the high threshold (85%). Trying to free 3774873 bytes down to the low threshold (80%).
E0608 04:40:40.631282    4996 kubelet.go:1231] Image garbage collection failed multiple times in a row: failed to garbage collect required amount of images. Wanted to free 3774873 bytes, but freed 0 bytes
I0608 04:40:40.631730    4996 kubelet_getters.go:173] "Pod status updated" pod="kube-system/kube-proxy-ip-172-20-42-239.ap-northeast-2.compute.internal" status="Running"
```

I tried to understand what exactly happens, but I am stuck at finding the root cause. For know, I know that:
* Kubernetes 1.18 works OK
* using containerd 1.3.4 as container runtime works OK
* using Docker 19.03.x + Kubernetes 1.19 doesn't work