### PR TITLE
Fix dns selectors for older k8s

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -1281,7 +1281,7 @@ spec:
           - --logtostderr=true
           - --v=2
       nodeSelector:
-        kubernetes.io/arch: amd64
+        kubernetes.io/role: master
       priorityClassName: system-cluster-critical
       tolerations:
       - key: "CriticalAddonsOnly"
@@ -2706,7 +2706,7 @@ spec:
           - --logtostderr=true
           - --v=2
       nodeSelector:
-        kubernetes.io/arch: amd64
+        kubernetes.io/role: master
       priorityClassName: system-cluster-critical
       tolerations:
       - key: "CriticalAddonsOnly"
@@ -3062,9 +3062,13 @@ spec:
           - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
           - --logtostderr=true
           - --v=2
+      nodeSelector:
+        kubernetes.io/role: master
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
+      - key: node-role.kubernetes.io/master
+        operator: Exists
       serviceAccountName: kube-dns-autoscaler
 
 ---

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -119,7 +119,7 @@ spec:
           - --logtostderr=true
           - --v=2
       nodeSelector:
-        kubernetes.io/arch: amd64
+        kubernetes.io/role: master
       priorityClassName: system-cluster-critical
       tolerations:
       - key: "CriticalAddonsOnly"

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
@@ -70,7 +70,7 @@ spec:
           - --logtostderr=true
           - --v=2
       nodeSelector:
-        kubernetes.io/arch: amd64
+        kubernetes.io/role: master
       priorityClassName: system-cluster-critical
       tolerations:
       - key: "CriticalAddonsOnly"

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -68,9 +68,13 @@ spec:
           - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
           - --logtostderr=true
           - --v=2
+      nodeSelector:
+        kubernetes.io/role: master
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
+      - key: node-role.kubernetes.io/master
+        operator: Exists
       serviceAccountName: kube-dns-autoscaler
 
 ---

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -21,7 +21,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 7778a47fa6bda0bae9e0eeea1593a117a9b8bba4
+    manifestHash: 9fd3af6ffc7eb38e9e4d65326eff859dbe188be6
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -29,7 +29,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c1d396ba1997d0eb54586cc14da24fb07548e215
+    manifestHash: 5542a0a05fb3bf378d7aebebf0f5dcf2c4b2071e
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -21,7 +21,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 7778a47fa6bda0bae9e0eeea1593a117a9b8bba4
+    manifestHash: 9fd3af6ffc7eb38e9e4d65326eff859dbe188be6
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -29,7 +29,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c1d396ba1997d0eb54586cc14da24fb07548e215
+    manifestHash: 5542a0a05fb3bf378d7aebebf0f5dcf2c4b2071e
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -21,7 +21,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 7778a47fa6bda0bae9e0eeea1593a117a9b8bba4
+    manifestHash: 9fd3af6ffc7eb38e9e4d65326eff859dbe188be6
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -29,7 +29,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c1d396ba1997d0eb54586cc14da24fb07548e215
+    manifestHash: 5542a0a05fb3bf378d7aebebf0f5dcf2c4b2071e
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -21,7 +21,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 7778a47fa6bda0bae9e0eeea1593a117a9b8bba4
+    manifestHash: 9fd3af6ffc7eb38e9e4d65326eff859dbe188be6
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -29,7 +29,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c1d396ba1997d0eb54586cc14da24fb07548e215
+    manifestHash: 5542a0a05fb3bf378d7aebebf0f5dcf2c4b2071e
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io


### PR DESCRIPTION
Use `kubernetes.io/role` instead of `kubernetes.io/arch` as nodeselector. This will work for all supported versions of K8s.
ref #9418 

/cc @hakman @johngmyers 