### PR TITLE
Release 1.19.0-alpha.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,11 +56,11 @@ unexport KOPS_BASE_URL KOPS_CLUSTER_NAME KOPS_RUN_OBSOLETE_VERSION KOPS_STATE_ST
 unexport SKIP_REGION_CHECK S3_ACCESS_KEY_ID S3_ENDPOINT S3_REGION S3_SECRET_ACCESS_KEY
 
 # Keep in sync with upup/models/cloudup/resources/addons/dns-controller/
-DNS_CONTROLLER_TAG=1.18.0-alpha.3
+DNS_CONTROLLER_TAG=1.19.0-alpha.1
 # Keep in sync with upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/
-KOPS_CONTROLLER_TAG=1.18.0-alpha.3
+KOPS_CONTROLLER_TAG=1.19.0-alpha.1
 # Keep in sync with pkg/model/components/kubeapiserver/model.go
-KUBE_APISERVER_HEALTHCHECK_TAG=1.18.0-alpha.3
+KUBE_APISERVER_HEALTHCHECK_TAG=1.19.0-alpha.1
 
 
 VERSION=$(shell tools/get_version.sh | grep VERSION | awk '{print $$2}')

--- a/pkg/model/components/kubeapiserver/model.go
+++ b/pkg/model/components/kubeapiserver/model.go
@@ -95,7 +95,7 @@ kind: Pod
 spec:
   containers:
   - name: healthcheck
-    image: kope/kube-apiserver-healthcheck:1.18.0-alpha.3
+    image: kope/kube-apiserver-healthcheck:1.19.0-alpha.1
     livenessProbe:
       httpGet:
         # The sidecar serves a healthcheck on the same port,

--- a/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
+++ b/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
@@ -14,7 +14,7 @@ Contents:
         - --client-key=/secrets/client.key
         command:
         - /usr/bin/kube-apiserver-healthcheck
-        image: kope/kube-apiserver-healthcheck:1.18.0-alpha.3
+        image: kope/kube-apiserver-healthcheck:1.19.0-alpha.1
         livenessProbe:
           httpGet:
             host: 127.0.0.1

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -1911,7 +1911,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.18.0-alpha.3
+    version: v1.19.0-alpha.1
 spec:
   replicas: 1
   strategy:
@@ -1924,7 +1924,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.18.0-alpha.3
+        version: v1.19.0-alpha.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -1938,7 +1938,7 @@ spec:
       serviceAccount: dns-controller
       containers:
       - name: dns-controller
-        image: kope/dns-controller:1.18.0-alpha.3
+        image: kope/dns-controller:1.19.0-alpha.1
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"
@@ -2047,7 +2047,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.18.0-alpha.3
+    version: v1.19.0-alpha.1
 spec:
   replicas: 1
   selector:
@@ -2058,7 +2058,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.18.0-alpha.3
+        version: v1.19.0-alpha.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         # For 1.6, we keep the old tolerations in case of a downgrade to 1.5
@@ -2074,7 +2074,7 @@ spec:
       serviceAccount: dns-controller
       containers:
       - name: dns-controller
-        image: kope/dns-controller:1.18.0-alpha.3
+        image: kope/dns-controller:1.19.0-alpha.1
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"
@@ -2452,7 +2452,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.18.0-alpha.3
+    version: v1.19.0-alpha.1
 spec:
   selector:
     matchLabels:
@@ -2466,7 +2466,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.18.0-alpha.3
+        version: v1.19.0-alpha.1
     spec:
       priorityClassName: system-node-critical
       tolerations:
@@ -2479,7 +2479,7 @@ spec:
       serviceAccount: kops-controller
       containers:
       - name: kops-controller
-        image: kope/kops-controller:1.18.0-alpha.3
+        image: kope/kops-controller:1.19.0-alpha.1
         volumeMounts:
 {{ if .UseHostCertificates }}
         - mountPath: /etc/ssl/certs

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.18.0-alpha.3
+    version: v1.19.0-alpha.1
 spec:
   replicas: 1
   strategy:
@@ -19,7 +19,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.18.0-alpha.3
+        version: v1.19.0-alpha.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -33,7 +33,7 @@ spec:
       serviceAccount: dns-controller
       containers:
       - name: dns-controller
