### PR TITLE
Automated cherry pick of #9491: Default ClusterDNS appropriately when NodeLocalDNS is enabled

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -583,7 +583,7 @@ spec:
 
 ## Node local DNS cache
 
-If you are using CoreDNS, you can enable NodeLocal DNSCache. It is used to improve improve the Cluster DNS performance by running a dns caching agent on cluster nodes as a DaemonSet.
+If you are using CoreDNS, you can enable NodeLocal DNSCache. It is used to improve the Cluster DNS performance by running a dns caching agent on cluster nodes as a DaemonSet.
 
 ```yaml
 spec:
@@ -591,16 +591,6 @@ spec:
     provider: CoreDNS
     nodeLocalDNS:
       enabled: true
-```
-
-If you are using kube-proxy in ipvs mode or Cilium as CNI, you have to set the nodeLocalDNS as ClusterDNS.
-
-```yaml
-spec:
-  kubelet:
-    clusterDNS: 169.254.20.10
-  masterKubelet:
-    clusterDNS: 169.254.20.10
 ```
 
 ## kubeControllerManager

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -775,11 +775,11 @@ func validateNodeLocalDNS(spec *kops.ClusterSpec, fldpath *field.Path) field.Err
 	}
 
 	if (spec.KubeProxy != nil && spec.KubeProxy.ProxyMode == "ipvs") || (spec.Networking != nil && spec.Networking.Cilium != nil) {
-		if spec.Kubelet != nil && spec.Kubelet.ClusterDNS != spec.KubeDNS.NodeLocalDNS.LocalIP {
+		if spec.Kubelet != nil && spec.Kubelet.ClusterDNS != "" && spec.Kubelet.ClusterDNS != spec.KubeDNS.NodeLocalDNS.LocalIP {
 			allErrs = append(allErrs, field.Forbidden(fldpath.Child("kubelet", "clusterDNS"), "Kubelet ClusterDNS must be set to the default IP address for LocalIP"))
 		}
 
-		if spec.MasterKubelet != nil && spec.MasterKubelet.ClusterDNS != spec.KubeDNS.NodeLocalDNS.LocalIP {
+		if spec.MasterKubelet != nil && spec.MasterKubelet.ClusterDNS != "" && spec.MasterKubelet.ClusterDNS != spec.KubeDNS.NodeLocalDNS.LocalIP {
 			allErrs = append(allErrs, field.Forbidden(fldpath.Child("kubelet", "clusterDNS"), "MasterKubelet ClusterDNS must be set to the default IP address for LocalIP"))
 		}
 	}


### PR DESCRIPTION
Cherry pick of #9491 on release-1.18.

#9491: Default ClusterDNS appropriately when NodeLocalDNS is enabled

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.