### PR TITLE
Automated cherry pick of #9330: Update Weave Net to 2.6.5

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -14330,7 +14330,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.4'
+          image: 'weaveworks/weave-kube:2.6.5'
           ports:
             - name: metrics
               containerPort: 6782
@@ -14377,7 +14377,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.4'
+          image: 'weaveworks/weave-npc:2.6.5'
           ports:
             - name: metrics
               containerPort: 6781
@@ -14627,7 +14627,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.4'
+          image: 'weaveworks/weave-kube:2.6.5'
           ports:
             - name: metrics
               containerPort: 6782
@@ -14674,7 +14674,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.4'
+          image: 'weaveworks/weave-npc:2.6.5'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -175,7 +175,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.4'
+          image: 'weaveworks/weave-kube:2.6.5'
           ports:
             - name: metrics
               containerPort: 6782
@@ -222,7 +222,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.4'
+          image: 'weaveworks/weave-npc:2.6.5'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -172,7 +172,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.4'
+          image: 'weaveworks/weave-kube:2.6.5'
           ports:
             - name: metrics
               containerPort: 6782
@@ -219,7 +219,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.4'
+          image: 'weaveworks/weave-npc:2.6.5'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -651,8 +651,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 	if b.cluster.Spec.Networking.Weave != nil {
 		key := "networking.weave"
 		versions := map[string]string{
-			"k8s-1.8":  "2.6.4-kops.1",
-			"k8s-1.12": "2.6.4-kops.1",
+			"k8s-1.8":  "2.6.5-kops.1",
+			"k8s-1.12": "2.6.5-kops.1",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -89,16 +89,16 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: <1.12.0
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: f8b6cd9ce602b4c812cb6a60b8a5d7639bab75d5
+    manifestHash: d1bc5539972f06bbad6427651900d896ecaaaf34
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.4-kops.1
+    version: 2.6.5-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: 9274099876041660ea8a7048a43a3512f7339021
+    manifestHash: 8b47cd3c6e82e5f0c8f9a13ccb34b730bb0b6da3
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.4-kops.1
+    version: 2.6.5-kops.1


### PR DESCRIPTION
Cherry pick of #9330 on release-1.18.

#9330: Update Weave Net to 2.6.5

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.