### PR TITLE
Update KubeDNS to v1.15.13

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -1265,7 +1265,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.4.0
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.8.1
         resources:
             requests:
                 cpu: "20m"
@@ -2691,7 +2691,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.4.0
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.8.1
         resources:
             requests:
                 cpu: "20m"
@@ -2772,7 +2772,7 @@ spec:
 
       containers:
       - name: kubedns
-        image: k8s.gcr.io/k8s-dns-kube-dns:1.14.13
+        image: k8s.gcr.io/k8s-dns-kube-dns:1.15.13
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -2866,7 +2866,7 @@ spec:
           mountPath: /etc/k8s/dns/dnsmasq-nanny
 
       - name: sidecar
-        image: k8s.gcr.io/k8s-dns-sidecar:1.14.13
+        image: k8s.gcr.io/k8s-dns-sidecar:1.15.13
         livenessProbe:
           httpGet:
             path: /metrics
@@ -3048,7 +3048,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2-r2
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.8.1
         resources:
             requests:
                 cpu: "20m"
@@ -3117,7 +3117,7 @@ spec:
 
       containers:
       - name: kubedns
-        image: k8s.gcr.io/k8s-dns-kube-dns:1.14.10
+        image: k8s.gcr.io/k8s-dns-kube-dns:1.15.13
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -3169,7 +3169,7 @@ spec:
           mountPath: /kube-dns-config
 
       - name: dnsmasq
-        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.10
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.15.13
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -3211,7 +3211,7 @@ spec:
           mountPath: /etc/k8s/dns/dnsmasq-nanny
 
       - name: sidecar
-        image: k8s.gcr.io/k8s-dns-sidecar:1.14.10
+        image: k8s.gcr.io/k8s-dns-sidecar:1.15.13
         livenessProbe:
           httpGet:
             path: /metrics

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -103,7 +103,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.4.0
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.8.1
         resources:
             requests:
                 cpu: "20m"

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.4.0
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.8.1
         resources:
             requests:
                 cpu: "20m"
@@ -134,7 +134,7 @@ spec:
 
       containers:
       - name: kubedns
-        image: k8s.gcr.io/k8s-dns-kube-dns:1.14.13
+        image: k8s.gcr.io/k8s-dns-kube-dns:1.15.13
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -228,7 +228,7 @@ spec:
           mountPath: /etc/k8s/dns/dnsmasq-nanny
 
       - name: sidecar
-        image: k8s.gcr.io/k8s-dns-sidecar:1.14.13
+        image: k8s.gcr.io/k8s-dns-sidecar:1.15.13
         livenessProbe:
           httpGet:
             path: /metrics

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2-r2
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.8.1
         resources:
             requests:
                 cpu: "20m"
@@ -121,7 +121,7 @@ spec:
 
       containers:
       - name: kubedns
-        image: k8s.gcr.io/k8s-dns-kube-dns:1.14.10
+        image: k8s.gcr.io/k8s-dns-kube-dns:1.15.13
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -173,7 +173,7 @@ spec:
           mountPath: /kube-dns-config
 
       - name: dnsmasq
-        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.10
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.15.13
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -215,7 +215,7 @@ spec:
           mountPath: /etc/k8s/dns/dnsmasq-nanny
 
       - name: sidecar
-        image: k8s.gcr.io/k8s-dns-sidecar:1.14.10
+        image: k8s.gcr.io/k8s-dns-sidecar:1.15.13
         livenessProbe:
           httpGet:
             path: /metrics

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -226,7 +226,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 		{
 			key := "kube-dns.addons.k8s.io"
-			version := "1.14.13-kops.2"
+			version := "1.15.13-kops.1"
 
 			{
 				location := key + "/k8s-1.6.yaml"
@@ -280,7 +280,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.6.7-kops.1"
+			version := "1.6.7-kops.2"
 
 			{
 				location := key + "/k8s-1.12.yaml"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -21,19 +21,19 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 9fd3af6ffc7eb38e9e4d65326eff859dbe188be6
+    manifestHash: dc3d42acafa02913589a75b6800ed22aa4ff97b1
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.13-kops.2
+    version: 1.15.13-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 5542a0a05fb3bf378d7aebebf0f5dcf2c4b2071e
+    manifestHash: bef376880342f3d48af99b0d9cb2298a0d77c620
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.13-kops.2
+    version: 1.15.13-kops.1
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
     manifestHash: 5d53ce7b920cd1e8d65d2306d80a041420711914

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -21,19 +21,19 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 9fd3af6ffc7eb38e9e4d65326eff859dbe188be6
+    manifestHash: dc3d42acafa02913589a75b6800ed22aa4ff97b1
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.13-kops.2
+    version: 1.15.13-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 5542a0a05fb3bf378d7aebebf0f5dcf2c4b2071e
+    manifestHash: bef376880342f3d48af99b0d9cb2298a0d77c620
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.13-kops.2
+    version: 1.15.13-kops.1
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
     manifestHash: 5d53ce7b920cd1e8d65d2306d80a041420711914

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -21,19 +21,19 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 9fd3af6ffc7eb38e9e4d65326eff859dbe188be6
+    manifestHash: dc3d42acafa02913589a75b6800ed22aa4ff97b1
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.13-kops.2
+    version: 1.15.13-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 5542a0a05fb3bf378d7aebebf0f5dcf2c4b2071e
+    manifestHash: bef376880342f3d48af99b0d9cb2298a0d77c620
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.13-kops.2
+    version: 1.15.13-kops.1
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
     manifestHash: 5d53ce7b920cd1e8d65d2306d80a041420711914

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -21,19 +21,19 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 9fd3af6ffc7eb38e9e4d65326eff859dbe188be6
+    manifestHash: dc3d42acafa02913589a75b6800ed22aa4ff97b1
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.13-kops.2
+    version: 1.15.13-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 5542a0a05fb3bf378d7aebebf0f5dcf2c4b2071e
+    manifestHash: bef376880342f3d48af99b0d9cb2298a0d77c620
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.13-kops.2
+    version: 1.15.13-kops.1
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
     manifestHash: 5d53ce7b920cd1e8d65d2306d80a041420711914


### PR DESCRIPTION
During the move from https://console.cloud.google.com/gcr/images/google-containers to https://console.cloud.google.com/gcr/images/k8s-artifacts-prod, some images were lost so older versions are not starting because of this.

This is also a good opportunity to bump the version to latest for `kube-dns` and `cluster-proportional-autoscaler`.