### PR TITLE
Automated cherry pick of #9590: Promote Ciprian & John to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,8 @@ emeritus_approvers:
   - gambol99
   - granular-ryanbonham
 approvers:
+  - hakman
+  - johngmyers
   - justinsb
   - geojaz
   - kashifsaadat


### PR DESCRIPTION
Cherry pick of #9590 on release-1.18.

#9590: Promote Ciprian & John to approvers

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.