### PR TITLE
Use kubelet docker-specific flags only for Docker

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -195,9 +195,6 @@ func (b *KubeletBuilder) buildSystemdEnvironmentFile(kubeletConfig *kops.Kubelet
 		flags += " --cloud-config=" + CloudConfigFilePath
 	}
 
-	flags += " --cni-bin-dir=" + b.CNIBinDir()
-	flags += " --cni-conf-dir=" + b.CNIConfDir()
-
 	if b.UsesSecondaryIP() {
 		sess := session.Must(session.NewSession())
 		metadata := ec2metadata.New(sess)
@@ -208,18 +205,17 @@ func (b *KubeletBuilder) buildSystemdEnvironmentFile(kubeletConfig *kops.Kubelet
 		flags += " --node-ip=" + localIpv4
 	}
 
-	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.Kubenet != nil {
-		// Kubenet is neither CNI nor not-CNI, so we need to pass it `--cni-bin-dir` also
-		flags += " --cni-bin-dir=" + b.CNIBinDir()
-	}
-
 	if b.usesContainerizedMounter() {
 		// We don't want to expose this in the model while it is experimental, but it is needed on COS
 		flags += " --experimental-mounter-path=" + path.Join(containerizedMounterHome, "mounter")
 	}
 
-	// Add container runtime flags
-	if b.Cluster.Spec.ContainerRuntime == "containerd" {
+	// Add container runtime spcific flags
+	switch b.Cluster.Spec.ContainerRuntime {
+	case "docker", "":
+		flags += " --cni-bin-dir=" + b.CNIBinDir()
+		flags += " --cni-conf-dir=" + b.CNIConfDir()
+	case "containerd":
 		flags += " --container-runtime=remote"
 		flags += " --runtime-request-timeout=15m"
 		if b.Cluster.Spec.Containerd == nil || b.Cluster.Spec.Containerd.Address == nil {

--- a/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
@@ -3,7 +3,7 @@ path: /etc/kubernetes/manifests
 type: directory
 ---
 contents: |
-  DAEMON_ARGS="--feature-gates=AllowExtTrafficLocalEndpoints=false,ExperimentalCriticalPodAnnotation=true --node-labels=kubernetes.io/role=node,node-role.kubernetes.io/node= --pod-manifest-path=/etc/kubernetes/manifests --register-schedulable=true --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cni-bin-dir=/opt/cni/bin/ --cni-conf-dir=/etc/cni/net.d/ --cni-bin-dir=/opt/cni/bin/"
+  DAEMON_ARGS="--feature-gates=AllowExtTrafficLocalEndpoints=false,ExperimentalCriticalPodAnnotation=true --node-labels=kubernetes.io/role=node,node-role.kubernetes.io/node= --pod-manifest-path=/etc/kubernetes/manifests --register-schedulable=true --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cni-bin-dir=/opt/cni/bin/ --cni-conf-dir=/etc/cni/net.d/"
   HOME="/root"
 path: /etc/sysconfig/kubelet
 type: file

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -179,24 +179,26 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.Kubelet.CloudProvider = "external"
 	}
 
-	networking := clusterSpec.Networking
-	if networking == nil {
-		return fmt.Errorf("no networking mode set")
+	if clusterSpec.ContainerRuntime == "docker" || clusterSpec.ContainerRuntime == "" {
+		networking := clusterSpec.Networking
+		if networking == nil {
+			return fmt.Errorf("no networking mode set")
 
-	}
-	if UsesKubenet(networking) {
-		clusterSpec.Kubelet.NetworkPluginName = "kubenet"
+		}
+		if UsesKubenet(networking) {
+			clusterSpec.Kubelet.NetworkPluginName = "kubenet"
 
-		// AWS MTU is 9001
-		clusterSpec.Kubelet.NetworkPluginMTU = fi.Int32(9001)
-	}
+			// AWS MTU is 9001
+			clusterSpec.Kubelet.NetworkPluginMTU = fi.Int32(9001)
+		}
 
-	// Specify our pause image
-	image := "k8s.gcr.io/pause:3.2"
-	if image, err = b.Context.AssetBuilder.RemapImage(image); err != nil {
-		return err
+		// Specify our pause image
+		image := "k8s.gcr.io/pause:3.2"
+		if image, err = b.Context.AssetBuilder.RemapImage(image); err != nil {
+			return err
+		}
+		clusterSpec.Kubelet.PodInfraContainerImage = image
 	}
-	clusterSpec.Kubelet.PodInfraContainerImage = image
 
 	if clusterSpec.Kubelet.FeatureGates == nil {
 		clusterSpec.Kubelet.FeatureGates = make(map[string]string)

--- a/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
@@ -244,10 +244,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
-    networkPluginMTU: 9001
-    networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: k8s.gcr.io/pause:3.2
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
     anonymousAuth: false
@@ -262,10 +259,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
-    networkPluginMTU: 9001
-    networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: k8s.gcr.io/pause:3.2
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
 
@@ -303,13 +297,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
-    networkPluginMTU: 9001
-    networkPluginName: kubenet
     nodeLabels:
       kubernetes.io/role: master
       node-role.kubernetes.io/master: ""
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: k8s.gcr.io/pause:3.2
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
   Tags:
@@ -514,10 +505,7 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
-    networkPluginMTU: 9001
-    networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: k8s.gcr.io/pause:3.2
     podManifestPath: /etc/kubernetes/manifests
 
   __EOF_CLUSTER_SPEC
@@ -554,13 +542,10 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
-    networkPluginMTU: 9001
-    networkPluginName: kubenet
     nodeLabels:
       kubernetes.io/role: node
       node-role.kubernetes.io/node: ""
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: k8s.gcr.io/pause:3.2
     podManifestPath: /etc/kubernetes/manifests
   Tags:
   - _automatic_upgrades


### PR DESCRIPTION
xRef: https://github.com/kubernetes/kubernetes/pull/62982

```bash
$ kubelet --help | grep  docker-specific | tr -s " " | cut -d " " -f 2
--cni-bin-dir
--cni-cache-dir
--cni-conf-dir
--docker-endpoint
--image-pull-progress-deadline
--network-plugin
--network-plugin-mtu
--pod-infra-container-image
```