### PR TITLE
Add master and node image options when creating a cluster

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -305,8 +305,8 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().Int32Var(&options.NodeCount, "node-count", options.NodeCount, "Set number of nodes")
 
 	cmd.Flags().StringVar(&options.Image, "image", options.Image, "Set image for all instances.")
-	cmd.Flags().StringVar(&options.NodeImage, "node-image", options.NodeImage, "Set image for nodes")
-	cmd.Flags().StringVar(&options.MasterImage, "master-image", options.MasterImage, "Set image for masters")
+	cmd.Flags().StringVar(&options.NodeImage, "node-image", options.NodeImage, "Set image for nodes. Takes precedence over --image")
+	cmd.Flags().StringVar(&options.MasterImage, "master-image", options.MasterImage, "Set image for masters. Takes precedence over --image")
 
 	cmd.Flags().StringVar(&options.NodeSize, "node-size", options.NodeSize, "Set instance size for nodes")
 	cmd.Flags().StringVar(&options.MasterSize, "master-size", options.MasterSize, "Set instance size for masters")

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -83,9 +83,10 @@ kops create cluster [flags]
       --etcd-storage-type string         The default storage type for etc members
       --gce-service-account string       Service account with which the GCE VM runs. Warning: if not set, VMs will run as default compute service account.
   -h, --help                             help for cluster
-      --image string                     Image to use for all instances.
+      --image string                     Set image for all instances.
       --kubernetes-version string        Version of kubernetes to run (defaults to version in channel)
-      --master-count int32               Set the number of masters.  Defaults to one master per master-zone
+      --master-count int32               Set number of masters. Defaults to one master per master-zone
+      --master-image string              Set image for masters
       --master-public-name string        Sets the public master public name
       --master-security-groups strings   Add precreated additional security groups to masters.
       --master-size string               Set instance size for masters
@@ -95,7 +96,8 @@ kops create cluster [flags]
       --model string                     Models to apply (separate multiple models with commas) (default "proto,cloudup")
       --network-cidr string              Set to override the default network CIDR
       --networking string                Networking mode to use.  kubenet, external, weave, flannel-vxlan (or flannel), flannel-udp, calico, canal, kube-router, amazon-vpc-routed-eni, cilium, cni, lyftvpc. (default "kubenet")
-      --node-count int32                 Set the number of nodes
+      --node-count int32                 Set number of nodes
+      --node-image string                Set image for nodes
       --node-security-groups strings     Add precreated additional security groups to nodes.
       --node-size string                 Set instance size for nodes
       --node-tenancy string              The tenancy of the node group on AWS. Can be either default or dedicated.

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -86,7 +86,7 @@ kops create cluster [flags]
       --image string                     Set image for all instances.
       --kubernetes-version string        Version of kubernetes to run (defaults to version in channel)
       --master-count int32               Set number of masters. Defaults to one master per master-zone
-      --master-image string              Set image for masters
+      --master-image string              Set image for masters. Takes precedence over --image
       --master-public-name string        Sets the public master public name
       --master-security-groups strings   Add precreated additional security groups to masters.
       --master-size string               Set instance size for masters
@@ -97,7 +97,7 @@ kops create cluster [flags]
       --network-cidr string              Set to override the default network CIDR
       --networking string                Networking mode to use.  kubenet, external, weave, flannel-vxlan (or flannel), flannel-udp, calico, canal, kube-router, amazon-vpc-routed-eni, cilium, cni, lyftvpc. (default "kubenet")
       --node-count int32                 Set number of nodes
-      --node-image string                Set image for nodes
+      --node-image string                Set image for nodes. Takes precedence over --image
       --node-security-groups strings     Add precreated additional security groups to nodes.
       --node-size string                 Set instance size for nodes
       --node-tenancy string              The tenancy of the node group on AWS. Can be either default or dedicated.


### PR DESCRIPTION
As discussed during office hours, we decided to add these new options to help test ARM64 deployments.