### PR TITLE
Add tag support to AWS launch templates

### DIFF
--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -430,6 +430,13 @@ resource "aws_launch_template" "bastion-bastionuserdata-example-com" {
       "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                                 = "bastionuserdata.example.com"
+    "Name"                                              = "bastion.bastionuserdata.example.com"
+    "k8s.io/role/bastion"                               = "1"
+    "kops.k8s.io/instancegroup"                         = "bastion"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_bastion.bastionuserdata.example.com_user_data")
 }
 
@@ -481,6 +488,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-bastionuserdata-exampl
       "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                                 = "bastionuserdata.example.com"
+    "Name"                                              = "master-us-test-1a.masters.bastionuserdata.example.com"
+    "k8s.io/role/master"                                = "1"
+    "kops.k8s.io/instancegroup"                         = "master-us-test-1a"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data")
 }
 
@@ -527,6 +541,13 @@ resource "aws_launch_template" "nodes-bastionuserdata-example-com" {
       "kops.k8s.io/instancegroup"                         = "nodes"
       "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                                 = "bastionuserdata.example.com"
+    "Name"                                              = "nodes.bastionuserdata.example.com"
+    "k8s.io/role/node"                                  = "1"
+    "kops.k8s.io/instancegroup"                         = "nodes"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.bastionuserdata.example.com_user_data")
 }

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -337,6 +337,15 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
       "kubernetes.io/cluster/complex.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                         = "complex.example.com"
+    "Name"                                      = "master-us-test-1a.masters.complex.example.com"
+    "Owner"                                     = "John Doe"
+    "foo/bar"                                   = "fib+baz"
+    "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
+    "kubernetes.io/cluster/complex.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data")
 }
 
@@ -394,6 +403,15 @@ resource "aws_launch_template" "nodes-complex-example-com" {
       "kops.k8s.io/instancegroup"                 = "nodes"
       "kubernetes.io/cluster/complex.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                         = "complex.example.com"
+    "Name"                                      = "nodes.complex.example.com"
+    "Owner"                                     = "John Doe"
+    "foo/bar"                                   = "fib+baz"
+    "k8s.io/role/node"                          = "1"
+    "kops.k8s.io/instancegroup"                 = "nodes"
+    "kubernetes.io/cluster/complex.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.complex.example.com_user_data")
 }

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -368,6 +368,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-existing-iam-example-c
       "kubernetes.io/cluster/existing-iam.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                              = "existing-iam.example.com"
+    "Name"                                           = "master-us-test-1a.masters.existing-iam.example.com"
+    "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
+    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data")
 }
 
@@ -418,6 +425,13 @@ resource "aws_launch_template" "master-us-test-1b-masters-existing-iam-example-c
       "kops.k8s.io/instancegroup"                      = "master-us-test-1b"
       "kubernetes.io/cluster/existing-iam.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                              = "existing-iam.example.com"
+    "Name"                                           = "master-us-test-1b.masters.existing-iam.example.com"
+    "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1b"
+    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1b.masters.existing-iam.example.com_user_data")
 }
@@ -470,6 +484,13 @@ resource "aws_launch_template" "master-us-test-1c-masters-existing-iam-example-c
       "kubernetes.io/cluster/existing-iam.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                              = "existing-iam.example.com"
+    "Name"                                           = "master-us-test-1c.masters.existing-iam.example.com"
+    "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1c"
+    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1c.masters.existing-iam.example.com_user_data")
 }
 
@@ -516,6 +537,13 @@ resource "aws_launch_template" "nodes-existing-iam-example-com" {
       "kops.k8s.io/instancegroup"                      = "nodes"
       "kubernetes.io/cluster/existing-iam.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                              = "existing-iam.example.com"
+    "Name"                                           = "nodes.existing-iam.example.com"
+    "k8s.io/role/node"                               = "1"
+    "kops.k8s.io/instancegroup"                      = "nodes"
+    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.existing-iam.example.com_user_data")
 }

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -462,6 +462,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-existingsg-example-com
       "kubernetes.io/cluster/existingsg.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                            = "existingsg.example.com"
