### PR TITLE
Automated cherry pick of #9512: Update kube-router to v1.0.0 #9547: Widen the tolerations of kuberouter

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -6515,9 +6515,12 @@ spec:
         - name: kubeconfig
           mountPath: /var/lib/kube-router/kubeconfig
           readOnly: true
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+          readOnly: false
       initContainers:
       - name: install-cni
-        image: busybox
+        image: docker.io/cloudnativelabs/kube-router:v1.0.0
         command:
         - /bin/sh
         - -c
@@ -6700,12 +6703,9 @@ spec:
         - name: kubeconfig
           mountPath: /var/lib/kube-router/kubeconfig
           readOnly: true
-        - name: xtables-lock
-          mountPath: /run/xtables.lock
-          readOnly: false
       initContainers:
       - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router:v1.0.0
+        image: busybox
         command:
         - /bin/sh
         - -c

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -6537,14 +6537,7 @@ spec:
           name: kube-router-cfg
       hostNetwork: true
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-        operator: Exists
+      - operator: Exists
       volumes:
       - name: lib-modules
         hostPath:
@@ -6730,10 +6723,7 @@ spec:
       hostNetwork: true
       serviceAccountName: kube-router
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoSchedule
-        operator: Exists
+      - operator: Exists
       volumes:
       - hostPath:
           path: /lib/modules

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -6429,7 +6429,7 @@ func cloudupResourcesAddonsNetworkingKopeIoK8s16Yaml() (*asset, error) {
 	return a, nil
 }
 
-var _cloudupResourcesAddonsNetworkingKuberouterK8s112YamlTemplate = []byte(`# Pulled and modified from https://github.com/cloudnativelabs/kube-router/blob/v0.4.0/daemonset/kubeadm-kuberouter.yaml
+var _cloudupResourcesAddonsNetworkingKuberouterK8s112YamlTemplate = []byte(`# Pulled and modified from https://raw.githubusercontent.com/cloudnativelabs/kube-router/v1.0.0/daemonset/kubeadm-kuberouter.yaml
 
 apiVersion: v1
 kind: ConfigMap
@@ -6480,7 +6480,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: docker.io/cloudnativelabs/kube-router:v0.4.0
+        image: docker.io/cloudnativelabs/kube-router:v1.0.0
         args:
         - --run-router=true
         - --run-firewall=true
@@ -6558,6 +6558,10 @@ spec:
       - name: kubeconfig
         hostPath:
           path: /var/lib/kube-router/kubeconfig
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -6703,9 +6707,12 @@ spec:
         - name: kubeconfig
           mountPath: /var/lib/kube-router/kubeconfig
           readOnly: true
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+          readOnly: false
       initContainers:
       - name: install-cni
-        image: busybox
+        image: docker.io/cloudnativelabs/kube-router:v1.0.0
         command:
         - /bin/sh
         - -c

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -109,14 +109,7 @@ spec:
           name: kube-router-cfg
       hostNetwork: true
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-        operator: Exists
+      - operator: Exists
       volumes:
       - name: lib-modules
         hostPath:

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -1,4 +1,4 @@
-# Pulled and modified from https://github.com/cloudnativelabs/kube-router/blob/v0.4.0/daemonset/kubeadm-kuberouter.yaml
+# Pulled and modified from https://raw.githubusercontent.com/cloudnativelabs/kube-router/v1.0.0/daemonset/kubeadm-kuberouter.yaml
 
 apiVersion: v1
 kind: ConfigMap
@@ -49,7 +49,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: docker.io/cloudnativelabs/kube-router:v0.4.0
+        image: docker.io/cloudnativelabs/kube-router:v1.0.0
         args:
         - --run-router=true
         - --run-firewall=true
@@ -84,9 +84,12 @@ spec:
         - name: kubeconfig
           mountPath: /var/lib/kube-router/kubeconfig
           readOnly: true
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+          readOnly: false
       initContainers:
       - name: install-cni
-        image: busybox
+        image: docker.io/cloudnativelabs/kube-router:v1.0.0
         command:
         - /bin/sh
         - -c
@@ -127,6 +130,10 @@ spec:
       - name: kubeconfig
         hostPath:
           path: /var/lib/kube-router/kubeconfig
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template
@@ -90,10 +90,7 @@ spec:
       hostNetwork: true
       serviceAccountName: kube-router
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoSchedule
-        operator: Exists
+      - operator: Exists
       volumes:
       - hostPath:
           path: /lib/modules

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -853,8 +853,8 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 	if b.cluster.Spec.Networking.Kuberouter != nil {
 		key := "networking.kuberouter"
 		versions := map[string]string{
-			"k8s-1.6":  "0.3.1-kops.3",
-			"k8s-1.12": "1.0.0-kops.1",
+			"k8s-1.6":  "0.3.1-kops.4",
+			"k8s-1.12": "1.0.0-kops.2",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -854,7 +854,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		key := "networking.kuberouter"
 		versions := map[string]string{
 			"k8s-1.6":  "0.3.1-kops.3",
-			"k8s-1.12": "0.4.0-kops.3",
+			"k8s-1.12": "1.0.0-kops.1",
 		}
 
 		{


### PR DESCRIPTION
Cherry pick of #9512 #9547 on release-1.18.

#9512: Update kube-router to v1.0.0
#9547: Widen the tolerations of kuberouter

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.