### PR TITLE
Spotinst: Add missing lifecycle to awstasks.SecurityGroup

### DIFF
--- a/pkg/model/spotinstmodel/instance_group.go
+++ b/pkg/model/spotinstmodel/instance_group.go
@@ -572,9 +572,10 @@ func (b *InstanceGroupModelBuilder) buildSecurityGroups(c *fi.ModelBuilderContex
 
 	for _, id := range ig.Spec.AdditionalSecurityGroups {
 		sg := &awstasks.SecurityGroup{
-			Name:   fi.String(id),
-			ID:     fi.String(id),
-			Shared: fi.Bool(true),
+			Lifecycle: b.SecurityLifecycle,
+			ID:        fi.String(id),
+			Name:      fi.String(id),
+			Shared:    fi.Bool(true),
 		}
 		if err := c.EnsureTask(sg); err != nil {
 			return nil, err


### PR DESCRIPTION
This PR aligns the [Spotinst Instance Group model](https://github.com/kubernetes/kops/blob/master/pkg/model/spotinstmodel/instance_group.go#L573-L583) with the [AWS one](https://github.com/kubernetes/kops/blob/master/pkg/model/awsmodel/autoscalinggroup.go#L218-L229) by adding the missing `Lifecycle` field to `awstasks.SecurityGroup` for every additional security groups.