### PR TITLE
Force single arch support via env var

### DIFF
--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1008,7 +1008,7 @@ func (c *ApplyClusterCmd) addFileAssets(assetBuilder *assets.AssetBuilder) error
 	c.Assets = make(map[architectures.Architecture][]*MirroredAsset)
 	c.NodeUpSource = make(map[architectures.Architecture]string)
 	c.NodeUpHash = make(map[architectures.Architecture]string)
-	for _, arch := range architectures.GetSupprted() {
+	for _, arch := range architectures.GetSupported() {
 		c.Assets[arch] = []*MirroredAsset{}
 		c.NodeUpSource[arch] = ""
 		c.NodeUpHash[arch] = ""
@@ -1177,7 +1177,7 @@ func (c *ApplyClusterCmd) newNodeUpConfigBuilder(assetBuilder *assets.AssetBuild
 				components = append(components, "kube-apiserver", "kube-controller-manager", "kube-scheduler")
 			}
 
-			for _, arch := range architectures.GetSupprted() {
+			for _, arch := range architectures.GetSupported() {
 				for _, component := range components {
 					baseURL, err := url.Parse(cluster.Spec.KubernetesVersion)
 					if err != nil {
@@ -1203,7 +1203,7 @@ func (c *ApplyClusterCmd) newNodeUpConfigBuilder(assetBuilder *assets.AssetBuild
 		// `docker load` our images when using a KOPS_BASE_URL, so we
 		// don't need to push/pull from a registry
 		if os.Getenv("KOPS_BASE_URL") != "" && isMaster {
-			for _, arch := range architectures.GetSupprted() {
+			for _, arch := range architectures.GetSupported() {
 				// TODO: Build multi-arch Kops images
 				if arch != architectures.ArchitectureAmd64 {
 					continue
@@ -1287,7 +1287,7 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAddit
 	config.Tags = append(config.Tags, n.nodeUpTags...)
 
 	config.Assets = make(map[architectures.Architecture][]string)
-	for _, arch := range architectures.GetSupprted() {
+	for _, arch := range architectures.GetSupported() {
 		config.Assets[arch] = []string{}
 		for _, a := range n.Assets[arch] {
 			config.Assets[arch] = append(config.Assets[arch], a.CompactString())

--- a/util/pkg/architectures/architectures.go
+++ b/util/pkg/architectures/architectures.go
@@ -18,6 +18,7 @@ package architectures
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 
 	"k8s.io/klog"
@@ -42,6 +43,12 @@ func FindArchitecture() (Architecture, error) {
 }
 
 func GetSupprted() []Architecture {
+	// Force support for AMD64 only if env var is set
+	arch := os.Getenv("KOPS_ARCH_AMD64")
+	if arch != "" {
+		return []Architecture{ArchitectureAmd64}
+	}
+
 	return []Architecture{
 		ArchitectureAmd64,
 		ArchitectureArm64,

--- a/util/pkg/architectures/architectures.go
+++ b/util/pkg/architectures/architectures.go
@@ -43,10 +43,14 @@ func FindArchitecture() (Architecture, error) {
 }
 
 func GetSupported() []Architecture {
-	// Force support for AMD64 only if env var is set
-	arch := os.Getenv("KOPS_ARCH_AMD64")
-	if arch != "" {
+	// Kubernetes PR builds only generate AMD64 binaries at the moment
+	// Force support only for AMD64 or ARM64
+	arch := os.Getenv("KOPS_ARCH")
+	switch arch {
+	case "amd64":
 		return []Architecture{ArchitectureAmd64}
+	case "arm64":
+		return []Architecture{ArchitectureArm64}
 	}
 
 	return []Architecture{

--- a/util/pkg/architectures/architectures.go
+++ b/util/pkg/architectures/architectures.go
@@ -42,7 +42,7 @@ func FindArchitecture() (Architecture, error) {
 	}
 }
 
-func GetSupprted() []Architecture {
+func GetSupported() []Architecture {
 	// Force support for AMD64 only if env var is set
 	arch := os.Getenv("KOPS_ARCH_AMD64")
 	if arch != "" {


### PR DESCRIPTION
Force AMD64 or ARM64 only support via env var to address the issues with Kubernetes PR binaries being AMD64 only.

Fixes: #9526