### PR TITLE
cloudbuild: Push additional images from cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,6 +16,8 @@ steps:
   - DOCKER_IMAGE_PREFIX=$_DOCKER_IMAGE_PREFIX
   args:
   - kops-controller-push
+  - dns-controller-push
+  - kube-apiserver-healthcheck-push
 - name: 'gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.2.0'
   entrypoint: make
   env:


### PR DESCRIPTION
This allows them to be promoted to k8s.gcr.io (when we nominate them
for promotion)