### PR TITLE
Fix kube-apiserver-healthcheck image

### DIFF
--- a/pkg/model/components/kubeapiserver/model.go
+++ b/pkg/model/components/kubeapiserver/model.go
@@ -94,7 +94,7 @@ kind: Pod
 spec:
   containers:
   - name: healthcheck
-    image: kope/kube-apiserver-healthcheck:1.18.0-alpha.3
+    image: kope/kube-apiserver-healthcheck:1.18.0-beta.1
     livenessProbe:
       httpGet:
         # The sidecar serves a healthcheck on the same port,

--- a/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
+++ b/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
@@ -13,7 +13,7 @@ Contents:
         - --client-key=/secrets/client.key
         command:
         - /usr/bin/kube-apiserver-healthcheck
-        image: kope/kube-apiserver-healthcheck:1.18.0-alpha.3
+        image: kope/kube-apiserver-healthcheck:1.18.0-beta.1
         livenessProbe:
           httpGet:
             host: 127.0.0.1


### PR DESCRIPTION
Use a [valid tag](https://hub.docker.com/r/kope/kube-apiserver-healthcheck/tags) for the kube-apiserver-healthcheck image