### PR TITLE
Automated cherry pick of #8798 #8800: Update default users for kubeconfig with supported distros

### DIFF
--- a/nodeup/pkg/model/kubectl.go
+++ b/nodeup/pkg/model/kubectl.go
@@ -112,6 +112,8 @@ func (b *KubectlBuilder) findKubeconfigUser() (*fi.User, *fi.Group, error) {
 		users = []string{"centos"}
 	case distros.DistributionRhel7, distros.DistributionRhel8:
 		users = []string{"ec2-user"}
+	case distros.DistributionCoreOS, distros.DistributionFlatcar:
+		users = []string{"core"}
 	default:
 		klog.Warningf("Unknown distro; won't write kubeconfig to homedir %s", b.Distribution)
 		return nil, nil, nil

--- a/nodeup/pkg/model/kubectl.go
+++ b/nodeup/pkg/model/kubectl.go
@@ -106,8 +106,12 @@ func (b *KubectlBuilder) findKubeconfigUser() (*fi.User, *fi.Group, error) {
 	switch b.Distribution {
 	case distros.DistributionJessie, distros.DistributionDebian9, distros.DistributionDebian10:
 		users = []string{"admin", "root"}
-	case distros.DistributionCentos7:
+	case distros.DistributionXenial, distros.DistributionBionic, distros.DistributionFocal:
+		users = []string{"ubuntu"}
+	case distros.DistributionCentos7, distros.DistributionCentos8:
 		users = []string{"centos"}
+	case distros.DistributionRhel7, distros.DistributionRhel8:
+		users = []string{"ec2-user"}
 	default:
 		klog.Warningf("Unknown distro; won't write kubeconfig to homedir %s", b.Distribution)
 		return nil, nil, nil


### PR DESCRIPTION
Cherry pick of #8798 #8800 on release-1.17.

#8798: Update default users for kubeconfig with supported distros
#8800: Update default user for CoreOS, Flatcar for kubecfg

Fixes #9358

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.