### PR TITLE
Validate cloud labels

### DIFF
--- a/docs/releases/1.19-NOTES.md
+++ b/docs/releases/1.19-NOTES.md
@@ -4,7 +4,7 @@
 
 # Significant changes
 
-* On AWS kops now defaults to using launch templates instead of launch configurations.
+* On AWS kops now defaults to using launch templates instead of launch configurations. See "Breaking changes" below.
 
 * Clusters using the Amazon VPC CNI provider now perform an `ec2.DescribeInstanceTypes` call at instance launch time. In large clusters or AWS accounts this may lead to API throttling which could delay node readiness. If this becomes a problem please open a GitHub issue.
 
@@ -17,6 +17,8 @@
 * Support for Kubernetes 1.9 and 1.10 has been removed.
 
 * Support for the Romana networking provider has been removed.
+
+* Launch templates do not support empty tag keys or values. Ensure that all keys specified in `spec.cloudLabels` in any instance group are non-empty values.
 
 # Required Actions
 

--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -119,6 +119,8 @@ func ValidateInstanceGroup(g *kops.InstanceGroup, cloud fi.Cloud) field.ErrorLis
 		allErrs = append(allErrs, awsValidateInstanceGroup(g, cloud.(awsup.AWSCloud))...)
 	}
 
+	allErrs = append(allErrs, validateCloudLabels(g.Spec.CloudLabels, field.NewPath("spec", "cloudLabels"))...)
+
 	return allErrs
 }
 
@@ -240,6 +242,19 @@ func validateInstanceProfile(v *kops.IAMProfileSpec, fldPath *field.Path) field.
 		if err != nil || !strings.HasPrefix(parsedARN.Resource, "instance-profile") {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("profile"), instanceProfileARN,
 				"Instance Group IAM Instance Profile must be a valid aws arn such as arn:aws:iam::123456789012:instance-profile/KopsExampleRole"))
+		}
+	}
+	return allErrs
+}
+
+func validateCloudLabels(labels map[string]string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for tag, val := range labels {
+		if tag == "" {
+			allErrs = append(allErrs, field.Invalid(fldPath, tag, "cloud labels cannot be cannot be empty strings"))
+		}
+		if val == "" {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child(tag), val, "cloud labels cannot have empty values"))
 		}
 	}
 	return allErrs

--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -251,7 +251,7 @@ func validateCloudLabels(labels map[string]string, fldPath *field.Path) field.Er
 	allErrs := field.ErrorList{}
 	for tag, val := range labels {
 		if tag == "" {
-			allErrs = append(allErrs, field.Invalid(fldPath, tag, "cloud labels cannot be cannot be empty strings"))
+			allErrs = append(allErrs, field.Invalid(fldPath, tag, "cloud labels cannot be empty strings"))
 		}
 		if val == "" {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child(tag), val, "cloud labels cannot have empty values"))

--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -221,3 +221,19 @@ func TestValidBootDevice(t *testing.T) {
 		testErrors(t, g.volumeType, errs, g.expected)
 	}
 }
+
+func TestValidateCloudLabels(t *testing.T) {
+	labels := map[string]string{
+		"nonEmptyLabel": "value",
+		"emptyValue":    "",
+		"":              "emptyTag",
+	}
+
+	expected := []string{
+		"Invalid value::spec.cloudLabels.emptyValue",
+		"Invalid value::spec.cloudLabels",
+	}
+	errs := validateCloudLabels(labels, field.NewPath("spec", "cloudLabels"))
+	testErrors(t, "cloudLabels", errs, expected)
+
+}


### PR DESCRIPTION
Since moving to LaunchTemplates, cloudLabels cannot have empty values anymore. If one tries to, kops will just loop endlessly with AWS errors when trying to create the launch template.

/cc @rifelpet 