### PR TITLE
Fix NPD when creating a kube-router cluster

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -1007,6 +1007,9 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 		cluster.Spec.Networking.Canal = &api.CanalNetworkingSpec{}
 	case "kube-router":
 		cluster.Spec.Networking.Kuberouter = &api.KuberouterNetworkingSpec{}
+		if cluster.Spec.KubeProxy == nil {
+			cluster.Spec.KubeProxy = &api.KubeProxyConfig{}
+		}
 		enabled := false
 		cluster.Spec.KubeProxy.Enabled = &enabled
 	case "amazonvpc", "amazon-vpc-routed-eni":


### PR DESCRIPTION
Followup to https://github.com/kubernetes/kops/pull/9321 addressing this test failure: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-cni-kuberouter/1270661420639326208