### PR TITLE
Automated cherry pick of #9462: Update KubeDNS to v1.15.13

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -1272,7 +1272,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-{{Arch}}:1.4.0
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.8.1
         resources:
             requests:
                 cpu: "20m"
@@ -2694,7 +2694,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-{{Arch}}:1.4.0
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.8.1
         resources:
             requests:
                 cpu: "20m"
@@ -2771,7 +2771,7 @@ spec:
 
       containers:
       - name: kubedns
-        image: k8s.gcr.io/k8s-dns-kube-dns-{{Arch}}:1.14.13
+        image: k8s.gcr.io/k8s-dns-kube-dns:1.15.13
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -2865,7 +2865,7 @@ spec:
           mountPath: /etc/k8s/dns/dnsmasq-nanny
 
       - name: sidecar
-        image: k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.13
+        image: k8s.gcr.io/k8s-dns-sidecar:1.15.13
         livenessProbe:
           httpGet:
             path: /metrics
@@ -3047,7 +3047,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-{{Arch}}:1.1.2-r2
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.8.1
         resources:
             requests:
                 cpu: "20m"
@@ -3112,7 +3112,7 @@ spec:
 
       containers:
       - name: kubedns
-        image: k8s.gcr.io/k8s-dns-kube-dns-{{Arch}}:1.14.10
+        image: k8s.gcr.io/k8s-dns-kube-dns:1.15.13
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -3164,7 +3164,7 @@ spec:
           mountPath: /kube-dns-config
 
       - name: dnsmasq
-        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-{{Arch}}:1.14.10
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.15.13
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -3206,7 +3206,7 @@ spec:
           mountPath: /etc/k8s/dns/dnsmasq-nanny
 
       - name: sidecar
-        image: k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+        image: k8s.gcr.io/k8s-dns-sidecar:1.15.13
         livenessProbe:
           httpGet:
             path: /metrics

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -103,7 +103,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-{{Arch}}:1.4.0
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.8.1
         resources:
             requests:
                 cpu: "20m"

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-{{Arch}}:1.4.0
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.8.1
         resources:
             requests:
                 cpu: "20m"
@@ -130,7 +130,7 @@ spec:
 
       containers:
       - name: kubedns
-        image: k8s.gcr.io/k8s-dns-kube-dns-{{Arch}}:1.14.13
+        image: k8s.gcr.io/k8s-dns-kube-dns:1.15.13
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -224,7 +224,7 @@ spec:
           mountPath: /etc/k8s/dns/dnsmasq-nanny
 
       - name: sidecar
-        image: k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.13
+        image: k8s.gcr.io/k8s-dns-sidecar:1.15.13
         livenessProbe:
           httpGet:
             path: /metrics

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-{{Arch}}:1.1.2-r2
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.8.1
         resources:
             requests:
                 cpu: "20m"
@@ -117,7 +117,7 @@ spec:
 
       containers:
       - name: kubedns
-        image: k8s.gcr.io/k8s-dns-kube-dns-{{Arch}}:1.14.10
+        image: k8s.gcr.io/k8s-dns-kube-dns:1.15.13
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -169,7 +169,7 @@ spec:
           mountPath: /kube-dns-config
 
       - name: dnsmasq
-        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-{{Arch}}:1.14.10
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.15.13
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -211,7 +211,7 @@ spec:
           mountPath: /etc/k8s/dns/dnsmasq-nanny
 
       - name: sidecar
-        image: k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+        image: k8s.gcr.io/k8s-dns-sidecar:1.15.13
         livenessProbe:
           httpGet:
             path: /metrics

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -240,7 +240,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 		{
 			key := "kube-dns.addons.k8s.io"
-			version := "1.14.13-kops.2"
+			version := "1.15.13-kops.1"
 
 			{
 				location := key + "/k8s-1.6.yaml"
@@ -294,7 +294,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.6.7-kops.1"
+			version := "1.6.7-kops.2"
 
 			{
 				location := key + "/k8s-1.12.yaml"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -21,19 +21,19 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 555f952a8b955ce7a5dd0bcd06a5be9e72bd2895
+    manifestHash: ec19148bdfd08c59c75a4806e53672a00f0209c6
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.13-kops.2
+    version: 1.15.13-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 15ade04df128488a534141bd5b8593d078f4953f
+    manifestHash: 42ba17717415e9c2e3c9a2142654c2a48a915318
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.13-kops.2
+    version: 1.15.13-kops.1
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
     manifestHash: 5d53ce7b920cd1e8d65d2306d80a041420711914

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -21,19 +21,19 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 555f952a8b955ce7a5dd0bcd06a5be9e72bd2895
+    manifestHash: ec19148bdfd08c59c75a4806e53672a00f0209c6
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.13-kops.2
+    version: 1.15.13-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 15ade04df128488a534141bd5b8593d078f4953f
+    manifestHash: 42ba17717415e9c2e3c9a2142654c2a48a915318
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.13-kops.2
+    version: 1.15.13-kops.1
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
     manifestHash: 5d53ce7b920cd1e8d65d2306d80a041420711914

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -21,19 +21,19 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 555f952a8b955ce7a5dd0bcd06a5be9e72bd2895
+    manifestHash: ec19148bdfd08c59c75a4806e53672a00f0209c6
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.13-kops.2
+    version: 1.15.13-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 15ade04df128488a534141bd5b8593d078f4953f
+    manifestHash: 42ba17717415e9c2e3c9a2142654c2a48a915318
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.13-kops.2
+    version: 1.15.13-kops.1
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
     manifestHash: 5d53ce7b920cd1e8d65d2306d80a041420711914

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -21,19 +21,19 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 555f952a8b955ce7a5dd0bcd06a5be9e72bd2895
+    manifestHash: ec19148bdfd08c59c75a4806e53672a00f0209c6
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.13-kops.2
+    version: 1.15.13-kops.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 15ade04df128488a534141bd5b8593d078f4953f
+    manifestHash: 42ba17717415e9c2e3c9a2142654c2a48a915318
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.14.13-kops.2
+    version: 1.15.13-kops.1
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
     manifestHash: 5d53ce7b920cd1e8d65d2306d80a041420711914


### PR DESCRIPTION
Cherry pick of #9462 on release-1.18.

#9462: Update KubeDNS to v1.15.13

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.