+    "Name"                                         = "master-us-test-1a.masters.existingsg.example.com"
+    "k8s.io/role/master"                           = "1"
+    "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
+    "kubernetes.io/cluster/existingsg.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data")
 }
 
@@ -512,6 +519,13 @@ resource "aws_launch_template" "master-us-test-1b-masters-existingsg-example-com
       "kops.k8s.io/instancegroup"                    = "master-us-test-1b"
       "kubernetes.io/cluster/existingsg.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                            = "existingsg.example.com"
+    "Name"                                         = "master-us-test-1b.masters.existingsg.example.com"
+    "k8s.io/role/master"                           = "1"
+    "kops.k8s.io/instancegroup"                    = "master-us-test-1b"
+    "kubernetes.io/cluster/existingsg.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data")
 }
@@ -564,6 +578,13 @@ resource "aws_launch_template" "master-us-test-1c-masters-existingsg-example-com
       "kubernetes.io/cluster/existingsg.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                            = "existingsg.example.com"
+    "Name"                                         = "master-us-test-1c.masters.existingsg.example.com"
+    "k8s.io/role/master"                           = "1"
+    "kops.k8s.io/instancegroup"                    = "master-us-test-1c"
+    "kubernetes.io/cluster/existingsg.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data")
 }
 
@@ -610,6 +631,13 @@ resource "aws_launch_template" "nodes-existingsg-example-com" {
       "kops.k8s.io/instancegroup"                    = "nodes"
       "kubernetes.io/cluster/existingsg.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                            = "existingsg.example.com"
+    "Name"                                         = "nodes.existingsg.example.com"
+    "k8s.io/role/node"                             = "1"
+    "kops.k8s.io/instancegroup"                    = "nodes"
+    "kubernetes.io/cluster/existingsg.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.existingsg.example.com_user_data")
 }

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -293,6 +293,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-externallb-example-com
       "kubernetes.io/cluster/externallb.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                            = "externallb.example.com"
+    "Name"                                         = "master-us-test-1a.masters.externallb.example.com"
+    "k8s.io/role/master"                           = "1"
+    "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
+    "kubernetes.io/cluster/externallb.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data")
 }
 
@@ -339,6 +346,13 @@ resource "aws_launch_template" "nodes-externallb-example-com" {
       "kops.k8s.io/instancegroup"                    = "nodes"
       "kubernetes.io/cluster/externallb.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                            = "externallb.example.com"
+    "Name"                                         = "nodes.externallb.example.com"
+    "k8s.io/role/node"                             = "1"
+    "kops.k8s.io/instancegroup"                    = "nodes"
+    "kubernetes.io/cluster/externallb.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.externallb.example.com_user_data")
 }

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -353,6 +353,15 @@ resource "aws_launch_template" "master-us-test-1a-masters-externalpolicies-examp
       "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                                  = "externalpolicies.example.com"
+    "Name"                                               = "master-us-test-1a.masters.externalpolicies.example.com"
+    "Owner"                                              = "John Doe"
+    "foo/bar"                                            = "fib+baz"
+    "k8s.io/role/master"                                 = "1"
+    "kops.k8s.io/instancegroup"                          = "master-us-test-1a"
+    "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data")
 }
 
@@ -403,6 +412,15 @@ resource "aws_launch_template" "nodes-externalpolicies-example-com" {
       "kops.k8s.io/instancegroup"                          = "nodes"
       "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                                  = "externalpolicies.example.com"
+    "Name"                                               = "nodes.externalpolicies.example.com"
+    "Owner"                                              = "John Doe"
+    "foo/bar"                                            = "fib+baz"
+    "k8s.io/role/node"                                   = "1"
+    "kops.k8s.io/instancegroup"                          = "nodes"
+    "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.externalpolicies.example.com_user_data")
 }

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -420,6 +420,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-ha-example-com" {
       "kubernetes.io/cluster/ha.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                    = "ha.example.com"
