### PR TITLE
Automated cherry pick of #8965: Fix missing changes in Weave manifest #9285: Update Weave for CVE-2020-13597

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -13,18 +13,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 rules:
   - apiGroups:
       - ''
@@ -64,10 +64,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: weave-net
@@ -121,17 +121,17 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 spec:
   # Wait 5 seconds to let pod connect before rolling next pod
-  minReadySeconds: 5
   selector:
     matchLabels:
       name: weave-net
       role.kubernetes.io/networking: "1"
+  minReadySeconds: 5
   template:
     metadata:
       labels:
@@ -175,7 +175,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.5.2'
+          image: 'weaveworks/weave-kube:2.6.4'
           ports:
             - name: metrics
               containerPort: 6782
@@ -207,6 +207,7 @@ spec:
               mountPath: /lib/modules
             - name: xtables-lock
               mountPath: /run/xtables.lock
+              readOnly: false
         - name: weave-npc
           env:
             - name: HOSTNAME
@@ -214,7 +215,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.5.2'
+          image: 'weaveworks/weave-npc:2.6.4'
           ports:
             - name: metrics
               containerPort: 6781
@@ -229,7 +230,9 @@ spec:
           volumeMounts:
             - name: xtables-lock
               mountPath: /run/xtables.lock
+              readOnly: false
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       restartPolicy: Always
       securityContext:

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -37,6 +37,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - extensions
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - 'networking.k8s.io'
     resources:
       - networkpolicies
@@ -131,7 +139,6 @@ spec:
         role.kubernetes.io/networking: "1"
       annotations:
         prometheus.io/scrape: "true"
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
         - name: weave
@@ -201,7 +208,6 @@ spec:
             - name: xtables-lock
               mountPath: /run/xtables.lock
         - name: weave-npc
-          args: []
           env:
             - name: HOSTNAME
               valueFrom:
@@ -231,6 +237,8 @@ spec:
       serviceAccountName: weave-net
       tolerations:
         - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
           operator: Exists
         - key: CriticalAddonsOnly
           operator: Exists

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -13,18 +13,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
+  namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 rules:
   - apiGroups:
       - ''
@@ -60,14 +60,14 @@ rules:
       - patch
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: weave-net
@@ -77,7 +77,7 @@ subjects:
     name: weave-net
     namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: weave-net
@@ -101,7 +101,7 @@ rules:
     verbs:
       - create
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: weave-net
@@ -121,10 +121,10 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: weave-net
-  namespace: kube-system
   labels:
     name: weave-net
     role.kubernetes.io/networking: "1"
+  namespace: kube-system
 spec:
   # Wait 5 seconds to let pod connect before rolling next pod
   minReadySeconds: 5
@@ -172,7 +172,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.5.2'
+          image: 'weaveworks/weave-kube:2.6.4'
           ports:
             - name: metrics
               containerPort: 6782
@@ -204,6 +204,7 @@ spec:
               mountPath: /lib/modules
             - name: xtables-lock
               mountPath: /run/xtables.lock
+              readOnly: false
         - name: weave-npc
           env:
             - name: HOSTNAME
@@ -211,7 +212,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.5.2'
+          image: 'weaveworks/weave-npc:2.6.4'
           ports:
             - name: metrics
               containerPort: 6781
@@ -226,6 +227,7 @@ spec:
           volumeMounts:
             - name: xtables-lock
               mountPath: /run/xtables.lock
+              readOnly: false
       hostNetwork: true
       hostPID: true
       restartPolicy: Always

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -37,6 +37,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - extensions
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - 'networking.k8s.io'
     resources:
       - networkpolicies
@@ -197,7 +205,6 @@ spec:
             - name: xtables-lock
               mountPath: /run/xtables.lock
         - name: weave-npc
-          args: []
           env:
             - name: HOSTNAME
               valueFrom:
@@ -227,6 +234,8 @@ spec:
       serviceAccountName: weave-net
       tolerations:
         - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
           operator: Exists
         - key: CriticalAddonsOnly
           operator: Exists

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -695,8 +695,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"pre-k8s-1.6": "2.3.0-kops.3",
 			"k8s-1.6":     "2.3.0-kops.3",
 			"k8s-1.7":     "2.5.2-kops.2",
-			"k8s-1.8":     "2.5.2-kops.4",
-			"k8s-1.12":    "2.5.2-kops.4",
+			"k8s-1.8":     "2.6.4-kops.1",
+			"k8s-1.12":    "2.6.4-kops.1",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -695,8 +695,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"pre-k8s-1.6": "2.3.0-kops.3",
 			"k8s-1.6":     "2.3.0-kops.3",
 			"k8s-1.7":     "2.5.2-kops.2",
-			"k8s-1.8":     "2.5.2-kops.2",
-			"k8s-1.12":    "2.5.2-kops.3",
+			"k8s-1.8":     "2.5.2-kops.4",
+			"k8s-1.12":    "2.5.2-kops.4",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -143,7 +143,7 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.2-kops.2
+    version: 2.5.2-kops.4
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
@@ -151,4 +151,4 @@ spec:
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.2-kops.3
+    version: 2.5.2-kops.4

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -139,16 +139,16 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: 748a1526515a719058b99c203cd943a740675e21
+    manifestHash: 04b76e2d427fcdd14c042eb63b44c3a9d34ece33
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.2-kops.4
+    version: 2.6.4-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: 96334bfcfa6a3ec9791b50c94674a8821cb6ad67
+    manifestHash: eb0ee027200ce4fbe3f99b656474c0891d15d6aa
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.5.2-kops.4
+    version: 2.6.4-kops.1


### PR DESCRIPTION
Cherry pick of #8965 #9285 on release-1.16.

#8965: Fix missing changes in Weave manifest
#9285: Update Weave for CVE-2020-13597

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.