### PR TITLE
Fix where etcd-cluster-spec is writen when etcd's BackupStore is defined -v2

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -97,11 +97,19 @@ func (b *EtcdManagerBuilder) Build(c *fi.ModelBuilderContext) error {
 			return err
 		}
 
+		// Ensure a unique backup location for each etcd cluster
+		// if a backupStore is not specified.
+		var location string
+		if backupStore == "" {
+			location = "backups/etcd/" + etcdCluster.Name
+		}
+
 		c.AddTask(&fitasks.ManagedFile{
 			Contents:  fi.WrapResource(fi.NewBytesResource(d)),
 			Lifecycle: b.Lifecycle,
+			Base:      fi.String(backupStore),
 			// TODO: We need this to match the backup base (currently)
-			Location: fi.String("backups/etcd/" + etcdCluster.Name + "/control/etcd-cluster-spec"),
+			Location: fi.String(location + "/control/etcd-cluster-spec"),
 			Name:     fi.String("etcd-cluster-spec-" + name),
 		})
 

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -43,6 +43,7 @@ oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
+Base: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
 Contents:
   Name: ""
   Resource: |-
@@ -50,9 +51,10 @@ Contents:
       "memberCount": 1
     }
 Lifecycle: null
-Location: backups/etcd/events/control/etcd-cluster-spec
+Location: /control/etcd-cluster-spec
 Name: etcd-cluster-spec-events
 ---
+Base: memfs://clusters.example.com/minimal.example.com/backups/etcd-main
 Contents:
   Name: ""
   Resource: |-
@@ -60,9 +62,10 @@ Contents:
       "memberCount": 1
     }
 Lifecycle: null
-Location: backups/etcd/main/control/etcd-cluster-spec
+Location: /control/etcd-cluster-spec
 Name: etcd-cluster-spec-main
 ---
+Base: null
 Contents:
   Name: ""
   Resource: |
@@ -128,6 +131,7 @@ Lifecycle: null
 Location: manifests/etcd/events.yaml
 Name: manifests-etcdmanager-events
 ---
+Base: null
 Contents:
   Name: ""
   Resource: |

--- a/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
@@ -43,6 +43,7 @@ oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
+Base: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
 Contents:
   Name: ""
   Resource: |-
@@ -50,9 +51,10 @@ Contents:
       "memberCount": 1
     }
 Lifecycle: null
-Location: backups/etcd/events/control/etcd-cluster-spec
+Location: /control/etcd-cluster-spec
 Name: etcd-cluster-spec-events
 ---
+Base: memfs://clusters.example.com/minimal.example.com/backups/etcd-main
 Contents:
   Name: ""
   Resource: |-
@@ -60,9 +62,10 @@ Contents:
       "memberCount": 1
     }
 Lifecycle: null
-Location: backups/etcd/main/control/etcd-cluster-spec
+Location: /control/etcd-cluster-spec
 Name: etcd-cluster-spec-main
 ---
+Base: null
 Contents:
   Name: ""
   Resource: |
@@ -134,6 +137,7 @@ Lifecycle: null
 Location: manifests/etcd/events.yaml
 Name: manifests-etcdmanager-events
 ---
+Base: null
 Contents:
   Name: ""
   Resource: |

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -43,6 +43,7 @@ oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
+Base: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
 Contents:
   Name: ""
   Resource: |-
@@ -50,9 +51,10 @@ Contents:
       "memberCount": 1
     }
 Lifecycle: null
-Location: backups/etcd/events/control/etcd-cluster-spec
+Location: /control/etcd-cluster-spec
 Name: etcd-cluster-spec-events
 ---
+Base: memfs://clusters.example.com/minimal.example.com/backups/etcd-main
 Contents:
   Name: ""
   Resource: |-
@@ -60,9 +62,10 @@ Contents:
       "memberCount": 1
     }
 Lifecycle: null
-Location: backups/etcd/main/control/etcd-cluster-spec
+Location: /control/etcd-cluster-spec
 Name: etcd-cluster-spec-main
 ---
+Base: null
 Contents:
   Name: ""
   Resource: |
@@ -131,6 +134,7 @@ Lifecycle: null
 Location: manifests/etcd/events.yaml
 Name: manifests-etcdmanager-events
 ---
+Base: null
 Contents:
   Name: ""
   Resource: |

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -43,6 +43,7 @@ oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
+Base: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
 Contents:
   Name: ""
   Resource: |-
@@ -50,9 +51,10 @@ Contents:
       "memberCount": 1
     }
 Lifecycle: null
-Location: backups/etcd/events/control/etcd-cluster-spec
+Location: /control/etcd-cluster-spec
 Name: etcd-cluster-spec-events
 ---
+Base: memfs://clusters.example.com/minimal.example.com/backups/etcd-main
 Contents:
   Name: ""
   Resource: |-
@@ -60,9 +62,10 @@ Contents:
       "memberCount": 1
     }
 Lifecycle: null
-Location: backups/etcd/main/control/etcd-cluster-spec
+Location: /control/etcd-cluster-spec
 Name: etcd-cluster-spec-main
 ---
+Base: null
 Contents:
   Name: ""
   Resource: |
@@ -143,6 +146,7 @@ Lifecycle: null
 Location: manifests/etcd/events.yaml
 Name: manifests-etcdmanager-events
 ---
+Base: null
 Contents:
   Name: ""
   Resource: |

--- a/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
+++ b/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
@@ -1,3 +1,4 @@
+Base: null
 Contents:
   Name: ""
   Resource: |


### PR DESCRIPTION
Currently if a user defines a non-standard backupStore location, such as:

  - backups:
      backupStore: s3://my-bucket/etcdBackup/my-cluster.local

the etcd-cluster-spec is still written to the default location and ignores the store set in backupStore. This in turn causes etcd-manager to not start etcd since it still honors the user defined backupStore location.

------
This is an alternative to #9319

/assign @justinsb 