-        image: kope/dns-controller:1.18.0-alpha.3
+        image: kope/dns-controller:1.19.0-alpha.1
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.6.yaml.template
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.18.0-alpha.3
+    version: v1.19.0-alpha.1
 spec:
   replicas: 1
   selector:
@@ -17,7 +17,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.18.0-alpha.3
+        version: v1.19.0-alpha.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         # For 1.6, we keep the old tolerations in case of a downgrade to 1.5
@@ -33,7 +33,7 @@ spec:
       serviceAccount: dns-controller
       containers:
       - name: dns-controller
-        image: kope/dns-controller:1.18.0-alpha.3
+        image: kope/dns-controller:1.19.0-alpha.1
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.18.0-alpha.3
+    version: v1.19.0-alpha.1
 spec:
   selector:
     matchLabels:
@@ -33,7 +33,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.18.0-alpha.3
+        version: v1.19.0-alpha.1
     spec:
       priorityClassName: system-node-critical
       tolerations:
@@ -46,7 +46,7 @@ spec:
       serviceAccount: kops-controller
       containers:
       - name: kops-controller
-        image: kope/kops-controller:1.18.0-alpha.3
+        image: kope/kops-controller:1.19.0-alpha.1
         volumeMounts:
 {{ if .UseHostCertificates }}
         - mountPath: /etc/ssl/certs

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -124,7 +124,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 	{
 		key := "kops-controller.addons.k8s.io"
-		version := "1.18.0-alpha.3"
+		version := "1.19.0-alpha.1"
 
 		{
 			location := key + "/k8s-1.16.yaml"
@@ -372,7 +372,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 	if externalDNS == nil || !externalDNS.Disable {
 		{
 			key := "dns-controller.addons.k8s.io"
-			version := "1.18.0-alpha.3"
+			version := "1.19.0-alpha.1"
 
 			{
 				location := key + "/k8s-1.6.yaml"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -7,11 +7,11 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 03852185a7f76734edc29188f38b11b0a69d211f
+    manifestHash: cafdcd2b3f237ae82d0b1ccc42331480be24271d
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.18.0-alpha.3
+    version: 1.19.0-alpha.1
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
     name: core.addons.k8s.io
@@ -57,19 +57,19 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: dns-controller.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 9215321bd31881305f4a6e96a7d7bfb722d9388c
+    manifestHash: 224077cac498b4c3a06c43e8a7689d3927e28246
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.18.0-alpha.3
+    version: 1.19.0-alpha.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e49c5642ebc6965566cc03891a8e116030684d00
+    manifestHash: c497df601c2e5a7c19f216b8b64b30282dabba9f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.18.0-alpha.3
+    version: 1.19.0-alpha.1
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.18.0-alpha.3
+    version: v1.19.0-alpha.1
   name: dns-controller
   namespace: kube-system
 spec:
@@ -21,7 +21,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.18.0-alpha.3
+        version: v1.19.0-alpha.1
     spec:
       containers:
       - command:
@@ -34,7 +34,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: kope/dns-controller:1.18.0-alpha.3
+        image: kope/dns-controller:1.19.0-alpha.1
         name: dns-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -17,7 +17,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.18.0-alpha.3
+    version: v1.19.0-alpha.1
   name: kops-controller
   namespace: kube-system
 spec:
@@ -29,14 +29,14 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.18.0-alpha.3
+        version: v1.19.0-alpha.1
     spec:
       containers:
       - command:
         - /usr/bin/kops-controller
         - --v=2
         - --conf=/etc/kubernetes/kops-controller/config.yaml
-        image: kope/kops-controller:1.18.0-alpha.3
+        image: kope/kops-controller:1.19.0-alpha.1
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -7,11 +7,11 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 03852185a7f76734edc29188f38b11b0a69d211f
+    manifestHash: cafdcd2b3f237ae82d0b1ccc42331480be24271d
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.18.0-alpha.3
+    version: 1.19.0-alpha.1
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
     name: core.addons.k8s.io
@@ -57,19 +57,19 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: dns-controller.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 9215321bd31881305f4a6e96a7d7bfb722d9388c
+    manifestHash: 224077cac498b4c3a06c43e8a7689d3927e28246
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.18.0-alpha.3
+    version: 1.19.0-alpha.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e49c5642ebc6965566cc03891a8e116030684d00
+    manifestHash: c497df601c2e5a7c19f216b8b64b30282dabba9f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.18.0-alpha.3
+    version: 1.19.0-alpha.1
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.18.0-alpha.3
+    version: v1.19.0-alpha.1
   name: dns-controller
   namespace: kube-system
 spec:
@@ -21,7 +21,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.18.0-alpha.3
+        version: v1.19.0-alpha.1
     spec:
       containers:
       - command:
@@ -34,7 +34,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: kope/dns-controller:1.18.0-alpha.3
+        image: kope/dns-controller:1.19.0-alpha.1
         name: dns-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -17,7 +17,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.18.0-alpha.3
+    version: v1.19.0-alpha.1
   name: kops-controller
   namespace: kube-system
 spec:
@@ -29,14 +29,14 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.18.0-alpha.3
+        version: v1.19.0-alpha.1
     spec:
       containers:
       - command:
         - /usr/bin/kops-controller
         - --v=2
         - --conf=/etc/kubernetes/kops-controller/config.yaml
-        image: kope/kops-controller:1.18.0-alpha.3
+        image: kope/kops-controller:1.19.0-alpha.1
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -7,11 +7,11 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 03852185a7f76734edc29188f38b11b0a69d211f
+    manifestHash: cafdcd2b3f237ae82d0b1ccc42331480be24271d
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.18.0-alpha.3
+    version: 1.19.0-alpha.1
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
     name: core.addons.k8s.io
@@ -57,19 +57,19 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: dns-controller.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 9215321bd31881305f4a6e96a7d7bfb722d9388c
+    manifestHash: 224077cac498b4c3a06c43e8a7689d3927e28246
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.18.0-alpha.3
+    version: 1.19.0-alpha.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e49c5642ebc6965566cc03891a8e116030684d00
+    manifestHash: c497df601c2e5a7c19f216b8b64b30282dabba9f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.18.0-alpha.3
+    version: 1.19.0-alpha.1
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -7,11 +7,11 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 03852185a7f76734edc29188f38b11b0a69d211f
+    manifestHash: cafdcd2b3f237ae82d0b1ccc42331480be24271d
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.18.0-alpha.3
+    version: 1.19.0-alpha.1
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
     name: core.addons.k8s.io
@@ -57,19 +57,19 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: dns-controller.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 9215321bd31881305f4a6e96a7d7bfb722d9388c
+    manifestHash: 224077cac498b4c3a06c43e8a7689d3927e28246
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.18.0-alpha.3
+    version: 1.19.0-alpha.1
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e49c5642ebc6965566cc03891a8e116030684d00
+    manifestHash: c497df601c2e5a7c19f216b8b64b30282dabba9f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.18.0-alpha.3
+    version: 1.19.0-alpha.1
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/version.go
+++ b/version.go
@@ -23,8 +23,8 @@ var Version = KOPS_RELEASE_VERSION
 
 // These constants are parsed by build tooling - be careful about changing the formats
 const (
-	KOPS_RELEASE_VERSION = "1.18.0-alpha.3"
-	KOPS_CI_VERSION      = "1.18.0-alpha.4"
+	KOPS_RELEASE_VERSION = "1.19.0-alpha.1"
+	KOPS_CI_VERSION      = "1.19.0-alpha.2"
 )
 
 // GitVersion should be replaced by the makefile


### PR DESCRIPTION
As this is the first release of the 1.19.0 alpha series, I think we
can try releasing from the automated build.  I _believe_ that tags
will now be automatically be built by CI.  So (if this works) the
process will be:

* We merge the "release" PR, but it's not yet tagged

* It merges and prow and cloudbuild build it like any other PR, with a
"CI" version (i.e. not the correct version number, yet).

* Our normal e2e tests will run against it (and our normal PR tests
  run against it).

* We then tag that version (manually, currently).  This should trigger
  a build with the version set to that tag - though it still goes to
  our staging area.

* We can perform additional validation against that build (including,
  in future, automated validation against the "last tag"?)

* We then promote that build to the release GCS / GCR / other registry
  / github areas.  Ideally we use a PR, wg-k8s-infra has some
  mechanics here, but we'll likely need our own tooling for github
  (until we can contribute those upstream).