### PR TITLE
Automated cherry pick of #9553: Add missing lifecycle to etcd keypair tasks

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -115,32 +115,36 @@ func (b *EtcdManagerBuilder) Build(c *fi.ModelBuilderContext) error {
 
 		// We create a CA keypair to enable secure communication
 		c.AddTask(&fitasks.Keypair{
-			Name:    fi.String("etcd-manager-ca-" + etcdCluster.Name),
-			Subject: "cn=etcd-manager-ca-" + etcdCluster.Name,
-			Type:    "ca",
+			Name:      fi.String("etcd-manager-ca-" + etcdCluster.Name),
+			Lifecycle: b.Lifecycle,
+			Subject:   "cn=etcd-manager-ca-" + etcdCluster.Name,
+			Type:      "ca",
 		})
 
 		// We create a CA for etcd peers and a separate one for clients
 		c.AddTask(&fitasks.Keypair{
-			Name:    fi.String("etcd-peers-ca-" + etcdCluster.Name),
-			Subject: "cn=etcd-peers-ca-" + etcdCluster.Name,
-			Type:    "ca",
+			Name:      fi.String("etcd-peers-ca-" + etcdCluster.Name),
+			Lifecycle: b.Lifecycle,
+			Subject:   "cn=etcd-peers-ca-" + etcdCluster.Name,
+			Type:      "ca",
 		})
 
 		// Because API server can only have a single client-cert, we need to share a client CA
 		if err := c.EnsureTask(&fitasks.Keypair{
-			Name:    fi.String("etcd-clients-ca"),
-			Subject: "cn=etcd-clients-ca",
-			Type:    "ca",
+			Name:      fi.String("etcd-clients-ca"),
+			Lifecycle: b.Lifecycle,
+			Subject:   "cn=etcd-clients-ca",
+			Type:      "ca",
 		}); err != nil {
 			return err
 		}
 
 		if etcdCluster.Name == "cilium" {
 			c.AddTask(&fitasks.Keypair{
-				Name:    fi.String("etcd-clients-ca-cilium"),
-				Subject: "cn=etcd-clients-ca-cilium",
-				Type:    "ca",
+				Name:      fi.String("etcd-clients-ca-cilium"),
+				Lifecycle: b.Lifecycle,
+				Subject:   "cn=etcd-clients-ca-cilium",
+				Type:      "ca",
 			})
 		}
 	}


### PR DESCRIPTION
Cherry pick of #9553 on release-1.18.

#9553: Add missing lifecycle to etcd keypair tasks

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.