### PR TITLE
Automated cherry pick of #9389: Run "go mod vendor" in verify-gomod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -516,7 +516,7 @@ ci: govet verify-gofmt verify-generate verify-gomod verify-goimports verify-boil
 # verify-gofmt: uses bazel, covered by pull-kops-verify
 # govet needs to be after verify-goimports because it generates bindata.go
 .PHONY: travis-ci
-travis-ci: verify-generate verify-gomod verify-goimports govet verify-boilerplate verify-bazel verify-misspelling verify-shellcheck verify-bindata | verify-gendocs verify-packages verify-apimachinery
+travis-ci: verify-generate verify-goimports govet verify-boilerplate verify-bazel verify-misspelling verify-shellcheck verify-bindata | verify-gendocs verify-packages verify-apimachinery
 	echo "Done!"
 
 .PHONY: pr

--- a/Makefile
+++ b/Makefile
@@ -411,11 +411,6 @@ dns-controller-push:
 gomod-prereqs:
 	(which bazel > /dev/null) || (echo "gomod requires that bazel is installed"; exit 1)
 
-.PHONY: dep-ensure
-dep-ensure:
-	echo "'make dep-ensure' has been replaced by 'make gomod'"
-	exit 1
-
 .PHONY: gomod
 gomod: gomod-prereqs
 	GO111MODULE=on go mod vendor
@@ -461,7 +456,7 @@ verify-gofmt:
 
 .PHONY: verify-gomod
 verify-gomod:
-	hack/verify-gomod
+	hack/verify-gomod.sh
 
 .PHONY: verify-packages
 verify-packages: ${BINDATA_TARGETS}

--- a/hack/verify-gomod.sh
+++ b/hack/verify-gomod.sh
@@ -22,6 +22,8 @@ set -o pipefail
 
 cd "${KOPS_ROOT}"
 
+make gomod
+
 changes=$(git status --porcelain || true)
 if [ -n "${changes}" ]; then
   echo "ERROR: go modules are not up to date; please run: go mod tidy"


### PR DESCRIPTION
Cherry pick of #9389 on release-1.18.

#9389: Run "go mod vendor" in verify-gomod

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.