### PR TITLE
Automated cherry pick of #9284: Don't export basic auth credentials if basic auth is disabled

### DIFF
--- a/pkg/kubeconfig/BUILD.bazel
+++ b/pkg/kubeconfig/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/kops:go_default_library",
+        "//pkg/apis/kops/util:go_default_library",
         "//pkg/dns:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",


### PR DESCRIPTION
Cherry pick of #9284 on release-1.18.

#9284: Don't export basic auth credentials if basic auth is disabled

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.