### PR TITLE
Restore default SELinux security contexts for container runtime binaries

### DIFF
--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -265,6 +265,12 @@ func (b *ContainerdBuilder) buildSystemdService() *nodetasks.Service {
 	manifest.Set("Unit", "Documentation", "https://containerd.io")
 	manifest.Set("Unit", "After", "network.target local-fs.target")
 
+	// Restore the default SELinux security contexts for the containerd and runc binaries
+	if b.Distribution.IsRHELFamily() && b.Cluster.Spec.Docker != nil && fi.BoolValue(b.Cluster.Spec.Docker.SelinuxEnabled) {
+		manifest.Set("Service", "ExecStartPre", "/bin/sh -c 'restorecon -v /usr/bin/runc'")
+		manifest.Set("Service", "ExecStartPre", "/bin/sh -c 'restorecon -v /usr/bin/containerd*'")
+	}
+
 	manifest.Set("Service", "EnvironmentFile", "/etc/sysconfig/containerd")
 	manifest.Set("Service", "EnvironmentFile", "/etc/environment")
 	manifest.Set("Service", "ExecStartPre", "-/sbin/modprobe overlay")

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -558,6 +558,11 @@ func (b *DockerBuilder) buildSystemdService(dockerVersion semver.Version) *nodet
 	manifest.Set("Service", "EnvironmentFile", "/etc/sysconfig/docker")
 	manifest.Set("Service", "EnvironmentFile", "/etc/environment")
 
+	// Restore the default SELinux security contexts for the Docker binaries
+	if b.Distribution.IsRHELFamily() && b.Cluster.Spec.Docker != nil && fi.BoolValue(b.Cluster.Spec.Docker.SelinuxEnabled) {
+		manifest.Set("Service", "ExecStartPre", "/bin/sh -c 'restorecon -v /usr/bin/docker*'")
+	}
+
 	// the default is not to use systemd for cgroups because the delegate issues still
 	// exists and systemd currently does not support the cgroup feature set required
 	// for containers run by docker


### PR DESCRIPTION
With RPMs, SELinux security contexts are magically set for installed files.
In the case of the ones Kops extracts, those security contexts have to be set some other way. Easiest way is to do it during service start.

Note that, at the moment, SELinux support in Kops is limited to worker nodes.