### PR TITLE
Create one nodes instance group per zone

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -215,7 +215,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&sshPublicKey, "ssh-public-key", sshPublicKey, "SSH public key to use (defaults to ~/.ssh/id_rsa.pub on AWS)")
 
 	cmd.Flags().Int32Var(&options.MasterCount, "master-count", options.MasterCount, "Set number of masters. Defaults to one master per master-zone")
-	cmd.Flags().Int32Var(&options.NodeCount, "node-count", options.NodeCount, "Set number of nodes")
+	cmd.Flags().Int32Var(&options.NodeCount, "node-count", options.NodeCount, "Set number of nodes. Defaults to one node per zone")
 
 	cmd.Flags().StringVar(&options.Image, "image", options.Image, "Set image for all instances.")
 	cmd.Flags().StringVar(&options.NodeImage, "node-image", options.NodeImage, "Set image for nodes. Takes precedence over --image")

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -215,7 +215,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&sshPublicKey, "ssh-public-key", sshPublicKey, "SSH public key to use (defaults to ~/.ssh/id_rsa.pub on AWS)")
 
 	cmd.Flags().Int32Var(&options.MasterCount, "master-count", options.MasterCount, "Set number of masters. Defaults to one master per master-zone")
-	cmd.Flags().Int32Var(&options.NodeCount, "node-count", options.NodeCount, "Set number of nodes. Defaults to one node per zone")
+	cmd.Flags().Int32Var(&options.NodeCount, "node-count", options.NodeCount, "Set total number of nodes. Defaults to one node per zone")
 
 	cmd.Flags().StringVar(&options.Image, "image", options.Image, "Set image for all instances.")
 	cmd.Flags().StringVar(&options.NodeImage, "node-image", options.NodeImage, "Set image for nodes. Takes precedence over --image")

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -95,7 +95,7 @@ kops create cluster [flags]
       --master-zones strings             Zones in which to run masters (must be an odd number)
       --network-cidr string              Set to override the default network CIDR
       --networking string                Networking mode to use.  kubenet, external, weave, flannel-vxlan (or flannel), flannel-udp, calico, canal, kube-router, amazonvpc, cilium, cilium-etcd, cni, lyftvpc. (default "kubenet")
-      --node-count int32                 Set number of nodes. Defaults to one node per zone
+      --node-count int32                 Set total number of nodes. Defaults to one node per zone
       --node-image string                Set image for nodes. Takes precedence over --image
       --node-security-groups strings     Add precreated additional security groups to nodes.
       --node-size string                 Set instance size for nodes

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -95,7 +95,7 @@ kops create cluster [flags]
       --master-zones strings             Zones in which to run masters (must be an odd number)
       --network-cidr string              Set to override the default network CIDR
       --networking string                Networking mode to use.  kubenet, external, weave, flannel-vxlan (or flannel), flannel-udp, calico, canal, kube-router, amazonvpc, cilium, cilium-etcd, cni, lyftvpc. (default "kubenet")
-      --node-count int32                 Set number of nodes
+      --node-count int32                 Set number of nodes. Defaults to one node per zone
       --node-image string                Set image for nodes. Takes precedence over --image
       --node-security-groups strings     Add precreated additional security groups to nodes.
       --node-size string                 Set instance size for nodes

--- a/docs/releases/1.19-NOTES.md
+++ b/docs/releases/1.19-NOTES.md
@@ -14,6 +14,8 @@ Similarly, `kops export kubecfg` will also require passing either the `--admin` 
 
 ## Other significant changes
 
+* New clusters will now have one nodes group per zone. The number of nodes now defaults to the number of zones.
+
 * On AWS kops now defaults to using launch templates instead of launch configurations.
 
 * Clusters using the Amazon VPC CNI provider now perform an `ec2.DescribeInstanceTypes` call at instance launch time. In large clusters or AWS accounts this may lead to API throttling which could delay node readiness. If this becomes a problem please open a GitHub issue.

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -79,14 +79,14 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: complex.example.com
-  name: nodes
+  name: nodes-us-test-1a
 spec:
   image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: t2.medium
-  maxSize: 2
-  minSize: 2
+  maxSize: 1
+  minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
@@ -83,15 +83,15 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: gce.example.com
-  name: nodes
+  name: nodes-us-test1-a
 spec:
   image: cos-cloud/cos-stable-65-10323-99-0
   machineType: n1-standard-2
-  maxSize: 2
-  minSize: 2
+  maxSize: 1
+  minSize: 1
   nodeLabels:
     cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-us-test1-a
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -135,16 +135,54 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: ha.example.com
-  name: nodes
+  name: nodes-us-test-1a
 spec:
   image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: t2.medium
