### PR TITLE
Revert move to explicit dependencies

### DIFF
--- a/upup/pkg/fi/cloudup/alitasks/launchconfiguration.go
+++ b/upup/pkg/fi/cloudup/alitasks/launchconfiguration.go
@@ -74,14 +74,9 @@ type LaunchConfiguration struct {
 
 var _ fi.Task = &LaunchConfiguration{}
 var _ fi.CompareWithID = &LaunchConfiguration{}
-var _ fi.HasDependencies = &LaunchConfiguration{}
 
 func (l *LaunchConfiguration) CompareWithID() *string {
 	return l.ID
-}
-
-func (l *LaunchConfiguration) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	return l.UserData.GetDependencies(tasks)
 }
 
 func (l *LaunchConfiguration) Find(c *fi.Context) (*LaunchConfiguration, error) {

--- a/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
@@ -94,15 +94,10 @@ type LaunchConfiguration struct {
 }
 
 var _ fi.CompareWithID = &LaunchConfiguration{}
-var _ fi.HasDependencies = &LaunchConfiguration{}
 var _ fi.ProducesDeletions = &LaunchConfiguration{}
 
 func (e *LaunchConfiguration) CompareWithID() *string {
 	return e.ID
-}
-
-func (l *LaunchConfiguration) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	return l.UserData.GetDependencies(tasks)
 }
 
 // findLaunchConfigurations returns matching LaunchConfigurations, sorted by CreatedTime (ascending)

--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -47,14 +47,9 @@ type Droplet struct {
 
 var _ fi.Task = &Droplet{}
 var _ fi.CompareWithID = &Droplet{}
-var _ fi.HasDependencies = &Droplet{}
 
 func (d *Droplet) CompareWithID() *string {
 	return d.Name
-}
-
-func (l *Droplet) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	return l.UserData.GetDependencies(tasks)
 }
 
 func (d *Droplet) Find(c *fi.Context) (*Droplet, error) {

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -70,18 +70,9 @@ type InstanceTemplate struct {
 
 var _ fi.Task = &InstanceTemplate{}
 var _ fi.CompareWithID = &InstanceTemplate{}
-var _ fi.HasDependencies = &InstanceTemplate{}
 
 func (e *InstanceTemplate) CompareWithID() *string {
 	return e.ID
-}
-
-func (l *InstanceTemplate) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
-	for _, resource := range l.Metadata {
-		deps = append(deps, resource.GetDependencies(tasks)...)
-	}
-	return deps
 }
 
 func (e *InstanceTemplate) Find(c *fi.Context) (*InstanceTemplate, error) {


### PR DESCRIPTION
The change to explicit dependencies lost the dependencies
that were previously found by reflection.

/kind bug
Fixes #9602 