+    "Name"                                 = "master-us-test-1a.masters.ha.example.com"
+    "k8s.io/role/master"                   = "1"
+    "kops.k8s.io/instancegroup"            = "master-us-test-1a"
+    "kubernetes.io/cluster/ha.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data")
 }
 
@@ -470,6 +477,13 @@ resource "aws_launch_template" "master-us-test-1b-masters-ha-example-com" {
       "kops.k8s.io/instancegroup"            = "master-us-test-1b"
       "kubernetes.io/cluster/ha.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                    = "ha.example.com"
+    "Name"                                 = "master-us-test-1b.masters.ha.example.com"
+    "k8s.io/role/master"                   = "1"
+    "kops.k8s.io/instancegroup"            = "master-us-test-1b"
+    "kubernetes.io/cluster/ha.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data")
 }
@@ -522,6 +536,13 @@ resource "aws_launch_template" "master-us-test-1c-masters-ha-example-com" {
       "kubernetes.io/cluster/ha.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                    = "ha.example.com"
+    "Name"                                 = "master-us-test-1c.masters.ha.example.com"
+    "k8s.io/role/master"                   = "1"
+    "kops.k8s.io/instancegroup"            = "master-us-test-1c"
+    "kubernetes.io/cluster/ha.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data")
 }
 
@@ -568,6 +589,13 @@ resource "aws_launch_template" "nodes-ha-example-com" {
       "kops.k8s.io/instancegroup"            = "nodes"
       "kubernetes.io/cluster/ha.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                    = "ha.example.com"
+    "Name"                                 = "nodes.ha.example.com"
+    "k8s.io/role/node"                     = "1"
+    "kops.k8s.io/instancegroup"            = "nodes"
+    "kubernetes.io/cluster/ha.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.ha.example.com_user_data")
 }

--- a/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
+++ b/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
@@ -306,6 +306,13 @@
             ]
           }
         ],
+        "tags": {
+          "KubernetesCluster": "minimal-json.example.com",
+          "Name": "master-us-test-1a.masters.minimal-json.example.com",
+          "k8s.io/role/master": "1",
+          "kops.k8s.io/instancegroup": "master-us-test-1a",
+          "kubernetes.io/cluster/minimal-json.example.com": "owned"
+        },
         "tag_specifications": [
           {
             "resource_type": "instance",
@@ -364,6 +371,13 @@
             ]
           }
         ],
+        "tags": {
+          "KubernetesCluster": "minimal-json.example.com",
+          "Name": "nodes.minimal-json.example.com",
+          "k8s.io/role/node": "1",
+          "kops.k8s.io/instancegroup": "nodes",
+          "kubernetes.io/cluster/minimal-json.example.com": "owned"
+        },
         "tag_specifications": [
           {
             "resource_type": "instance",

--- a/tests/integration/update_cluster/minimal-tf11/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-tf11/kubernetes.tf
@@ -285,6 +285,14 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-tf11-example-c
     security_groups             = ["${aws_security_group.masters-minimal-tf11-example-com.id}"]
   }
 
+  tags = {
+    KubernetesCluster                                = "minimal-tf11.example.com"
+    Name                                             = "master-us-test-1a.masters.minimal-tf11.example.com"
+    "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
+    "kubernetes.io/cluster/minimal-tf11.example.com" = "owned"
+  }
+
   tag_specifications = {
     resource_type = "instance"
 
@@ -341,6 +349,14 @@ resource "aws_launch_template" "nodes-minimal-tf11-example-com" {
     associate_public_ip_address = true
     delete_on_termination       = true
     security_groups             = ["${aws_security_group.nodes-minimal-tf11-example-com.id}"]
+  }
+
+  tags = {
+    KubernetesCluster                                = "minimal-tf11.example.com"
+    Name                                             = "nodes.minimal-tf11.example.com"
+    "k8s.io/role/node"                               = "1"
+    "kops.k8s.io/instancegroup"                      = "nodes"
+    "kubernetes.io/cluster/minimal-tf11.example.com" = "owned"
   }
 
   tag_specifications = {

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -278,6 +278,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "master-us-test-1a.masters.minimal.example.com"
+    "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data")
 }
 
@@ -324,6 +331,13 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
       "kops.k8s.io/instancegroup"                 = "nodes"
       "kubernetes.io/cluster/minimal.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "nodes.minimal.example.com"
+    "k8s.io/role/node"                          = "1"
+    "kops.k8s.io/instancegroup"                 = "nodes"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.minimal.example.com_user_data")
 }

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -438,6 +438,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
       "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "master-us-test-1a.masters.mixedinstances.example.com"
