### PR TITLE
Move remaining new cluster setup to pkg

### DIFF
--- a/cmd/kops/BUILD.bazel
+++ b/cmd/kops/BUILD.bazel
@@ -66,7 +66,6 @@ go_library(
         "//pkg/client/simple:go_default_library",
         "//pkg/cloudinstances:go_default_library",
         "//pkg/commands:go_default_library",
-        "//pkg/dns:go_default_library",
         "//pkg/edit:go_default_library",
         "//pkg/featureflag:go_default_library",
         "//pkg/formatter:go_default_library",

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -335,10 +335,6 @@ type AccessSpec struct {
 	LoadBalancer *LoadBalancerAccessSpec `json:"loadBalancer,omitempty"`
 }
 
-func (s *AccessSpec) IsEmpty() bool {
-	return s.DNS == nil && s.LoadBalancer == nil
-}
-
 type DNSAccessSpec struct {
 }
 

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -17,8 +17,6 @@ limitations under the License.
 package kops
 
 import (
-	"fmt"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 )
@@ -249,33 +247,6 @@ type IAMProfileSpec struct {
 	// Profile is the AWS IAM Profile to attach to instances in this instance group.
 	// Specify the ARN for the IAM instance profile. (AWS only)
 	Profile *string `json:"profile,omitempty"`
-}
-
-// PerformAssignmentsInstanceGroups populates InstanceGroups with default values
-func PerformAssignmentsInstanceGroups(groups []*InstanceGroup) error {
-	names := map[string]bool{}
-	for _, group := range groups {
-		names[group.ObjectMeta.Name] = true
-	}
-
-	for _, group := range groups {
-		// We want to give them a stable Name as soon as possible
-		if group.ObjectMeta.Name == "" {
-			// Loop to find the first unassigned name like `nodes-%d`
-			i := 0
-			for {
-				key := fmt.Sprintf("nodes-%d", i)
-				if !names[key] {
-					group.ObjectMeta.Name = key
-					names[key] = true
-					break
-				}
-				i++
-			}
-		}
-	}
-
-	return nil
 }
 
 // IsMaster checks if instanceGroup is a master


### PR DESCRIPTION
This is intended to be the last PR in the series.

The intent is to leave settings with trivial logic in cmd: the assumption is that external callers could just as easily implement that themselves.