### PR TITLE
Automated cherry pick of #9285: Update Weave for CVE-2020-13597

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -14168,18 +14168,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 rules:
   - apiGroups:
       - ''
@@ -14219,10 +14219,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: weave-net
@@ -14276,17 +14276,17 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 spec:
   # Wait 5 seconds to let pod connect before rolling next pod
-  minReadySeconds: 5
   selector:
     matchLabels:
       name: weave-net
       role.kubernetes.io/networking: "1"
+  minReadySeconds: 5
   template:
     metadata:
       labels:
@@ -14330,7 +14330,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.2'
+          image: 'weaveworks/weave-kube:2.6.4'
           ports:
             - name: metrics
               containerPort: 6782
@@ -14377,7 +14377,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.2'
+          image: 'weaveworks/weave-npc:2.6.4'
           ports:
             - name: metrics
               containerPort: 6781
@@ -14468,18 +14468,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
+  namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 rules:
   - apiGroups:
       - ''
@@ -14515,14 +14515,14 @@ rules:
       - patch
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: weave-net
@@ -14532,7 +14532,7 @@ subjects:
     name: weave-net
     namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: weave-net
@@ -14556,7 +14556,7 @@ rules:
     verbs:
       - create
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: weave-net
@@ -14576,10 +14576,10 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 spec:
   # Wait 5 seconds to let pod connect before rolling next pod
   minReadySeconds: 5
@@ -14627,7 +14627,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.2'
+          image: 'weaveworks/weave-kube:2.6.4'
           ports:
             - name: metrics
               containerPort: 6782
@@ -14674,7 +14674,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.2'
+          image: 'weaveworks/weave-npc:2.6.4'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -13,18 +13,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 rules:
   - apiGroups:
       - ''
@@ -64,10 +64,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: weave-net
@@ -121,17 +121,17 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 spec:
   # Wait 5 seconds to let pod connect before rolling next pod
-  minReadySeconds: 5
   selector:
     matchLabels:
       name: weave-net
       role.kubernetes.io/networking: "1"
+  minReadySeconds: 5
   template:
     metadata:
       labels:
@@ -175,7 +175,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.2'
+          image: 'weaveworks/weave-kube:2.6.4'
           ports:
             - name: metrics
               containerPort: 6782
@@ -222,7 +222,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.2'
+          image: 'weaveworks/weave-npc:2.6.4'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -13,18 +13,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
+  namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 rules:
   - apiGroups:
       - ''
@@ -60,14 +60,14 @@ rules:
       - patch
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: weave-net
@@ -77,7 +77,7 @@ subjects:
     name: weave-net
     namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: weave-net
@@ -101,7 +101,7 @@ rules:
     verbs:
       - create
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: weave-net
@@ -121,10 +121,10 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 spec:
   # Wait 5 seconds to let pod connect before rolling next pod
   minReadySeconds: 5
@@ -172,7 +172,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.2'
+          image: 'weaveworks/weave-kube:2.6.4'
           ports:
             - name: metrics
               containerPort: 6782
@@ -219,7 +219,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.2'
+          image: 'weaveworks/weave-npc:2.6.4'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -651,8 +651,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 	if b.cluster.Spec.Networking.Weave != nil {
 		key := "networking.weave"
 		versions := map[string]string{
-			"k8s-1.8":  "2.6.2-kops.2",
-			"k8s-1.12": "2.6.2-kops.2",
+			"k8s-1.8":  "2.6.4-kops.1",
+			"k8s-1.12": "2.6.4-kops.1",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -89,16 +89,16 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: <1.12.0
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: 6d1820c37afaee6423b9d16cfbc45fcca281b18f
+    manifestHash: f8b6cd9ce602b4c812cb6a60b8a5d7639bab75d5
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.2-kops.2
+    version: 2.6.4-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: 103cd60b880d9bab489b80c81a307a60a8328c69
+    manifestHash: 9274099876041660ea8a7048a43a3512f7339021
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.2-kops.2
+    version: 2.6.4-kops.1


### PR DESCRIPTION
Cherry pick of #9285 on release-1.18.

#9285: Update Weave for CVE-2020-13597

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.