+    "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data")
 }
 
@@ -488,6 +495,13 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
       "kops.k8s.io/instancegroup"                        = "master-us-test-1b"
       "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "master-us-test-1b.masters.mixedinstances.example.com"
+    "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1b"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data")
 }
@@ -540,6 +554,13 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
       "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "master-us-test-1c.masters.mixedinstances.example.com"
+    "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1c"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data")
 }
 
@@ -586,6 +607,13 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
       "kops.k8s.io/instancegroup"                        = "nodes"
       "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "nodes.mixedinstances.example.com"
+    "k8s.io/role/node"                                 = "1"
+    "kops.k8s.io/instancegroup"                        = "nodes"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.mixedinstances.example.com_user_data")
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -438,6 +438,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
       "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "master-us-test-1a.masters.mixedinstances.example.com"
+    "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data")
 }
 
@@ -488,6 +495,13 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
       "kops.k8s.io/instancegroup"                        = "master-us-test-1b"
       "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "master-us-test-1b.masters.mixedinstances.example.com"
+    "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1b"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data")
 }
@@ -540,6 +554,13 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
       "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "master-us-test-1c.masters.mixedinstances.example.com"
+    "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1c"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data")
 }
 
@@ -586,6 +607,13 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
       "kops.k8s.io/instancegroup"                        = "nodes"
       "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "nodes.mixedinstances.example.com"
+    "k8s.io/role/node"                                 = "1"
+    "kops.k8s.io/instancegroup"                        = "nodes"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.mixedinstances.example.com_user_data")
 }

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -402,6 +402,13 @@ resource "aws_launch_template" "bastion-private-shared-subnet-example-com" {
       "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
+    "Name"                                                    = "bastion.private-shared-subnet.example.com"
+    "k8s.io/role/bastion"                                     = "1"
+    "kops.k8s.io/instancegroup"                               = "bastion"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-private-shared-subnet-example-com" {
@@ -452,6 +459,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-private-shared-subnet-
       "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
+    "Name"                                                    = "master-us-test-1a.masters.private-shared-subnet.example.com"
+    "k8s.io/role/master"                                      = "1"
+    "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data")
 }
 
