### PR TITLE
Start pushing create_cluster logic into pkg

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog"
-	"k8s.io/kops"
 	"k8s.io/kops/cmd/kops/util"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/model"
@@ -407,11 +406,6 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 		return fmt.Errorf("unable to execute --dry-run without setting --output")
 	}
 
-	clusterName := c.ClusterName
-	if clusterName == "" {
-		return fmt.Errorf("--name is required")
-	}
-
 	// TODO: Reuse rootCommand stateStore logic?
 
 	if c.OutDir == "" {
@@ -429,7 +423,16 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 		return err
 	}
 
-	cluster, err := clientset.GetCluster(ctx, clusterName)
+	options := &cloudup.NewClusterOptions{
+		Name:    c.ClusterName,
+		Channel: c.Channel,
+	}
+
+	if options.Name == "" {
+		return fmt.Errorf("--name is required")
+	}
+
+	cluster, err := clientset.GetCluster(ctx, options.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			cluster = nil
@@ -439,26 +442,16 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 	}
 
 	if cluster != nil {
-		return fmt.Errorf("cluster %q already exists; use 'kops update cluster' to apply changes", clusterName)
+		return fmt.Errorf("cluster %q already exists; use 'kops update cluster' to apply changes", options.Name)
 	}
 
-	cluster = &api.Cluster{}
-	cluster.ObjectMeta.Name = clusterName
-
-	channel, err := api.LoadChannel(c.Channel)
+	clusterResult, err := cloudup.NewCluster(options)
 	if err != nil {
 		return err
 	}
 
-	if channel.Spec.Cluster != nil {
-		cluster.Spec = *channel.Spec.Cluster
-
-		kubernetesVersion := api.RecommendedKubernetesVersion(channel, kops.Version)
-		if kubernetesVersion != nil {
-			cluster.Spec.KubernetesVersion = kubernetesVersion.String()
-		}
-	}
-	cluster.Spec.Channel = c.Channel
+	// TODO: push more of the following logic into cloudup.NewCluster()
+	cluster = clusterResult.Cluster
 
 	cluster.Spec.ConfigBase = c.ConfigBase
 	configBase, err := clientset.ConfigBaseFor(cluster)
@@ -1110,9 +1103,9 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 			bastionGroup.Spec.Image = c.Image
 			instanceGroups = append(instanceGroups, bastionGroup)
 
-			if !dns.IsGossipHostname(clusterName) {
+			if !dns.IsGossipHostname(cluster.Name) {
 				cluster.Spec.Topology.Bastion = &api.BastionSpec{
-					BastionPublicName: "bastion." + clusterName,
+					BastionPublicName: "bastion." + cluster.Name,
 				}
 			}
 		}
@@ -1249,7 +1242,7 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 
 	var fullInstanceGroups []*api.InstanceGroup
 	for _, group := range instanceGroups {
-		fullGroup, err := cloudup.PopulateInstanceGroupSpec(fullCluster, group, channel)
+		fullGroup, err := cloudup.PopulateInstanceGroupSpec(fullCluster, group, clusterResult.Channel)
 		if err != nil {
 			return err
 		}
@@ -1361,7 +1354,7 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 		//  updateClusterOptions.MaxTaskDuration = c.MaxTaskDuration
 		//  updateClusterOptions.CreateKubecfg = c.CreateKubecfg
 
-		_, err := RunUpdateCluster(ctx, f, clusterName, out, updateClusterOptions)
+		_, err := RunUpdateCluster(ctx, f, cluster.Name, out, updateClusterOptions)
 		if err != nil {
 			return err
 		}
@@ -1373,15 +1366,15 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 			fmt.Fprintf(&sb, "\n")
 			fmt.Fprintf(&sb, "Suggestions:\n")
 			fmt.Fprintf(&sb, " * list clusters with: kops get cluster\n")
-			fmt.Fprintf(&sb, " * edit this cluster with: kops edit cluster %s\n", clusterName)
+			fmt.Fprintf(&sb, " * edit this cluster with: kops edit cluster %s\n", cluster.Name)
 			if len(nodes) > 0 {
-				fmt.Fprintf(&sb, " * edit your node instance group: kops edit ig --name=%s %s\n", clusterName, nodes[0].ObjectMeta.Name)
+				fmt.Fprintf(&sb, " * edit your node instance group: kops edit ig --name=%s %s\n", cluster.Name, nodes[0].ObjectMeta.Name)
 			}
 			if len(masters) > 0 {
-				fmt.Fprintf(&sb, " * edit your master instance group: kops edit ig --name=%s %s\n", clusterName, masters[0].ObjectMeta.Name)
+				fmt.Fprintf(&sb, " * edit your master instance group: kops edit ig --name=%s %s\n", cluster.Name, masters[0].ObjectMeta.Name)
 			}
 			fmt.Fprintf(&sb, "\n")
-			fmt.Fprintf(&sb, "Finally configure your cluster with: kops update cluster --name %s --yes\n", clusterName)
+			fmt.Fprintf(&sb, "Finally configure your cluster with: kops update cluster --name %s --yes\n", cluster.Name)
 			fmt.Fprintf(&sb, "\n")
 
 			_, err := out.Write(sb.Bytes())

--- a/upup/pkg/fi/cloudup/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "dns.go",
         "loader.go",
         "networking.go",
+        "new_cluster.go",
         "phase.go",
         "populate_cluster_spec.go",
         "populate_instancegroup_spec.go",

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudup
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kops"
+	api "k8s.io/kops/pkg/apis/kops"
+)
+
+type NewClusterOptions struct {
+	// Name is the name of the cluster to initialize.
+	Name string
+
+	// Channel is a channel location for initializing the cluster.
+	Channel string
+}
+
+type NewClusterResult struct {
+	// Cluster is the initialized Cluster resource.
+	Cluster *api.Cluster
+
+	// TODO remove after more create_cluster logic refactored in
+	Channel *api.Channel
+}
+
+// NewCluster initializes cluster and instance groups specifications as
+// intended for newly created clusters.
+func NewCluster(opt *NewClusterOptions) (*NewClusterResult, error) {
+	if opt.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	channel, err := api.LoadChannel(opt.Channel)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster := api.Cluster{
+		ObjectMeta: v1.ObjectMeta{
+			Name: opt.Name,
+		},
+	}
+
+	if channel.Spec.Cluster != nil {
+		cluster.Spec = *channel.Spec.Cluster
+
+		kubernetesVersion := api.RecommendedKubernetesVersion(channel, kops.Version)
+		if kubernetesVersion != nil {
+			cluster.Spec.KubernetesVersion = kubernetesVersion.String()
+		}
+	}
+	cluster.Spec.Channel = opt.Channel
+
+	result := NewClusterResult{
+		Cluster: &cluster,
+		Channel: channel,
+	}
+	return &result, nil
+}


### PR DESCRIPTION
This is initial work in pushing some of the logic that is in create_cluster into pkg for use as an import.

My intent for `NewCluster()` is for it to initialize the cluster and instance group specs, but not query or update the cluster state in the state store.

We try to approximate GitOps and want to avoid configuration drift between "defaults for new clusters" and "defaults or existing clusters". Our existing update cluster code always goes through a `kops create cluster --dry-run` for that reason and we would like to instead call this `NewCluster()` code.