### PR TITLE
Automated cherry pick of #9451: Deploy cilium etcd credentials if the cilium cluster

### DIFF
--- a/docs/networking/cilium.md
+++ b/docs/networking/cilium.md
@@ -27,7 +27,9 @@ kops create cluster \
 
 ### Using etcd for agent state sync
 
-By default, Cilium will use CRDs for synchronizing agent state. This can cause performance problems on larger clusters. As of kops 1.18, kops can manage an etcd cluster using etcd-manager dedicated for cilium agent state sync. The [Cilium docs](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-external-etcd/) contains recommendations for this must be enabled.
+This feature is in beta state as of kops 1.18.
+
+By default, Cilium will use CRDs for synchronizing agent state. This can cause performance problems on larger clusters. As of kops 1.18, kops can manage an etcd cluster using etcd-manager dedicated for cilium agent state sync. The [Cilium docs](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-external-etcd/) contains recommendations for when this must be enabled.
 
 Add the following to `spec.etcdClusters`:
 Make sure `instanceGroup` match the other etcd clusters.
@@ -41,6 +43,15 @@ Make sure `instanceGroup` match the other etcd clusters.
     - instanceGroup: master-az-1c
       name: c
     name: cilium
+```
+
+If this is an existing cluster, it is important that you roll the entire cluster so that all the nodes can connect to the new etcd cluster.
+
+```sh
+kops update cluster
+kops update cluster --yes
+kops rolling-update cluster --force --yes
+
 ```
 
 Then enable etcd as kvstore:
@@ -60,6 +71,8 @@ Read more about this in the [Cilium docs](https://docs.cilium.io/en/stable/getti
 
 Be aware that you need to use an AMI with at least Linux 4.19.57 for this feature to work.
 
+Also be aware that while enabling this on an existing cluster is safe, disabling this is disruptive and requires you to run `kops rolling-upgrade cluster --cloudonly`.
+
 ```yaml
   kubeProxy:
     enabled: false
@@ -69,6 +82,8 @@ Be aware that you need to use an AMI with at least Linux 4.19.57 for this featur
 ```
 
 ### Enabling Cilium ENI IPAM
+
+This feature is in beta state as of kops 1.18.
 
 As of Kops 1.18, you can have Cilium provision AWS managed adresses and attach them directly to Pods much like Lyft VPC and AWS VPC. See [the Cilium docs for more information](https://docs.cilium.io/en/v1.6/concepts/ipam/eni/)
 

--- a/docs/networking/cilium.md
+++ b/docs/networking/cilium.md
@@ -45,7 +45,7 @@ Make sure `instanceGroup` match the other etcd clusters.
     name: cilium
 ```
 
-If this is an existing cluster, it is important that you roll the entire cluster so that all the nodes can connect to the new etcd cluster.
+If this is an existing cluster, it is important that you perform a rolling update on the entire cluster so that all the nodes can connect to the new etcd cluster.
 
 ```sh
 kops update cluster

--- a/nodeup/pkg/model/cilium.go
+++ b/nodeup/pkg/model/cilium.go
@@ -42,18 +42,28 @@ var _ fi.ModelBuilder = &CiliumBuilder{}
 func (b *CiliumBuilder) Build(c *fi.ModelBuilderContext) error {
 	networking := b.Cluster.Spec.Networking
 
+	// As long as the cilium cluster exists, we should do this
+	ciliumEtcd := false
+
+	for _, cluster := range b.Cluster.Spec.EtcdClusters {
+		if cluster.Name == "cilium" {
+			ciliumEtcd = true
+			break
+		}
+	}
+
+	if ciliumEtcd {
+		if err := b.buildCiliumEtcdSecrets(c); err != nil {
+			return err
+		}
+	}
+
 	if networking.Cilium == nil {
 		return nil
 	}
 
 	if err := b.buildBPFMount(c); err != nil {
 		return err
-	}
-
-	if networking.Cilium.EtcdManaged {
-		if err := b.buildCiliumEtcdSecrets(c); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/nodeup/pkg/model/cilium.go
+++ b/nodeup/pkg/model/cilium.go
@@ -42,7 +42,7 @@ var _ fi.ModelBuilder = &CiliumBuilder{}
 func (b *CiliumBuilder) Build(c *fi.ModelBuilderContext) error {
 	networking := b.Cluster.Spec.Networking
 
-	// As long as the cilium cluster exists, we should do this
+	// As long as the Cilium Etcd cluster exists, we should do this
 	ciliumEtcd := false
 
 	for _, cluster := range b.Cluster.Spec.EtcdClusters {

--- a/nodeup/pkg/model/cilium.go
+++ b/nodeup/pkg/model/cilium.go
@@ -161,7 +161,7 @@ func (b *CiliumBuilder) buildCiliumEtcdSecrets(c *fi.ModelBuilderContext) error 
 		}
 	}
 
-	name := "etcd-client"
+	name := "etcd-client-cilium"
 
 	humanName := dir + "/" + name
 	privateKey, err := pki.GeneratePrivateKey()

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -409,7 +409,7 @@ func (b *PolicyBuilder) AddS3Permissions(p *Policy) (*Policy, error) {
 						}
 
 						// @check if cilium is enabled as the CNI provider and permit access to the cilium etc client TLS certificate by default
-						// As long as the cilium cluster exists, we should do this
+						// As long as the Cilium Etcd cluster exists, we should do this
 						ciliumEtcd := false
 
 						for _, cluster := range b.Cluster.Spec.EtcdClusters {

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -409,7 +409,17 @@ func (b *PolicyBuilder) AddS3Permissions(p *Policy) (*Policy, error) {
 						}
 
 						// @check if cilium is enabled as the CNI provider and permit access to the cilium etc client TLS certificate by default
-						if networkingSpec.Cilium != nil && networkingSpec.Cilium.EtcdManaged {
+						// As long as the cilium cluster exists, we should do this
+						ciliumEtcd := false
+
+						for _, cluster := range b.Cluster.Spec.EtcdClusters {
+							if cluster.Name == "cilium" {
+								ciliumEtcd = true
+								break
+							}
+						}
+
+						if networkingSpec.Cilium != nil && ciliumEtcd {
 							p.Statement = append(p.Statement, &Statement{
 								Effect: StatementEffectAllow,
 								Action: stringorslice.Slice([]string{"s3:Get*"}),

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -4319,8 +4319,8 @@ data:
       - https://{{ $.MasterInternalName }}:4003
 
     trusted-ca-file: '/var/lib/etcd-secrets/etcd-ca.crt'
-    key-file: '/var/lib/etcd-secrets/etcd-client.key'
-    cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
+    key-file: '/var/lib/etcd-secrets/etcd-client-cilium.key'
+    cert-file: '/var/lib/etcd-secrets/etcd-client-cilium.crt'
 {{ end }}
 
   # Identity allocation mode selects how identities are shared between cilium

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -18,8 +18,8 @@ data:
       - https://{{ $.MasterInternalName }}:4003
 
     trusted-ca-file: '/var/lib/etcd-secrets/etcd-ca.crt'
-    key-file: '/var/lib/etcd-secrets/etcd-client.key'
-    cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
+    key-file: '/var/lib/etcd-secrets/etcd-client-cilium.key'
+    cert-file: '/var/lib/etcd-secrets/etcd-client-cilium.crt'
 {{ end }}
 
   # Identity allocation mode selects how identities are shared between cilium


### PR DESCRIPTION
Cherry pick of #9451 on release-1.18.

#9451: Deploy cilium etcd credentials if the cilium cluster

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.