### PR TITLE
Automated cherry pick of #9495: Use kubelet docker-specific flags only for Docker

### DIFF
--- a/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
@@ -3,7 +3,7 @@ path: /etc/kubernetes/manifests
 type: directory
 ---
 contents: |
-  DAEMON_ARGS="--feature-gates=AllowExtTrafficLocalEndpoints=false,ExperimentalCriticalPodAnnotation=true --node-labels=kubernetes.io/role=node,node-role.kubernetes.io/node= --pod-manifest-path=/etc/kubernetes/manifests --register-schedulable=true --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cni-bin-dir=/opt/cni/bin/ --cni-conf-dir=/etc/cni/net.d/ --cni-bin-dir=/opt/cni/bin/"
+  DAEMON_ARGS="--feature-gates=AllowExtTrafficLocalEndpoints=false,ExperimentalCriticalPodAnnotation=true --node-labels=kubernetes.io/role=node,node-role.kubernetes.io/node= --pod-manifest-path=/etc/kubernetes/manifests --register-schedulable=true --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cni-bin-dir=/opt/cni/bin/ --cni-conf-dir=/etc/cni/net.d/"
   HOME="/root"
 path: /etc/sysconfig/kubelet
 type: file

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -175,24 +175,26 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.Kubelet.CloudProvider = "external"
 	}
 
-	networking := clusterSpec.Networking
-	if networking == nil {
-		return fmt.Errorf("no networking mode set")
+	if clusterSpec.ContainerRuntime == "docker" || clusterSpec.ContainerRuntime == "" {
+		networking := clusterSpec.Networking
+		if networking == nil {
+			return fmt.Errorf("no networking mode set")
 
-	}
-	if UsesKubenet(networking) {
-		clusterSpec.Kubelet.NetworkPluginName = "kubenet"
+		}
+		if UsesKubenet(networking) {
+			clusterSpec.Kubelet.NetworkPluginName = "kubenet"
 
-		// AWS MTU is 9001
-		clusterSpec.Kubelet.NetworkPluginMTU = fi.Int32(9001)
-	}
+			// AWS MTU is 9001
+			clusterSpec.Kubelet.NetworkPluginMTU = fi.Int32(9001)
+		}
 
-	// Specify our pause image
-	image := "k8s.gcr.io/pause-amd64:3.2"
-	if image, err = b.Context.AssetBuilder.RemapImage(image); err != nil {
-		return err
+		// Specify our pause image
+		image := "k8s.gcr.io/pause-amd64:3.2"
+		if image, err = b.Context.AssetBuilder.RemapImage(image); err != nil {
+			return err
+		}
+		clusterSpec.Kubelet.PodInfraContainerImage = image
 	}
-	clusterSpec.Kubelet.PodInfraContainerImage = image
 
 	if clusterSpec.Kubelet.FeatureGates == nil {
 		clusterSpec.Kubelet.FeatureGates = make(map[string]string)

--- a/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
@@ -227,10 +227,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscontainerdexampl
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
-    networkPluginMTU: 9001
-    networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.2
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
     anonymousAuth: false
@@ -245,10 +242,7 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterscontainerdexampl
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
-    networkPluginMTU: 9001
-    networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.2
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
 
@@ -454,10 +448,7 @@ Resources.AWSAutoScalingLaunchConfigurationnodescontainerdexamplecom.Properties.
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
-    networkPluginMTU: 9001
-    networkPluginName: kubenet
     nonMasqueradeCIDR: 100.64.0.0/10
-    podInfraContainerImage: k8s.gcr.io/pause-amd64:3.2
     podManifestPath: /etc/kubernetes/manifests
 
   __EOF_CLUSTER_SPEC


### PR DESCRIPTION
Cherry pick of #9495 on release-1.18.

#9495: Use kubelet docker-specific flags only for Docker

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.