### PR TITLE
Remove go 1.14 CI jobs for k8s 1.18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15]
-        go: [1.13, 1.14]
-        exclude:
-          - os: macos-10.15
-            go: 1.14
+        go: [1.13]
       fail-fast: true
 
     runs-on: ${{ matrix.os }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ os:
   - linux
   - osx
 go:
-  # 1.12 is no longer supported by apimachinery; we recommend 1.13
   - 1.13.x
-  - 1.14.x
 
 go_import_path: k8s.io/kops
 
@@ -13,11 +11,6 @@ script:
   - GOPROXY=https://proxy.golang.org make nodeup examples test
 
 jobs:
-  # Exclude GO 1.14 for OSX until it becomes the default because of limited availability
-  exclude:
-    - os: osx
-      go: 1.14.x
-
   include:
     - name: Verify
       os: linux


### PR DESCRIPTION
GO 1.14 is planned for Kubernetes 1.19. There is no reason to keep CI jobs for it for Kubernetes 1.18.