### PR TITLE
Allow CI builds to build a tagged version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,9 @@ KOPS_CONTROLLER_TAG=1.18.0-alpha.3
 # Keep in sync with pkg/model/components/kubeapiserver/model.go
 KUBE_APISERVER_HEALTHCHECK_TAG=1.18.0-alpha.3
 
-# Keep in sync with logic in get_workspace_status
-# TODO: just invoke tools/get_workspace_status.sh?
+
+VERSION=$(shell tools/get_version.sh | grep VERSION | awk '{print $$2}')
+
 KOPS_RELEASE_VERSION:=$(shell grep 'KOPS_RELEASE_VERSION\s*=' version.go | awk '{print $$3}' | sed -e 's_"__g')
 KOPS_CI_VERSION:=$(shell grep 'KOPS_CI_VERSION\s*=' version.go | awk '{print $$3}' | sed -e 's_"__g')
 
@@ -71,25 +72,6 @@ KOPS_CI_VERSION:=$(shell grep 'KOPS_CI_VERSION\s*=' version.go | awk '{print $$3
 KOPS                 = ${LOCAL}/kops
 
 GITSHA := $(shell cd ${KOPS_ROOT}; git describe --always)
-
-# Keep in sync with logic in get_workspace_status
-ifndef VERSION
-  # To keep both CI and end-users building from source happy,
-  # we expect that CI sets CI=1.
-  #
-  # For end users, they need only build kops, and they can use the last
-  # released version of nodeup/protokube.
-  # For CI, we continue to build a synthetic version from the git SHA, so
-  # we never cross versions.
-  #
-  # We expect that if you are uploading nodeup/protokube, you will set
-  # VERSION (along with UPLOAD_DEST), either directly or by setting CI=1
-  ifndef CI
-    VERSION=${KOPS_RELEASE_VERSION}
-  else
-    VERSION := ${KOPS_CI_VERSION}+${GITSHA}
-  endif
-endif
 
 # + is valid in semver, but not in docker tags. Fixup CI versions.
 # Note that this mirrors the logic in DefaultProtokubeImageName

--- a/tools/get_version.sh
+++ b/tools/get_version.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Outputs the main kops version; as reported in `kops version`.
+
+GITSHA=$(git describe --always 2>/dev/null)
+
+# When we cut a new release we need to increment these accordingly
+KOPS_RELEASE_VERSION=$(grep 'KOPS_RELEASE_VERSION\s*=' version.go  | awk '{print $3}' | sed -e 's_"__g')
+KOPS_CI_VERSION=$(grep 'KOPS_CI_VERSION\s*=' version.go  |  awk '{print $3}' | sed -e 's_"__g')
+
+if [[ -z "${VERSION}" ]]; then
+  if [[ -z "${CI}" ]]; then
+    VERSION=${KOPS_RELEASE_VERSION}
+  else
+    VERSION="${KOPS_CI_VERSION}+${GITSHA}"
+  fi
+fi
+
+# If we are CI-building something that is exactly a tag, then we use that as the version.
+# This let us do release (candidate) builds from our CI pipeline.
+if [[ -n "${CI}" ]]; then
+    EXACT_TAG=$(git describe --tags --exact-match 2>/dev/null || true)
+    if [[ -n "${EXACT_TAG}" ]]; then
+        VERSION="${EXACT_TAG#v}" # Remove the v prefix from the git tag
+        if [[ "${VERSION}" != "${KOPS_RELEASE_VERSION}" ]]; then
+            echo "Build was tagged with ${VERSION}, but version.go had version ${KOPS_RELEASE_VERSION}"
+            exit 1
+        fi
+    fi
+fi
+
+echo "VERSION ${VERSION}"

--- a/tools/get_workspace_status.sh
+++ b/tools/get_workspace_status.sh
@@ -38,24 +38,8 @@ else
 fi
 echo "BUILD_SCM_STATUS ${tree_status}"
 
-# Compute KOPS_VERSION.  Keep in sync with logic in Makefile
-GITSHA=$(git describe --always 2>/dev/null)
-
-# These variables need to match the values in our Makefile
-# When we cut a new release we need to increment these accordingly
-KOPS_RELEASE_VERSION=`grep 'KOPS_RELEASE_VERSION\s*=' version.go  | awk '{print $3}' | sed -e 's_"__g'`
-KOPS_CI_VERSION=`grep 'KOPS_CI_VERSION\s*=' version.go  |  awk '{print $3}' | sed -e 's_"__g'`
-
-if [[ -z "${VERSION}" ]]; then
-  if [[ -z "${CI}" ]]; then
-    VERSION=${KOPS_RELEASE_VERSION}
-  else
-    VERSION="${KOPS_CI_VERSION}+${GITSHA}"
-  fi
-fi
-
+VERSION=`tools/get_version.sh | grep VERSION | awk '{print $2}'`
 echo "STABLE_KOPS_VERSION ${VERSION}"
-
 
 PROTOKUBE_TAG=${VERSION/+/-}
 echo "STABLE_PROTOKUBE_TAG ${PROTOKUBE_TAG}"


### PR DESCRIPTION
This is working towards "hands off" release builds, where we just tag
the release.  When CI=1 and the git sha we are building _exactly_
matches a tag, we build that version.  We enforce that version.go must
have previously been updated to match the tag.

We also refactor out the duplicated code into a shared script (tools/get_version.sh)