### PR TITLE
Determine fixedip during nodeup directly

### DIFF
--- a/pkg/model/openstackmodel/network.go
+++ b/pkg/model/openstackmodel/network.go
@@ -50,6 +50,10 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 
 	needRouter := true
+	//Do not need router if there is no external network
+	if b.Cluster.Spec.CloudConfig.Openstack.Router.ExternalNetwork == nil {
+		needRouter = false
+	}
 	routerName := strings.Replace(clusterName, ".", "-", -1)
 	for _, sp := range b.Cluster.Spec.Subnets {
 		// assumes that we do not need to create routers if we use existing subnets

--- a/pkg/model/openstackmodel/network.go
+++ b/pkg/model/openstackmodel/network.go
@@ -49,9 +49,11 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		c.AddTask(t)
 	}
 
+	osSpec := b.Cluster.Spec.CloudConfig.Openstack
+
 	needRouter := true
 	//Do not need router if there is no external network
-	if b.Cluster.Spec.CloudConfig.Openstack.Router.ExternalNetwork == nil {
+	if osSpec.Router == nil || osSpec.Router.ExternalNetwork == nil {
 		needRouter = false
 	}
 	routerName := strings.Replace(clusterName, ".", "-", -1)
@@ -72,8 +74,8 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Lifecycle:  b.Lifecycle,
 			Tag:        s(clusterName),
 		}
