### PR TITLE
Automated cherry pick of #9581: Use fixed UID for etcd user and restrict to legacy provider

### DIFF
--- a/nodeup/pkg/model/etcd.go
+++ b/nodeup/pkg/model/etcd.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"k8s.io/kops/nodeup/pkg/distros"
+	"k8s.io/kops/pkg/wellknownusers"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 
@@ -33,7 +34,7 @@ var _ fi.ModelBuilder = &EtcdBuilder{}
 
 // Build is responsible for creating the etcd user
 func (b *EtcdBuilder) Build(c *fi.ModelBuilderContext) error {
-	if !b.IsMaster {
+	if !b.IsMaster || b.UseEtcdManager() {
 		return nil
 	}
 
@@ -50,8 +51,8 @@ func (b *EtcdBuilder) Build(c *fi.ModelBuilderContext) error {
 	// TODO: Do we actually use the user anywhere?
 
 	c.AddTask(&nodetasks.UserTask{
-		// TODO: Should we set a consistent UID in case we remount?
 		Name:  "user",
+		UID:   wellknownusers.LegacyEtcd,
 		Shell: "/sbin/nologin",
 		Home:  "/var/etcd",
 	})

--- a/pkg/wellknownusers/wellknownusers.go
+++ b/pkg/wellknownusers/wellknownusers.go
@@ -24,6 +24,9 @@ const (
 	// Used by e.g. dns-controller, kops-controller
 	Generic = 10001
 
+	// LegacyEtcd is the user id for the etcd user under the legacy provider
+	LegacyEtcd = 10002
+
 	// AWSAuthenticator is the user-id for the aws-iam-authenticator (built externally)
 	AWSAuthenticator = 10000
 


### PR DESCRIPTION
Cherry pick of #9581 on release-1.18.

#9581: Use fixed UID for etcd user and restrict to legacy provider

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.