### PR TITLE
Re-enable disk based evictions for Kubernetes 1.19

### DIFF
--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -101,17 +101,13 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 			evictionHard := []string{
 				// TODO: Some people recommend 250Mi, but this would hurt small machines
 				"memory.available<100Mi",
-			}
-			// Disk based evictions are not detecting the correct disk capacity in Kubernetes 1.19 and are
-			// blocking scheduling by tainting worker nodes with "node.kubernetes.io/disk-pressure:NoSchedule"
-			// TODO: Re-enable once the Kubelet issue is fixed
-			if b.IsKubernetesLT("1.19") {
+
 				// Disk based eviction (evict old images)
 				// We don't need to specify both, but it seems harmless / safer
-				evictionHard = append(evictionHard, "nodefs.available<10%")
-				evictionHard = append(evictionHard, "nodefs.inodesFree<5%")
-				evictionHard = append(evictionHard, "imagefs.available<10%")
-				evictionHard = append(evictionHard, "imagefs.inodesFree<5%")
+				"nodefs.available<10%",
+				"nodefs.inodesFree<5%",
+				"imagefs.available<10%",
+				"imagefs.inodesFree<5%",
 			}
 			clusterSpec.Kubelet.EvictionHard = fi.String(strings.Join(evictionHard, ","))
 		}


### PR DESCRIPTION
Issues with cAdvisor were fixed and merged into Kubernetes 1.19.
The fix should be available in 1.19.0-rc.1 next week. Until then, the e2e test will fail.

xRef: https://github.com/google/cadvisor/pull/2586
Reverts: #9296 
Fixes: #9301