### PR TITLE
Allow docker options to be specified by create cluster overrides

### DIFF
--- a/pkg/commands/set_cluster.go
+++ b/pkg/commands/set_cluster.go
@@ -92,6 +92,11 @@ func SetClusterFields(fields []string, cluster *api.Cluster, instanceGroups []*a
 			cluster.Spec.Kubelet.AuthenticationTokenWebhook = &v
 		case "cluster.spec.nodePortAccess":
 			cluster.Spec.NodePortAccess = append(cluster.Spec.NodePortAccess, kv[1])
+		case "spec.docker.execOpt":
+			if cluster.Spec.Docker == nil {
+				cluster.Spec.Docker = &api.DockerConfig{}
+			}
+			cluster.Spec.Docker.ExecOpt = append(cluster.Spec.Docker.ExecOpt, kv[1])
 		case "spec.kubernetesVersion":
 			cluster.Spec.KubernetesVersion = kv[1]
 		case "spec.masterPublicName":


### PR DESCRIPTION
This will allow our end-to-end testing to enable SELinux.

xref https://github.com/kubernetes/test-infra/pull/17902

CC @hakman @rifelpet @jsafrane 