@@ -498,6 +512,13 @@ resource "aws_launch_template" "nodes-private-shared-subnet-example-com" {
       "kops.k8s.io/instancegroup"                               = "nodes"
       "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
+    "Name"                                                    = "nodes.private-shared-subnet.example.com"
+    "k8s.io/role/node"                                        = "1"
+    "kops.k8s.io/instancegroup"                               = "nodes"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.private-shared-subnet.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -430,6 +430,13 @@ resource "aws_launch_template" "bastion-privatecalico-example-com" {
       "kubernetes.io/cluster/privatecalico.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                               = "privatecalico.example.com"
+    "Name"                                            = "bastion.privatecalico.example.com"
+    "k8s.io/role/bastion"                             = "1"
+    "kops.k8s.io/instancegroup"                       = "bastion"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-privatecalico-example-com" {
@@ -480,6 +487,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecalico-example-
       "kubernetes.io/cluster/privatecalico.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                               = "privatecalico.example.com"
+    "Name"                                            = "master-us-test-1a.masters.privatecalico.example.com"
+    "k8s.io/role/master"                              = "1"
+    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data")
 }
 
@@ -526,6 +540,13 @@ resource "aws_launch_template" "nodes-privatecalico-example-com" {
       "kops.k8s.io/instancegroup"                       = "nodes"
       "kubernetes.io/cluster/privatecalico.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                               = "privatecalico.example.com"
+    "Name"                                            = "nodes.privatecalico.example.com"
+    "k8s.io/role/node"                                = "1"
+    "kops.k8s.io/instancegroup"                       = "nodes"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.privatecalico.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -430,6 +430,13 @@ resource "aws_launch_template" "bastion-privatecanal-example-com" {
       "kubernetes.io/cluster/privatecanal.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                              = "privatecanal.example.com"
+    "Name"                                           = "bastion.privatecanal.example.com"
+    "k8s.io/role/bastion"                            = "1"
+    "kops.k8s.io/instancegroup"                      = "bastion"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-privatecanal-example-com" {
@@ -480,6 +487,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecanal-example-c
       "kubernetes.io/cluster/privatecanal.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                              = "privatecanal.example.com"
+    "Name"                                           = "master-us-test-1a.masters.privatecanal.example.com"
+    "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data")
 }
 
@@ -526,6 +540,13 @@ resource "aws_launch_template" "nodes-privatecanal-example-com" {
       "kops.k8s.io/instancegroup"                      = "nodes"
       "kubernetes.io/cluster/privatecanal.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                              = "privatecanal.example.com"
+    "Name"                                           = "nodes.privatecanal.example.com"
+    "k8s.io/role/node"                               = "1"
+    "kops.k8s.io/instancegroup"                      = "nodes"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.privatecanal.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -430,6 +430,13 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
       "kubernetes.io/cluster/privatecilium.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "bastion.privatecilium.example.com"
+    "k8s.io/role/bastion"                             = "1"
+    "kops.k8s.io/instancegroup"                       = "bastion"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-com" {
@@ -480,6 +487,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
       "kubernetes.io/cluster/privatecilium.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "master-us-test-1a.masters.privatecilium.example.com"
+    "k8s.io/role/master"                              = "1"
+    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data")
 }
 
@@ -526,6 +540,13 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
       "kops.k8s.io/instancegroup"                       = "nodes"
       "kubernetes.io/cluster/privatecilium.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "nodes.privatecilium.example.com"
+    "k8s.io/role/node"                                = "1"
+    "kops.k8s.io/instancegroup"                       = "nodes"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.privatecilium.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -430,6 +430,13 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
       "kubernetes.io/cluster/privatecilium.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "bastion.privatecilium.example.com"
+    "k8s.io/role/bastion"                             = "1"
+    "kops.k8s.io/instancegroup"                       = "bastion"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-com" {
@@ -480,6 +487,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
       "kubernetes.io/cluster/privatecilium.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "master-us-test-1a.masters.privatecilium.example.com"
+    "k8s.io/role/master"                              = "1"
+    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data")
 }
 
@@ -526,6 +540,13 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
       "kops.k8s.io/instancegroup"                       = "nodes"
       "kubernetes.io/cluster/privatecilium.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "nodes.privatecilium.example.com"
+    "k8s.io/role/node"                                = "1"
+    "kops.k8s.io/instancegroup"                       = "nodes"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.privatecilium.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -444,6 +444,13 @@ resource "aws_launch_template" "bastion-privateciliumadvanced-example-com" {
       "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+    "Name"                                                    = "bastion.privateciliumadvanced.example.com"
+    "k8s.io/role/bastion"                                     = "1"
+    "kops.k8s.io/instancegroup"                               = "bastion"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-privateciliumadvanced-example-com" {
@@ -494,6 +501,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateciliumadvanced-
       "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+    "Name"                                                    = "master-us-test-1a.masters.privateciliumadvanced.example.com"
+    "k8s.io/role/master"                                      = "1"
+    "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data")
 }
 
