### PR TITLE
Automated cherry pick of #9465: Update the service manifest for Docker

### DIFF
--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -578,28 +578,11 @@ func (b *DockerBuilder) buildSystemdService(dockerVersionMajor int, dockerVersio
 		manifest.Set("Service", "TimeoutStartSec", "0")
 	}
 
-	if oldDocker {
-		// Only in older versions of docker (< 1.12)
-		manifest.Set("Service", "MountFlags", "slave")
-	}
-
-	// Having non-zero Limit*s causes performance problems due to accounting overhead
-	// in the kernel. We recommend using cgroups to do container-local accounting.
-	// TODO: Should we set this? https://github.com/kubernetes/kubernetes/issues/39682
-	//service.Set("Service", "LimitNOFILE", "infinity")
-	//service.Set("Service", "LimitNPROC", "infinity")
-	//service.Set("Service", "LimitCORE", "infinity")
-	manifest.Set("Service", "LimitNOFILE", "1048576")
-	manifest.Set("Service", "LimitNPROC", "1048576")
+	manifest.Set("Service", "LimitNOFILE", "infinity")
+	manifest.Set("Service", "LimitNPROC", "infinity")
 	manifest.Set("Service", "LimitCORE", "infinity")
 
-	//# Uncomment TasksMax if your systemd version supports it.
-	//# Only systemd 226 and above support this version.
-	//#TasksMax=infinity
-	if b.IsKubernetesGTE("1.10") {
-		// Equivalent of https://github.com/kubernetes/kubernetes/pull/51986
-		manifest.Set("Service", "TasksMax", "infinity")
-	}
+	manifest.Set("Service", "TasksMax", "infinity")
 
 	manifest.Set("Service", "Restart", "always")
 	manifest.Set("Service", "RestartSec", "2s")

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -413,9 +413,7 @@ func (b *DockerBuilder) Build(c *fi.ModelBuilderContext) error {
 				c.AddTask(packageTask)
 
 				c.AddTask(b.buildDockerGroup())
-				if b.Distribution.IsDebianFamily() {
-					c.AddTask(b.buildSystemdSocket())
-				}
+				c.AddTask(b.buildSystemdSocket())
 			} else {
 				var extraPkgs []*nodetasks.Package
 				for name, pkg := range dv.ExtraPackages {
@@ -531,33 +529,18 @@ func (b *DockerBuilder) buildSystemdSocket() *nodetasks.Service {
 }
 
 func (b *DockerBuilder) buildSystemdService(dockerVersionMajor int, dockerVersionMinor int) *nodetasks.Service {
-	usesDockerSocket := true
-
 	manifest := &systemd.Manifest{}
 	manifest.Set("Unit", "Description", "Docker Application Container Engine")
 	manifest.Set("Unit", "Documentation", "https://docs.docker.com")
 
-	if b.Distribution.IsRHELFamily() {
-		// See https://github.com/docker/docker/pull/24804
-		usesDockerSocket = false
-	}
-
-	if usesDockerSocket {
-		manifest.Set("Unit", "After", "network.target docker.socket")
-		manifest.Set("Unit", "Requires", "docker.socket")
-	} else {
-		manifest.Set("Unit", "After", "network.target")
-	}
+	manifest.Set("Unit", "After", "network.target docker.socket")
+	manifest.Set("Unit", "Requires", "docker.socket")
 
 	manifest.Set("Service", "Type", "notify")
 	manifest.Set("Service", "EnvironmentFile", "/etc/sysconfig/docker")
 	manifest.Set("Service", "EnvironmentFile", "/etc/environment")
 
-	if usesDockerSocket {
-		manifest.Set("Service", "ExecStart", "/usr/bin/dockerd -H fd:// \"$DOCKER_OPTS\"")
-	} else {
-		manifest.Set("Service", "ExecStart", "/usr/bin/dockerd \"$DOCKER_OPTS\"")
-	}
+	manifest.Set("Service", "ExecStart", "/usr/bin/dockerd -H fd:// \"$DOCKER_OPTS\"")
 
 	manifest.Set("Service", "ExecReload", "/bin/kill -s HUP $MAINPID")
 	// kill only the docker process, not all processes in the cgroup

--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -40,6 +40,7 @@ func (b *PackagesBuilder) Build(c *fi.ModelBuilderContext) error {
 	if b.Distribution.IsDebianFamily() {
 		// From containerd: https://github.com/containerd/cri/blob/master/contrib/ansible/tasks/bootstrap_ubuntu.yaml
 		c.AddTask(&nodetasks.Package{Name: "bridge-utils"})
+		c.AddTask(&nodetasks.Package{Name: "cgroupfs-mount"})
 		c.AddTask(&nodetasks.Package{Name: "conntrack"})
 		c.AddTask(&nodetasks.Package{Name: "ebtables"})
 		c.AddTask(&nodetasks.Package{Name: "ethtool"})
@@ -56,6 +57,7 @@ func (b *PackagesBuilder) Build(c *fi.ModelBuilderContext) error {
 		c.AddTask(&nodetasks.Package{Name: "ebtables"})
 		c.AddTask(&nodetasks.Package{Name: "ethtool"})
 		c.AddTask(&nodetasks.Package{Name: "iptables"})
+		c.AddTask(&nodetasks.Package{Name: "libcgroup"})
 		c.AddTask(&nodetasks.Package{Name: "libseccomp"})
 		c.AddTask(&nodetasks.Package{Name: "libtool-ltdl"})
 		c.AddTask(&nodetasks.Package{Name: "socat"})

--- a/nodeup/pkg/model/tests/dockerbuilder/docker_18.06.3/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/docker_18.06.3/tasks.yaml
@@ -324,8 +324,8 @@ definition: |
   ExecReload=/bin/kill -s HUP $MAINPID
   KillMode=process
   TimeoutStartSec=0
-  LimitNOFILE=1048576
-  LimitNPROC=1048576
+  LimitNOFILE=infinity
+  LimitNPROC=infinity
   LimitCORE=infinity
   TasksMax=infinity
   Restart=always

--- a/nodeup/pkg/model/tests/dockerbuilder/docker_18.06.3/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/docker_18.06.3/tasks.yaml
@@ -313,25 +313,27 @@ definition: |
   [Unit]
   Description=Docker Application Container Engine
   Documentation=https://docs.docker.com
-  After=network.target docker.socket
+  After=network-online.target firewalld.service
+  Wants=network-online.target
   Requires=docker.socket
 
   [Service]
-  Type=notify
   EnvironmentFile=/etc/sysconfig/docker
   EnvironmentFile=/etc/environment
+  Type=notify
   ExecStart=/usr/bin/dockerd -H fd:// "$DOCKER_OPTS"
   ExecReload=/bin/kill -s HUP $MAINPID
-  KillMode=process
-  TimeoutStartSec=0
+  TimeoutSec=0
+  RestartSec=2s
+  Restart=always
+  StartLimitBurst=3
+  StartLimitInterval=60s
   LimitNOFILE=infinity
   LimitNPROC=infinity
   LimitCORE=infinity
   TasksMax=infinity
-  Restart=always
-  RestartSec=2s
-  StartLimitInterval=0
   Delegate=yes
+  KillMode=process
 
   [Install]
   WantedBy=multi-user.target

--- a/nodeup/pkg/model/tests/dockerbuilder/healthcheck/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/healthcheck/tasks.yaml
@@ -327,8 +327,8 @@ definition: |
   ExecReload=/bin/kill -s HUP $MAINPID
   KillMode=process
   TimeoutStartSec=0
-  LimitNOFILE=1048576
-  LimitNPROC=1048576
+  LimitNOFILE=infinity
+  LimitNPROC=infinity
   LimitCORE=infinity
   Restart=always
   RestartSec=2s

--- a/nodeup/pkg/model/tests/dockerbuilder/healthcheck/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/healthcheck/tasks.yaml
@@ -316,24 +316,27 @@ definition: |
   [Unit]
   Description=Docker Application Container Engine
   Documentation=https://docs.docker.com
-  After=network.target docker.socket
+  After=network-online.target firewalld.service
+  Wants=network-online.target
   Requires=docker.socket
 
   [Service]
-  Type=notify
   EnvironmentFile=/etc/sysconfig/docker
   EnvironmentFile=/etc/environment
+  Type=notify
   ExecStart=/usr/bin/dockerd -H fd:// "$DOCKER_OPTS"
   ExecReload=/bin/kill -s HUP $MAINPID
-  KillMode=process
-  TimeoutStartSec=0
+  TimeoutSec=0
+  RestartSec=2s
+  Restart=always
+  StartLimitBurst=3
+  StartLimitInterval=60s
   LimitNOFILE=infinity
   LimitNPROC=infinity
   LimitCORE=infinity
-  Restart=always
-  RestartSec=2s
-  StartLimitInterval=0
+  TasksMax=infinity
   Delegate=yes
+  KillMode=process
 
   [Install]
   WantedBy=multi-user.target

--- a/nodeup/pkg/model/tests/dockerbuilder/logflags/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/logflags/tasks.yaml
@@ -327,8 +327,8 @@ definition: |
   ExecReload=/bin/kill -s HUP $MAINPID
   KillMode=process
   TimeoutStartSec=0
-  LimitNOFILE=1048576
-  LimitNPROC=1048576
+  LimitNOFILE=infinity
+  LimitNPROC=infinity
   LimitCORE=infinity
   TasksMax=infinity
   Restart=always

--- a/nodeup/pkg/model/tests/dockerbuilder/logflags/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/logflags/tasks.yaml
@@ -316,25 +316,27 @@ definition: |
   [Unit]
   Description=Docker Application Container Engine
   Documentation=https://docs.docker.com
-  After=network.target docker.socket
+  After=network-online.target firewalld.service
+  Wants=network-online.target
   Requires=docker.socket
 
   [Service]
-  Type=notify
   EnvironmentFile=/etc/sysconfig/docker
   EnvironmentFile=/etc/environment
+  Type=notify
   ExecStart=/usr/bin/dockerd -H fd:// "$DOCKER_OPTS"
   ExecReload=/bin/kill -s HUP $MAINPID
-  KillMode=process
-  TimeoutStartSec=0
+  TimeoutSec=0
+  RestartSec=2s
+  Restart=always
+  StartLimitBurst=3
+  StartLimitInterval=60s
   LimitNOFILE=infinity
   LimitNPROC=infinity
   LimitCORE=infinity
   TasksMax=infinity
-  Restart=always
-  RestartSec=2s
-  StartLimitInterval=0
   Delegate=yes
+  KillMode=process
 
   [Install]
   WantedBy=multi-user.target

--- a/nodeup/pkg/model/tests/dockerbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/simple/tasks.yaml
@@ -327,8 +327,8 @@ definition: |
   ExecReload=/bin/kill -s HUP $MAINPID
   KillMode=process
   TimeoutStartSec=0
-  LimitNOFILE=1048576
-  LimitNPROC=1048576
+  LimitNOFILE=infinity
+  LimitNPROC=infinity
   LimitCORE=infinity
   TasksMax=infinity
   Restart=always

--- a/nodeup/pkg/model/tests/dockerbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/simple/tasks.yaml
@@ -316,25 +316,27 @@ definition: |
   [Unit]
   Description=Docker Application Container Engine
   Documentation=https://docs.docker.com
-  After=network.target docker.socket
+  After=network-online.target firewalld.service
+  Wants=network-online.target
   Requires=docker.socket
 
   [Service]
-  Type=notify
   EnvironmentFile=/etc/sysconfig/docker
   EnvironmentFile=/etc/environment
+  Type=notify
   ExecStart=/usr/bin/dockerd -H fd:// "$DOCKER_OPTS"
   ExecReload=/bin/kill -s HUP $MAINPID
-  KillMode=process
-  TimeoutStartSec=0
+  TimeoutSec=0
+  RestartSec=2s
+  Restart=always
+  StartLimitBurst=3
+  StartLimitInterval=60s
   LimitNOFILE=infinity
   LimitNPROC=infinity
   LimitCORE=infinity
   TasksMax=infinity
-  Restart=always
-  RestartSec=2s
-  StartLimitInterval=0
   Delegate=yes
+  KillMode=process
 
   [Install]
   WantedBy=multi-user.target


### PR DESCRIPTION
Cherry pick of #9465 on release-1.18.

#9465: Update the service manifest for Docker 

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.