### PR TITLE
Cloudmock cleanup - preparation for EC2 tag-on-create

### DIFF
--- a/cloudmock/aws/mockec2/api.go
+++ b/cloudmock/aws/mockec2/api.go
@@ -55,7 +55,8 @@ type MockEC2 struct {
 
 	InternetGateways map[string]*ec2.InternetGateway
 
-	LaunchTemplates map[string]*ec2.ResponseLaunchTemplateData
+	launchTemplateNumber int
+	LaunchTemplates      map[string]*launchTemplateInfo
 
 	NatGateways map[string]*ec2.NatGateway
 
@@ -96,6 +97,9 @@ func (m *MockEC2) All() map[string]interface{} {
 		all[id] = o
 	}
 	for id, o := range m.InternetGateways {
+		all[id] = o
+	}
+	for id, o := range m.LaunchTemplates {
 		all[id] = o
 	}
 	for id, o := range m.NatGateways {

--- a/cloudmock/aws/mockec2/dhcpoptions.go
+++ b/cloudmock/aws/mockec2/dhcpoptions.go
@@ -126,9 +126,10 @@ func (m *MockEC2) CreateDhcpOptions(request *ec2.CreateDhcpOptionsInput) (*ec2.C
 	}
 
 	n := len(m.DhcpOptions) + 1
+	id := fmt.Sprintf("dopt-%d", n)
 
 	dhcpOptions := &ec2.DhcpOptions{
-		DhcpOptionsId: s(fmt.Sprintf("dopt-%d", n)),
+		DhcpOptionsId: s(id),
 	}
 
 	for _, o := range request.DhcpConfigurations {
@@ -146,6 +147,8 @@ func (m *MockEC2) CreateDhcpOptions(request *ec2.CreateDhcpOptionsInput) (*ec2.C
 		m.DhcpOptions = make(map[string]*ec2.DhcpOptions)
 	}
 	m.DhcpOptions[*dhcpOptions.DhcpOptionsId] = dhcpOptions
+
+	m.addTags(id, tagSpecificationsToTags(request.TagSpecifications, ec2.ResourceTypeDhcpOptions)...)
 
 	copy := *dhcpOptions
 	copy.Tags = m.getTags(ec2.ResourceTypeDhcpOptions, *dhcpOptions.DhcpOptionsId)

--- a/cloudmock/aws/mockec2/internetgateways.go
+++ b/cloudmock/aws/mockec2/internetgateways.go
@@ -66,15 +66,19 @@ func (m *MockEC2) CreateInternetGateway(request *ec2.CreateInternetGatewayInput)
 	klog.Infof("CreateInternetGateway: %v", request)
 
 	id := m.allocateId("igw")
+	tags := tagSpecificationsToTags(request.TagSpecifications, ec2.ResourceTypeInternetGateway)
 
 	igw := &ec2.InternetGateway{
 		InternetGatewayId: s(id),
+		Tags:              tags,
 	}
 
 	if m.InternetGateways == nil {
 		m.InternetGateways = make(map[string]*ec2.InternetGateway)
 	}
 	m.InternetGateways[id] = igw
+
+	m.addTags(id, tags...)
 
 	response := &ec2.CreateInternetGatewayOutput{
 		InternetGateway: igw,

--- a/cloudmock/aws/mockec2/natgateway.go
+++ b/cloudmock/aws/mockec2/natgateway.go
@@ -30,9 +30,12 @@ func (m *MockEC2) CreateNatGatewayWithId(request *ec2.CreateNatGatewayInput, id 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
+	tags := tagSpecificationsToTags(request.TagSpecifications, ec2.ResourceTypeNatgateway)
+
 	ngw := &ec2.NatGateway{
 		NatGatewayId: s(id),
 		SubnetId:     request.SubnetId,
+		Tags:         tags,
 	}
 
 	if request.AllocationId != nil {
@@ -56,6 +59,8 @@ func (m *MockEC2) CreateNatGatewayWithId(request *ec2.CreateNatGatewayInput, id 
 		m.NatGateways = make(map[string]*ec2.NatGateway)
 	}
 	m.NatGateways[*ngw.NatGatewayId] = ngw
+
+	m.addTags(id, tags...)
 
 	copy := *ngw
 

--- a/cloudmock/aws/mockec2/natgateway.go
+++ b/cloudmock/aws/mockec2/natgateway.go
@@ -128,7 +128,7 @@ func (m *MockEC2) DescribeNatGateways(request *ec2.DescribeNatGatewaysInput) (*e
 				}
 			default:
 				if strings.HasPrefix(*filter.Name, "tag:") {
-					match = m.hasTag(ResourceTypeNatGateway, *ngw.NatGatewayId, filter)
+					match = m.hasTag(ec2.ResourceTypeNatgateway, *ngw.NatGatewayId, filter)
 				} else {
 					return nil, fmt.Errorf("unknown filter name: %q", *filter.Name)
 				}
@@ -145,7 +145,7 @@ func (m *MockEC2) DescribeNatGateways(request *ec2.DescribeNatGatewaysInput) (*e
 		}
 
 		copy := *ngw
-		copy.Tags = m.getTags(ResourceTypeNatGateway, id)
+		copy.Tags = m.getTags(ec2.ResourceTypeNatgateway, id)
 		ngws = append(ngws, &copy)
 	}
 

--- a/cloudmock/aws/mockec2/routetable.go
+++ b/cloudmock/aws/mockec2/routetable.go
@@ -32,10 +32,9 @@ func (m *MockEC2) AddRouteTable(rt *ec2.RouteTable) {
 	if m.RouteTables == nil {
 		m.RouteTables = make(map[string]*ec2.RouteTable)
 	}
-	for _, tag := range rt.Tags {
-		m.addTag(*rt.RouteTableId, tag)
-	}
-	rt.Tags = nil
+
+	m.addTags(*rt.RouteTableId, rt.Tags...)
+
 	m.RouteTables[*rt.RouteTableId] = rt
 }
 

--- a/cloudmock/aws/mockec2/securitygroups.go
+++ b/cloudmock/aws/mockec2/securitygroups.go
@@ -41,17 +41,22 @@ func (m *MockEC2) CreateSecurityGroup(request *ec2.CreateSecurityGroupInput) (*e
 
 	m.securityGroupNumber++
 	n := m.securityGroupNumber
+	id := fmt.Sprintf("sg-%d", n)
+	tags := tagSpecificationsToTags(request.TagSpecifications, ec2.ResourceTypeSecurityGroup)
 
 	sg := &ec2.SecurityGroup{
 		GroupName:   request.GroupName,
-		GroupId:     s(fmt.Sprintf("sg-%d", n)),
+		GroupId:     s(id),
 		VpcId:       request.VpcId,
 		Description: request.Description,
+		Tags:        tags,
 	}
 	if m.SecurityGroups == nil {
 		m.SecurityGroups = make(map[string]*ec2.SecurityGroup)
 	}
 	m.SecurityGroups[*sg.GroupId] = sg
+
+	m.addTags(id, tags...)
 
 	response := &ec2.CreateSecurityGroupOutput{
 		GroupId: sg.GroupId,

--- a/cloudmock/aws/mockec2/subnets.go
+++ b/cloudmock/aws/mockec2/subnets.go
@@ -81,6 +81,8 @@ func (m *MockEC2) CreateSubnetWithId(request *ec2.CreateSubnetInput, id string) 
 		main: *subnet,
 	}
 
+	m.addTags(id, tagSpecificationsToTags(request.TagSpecifications, ec2.ResourceTypeSubnet)...)
+
 	response := &ec2.CreateSubnetOutput{
 		Subnet: subnet,
 	}

--- a/cloudmock/aws/mockec2/tags.go
+++ b/cloudmock/aws/mockec2/tags.go
@@ -69,6 +69,8 @@ func (m *MockEC2) addTags(resourceId string, tags ...*ec2.Tag) {
 		resourceType = ec2.ResourceTypeRouteTable
 	} else if strings.HasPrefix(resourceId, "eipalloc-") {
 		resourceType = ec2.ResourceTypeElasticIp
+	} else if strings.HasPrefix(resourceId, "lt-") {
+		resourceType = ec2.ResourceTypeLaunchTemplate
 	} else {
 		klog.Fatalf("Unknown resource-type in create tags: %v", resourceId)
 	}

--- a/cloudmock/aws/mockec2/tags.go
+++ b/cloudmock/aws/mockec2/tags.go
@@ -27,12 +27,6 @@ import (
 	"k8s.io/klog"
 )
 
-const (
-	// Not (yet?) in aws-sdk-go
-	ResourceTypeNatGateway = "nat-gateway"
-	ResourceTypeAddress    = "elastic-ip"
-)
-
 func (m *MockEC2) CreateTagsRequest(*ec2.CreateTagsInput) (*request.Request, *ec2.CreateTagsOutput) {
 	panic("Not implemented")
 }
@@ -70,13 +64,13 @@ func (m *MockEC2) addTag(resourceId string, tag *ec2.Tag) {
 	} else if strings.HasPrefix(resourceId, "igw-") {
 		resourceType = ec2.ResourceTypeInternetGateway
 	} else if strings.HasPrefix(resourceId, "nat-") {
-		resourceType = ResourceTypeNatGateway
+		resourceType = ec2.ResourceTypeNatgateway
 	} else if strings.HasPrefix(resourceId, "dopt-") {
 		resourceType = ec2.ResourceTypeDhcpOptions
 	} else if strings.HasPrefix(resourceId, "rtb-") {
 		resourceType = ec2.ResourceTypeRouteTable
 	} else if strings.HasPrefix(resourceId, "eipalloc-") {
-		resourceType = ResourceTypeAddress
+		resourceType = ec2.ResourceTypeElasticIp
 	} else {
 		klog.Fatalf("Unknown resource-type in create tags: %v", resourceId)
 	}

--- a/cloudmock/aws/mockec2/volumes.go
+++ b/cloudmock/aws/mockec2/volumes.go
@@ -37,9 +37,10 @@ func (m *MockEC2) CreateVolume(request *ec2.CreateVolumeInput) (*ec2.Volume, err
 	}
 
 	n := len(m.Volumes) + 1
+	id := fmt.Sprintf("vol-%d", n)
 
 	volume := &ec2.Volume{
-		VolumeId:         s(fmt.Sprintf("vol-%d", n)),
+		VolumeId:         s(id),
 		AvailabilityZone: request.AvailabilityZone,
 		Encrypted:        request.Encrypted,
 		Iops:             request.Iops,
@@ -49,19 +50,15 @@ func (m *MockEC2) CreateVolume(request *ec2.CreateVolumeInput) (*ec2.Volume, err
 		VolumeType:       request.VolumeType,
 	}
 
-	for _, tags := range request.TagSpecifications {
-		for _, tag := range tags.Tags {
-			m.addTag(*volume.VolumeId, tag)
-		}
-	}
 	if m.Volumes == nil {
 		m.Volumes = make(map[string]*ec2.Volume)
 	}
 	m.Volumes[*volume.VolumeId] = volume
 
+	m.addTags(id, tagSpecificationsToTags(request.TagSpecifications, ec2.ResourceTypeVolume)...)
+
 	copy := *volume
 	copy.Tags = m.getTags(ec2.ResourceTypeVolume, *volume.VolumeId)
-
 	// TODO: a few fields
 	// // Information about the volume attachments.
 	// Attachments []*VolumeAttachment `locationName:"attachmentSet" locationNameList:"item" type:"list"`

--- a/cloudmock/aws/mockec2/vpcs.go
+++ b/cloudmock/aws/mockec2/vpcs.go
@@ -55,11 +55,14 @@ func (m *MockEC2) CreateVpcWithId(request *ec2.CreateVpcInput, id string) (*ec2.
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
+	tags := tagSpecificationsToTags(request.TagSpecifications, ec2.ResourceTypeVpc)
+
 	vpc := &vpcInfo{
 		main: ec2.Vpc{
 			VpcId:     s(id),
 			CidrBlock: request.CidrBlock,
 			IsDefault: aws.Bool(false),
+			Tags:      tags,
 		},
 		attributes: ec2.DescribeVpcAttributeOutput{
 			EnableDnsHostnames: &ec2.AttributeBooleanValue{Value: aws.Bool(true)},
@@ -71,6 +74,8 @@ func (m *MockEC2) CreateVpcWithId(request *ec2.CreateVpcInput, id string) (*ec2.
 		m.Vpcs = make(map[string]*vpcInfo)
 	}
 	m.Vpcs[id] = vpc
+
+	m.addTags(id, tags...)
 
 	response := &ec2.CreateVpcOutput{
 		Vpc: &vpc.main,

--- a/pkg/resources/aws/aws_test.go
+++ b/pkg/resources/aws/aws_test.go
@@ -155,6 +155,7 @@ func TestSharedVolume(t *testing.T) {
 	sharedVolume, err := c.CreateVolume(&ec2.CreateVolumeInput{
 		TagSpecifications: []*ec2.TagSpecification{
 			{
+				ResourceType: aws.String(ec2.ResourceTypeVolume),
 				Tags: []*ec2.Tag{
 					{
 						Key:   aws.String(ownershipTagKey),

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup_test.go
@@ -149,6 +149,7 @@ func TestSecurityGroupCreate(t *testing.T) {
 			Description: s("Description"),
 			GroupId:     sg1.ID,
 			VpcId:       vpc1.ID,
+			Tags:        []*ec2.Tag{},
 			GroupName:   s("sg1"),
 		}
 		actual := c.SecurityGroups[*sg1.ID]


### PR DESCRIPTION
In order to add "tag-on-create" support for ec2 resources, cloudmock first needs to support recognizing and storing tags provided in `ec2.Create*` requests. This way a `DescribeTags` call will return the tags provided either by the resource's `Create` call or in a `CreateTags` call.

Additionally this sets up launch templates to use their `lt-` ID prefix so that we can get/set their tags more easily (now that #9519 is merged).