-  maxSize: 2
-  minSize: 2
+  maxSize: 1
+  minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha.example.com
+  name: nodes-us-test-1b
+spec:
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-01-17
+  machineType: t2.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1b
+  role: Node
+  subnets:
   - us-test-1b
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha.example.com
+  name: nodes-us-test-1c
+spec:
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-01-17
+  machineType: t2.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1c
+  role: Node
+  subnets:
   - us-test-1c

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -141,16 +141,54 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: ha.example.com
-  name: nodes
+  name: nodes-us-test-1a
 spec:
   image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: t2.medium
-  maxSize: 2
-  minSize: 2
+  maxSize: 1
+  minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha.example.com
+  name: nodes-us-test-1b
+spec:
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-01-17
+  machineType: t2.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1b
+  role: Node
+  subnets:
   - us-test-1b
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha.example.com
+  name: nodes-us-test-1c
+spec:
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-01-17
+  machineType: t2.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1c
+  role: Node
+  subnets:
   - us-test-1c

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -137,19 +137,63 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: ha-gce.example.com
-  name: nodes
+  name: nodes-us-test1-a
 spec:
   image: cos-cloud/cos-stable-65-10323-99-0
   machineType: n1-standard-2
-  maxSize: 2
-  minSize: 2
+  maxSize: 1
+  minSize: 1
   nodeLabels:
     cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-us-test1-a
   role: Node
   subnets:
   - us-test1
   zones:
   - us-test1-a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha-gce.example.com
+  name: nodes-us-test1-b
+spec:
+  image: cos-cloud/cos-stable-65-10323-99-0
+  machineType: n1-standard-2
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
+    kops.k8s.io/instancegroup: nodes-us-test1-b
+  role: Node
+  subnets:
+  - us-test1
+  zones:
   - us-test1-b
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha-gce.example.com
+  name: nodes-us-test1-c
+spec:
+  image: cos-cloud/cos-stable-65-10323-99-0
+  machineType: n1-standard-2
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
+    kops.k8s.io/instancegroup: nodes-us-test1-c
+  role: Node
+  subnets:
+  - us-test1
+  zones:
   - us-test1-c

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -179,15 +179,34 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: ha.example.com
-  name: nodes
+  name: nodes-us-test-1a
 spec:
   image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: t2.medium
-  maxSize: 2
-  minSize: 2
+  maxSize: 1
+  minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha.example.com
+  name: nodes-us-test-1b
+spec:
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
+  machineType: t2.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1b
+  role: Node
+  subnets:
   - us-test-1b

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -107,14 +107,14 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: private.example.com
-  name: nodes
+  name: nodes-us-test-1a
 spec:
   image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: t2.medium
-  maxSize: 2
-  minSize: 2
+  maxSize: 1
+  minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
@@ -79,14 +79,14 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: minimal.example.com
-  name: nodes
+  name: nodes-us-test-1a
 spec:
   image: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: t2.medium
-  maxSize: 2
-  minSize: 2
+  maxSize: 1
+  minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -107,14 +107,14 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: private.example.com
-  name: nodes
+  name: nodes-us-test-1a
 spec:
   image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: t2.medium
-  maxSize: 2
-  minSize: 2
+  maxSize: 1
+  minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -82,14 +82,14 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: overrides.example.com
-  name: nodes
+  name: nodes-us-test-1a
 spec:
   image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: t2.medium
-  maxSize: 2
-  minSize: 2
+  maxSize: 1
+  minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -113,17 +113,17 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: private.example.com
-  name: nodes
+  name: nodes-us-test-1a
 spec:
   additionalSecurityGroups:
   - sg-exampleid
   - sg-exampleid2
   image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: t2.medium
-  maxSize: 2
-  minSize: 2
+  maxSize: 1
+  minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -87,14 +87,14 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: private-subnets.example.com
-  name: nodes
+  name: nodes-us-test-1a
 spec:
   image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: t2.medium
-  maxSize: 2
-  minSize: 2
+  maxSize: 1
+  minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
@@ -81,14 +81,14 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: subnet.example.com
-  name: nodes
+  name: nodes-us-test-1a
 spec:
   image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: t2.medium
-  maxSize: 2
-  minSize: 2
+  maxSize: 1
+  minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
@@ -81,14 +81,14 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: subnet.example.com
-  name: nodes
+  name: nodes-us-test-1a
 spec:
   image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: t2.medium
-  maxSize: 2
-  minSize: 2
+  maxSize: 1
+  minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -80,14 +80,14 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: vpc.example.com
-  name: nodes
+  name: nodes-us-test-1a
 spec:
   image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: t2.medium
-  maxSize: 2
-  minSize: 2
+  maxSize: 1
+  minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -715,8 +715,6 @@ func setupNodes(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetMap ma
 		count := countPerIG
 		if i < remainder {
 			count++
-		} else if count == 0 {
-			break
 		}
 
 		g := &api.InstanceGroup{}


### PR DESCRIPTION
Creates one nodes instance group per zone, restricted to that zone. Changes the default number of nodes to the number of zones. If fewer nodes than zones, only creates one instance group per node.

Fixes #8152 
