### PR TITLE
Bump k8s versions for alpha channel with latest releases

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -59,13 +59,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.18.0-alpha.1"
-    recommendedVersion: 1.18.4
+    recommendedVersion: 1.18.5
     requiredVersion: 1.18.0
   - range: ">=1.17.0"
-    recommendedVersion: 1.17.7
+    recommendedVersion: 1.17.8
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
-    recommendedVersion: 1.16.11
+    recommendedVersion: 1.16.12
     requiredVersion: 1.16.0
   - range: ">=1.15.0"
     recommendedVersion: 1.15.12
@@ -93,15 +93,15 @@ spec:
   - range: ">=1.18.0-alpha.1"
     recommendedVersion: "1.18.0-beta.1"
     #requiredVersion: 1.18.0
-    kubernetesVersion: 1.18.4
+    kubernetesVersion: 1.18.5
   - range: ">=1.17.0-alpha.1"
     recommendedVersion: "1.17.0"
     #requiredVersion: 1.17.0
-    kubernetesVersion: 1.17.7
+    kubernetesVersion: 1.17.8
   - range: ">=1.16.0-alpha.1"
     recommendedVersion: "1.16.3"
     #requiredVersion: 1.16.0
-    kubernetesVersion: 1.16.11
+    kubernetesVersion: 1.16.12
   - range: ">=1.15.0-alpha.1"
     recommendedVersion: "1.15.3"
     #requiredVersion: 1.15.0


### PR DESCRIPTION
Updating alpha channel with k8s releases from yesterday.
The previously set versions in this channel seem to have had a bug/regression with hyperkube, so I figured there's no point pushing those into `stable` channel. Instead- we'll let the new releases bake-in for about a week and then push them to `stable`.
[More info about the bug in the release page](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md#bug-or-regression)