-		if b.Cluster.Spec.CloudConfig.Openstack.Router != nil && b.Cluster.Spec.CloudConfig.Openstack.Router.DNSServers != nil {
-			dnsSplitted := strings.Split(fi.StringValue(b.Cluster.Spec.CloudConfig.Openstack.Router.DNSServers), ",")
+		if osSpec.Router != nil && osSpec.Router.DNSServers != nil {
+			dnsSplitted := strings.Split(fi.StringValue(osSpec.Router.DNSServers), ",")
 			dnsNameSrv := make([]*string, len(dnsSplitted))
 			for i, ns := range dnsSplitted {
 				dnsNameSrv[i] = fi.String(ns)

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -150,9 +150,6 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 		// associate it to a node if bastion is not used
 		if b.Cluster.Spec.CloudConfig.Openstack != nil && b.Cluster.Spec.CloudConfig.Openstack.Router != nil {
 			if ig.Spec.AssociatePublicIP != nil && !fi.BoolValue(ig.Spec.AssociatePublicIP) {
-				if ig.Spec.Role == kops.InstanceGroupRoleMaster {
-					b.associateFixedIPToKeypair(instanceTask)
-				}
 				continue
 			}
 			switch ig.Spec.Role {
@@ -183,21 +180,10 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 					instanceTask.FloatingIP = t
 				}
 			}
-		} else if b.Cluster.Spec.CloudConfig.Openstack != nil && b.Cluster.Spec.CloudConfig.Openstack.Router == nil {
-			// No external router, but we need to add master fixed ips to certificates
-			if ig.Spec.Role == kops.InstanceGroupRoleMaster {
-				b.associateFixedIPToKeypair(instanceTask)
-			}
 		}
 	}
 
 	return nil
-}
-
-func (b *ServerGroupModelBuilder) associateFixedIPToKeypair(fipTask *openstacktasks.Instance) {
-	// Ensure the floating IP is included in the TLS certificate,
-	// if we're not going to use an alias for it
-	fipTask.ForAPIServer = true
 }
 
 func (b *ServerGroupModelBuilder) associateFIPToKeypair(fipTask *openstacktasks.FloatingIP) {

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -77,7 +77,7 @@ var readBackoff = wait.Backoff{
 	Duration: time.Second,
 	Factor:   1.5,
 	Jitter:   0.1,
-	Steps:    4,
+	Steps:    10,
 }
 
 // writeBackoff is the backoff strategy for openstack write retries.
@@ -651,38 +651,49 @@ func (c *openstackCloud) GetApiIngressStatus(cluster *kops.Cluster) ([]kops.ApiI
 }
 
 func getApiIngressStatus(c OpenstackCloud, cluster *kops.Cluster) ([]kops.ApiIngressStatus, error) {
-	var ingresses []kops.ApiIngressStatus
 	if cluster.Spec.CloudConfig.Openstack.Loadbalancer != nil {
-		if cluster.Spec.MasterPublicName != "" {
-			// Note that this must match OpenstackModel lb name
-			klog.V(2).Infof("Querying Openstack to find Loadbalancers for API (%q)", cluster.Name)
-			lbList, err := c.ListLBs(loadbalancers.ListOpts{
-				Name: cluster.Spec.MasterPublicName,
+		return getLoadBalancerIngressStatus(c, cluster)
+	} else {
+		return getIPIngressStatus(c, cluster)
+	}
+}
+
+func getLoadBalancerIngressStatus(c OpenstackCloud, cluster *kops.Cluster) ([]kops.ApiIngressStatus, error) {
+	var ingresses []kops.ApiIngressStatus
+	if cluster.Spec.MasterPublicName != "" {
+		// Note that this must match OpenstackModel lb name
+		klog.V(2).Infof("Querying Openstack to find Loadbalancers for API (%q)", cluster.Name)
+		lbList, err := c.ListLBs(loadbalancers.ListOpts{
+			Name: cluster.Spec.MasterPublicName,
+		})
+		if err != nil {
+			return ingresses, fmt.Errorf("GetApiIngressStatus: Failed to list openstack loadbalancers: %v", err)
+		}
+		for _, lb := range lbList {
+			// Must Find Floating IP related to this lb
+			fips, err := c.ListL3FloatingIPs(l3floatingip.ListOpts{
+				PortID: lb.VipPortID,
 			})
 			if err != nil {
-				return ingresses, fmt.Errorf("GetApiIngressStatus: Failed to list openstack loadbalancers: %v", err)
+				return ingresses, fmt.Errorf("GetApiIngressStatus: Failed to list floating IP's: %v", err)
 			}
-			for _, lb := range lbList {
-				// Must Find Floating IP related to this lb
-				fips, err := c.ListL3FloatingIPs(l3floatingip.ListOpts{
-					PortID: lb.VipPortID,
-				})
-				if err != nil {
-					return ingresses, fmt.Errorf("GetApiIngressStatus: Failed to list floating IP's: %v", err)
-				}
-				for _, fip := range fips {
-					if fip.PortID == lb.VipPortID {
-						ingresses = append(ingresses, kops.ApiIngressStatus{
-							IP: fip.FloatingIP,
-						})
-					}
+			for _, fip := range fips {
+				if fip.PortID == lb.VipPortID {
+					ingresses = append(ingresses, kops.ApiIngressStatus{
+						IP: fip.FloatingIP,
+					})
 				}
 			}
 		}
-	} else {
+	}
+	return ingresses, nil
+}
+
+func getIPIngressStatus(c OpenstackCloud, cluster *kops.Cluster) (ingresses []kops.ApiIngressStatus, err error) {
+	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
 		instances, err := c.ListInstances(servers.ListOpts{})
 		if err != nil {
-			return ingresses, fmt.Errorf("GetApiIngressStatus: Failed to list master nodes: %v", err)
+			return false, fmt.Errorf("GetApiIngressStatus: Failed to list master nodes: %v", err)
 		}
 		for _, instance := range instances {
 			val, ok := instance.Metadata["k8s"]
@@ -694,16 +705,15 @@ func getApiIngressStatus(c OpenstackCloud, cluster *kops.Cluster) ([]kops.ApiIng
 						ifName := instance.Metadata[TagKopsNetwork]
 						address, err := GetServerFixedIP(&instance, ifName)
 						if err != nil {
-							return ingresses, fmt.Errorf("failed to get interface address: %v", err)
+							return false, fmt.Errorf("failed to get interface address: %v", err)
 						}
 						ingresses = append(ingresses, kops.ApiIngressStatus{
 							IP: address,
 						})
-
 					} else {
 						ips, err := c.ListServerFloatingIPs(instance.ID)
 						if err != nil {
-							return ingresses, err
+							return false, err
 						}
 						for _, ip := range ips {
 							ingresses = append(ingresses, kops.ApiIngressStatus{
@@ -714,9 +724,16 @@ func getApiIngressStatus(c OpenstackCloud, cluster *kops.Cluster) ([]kops.ApiIng
 				}
 			}
 		}
+		return true, nil
+	})
+	if done {
+		return ingresses, nil
+	} else {
+		if err == nil {
+			err = wait.ErrWaitTimeout
+		}
+		return ingresses, err
 	}
-
-	return ingresses, nil
 }
 
 func isNotFound(err error) bool {

--- a/util/pkg/vfs/context.go
+++ b/util/pkg/vfs/context.go
@@ -117,6 +117,9 @@ func (c *VFSContext) ReadFile(location string, options ...VFSOption) ([]byte, er
 			case "alicloud":
 				httpURL := "http://100.100.100.200/latest/meta-data/" + u.Path
 				return c.readHTTPLocation(httpURL, nil, opts)
+			case "openstack":
+				httpURL := "http://169.254.169.254/latest/meta-data/" + u.Path
+				return c.readHTTPLocation(httpURL, nil, opts)
 			default:
 				return nil, fmt.Errorf("unknown metadata type: %q in %q", u.Host, location)
 			}


### PR DESCRIPTION
As discussed in #9554 

This will break the task dependency cycle. It is a bit hackish with directly using protokube-code. That part should be moved to something shared, but perhaps best done in a followup PR?