@@ -540,6 +554,13 @@ resource "aws_launch_template" "nodes-privateciliumadvanced-example-com" {
       "kops.k8s.io/instancegroup"                               = "nodes"
       "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+    "Name"                                                    = "nodes.privateciliumadvanced.example.com"
+    "k8s.io/role/node"                                        = "1"
+    "kops.k8s.io/instancegroup"                               = "nodes"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -476,6 +476,15 @@ resource "aws_launch_template" "bastion-privatedns1-example-com" {
       "kubernetes.io/cluster/privatedns1.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                             = "privatedns1.example.com"
+    "Name"                                          = "bastion.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
+    "k8s.io/role/bastion"                           = "1"
+    "kops.k8s.io/instancegroup"                     = "bastion"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-privatedns1-example-com" {
@@ -530,6 +539,15 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns1-example-co
       "kubernetes.io/cluster/privatedns1.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                             = "privatedns1.example.com"
+    "Name"                                          = "master-us-test-1a.masters.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
+    "k8s.io/role/master"                            = "1"
+    "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data")
 }
 
@@ -580,6 +598,15 @@ resource "aws_launch_template" "nodes-privatedns1-example-com" {
       "kops.k8s.io/instancegroup"                     = "nodes"
       "kubernetes.io/cluster/privatedns1.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                             = "privatedns1.example.com"
+    "Name"                                          = "nodes.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
+    "k8s.io/role/node"                              = "1"
+    "kops.k8s.io/instancegroup"                     = "nodes"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.privatedns1.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -416,6 +416,13 @@ resource "aws_launch_template" "bastion-privatedns2-example-com" {
       "kubernetes.io/cluster/privatedns2.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                             = "privatedns2.example.com"
+    "Name"                                          = "bastion.privatedns2.example.com"
+    "k8s.io/role/bastion"                           = "1"
+    "kops.k8s.io/instancegroup"                     = "bastion"
+    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-privatedns2-example-com" {
@@ -466,6 +473,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns2-example-co
       "kubernetes.io/cluster/privatedns2.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                             = "privatedns2.example.com"
+    "Name"                                          = "master-us-test-1a.masters.privatedns2.example.com"
+    "k8s.io/role/master"                            = "1"
+    "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
+    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data")
 }
 
@@ -512,6 +526,13 @@ resource "aws_launch_template" "nodes-privatedns2-example-com" {
       "kops.k8s.io/instancegroup"                     = "nodes"
       "kubernetes.io/cluster/privatedns2.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                             = "privatedns2.example.com"
+    "Name"                                          = "nodes.privatedns2.example.com"
+    "k8s.io/role/node"                              = "1"
+    "kops.k8s.io/instancegroup"                     = "nodes"
+    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.privatedns2.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -430,6 +430,13 @@ resource "aws_launch_template" "bastion-privateflannel-example-com" {
       "kubernetes.io/cluster/privateflannel.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                                = "privateflannel.example.com"
+    "Name"                                             = "bastion.privateflannel.example.com"
+    "k8s.io/role/bastion"                              = "1"
+    "kops.k8s.io/instancegroup"                        = "bastion"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-privateflannel-example-com" {
@@ -480,6 +487,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateflannel-example
       "kubernetes.io/cluster/privateflannel.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                                = "privateflannel.example.com"
+    "Name"                                             = "master-us-test-1a.masters.privateflannel.example.com"
+    "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data")
 }
 
@@ -526,6 +540,13 @@ resource "aws_launch_template" "nodes-privateflannel-example-com" {
       "kops.k8s.io/instancegroup"                        = "nodes"
       "kubernetes.io/cluster/privateflannel.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                                = "privateflannel.example.com"
+    "Name"                                             = "nodes.privateflannel.example.com"
+    "k8s.io/role/node"                                 = "1"
+    "kops.k8s.io/instancegroup"                        = "nodes"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.privateflannel.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -436,6 +436,13 @@ resource "aws_launch_template" "bastion-privatekopeio-example-com" {
       "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "bastion.privatekopeio.example.com"
+    "k8s.io/role/bastion"                             = "1"
+    "kops.k8s.io/instancegroup"                       = "bastion"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-privatekopeio-example-com" {
@@ -486,6 +493,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatekopeio-example-
       "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "master-us-test-1a.masters.privatekopeio.example.com"
+    "k8s.io/role/master"                              = "1"
+    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data")
 }
 
@@ -532,6 +546,13 @@ resource "aws_launch_template" "nodes-privatekopeio-example-com" {
       "kops.k8s.io/instancegroup"                       = "nodes"
       "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "nodes.privatekopeio.example.com"
+    "k8s.io/role/node"                                = "1"
+    "kops.k8s.io/instancegroup"                       = "nodes"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.privatekopeio.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -430,6 +430,13 @@ resource "aws_launch_template" "bastion-privateweave-example-com" {
       "kubernetes.io/cluster/privateweave.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                              = "privateweave.example.com"
+    "Name"                                           = "bastion.privateweave.example.com"
+    "k8s.io/role/bastion"                            = "1"
+    "kops.k8s.io/instancegroup"                      = "bastion"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-privateweave-example-com" {
@@ -480,6 +487,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateweave-example-c
       "kubernetes.io/cluster/privateweave.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                              = "privateweave.example.com"
+    "Name"                                           = "master-us-test-1a.masters.privateweave.example.com"
+    "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privateweave.example.com_user_data")
 }
 
@@ -526,6 +540,13 @@ resource "aws_launch_template" "nodes-privateweave-example-com" {
       "kops.k8s.io/instancegroup"                      = "nodes"
       "kubernetes.io/cluster/privateweave.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                              = "privateweave.example.com"
+    "Name"                                           = "nodes.privateweave.example.com"
+    "k8s.io/role/node"                               = "1"
+    "kops.k8s.io/instancegroup"                      = "nodes"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.privateweave.example.com_user_data")
 }

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -264,6 +264,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedsubnet-example-c
       "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                              = "sharedsubnet.example.com"
+    "Name"                                           = "master-us-test-1a.masters.sharedsubnet.example.com"
+    "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
+    "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data")
 }
 
