### PR TITLE
fix(docs): render double curly braces

### DIFF
--- a/docs/development/adding_a_feature.md
+++ b/docs/development/adding_a_feature.md
@@ -57,20 +57,20 @@ one file per range of Kubernetes versions. These files are referenced by upup/pk
 First we add to the `cilium-config` ConfigMap:
 
 ```go
-  {{ with .Ipam }}
-  ipam: {{ . }}
-  {{ if eq . "eni" }}
+  {{ '{{ with .Ipam }}' }}
+  ipam: {{ '{{ . }}' }}
+  {{ '{{ if eq . "eni" }}' }}
   enable-endpoint-routes: "true"
   auto-create-cilium-node-resource: "true"
   blacklist-conflicting-routes: "false"
-  {{ end }}
-  {{ end }}
+  {{ '{{ end }}' }}
+  {{ '{{ end }}' }}
 ```
 
 Then we conditionally move cilium-operator to masters:
 
 ```go
-      {{ if eq .Ipam "eni" }}
+      {{ '{{ if eq .Ipam "eni" }}' }}
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
@@ -84,7 +84,7 @@ Then we conditionally move cilium-operator to masters:
         key: node.kubernetes.io/unreachable
         operator: Exists
         tolerationSeconds: 300
-      {{ end }}
+      {{ '{{ end }}' }}
 ```
 
 ## Configuring kubelet

--- a/docs/operations/cluster_template.md
+++ b/docs/operations/cluster_template.md
@@ -13,11 +13,11 @@ apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   labels:
-  kops.k8s.io/cluster: {{.clusterName}}.{{.dnsZone}}
+  kops.k8s.io/cluster: {{ '{{.clusterName}}.{{.dnsZone}}' }}
   name: nodes
 spec:
   image: coreos.com/CoreOS-stable-1409.6.0-hvm
-  kubernetesVersion: {{.kubernetesVersion}
+  kubernetesVersion: {{ '{{.kubernetesVersion}}' }}
   machineType: m4.large
   maxPrice: "0.5"
   maxSize: 20
@@ -25,9 +25,9 @@ spec:
   role: Node
   rootVolumeSize: 100
   subnets:
-  - {{.awsRegion}}a
-  - {{.awsRegion}}b
-  - {{.awsRegion}}c
+  - {{ '{{.awsRegion}}' }}a
+  - {{ '{{.awsRegion}}' }}b
+  - {{ '{{.awsRegion}}' }}c
 ```
 
 You can pass configuration such as an environment file by using the `--values PATH` command line option. Note `--values` is a slice so can be defined multiple times; the configuration is overridden by each configuration file *(so order is important assuming duplicating values)*; a use-case for this would be a default configuration which upstream clusters can override.
@@ -108,15 +108,15 @@ The example below assumes you have placed the appropriate files i.e. *(nodes.jso
 apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
-  name: {{ .environment }}.{{ .dns_zone }}
+  name: {{ '{{ .environment }}.{{ .dns_zone }}' }}
 spec:
   docker:
-    {{ include "docker" . | indent 4 }}
+    {{ '{{ include "docker" . | indent 4 }}' }}
   additionalPolicies:
     master: |
-      {{ include "masters.json" . | indent 6 }}
+      {{ '{{ include "masters.json" . | indent 6 }}' }}
     node: |
-      {{ include "nodes.json" . | indent 6 }}
+      {{ '{{ include "nodes.json" . | indent 6 }}' }}
 ```
 
 ### Template Functions
@@ -124,10 +124,10 @@ spec:
 The entire set of https://github.com/Masterminds/sprig functions are available within the templates for you. Note if you want to use the 'defaults' functions switch off the verification check on the command line by `--fail-on-missing=false`;
 
 ```YAML
-image: {{ default $image $node.image }}
-machineType: {{ default $instance $node.machine_type }}
-maxSize: {{ default "10" $node.max_size }}
-minSize: {{ default "1" $node.min_size }}
+image: {{ '{{ default $image $node.image }}' }}
+machineType: {{ '{{ default $instance $node.machine_type }}' }}
+maxSize: {{ '{{ default "10" $node.max_size }}' }}
+minSize: {{ '{{ default "1" $node.min_size }}' }}
 ```
 
 ### Formatting


### PR DESCRIPTION
Fix jinja render double curly braces error.

```
Traceback (most recent call last):
  File "/opt/buildhome/python3.7/lib/python3.7/site-packages/macros/plugin.py", line 261, in render
    md_template = self.env.from_string(markdown)
  File "/opt/buildhome/python3.7/lib/python3.7/site-packages/jinja2/environment.py", line 941, in from_string
    return cls.from_code(self, self.compile(source), globals, None)
  File "/opt/buildhome/python3.7/lib/python3.7/site-packages/jinja2/environment.py", line 638, in compile
    self.handle_exception(source=source_hint)
  File "/opt/buildhome/python3.7/lib/python3.7/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/opt/buildhome/python3.7/lib/python3.7/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "<unknown>", line 61, in template
jinja2.exceptions.TemplateSyntaxError: unexpected '.'
```