### PR TITLE
Update AWS VPC CNI docs to use `--networking amazonvpc`

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -279,7 +279,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVar(&options.EncryptEtcdStorage, "encrypt-etcd-storage", options.EncryptEtcdStorage, "Generate key in aws kms and use it for encrypt etcd volumes")
 	cmd.Flags().StringVar(&options.EtcdStorageType, "etcd-storage-type", options.EtcdStorageType, "The default storage type for etc members")
 
-	cmd.Flags().StringVar(&options.Networking, "networking", options.Networking, "Networking mode to use.  kubenet, external, weave, flannel-vxlan (or flannel), flannel-udp, calico, canal, kube-router, amazon-vpc-routed-eni, cilium, cni, lyftvpc.")
+	cmd.Flags().StringVar(&options.Networking, "networking", options.Networking, "Networking mode to use.  kubenet, external, weave, flannel-vxlan (or flannel), flannel-udp, calico, canal, kube-router, amazonvpc, cilium, cni, lyftvpc.")
 
 	cmd.Flags().StringVar(&options.DNSZone, "dns-zone", options.DNSZone, "DNS hosted zone to use (defaults to longest matching zone)")
 	cmd.Flags().StringVar(&options.OutDir, "out", options.OutDir, "Path to write any local output")

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -94,7 +94,7 @@ kops create cluster [flags]
       --master-volume-size int32         Set instance volume size (in GB) for masters
       --master-zones strings             Zones in which to run masters (must be an odd number)
       --network-cidr string              Set to override the default network CIDR
-      --networking string                Networking mode to use.  kubenet, external, weave, flannel-vxlan (or flannel), flannel-udp, calico, canal, kube-router, amazon-vpc-routed-eni, cilium, cni, lyftvpc. (default "kubenet")
+      --networking string                Networking mode to use.  kubenet, external, weave, flannel-vxlan (or flannel), flannel-udp, calico, canal, kube-router, amazonvpc, cilium, cni, lyftvpc. (default "kubenet")
       --node-count int32                 Set number of nodes
       --node-image string                Set image for nodes. Takes precedence over --image
       --node-security-groups strings     Add precreated additional security groups to nodes.

--- a/docs/networking/aws-vpc.md
+++ b/docs/networking/aws-vpc.md
@@ -11,13 +11,13 @@ To use Amazon VPC, specify the following in the cluster spec:
     amazonvpc: {}
 ```
 
-in the cluster spec file or pass the `--networking amazon-vpc-routed-eni` option on the command line to kops:
+in the cluster spec file or pass the `--networking amazonvpc` option on the command line to kops:
 
 ```sh
 export ZONES=<mylistofzones>
 kops create cluster \
   --zones $ZONES \
-  --networking amazon-vpc-routed-eni \
+  --networking amazonvpc \
   --yes \
   --name myclustername.mydns.io
 ```


### PR DESCRIPTION
Both values are valid:

https://github.com/kubernetes/kops/blob/030b7dc7401d5e12eddf2abcf48f2ba3f7547cea/cmd/kops/create_cluster.go#L615-L616

but `amazonvpc` is more concise so it probably makes more sense to use that in the `create cluster` help text and the docs.