### PR TITLE
Use a stable key for signing service account tokens

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1571,8 +1571,8 @@ spec:
                       a valid PEM-encoded CA bundle.
                     type: string
                   serviceAccountPrivateKeyFile:
-                    description: ServiceAccountPrivateKeyFile the location for a certificate
-                      for service account signing
+                    description: ServiceAccountPrivateKeyFile is the location of the
+                      private key for service account token signing.
                     type: string
                   terminatedPodGCThreshold:
                     description: TerminatedPodGCThreshold is the number of terminated

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -287,6 +287,8 @@ func (b *KubeAPIServerBuilder) writeAuthenticationConfig(c *fi.ModelBuilderConte
 // buildPod is responsible for generating the kube-apiserver pod and thus manifest file
 func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 	kubeAPIServer := b.Cluster.Spec.KubeAPIServer
+	// TODO pass the public key instead. We would first need to segregate the secrets better.
+	kubeAPIServer.ServiceAccountKeyFile = append(kubeAPIServer.ServiceAccountKeyFile, filepath.Join(b.PathSrvKubernetes(), "service-account.key"))
 	kubeAPIServer.ClientCAFile = filepath.Join(b.PathSrvKubernetes(), "ca.crt")
 	kubeAPIServer.TLSCertFile = filepath.Join(b.PathSrvKubernetes(), "server.crt")
 	kubeAPIServer.TLSPrivateKeyFile = filepath.Join(b.PathSrvKubernetes(), "server.key")

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -104,7 +104,7 @@ func (b *KubeControllerManagerBuilder) buildPod() (*v1.Pod, error) {
 
 	kcm := b.Cluster.Spec.KubeControllerManager
 	kcm.RootCAFile = filepath.Join(b.PathSrvKubernetes(), "ca.crt")
-	kcm.ServiceAccountPrivateKeyFile = filepath.Join(b.PathSrvKubernetes(), "server.key")
+	kcm.ServiceAccountPrivateKeyFile = filepath.Join(b.PathSrvKubernetes(), "service-account.key")
 
 	flags, err := flagbuilder.BuildFlagsList(kcm)
 	if err != nil {

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -285,6 +285,7 @@ func RunGoldenTest(t *testing.T, basedir string, key string, builder func(*Nodeu
 		"kube-controller-manager": mustParsePrivateKey(dummyKey),
 		"kube-proxy":              mustParsePrivateKey(dummyKey),
 		"kube-scheduler":          mustParsePrivateKey(dummyKey),
+		"master":                  mustParsePrivateKey(dummyKey),
 	}
 	keystore.certs = map[string]*pki.Certificate{
 		"ca":                      mustParseCertificate(dummyCertificate),

--- a/nodeup/pkg/model/secrets.go
+++ b/nodeup/pkg/model/secrets.go
@@ -128,6 +128,10 @@ func (b *SecretBuilder) Build(c *fi.ModelBuilderContext) error {
 		}
 	}
 
+	if err := b.BuildPrivateKeyTask(c, "master", "service-account.key"); err != nil {
+		return err
+	}
+
 	// Support for basic auth was deprecated 1.16 and removed in 1.19
 	// https://github.com/kubernetes/kubernetes/pull/89069
 	if b.IsKubernetesLT("1.19") && b.SecretStore != nil {

--- a/nodeup/pkg/model/tests/golden/awsiam/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/awsiam/tasks-kube-apiserver.yaml
@@ -62,6 +62,7 @@ contents: |
       - --requestheader-group-headers=X-Remote-Group
       - --requestheader-username-headers=X-Remote-User
       - --secure-port=443
+      - --service-account-key-file=/srv/kubernetes/service-account.key
       - --service-cluster-ip-range=100.64.0.0/13
       - --storage-backend=etcd3
       - --tls-cert-file=/srv/kubernetes/server.crt

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
@@ -40,6 +40,7 @@ contents: |
       - --requestheader-group-headers=X-Remote-Group
       - --requestheader-username-headers=X-Remote-User
       - --secure-port=443
+      - --service-account-key-file=/srv/kubernetes/service-account.key
       - --service-cluster-ip-range=100.64.0.0/13
       - --storage-backend=etcd3
       - --tls-cert-file=/srv/kubernetes/server.crt

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-controller-manager.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-controller-manager.yaml
@@ -24,7 +24,7 @@ contents: |
       - --kubeconfig=/var/lib/kube-controller-manager/kubeconfig
       - --leader-elect=true
       - --root-ca-file=/srv/kubernetes/ca.crt
-      - --service-account-private-key-file=/srv/kubernetes/server.key
+      - --service-account-private-key-file=/srv/kubernetes/service-account.key
       - --use-service-account-credentials=true
       - --v=2
       - --logtostderr=false

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-secret.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-secret.yaml
@@ -98,6 +98,38 @@ mode: "0600"
 path: /srv/kubernetes/server.key
 type: file
 ---
+contents: |
+  -----BEGIN RSA PRIVATE KEY-----
+  MIIEpAIBAAKCAQEA4JwpEprZ5n8RIEt6jT2lAh+UDgRgx/4px21gjgywQivYHVxH
+  AZexVb/E9pBa9Q2G9B1Q7TCO7YsUVRQy4JMDZVt+McFnWVwexnqBYFNcVjkEmDgA
+  gvCYGE0P9d/RwRL4KuLHo+u6fv7P0jXMN+CpOxyLhYZZNa0ZOZDHsSiJSQSj9WGF
+  GHrbCf0KVDpKieR1uBqHrRO+mLR5zkX2L58m74kjK4dsBhmjeq/7OAoTmiG2QgJ/
+  P2IjyhiA2mRqY+hl55lwEUV/0yHYEkJC8LdGkwwZz2eF77aSPGmi/A2CSKgMwDTx
+  9m+P7jcpWreYw6NG9BueGoDIve/tgFKwvVFF6QIDAQABAoIBAA0ktjaTfyrAxsTI
+  Bezb7Zr5NBW55dvuII299cd6MJo+rI/TRYhvUv48kY8IFXp/hyUjzgeDLunxmIf9
+  /Zgsoic9Ol44/g45mMduhcGYPzAAeCdcJ5OB9rR9VfDCXyjYLlN8H8iU0734tTqM
+  0V13tQ9zdSqkGPZOIcq/kR/pylbOZaQMe97BTlsAnOMSMKDgnftY4122Lq3GYy+t
+  vpr+bKVaQZwvkLoSU3rECCaKaghgwCyX7jft9aEkhdJv+KlwbsGY6WErvxOaLWHd
+  cuMQjGapY1Fa/4UD00mvrA260NyKfzrp6+P46RrVMwEYRJMIQ8YBAk6N6Hh7dc0G
+  8Z6i1m0CgYEA9HeCJR0TSwbIQ1bDXUrzpftHuidG5BnSBtax/ND9qIPhR/FBW5nj
+  22nwLc48KkyirlfIULd0ae4qVXJn7wfYcuX/cJMLDmSVtlM5Dzmi/91xRiFgIzx1
+  AsbBzaFjISP2HpSgL+e9FtSXaaqeZVrflitVhYKUpI/AKV31qGHf04sCgYEA6zTV
+  99Sb49Wdlns5IgsfnXl6ToRttB18lfEKcVfjAM4frnkk06JpFAZeR+9GGKUXZHqs
+  z2qcplw4d/moCC6p3rYPBMLXsrGNEUFZqBlgz72QA6BBq3X0Cg1Bc2ZbK5VIzwkg
+  ST2SSux6ccROfgULmN5ZiLOtdUKNEZpFF3i3qtsCgYADT/s7dYFlatobz3kmMnXK
+  sfTu2MllHdRys0YGHu7Q8biDuQkhrJwhxPW0KS83g4JQym+0aEfzh36bWcl+u6R7
+  KhKj+9oSf9pndgk345gJz35RbPJYh+EuAHNvzdgCAvK6x1jETWeKf6btj5pF1U1i
+  Q4QNIw/QiwIXjWZeubTGsQKBgQCbduLu2rLnlyyAaJZM8DlHZyH2gAXbBZpxqU8T
+  t9mtkJDUS/KRiEoYGFV9CqS0aXrayVMsDfXY6B/S/UuZjO5u7LtklDzqOf1aKG3Q
+  dGXPKibknqqJYH+bnUNjuYYNerETV57lijMGHuSYCf8vwLn3oxBfERRX61M/DU8Z
+  worz/QKBgQDCTJI2+jdXg26XuYUmM4XXfnocfzAXhXBULt1nENcogNf1fcptAVtu
+  BAiz4/HipQKqoWVUYmxfgbbLRKKLK0s0lOWKbYdVjhEm/m2ZU8wtXTagNwkIGoyq
+  Y/C1Lox4f1ROJnCjc/hfcOjcxX5M8A8peecHWlVtUPKTJgxQ7oMKcw==
+  -----END RSA PRIVATE KEY-----
+mode: "0600"
+path: /srv/kubernetes/service-account.key
+type: file
+---
 Name: apiserver-aggregator
 signer: apiserver-aggregator-ca
 subject:

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-amd64.yaml
@@ -40,6 +40,7 @@ contents: |
       - --requestheader-group-headers=X-Remote-Group
       - --requestheader-username-headers=X-Remote-User
       - --secure-port=443
+      - --service-account-key-file=/srv/kubernetes/service-account.key
       - --service-cluster-ip-range=100.64.0.0/13
       - --storage-backend=etcd3
       - --tls-cert-file=/srv/kubernetes/server.crt

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-arm64.yaml
@@ -40,6 +40,7 @@ contents: |
       - --requestheader-group-headers=X-Remote-Group
       - --requestheader-username-headers=X-Remote-User
       - --secure-port=443
+      - --service-account-key-file=/srv/kubernetes/service-account.key
       - --service-cluster-ip-range=100.64.0.0/13
       - --storage-backend=etcd3
       - --tls-cert-file=/srv/kubernetes/server.crt

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-amd64.yaml
@@ -24,7 +24,7 @@ contents: |
       - --kubeconfig=/var/lib/kube-controller-manager/kubeconfig
       - --leader-elect=true
       - --root-ca-file=/srv/kubernetes/ca.crt
-      - --service-account-private-key-file=/srv/kubernetes/server.key
+      - --service-account-private-key-file=/srv/kubernetes/service-account.key
       - --use-service-account-credentials=true
       - --v=2
       - --logtostderr=false

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-arm64.yaml
@@ -24,7 +24,7 @@ contents: |
       - --kubeconfig=/var/lib/kube-controller-manager/kubeconfig
       - --leader-elect=true
       - --root-ca-file=/srv/kubernetes/ca.crt
-      - --service-account-private-key-file=/srv/kubernetes/server.key
+      - --service-account-private-key-file=/srv/kubernetes/service-account.key
       - --use-service-account-credentials=true
       - --v=2
       - --logtostderr=false

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -483,7 +483,7 @@ type KubeControllerManagerConfig struct {
 	Master string `json:"master,omitempty" flag:"master"`
 	// LogLevel is the defined logLevel
 	LogLevel int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
-	// ServiceAccountPrivateKeyFile the location for a certificate for service account signing
+	// ServiceAccountPrivateKeyFile is the location of the private key for service account token signing.
 	ServiceAccountPrivateKeyFile string `json:"serviceAccountPrivateKeyFile,omitempty" flag:"service-account-private-key-file"`
 	// Image is the docker image to use
 	Image string `json:"image,omitempty"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -483,7 +483,7 @@ type KubeControllerManagerConfig struct {
 	Master string `json:"master,omitempty" flag:"master"`
 	// LogLevel is the defined logLevel
 	LogLevel int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
-	// ServiceAccountPrivateKeyFile the location for a certificate for service account signing
+	// ServiceAccountPrivateKeyFile is the location of the private key for service account token signing.
 	ServiceAccountPrivateKeyFile string `json:"serviceAccountPrivateKeyFile,omitempty" flag:"service-account-private-key-file"`
 	// Image is the docker image to use
 	Image string `json:"image,omitempty"`

--- a/pkg/model/pki.go
+++ b/pkg/model/pki.go
@@ -171,6 +171,18 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		c.AddTask(aggregatorCA)
 	}
 
+	{
+		serviceAccount := &fitasks.Keypair{
+			// We only need the private key, but it's easier to create a certificate as well.
+			// The strange name is because Kops prior to 1.19 used the api-server TLS key for this.
+			Name:      fi.String("master"),
+			Lifecycle: b.Lifecycle,
+			Subject:   "cn=service-account",
+			Type:      "ca",
+		}
+		c.AddTask(serviceAccount)
+	}
+
 	// @TODO this is VERY presumptuous, i'm going on the basis we can make it configurable in the future.
 	// But I'm conscious not to do too much work on bootstrap tokens as it might overlay further down the
 	// line with the machines api


### PR DESCRIPTION
Service account tokens were signed by the private key of the api-server TLS certificate. When #9354 changed the latter to being issued out of nodeup, multiple masters would fail to verify each other's service account tokens. Single masters would work for a while, but would invalidate all extant service account tokens whenever the master was replaced.

This PR stops reusing the api-server TLS private key as the service account signing key, instead using a key generated by cloudup. In order to keep clusters created by kops 1.18 and earlier working, this key is named "master" so that such clusters will continue to use the (previous) api-server TLS private key as the service account signing key.

Fixes #9531 
