### PR TITLE
Automated cherry pick of #9288: Fix mismatch in SecurityGroups handling with launch

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -208,6 +208,10 @@ func (t *LaunchTemplate) Find(c *fi.Context) (*LaunchTemplate, error) {
 			actual.SecurityGroups = append(actual.SecurityGroups, &SecurityGroup{ID: id})
 		}
 	}
+	// In older Kops versions, security groups were added to LaunchTemplateData.SecurityGroupIds
+	for _, id := range lt.LaunchTemplateData.SecurityGroupIds {
+		actual.SecurityGroups = append(actual.SecurityGroups, &SecurityGroup{ID: fi.String("legacy-" + *id)})
+	}
 	sort.Sort(OrderSecurityGroupsById(actual.SecurityGroups))
 
 	// @step: check if monitoring it enabled


### PR DESCRIPTION
Cherry pick of #9288 on release-1.18.

#9288: Fix mismatch in SecurityGroups handling with launch

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.