### PR TITLE
Cache terraform's providers between tests

### DIFF
--- a/hack/verify-terraform.sh
+++ b/hack/verify-terraform.sh
@@ -26,17 +26,20 @@ CLUSTERS_0_11=(
 )
 
 # Terraform versions
-TAG_0_12=0.12.24
+TAG_0_13=0.13.0-beta2
 TAG_0_11=0.11.14
+
+PROVIDER_CACHE=$(mktemp -d)
+trap '{ rm -rf ${PROVIDER_CACHE}; }' EXIT
 
 RC=0
 while IFS= read -r -d '' -u 3 test_dir; do
   [ -f "${test_dir}/kubernetes.tf" ] || [ -f "${test_dir}/kubernetes.tf.json" ] || continue
   echo -e "${test_dir}\n"
   cluster=$(basename "${test_dir}")
-  kube::util::array_contains "${cluster}" "${CLUSTERS_0_11[@]}" && tag=$TAG_0_11 || tag=$TAG_0_12
+  kube::util::array_contains "${cluster}" "${CLUSTERS_0_11[@]}" && tag=$TAG_0_11 || tag=$TAG_0_13
 
-  docker run --rm -v "${test_dir}":"${test_dir}" -w "${test_dir}" --entrypoint=sh hashicorp/terraform:$tag -c '/bin/terraform init >/dev/null && /bin/terraform validate' || RC=$?
+  docker run --rm -e "TF_PLUGIN_CACHE_DIR=${PROVIDER_CACHE}" -v "${PROVIDER_CACHE}:${PROVIDER_CACHE}" -v "${test_dir}":"${test_dir}" -w "${test_dir}" --entrypoint=sh hashicorp/terraform:$tag -c '/bin/terraform init >/dev/null && /bin/terraform validate' || RC=$?
 done 3< <(find "${KOPS_ROOT}/tests/integration/update_cluster" -type d -maxdepth 1 -print0)
 
 if [ $RC != 0 ]; then


### PR DESCRIPTION
The provider binaries are in the hundreds of MBs and by defaulta are redownloaded into each integration tests' directory, this is a waste of bandwidth, time, and space.

TF supports specifying a [provider cache directory](https://www.terraform.io/docs/configuration/providers.html#provider-plugin-cache) which will avoid redownloading them and storing them in multiple places, which should speed up the job time by a bit.

I was having trouble getting it to work with TF 0.12 so I bumped us up to the latest 0.13 beta (stable is scheduled for ~1 month from now)