### PR TITLE
Refactor kubemanifest to be clearer

### DIFF
--- a/pkg/kubemanifest/images.go
+++ b/pkg/kubemanifest/images.go
@@ -25,7 +25,7 @@ import (
 
 type ImageRemapFunction func(image string) (string, error)
 
-func (m *Manifest) RemapImages(mapper ImageRemapFunction) error {
+func (m *Object) RemapImages(mapper ImageRemapFunction) error {
 	visitor := &imageRemapVisitor{
 		mapper: mapper,
 	}


### PR DESCRIPTION
Primarily renaming manifests to objects, which is a more accurate
term.