@@ -310,6 +317,13 @@ resource "aws_launch_template" "nodes-sharedsubnet-example-com" {
       "kops.k8s.io/instancegroup"                      = "nodes"
       "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                              = "sharedsubnet.example.com"
+    "Name"                                           = "nodes.sharedsubnet.example.com"
+    "k8s.io/role/node"                               = "1"
+    "kops.k8s.io/instancegroup"                      = "nodes"
+    "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data")
 }

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -264,6 +264,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedvpc-example-com"
       "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                           = "sharedvpc.example.com"
+    "Name"                                        = "master-us-test-1a.masters.sharedvpc.example.com"
+    "k8s.io/role/master"                          = "1"
+    "kops.k8s.io/instancegroup"                   = "master-us-test-1a"
+    "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data")
 }
 
@@ -310,6 +317,13 @@ resource "aws_launch_template" "nodes-sharedvpc-example-com" {
       "kops.k8s.io/instancegroup"                   = "nodes"
       "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                           = "sharedvpc.example.com"
+    "Name"                                        = "nodes.sharedvpc.example.com"
+    "k8s.io/role/node"                            = "1"
+    "kops.k8s.io/instancegroup"                   = "nodes"
+    "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.sharedvpc.example.com_user_data")
 }

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -407,6 +407,13 @@ resource "aws_launch_template" "bastion-unmanaged-example-com" {
       "kubernetes.io/cluster/unmanaged.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                           = "unmanaged.example.com"
+    "Name"                                        = "bastion.unmanaged.example.com"
+    "k8s.io/role/bastion"                         = "1"
+    "kops.k8s.io/instancegroup"                   = "bastion"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-unmanaged-example-com" {
@@ -457,6 +464,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-unmanaged-example-com"
       "kubernetes.io/cluster/unmanaged.example.com" = "owned"
     }
   }
