### PR TITLE
Automated cherry pick of #9552: Use stable names for GH workflow jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 ---
-name: build
+name: CI
 
 'on':
   - push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Set up go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.13
           stable: true
@@ -32,7 +32,7 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Set up go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.13
         stable: true
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Set up go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.13
           stable: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,21 +10,14 @@ env:
   GOPATH: ${{ github.workspace }}/go
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, macos-10.15]
-        go: [1.13]
-      fail-fast: true
-
-    runs-on: ${{ matrix.os }}
-
+  build-linux-amd64:
+    runs-on: ubuntu-20.04
     steps:
       - name: Set up go
         uses: actions/setup-go@v1
         with:
-          go-version: ${{ matrix.go }}
-        id: go
+          go-version: 1.13
+          stable: true
 
       - uses: actions/checkout@v2
         with:
@@ -35,21 +28,32 @@ jobs:
         run: |
           make nodeup examples test
 
+  build-macos-amd64:
+    runs-on: macos-10.15
+    steps:
+    - name: Set up go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+        stable: true
+
+    - uses: actions/checkout@v2
+      with:
+        path: ${{ env.GOPATH }}/src/k8s.io/kops
+
+    - name: make nodeup examples test
+      working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
+      run: |
+        make nodeup examples test
+
   verify:
-    strategy:
-      matrix:
-        os: [ubuntu-18.04]
-        go: [1.13]
-      fail-fast: true
-
-    runs-on: ${{ matrix.os }}
-
+    runs-on: ubuntu-20.04
     steps:
       - name: Set up go
         uses: actions/setup-go@v1
         with:
-          go-version: ${{ matrix.go }}
-        id: go
+          go-version: 1.13
+          stable: true
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,10 @@ jobs:
         with:
           path: ${{ env.GOPATH }}/src/k8s.io/kops
 
-      - name: make nodeup examples test
+      - name: make all examples test
         working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
         run: |
-          make nodeup examples test
+          make all examples test
 
   build-macos-amd64:
     runs-on: macos-10.15

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,10 +41,10 @@ jobs:
       with:
         path: ${{ env.GOPATH }}/src/k8s.io/kops
 
-    - name: make nodeup examples test
+    - name: make kops examples test
       working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
       run: |
-        make nodeup examples test
+        make kops examples test
 
   verify:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Cherry pick of #9552 on release-1.18.

#9552: Use stable names for GH workflow jobs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.