### PR TITLE
Improve locking in memfs

### DIFF
--- a/util/pkg/vfs/memfs.go
+++ b/util/pkg/vfs/memfs.go
@@ -57,6 +57,9 @@ func (c *MemFSContext) MarkClusterReadable() {
 }
 
 func (c *MemFSPath) HasChildren() bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
 	return len(c.children) != 0
 }
 
@@ -90,6 +93,8 @@ func (p *MemFSPath) Join(relativePath ...string) Path {
 			current.children[token] = child
 		}
 		current = child
+		current.mutex.Lock()
+		defer current.mutex.Unlock()
 	}
 	return current
 }
@@ -131,6 +136,9 @@ func (p *MemFSPath) WriteTo(out io.Writer) (int64, error) {
 }
 
 func (p *MemFSPath) ReadDir() ([]Path, error) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
 	var paths []Path
 	for _, f := range p.children {
 		paths = append(paths, f)
@@ -145,6 +153,9 @@ func (p *MemFSPath) ReadTree() ([]Path, error) {
 }
 
 func (p *MemFSPath) readTree(dest *[]Path) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
 	for _, f := range p.children {
 		if !f.HasChildren() {
 			*dest = append(*dest, f)


### PR DESCRIPTION
/kind bug

The locking in memfs is insufficient.

```
2020-07-19T21:04:48.9844960Z I0719 21:04:48.217197    3957 executor.go:103] Tasks: 0 done / 103 total; 48 can run
2020-07-19T21:04:48.9845540Z I0719 21:04:48.217788    3957 keypair.go:187] Issuing new certificate: "etcd-peers-ca-main"
2020-07-19T21:04:48.9845680Z fatal error: concurrent map read and map write
2020-07-19T21:04:48.9845750Z 
2020-07-19T21:04:48.9845850Z goroutine 6492 [running]:
2020-07-19T21:04:48.9845940Z runtime.throw(0x4b60bdc, 0x21)
2020-07-19T21:04:48.9846240Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/runtime/panic.go:1116 +0x72 fp=0xc0000806f8 sp=0xc0000806c8 pc=0x10366a2
2020-07-19T21:04:48.9846370Z runtime.mapaccess1_faststr(0x4325920, 0xc000c86ed0, 0xc000225590, 0x6, 0x0)
2020-07-19T21:04:48.9846590Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/runtime/map_faststr.go:21 +0x43c fp=0xc000080768 sp=0xc0000806f8 pc=0x1014f0c
2020-07-19T21:04:48.9846730Z k8s.io/kops/util/pkg/vfs.(*MemFSPath).Join(0xc0012a6580, 0xc00155a460, 0x1, 0x1, 0x0, 0x0)
2020-07-19T21:04:48.9846930Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/util/pkg/vfs/memfs.go:84 +0x186 fp=0xc000080848 sp=0xc000080768 pc=0x1f31eb6
2020-07-19T21:04:48.9847070Z k8s.io/kops/upup/pkg/fi/fitasks.(*ManagedFile).Find(0xc0002a8ff0, 0xc000f1b2c0, 0x0, 0x0, 0x0)
2020-07-19T21:04:48.9847270Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/fitasks/managedfile.go:51 +0x101 fp=0xc0000808e0 sp=0xc000080848 pc=0x38e5f11
2020-07-19T21:04:48.9847390Z runtime.call64(0xc000d9c210, 0xc0006d0208, 0xc0010bc2d0, 0x1000000028)
2020-07-19T21:04:48.9847570Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/runtime/asm_amd64.s:540 +0x3b fp=0xc000080930 sp=0xc0000808e0 pc=0x10678bb
2020-07-19T21:04:48.9847700Z reflect.Value.call(0x47ab160, 0xc0002a8ff0, 0x613, 0x4b0eba6, 0x4, 0xc0007fc860, 0x1, 0x1, 0x5298d00, 0xc000a1e240, ...)
2020-07-19T21:04:48.9848120Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/value.go:460 +0x8ab fp=0xc000080b48 sp=0xc000080930 pc=0x10c983b
2020-07-19T21:04:48.9848260Z reflect.Value.Call(0x47ab160, 0xc0002a8ff0, 0x613, 0xc0007fc860, 0x1, 0x1, 0xc0002a8ff0, 0x613, 0xc000a1e240)
2020-07-19T21:04:48.9848460Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/value.go:321 +0xb4 fp=0xc000080bc8 sp=0xc000080b48 pc=0x10c8d44
2020-07-19T21:04:48.9848610Z k8s.io/kops/util/pkg/reflectutils.InvokeMethod(0x47ab160, 0xc0002a8ff0, 0x4b0ec32, 0x4, 0xc000080dd0, 0x1, 0x1, 0xc00003c000, 0x43cf040, 0x47ab160, ...)
2020-07-19T21:04:48.9848820Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/util/pkg/reflectutils/walk.go:76 +0x35d fp=0xc000080d38 sp=0xc000080bc8 pc=0x1fc772d
2020-07-19T21:04:48.9848960Z k8s.io/kops/upup/pkg/fi.invokeFind(0x51c4cc0, 0xc0002a8ff0, 0xc000f1b2c0, 0x0, 0x0, 0xc00155a400, 0x8799a80)
2020-07-19T21:04:48.9849170Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:123 +0xb4 fp=0xc000080df0 sp=0xc000080d38 pc=0x1ffdf04
2020-07-19T21:04:48.9849310Z k8s.io/kops/upup/pkg/fi.DefaultDeltaRunMethod(0x51c4cc0, 0xc0002a8ff0, 0xc000f1b2c0, 0x1, 0xc00155a440)
2020-07-19T21:04:48.9849510Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:47 +0x6e5 fp=0xc000080ee0 sp=0xc000080df0 pc=0x1ffd9d5
2020-07-19T21:04:48.9849640Z k8s.io/kops/upup/pkg/fi/fitasks.(*ManagedFile).Run(0xc0002a8ff0, 0xc000f1b2c0, 0xc00155a440, 0x0)
2020-07-19T21:04:48.9849840Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/fitasks/managedfile.go:73 +0x41 fp=0xc000080f18 sp=0xc000080ee0 pc=0x38e6251
2020-07-19T21:04:48.9849980Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001430b60, 0xb)
2020-07-19T21:04:48.9850170Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:175 +0x188 fp=0xc000080fa8 sp=0xc000080f18 pc=0x200f578
2020-07-19T21:04:48.9850300Z runtime.goexit()
2020-07-19T21:04:48.9850470Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc000080fb0 sp=0xc000080fa8 pc=0x1069571
2020-07-19T21:04:48.9850720Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9850940Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9851020Z 
2020-07-19T21:04:48.9851120Z goroutine 1 [chan receive]:
2020-07-19T21:04:48.9851990Z testing.(*T).Run(0xc000886ea0, 0x4b5c4f0, 0x20, 0x4c6d7e8, 0x1090301)
2020-07-19T21:04:48.9852200Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/testing/testing.go:1043 +0x37e
2020-07-19T21:04:48.9852700Z testing.runTests.func1(0xc000bb6360)
2020-07-19T21:04:48.9852920Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/testing/testing.go:1284 +0x78
2020-07-19T21:04:48.9853050Z testing.tRunner(0xc000bb6360, 0xc00099fe10)
2020-07-19T21:04:48.9853220Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/testing/testing.go:991 +0xdc
2020-07-19T21:04:48.9853350Z testing.runTests(0xc000b93360, 0x7338ca0, 0x3a, 0x3a, 0x0)
2020-07-19T21:04:48.9853520Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/testing/testing.go:1282 +0x2a7
2020-07-19T21:04:48.9853640Z testing.(*M).Run(0xc000bd2100, 0x0)
2020-07-19T21:04:48.9853810Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/testing/testing.go:1199 +0x15f
2020-07-19T21:04:48.9853910Z main.main()
2020-07-19T21:04:48.9854010Z 	_testmain.go:158 +0x135
2020-07-19T21:04:48.9854080Z 
2020-07-19T21:04:48.9854180Z goroutine 19 [chan receive]:
2020-07-19T21:04:48.9854270Z k8s.io/klog.(*loggingT).flushDaemon(0x734f660)
2020-07-19T21:04:48.9854450Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/vendor/k8s.io/klog/klog.go:1010 +0x8b
2020-07-19T21:04:48.9854570Z created by k8s.io/klog.init.0
2020-07-19T21:04:48.9854730Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/vendor/k8s.io/klog/klog.go:411 +0xd6
2020-07-19T21:04:48.9854810Z 
2020-07-19T21:04:48.9855140Z goroutine 20 [select]:
2020-07-19T21:04:48.9855260Z go.opencensus.io/stats/view.(*worker).start(0xc000167720)
2020-07-19T21:04:48.9855460Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/vendor/go.opencensus.io/stats/view/worker.go:154 +0x100
2020-07-19T21:04:48.9855600Z created by go.opencensus.io/stats/view.init.0
2020-07-19T21:04:48.9855780Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/vendor/go.opencensus.io/stats/view/worker.go:32 +0x57
2020-07-19T21:04:48.9855870Z 
2020-07-19T21:04:48.9855950Z goroutine 83 [IO wait]:
2020-07-19T21:04:48.9856060Z internal/poll.runtime_pollWait(0x81bf010, 0x72, 0xffffffffffffffff)
2020-07-19T21:04:48.9856230Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/runtime/netpoll.go:203 +0x55
2020-07-19T21:04:48.9856360Z internal/poll.(*pollDesc).wait(0xc000e28398, 0x72, 0x1000, 0x1008, 0xffffffffffffffff)
2020-07-19T21:04:48.9856540Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/internal/poll/fd_poll_runtime.go:87 +0x45
2020-07-19T21:04:48.9856660Z internal/poll.(*pollDesc).waitRead(...)
2020-07-19T21:04:48.9856830Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/internal/poll/fd_poll_runtime.go:92
2020-07-19T21:04:48.9856960Z internal/poll.(*FD).Read(0xc000e28380, 0xc00077d900, 0x1008, 0x1008, 0x0, 0x0, 0x0)
2020-07-19T21:04:48.9857140Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/internal/poll/fd_unix.go:169 +0x201
2020-07-19T21:04:48.9857260Z net.(*netFD).Read(0xc000e28380, 0xc00077d900, 0x1008, 0x1008, 0x203000, 0xc000062800, 0xc000635910)
2020-07-19T21:04:48.9857440Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/net/fd_unix.go:202 +0x4f
2020-07-19T21:04:48.9857560Z net.(*conn).Read(0xc000010010, 0xc00077d900, 0x1008, 0x1008, 0x0, 0x0, 0x0)
2020-07-19T21:04:48.9857730Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/net/net.go:184 +0x8e
2020-07-19T21:04:48.9857860Z crypto/tls.(*atLeastReader).Read(0xc000ce6d60, 0xc00077d900, 0x1008, 0x1008, 0xc0006359b0, 0x10988f2, 0xc0006359c8)
2020-07-19T21:04:48.9858040Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/crypto/tls/conn.go:760 +0x60
2020-07-19T21:04:48.9858170Z bytes.(*Buffer).ReadFrom(0xc000e0a258, 0x51c0800, 0xc000ce6d60, 0x100c5e5, 0x43cb4c0, 0x49c14a0)
2020-07-19T21:04:48.9858630Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/bytes/buffer.go:204 +0xb1
2020-07-19T21:04:48.9858930Z crypto/tls.(*Conn).readFromUntil(0xc000e0a000, 0x8759428, 0xc000010010, 0x5, 0xc000010010, 0x27)
2020-07-19T21:04:48.9859140Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/crypto/tls/conn.go:782 +0xec
2020-07-19T21:04:48.9859240Z crypto/tls.(*Conn).readRecordOrCCS(0xc000e0a000, 0x0, 0x0, 0xc000e0a320)
2020-07-19T21:04:48.9859410Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/crypto/tls/conn.go:589 +0x115
2020-07-19T21:04:48.9859520Z crypto/tls.(*Conn).readRecord(...)
2020-07-19T21:04:48.9859670Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/crypto/tls/conn.go:557
2020-07-19T21:04:48.9859790Z crypto/tls.(*Conn).Read(0xc000e0a000, 0xc00021e000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-07-19T21:04:48.9859960Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/crypto/tls/conn.go:1233 +0x15b
2020-07-19T21:04:48.9860090Z bufio.(*Reader).Read(0xc000bac000, 0xc00017db58, 0x9, 0x9, 0x0, 0xc000635d20, 0x13c5ca4)
2020-07-19T21:04:48.9860240Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/bufio/bufio.go:226 +0x24f
2020-07-19T21:04:48.9860380Z io.ReadAtLeast(0x51c0600, 0xc000bac000, 0xc00017db58, 0x9, 0x9, 0x9, 0xc0001bdfc0, 0xc000f67000, 0x11)
2020-07-19T21:04:48.9860530Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/io/io.go:310 +0x87
2020-07-19T21:04:48.9860630Z io.ReadFull(...)
2020-07-19T21:04:48.9860770Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/io/io.go:329
2020-07-19T21:04:48.9860900Z net/http.http2readFrameHeader(0xc00017db58, 0x9, 0x9, 0x51c0600, 0xc000bac000, 0x0, 0x0, 0x0, 0x0)
2020-07-19T21:04:48.9861070Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/net/http/h2_bundle.go:1479 +0x87
2020-07-19T21:04:48.9861200Z net/http.(*http2Framer).ReadFrame(0xc00017db20, 0xc000abb8c0, 0x0, 0x0, 0x0)
2020-07-19T21:04:48.9861540Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/net/http/h2_bundle.go:1737 +0xa1
2020-07-19T21:04:48.9861670Z net/http.(*http2clientConnReadLoop).run(0xc000635fa8, 0x0, 0x0)
2020-07-19T21:04:48.9861840Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/net/http/h2_bundle.go:8246 +0x8d
2020-07-19T21:04:48.9861960Z net/http.(*http2ClientConn).readLoop(0xc000001980)
2020-07-19T21:04:48.9862110Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/net/http/h2_bundle.go:8174 +0x6f
2020-07-19T21:04:48.9862230Z created by net/http.(*http2Transport).newClientConn
2020-07-19T21:04:48.9862390Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/net/http/h2_bundle.go:7174 +0x64a
2020-07-19T21:04:48.9862480Z 
2020-07-19T21:04:48.9862570Z goroutine 6527 [runnable]:
2020-07-19T21:04:48.9862680Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001431ab0, 0x2e)
2020-07-19T21:04:48.9862850Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9862970Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9863120Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9863200Z 
2020-07-19T21:04:48.9863300Z goroutine 6494 [runnable]:
2020-07-19T21:04:48.9863410Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001431dc0, 0xd)
2020-07-19T21:04:48.9863580Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9863690Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9863850Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9863920Z 
2020-07-19T21:04:48.9864010Z goroutine 6505 [runnable]:
2020-07-19T21:04:48.9864130Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001430af0, 0x18)
2020-07-19T21:04:48.9864290Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9864410Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9864560Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9864770Z 
2020-07-19T21:04:48.9864880Z goroutine 6509 [runnable]:
2020-07-19T21:04:48.9865010Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001430310, 0x1c)
2020-07-19T21:04:48.9865170Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9865290Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9865440Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9865510Z 
2020-07-19T21:04:48.9865610Z goroutine 6490 [runnable]:
2020-07-19T21:04:48.9865710Z reflect.(*rtype).NumMethod(0x47ab160, 0x4b11341)
2020-07-19T21:04:48.9865850Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/type.go:791 +0x64
2020-07-19T21:04:48.9865990Z k8s.io/kops/upup/pkg/fi.(*Context).Render(0xc000f1b2c0, 0x51c4cc0, 0x0, 0x51c4cc0, 0xc000813740, 0x51c4cc0, 0xc0010bc0f0, 0x0, 0x0)
2020-07-19T21:04:48.9866160Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/context.go:181 +0x3dc
2020-07-19T21:04:48.9866290Z k8s.io/kops/upup/pkg/fi.DefaultDeltaRunMethod(0x51c4cc0, 0xc000813740, 0xc000f1b2c0, 0x1, 0xc00155a160)
2020-07-19T21:04:48.9866460Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:79 +0x533
2020-07-19T21:04:48.9866590Z k8s.io/kops/upup/pkg/fi/fitasks.(*ManagedFile).Run(0xc000813740, 0xc000f1b2c0, 0xc00155a160, 0x0)
2020-07-19T21:04:48.9866760Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/fitasks/managedfile.go:73 +0x41
2020-07-19T21:04:48.9866880Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001432540, 0x9)
2020-07-19T21:04:48.9867040Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:175 +0x188
2020-07-19T21:04:48.9867530Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9867690Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9867780Z 
2020-07-19T21:04:48.9867870Z goroutine 6500 [runnable]:
2020-07-19T21:04:48.9867980Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc0014319d0, 0x13)
2020-07-19T21:04:48.9868150Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9868260Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9868420Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9868490Z 
2020-07-19T21:04:48.9868580Z goroutine 6507 [runnable]:
2020-07-19T21:04:48.9868700Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001431030, 0x1a)
2020-07-19T21:04:48.9868860Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9868990Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9869140Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9869220Z 
2020-07-19T21:04:48.9869300Z goroutine 6513 [runnable]:
2020-07-19T21:04:48.9869420Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001430070, 0x20)
2020-07-19T21:04:48.9869580Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9869690Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9869850Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9869910Z 
2020-07-19T21:04:48.9870010Z goroutine 6510 [runnable]:
2020-07-19T21:04:48.9870130Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001431c00, 0x1d)
2020-07-19T21:04:48.9870290Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9870410Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9870690Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9870790Z 
2020-07-19T21:04:48.9870900Z goroutine 6521 [runnable]:
2020-07-19T21:04:48.9871020Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001431b90, 0x28)
2020-07-19T21:04:48.9871180Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9871290Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9871440Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9871510Z 
2020-07-19T21:04:48.9871600Z goroutine 6515 [runnable]:
2020-07-19T21:04:48.9871730Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc0014324d0, 0x22)
2020-07-19T21:04:48.9871890Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9872010Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9872160Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9872230Z 
2020-07-19T21:04:48.9872320Z goroutine 6511 [runnable]:
2020-07-19T21:04:48.9872440Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001431e30, 0x1e)
2020-07-19T21:04:48.9872600Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9872710Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9872860Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9873080Z 
2020-07-19T21:04:48.9873190Z goroutine 6496 [runnable]:
2020-07-19T21:04:48.9873300Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001430000, 0xf)
2020-07-19T21:04:48.9873470Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9873590Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9873830Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9873900Z 
2020-07-19T21:04:48.9874000Z goroutine 6504 [runnable]:
2020-07-19T21:04:48.9874120Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001430620, 0x17)
2020-07-19T21:04:48.9874270Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9874390Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9874540Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9874610Z 
2020-07-19T21:04:48.9874710Z goroutine 6522 [runnable]:
2020-07-19T21:04:48.9874830Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc00142ff80, 0x29)
2020-07-19T21:04:48.9874990Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9875550Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9875730Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9875810Z 
2020-07-19T21:04:48.9875910Z goroutine 6486 [runnable]:
2020-07-19T21:04:48.9876030Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc0014308c0, 0x5)
2020-07-19T21:04:48.9876180Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9876300Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9876460Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9876540Z 
2020-07-19T21:04:48.9876630Z goroutine 6501 [runnable]:
2020-07-19T21:04:48.9876910Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001431b20, 0x14)
2020-07-19T21:04:48.9877110Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9877220Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9877370Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9877450Z 
2020-07-19T21:04:48.9877540Z goroutine 6514 [runnable]:
2020-07-19T21:04:48.9877660Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001431ce0, 0x21)
2020-07-19T21:04:48.9877800Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9877920Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9878080Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9878160Z 
2020-07-19T21:04:48.9878250Z goroutine 6520 [runnable]:
2020-07-19T21:04:48.9878370Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001431a40, 0x27)
2020-07-19T21:04:48.9878520Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9878640Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9878790Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9878870Z 
2020-07-19T21:04:48.9878960Z goroutine 6482 [runnable]:
2020-07-19T21:04:48.9879070Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001430f50, 0x1)
2020-07-19T21:04:48.9879230Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9879520Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9879670Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9879750Z 
2020-07-19T21:04:48.9879850Z goroutine 6484 [semacquire]:
2020-07-19T21:04:48.9879970Z sync.runtime_SemacquireMutex(0xc000bc7874, 0x1004d00, 0x1)
2020-07-19T21:04:48.9880120Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/runtime/sema.go:71 +0x47
2020-07-19T21:04:48.9880240Z sync.(*Mutex).lockSlow(0xc000bc7870)
2020-07-19T21:04:48.9880380Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/sync/mutex.go:138 +0xfc
2020-07-19T21:04:48.9880490Z sync.(*Mutex).Lock(...)
2020-07-19T21:04:48.9880630Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/sync/mutex.go:81
2020-07-19T21:04:48.9880750Z k8s.io/kops/cloudmock/aws/mockec2.(*MockEC2).DescribeVpcs(0xc000bc7860, 0xc00079c000, 0x0, 0x0, 0x0)
2020-07-19T21:04:48.9880920Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/cloudmock/aws/mockec2/vpcs.go:107 +0x7b6
2020-07-19T21:04:48.9881050Z k8s.io/kops/upup/pkg/fi/cloudup/awstasks.(*VPC).Find(0xc000651d00, 0xc000f1b2c0, 0x0, 0x0, 0x0)
2020-07-19T21:04:48.9881220Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/cloudup/awstasks/vpc.go:66 +0x13a
2020-07-19T21:04:48.9881360Z reflect.Value.call(0x48fb280, 0xc000651d00, 0xe13, 0x4b0eba6, 0x4, 0xc000cee060, 0x1, 0x1, 0x5298d00, 0xc000a1e780, ...)
2020-07-19T21:04:48.9881520Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/value.go:460 +0x8ab
2020-07-19T21:04:48.9881650Z reflect.Value.Call(0x48fb280, 0xc000651d00, 0xe13, 0xc000cee060, 0x1, 0x1, 0xc000651d00, 0xe13, 0xc000a1e780)
2020-07-19T21:04:48.9881810Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/value.go:321 +0xb4
2020-07-19T21:04:48.9881950Z k8s.io/kops/util/pkg/reflectutils.InvokeMethod(0x48fb280, 0xc000651d00, 0x4b0ec32, 0x4, 0xc00148ddd0, 0x1, 0x1, 0xc00003c000, 0x43cf040, 0x48fb280, ...)
2020-07-19T21:04:48.9882120Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/util/pkg/reflectutils/walk.go:76 +0x35d
2020-07-19T21:04:48.9882260Z k8s.io/kops/upup/pkg/fi.invokeFind(0x51c4820, 0xc000651d00, 0xc000f1b2c0, 0x0, 0x0, 0x0, 0xc00063c000)
2020-07-19T21:04:48.9882560Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:123 +0xb4
2020-07-19T21:04:48.9882730Z k8s.io/kops/upup/pkg/fi.DefaultDeltaRunMethod(0x51c4820, 0xc000651d00, 0xc000f1b2c0, 0x1, 0xc00063c010)
2020-07-19T21:04:48.9882890Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:47 +0x6e5
2020-07-19T21:04:48.9883010Z k8s.io/kops/upup/pkg/fi/cloudup/awstasks.(*VPC).Run(0xc000651d00, 0xc000f1b2c0, 0xc00063c010, 0x0)
2020-07-19T21:04:48.9883180Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/cloudup/awstasks/vpc.go:133 +0x41
2020-07-19T21:04:48.9883310Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001431730, 0x3)
2020-07-19T21:04:48.9883470Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:175 +0x188
2020-07-19T21:04:48.9883600Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9883760Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9883830Z 
2020-07-19T21:04:48.9883930Z goroutine 6483 [runnable]:
2020-07-19T21:04:48.9884050Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001431340, 0x2)
2020-07-19T21:04:48.9884210Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9884320Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9884470Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9884540Z 
2020-07-19T21:04:48.9884640Z goroutine 6498 [semacquire]:
2020-07-19T21:04:48.9884760Z reflect.(*rtype).Method(0x47ab160, 0x1, 0x3d761ea, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2020-07-19T21:04:48.9885080Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/type.go:814 +0x1b9
2020-07-19T21:04:48.9885210Z reflect.(*rtype).MethodByName(0x47ab160, 0x4b0ec32, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2020-07-19T21:04:48.9885370Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/type.go:845 +0x1c2
2020-07-19T21:04:48.9885510Z k8s.io/kops/util/pkg/reflectutils.InvokeMethod(0x47ab160, 0xc000cde030, 0x4b0ec32, 0x4, 0xc0003e8dd0, 0x1, 0x1, 0xc00003c000, 0x43cf040, 0x47ab160, ...)
2020-07-19T21:04:48.9885690Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/util/pkg/reflectutils/walk.go:62 +0x10f
2020-07-19T21:04:48.9885810Z k8s.io/kops/upup/pkg/fi.invokeFind(0x51c4cc0, 0xc000cde030, 0xc000f1b2c0, 0x0, 0x0, 0x0, 0xc001438160)
2020-07-19T21:04:48.9885980Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:123 +0xb4
2020-07-19T21:04:48.9886100Z k8s.io/kops/upup/pkg/fi.DefaultDeltaRunMethod(0x51c4cc0, 0xc000cde030, 0xc000f1b2c0, 0x1, 0xc001438170)
2020-07-19T21:04:48.9886270Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:47 +0x6e5
2020-07-19T21:04:48.9886390Z k8s.io/kops/upup/pkg/fi/fitasks.(*ManagedFile).Run(0xc000cde030, 0xc000f1b2c0, 0xc001438170, 0x0)
2020-07-19T21:04:48.9886570Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/fitasks/managedfile.go:73 +0x41
2020-07-19T21:04:48.9886700Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001432230, 0x11)
2020-07-19T21:04:48.9886870Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:175 +0x188
2020-07-19T21:04:48.9886990Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9887140Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9887200Z 
2020-07-19T21:04:48.9887300Z goroutine 6525 [runnable]:
2020-07-19T21:04:48.9887420Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001432850, 0x2c)
2020-07-19T21:04:48.9887590Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9887700Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9887980Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9888080Z 
2020-07-19T21:04:48.9888190Z goroutine 6508 [runnable]:
2020-07-19T21:04:48.9888310Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001432620, 0x1b)
2020-07-19T21:04:48.9888470Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9888590Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9888740Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9888810Z 
2020-07-19T21:04:48.9888900Z goroutine 6495 [runnable]:
2020-07-19T21:04:48.9889010Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc0014322a0, 0xe)
2020-07-19T21:04:48.9889180Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9889300Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9889460Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9889520Z 
2020-07-19T21:04:48.9889620Z goroutine 6449 [runnable]:
2020-07-19T21:04:48.9889730Z math/big.nat.clear(0xc000800a80, 0x8, 0xc)
2020-07-19T21:04:48.9889870Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/math/big/nat.go:44 +0x4f
2020-07-19T21:04:48.9890000Z math/big.nat.montgomery(0x0, 0x0, 0x0, 0xc000800a20, 0x4, 0xc, 0xc000800240, 0x4, 0xc, 0xc001068080, ...)
2020-07-19T21:04:48.9890150Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/math/big/nat.go:222 +0xb4
2020-07-19T21:04:48.9890280Z math/big.nat.expNNMontgomery(0xc001068340, 0x4, 0x8, 0xc001068300, 0x4, 0x8, 0xc001068280, 0x4, 0x8, 0xc001068080, ...)
2020-07-19T21:04:48.9890610Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/math/big/nat.go:1432 +0x4f2
2020-07-19T21:04:48.9890740Z math/big.nat.expNN(0x0, 0x0, 0x0, 0xc001068300, 0x4, 0x8, 0xc001068280, 0x4, 0x8, 0xc001068080, ...)
2020-07-19T21:04:48.9890900Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/math/big/nat.go:1261 +0x95f
2020-07-19T21:04:48.9891030Z math/big.nat.probablyPrimeMillerRabin(0xc001068080, 0x4, 0x8, 0x15, 0x78c88fa4ba5d7401, 0x40)
2020-07-19T21:04:48.9891190Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/math/big/prime.go:106 +0x49c
2020-07-19T21:04:48.9891310Z math/big.(*Int).ProbablyPrime(0xc000cee660, 0x14, 0xc0014a0b68)
2020-07-19T21:04:48.9891460Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/math/big/prime.go:78 +0x20c
2020-07-19T21:04:48.9891590Z crypto/rand.Prime(0x51c07a0, 0xc00011c750, 0x100, 0xc00063c260, 0x19, 0x5555555555555555)
2020-07-19T21:04:48.9891750Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/crypto/rand/util.go:99 +0x173
2020-07-19T21:04:48.9891870Z crypto/rsa.GenerateMultiPrimeKey(0x51c07a0, 0xc00011c750, 0x2, 0x200, 0x20, 0xc0004752d8, 0xc000475338)
2020-07-19T21:04:48.9892030Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/crypto/rsa/rsa.go:268 +0x167
2020-07-19T21:04:48.9892150Z crypto/rsa.GenerateKey(...)
2020-07-19T21:04:48.9892300Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/crypto/rsa/rsa.go:208
2020-07-19T21:04:48.9892420Z k8s.io/kops/pkg/pki.GeneratePrivateKey(0x404a080, 0x0, 0x0)
2020-07-19T21:04:48.9892570Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/pkg/pki/privatekey.go:65 +0x8f
2020-07-19T21:04:48.9892700Z k8s.io/kops/pkg/pki.IssueCert(0xc001527680, 0x8759878, 0xc000959770, 0x8759878, 0xc000959770, 0x0, 0x0, 0x0)
2020-07-19T21:04:48.9892860Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/pkg/pki/issue.go:135 +0x4b8
2020-07-19T21:04:48.9892990Z k8s.io/kops/upup/pkg/fi/fitasks.(*Keypair).Render(0xc0010d5c80, 0xc000f1b2c0, 0x0, 0xc0010d5c80, 0xc0012de240, 0x0, 0x0)
2020-07-19T21:04:48.9893160Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/fitasks/keypair.go:208 +0x680
2020-07-19T21:04:48.9893290Z reflect.Value.call(0x4890b20, 0xc0010d5c80, 0x1a13, 0x4b0eba6, 0x4, 0xc0012de840, 0x4, 0x4, 0x5298d00, 0xc000de9c00, ...)
2020-07-19T21:04:48.9893580Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/value.go:460 +0x8ab
2020-07-19T21:04:48.9893750Z reflect.Value.Call(0x4890b20, 0xc0010d5c80, 0x1a13, 0xc0012de840, 0x4, 0x4, 0xc0010d5c80, 0x1a13, 0xc000098420)
2020-07-19T21:04:48.9893910Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/value.go:321 +0xb4
2020-07-19T21:04:48.9894040Z k8s.io/kops/upup/pkg/fi.(*Context).Render(0xc000f1b2c0, 0x51c4ca0, 0x0, 0x51c4ca0, 0xc0010d5c80, 0x51c4ca0, 0xc0012de240, 0x0, 0x0)
2020-07-19T21:04:48.9894210Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/context.go:222 +0xeb5
2020-07-19T21:04:48.9894340Z k8s.io/kops/upup/pkg/fi.DefaultDeltaRunMethod(0x51c4ca0, 0xc0010d5c80, 0xc000f1b2c0, 0x1, 0xc00063c040)
2020-07-19T21:04:48.9894500Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:79 +0x533
2020-07-19T21:04:48.9894630Z k8s.io/kops/upup/pkg/fi/fitasks.(*Keypair).Run(0xc0010d5c80, 0xc000f1b2c0, 0xc00063c040, 0x0)
2020-07-19T21:04:48.9894800Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/fitasks/keypair.go:109 +0x76
2020-07-19T21:04:48.9894930Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001430ee0, 0x0)
2020-07-19T21:04:48.9895100Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:175 +0x188
2020-07-19T21:04:48.9895210Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9895360Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9895440Z 
2020-07-19T21:04:48.9895530Z goroutine 6493 [runnable]:
2020-07-19T21:04:48.9895650Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001430e70, 0xc)
2020-07-19T21:04:48.9895960Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9896080Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9896250Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9896320Z 
2020-07-19T21:04:48.9896420Z goroutine 6519 [runnable]:
2020-07-19T21:04:48.9896530Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc0014316c0, 0x26)
2020-07-19T21:04:48.9896690Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9896810Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9896960Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9897040Z 
2020-07-19T21:04:48.9897140Z goroutine 6488 [runnable]:
2020-07-19T21:04:48.9897230Z bytes.makeSlice(0x1e00, 0x0, 0x0, 0x0)
2020-07-19T21:04:48.9897380Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/bytes/buffer.go:229 +0x73
2020-07-19T21:04:48.9897500Z bytes.(*Buffer).grow(0xc0014cf660, 0x200, 0x800)
2020-07-19T21:04:48.9897650Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/bytes/buffer.go:142 +0x15b
2020-07-19T21:04:48.9897780Z bytes.(*Buffer).ReadFrom(0xc0014cf660, 0x51c06a0, 0xc0009fe030, 0x51c06a0, 0x28, 0x458f7a0)
2020-07-19T21:04:48.9897940Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/bytes/buffer.go:202 +0x48
2020-07-19T21:04:48.9898050Z io/ioutil.readAll(0x51c06a0, 0xc0009fe030, 0x200, 0x0, 0x0, 0x0, 0x0, 0x0)
2020-07-19T21:04:48.9898210Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/io/ioutil/ioutil.go:36 +0xe3
2020-07-19T21:04:48.9898310Z io/ioutil.ReadAll(...)
2020-07-19T21:04:48.9898450Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/io/ioutil/ioutil.go:45
2020-07-19T21:04:48.9898580Z k8s.io/kops/util/pkg/vfs.(*MemFSPath).WriteFile(0xc000c84180, 0x51d9be0, 0xc0009fe030, 0x0, 0x0, 0x0, 0x0)
2020-07-19T21:04:48.9898750Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/util/pkg/vfs/memfs.go:98 +0x66
2020-07-19T21:04:48.9898880Z k8s.io/kops/upup/pkg/fi/fitasks.(*ManagedFile).Render(0xc00086ef00, 0xc000f1b2c0, 0x0, 0xc00086ef00, 0xc001103650, 0x0, 0x0)
2020-07-19T21:04:48.9899180Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/fitasks/managedfile.go:110 +0x2c6
2020-07-19T21:04:48.9899360Z reflect.Value.call(0x47ab160, 0xc00086ef00, 0x1213, 0x4b0eba6, 0x4, 0xc001396120, 0x4, 0x4, 0x5298d00, 0xc000e28780, ...)
2020-07-19T21:04:48.9899530Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/value.go:460 +0x8ab
2020-07-19T21:04:48.9899650Z reflect.Value.Call(0x47ab160, 0xc00086ef00, 0x1213, 0xc001396120, 0x4, 0x4, 0xc00086ef00, 0x1213, 0xc000a1eba0)
2020-07-19T21:04:48.9899810Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/value.go:321 +0xb4
2020-07-19T21:04:48.9899940Z k8s.io/kops/upup/pkg/fi.(*Context).Render(0xc000f1b2c0, 0x51c4cc0, 0x0, 0x51c4cc0, 0xc00086ef00, 0x51c4cc0, 0xc001103650, 0x0, 0x0)
2020-07-19T21:04:48.9900120Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/context.go:222 +0xeb5
2020-07-19T21:04:48.9900240Z k8s.io/kops/upup/pkg/fi.DefaultDeltaRunMethod(0x51c4cc0, 0xc00086ef00, 0xc000f1b2c0, 0x1, 0xc000535370)
2020-07-19T21:04:48.9900400Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:79 +0x533
2020-07-19T21:04:48.9900530Z k8s.io/kops/upup/pkg/fi/fitasks.(*ManagedFile).Run(0xc00086ef00, 0xc000f1b2c0, 0xc000535370, 0x0)
2020-07-19T21:04:48.9900700Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/fitasks/managedfile.go:73 +0x41
2020-07-19T21:04:48.9900830Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001430770, 0x7)
2020-07-19T21:04:48.9901000Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:175 +0x188
2020-07-19T21:04:48.9901120Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9901270Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9901490Z 
2020-07-19T21:04:48.9901600Z goroutine 6499 [runnable]:
2020-07-19T21:04:48.9901730Z reflect.(*rtype).Method(0x47ab160, 0x0, 0xc, 0x10c0101, 0x407fdc0, 0xc000062800, 0xc0003edb48, 0x10160b3, 0xc00110a350, 0xc000dd7190, ...)
2020-07-19T21:04:48.9901900Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/type.go:799 +0x760
2020-07-19T21:04:48.9902020Z reflect.(*rtype).MethodByName(0x47ab160, 0x4b1cdc1, 0xc, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2020-07-19T21:04:48.9902190Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/type.go:845 +0x1c2
2020-07-19T21:04:48.9902320Z k8s.io/kops/util/pkg/reflectutils.InvokeMethod(0x47ab160, 0xc000dd7170, 0x4b1cdc1, 0xc, 0xc0003eddb0, 0x3, 0x3, 0x8, 0x0, 0x0, ...)
2020-07-19T21:04:48.9902490Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/util/pkg/reflectutils/walk.go:62 +0x10f
2020-07-19T21:04:48.9902620Z k8s.io/kops/upup/pkg/fi.invokeCheckChanges(0x51c4cc0, 0x0, 0x51c4cc0, 0xc000dd7170, 0x51c4cc0, 0xc00110a330, 0x1, 0x2)
2020-07-19T21:04:48.9902790Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:111 +0x106
2020-07-19T21:04:48.9902920Z k8s.io/kops/upup/pkg/fi.DefaultDeltaRunMethod(0x51c4cc0, 0xc000dd7170, 0xc000f1b2c0, 0x1, 0xc001438190)
2020-07-19T21:04:48.9903090Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:68 +0x457
2020-07-19T21:04:48.9903220Z k8s.io/kops/upup/pkg/fi/fitasks.(*ManagedFile).Run(0xc000dd7170, 0xc000f1b2c0, 0xc001438190, 0x0)
2020-07-19T21:04:48.9903380Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/fitasks/managedfile.go:73 +0x41
2020-07-19T21:04:48.9904070Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc0014300e0, 0x12)
2020-07-19T21:04:48.9904300Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:175 +0x188
2020-07-19T21:04:48.9904410Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9904580Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9904650Z 
2020-07-19T21:04:48.9904750Z goroutine 6512 [runnable]:
2020-07-19T21:04:48.9905040Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001432070, 0x1f)
2020-07-19T21:04:48.9905250Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9905370Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9905520Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9905590Z 
2020-07-19T21:04:48.9905690Z goroutine 6516 [runnable]:
2020-07-19T21:04:48.9905820Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc0014310a0, 0x23)
2020-07-19T21:04:48.9905980Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9906100Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9906340Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9906420Z 
2020-07-19T21:04:48.9906560Z goroutine 6524 [runnable]:
2020-07-19T21:04:48.9907030Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001432a10, 0x2b)
2020-07-19T21:04:48.9907200Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9907360Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9909250Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9920680Z 
2020-07-19T21:04:48.9920800Z goroutine 6523 [runnable]:
2020-07-19T21:04:48.9920930Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc0014307e0, 0x2a)
2020-07-19T21:04:48.9921100Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9921690Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9921840Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9921920Z 
2020-07-19T21:04:48.9922030Z goroutine 6528 [runnable]:
2020-07-19T21:04:48.9922140Z strings.(*Replacer).build(0xc0011fa6c0, 0x38, 0x45d0de0)
2020-07-19T21:04:48.9922290Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/strings/replace.go:75 +0x1ce
2020-07-19T21:04:48.9922400Z strings.(*Replacer).buildOnce(...)
2020-07-19T21:04:48.9922540Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/strings/replace.go:40
2020-07-19T21:04:48.9922660Z sync.(*Once).doSlow(0xc0011fa6c0, 0xc0003e8610)
2020-07-19T21:04:48.9922800Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/sync/once.go:66 +0xec
2020-07-19T21:04:48.9922910Z sync.(*Once).Do(...)
2020-07-19T21:04:48.9923050Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/sync/once.go:57
2020-07-19T21:04:48.9923170Z strings.(*Replacer).Replace(0xc0011fa6c0, 0xc0008b3130, 0xac, 0x6, 0xc0003e86b8)
2020-07-19T21:04:48.9923340Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/strings/replace.go:96 +0x9e
2020-07-19T21:04:48.9923440Z k8s.io/kops/upup/pkg/fi.CreateSecret(0x0, 0xc0005d4460, 0x737c6c0)
2020-07-19T21:04:48.9923610Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/secrets.go:68 +0x2b2
2020-07-19T21:04:48.9923740Z k8s.io/kops/upup/pkg/fi/fitasks.(*Secret).Render(0xc00093ffe0, 0xc000f1b2c0, 0x0, 0xc00093ffe0, 0xc001438050, 0x0, 0x0)
2020-07-19T21:04:48.9923910Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/fitasks/secret.go:85 +0x7c
2020-07-19T21:04:48.9924040Z reflect.Value.call(0x4800940, 0xc00093ffe0, 0x1613, 0x4b0eba6, 0x4, 0xc000da4660, 0x4, 0x4, 0x5298d00, 0xc000de9880, ...)
2020-07-19T21:04:48.9924200Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/value.go:460 +0x8ab
2020-07-19T21:04:48.9924330Z reflect.Value.Call(0x4800940, 0xc00093ffe0, 0x1613, 0xc000da4660, 0x4, 0x4, 0xc00093ffe0, 0x1613, 0xc000125e00)
2020-07-19T21:04:48.9924500Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/value.go:321 +0xb4
2020-07-19T21:04:48.9924790Z k8s.io/kops/upup/pkg/fi.(*Context).Render(0xc000f1b2c0, 0x51c4d20, 0x0, 0x51c4d20, 0xc00093ffe0, 0x51c4d20, 0xc001438050, 0x0, 0x0)
2020-07-19T21:04:48.9925000Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/context.go:222 +0xeb5
2020-07-19T21:04:48.9925130Z k8s.io/kops/upup/pkg/fi.DefaultDeltaRunMethod(0x51c4d20, 0xc00093ffe0, 0xc000f1b2c0, 0x1, 0xc001438000)
2020-07-19T21:04:48.9925300Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:79 +0x533
2020-07-19T21:04:48.9925420Z k8s.io/kops/upup/pkg/fi/fitasks.(*Secret).Run(0xc00093ffe0, 0xc000f1b2c0, 0xc001438000, 0x0)
2020-07-19T21:04:48.9925580Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/fitasks/secret.go:65 +0x41
2020-07-19T21:04:48.9925710Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001430850, 0x2f)
2020-07-19T21:04:48.9925880Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:175 +0x188
2020-07-19T21:04:48.9926010Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9926170Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9926240Z 
2020-07-19T21:04:48.9926330Z goroutine 6518 [runnable]:
2020-07-19T21:04:48.9926460Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc0014315e0, 0x25)
2020-07-19T21:04:48.9926620Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9926740Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9926890Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9926950Z 
2020-07-19T21:04:48.9927050Z goroutine 6489 [runnable]:
2020-07-19T21:04:48.9927160Z reflect.(*rtype).Out(0xc0001242a0, 0x0, 0x5298d00, 0x4800940)
2020-07-19T21:04:48.9927490Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/type.go:995 +0x149
2020-07-19T21:04:48.9927610Z reflect.haveIdenticalUnderlyingType(0xc001206120, 0xc0001242a0, 0xc000083801, 0x3fc10c0)
2020-07-19T21:04:48.9927780Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/type.go:1630 +0x208
2020-07-19T21:04:48.9927900Z reflect.FuncOf(0xc0007fc160, 0x2, 0x2, 0xc0007fc180, 0x2, 0x2, 0x0, 0x0, 0x0)
2020-07-19T21:04:48.9928060Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/type.go:2004 +0x4f1
2020-07-19T21:04:48.9928180Z reflect.(*rtype).Method(0x4800940, 0x2, 0x3d761ea, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2020-07-19T21:04:48.9928330Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/type.go:823 +0x500
2020-07-19T21:04:48.9928450Z reflect.(*rtype).MethodByName(0x4800940, 0x4b0ec32, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2020-07-19T21:04:48.9928620Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/type.go:845 +0x1c2
2020-07-19T21:04:48.9928760Z k8s.io/kops/util/pkg/reflectutils.InvokeMethod(0x4800940, 0xc000ba01c0, 0x4b0ec32, 0x4, 0xc000083dd0, 0x1, 0x1, 0xc00003c000, 0x43cf040, 0x4800940, ...)
2020-07-19T21:04:48.9928940Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/util/pkg/reflectutils/walk.go:62 +0x10f
2020-07-19T21:04:48.9929080Z k8s.io/kops/upup/pkg/fi.invokeFind(0x51c4d20, 0xc000ba01c0, 0xc000f1b2c0, 0x8759640, 0xc000ba01c0, 0x1, 0xc00155a130)
2020-07-19T21:04:48.9929780Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:123 +0xb4
2020-07-19T21:04:48.9929920Z k8s.io/kops/upup/pkg/fi.DefaultDeltaRunMethod(0x51c4d20, 0xc000ba01c0, 0xc000f1b2c0, 0x1, 0xc00155a140)
2020-07-19T21:04:48.9930090Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:47 +0x6e5
2020-07-19T21:04:48.9930220Z k8s.io/kops/upup/pkg/fi/fitasks.(*Secret).Run(0xc000ba01c0, 0xc000f1b2c0, 0xc00155a140, 0x0)
2020-07-19T21:04:48.9930380Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/fitasks/secret.go:65 +0x41
2020-07-19T21:04:48.9930510Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001431650, 0x8)
2020-07-19T21:04:48.9930830Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:175 +0x188
2020-07-19T21:04:48.9930990Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9931140Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9931220Z 
2020-07-19T21:04:48.9931320Z goroutine 6485 [runnable]:
2020-07-19T21:04:48.9931430Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc0014303f0, 0x4)
2020-07-19T21:04:48.9931590Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9931710Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9931860Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9931950Z 
2020-07-19T21:04:48.9932040Z goroutine 6436 [semacquire]:
2020-07-19T21:04:48.9932140Z sync.runtime_Semacquire(0xc000a942b8)
2020-07-19T21:04:48.9932280Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/runtime/sema.go:56 +0x42
2020-07-19T21:04:48.9932400Z sync.(*WaitGroup).Wait(0xc000a942b0)
2020-07-19T21:04:48.9932550Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/sync/waitgroup.go:130 +0x64
2020-07-19T21:04:48.9932680Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin(0xc000192ae0, 0xc000a70780, 0x30, 0x30, 0xc000365a00, 0x30, 0x40)
2020-07-19T21:04:48.9932840Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:179 +0x128
2020-07-19T21:04:48.9932970Z k8s.io/kops/upup/pkg/fi.(*executor).RunTasks(0xc000192ae0, 0xc000959680, 0xc0002e0000, 0x81cd3b8)
2020-07-19T21:04:48.9933130Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:113 +0xa10
2020-07-19T21:04:48.9933240Z k8s.io/kops/upup/pkg/fi.(*Context).RunTasks(...)
2020-07-19T21:04:48.9933560Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/context.go:87
2020-07-19T21:04:48.9933790Z k8s.io/kops/upup/pkg/fi/cloudup.(*ApplyClusterCmd).Run(0xc000f1f760, 0x5222b20, 0xc000126008, 0x0, 0x0)
2020-07-19T21:04:48.9933970Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/cloudup/apply_cluster.go:818 +0x21fa
2020-07-19T21:04:48.9934120Z k8s.io/kops/cmd/kops.RunUpdateCluster(0x5222b20, 0xc000126008, 0xc000bf74c0, 0xc000580900, 0x21, 0x51c0680, 0xc0010dced0, 0xc0003e59e0, 0x10, 0x0, ...)
2020-07-19T21:04:48.9934290Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/cmd/kops/update_cluster.go:272 +0x616
2020-07-19T21:04:48.9934420Z k8s.io/kops/cmd/kops.runLifecycleTest(0xc0013fc380, 0xc001561f20, 0xc000f1e0b0)
2020-07-19T21:04:48.9934590Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/cmd/kops/lifecycle_integration_test.go:158 +0x543
2020-07-19T21:04:48.9934710Z k8s.io/kops/cmd/kops.runLifecycleTestAWS(0xc00154df20)
2020-07-19T21:04:48.9934880Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/cmd/kops/lifecycle_integration_test.go:285 +0x278
2020-07-19T21:04:48.9935010Z k8s.io/kops/cmd/kops.TestLifecyclePrivateSharedSubnet(0xc000886ea0)
2020-07-19T21:04:48.9935280Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/cmd/kops/lifecycle_integration_test.go:102 +0xda
2020-07-19T21:04:48.9935400Z testing.tRunner(0xc000886ea0, 0x4c6d7e8)
2020-07-19T21:04:48.9935560Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/testing/testing.go:991 +0xdc
2020-07-19T21:04:48.9935680Z created by testing.(*T).Run
2020-07-19T21:04:48.9935830Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/testing/testing.go:1042 +0x357
2020-07-19T21:04:48.9935910Z 
2020-07-19T21:04:48.9936000Z goroutine 6503 [runnable]:
2020-07-19T21:04:48.9936120Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc0014327e0, 0x16)
2020-07-19T21:04:48.9936280Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9936410Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9936570Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9936630Z 
2020-07-19T21:04:48.9936730Z goroutine 6526 [runnable]:
2020-07-19T21:04:48.9937010Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001430e00, 0x2d)
2020-07-19T21:04:48.9937220Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9937340Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9937490Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9937560Z 
2020-07-19T21:04:48.9937660Z goroutine 6502 [runnable]:
2020-07-19T21:04:48.9937770Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001430fc0, 0x15)
2020-07-19T21:04:48.9937930Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9938050Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9938200Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9938270Z 
2020-07-19T21:04:48.9938370Z goroutine 6506 [runnable]:
2020-07-19T21:04:48.9938490Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001430d20, 0x19)
2020-07-19T21:04:48.9938650Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9938770Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9938920Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9938980Z 
2020-07-19T21:04:48.9939080Z goroutine 6487 [runnable]:
2020-07-19T21:04:48.9939200Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001430a10, 0x6)
2020-07-19T21:04:48.9939530Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9939650Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9939800Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9939870Z 
2020-07-19T21:04:48.9939970Z goroutine 6497 [semacquire]:
2020-07-19T21:04:48.9940080Z bytes.makeSlice(0x197, 0x0, 0x0, 0x0)
2020-07-19T21:04:48.9940220Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/bytes/buffer.go:229 +0x73
2020-07-19T21:04:48.9940340Z bytes.(*Buffer).grow(0xc0010bc030, 0x23, 0x49ffa00)
2020-07-19T21:04:48.9940490Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/bytes/buffer.go:142 +0x15b
2020-07-19T21:04:48.9940600Z bytes.(*Buffer).Write(0xc0010bc030, 0xc000723900, 0x23, 0xc80, 0x1, 0x1, 0x404a080)
2020-07-19T21:04:48.9940750Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/bytes/buffer.go:172 +0xdc
2020-07-19T21:04:48.9940880Z fmt.Fprintf(0x51c0680, 0xc0010bc030, 0x4b0dccf, 0x2, 0xc0015644f0, 0x1, 0x1, 0x1, 0x22, 0xc001167728)
2020-07-19T21:04:48.9941040Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/fmt/print.go:205 +0xa5
2020-07-19T21:04:48.9942180Z github.com/aws/aws-sdk-go/aws/awsutil.prettify(0x3f96a00, 0xc0006d0028, 0x196, 0x8, 0xc0010bc030)
2020-07-19T21:04:48.9942800Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/vendor/github.com/aws/aws-sdk-go/aws/awsutil/prettify.go:111 +0x99a
2020-07-19T21:04:48.9943330Z github.com/aws/aws-sdk-go/aws/awsutil.prettify(0x3fc1600, 0xc0007fc108, 0x197, 0x6, 0xc0010bc030)
2020-07-19T21:04:48.9944020Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/vendor/github.com/aws/aws-sdk-go/aws/awsutil/prettify.go:77 +0xcb0
2020-07-19T21:04:48.9944560Z github.com/aws/aws-sdk-go/aws/awsutil.prettify(0x4493b60, 0xc00155a078, 0x196, 0x4, 0xc0010bc030)
2020-07-19T21:04:48.9945140Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/vendor/github.com/aws/aws-sdk-go/aws/awsutil/prettify.go:55 +0x68c
2020-07-19T21:04:48.9945670Z github.com/aws/aws-sdk-go/aws/awsutil.prettify(0x3fa5340, 0xc000504328, 0x97, 0x2, 0xc0010bc030)
2020-07-19T21:04:48.9946250Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/vendor/github.com/aws/aws-sdk-go/aws/awsutil/prettify.go:77 +0xcb0
2020-07-19T21:04:48.9947130Z github.com/aws/aws-sdk-go/aws/awsutil.prettify(0x487f540, 0xc000504320, 0x99, 0x0, 0xc0010bc030)
2020-07-19T21:04:48.9947810Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/vendor/github.com/aws/aws-sdk-go/aws/awsutil/prettify.go:55 +0x68c
2020-07-19T21:04:48.9948350Z github.com/aws/aws-sdk-go/aws/awsutil.Prettify(0x487f540, 0xc000504320, 0x487f540, 0xc000504320)
2020-07-19T21:04:48.9948930Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/vendor/github.com/aws/aws-sdk-go/aws/awsutil/prettify.go:14 +0xcb
2020-07-19T21:04:48.9949430Z github.com/aws/aws-sdk-go/service/ec2.DescribeVolumesInput.String(...)
2020-07-19T21:04:48.9950010Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go:68935
2020-07-19T21:04:48.9950160Z fmt.(*pp).handleMethods(0xc000c8d5f0, 0x1000000000076, 0x1)
2020-07-19T21:04:48.9950310Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/fmt/print.go:630 +0x302
2020-07-19T21:04:48.9950430Z fmt.(*pp).printArg(0xc000c8d5f0, 0x46224a0, 0xc0005042d0, 0xc000000076)
2020-07-19T21:04:48.9950590Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/fmt/print.go:713 +0x1e4
2020-07-19T21:04:48.9950700Z fmt.(*pp).doPrintf(0xc000c8d5f0, 0x4b2fcf5, 0x13, 0xc001565760, 0x1, 0x1)
2020-07-19T21:04:48.9950860Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/fmt/print.go:1030 +0x15a
2020-07-19T21:04:48.9950980Z fmt.Fprintf(0x51c37c0, 0xc0002f3730, 0x4b2fcf5, 0x13, 0xc000637760, 0x1, 0x1, 0xc0006376c8, 0x1019afe, 0x81c3c48)
2020-07-19T21:04:48.9951140Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/fmt/print.go:204 +0x72
2020-07-19T21:04:48.9951260Z k8s.io/klog.(*loggingT).printf(0x734f660, 0x0, 0x4b2fcf5, 0x13, 0xc000637760, 0x1, 0x1)
2020-07-19T21:04:48.9951430Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/vendor/k8s.io/klog/klog.go:703 +0xc4
2020-07-19T21:04:48.9951730Z k8s.io/klog.Infof(...)
2020-07-19T21:04:48.9951890Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/vendor/k8s.io/klog/klog.go:1201
2020-07-19T21:04:48.9952020Z k8s.io/kops/cloudmock/aws/mockec2.(*MockEC2).DescribeVolumes(0xc000bc7860, 0xc0005042d0, 0x0, 0x0, 0x0)
2020-07-19T21:04:48.9952200Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/cloudmock/aws/mockec2/volumes.go:116 +0x10b
2020-07-19T21:04:48.9952320Z k8s.io/kops/upup/pkg/fi/cloudup/awstasks.(*EBSVolume).find(0xc0000a3b30, 0x529afa0, 0xc000904c60, 0x529afa0, 0xc000904c60, 0x0)
2020-07-19T21:04:48.9952500Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/cloudup/awstasks/ebsvolume.go:85 +0xf9
2020-07-19T21:04:48.9952630Z k8s.io/kops/upup/pkg/fi/cloudup/awstasks.(*EBSVolume).Find(0xc0000a3b30, 0xc000f1b2c0, 0x0, 0x0, 0x0)
2020-07-19T21:04:48.9952790Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/cloudup/awstasks/ebsvolume.go:71 +0x6a
2020-07-19T21:04:48.9952930Z reflect.Value.call(0x49893a0, 0xc0000a3b30, 0xe13, 0x4b0eba6, 0x4, 0xc0007fc080, 0x1, 0x1, 0x5298d00, 0xc001206c00, ...)
2020-07-19T21:04:48.9953100Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/value.go:460 +0x8ab
2020-07-19T21:04:48.9953230Z reflect.Value.Call(0x49893a0, 0xc0000a3b30, 0xe13, 0xc0007fc080, 0x1, 0x1, 0xc0000a3b30, 0xe13, 0xc001206c00)
2020-07-19T21:04:48.9953390Z 	/Users/runner/hostedtoolcache/go/1.14.4/x64/src/reflect/value.go:321 +0xb4
2020-07-19T21:04:48.9953530Z k8s.io/kops/util/pkg/reflectutils.InvokeMethod(0x49893a0, 0xc0000a3b30, 0x4b0ec32, 0x4, 0xc000083dd0, 0x1, 0x1, 0xc00003c000, 0x43cf040, 0x49893a0, ...)
2020-07-19T21:04:48.9953710Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/util/pkg/reflectutils/walk.go:76 +0x35d
2020-07-19T21:04:48.9953840Z k8s.io/kops/upup/pkg/fi.invokeFind(0x51c4540, 0xc0000a3b30, 0xc000f1b2c0, 0x0, 0x0, 0xc00093ce00, 0x291575d)
2020-07-19T21:04:48.9954000Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:123 +0xb4
2020-07-19T21:04:48.9954130Z k8s.io/kops/upup/pkg/fi.DefaultDeltaRunMethod(0x51c4540, 0xc0000a3b30, 0xc000f1b2c0, 0x529afa0, 0xc000904c60)
2020-07-19T21:04:48.9954290Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/default_methods.go:47 +0x6e5
2020-07-19T21:04:48.9954550Z k8s.io/kops/upup/pkg/fi/cloudup/awstasks.(*EBSVolume).Run(0xc0000a3b30, 0xc000f1b2c0, 0xc00155a010, 0x0)
2020-07-19T21:04:48.9954770Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/cloudup/awstasks/ebsvolume.go:120 +0x96
2020-07-19T21:04:48.9954900Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001430150, 0x10)
2020-07-19T21:04:48.9955070Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:175 +0x188
2020-07-19T21:04:48.9955190Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9955340Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9955410Z 
2020-07-19T21:04:48.9955510Z goroutine 6517 [runnable]:
2020-07-19T21:04:48.9955640Z k8s.io/kops/upup/pkg/fi.(*executor).forkJoin.func1(0xc001395500, 0x30, 0x30, 0xc000a942b0, 0xc000192ae0, 0xc001431260, 0x24)
2020-07-19T21:04:48.9955800Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171
2020-07-19T21:04:48.9955920Z created by k8s.io/kops/upup/pkg/fi.(*executor).forkJoin
2020-07-19T21:04:48.9956080Z 	/Users/runner/work/kops/kops/go/src/k8s.io/kops/upup/pkg/fi/executor.go:171 +0xfb
2020-07-19T21:04:48.9956190Z FAIL	k8s.io/kops/cmd/kops	22.322s
```