### PR TITLE
Fix: dns-controller: 3999 port address already in use

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -1910,6 +1910,8 @@ metadata:
     version: v1.18.0-alpha.3
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       k8s-app: dns-controller

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -9,6 +9,8 @@ metadata:
     version: v1.18.0-alpha.3
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       k8s-app: dns-controller

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -65,7 +65,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 05888879a235e345795776c9678acf2f15e92c56
+    manifestHash: e49c5642ebc6965566cc03891a8e116030684d00
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -12,6 +12,8 @@ spec:
   selector:
     matchLabels:
       k8s-app: dns-controller
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -65,7 +65,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 05888879a235e345795776c9678acf2f15e92c56
+    manifestHash: e49c5642ebc6965566cc03891a8e116030684d00
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -12,6 +12,8 @@ spec:
   selector:
     matchLabels:
       k8s-app: dns-controller
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -65,7 +65,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 05888879a235e345795776c9678acf2f15e92c56
+    manifestHash: e49c5642ebc6965566cc03891a8e116030684d00
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -65,7 +65,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 05888879a235e345795776c9678acf2f15e92c56
+    manifestHash: e49c5642ebc6965566cc03891a8e116030684d00
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io


### PR DESCRIPTION
Fixes #4877

The main problem is using the default rolling upgrade strategy. If the `dns-controller` is created on the same node during the upgrade we are seeing this issue as this is `hostNetwork` pod

```
panic: listen tcp4 0.0.0.0:3998: bind: address already in use
```

example:
```
dns-controller-5f88fdd576-d8d6m     0/1     CrashLoopBackOff   11         35m   172.16.45.40        ip-172-16-45-40.us-west-2.compute.internal    <none>           <none>
dns-controller-68f76b5848-kdfhm     1/1     Running            0          51m   172.16.45.40        ip-172-16-45-40.us-west-2.compute.internal    <none>           <none>
```

This PR will use `Recreate` strategy to avoid this issue 
