### PR TITLE
Automated cherry pick of #9337: Explicitly set default storageclass to support upgrades

### DIFF
--- a/upup/models/cloudup/resources/addons/storage-aws.addons.k8s.io/v1.15.0.yaml
+++ b/upup/models/cloudup/resources/addons/storage-aws.addons.k8s.io/v1.15.0.yaml
@@ -14,6 +14,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: gp2
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "false"
   labels:
     k8s-addon: storage-aws.addons.k8s.io
 provisioner: kubernetes.io/aws-ebs

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -91,7 +91,7 @@ spec:
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: 5e829e8981470696bef2ed5e96839ea83cb36d24
+    manifestHash: 00cf6e46e25b736b2da93c6025ce482474d83904
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -91,7 +91,7 @@ spec:
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: 5e829e8981470696bef2ed5e96839ea83cb36d24
+    manifestHash: 00cf6e46e25b736b2da93c6025ce482474d83904
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -91,7 +91,7 @@ spec:
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: 5e829e8981470696bef2ed5e96839ea83cb36d24
+    manifestHash: 00cf6e46e25b736b2da93c6025ce482474d83904
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -91,7 +91,7 @@ spec:
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: 5e829e8981470696bef2ed5e96839ea83cb36d24
+    manifestHash: 00cf6e46e25b736b2da93c6025ce482474d83904
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #9337 on release-1.17.

#9337: Explicitly set default storageclass to support upgrades

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.