### PR TITLE
Docs helptext

### DIFF
--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -358,19 +358,19 @@ func RunUpdateCluster(ctx context.Context, f *util.Factory, clusterName string, 
 		// More suggestions on first run
 		if firstRun {
 			fmt.Fprintf(sb, "Suggestions:\n")
-			fmt.Fprintf(sb, " * validate cluster: kops validate cluster\n")
+			fmt.Fprintf(sb, " * validate cluster: kops validate cluster --wait 10m\n")
 			fmt.Fprintf(sb, " * list nodes: kubectl get nodes --show-labels\n")
 			if !usesBastion(instanceGroups) {
-				fmt.Fprintf(sb, " * ssh to the master: ssh -i ~/.ssh/id_rsa admin@%s\n", cluster.Spec.MasterPublicName)
+				fmt.Fprintf(sb, " * ssh to the master: ssh -i ~/.ssh/id_rsa ubuntu@%s\n", cluster.Spec.MasterPublicName)
 			} else {
 				bastionPublicName := findBastionPublicName(cluster)
 				if bastionPublicName != "" {
-					fmt.Fprintf(sb, " * ssh to the bastion: ssh -A -i ~/.ssh/id_rsa admin@%s\n", bastionPublicName)
+					fmt.Fprintf(sb, " * ssh to the bastion: ssh -A -i ~/.ssh/id_rsa ubuntu@%s\n", bastionPublicName)
 				} else {
 					fmt.Fprintf(sb, " * to ssh to the bastion, you probably want to configure a bastionPublicName.\n")
 				}
 			}
-			fmt.Fprintf(sb, " * the admin user is specific to Debian. If not using Debian please use the appropriate user based on your OS.\n")
+			fmt.Fprintf(sb, " * the ubuntu user is specific to Ubuntu. If not using Ubuntu please use the appropriate user based on your OS.\n")
 			fmt.Fprintf(sb, " * read about installing addons at: https://kops.sigs.k8s.io/operations/addons.\n")
 			fmt.Fprintf(sb, "\n")
 		}

--- a/cmd/kops/validate.go
+++ b/cmd/kops/validate.go
@@ -27,19 +27,15 @@ import (
 
 var (
 	validateLong = templates.LongDesc(i18n.T(`
-	This commands validates the following components:
-
-	1. All k8s masters are running and have "Ready" status.
-	2. All k8s nodes are running and have "Ready" status.
-	3. Component status returns healthy for all components.
-	4. All pods with a critical priority are running and healthy.
+	This command validates a cluster.
+	See:
+	kops validate cluster -h
 	`))
 
 	validateExample = templates.Examples(i18n.T(`
-	# Validate a cluster.
-	# This command uses the currently selected kops cluster as
-	# set by the kubectl config.
-	kops validate cluster`))
+	# Validate the cluster set as the current context of the kube config.
+	# Kops will try for 10 minutes to validate the cluster 3 times.
+	kops validate cluster --wait 10m --count 3`))
 
 	validateShort = i18n.T(`Validate a kops cluster.`)
 )

--- a/cmd/kops/validate_cluster.go
+++ b/cmd/kops/validate_cluster.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	"k8s.io/kops/upup/pkg/fi/cloudup"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
@@ -55,10 +57,19 @@ func NewCmdValidateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	options := &ValidateClusterOptions{}
 	options.InitDefaults()
 
+	validateClusterLong := templates.LongDesc(i18n.T(`
+	This commands validates the following components:
+
+	1. All k8s masters are running and have "Ready" status.
+	2. All k8s nodes are running and have "Ready" status.
+	3. Component status returns healthy for all components.
+	4. All pods with a critical priority are running and healthy.
+	`))
+
 	cmd := &cobra.Command{
 		Use:     "cluster",
 		Short:   validateShort,
-		Long:    validateLong,
+		Long:    validateClusterLong,
 		Example: validateExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := context.TODO()

--- a/docs/cli/kops_validate.md
+++ b/docs/cli/kops_validate.md
@@ -7,20 +7,14 @@ Validate a kops cluster.
 
 ### Synopsis
 
-This commands validates the following components:
-
-  1.  All k8s masters are running and have "Ready" status.
-  2.  All k8s nodes are running and have "Ready" status.
-  3.  Component status returns healthy for all components.
-  4.  All pods with a critical priority are running and healthy.
+This command validates a cluster. See: kops validate cluster -h
 
 ### Examples
 
 ```
-  # Validate a cluster.
-  # This command uses the currently selected kops cluster as
-  # set by the kubectl config.
-  kops validate cluster
+  # Validate the cluster set as the current context of the kube config.
+  # Kops will try for 10 minutes to validate the cluster 3 times.
+  kops validate cluster --wait 10m --count 3
 ```
 
 ### Options

--- a/docs/cli/kops_validate_cluster.md
+++ b/docs/cli/kops_validate_cluster.md
@@ -21,10 +21,9 @@ kops validate cluster [flags]
 ### Examples
 
 ```
-  # Validate a cluster.
-  # This command uses the currently selected kops cluster as
-  # set by the kubectl config.
-  kops validate cluster
+  # Validate the cluster set as the current context of the kube config.
+  # Kops will try for 10 minutes to validate the cluster 3 times.
+  kops validate cluster --wait 10m --count 3
 ```
 
 ### Options

--- a/docs/getting_started/aws.md
+++ b/docs/getting_started/aws.md
@@ -374,7 +374,7 @@ working.
 cluster is working as expected.
 
 ```bash
-kops validate cluster
+kops validate cluster --wait 10m
 ```
 
 You can look at all system components with the following command.

--- a/docs/rotate-secrets.md
+++ b/docs/rotate-secrets.md
@@ -77,5 +77,5 @@ kubectl delete pods --all --all-namespaces
 The last command from the previous section will take some time. Meanwhile you can check validation to see the cluster gradually coming back online.
 
 ```
-kops validate cluster
+kops validate cluster --wait 10m
 ```

--- a/docs/single-to-multi-master.md
+++ b/docs/single-to-multi-master.md
@@ -118,7 +118,7 @@ This will launch the two new masters. You will also need to roll the old master 
 After about 5 minutes all three masters should have found each other. Run the following to ensure everything is running as expected.
 
 ```bash
-kops validate cluster
+kops validate cluster --wait 10m
 ```
 
 While rotating the original master is not strictly necessary, kops will say it needs updating because of the configuration change.


### PR DESCRIPTION
* Add `--wait` to most `kops validate cluster` examples. Some confusion there because the help text is reused as well. See #1517 
* Ubuntu instead of Debian since I was in the neighbourhood