### PR TITLE
Automated cherry pick of #9367: Bump cilium to 1.7.5

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -389,7 +389,7 @@ spec:
           value: {{ . }}
         {{ end }}
 {{ with .Networking.Cilium }}
-        image: "docker.io/cilium/cilium:{{- or .Version "v1.7.3" }}"
+        image: "docker.io/cilium/cilium:{{- or .Version "v1.7.5" }}"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -484,7 +484,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: "docker.io/cilium/cilium:{{- or .Version "v1.7.3" }}"
+        image: "docker.io/cilium/cilium:{{- or .Version "v1.7.5" }}"
 ## end of `with .Networking.Cilium`
 #{{ end }}
         imagePullPolicy: IfNotPresent
@@ -664,7 +664,7 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
-        image: "docker.io/cilium/operator:{{- if eq .Version "" -}}v1.7.3{{- else -}}{{ .Version }}{{- end -}}"
+        image: "docker.io/cilium/operator:{{- if eq .Version "" -}}v1.7.5{{- else -}}{{ .Version }}{{- end -}}"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         {{ if .EnablePrometheusMetrics }}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -123,7 +123,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12.yaml
-    manifestHash: 75c997c0d694e5607f754047d3f64634e3eb3bd6
+    manifestHash: 20512f4e48717bd3c75d19e1e8a782e52fda2af5
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
Cherry pick of #9367 on release-1.17.

#9367: Bump cilium to 1.7.5

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.