### PR TITLE
Add nodelocal dns cache to release notes and add kops version to docs

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -583,7 +583,7 @@ spec:
 
 ## Node local DNS cache
 
-If you are using CoreDNS, you can enable NodeLocal DNSCache. It is used to improve improve the Cluster DNS performance by running a dns caching agent on cluster nodes as a DaemonSet.
+As of kops 1.18, you can enable NodeLocal DNSCache if you are using CoreDNS. It is used to improve improve the Cluster DNS performance by running a dns caching agent on cluster nodes as a DaemonSet.
 
 ```yaml
 spec:

--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -26,6 +26,8 @@
 
 * Google API client libraries updated from v0.beta to v1.
 
+* Support for [NodeLocalDNS cache](https://kops.sigs.k8s.io/cluster_spec/#node-local-dns-cache).
+
 # Breaking changes
 
 * Support for Docker versions 1.11, 1.12 and 1.13 has been removed because of the [dockerproject.org shut down](https://www.docker.com/blog/changes-dockerproject-org-apt-yum-repositories/). Those affected must upgrade to a newer Docker version.


### PR DESCRIPTION
Another instance of #9151. See #9350 

Also think this deserves a mention in the release notes