### PR TITLE
Update goimports script for go 1.14

### DIFF
--- a/hack/update-goimports
+++ b/hack/update-goimports
@@ -36,7 +36,4 @@ for package in packages:
 
 print("packages %s" % paths)
 
-env = os.environ
-env["GO111MODULE"] = "on"
-
-subprocess.call(['go', 'run', 'golang.org/x/tools/cmd/goimports', '-w'] + paths, cwd=path.join(gopath, 'src'), env=env)
+subprocess.call(['go', 'run', 'golang.org/x/tools/cmd/goimports', '-w'] + paths, cwd=path.join(gopath, 'src'))


### PR DESCRIPTION
Without this change, go 1.14 reports this error:

```
cannot find module providing package golang.org/x/tools/cmd/goimports: working directory is not part of a module
```

Ideally this wouldn't rely on kops being in the GOPATH but that may require updating goimports. This can happen in a followup PR