### PR TITLE
Automated cherry pick of #9330: Update Weave Net to 2.6.5

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -175,7 +175,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.4'
+          image: 'weaveworks/weave-kube:2.6.5'
           ports:
             - name: metrics
               containerPort: 6782
@@ -215,7 +215,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.6.4'
+          image: 'weaveworks/weave-npc:2.6.5'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.8.yaml.template
@@ -172,7 +172,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.4'
+          image: 'weaveworks/weave-kube:2.6.5'
           ports:
             - name: metrics
               containerPort: 6782
@@ -212,7 +212,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'weaveworks/weave-npc:2.6.4'
+          image: 'weaveworks/weave-npc:2.6.5'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -695,8 +695,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"pre-k8s-1.6": "2.3.0-kops.3",
 			"k8s-1.6":     "2.3.0-kops.3",
 			"k8s-1.7":     "2.5.2-kops.2",
-			"k8s-1.8":     "2.6.4-kops.1",
-			"k8s-1.12":    "2.6.4-kops.1",
+			"k8s-1.8":     "2.6.5-kops.1",
+			"k8s-1.12":    "2.6.5-kops.1",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -139,16 +139,16 @@ spec:
   - id: k8s-1.8
     kubernetesVersion: '>=1.8.0 <1.12.0'
     manifest: networking.weave/k8s-1.8.yaml
-    manifestHash: 04b76e2d427fcdd14c042eb63b44c3a9d34ece33
+    manifestHash: 8f4fda7c8f4d080e0b1de60636103f3f64c7943a
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.4-kops.1
+    version: 2.6.5-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: eb0ee027200ce4fbe3f99b656474c0891d15d6aa
+    manifestHash: aa126e872270f046384926121d1f6beee982f28e
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"
-    version: 2.6.4-kops.1
+    version: 2.6.5-kops.1


### PR DESCRIPTION
Cherry pick of #9330 on release-1.16.

#9330: Update Weave Net to 2.6.5

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.