### PR TITLE
Prepatory refactoring of BootstrapScript

### DIFF
--- a/pkg/model/BUILD.bazel
+++ b/pkg/model/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "//upup/pkg/fi/cloudup/openstack:go_default_library",
         "//upup/pkg/fi/cloudup/openstacktasks:go_default_library",
         "//upup/pkg/fi/fitasks:go_default_library",
+        "//upup/pkg/fi/utils:go_default_library",
         "//util/pkg/architectures:go_default_library",
         "//util/pkg/vfs:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",

--- a/pkg/model/bootstrapscript_test.go
+++ b/pkg/model/bootstrapscript_test.go
@@ -53,6 +53,14 @@ func Test_ProxyFunc(t *testing.T) {
 	}
 }
 
+type nodeupConfigBuilder struct {
+	cluster *kops.Cluster
+}
+
+func (n *nodeupConfigBuilder) BuildConfig(ig *kops.InstanceGroup) (*nodeup.Config, error) {
+	return nodeup.NewConfig(n.cluster, ig), nil
+}
+
 func TestBootstrapUserData(t *testing.T) {
 	cs := []struct {
 		Role               kops.InstanceGroupRole
@@ -114,12 +122,8 @@ func TestBootstrapUserData(t *testing.T) {
 		cluster := makeTestCluster(x.HookSpecRoles, x.FileAssetSpecRoles)
 		group := makeTestInstanceGroup(x.Role, x.HookSpecRoles, x.FileAssetSpecRoles)
 
-		renderNodeUpConfig := func(ig *kops.InstanceGroup) (*nodeup.Config, error) {
-			return nodeup.NewConfig(cluster, ig), nil
-		}
-
 		bs := &BootstrapScript{
-			NodeUpConfigBuilder: renderNodeUpConfig,
+			NodeUpConfigBuilder: &nodeupConfigBuilder{cluster: cluster},
 			NodeUpSource: map[architectures.Architecture]string{
 				architectures.ArchitectureAmd64: "NUSourceAmd64",
 				architectures.ArchitectureArm64: "NUSourceArm64",

--- a/pkg/model/openstackmodel/servergroup_test.go
+++ b/pkg/model/openstackmodel/servergroup_test.go
@@ -2713,9 +2713,7 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 		t.Run(testCase.desc, func(t *testing.T) {
 			clusterLifecycle := fi.LifecycleSync
 			bootstrapScriptBuilder := &model.BootstrapScript{
-				NodeUpConfigBuilder: func(ig *kops.InstanceGroup) (*nodeup.Config, error) {
-					return &nodeup.Config{}, nil
-				},
+				NodeUpConfigBuilder: &nodeupConfigBuilder{},
 				NodeUpSource: map[architectures.Architecture]string{
 					architectures.ArchitectureAmd64: "source-amd64",
 					architectures.ArchitectureArm64: "source-arm64",
@@ -3181,11 +3179,16 @@ func compareErrors(t *testing.T, actual, expected error) {
 	}
 }
 
+type nodeupConfigBuilder struct {
+}
+
+func (n *nodeupConfigBuilder) BuildConfig(ig *kops.InstanceGroup) (*nodeup.Config, error) {
+	return &nodeup.Config{}, nil
+}
+
 func mustUserdataForClusterInstance(cluster *kops.Cluster, ig *kops.InstanceGroup) string {
 	bootstrapScriptBuilder := &model.BootstrapScript{
-		NodeUpConfigBuilder: func(ig *kops.InstanceGroup) (*nodeup.Config, error) {
-			return &nodeup.Config{}, nil
-		},
+		NodeUpConfigBuilder: &nodeupConfigBuilder{},
 		NodeUpSource: map[architectures.Architecture]string{
 			architectures.ArchitectureAmd64: "source-amd64",
 			architectures.ArchitectureArm64: "source-arm64",

--- a/upup/pkg/fi/cloudup/tagbuilder.go
+++ b/upup/pkg/fi/cloudup/tagbuilder.go
@@ -67,7 +67,7 @@ func buildCloudupTags(cluster *api.Cluster) (sets.String, error) {
 	return tags, nil
 }
 
-func buildNodeupTags(role api.InstanceGroupRole, cluster *api.Cluster, clusterTags sets.String) (sets.String, error) {
+func buildNodeupTags(cluster *api.Cluster, clusterTags sets.String) (sets.String, error) {
 	tags := sets.NewString()
 
 	networking := cluster.Spec.Networking

--- a/upup/pkg/fi/cloudup/tagbuilder_test.go
+++ b/upup/pkg/fi/cloudup/tagbuilder_test.go
@@ -79,7 +79,7 @@ func TestBuildTags_CloudProvider_AWS_Weave(t *testing.T) {
 		t.Fatal("tag _aws not found")
 	}
 
-	nodeUpTags, err := buildNodeupTags(api.InstanceGroupRoleNode, c, tags)
+	nodeUpTags, err := buildNodeupTags(c, tags)
 	if err != nil {
 		t.Fatalf("buildNodeupTags error: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestBuildTags_CloudProvider_AWS_Flannel(t *testing.T) {
 		t.Fatal("tag _aws not found")
 	}
 
-	nodeUpTags, err := buildNodeupTags(api.InstanceGroupRoleNode, c, tags)
+	nodeUpTags, err := buildNodeupTags(c, tags)
 	if err != nil {
 		t.Fatalf("buildNodeupTags error: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestBuildTags_CloudProvider_AWS_Calico(t *testing.T) {
 		t.Fatal("tag _aws not found")
 	}
 
-	nodeUpTags, err := buildNodeupTags(api.InstanceGroupRoleNode, c, tags)
+	nodeUpTags, err := buildNodeupTags(c, tags)
 	if err != nil {
 		t.Fatalf("buildNodeupTags error: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestBuildTags_CloudProvider_AWS_Canal(t *testing.T) {
 		t.Fatal("tag _aws not found")
 	}
 
-	nodeUpTags, err := buildNodeupTags(api.InstanceGroupRoleNode, c, tags)
+	nodeUpTags, err := buildNodeupTags(c, tags)
 	if err != nil {
 		t.Fatalf("buildNodeupTags error: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestBuildTags_CloudProvider_AWS(t *testing.T) {
 		t.Fatal("tag _aws not found")
 	}
 
-	nodeUpTags, err := buildNodeupTags(api.InstanceGroupRoleNode, c, tags)
+	nodeUpTags, err := buildNodeupTags(c, tags)
 	if err != nil {
 		t.Fatalf("buildNodeupTags error: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestBuildTags_UpdatePolicy_Nil(t *testing.T) {
 		t.Fatalf("buildCloudupTags error: %v", err)
 	}
 
-	nodeUpTags, err := buildNodeupTags(api.InstanceGroupRoleNode, c, tags)
+	nodeUpTags, err := buildNodeupTags(c, tags)
 	if err != nil {
 		t.Fatalf("buildNodeupTags error: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestBuildTags_UpdatePolicy_None(t *testing.T) {
 		t.Fatalf("buildTags error: %v", err)
 	}
 
-	nodeUpTags, err := buildNodeupTags(api.InstanceGroupRoleNode, c, tags)
+	nodeUpTags, err := buildNodeupTags(c, tags)
 	if err != nil {
 		t.Fatalf("buildNodeupTags error: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestBuildTags_CloudProvider_AWS_Cilium(t *testing.T) {
 		t.Fatal("tag _aws not found")
 	}
 
-	nodeUpTags, err := buildNodeupTags(api.InstanceGroupRoleNode, c, tags)
+	nodeUpTags, err := buildNodeupTags(c, tags)
 	if err != nil {
 		t.Fatalf("buildNodeupTags error: %v", err)
 	}

--- a/upup/pkg/fi/resources.go
+++ b/upup/pkg/fi/resources.go
@@ -207,6 +207,7 @@ type ResourceHolder struct {
 }
 
 var _ Resource = &ResourceHolder{}
+var _ HasDependencies = &ResourceHolder{}
 
 // Open implements the Open method of the Resource interface
 func (o *ResourceHolder) Open() (io.Reader, error) {
@@ -214,6 +215,13 @@ func (o *ResourceHolder) Open() (io.Reader, error) {
 		return nil, fmt.Errorf("ResourceHolder %q is not bound", o.Name)
 	}
 	return o.Resource.Open()
+}
+
+func (r *ResourceHolder) GetDependencies(tasks map[string]Task) []Task {
+	if hasDependencies, ok := r.Resource.(HasDependencies); ok {
+		return hasDependencies.GetDependencies(tasks)
+	}
+	return nil
 }
 
 // UnmarshalJSON implements the special JSON marshaling for the resource, rendering the name


### PR DESCRIPTION
In order to issue the `kubernetes-master` server cert out of nodeup, I'm going to need to pass the loadbalancer IP in userdata. That means the code that is currently in `BootstrapScript.ResourceNodeUp()` is going to have to run later, after the load balancer IPs have been determined.

This refactoring is in preparation for that. It pulls code out of `BootstrapScript.NodeupConfigBuilder` that probably should not be run later.