### PR TITLE
Enable nodeport by default

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -1019,7 +1019,14 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 	case "amazonvpc", "amazon-vpc-routed-eni":
 		cluster.Spec.Networking.AmazonVPC = &api.AmazonVPCNetworkingSpec{}
 	case "cilium":
-		cluster.Spec.Networking.Cilium = &api.CiliumNetworkingSpec{}
+		cluster.Spec.Networking.Cilium = &api.CiliumNetworkingSpec{
+			EnableNodePort: true,
+		}
+		if cluster.Spec.KubeProxy == nil {
+			cluster.Spec.KubeProxy = &api.KubeProxyConfig{}
+		}
+		enabled := false
+		cluster.Spec.KubeProxy.Enabled = &enabled
 	case "lyftvpc":
 		cluster.Spec.Networking.LyftVPC = &api.LyftVPCNetworkingSpec{}
 	case "gce":

--- a/docs/networking/cilium.md
+++ b/docs/networking/cilium.md
@@ -64,7 +64,7 @@ Then enable etcd as kvstore:
 
 ### Enabling BPF NodePort
 
-As of kops 1.19, BPF NodePort is enabled by default for new clusters. It can be safely enabled as of kops 1.18.
+As of kops 1.19, BPF NodePort is enabled by default for new clusters if the kubernetes version is 1.12 or newer. It can be safely enabled as of kops 1.18.
 
 In this mode, the cluster is fully functional without kube-proxy, with Cilium replacing kube-proxy's NodePort implementation using BPF.
 Read more about this in the [Cilium docs](https://docs.cilium.io/en/stable/gettingstarted/nodeport/)

--- a/docs/networking/cilium.md
+++ b/docs/networking/cilium.md
@@ -64,7 +64,7 @@ Then enable etcd as kvstore:
 
 ### Enabling BPF NodePort
 
-As of Kops 1.18 you can safely enable Cilium NodePort.
+As of kops 1.19, BPF NodePort is enabled by default for new clusters. It can be safely enabled as of kops 1.18.
 
 In this mode, the cluster is fully functional without kube-proxy, with Cilium replacing kube-proxy's NodePort implementation using BPF.
 Read more about this in the [Cilium docs](https://docs.cilium.io/en/stable/gettingstarted/nodeport/)

--- a/docs/releases/1.19-NOTES.md
+++ b/docs/releases/1.19-NOTES.md
@@ -10,7 +10,7 @@
 
 * Alpha support for Hashicorp Vault as store for secrets and keys. See the [Vault state store docs](/state/#vault-vault).
 
-* New clusters running Cilium will have enabled BPF NodePort by default.
+* New clusters running Cilium will have enabled BPF NodePort by default if kubernetes version is 1.12 or newer.
   
 # Breaking changes
 

--- a/docs/releases/1.19-NOTES.md
+++ b/docs/releases/1.19-NOTES.md
@@ -9,6 +9,8 @@
 * Clusters using the Amazon VPC CNI provider now perform an `ec2.DescribeInstanceTypes` call at instance launch time. In large clusters or AWS accounts this may lead to API throttling which could delay node readiness. If this becomes a problem please open a GitHub issue.
 
 * Alpha support for Hashicorp Vault as store for secrets and keys. See the [Vault state store docs](/state/#vault-vault).
+
+* New clusters running Cilium will have enabled BPF NodePort by default.
   
 # Breaking changes
 


### PR DESCRIPTION
Upstream default since cilium 1.7 and perhaps the primary reason why people pick cilium.