### PR TITLE
Remove min width on tables

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -1,7 +1,3 @@
-.md-typeset__table {
-    min-width: 100%;
-}
-
 @media only screen and (min-width: 768px){
 	td:nth-child(1){
 		white-space: nowrap;


### PR DESCRIPTION
Fixes table issue in firefox:

Before:
![Screen Shot 2020-07-17 at 4 36 38 PM](https://user-images.githubusercontent.com/881965/87828803-b996ed80-c84b-11ea-89a6-7856cd7c0579.png)
After:
![Screen Shot 2020-07-17 at 4 36 16 PM](https://user-images.githubusercontent.com/881965/87828811-bef43800-c84b-11ea-8790-f7e07ae2ca42.png)

At first I was going to fix it simply for the new feature boxes however I think this `min-width` is to blame for a number of issues that occur cross all browsers such as on the networking page (chrome): https://kops.sigs.k8s.io/networking/
![Screen Shot 2020-07-17 at 4 38 42 PM](https://user-images.githubusercontent.com/881965/87828927-037fd380-c84c-11ea-8bdd-273dda555c32.png)

Clearly that's not displaying properly so I'm going to remove the min-width param.  We can figure out the right way to set min-width on tables in a follow up, but this should clean up a number of things for now at least.

More context see https://github.com/kubernetes/kops/pull/9585#issuecomment-660244678