### PR TITLE
Adding feature stability table to docs and including one example for encryption support in cilium

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -11,3 +11,7 @@
 .hidden {
 	display: none;
 }
+
+.kops_feature_table .md-typeset__table table{
+	max-width: fit-content;
+}

--- a/docs/networking/cilium.md
+++ b/docs/networking/cilium.md
@@ -121,6 +121,8 @@ Note that since Cilium Operator is the entity that interacts with the EC2 API to
 Also note that this feature has only been tested on the default kops AMIs.
 
 #### Enabling Encryption in Cilium
+{{ kops_feature_table(kops_added_default='1.19', k8s_min='1.17') }}
+
 As of Kops 1.19, it is possible to enable encryption for Cilium agent.
 In order to enable encryption, you must first generate the pre-shared key using this command:
 ```bash

--- a/hack/__init__.py
+++ b/hack/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def main():
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/mkdocs_macros/__init__.py
+++ b/hack/mkdocs_macros/__init__.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from .feature_stability_table import define_env
+
+
+def main():
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/mkdocs_macros/feature_stability_table.py
+++ b/hack/mkdocs_macros/feature_stability_table.py
@@ -55,7 +55,9 @@ def define_env(env):
             separators,
             values
         ]
-        return '\n'.join(table)
+        table = '\n'.join(table)
+        table = f'<div class="kops_feature_table">{table}</div>'
+        return table
 
 
 def main():

--- a/hack/mkdocs_macros/feature_stability_table.py
+++ b/hack/mkdocs_macros/feature_stability_table.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# -*- coding: utf-8 -*-
-
 
 def define_env(env):
     """Hook function"""
@@ -64,5 +62,5 @@ def main():
     pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/hack/update-header.sh
+++ b/hack/update-header.sh
@@ -17,7 +17,7 @@
 . "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 BAD_HEADERS=$((${KOPS_ROOT}/hack/verify-boilerplate.sh || true) | awk '{ print $7}')
-FORMATS="sh go Makefile Dockerfile"
+FORMATS="sh go Makefile Dockerfile py"
 
 YEAR=`date -u +%Y`
 

--- a/images/mkdocs/requirements.txt
+++ b/images/mkdocs/requirements.txt
@@ -2,3 +2,4 @@ mkdocs-material~=5.2.3
 mkdocs~=1.1.2
 pymdown-extensions==7.1
 pygments~=2.6.1
+mkdocs-macros-plugin~=0.4.9

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,7 +26,8 @@ theme:
     accent: 'green'
 plugins:
   - search
-
+  - macros:
+      module_name: mkdocs_macros
 extra_css: [extra.css]
 
 nav:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,7 @@ theme:
 plugins:
   - search
   - macros:
-      module_name: mkdocs_macros
+      module_name: hack.mkdocs_macros
 extra_css: [extra.css]
 
 nav:

--- a/mkdocs_macros.py
+++ b/mkdocs_macros.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+def define_env(env):
+    """Hook function"""
+
+    @env.macro
+    def kops_feature_table(**kwargs):
+        """
+        Generate a markdown table which will be rendered when called, along with the supported passed keyword args.
+        :param kwargs:
+                       kops_added_ff => Kops version in which this feature was added as a feature flag
+                       kops_added_default => Kops version in which this feature was introduced as stable
+                       k8s_min => Minimum k8s version which supports this feature
+        :return: rendered markdown table
+        """
+
+        # this dict object maps the kwarg to its description, which will be used in the final table
+        supported_args = {
+            'kops_added_ff':  'Alpha (Feature Flag)',
+            'kops_added_default': 'Default',
+            'k8s_min': 'Minimum K8s Version'
+        }
+
+        # Create the initial strings to which we'll concatenate the relevant columns
+        title = '** FEATURE STATE **\n\n|'
+        separators = '|'
+        values = '|'
+
+        # Iterate over provided supported kwargs and match them with the provided values.
+        for arg in supported_args.keys():
+            if arg in kwargs.keys():
+                title += f' {supported_args[arg]}  |'
+                separators += ' :-: |'
+                values += f' Kops {kwargs[arg]}  |'
+
+        # Create a list object containing all the table rows,
+        # Then return a string object which contains every list item in a new line.
+        table = [
+            title,
+            separators,
+            values
+        ]
+        return '\n'.join(table)
+
+
+def main():
+    pass
+
+
+if __name__ == '__main__':
+    main()

--- a/mkdocs_macros.py
+++ b/mkdocs_macros.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # -*- coding: utf-8 -*-
 
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,6 @@
 [build]
 publish = "site"
 command = "make build-docs-netlify"
-ignore = "git diff --quiet HEAD^ HEAD netlify.toml Makefile mkdocs.yml docs/ images/"
+ignore = "git diff --quiet HEAD^ HEAD netlify.toml Makefile mkdocs.yml docs/ images/ hack/"
 # available here https://github.com/netlify/build-image/blob/xenial/included_software.md#languages
 environment = { PYTHON_VERSION = "3.7" }


### PR DESCRIPTION
Fixes #9151 
To get started, I also added this table to the `cilium` docs for a feature I previously added. This can provide an example for additional features to which we would like to add this table.
Example output of the table when rendered:

<img width="806" alt="image" src="https://user-images.githubusercontent.com/12524503/87258581-b0380a80-c472-11ea-9eb0-3ed986e7e185.png">

/cc @rifelpet @olemarkus 