+  tags = {
+    "KubernetesCluster"                           = "unmanaged.example.com"
+    "Name"                                        = "master-us-test-1a.masters.unmanaged.example.com"
+    "k8s.io/role/master"                          = "1"
+    "kops.k8s.io/instancegroup"                   = "master-us-test-1a"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+  }
   user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data")
 }
 
@@ -503,6 +517,13 @@ resource "aws_launch_template" "nodes-unmanaged-example-com" {
       "kops.k8s.io/instancegroup"                   = "nodes"
       "kubernetes.io/cluster/unmanaged.example.com" = "owned"
     }
+  }
+  tags = {
+    "KubernetesCluster"                           = "unmanaged.example.com"
+    "Name"                                        = "nodes.unmanaged.example.com"
+    "k8s.io/role/node"                            = "1"
+    "kops.k8s.io/instancegroup"                   = "nodes"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
   }
   user_data = file("${path.module}/data/aws_launch_template_nodes.unmanaged.example.com_user_data")
 }

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
@@ -64,7 +64,7 @@ type LaunchTemplate struct {
 	SpotPrice string
 	// SpotDurationInMinutes is set for requesting spot blocks
 	SpotDurationInMinutes *int64
-	// Tags are the keypairs to apply to the instance and volume on launch.
+	// Tags are the keypairs to apply to the instance and volume on launch as well as the launch template itself.
 	Tags map[string]string
 	// Tenancy. Can be either default or dedicated.
 	Tenancy *string

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -119,6 +119,10 @@ func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, ep, changes *Launch
 			ResourceType: aws.String(ec2.ResourceTypeVolume),
 			Tags:         tags,
 		})
+		input.TagSpecifications = append(input.TagSpecifications, &ec2.TagSpecification{
+			ResourceType: aws.String(ec2.ResourceTypeLaunchTemplate),
+			Tags:         tags,
+		})
 	}
 	// @step: add the userdata
 	if t.UserData != nil {

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -134,6 +134,8 @@ type terraformLaunchTemplate struct {
 	NetworkInterfaces []*terraformLaunchTemplateNetworkInterface `json:"network_interfaces,omitempty" cty:"network_interfaces"`
 	// Placement are the tenancy options
 	Placement []*terraformLaunchTemplatePlacement `json:"placement,omitempty" cty:"placement"`
+	// Tags is a map of tags applied to the launch template itself
+	Tags map[string]string `json:"tags,omitempty" cty:"tags"`
 	// TagSpecifications are the tags to apply to a resource when it is created.
 	TagSpecifications []*terraformLaunchTemplateTagSpecification `json:"tag_specifications,omitempty" cty:"tag_specifications"`
 	// UserData is the user data for the instances
@@ -289,6 +291,7 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 			ResourceType: fi.String("volume"),
 			Tags:         e.Tags,
 		})
+		tf.Tags = e.Tags
 	}
 
 	return target.RenderResource("aws_launch_template", fi.StringValue(e.Name), tf)


### PR DESCRIPTION
In addition to TagSpecifications which allow tagging of instances and volumes, launch templates support tags of their own.

This adds the usual tags to LTs, as seen in the kubernetes.tf additions. Cloudformation [does not yet support it](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-launchtemplatedata.html), so only "api" and "terraform" targets are updated.