### PR TITLE
Add tagging support for AWS Keypairs

### DIFF
--- a/cloudmock/aws/mockec2/api.go
+++ b/cloudmock/aws/mockec2/api.go
@@ -91,7 +91,7 @@ func (m *MockEC2) All() map[string]interface{} {
 		all[id] = o
 	}
 	for id, o := range m.KeyPairs {
-		all["sshkey-"+id] = o
+		all[id] = o
 	}
 	for id, o := range m.Vpcs {
 		all[id] = o

--- a/cloudmock/aws/mockec2/tags.go
+++ b/cloudmock/aws/mockec2/tags.go
@@ -71,6 +71,8 @@ func (m *MockEC2) addTags(resourceId string, tags ...*ec2.Tag) {
 		resourceType = ec2.ResourceTypeElasticIp
 	} else if strings.HasPrefix(resourceId, "lt-") {
 		resourceType = ec2.ResourceTypeLaunchTemplate
+	} else if strings.HasPrefix(resourceId, "key-") {
+		resourceType = ec2.ResourceTypeKeyPair
 	} else {
 		klog.Fatalf("Unknown resource-type in create tags: %v", resourceId)
 	}

--- a/pkg/model/sshkey.go
+++ b/pkg/model/sshkey.go
@@ -41,6 +41,8 @@ func (b *SSHKeyModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	t := &awstasks.SSHKey{
 		Name:      s(name),
 		Lifecycle: b.Lifecycle,
+		Tags:      b.CloudTags(b.ClusterName(), false),
+		Shared:    fi.StringValue(b.Cluster.Spec.SSHKeyName) != "",
 	}
 	if len(b.SSHPublicKeys) >= 1 {
 		t.PublicKey = fi.WrapResource(fi.NewStringResource(string(b.SSHPublicKeys[0])))

--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -674,15 +674,15 @@ func DescribeVolumes(cloud fi.Cloud) ([]*ec2.Volume, error) {
 func DeleteKeypair(cloud fi.Cloud, r *resources.Resource) error {
 	c := cloud.(awsup.AWSCloud)
 
-	name := r.Name
+	id := r.ID
 
-	klog.V(2).Infof("Deleting EC2 Keypair %q", name)
+	klog.V(2).Infof("Deleting EC2 Keypair %q", id)
 	request := &ec2.DeleteKeyPairInput{
-		KeyName: &name,
+		KeyPairId: &id,
 	}
 	_, err := c.EC2().DeleteKeyPair(request)
 	if err != nil {
-		return fmt.Errorf("error deleting KeyPair %q: %v", name, err)
+		return fmt.Errorf("error deleting KeyPair %q: %v", id, err)
 	}
 	return nil
 }
@@ -711,12 +711,13 @@ func ListKeypairs(cloud fi.Cloud, clusterName string) ([]*resources.Resource, er
 
 	for _, keypair := range response.KeyPairs {
 		name := aws.StringValue(keypair.KeyName)
+		id := aws.StringValue(keypair.KeyPairId)
 		if name != keypairName && !strings.HasPrefix(name, keypairName+"-") {
 			continue
 		}
 		resourceTracker := &resources.Resource{
 			Name:    name,
-			ID:      name,
+			ID:      id,
 			Type:    "keypair",
 			Deleter: DeleteKeypair,
 		}

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -384,6 +384,11 @@ resource "aws_internet_gateway" "bastionuserdata-example-com" {
 resource "aws_key_pair" "kubernetes-bastionuserdata-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.bastionuserdata.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.bastionuserdata.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                                 = "bastionuserdata.example.com"
+    "Name"                                              = "bastionuserdata.example.com"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "bastion-bastionuserdata-example-com" {

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -318,6 +318,11 @@ resource "aws_internet_gateway" "existing-iam-example-com" {
 resource "aws_key_pair" "kubernetes-existing-iam-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.existing-iam.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.existing-iam.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                              = "existing-iam.example.com"
+    "Name"                                           = "existing-iam.example.com"
+    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-existing-iam-example-com" {

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -412,6 +412,11 @@ resource "aws_internet_gateway" "existingsg-example-com" {
 resource "aws_key_pair" "kubernetes-existingsg-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.existingsg.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.existingsg.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                            = "existingsg.example.com"
+    "Name"                                         = "existingsg.example.com"
+    "kubernetes.io/cluster/existingsg.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-existingsg-example-com" {

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -243,6 +243,11 @@ resource "aws_internet_gateway" "externallb-example-com" {
 resource "aws_key_pair" "kubernetes-externallb-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.externallb.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.externallb.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                            = "externallb.example.com"
+    "Name"                                         = "externallb.example.com"
+    "kubernetes.io/cluster/externallb.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-externallb-example-com" {

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -299,6 +299,13 @@ resource "aws_internet_gateway" "externalpolicies-example-com" {
 resource "aws_key_pair" "kubernetes-externalpolicies-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.externalpolicies.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.externalpolicies.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                                  = "externalpolicies.example.com"
+    "Name"                                               = "externalpolicies.example.com"
+    "Owner"                                              = "John Doe"
+    "foo/bar"                                            = "fib+baz"
+    "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-externalpolicies-example-com" {

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -370,6 +370,11 @@ resource "aws_internet_gateway" "ha-example-com" {
 resource "aws_key_pair" "kubernetes-ha-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.ha.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.ha.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                    = "ha.example.com"
+    "Name"                                 = "ha.example.com"
+    "kubernetes.io/cluster/ha.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-ha-example-com" {

--- a/tests/integration/update_cluster/launch_templates/kubernetes.tf
+++ b/tests/integration/update_cluster/launch_templates/kubernetes.tf
@@ -359,6 +359,11 @@ resource "aws_internet_gateway" "launchtemplates-example-com" {
 resource "aws_key_pair" "kubernetes-launchtemplates-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.launchtemplates.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.launchtemplates.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                                 = "launchtemplates.example.com"
+    "Name"                                              = "launchtemplates.example.com"
+    "kubernetes.io/cluster/launchtemplates.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_configuration" "master-us-test-1a-masters-launchtemplates-example-com" {

--- a/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
+++ b/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
@@ -264,7 +264,12 @@
     "aws_key_pair": {
       "kubernetes-minimal-json-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157": {
         "key_name": "kubernetes.minimal-json.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57",
-        "public_key": "${file(\"${path.module}/data/aws_key_pair_kubernetes.minimal-json.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key\")}"
+        "public_key": "${file(\"${path.module}/data/aws_key_pair_kubernetes.minimal-json.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key\")}",
+        "tags": {
+          "KubernetesCluster": "minimal-json.example.com",
+          "Name": "minimal-json.example.com",
+          "kubernetes.io/cluster/minimal-json.example.com": "owned"
+        }
       }
     },
     "aws_launch_template": {

--- a/tests/integration/update_cluster/minimal-tf11/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-tf11/kubernetes.tf
@@ -247,6 +247,12 @@ resource "aws_internet_gateway" "minimal-tf11-example-com" {
 resource "aws_key_pair" "kubernetes-minimal-tf11-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.minimal-tf11.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = "${file("${path.module}/data/aws_key_pair_kubernetes.minimal-tf11.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")}"
+
+  tags = {
+    KubernetesCluster                                = "minimal-tf11.example.com"
+    Name                                             = "minimal-tf11.example.com"
+    "kubernetes.io/cluster/minimal-tf11.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-minimal-tf11-example-com" {

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -228,6 +228,11 @@ resource "aws_internet_gateway" "minimal-example-com" {
 resource "aws_key_pair" "kubernetes-minimal-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.minimal.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.minimal.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -388,6 +388,11 @@ resource "aws_internet_gateway" "mixedinstances-example-com" {
 resource "aws_key_pair" "kubernetes-mixedinstances-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.mixedinstances.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.mixedinstances.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "mixedinstances.example.com"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example-com" {

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -388,6 +388,11 @@ resource "aws_internet_gateway" "mixedinstances-example-com" {
 resource "aws_key_pair" "kubernetes-mixedinstances-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.mixedinstances.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.mixedinstances.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "mixedinstances.example.com"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example-com" {

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -356,6 +356,11 @@ resource "aws_iam_role" "nodes-private-shared-subnet-example-com" {
 resource "aws_key_pair" "kubernetes-private-shared-subnet-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.private-shared-subnet.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.private-shared-subnet.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
+    "Name"                                                    = "private-shared-subnet.example.com"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "bastion-private-shared-subnet-example-com" {

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -384,6 +384,11 @@ resource "aws_internet_gateway" "privatecalico-example-com" {
 resource "aws_key_pair" "kubernetes-privatecalico-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.privatecalico.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.privatecalico.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                               = "privatecalico.example.com"
+    "Name"                                            = "privatecalico.example.com"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "bastion-privatecalico-example-com" {

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -384,6 +384,11 @@ resource "aws_internet_gateway" "privatecanal-example-com" {
 resource "aws_key_pair" "kubernetes-privatecanal-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.privatecanal.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.privatecanal.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                              = "privatecanal.example.com"
+    "Name"                                           = "privatecanal.example.com"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "bastion-privatecanal-example-com" {

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -384,6 +384,11 @@ resource "aws_internet_gateway" "privatecilium-example-com" {
 resource "aws_key_pair" "kubernetes-privatecilium-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.privatecilium.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.privatecilium.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "privatecilium.example.com"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "bastion-privatecilium-example-com" {

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -384,6 +384,11 @@ resource "aws_internet_gateway" "privatecilium-example-com" {
 resource "aws_key_pair" "kubernetes-privatecilium-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.privatecilium.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.privatecilium.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "privatecilium.example.com"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "bastion-privatecilium-example-com" {

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -398,6 +398,11 @@ resource "aws_internet_gateway" "privateciliumadvanced-example-com" {
 resource "aws_key_pair" "kubernetes-privateciliumadvanced-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.privateciliumadvanced.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.privateciliumadvanced.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+    "Name"                                                    = "privateciliumadvanced.example.com"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "bastion-privateciliumadvanced-example-com" {

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -426,6 +426,13 @@ resource "aws_internet_gateway" "privatedns1-example-com" {
 resource "aws_key_pair" "kubernetes-privatedns1-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.privatedns1.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.privatedns1.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                             = "privatedns1.example.com"
+    "Name"                                          = "privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "bastion-privatedns1-example-com" {

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -370,6 +370,11 @@ resource "aws_iam_role" "nodes-privatedns2-example-com" {
 resource "aws_key_pair" "kubernetes-privatedns2-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.privatedns2.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.privatedns2.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                             = "privatedns2.example.com"
+    "Name"                                          = "privatedns2.example.com"
+    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "bastion-privatedns2-example-com" {

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -384,6 +384,11 @@ resource "aws_internet_gateway" "privateflannel-example-com" {
 resource "aws_key_pair" "kubernetes-privateflannel-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.privateflannel.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.privateflannel.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                                = "privateflannel.example.com"
+    "Name"                                             = "privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "bastion-privateflannel-example-com" {

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -390,6 +390,11 @@ resource "aws_internet_gateway" "privatekopeio-example-com" {
 resource "aws_key_pair" "kubernetes-privatekopeio-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.privatekopeio.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.privatekopeio.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "bastion-privatekopeio-example-com" {

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -384,6 +384,11 @@ resource "aws_internet_gateway" "privateweave-example-com" {
 resource "aws_key_pair" "kubernetes-privateweave-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.privateweave.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.privateweave.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                              = "privateweave.example.com"
+    "Name"                                           = "privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "bastion-privateweave-example-com" {

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -214,6 +214,11 @@ resource "aws_iam_role" "nodes-sharedsubnet-example-com" {
 resource "aws_key_pair" "kubernetes-sharedsubnet-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.sharedsubnet.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.sharedsubnet.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                              = "sharedsubnet.example.com"
+    "Name"                                           = "sharedsubnet.example.com"
+    "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-sharedsubnet-example-com" {

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -214,6 +214,11 @@ resource "aws_iam_role" "nodes-sharedvpc-example-com" {
 resource "aws_key_pair" "kubernetes-sharedvpc-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.sharedvpc.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.sharedvpc.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                           = "sharedvpc.example.com"
+    "Name"                                        = "sharedvpc.example.com"
+    "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-sharedvpc-example-com" {

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -361,6 +361,11 @@ resource "aws_iam_role" "nodes-unmanaged-example-com" {
 resource "aws_key_pair" "kubernetes-unmanaged-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
   key_name   = "kubernetes.unmanaged.example.com-c4:a6:ed:9a:a8:89:b9:e2:c3:9c:d6:63:eb:9c:71:57"
   public_key = file("${path.module}/data/aws_key_pair_kubernetes.unmanaged.example.com-c4a6ed9aa889b9e2c39cd663eb9c7157_public_key")
+  tags = {
+    "KubernetesCluster"                           = "unmanaged.example.com"
+    "Name"                                        = "unmanaged.example.com"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+  }
 }
 
 resource "aws_launch_template" "bastion-unmanaged-example-com" {


### PR DESCRIPTION
AWS recently added tagging support for keypairs as well as autogenerated IDs. This adds the usual cloud tags to keypairs as seen in the integration test outputs.

WIP while I figure out how to handle keys that are shared with the cluster rather than created by kops- would we tag it with "shared" like with do VPCs and Subnets or do we not tag it at all?

Also need to double check how kops deletes keypairs during a `delete cluster` and make sure these tags don't affect that process.

ref: #9640

At this point we could probably drop the cluster name prefix from key names but that's probably not necessary.