### PR TITLE
Don't try to delete terraform providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ addons/prometheus-operator/tmp # cloned git repo
 
 # Used by some of the verify scripts in the hack directory
 _output
+
+# Used to cache terraform providers etc during testing
+.cache/

--- a/hack/verify-terraform.sh
+++ b/hack/verify-terraform.sh
@@ -29,8 +29,7 @@ CLUSTERS_0_11=(
 TAG_0_13=0.13.0-beta2
 TAG_0_11=0.11.14
 
-PROVIDER_CACHE=$(mktemp -d)
-trap '{ rm -rf ${PROVIDER_CACHE}; }' EXIT
+PROVIDER_CACHE="${KOPS_ROOT}/.cache/terraform"
 
 RC=0
 while IFS= read -r -d '' -u 3 test_dir; do


### PR DESCRIPTION
Because we are running it in docker, I was hitting permission issues
during the cleanup step of verify-terraform.