### PR TITLE
Disable kubeproxy when creating a kube-router cluster

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -1007,6 +1007,8 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 		cluster.Spec.Networking.Canal = &api.CanalNetworkingSpec{}
 	case "kube-router":
 		cluster.Spec.Networking.Kuberouter = &api.KuberouterNetworkingSpec{}
+		enabled := false
+		cluster.Spec.KubeProxy.Enabled = &enabled
 	case "amazonvpc", "amazon-vpc-routed-eni":
 		cluster.Spec.Networking.AmazonVPC = &api.AmazonVPCNetworkingSpec{}
 	case "cilium":


### PR DESCRIPTION
kube-router e2e jobs have been failing for a while: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-cni-kuberouter/1270539617296191488

```
Completed cluster failed validation: spec.spec.kubeProxy.enabled: Forbidden: kube-router requires kubeProxy to be disabled
172
2020/06/10 02:15:10 process.go:155: Step '/tmp/kops502689941/kops create cluster --name e2e-kops-aws-cni-kuberouter.test-cncf-aws.k8s.io --ssh-public-key /workspace/.ssh/kube_aws_rsa.pub --node-count 4 --node-volume-size 48 --master-volume-size 48 --master-count 1 --zones eu-west-1b --master-size c5.large --kubernetes-version https://storage.googleapis.com/kubernetes-release/release/v1.18.3 --admin-access 35.238.143.128/32 --cloud aws --networking=kube-router --override cluster.spec.nodePortAccess=0.0.0.0/0' finished in 2.563231933s
```

This should fix the validation error. Existing clusters aren't affected, though they'd also fail validation if they are enabling kubeproxy.