### PR TITLE
Automated cherry pick of #9337: Explicitly set default storageclass to support upgrades

### DIFF
--- a/docs/releases/1.17-NOTES.md
+++ b/docs/releases/1.17-NOTES.md
@@ -71,6 +71,8 @@
 
 * Support for the "Legacy" etcd provider has been deprecated. It will not be supported for Kubernetes 1.18 or later. To migrate to the default "Manager" etcd provider see the [etcd migration documentation](../etcd3-migration.md).
 
+* The default StorageClass `gp2` prior to Kops 1.17.0 is no longer the default, replaced by StorageClass `kops-ssd-1-17`.
+
 # Known Issues
 
 * Kops 1.17.0-beta.1 included an update for AWS IAM Authenticator to 0.5.0.
@@ -78,6 +80,11 @@
   Any cluster with `spec.authentication.aws` defined according to the [docs](../authentication.md#aws-iam-authenticator) without overriding the `spec.authentication.aws.image` is affected.
   The workaround is to specify the old 0.4.0 image with `spec.authentication.aws.image=602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.4.0`.
   For the 1.17.0 release, this change was rolled back, and the AWS IAM authenticator defaults to version 0.4.0
+
+* Kops 1.17.0 includes a new StorageClass `kops-ssd-1-17` which is set as the default via the annotation `"storageclass.beta.kubernetes.io/is-default-class":"true"`.
+  If you have modified the previous `gp2` StorageClass, it could conflict with the defaulting behavior.
+  To resolve, patch the `gp2` StorageClass to have the annotation `"storageclass.beta.kubernetes.io/is-default-class":"false"`, which aligns with a patch to Kops 1.17.1 as well.
+  `kubectl patch storageclass.storage.k8s.io/gp2 --patch '{"metadata": {"annotations": {"storageclass.beta.kubernetes.io/is-default-class": "false"}}}'`
 
 # Full change list since 1.16.0 release
 

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -16682,6 +16682,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: gp2
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "false"
   labels:
     k8s-addon: storage-aws.addons.k8s.io
 provisioner: kubernetes.io/aws-ebs

--- a/upup/models/cloudup/resources/addons/storage-aws.addons.k8s.io/v1.15.0.yaml
+++ b/upup/models/cloudup/resources/addons/storage-aws.addons.k8s.io/v1.15.0.yaml
@@ -14,6 +14,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: gp2
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "false"
   labels:
     k8s-addon: storage-aws.addons.k8s.io
 provisioner: kubernetes.io/aws-ebs

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -73,7 +73,7 @@ spec:
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: 5e829e8981470696bef2ed5e96839ea83cb36d24
+    manifestHash: 00cf6e46e25b736b2da93c6025ce482474d83904
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -73,7 +73,7 @@ spec:
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: 5e829e8981470696bef2ed5e96839ea83cb36d24
+    manifestHash: 00cf6e46e25b736b2da93c6025ce482474d83904
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -73,7 +73,7 @@ spec:
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: 5e829e8981470696bef2ed5e96839ea83cb36d24
+    manifestHash: 00cf6e46e25b736b2da93c6025ce482474d83904
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -73,7 +73,7 @@ spec:
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: 5e829e8981470696bef2ed5e96839ea83cb36d24
+    manifestHash: 00cf6e46e25b736b2da93c6025ce482474d83904
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #9337 on release-1.18.

#9337: Explicitly set default storageclass to support upgrades

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.