### PR TITLE
Use -mod=vendor for most go commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -463,9 +463,8 @@ gomod-prereqs:
 	(which bazel > /dev/null) || (echo "gomod requires that bazel is installed"; exit 1)
 
 .PHONY: gomod
-gomod: export GOFLAGS=
 gomod: gomod-prereqs
-	GO111MODULE=on go mod vendor
+	GO111MODULE=on GOFLAGS= go mod vendor
 	# Switch weavemesh to use peer_name_hash - bazel rule-go doesn't support build tags yet
 	rm vendor/github.com/weaveworks/mesh/peer_name_mac.go
 	sed -i -e 's/peer_name_hash/!peer_name_mac/g' vendor/github.com/weaveworks/mesh/peer_name_hash.go

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ BAZEL_CONFIG?=
 API_OPTIONS?=
 GCFLAGS?=
 
+# This can be removed when we upgrade to go 1.14
+export GOFLAGS=-mod=vendor
+
 UPLOAD_CMD=$(KOPS_ROOT)/hack/upload
 
 # Unexport environment variables that can affect tests and are not used in builds
@@ -460,6 +463,7 @@ gomod-prereqs:
 	(which bazel > /dev/null) || (echo "gomod requires that bazel is installed"; exit 1)
 
 .PHONY: gomod
+gomod: export GOFLAGS=
 gomod: gomod-prereqs
 	GO111MODULE=on go mod vendor
 	# Switch weavemesh to use peer_name_hash - bazel rule-go doesn't support build tags yet

--- a/hack/make-apimachinery.sh
+++ b/hack/make-apimachinery.sh
@@ -30,6 +30,7 @@ mkdir -p "${WORK_DIR}/go/"
 cp -R "${GOPATH}/src/k8s.io/kops/vendor/" "${WORK_DIR}/go/src"
 
 unset GOBIN
+unset GOFLAGS
 
 env GOBIN="${WORK_DIR}/go/bin" GOPATH="${WORK_DIR}/go/" go install -v k8s.io/code-generator/cmd/conversion-gen/
 cp "${WORK_DIR}/go/bin/conversion-gen" "${GOPATH}/bin/"


### PR DESCRIPTION
Without this set, go 1.13 was redownloading all dependencies into the module cache, effectively ignoring the vendor directory.

This instructs go 1.13 to always use (and verify the contents of) the vendor directory.

See an example prow job [here](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kops/9389/pull-kops-verify-govet/1273460433402990595). All of the `go: downloading` and `go: extracting` lines indicate its downloading those dependencies rather than using the vendor directory.

Unsetting it for when we actually update the vendor directory with `make gomod`.

I'm not sure if/how this affects bazel

Ref: https://github.com/kubernetes/kops/pull/9389#issuecomment-645757357

/assign @justinsb