### PR TITLE
Add lyft hash environment variable

### DIFF
--- a/docs/networking/lyft-vpc.md
+++ b/docs/networking/lyft-vpc.md
@@ -42,6 +42,19 @@ You can specify which subnets to use for allocating Pod IPs by specifying
 
 In this example, new interfaces will be attached to subnets tagged with `KubernetesCluster = myclustername.mydns.io`.
 
+### Change the download location
+
+By default the plugin is downloaded from Github at node startup.  This location can be changed using environment variables
+
+```bash
+export LYFT_VPC_DOWNLOAD_URL="https://example.com/cni-ipvlan-vpc-k8s-amd64-v0.6.0.tar.gz"
+export LYFT_VPC_DOWNLOAD_HASH="3aadcb32ffda53990153790203eb72898e55a985207aa5b4451357f9862286f0"
+```
+
+The hash can be MD5, SHA1 or SHA256.
+
+
+
 ## Troubleshooting
 
 In case of any issues the directory `/var/log/aws-routed-eni` contains the log files of the CNI plugin. This directory is located in all the nodes in the cluster.

--- a/docs/networking/lyft-vpc.md
+++ b/docs/networking/lyft-vpc.md
@@ -53,8 +53,6 @@ export LYFT_VPC_DOWNLOAD_HASH="3aadcb32ffda53990153790203eb72898e55a985207aa5b44
 
 The hash can be MD5, SHA1 or SHA256.
 
-
-
 ## Troubleshooting
 
 In case of any issues the directory `/var/log/aws-routed-eni` contains the log files of the CNI plugin. This directory is located in all the nodes in the cluster.

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1063,6 +1063,11 @@ func (c *ApplyClusterCmd) addFileAssets(assetBuilder *assets.AssetBuilder) error
 				}
 			} else {
 				klog.Warningf("Using url from LYFT_VPC_DOWNLOAD_URL env var: %q", urlString)
+				hashString := os.Getenv("LYFT_VPC_DOWNLOAD_HASH")
+				hash, err = hashing.FromString(hashString)
+				if err != nil {
+					return fmt.Errorf("invalid hash supplied for lyft: %q", hashString)
+				}
 			}
 
 			u, err := url.Parse(urlString)


### PR DESCRIPTION
When setting the `LYFT_VPC_DOWNLOAD_URL` environment variable kops uses an empty hash in the user data.  This causes new nodes to fail to launch as the hash is unable to be verified.

Adding a new environment variable `LYFT_VPC_DOWNLOAD_HASH` allows a user to set the hash manually.