### PR TITLE
Fix where etcd-cluster-spec is writen when etcd's BackupStore is defined

### DIFF
--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/model/components"
-	"k8s.io/kops/pkg/urls"
 	"k8s.io/kops/upup/pkg/fi/loader"
 )
 
@@ -51,9 +50,9 @@ func (b *EtcdManagerOptionsBuilder) BuildOptions(o interface{}) error {
 		if etcdCluster.Backups == nil {
 			etcdCluster.Backups = &kops.EtcdBackupSpec{}
 		}
+
 		if etcdCluster.Backups.BackupStore == "" {
-			base := clusterSpec.ConfigBase
-			etcdCluster.Backups.BackupStore = urls.Join(base, "backups", "etcd", etcdCluster.Name)
+			etcdCluster.Backups.BackupStore = clusterSpec.ConfigBase
 		}
 
 		if etcdCluster.Version == "" {

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -43,6 +43,7 @@ oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
+Base: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
 Contents:
   Name: ""
   Resource: |-
@@ -53,6 +54,7 @@ Lifecycle: null
 Location: backups/etcd/events/control/etcd-cluster-spec
 Name: etcd-cluster-spec-events
 ---
+Base: memfs://clusters.example.com/minimal.example.com/backups/etcd-main
 Contents:
   Name: ""
   Resource: |-
@@ -63,6 +65,7 @@ Lifecycle: null
 Location: backups/etcd/main/control/etcd-cluster-spec
 Name: etcd-cluster-spec-main
 ---
+Base: null
 Contents:
   Name: ""
   Resource: |
@@ -82,7 +85,7 @@ Contents:
         - /bin/sh
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
-          --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events
+          --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events/backups/etcd/events
           --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
           --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3997
           --insecure=false --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
@@ -128,6 +131,7 @@ Lifecycle: null
 Location: manifests/etcd/events.yaml
 Name: manifests-etcdmanager-events
 ---
+Base: null
 Contents:
   Name: ""
   Resource: |
@@ -147,7 +151,7 @@ Contents:
         - /bin/sh
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
-          --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main
+          --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main/backups/etcd/main
           --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
           --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3996
           --insecure=false --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994

--- a/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
@@ -43,6 +43,7 @@ oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
+Base: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
 Contents:
   Name: ""
   Resource: |-
@@ -53,6 +54,7 @@ Lifecycle: null
 Location: backups/etcd/events/control/etcd-cluster-spec
 Name: etcd-cluster-spec-events
 ---
+Base: memfs://clusters.example.com/minimal.example.com/backups/etcd-main
 Contents:
   Name: ""
   Resource: |-
@@ -63,6 +65,7 @@ Lifecycle: null
 Location: backups/etcd/main/control/etcd-cluster-spec
 Name: etcd-cluster-spec-main
 ---
+Base: null
 Contents:
   Name: ""
   Resource: |
@@ -82,7 +85,7 @@ Contents:
         - /bin/sh
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
-          --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events
+          --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events/backups/etcd/events
           --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
           --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3997
           --insecure=false --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
@@ -134,6 +137,7 @@ Lifecycle: null
 Location: manifests/etcd/events.yaml
 Name: manifests-etcdmanager-events
 ---
+Base: null
 Contents:
   Name: ""
   Resource: |
@@ -153,7 +157,7 @@ Contents:
         - /bin/sh
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
-          --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main
+          --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main/backups/etcd/main
           --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
           --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3996
           --insecure=false --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -43,6 +43,7 @@ oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
+Base: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
 Contents:
   Name: ""
   Resource: |-
@@ -53,6 +54,7 @@ Lifecycle: null
 Location: backups/etcd/events/control/etcd-cluster-spec
 Name: etcd-cluster-spec-events
 ---
+Base: memfs://clusters.example.com/minimal.example.com/backups/etcd-main
 Contents:
   Name: ""
   Resource: |-
@@ -63,6 +65,7 @@ Lifecycle: null
 Location: backups/etcd/main/control/etcd-cluster-spec
 Name: etcd-cluster-spec-main
 ---
+Base: null
 Contents:
   Name: ""
   Resource: |
@@ -82,7 +85,7 @@ Contents:
         - /bin/sh
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
-          --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events
+          --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events/backups/etcd/events
           --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
           --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3997
           --insecure=false --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
@@ -131,6 +134,7 @@ Lifecycle: null
 Location: manifests/etcd/events.yaml
 Name: manifests-etcdmanager-events
 ---
+Base: null
 Contents:
   Name: ""
   Resource: |
@@ -150,7 +154,7 @@ Contents:
         - /bin/sh
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
-          --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main
+          --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main/backups/etcd/main
           --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
           --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3996
           --insecure=false --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -43,6 +43,7 @@ oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
+Base: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
 Contents:
   Name: ""
   Resource: |-
@@ -53,6 +54,7 @@ Lifecycle: null
 Location: backups/etcd/events/control/etcd-cluster-spec
 Name: etcd-cluster-spec-events
 ---
+Base: memfs://clusters.example.com/minimal.example.com/backups/etcd-main
 Contents:
   Name: ""
   Resource: |-
@@ -63,6 +65,7 @@ Lifecycle: null
 Location: backups/etcd/main/control/etcd-cluster-spec
 Name: etcd-cluster-spec-main
 ---
+Base: null
 Contents:
   Name: ""
   Resource: |
@@ -82,7 +85,7 @@ Contents:
         - /bin/sh
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
-          --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events
+          --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events/backups/etcd/events
           --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
           --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3997
           --insecure=false --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
@@ -143,6 +146,7 @@ Lifecycle: null
 Location: manifests/etcd/events.yaml
 Name: manifests-etcdmanager-events
 ---
+Base: null
 Contents:
   Name: ""
   Resource: |
@@ -162,7 +166,7 @@ Contents:
         - /bin/sh
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
-          --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main
+          --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main/backups/etcd/main
           --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
           --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3996
           --insecure=false --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994

--- a/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
+++ b/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
@@ -1,3 +1,4 @@
+Base: null
 Contents:
   Name: ""
   Resource: |


### PR DESCRIPTION
Currently if a user defines a non-standard backupStore location, such as:

```
  - backups:
      backupStore: s3://my-bucket/etcdBackup/my-cluster.local
```


the etcd-cluster-spec is still written to the default location and ignores the store set in backupStore. This in turn causes etcd-manager to not start etcd since it still honors the user defined backupStore location.