### PR TITLE
Automated cherry pick of #9330: Update Weave Net to 2.6.5

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -175,7 +175,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.4'
+          image: 'weaveworks/weave-kube:2.6.5'
           ports:
             - name: metrics
               containerPort: 6782
@@ -218,7 +218,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.6.4'
+          image: 'weaveworks/weave-npc:2.6.5'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -172,7 +172,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.4'
+          image: 'weaveworks/weave-kube:2.6.5'
           ports:
             - name: metrics
               containerPort: 6782
@@ -215,7 +215,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.6.4'
+          image: 'weaveworks/weave-npc:2.6.5'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -695,8 +695,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"pre-k8s-1.6": "2.3.0-kops.4",
 			"k8s-1.6":     "2.3.0-kops.4",
 			"k8s-1.7":     "2.5.2-kops.4",
-			"k8s-1.8":     "2.6.4-kops.1",
-			"k8s-1.12":    "2.6.4-kops.1",
+			"k8s-1.8":     "2.6.5-kops.1",
+			"k8s-1.12":    "2.6.5-kops.1",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -139,16 +139,16 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: 7a555cd2375dc344250bd039161e28d9d7a6e4fe
+    manifestHash: a4fa9bc98b1a5fca493ff77d17c57079116fe233
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.4-kops.1
+    version: 2.6.5-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: cf3e19d0ef67d8a43f378d6c0eb6ca24fa2c00f7
+    manifestHash: 116b35e7ec5186481106ccd38841ede453970ea1
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.4-kops.1
+    version: 2.6.5-kops.1


### PR DESCRIPTION
Cherry pick of #9330 on release-1.17.

#9330: Update Weave Net to 2.6.5

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.