### PR TITLE
Use filebase64 for launch template userdata and Terraform 0.12

### DIFF
--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -437,7 +437,7 @@ resource "aws_launch_template" "bastion-bastionuserdata-example-com" {
     "kops.k8s.io/instancegroup"                         = "bastion"
     "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_bastion.bastionuserdata.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_bastion.bastionuserdata.example.com_user_data")
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-bastionuserdata-example-com" {
@@ -495,7 +495,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-bastionuserdata-exampl
     "kops.k8s.io/instancegroup"                         = "master-us-test-1a"
     "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-bastionuserdata-example-com" {
@@ -549,7 +549,7 @@ resource "aws_launch_template" "nodes-bastionuserdata-example-com" {
     "kops.k8s.io/instancegroup"                         = "nodes"
     "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.bastionuserdata.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.bastionuserdata.example.com_user_data")
 }
 
 resource "aws_nat_gateway" "us-test-1a-bastionuserdata-example-com" {

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -346,7 +346,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
     "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-complex-example-com" {
@@ -413,7 +413,7 @@ resource "aws_launch_template" "nodes-complex-example-com" {
     "kops.k8s.io/instancegroup"                 = "nodes"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.complex.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.complex.example.com_user_data")
 }
 
 resource "aws_route53_record" "api-complex-example-com" {

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -375,7 +375,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-existing-iam-example-c
     "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/existing-iam.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data")
 }
 
 resource "aws_launch_template" "master-us-test-1b-masters-existing-iam-example-com" {
@@ -433,7 +433,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-existing-iam-example-c
     "kops.k8s.io/instancegroup"                      = "master-us-test-1b"
     "kubernetes.io/cluster/existing-iam.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1b.masters.existing-iam.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1b.masters.existing-iam.example.com_user_data")
 }
 
 resource "aws_launch_template" "master-us-test-1c-masters-existing-iam-example-com" {
@@ -491,7 +491,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-existing-iam-example-c
     "kops.k8s.io/instancegroup"                      = "master-us-test-1c"
     "kubernetes.io/cluster/existing-iam.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1c.masters.existing-iam.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1c.masters.existing-iam.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-existing-iam-example-com" {
@@ -545,7 +545,7 @@ resource "aws_launch_template" "nodes-existing-iam-example-com" {
     "kops.k8s.io/instancegroup"                      = "nodes"
     "kubernetes.io/cluster/existing-iam.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.existing-iam.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.existing-iam.example.com_user_data")
 }
 
 resource "aws_route_table_association" "us-test-1a-existing-iam-example-com" {

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -469,7 +469,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-existingsg-example-com
     "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
     "kubernetes.io/cluster/existingsg.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data")
 }
 
 resource "aws_launch_template" "master-us-test-1b-masters-existingsg-example-com" {
@@ -527,7 +527,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-existingsg-example-com
     "kops.k8s.io/instancegroup"                    = "master-us-test-1b"
     "kubernetes.io/cluster/existingsg.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data")
 }
 
 resource "aws_launch_template" "master-us-test-1c-masters-existingsg-example-com" {
@@ -585,7 +585,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-existingsg-example-com
     "kops.k8s.io/instancegroup"                    = "master-us-test-1c"
     "kubernetes.io/cluster/existingsg.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-existingsg-example-com" {
@@ -639,7 +639,7 @@ resource "aws_launch_template" "nodes-existingsg-example-com" {
     "kops.k8s.io/instancegroup"                    = "nodes"
     "kubernetes.io/cluster/existingsg.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.existingsg.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.existingsg.example.com_user_data")
 }
 
 resource "aws_route53_record" "api-existingsg-example-com" {

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -300,7 +300,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-externallb-example-com
     "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
     "kubernetes.io/cluster/externallb.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-externallb-example-com" {
@@ -354,7 +354,7 @@ resource "aws_launch_template" "nodes-externallb-example-com" {
     "kops.k8s.io/instancegroup"                    = "nodes"
     "kubernetes.io/cluster/externallb.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.externallb.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.externallb.example.com_user_data")
 }
 
 resource "aws_route_table_association" "us-test-1a-externallb-example-com" {

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -362,7 +362,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-externalpolicies-examp
     "kops.k8s.io/instancegroup"                          = "master-us-test-1a"
     "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-externalpolicies-example-com" {
@@ -422,7 +422,7 @@ resource "aws_launch_template" "nodes-externalpolicies-example-com" {
     "kops.k8s.io/instancegroup"                          = "nodes"
     "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.externalpolicies.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.externalpolicies.example.com_user_data")
 }
 
 resource "aws_route53_record" "api-externalpolicies-example-com" {

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -427,7 +427,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-ha-example-com" {
     "kops.k8s.io/instancegroup"            = "master-us-test-1a"
     "kubernetes.io/cluster/ha.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data")
 }
 
 resource "aws_launch_template" "master-us-test-1b-masters-ha-example-com" {
@@ -485,7 +485,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-ha-example-com" {
     "kops.k8s.io/instancegroup"            = "master-us-test-1b"
     "kubernetes.io/cluster/ha.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data")
 }
 
 resource "aws_launch_template" "master-us-test-1c-masters-ha-example-com" {
@@ -543,7 +543,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-ha-example-com" {
     "kops.k8s.io/instancegroup"            = "master-us-test-1c"
     "kubernetes.io/cluster/ha.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-ha-example-com" {
@@ -597,7 +597,7 @@ resource "aws_launch_template" "nodes-ha-example-com" {
     "kops.k8s.io/instancegroup"            = "nodes"
     "kubernetes.io/cluster/ha.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.ha.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.ha.example.com_user_data")
 }
 
 resource "aws_route_table_association" "us-test-1a-ha-example-com" {

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -285,7 +285,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
     "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-minimal-example-com" {
@@ -339,7 +339,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
     "kops.k8s.io/instancegroup"                 = "nodes"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.minimal.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.minimal.example.com_user_data")
 }
 
 resource "aws_route_table_association" "us-test-1a-minimal-example-com" {

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -445,7 +445,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
     "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data")
 }
 
 resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example-com" {
@@ -503,7 +503,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
     "kops.k8s.io/instancegroup"                        = "master-us-test-1b"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data")
 }
 
 resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example-com" {
@@ -561,7 +561,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
     "kops.k8s.io/instancegroup"                        = "master-us-test-1c"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-mixedinstances-example-com" {
@@ -615,7 +615,7 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
     "kops.k8s.io/instancegroup"                        = "nodes"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.mixedinstances.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.mixedinstances.example.com_user_data")
 }
 
 resource "aws_route_table_association" "us-test-1a-mixedinstances-example-com" {

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -445,7 +445,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
     "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data")
 }
 
 resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example-com" {
