### PR TITLE
Openstack fixes

### DIFF
--- a/pkg/apis/kops/v1alpha2/defaults.go
+++ b/pkg/apis/kops/v1alpha2/defaults.go
@@ -46,25 +46,28 @@ func SetDefaults_ClusterSpec(obj *ClusterSpec) {
 		obj.Topology.DNS.Type = DNSTypePublic
 	}
 
-	if obj.API == nil {
-		obj.API = &AccessSpec{}
-	}
-
-	if obj.API.IsEmpty() {
-		switch obj.Topology.Masters {
-		case TopologyPublic:
-			obj.API.DNS = &DNSAccessSpec{}
-
-		case TopologyPrivate:
-			obj.API.LoadBalancer = &LoadBalancerAccessSpec{}
-
-		default:
-			klog.Infof("unknown master topology type: %q", obj.Topology.Masters)
+	if obj.CloudProvider != "openstack" {
+		if obj.API == nil {
+			obj.API = &AccessSpec{}
 		}
-	}
 
-	if obj.API.LoadBalancer != nil && obj.API.LoadBalancer.Type == "" {
-		obj.API.LoadBalancer.Type = LoadBalancerTypePublic
+		if obj.API.IsEmpty() {
+			switch obj.Topology.Masters {
+			case TopologyPublic:
+				obj.API.DNS = &DNSAccessSpec{}
+
+			case TopologyPrivate:
+				obj.API.LoadBalancer = &LoadBalancerAccessSpec{}
+
+			default:
+				klog.Infof("unknown master topology type: %q", obj.Topology.Masters)
+			}
+		}
+
+		if obj.API.LoadBalancer != nil && obj.API.LoadBalancer.Type == "" {
+			obj.API.LoadBalancer.Type = LoadBalancerTypePublic
+		}
+
 	}
 
 	if obj.Authorization == nil {

--- a/pkg/model/openstackmodel/firewall.go
+++ b/pkg/model/openstackmodel/firewall.go
@@ -479,18 +479,16 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	if b.UseLoadBalancerForAPI() && b.UseVIPACL() {
 		useVIPACL = true
 	}
-	if b.UseLoadBalancerForAPI() {
-		sg := &openstacktasks.SecurityGroup{
-			Name:             s(b.Cluster.Spec.MasterPublicName),
-			Lifecycle:        b.Lifecycle,
-			RemoveExtraRules: []string{"port=443"},
-		}
-		if useVIPACL {
-			sg.RemoveGroup = true
-		}
-		c.AddTask(sg)
-		sgMap[b.Cluster.Spec.MasterPublicName] = sg
+	sg := &openstacktasks.SecurityGroup{
+		Name:             s(b.Cluster.Spec.MasterPublicName),
+		Lifecycle:        b.Lifecycle,
+		RemoveExtraRules: []string{"port=443"},
 	}
+	if useVIPACL {
+		sg.RemoveGroup = true
+	}
+	c.AddTask(sg)
+	sgMap[b.Cluster.Spec.MasterPublicName] = sg
 	for _, role := range roles {
 
 		// Create Security Group for Role

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -174,7 +174,7 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 					instanceTask.FloatingIP = t
 				}
 			default:
-				if !b.UsesSSHBastion() {
+				if b.Cluster.Spec.Topology.Nodes == "public" {
 					t := &openstacktasks.FloatingIP{
 						Name:      fi.String(fmt.Sprintf("%s-%s", "fip", *instanceTask.Name)),
 						Lifecycle: b.Lifecycle,

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -174,7 +174,7 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 					instanceTask.FloatingIP = t
 				}
 			default:
-				if b.Cluster.Spec.Topology.Nodes == "public" {
+				if b.Cluster.Spec.Topology == nil || b.Cluster.Spec.Topology.Nodes == "public" {
 					t := &openstacktasks.FloatingIP{
 						Name:      fi.String(fmt.Sprintf("%s-%s", "fip", *instanceTask.Name)),
 						Lifecycle: b.Lifecycle,

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -159,28 +159,28 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 			case kops.InstanceGroupRoleBastion:
 				t := &openstacktasks.FloatingIP{
 					Name:      fi.String(fmt.Sprintf("%s-%s", "fip", *instanceTask.Name)),
-					Server:    instanceTask,
 					Lifecycle: b.Lifecycle,
 				}
 				c.AddTask(t)
+				instanceTask.FloatingIP = t
 			case kops.InstanceGroupRoleMaster:
 				if b.Cluster.Spec.CloudConfig.Openstack.Loadbalancer == nil {
 					t := &openstacktasks.FloatingIP{
 						Name:      fi.String(fmt.Sprintf("%s-%s", "fip", *instanceTask.Name)),
-						Server:    instanceTask,
 						Lifecycle: b.Lifecycle,
 					}
 					c.AddTask(t)
 					b.associateFIPToKeypair(t)
+					instanceTask.FloatingIP = t
 				}
 			default:
 				if !b.UsesSSHBastion() {
 					t := &openstacktasks.FloatingIP{
 						Name:      fi.String(fmt.Sprintf("%s-%s", "fip", *instanceTask.Name)),
-						Server:    instanceTask,
 						Lifecycle: b.Lifecycle,
 					}
 					c.AddTask(t)
+					instanceTask.FloatingIP = t
 				}
 			}
 		} else if b.Cluster.Spec.CloudConfig.Openstack != nil && b.Cluster.Spec.CloudConfig.Openstack.Router == nil {

--- a/pkg/model/openstackmodel/servergroup_test.go
+++ b/pkg/model/openstackmodel/servergroup_test.go
@@ -224,6 +224,9 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 							Region: "region",
 						},
 					},
+					Topology: &kops.TopologySpec{
+						Nodes: "private",
+					},
 				},
 			},
 			instanceGroups: []*kops.InstanceGroup{

--- a/pkg/model/openstackmodel/servergroup_test.go
+++ b/pkg/model/openstackmodel/servergroup_test.go
@@ -140,7 +140,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				masterFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-master-1-cluster"),
-					Server:    masterInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				nodeServerGroup := &openstacktasks.ServerGroup{
@@ -186,7 +185,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				nodeFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-node-1-cluster"),
-					Server:    nodeInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				return map[string]fi.Task{
@@ -325,7 +323,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				masterFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-master-1-cluster"),
-					Server:    masterInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				nodeServerGroup := &openstacktasks.ServerGroup{
@@ -411,7 +408,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				bastionFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-bastion-1-cluster"),
-					Server:    bastionInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				return map[string]fi.Task{
@@ -592,7 +588,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				masterAFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-master-a-1-cluster"),
-					Server:    masterAInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				masterBServerGroup := &openstacktasks.ServerGroup{
@@ -639,7 +634,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				masterBFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-master-b-1-cluster"),
-					Server:    masterBInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				masterCServerGroup := &openstacktasks.ServerGroup{
@@ -686,7 +680,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				masterCFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-master-c-1-cluster"),
-					Server:    masterCInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				nodeAServerGroup := &openstacktasks.ServerGroup{
@@ -732,7 +725,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				nodeAFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-node-a-1-cluster"),
-					Server:    nodeAInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				nodeBServerGroup := &openstacktasks.ServerGroup{
@@ -778,7 +770,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				nodeBFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-node-b-1-cluster"),
-					Server:    nodeBInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				nodeCServerGroup := &openstacktasks.ServerGroup{
@@ -824,7 +815,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				nodeCFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-node-c-1-cluster"),
-					Server:    nodeCInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				return map[string]fi.Task{
@@ -1144,7 +1134,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				nodeAFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-node-a-1-cluster"),
-					Server:    nodeAInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				nodeBServerGroup := &openstacktasks.ServerGroup{
@@ -1190,7 +1179,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				nodeBFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-node-b-1-cluster"),
-					Server:    nodeBInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				nodeCServerGroup := &openstacktasks.ServerGroup{
@@ -1236,7 +1224,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				nodeCFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-node-c-1-cluster"),
-					Server:    nodeCInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				loadbalancer := &openstacktasks.LB{
@@ -1827,7 +1814,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				masterAFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-master-1-cluster"),
-					Server:    masterAInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				masterBPort := &openstacktasks.Port{
@@ -1866,7 +1852,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				masterBFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-master-2-cluster"),
-					Server:    masterBInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				masterCPort := &openstacktasks.Port{
@@ -1905,7 +1890,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				masterCFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-master-3-cluster"),
-					Server:    masterCInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				nodeServerGroup := &openstacktasks.ServerGroup{
@@ -1951,7 +1935,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				nodeAFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-node-1-cluster"),
-					Server:    nodeAInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				nodeBPort := &openstacktasks.Port{
@@ -1989,7 +1972,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				nodeBFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-node-2-cluster"),
-					Server:    nodeBInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				nodeCPort := &openstacktasks.Port{
@@ -2027,7 +2009,6 @@ func Test_ServerGroupModelBuilder(t *testing.T) {
 				}
 				nodeCFloatingIP := &openstacktasks.FloatingIP{
 					Name:      s("fip-node-3-cluster"),
-					Server:    nodeCInstance,
 					Lifecycle: &clusterLifecycle,
 				}
 				return map[string]fi.Task{
@@ -3040,11 +3021,7 @@ func compareFloatingIPs(t *testing.T, actualTask fi.Task, expected *openstacktas
 
 	compareStrings(t, "Name", actual.Name, expected.Name)
 	compareLifecycles(t, actual.Lifecycle, expected.Lifecycle)
-	if pointersAreBothNil(t, "Server", actual.Server, expected.Server) {
-		compareLoadbalancers(t, actual.LB, expected.LB)
-	} else {
-		compareInstances(t, actual.Server, expected.Server)
-	}
+	compareLoadbalancers(t, actual.LB, expected.LB)
 }
 
 func compareLifecycles(t *testing.T, actual, expected *fi.Lifecycle) {

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -83,7 +83,7 @@ var readBackoff = wait.Backoff{
 // writeBackoff is the backoff strategy for openstack write retries.
 var writeBackoff = wait.Backoff{
 	Duration: time.Second,
-	Factor:   1.5,
+	Factor:   2,
 	Jitter:   0.1,
 	Steps:    5,
 }

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -296,7 +296,6 @@ type OpenstackCloud interface {
 
 	ListFloatingIPs() (fips []floatingips.FloatingIP, err error)
 	ListL3FloatingIPs(opts l3floatingip.ListOpts) (fips []l3floatingip.FloatingIP, err error)
-	CreateFloatingIP(opts floatingips.CreateOpts) (*floatingips.FloatingIP, error)
 	CreateL3FloatingIP(opts l3floatingip.CreateOpts) (fip *l3floatingip.FloatingIP, err error)
 	DeleteFloatingIP(id string) error
 	DeleteL3FloatingIP(id string) error

--- a/upup/pkg/fi/cloudup/openstack/floatingip.go
+++ b/upup/pkg/fi/cloudup/openstack/floatingip.go
@@ -43,24 +43,6 @@ func (c *openstackCloud) GetFloatingIP(id string) (fip *floatingips.FloatingIP, 
 	return fip, nil
 }
 
-func (c *openstackCloud) CreateFloatingIP(opts floatingips.CreateOpts) (fip *floatingips.FloatingIP, err error) {
-	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-
-		fip, err = floatingips.Create(c.ComputeClient(), opts).Extract()
-		if err != nil {
-			return false, fmt.Errorf("CreateFloatingIP: create floating IP failed: %v", err)
-		}
-		return true, nil
-	})
-	if !done {
-		if err == nil {
-			err = wait.ErrWaitTimeout
-		}
-		return fip, err
-	}
-	return fip, nil
-}
-
 func (c *openstackCloud) AssociateFloatingIPToInstance(serverID string, opts floatingips.AssociateOpts) (err error) {
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
 		err = floatingips.AssociateInstance(c.ComputeClient(), serverID, opts).ExtractErr()

--- a/upup/pkg/fi/cloudup/openstacktasks/instance.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance.go
@@ -297,15 +297,3 @@ func bootFromVolume(m map[string]string) bool {
 		return false
 	}
 }
-
-func (e *Instance) findServerFloatingIP(context *fi.Context, cloud openstack.OpenstackCloud) (*string, error) {
-	ips, err := cloud.ListServerFloatingIPs(fi.StringValue(e.ID))
-	if err != nil {
-		return nil, err
-	}
-	// assumes that we do have only one interface and 0-1 floatingip in server, the setup that kops does
-	if len(ips) > 0 {
-		return ips[0], nil
-	}
-	return nil, nil
-}


### PR DESCRIPTION
The refactoring done lately have created cyclic dependencies in cloudup tasks when provisioning clusters that use floating or fixed ips for accessing the master API.
This PR breaks this cycle by provisioning floating IPs before the instances.

Using fixed IPs for the API is probably not possible to fix since they are created together with the instance, so one will always have the bootstrapscript -> instance -> bootstrapscript cycle. I think that should be removed in a later PR.

/cc @zetaab 