### PR TITLE
Install all CNI plugin binaries for all network plugins

### DIFF
--- a/nodeup/pkg/model/networking/calico.go
+++ b/nodeup/pkg/model/networking/calico.go
@@ -38,10 +38,6 @@ func (b *CalicoBuilder) Build(c *fi.ModelBuilderContext) error {
 		return nil
 	}
 
-	if err := b.AddCNIBinAssets(c, []string{"flannel"}); err != nil {
-		return err
-	}
-
 	// @check if tls is enabled and if so, we need to download the client certificates
 	if !b.UseEtcdManager() && b.UseEtcdTLS() {
 		name := "calico-client"

--- a/nodeup/pkg/model/networking/canal.go
+++ b/nodeup/pkg/model/networking/canal.go
@@ -36,10 +36,6 @@ func (b *CanalBuilder) Build(c *fi.ModelBuilderContext) error {
 		return nil
 	}
 
-	if err := b.AddCNIBinAssets(c, []string{"flannel"}); err != nil {
-		return err
-	}
-
 	buildFlannelTxChecksumOffloadDisableService(c)
 
 	return nil

--- a/nodeup/pkg/model/networking/common.go
+++ b/nodeup/pkg/model/networking/common.go
@@ -30,14 +30,28 @@ var _ fi.ModelBuilder = &CommonBuilder{}
 
 // Build is responsible for copying the common CNI binaries
 func (b *CommonBuilder) Build(c *fi.ModelBuilderContext) error {
+	// Based on https://github.com/containernetworking/plugins/releases/tag/v0.7.5
 	assets := []string{
-		"bandwidth",
 		"bridge",
+		"dhcp",
+		"flannel",
+		"host-device",
 		"host-local",
+		"ipvlan",
 		"loopback",
+		"macvlan",
 		"portmap",
 		"ptp",
 		"tuning",
+		"vlan",
+	}
+
+	// Additions in https://github.com/containernetworking/plugins/releases/tag/v0.8.6
+	if b.IsKubernetesGTE("1.15") {
+		assets = append(assets, "bandwidth")
+		assets = append(assets, "firewall")
+		assets = append(assets, "sbr")
+		assets = append(assets, "static")
 	}
 
 	if err := b.AddCNIBinAssets(c, assets); err != nil {

--- a/nodeup/pkg/model/networking/flannel.go
+++ b/nodeup/pkg/model/networking/flannel.go
@@ -39,10 +39,6 @@ func (b *FlannelBuilder) Build(c *fi.ModelBuilderContext) error {
 		return nil
 	}
 
-	if err := b.AddCNIBinAssets(c, []string{"flannel"}); err != nil {
-		return err
-	}
-
 	if networking.Flannel.Backend == "vxlan" {
 		buildFlannelTxChecksumOffloadDisableService(c)
 	}


### PR DESCRIPTION
Installing *all* CNI plugin binaries seems more reliable considering that we are supporting pretty much most known network plugins.

These binaries are harmless. Even the `flannel` one that was a concern previously is not such a big issue, just collecting and configuring other CNI plugins required for Flannel (such as bridge plugin).
https://github.com/containernetworking/plugins/tree/master/plugins/meta/flannel#overview

This should also fix the failing tests for older Kubernetes releases where not all binaries are available (in this case `bandwidth`):
```
W0609 20:53:12.021210    1202 main.go:138] got error running nodeup (will retry in 30s): error building loader: unable to locate asset "bandwidth"
```
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-k8s-1-14/1270458079854465025

/cc @rifelpet @olemarkus 