@@ -503,7 +503,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
     "kops.k8s.io/instancegroup"                        = "master-us-test-1b"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data")
 }
 
 resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example-com" {
@@ -561,7 +561,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
     "kops.k8s.io/instancegroup"                        = "master-us-test-1c"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-mixedinstances-example-com" {
@@ -615,7 +615,7 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
     "kops.k8s.io/instancegroup"                        = "nodes"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.mixedinstances.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.mixedinstances.example.com_user_data")
 }
 
 resource "aws_route_table_association" "us-test-1a-mixedinstances-example-com" {

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -466,7 +466,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-private-shared-subnet-
     "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
     "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-private-shared-subnet-example-com" {
@@ -520,7 +520,7 @@ resource "aws_launch_template" "nodes-private-shared-subnet-example-com" {
     "kops.k8s.io/instancegroup"                               = "nodes"
     "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.private-shared-subnet.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.private-shared-subnet.example.com_user_data")
 }
 
 resource "aws_route53_record" "api-private-shared-subnet-example-com" {

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -494,7 +494,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecalico-example-
     "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
     "kubernetes.io/cluster/privatecalico.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-privatecalico-example-com" {
@@ -548,7 +548,7 @@ resource "aws_launch_template" "nodes-privatecalico-example-com" {
     "kops.k8s.io/instancegroup"                       = "nodes"
     "kubernetes.io/cluster/privatecalico.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.privatecalico.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privatecalico.example.com_user_data")
 }
 
 resource "aws_nat_gateway" "us-test-1a-privatecalico-example-com" {

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -494,7 +494,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecanal-example-c
     "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/privatecanal.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-privatecanal-example-com" {
@@ -548,7 +548,7 @@ resource "aws_launch_template" "nodes-privatecanal-example-com" {
     "kops.k8s.io/instancegroup"                      = "nodes"
     "kubernetes.io/cluster/privatecanal.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.privatecanal.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privatecanal.example.com_user_data")
 }
 
 resource "aws_nat_gateway" "us-test-1a-privatecanal-example-com" {

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -494,7 +494,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
     "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
     "kubernetes.io/cluster/privatecilium.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-privatecilium-example-com" {
@@ -548,7 +548,7 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
     "kops.k8s.io/instancegroup"                       = "nodes"
     "kubernetes.io/cluster/privatecilium.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.privatecilium.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privatecilium.example.com_user_data")
 }
 
 resource "aws_nat_gateway" "us-test-1a-privatecilium-example-com" {

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -494,7 +494,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
     "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
     "kubernetes.io/cluster/privatecilium.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-privatecilium-example-com" {
@@ -548,7 +548,7 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
     "kops.k8s.io/instancegroup"                       = "nodes"
     "kubernetes.io/cluster/privatecilium.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.privatecilium.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privatecilium.example.com_user_data")
 }
 
 resource "aws_nat_gateway" "us-test-1a-privatecilium-example-com" {

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -508,7 +508,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateciliumadvanced-
     "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
     "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-privateciliumadvanced-example-com" {
@@ -562,7 +562,7 @@ resource "aws_launch_template" "nodes-privateciliumadvanced-example-com" {
     "kops.k8s.io/instancegroup"                               = "nodes"
     "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data")
 }
 
 resource "aws_nat_gateway" "us-test-1a-privateciliumadvanced-example-com" {

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -548,7 +548,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns1-example-co
     "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-privatedns1-example-com" {
@@ -608,7 +608,7 @@ resource "aws_launch_template" "nodes-privatedns1-example-com" {
     "kops.k8s.io/instancegroup"                     = "nodes"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.privatedns1.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privatedns1.example.com_user_data")
 }
 
 resource "aws_nat_gateway" "us-test-1a-privatedns1-example-com" {

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -480,7 +480,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns2-example-co
     "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
     "kubernetes.io/cluster/privatedns2.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-privatedns2-example-com" {
@@ -534,7 +534,7 @@ resource "aws_launch_template" "nodes-privatedns2-example-com" {
     "kops.k8s.io/instancegroup"                     = "nodes"
     "kubernetes.io/cluster/privatedns2.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.privatedns2.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privatedns2.example.com_user_data")
 }
 
 resource "aws_nat_gateway" "us-test-1a-privatedns2-example-com" {

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -494,7 +494,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateflannel-example
     "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
     "kubernetes.io/cluster/privateflannel.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-privateflannel-example-com" {
@@ -548,7 +548,7 @@ resource "aws_launch_template" "nodes-privateflannel-example-com" {
     "kops.k8s.io/instancegroup"                        = "nodes"
     "kubernetes.io/cluster/privateflannel.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.privateflannel.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privateflannel.example.com_user_data")
 }
 
 resource "aws_nat_gateway" "us-test-1a-privateflannel-example-com" {

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -500,7 +500,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatekopeio-example-
     "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
     "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-privatekopeio-example-com" {
@@ -554,7 +554,7 @@ resource "aws_launch_template" "nodes-privatekopeio-example-com" {
     "kops.k8s.io/instancegroup"                       = "nodes"
     "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.privatekopeio.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privatekopeio.example.com_user_data")
 }
 
 resource "aws_route53_record" "api-privatekopeio-example-com" {

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -494,7 +494,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateweave-example-c
     "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/privateweave.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privateweave.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privateweave.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-privateweave-example-com" {
@@ -548,7 +548,7 @@ resource "aws_launch_template" "nodes-privateweave-example-com" {
     "kops.k8s.io/instancegroup"                      = "nodes"
     "kubernetes.io/cluster/privateweave.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.privateweave.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privateweave.example.com_user_data")
 }
 
 resource "aws_nat_gateway" "us-test-1a-privateweave-example-com" {

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -271,7 +271,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedsubnet-example-c
     "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-sharedsubnet-example-com" {
@@ -325,7 +325,7 @@ resource "aws_launch_template" "nodes-sharedsubnet-example-com" {
     "kops.k8s.io/instancegroup"                      = "nodes"
     "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data")
 }
 
 resource "aws_security_group_rule" "all-master-to-master" {

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -271,7 +271,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedvpc-example-com"
     "kops.k8s.io/instancegroup"                   = "master-us-test-1a"
     "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-sharedvpc-example-com" {
@@ -325,7 +325,7 @@ resource "aws_launch_template" "nodes-sharedvpc-example-com" {
     "kops.k8s.io/instancegroup"                   = "nodes"
     "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.sharedvpc.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.sharedvpc.example.com_user_data")
 }
 
 resource "aws_route_table_association" "us-test-1a-sharedvpc-example-com" {

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -471,7 +471,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-unmanaged-example-com"
     "kops.k8s.io/instancegroup"                   = "master-us-test-1a"
     "kubernetes.io/cluster/unmanaged.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data")
 }
 
 resource "aws_launch_template" "nodes-unmanaged-example-com" {
@@ -525,7 +525,7 @@ resource "aws_launch_template" "nodes-unmanaged-example-com" {
     "kops.k8s.io/instancegroup"                   = "nodes"
     "kubernetes.io/cluster/unmanaged.example.com" = "owned"
   }
-  user_data = file("${path.module}/data/aws_launch_template_nodes.unmanaged.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_nodes.unmanaged.example.com_user_data")
 }
 
 resource "aws_route53_record" "api-unmanaged-example-com" {

--- a/upup/pkg/fi/cloudup/terraform/hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/hcl2.go
@@ -106,7 +106,7 @@ func writeLiteral(body *hclwrite.Body, key string, literal *Literal) {
 		tokens := hclwrite.Tokens{
 			{
 				Type:  hclsyntax.TokenIdent,
-				Bytes: []byte(fmt.Sprintf("file(%q)", literal.FilePath)),
+				Bytes: []byte(fmt.Sprintf("%v(%q)", literal.FileFn, literal.FilePath)),
 			},
 		}
 		body.SetAttributeRaw(key, tokens)
@@ -193,7 +193,7 @@ func writeMap(body *hclwrite.Body, key string, values map[string]cty.Value) {
 			// For maps of literals we currently only support file references
 			// If we ever need to support a map of strings to resource property references that can be added here
 			if literal.FilePath != "" {
-				tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte(fmt.Sprintf("file(%q)", literal.FilePath))})
+				tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte(fmt.Sprintf("%v(%q)", literal.FileFn, literal.FilePath))})
 			} else if literal.Value != "" {
 				tokens = append(tokens, []*hclwrite.Token{
 					{Type: hclsyntax.TokenOQuote, Bytes: []byte{'"'}, SpacesBefore: 1},

--- a/upup/pkg/fi/cloudup/terraform/hcl2_test.go
+++ b/upup/pkg/fi/cloudup/terraform/hcl2_test.go
@@ -134,6 +134,7 @@ func TestWriteLiteral(t *testing.T) {
 			name: "file",
 			literal: &Literal{
 				FilePath: "${path.module}/foo",
+				FileFn:   fileFnFile,
 			},
 			expected: `foo = file("${path.module}/foo")`,
 		},
@@ -273,13 +274,13 @@ func TestWriteMapLiterals(t *testing.T) {
 		{
 			name: "literal values",
 			values: map[string]Literal{
-				"key1": {FilePath: "${module.path}/path/to/value1"},
-				"key2": {FilePath: "${module.path}/path/to/value2"},
+				"key1": {FilePath: "${module.path}/path/to/value1", FileFn: fileFnFile},
+				"key2": {FilePath: "${module.path}/path/to/value2", FileFn: fileFnFileBase64},
 			},
 			expected: `
 metadata = {
   "key1" = file("${module.path}/path/to/value1")
-  "key2" = file("${module.path}/path/to/value2")
+  "key2" = filebase64("${module.path}/path/to/value2")
 }
 			`,
 		},


### PR DESCRIPTION
In order to provide the HCL2 generation code with knowledge of which function to use for each file reference (`file()` vs `filebase64()` we need to store that in the Literal, so this adds a new field with that information.

Fixes #9518