### PR TITLE
Use public client accessors within openstackCloud functions

### DIFF
--- a/upup/pkg/fi/cloudup/openstack/dns.go
+++ b/upup/pkg/fi/cloudup/openstack/dns.go
@@ -30,7 +30,7 @@ func (c *openstackCloud) ListDNSZones(opt zones.ListOptsBuilder) ([]zones.Zone, 
 	var zs []zones.Zone
 
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		allPages, err := zones.List(c.dnsClient, opt).AllPages()
+		allPages, err := zones.List(c.DNSClient(), opt).AllPages()
 		if err != nil {
 			return false, fmt.Errorf("failed to list dns zones: %s", err)
 		}
@@ -55,7 +55,7 @@ func (c *openstackCloud) ListDNSRecordsets(zoneID string, opt recordsets.ListOpt
 	var rrs []recordsets.RecordSet
 
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		allPages, err := recordsets.ListByZone(c.dnsClient, zoneID, opt).AllPages()
+		allPages, err := recordsets.ListByZone(c.DNSClient(), zoneID, opt).AllPages()
 		if err != nil {
 			return false, fmt.Errorf("failed to list dns recordsets: %s", err)
 		}

--- a/upup/pkg/fi/cloudup/openstack/instance.go
+++ b/upup/pkg/fi/cloudup/openstack/instance.go
@@ -49,7 +49,7 @@ func (c *openstackCloud) CreateInstance(opt servers.CreateOptsBuilder) (*servers
 	var server *servers.Server
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		v, err := servers.Create(c.novaClient, opt).Extract()
+		v, err := servers.Create(c.ComputeClient(), opt).Extract()
 		if err != nil {
 			return false, fmt.Errorf("error creating server %v: %v", opt, err)
 		}
@@ -107,7 +107,7 @@ func (c *openstackCloud) DeleteInstance(i *cloudinstances.CloudInstanceGroupMemb
 }
 
 func (c *openstackCloud) DeleteInstanceWithID(instanceID string) error {
-	return servers.Delete(c.novaClient, instanceID).ExtractErr()
+	return servers.Delete(c.ComputeClient(), instanceID).ExtractErr()
 }
 
 // DetachInstance is not implemented yet. It needs to cause a cloud instance to no longer be counted against the group's size limits.
@@ -120,7 +120,7 @@ func (c *openstackCloud) GetInstance(id string) (*servers.Server, error) {
 	var server *servers.Server
 
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		instance, err := servers.Get(c.novaClient, id).Extract()
+		instance, err := servers.Get(c.ComputeClient(), id).Extract()
 		if err != nil {
 			return false, err
 		}
@@ -140,7 +140,7 @@ func (c *openstackCloud) ListInstances(opt servers.ListOptsBuilder) ([]servers.S
 	var instances []servers.Server
 
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		allPages, err := servers.List(c.novaClient, opt).AllPages()
+		allPages, err := servers.List(c.ComputeClient(), opt).AllPages()
 		if err != nil {
 			return false, fmt.Errorf("error listing servers %v: %v", opt, err)
 		}

--- a/upup/pkg/fi/cloudup/openstack/keypair.go
+++ b/upup/pkg/fi/cloudup/openstack/keypair.go
@@ -27,7 +27,7 @@ import (
 func (c *openstackCloud) GetKeypair(name string) (*keypairs.KeyPair, error) {
 	var k *keypairs.KeyPair
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		rs, err := keypairs.Get(c.novaClient, name).Extract()
+		rs, err := keypairs.Get(c.ComputeClient(), name).Extract()
 		if err != nil {
 			if err.Error() == ErrNotFound {
 				return true, nil
@@ -50,7 +50,7 @@ func (c *openstackCloud) CreateKeypair(opt keypairs.CreateOptsBuilder) (*keypair
 	var k *keypairs.KeyPair
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		v, err := keypairs.Create(c.novaClient, opt).Extract()
+		v, err := keypairs.Create(c.ComputeClient(), opt).Extract()
 		if err != nil {
 			return false, fmt.Errorf("error creating keypair: %v", err)
 		}
@@ -68,7 +68,7 @@ func (c *openstackCloud) CreateKeypair(opt keypairs.CreateOptsBuilder) (*keypair
 
 func (c *openstackCloud) DeleteKeyPair(name string) error {
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		err := keypairs.Delete(c.novaClient, name).ExtractErr()
+		err := keypairs.Delete(c.ComputeClient(), name).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting keypair: %v", err)
 		}
@@ -87,7 +87,7 @@ func (c *openstackCloud) DeleteKeyPair(name string) error {
 func (c *openstackCloud) ListKeypairs() ([]keypairs.KeyPair, error) {
 	var k []keypairs.KeyPair
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		allPages, err := keypairs.List(c.novaClient).AllPages()
+		allPages, err := keypairs.List(c.ComputeClient()).AllPages()
 		if err != nil {
 			return false, fmt.Errorf("error listing keypairs: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/openstack/network.go
+++ b/upup/pkg/fi/cloudup/openstack/network.go
@@ -30,7 +30,7 @@ import (
 
 func (c *openstackCloud) AppendTag(resource string, id string, tag string) error {
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		err := attributestags.Add(c.neutronClient, resource, id, tag).ExtractErr()
+		err := attributestags.Add(c.NetworkingClient(), resource, id, tag).ExtractErr()
 		if err != nil {
 			return false, fmt.Errorf("error appending tag %s: %v", tag, err)
 		}
@@ -47,7 +47,7 @@ func (c *openstackCloud) AppendTag(resource string, id string, tag string) error
 
 func (c *openstackCloud) DeleteTag(resource string, id string, tag string) error {
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		err := attributestags.Delete(c.neutronClient, resource, id, tag).ExtractErr()
+		err := attributestags.Delete(c.NetworkingClient(), resource, id, tag).ExtractErr()
 		if err != nil {
 			return false, fmt.Errorf("error deleting tag %s: %v", tag, err)
 		}
@@ -90,7 +90,7 @@ func (c *openstackCloud) FindNetworkBySubnetID(subnetID string) (*networks.Netwo
 func (c *openstackCloud) GetNetwork(id string) (*networks.Network, error) {
 	var network *networks.Network
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		r, err := networks.Get(c.neutronClient, id).Extract()
+		r, err := networks.Get(c.NetworkingClient(), id).Extract()
 		if err != nil {
 			return false, fmt.Errorf("error retrieving network with id %s: %v", id, err)
 		}
@@ -110,7 +110,7 @@ func (c *openstackCloud) ListNetworks(opt networks.ListOptsBuilder) ([]networks.
 	var ns []networks.Network
 
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		allPages, err := networks.List(c.neutronClient, opt).AllPages()
+		allPages, err := networks.List(c.NetworkingClient(), opt).AllPages()
 		if err != nil {
 			return false, fmt.Errorf("error listing networks: %v", err)
 		}
@@ -172,7 +172,7 @@ func (c *openstackCloud) CreateNetwork(opt networks.CreateOptsBuilder) (*network
 	var n *networks.Network
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		r, err := networks.Create(c.neutronClient, opt).Extract()
+		r, err := networks.Create(c.NetworkingClient(), opt).Extract()
 		if err != nil {
 			return false, fmt.Errorf("error creating network: %v", err)
 		}
@@ -190,7 +190,7 @@ func (c *openstackCloud) CreateNetwork(opt networks.CreateOptsBuilder) (*network
 
 func (c *openstackCloud) DeleteNetwork(networkID string) error {
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		err := networks.Delete(c.neutronClient, networkID).ExtractErr()
+		err := networks.Delete(c.NetworkingClient(), networkID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting network: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/openstack/port.go
+++ b/upup/pkg/fi/cloudup/openstack/port.go
@@ -28,7 +28,7 @@ func (c *openstackCloud) CreatePort(opt ports.CreateOptsBuilder) (*ports.Port, e
 	var p *ports.Port
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		v, err := ports.Create(c.neutronClient, opt).Extract()
+		v, err := ports.Create(c.NetworkingClient(), opt).Extract()
 		if err != nil {
 			return false, fmt.Errorf("error creating port: %v", err)
 		}
@@ -48,7 +48,7 @@ func (c *openstackCloud) GetPort(id string) (*ports.Port, error) {
 	var p *ports.Port
 
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		port, err := ports.Get(c.neutronClient, id).Extract()
+		port, err := ports.Get(c.NetworkingClient(), id).Extract()
 		if err != nil {
 			return false, err
 		}
@@ -68,7 +68,7 @@ func (c *openstackCloud) ListPorts(opt ports.ListOptsBuilder) ([]ports.Port, err
 	var p []ports.Port
 
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		allPages, err := ports.List(c.neutronClient, opt).AllPages()
+		allPages, err := ports.List(c.NetworkingClient(), opt).AllPages()
 		if err != nil {
 			return false, fmt.Errorf("error listing ports: %v", err)
 		}
@@ -91,7 +91,7 @@ func (c *openstackCloud) ListPorts(opt ports.ListOptsBuilder) ([]ports.Port, err
 
 func (c *openstackCloud) DeletePort(portID string) error {
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		err := ports.Delete(c.neutronClient, portID).ExtractErr()
+		err := ports.Delete(c.NetworkingClient(), portID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting port: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/openstack/router.go
+++ b/upup/pkg/fi/cloudup/openstack/router.go
@@ -28,7 +28,7 @@ func (c *openstackCloud) ListRouters(opt routers.ListOpts) ([]routers.Router, er
 	var rs []routers.Router
 
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		allPages, err := routers.List(c.neutronClient, opt).AllPages()
+		allPages, err := routers.List(c.NetworkingClient(), opt).AllPages()
 		if err != nil {
 			return false, fmt.Errorf("error listing routers: %v", err)
 		}
@@ -53,7 +53,7 @@ func (c *openstackCloud) CreateRouter(opt routers.CreateOptsBuilder) (*routers.R
 	var r *routers.Router
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		v, err := routers.Create(c.neutronClient, opt).Extract()
+		v, err := routers.Create(c.NetworkingClient(), opt).Extract()
 		if err != nil {
 			return false, fmt.Errorf("error creating router: %v", err)
 		}
@@ -73,7 +73,7 @@ func (c *openstackCloud) CreateRouterInterface(routerID string, opt routers.AddI
 	var i *routers.InterfaceInfo
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		v, err := routers.AddInterface(c.neutronClient, routerID, opt).Extract()
+		v, err := routers.AddInterface(c.NetworkingClient(), routerID, opt).Extract()
 		if err != nil {
 			return false, fmt.Errorf("error creating router interface: %v", err)
 		}
@@ -91,7 +91,7 @@ func (c *openstackCloud) CreateRouterInterface(routerID string, opt routers.AddI
 
 func (c *openstackCloud) DeleteRouterInterface(routerID string, opt routers.RemoveInterfaceOptsBuilder) error {
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		_, err := routers.RemoveInterface(c.neutronClient, routerID, opt).Extract()
+		_, err := routers.RemoveInterface(c.NetworkingClient(), routerID, opt).Extract()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting router interface: %v", err)
 		}
@@ -108,7 +108,7 @@ func (c *openstackCloud) DeleteRouterInterface(routerID string, opt routers.Remo
 
 func (c *openstackCloud) DeleteRouter(routerID string) error {
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		err := routers.Delete(c.neutronClient, routerID).ExtractErr()
+		err := routers.Delete(c.NetworkingClient(), routerID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting router: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/openstack/security_group.go
+++ b/upup/pkg/fi/cloudup/openstack/security_group.go
@@ -29,7 +29,7 @@ func (c *openstackCloud) ListSecurityGroups(opt sg.ListOpts) ([]sg.SecGroup, err
 	var groups []sg.SecGroup
 
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		allPages, err := sg.List(c.neutronClient, opt).AllPages()
+		allPages, err := sg.List(c.NetworkingClient(), opt).AllPages()
 		if err != nil {
 			return false, fmt.Errorf("error listing security groups %v: %v", opt, err)
 		}
@@ -54,7 +54,7 @@ func (c *openstackCloud) CreateSecurityGroup(opt sg.CreateOptsBuilder) (*sg.SecG
 	var group *sg.SecGroup
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		g, err := sg.Create(c.neutronClient, opt).Extract()
+		g, err := sg.Create(c.NetworkingClient(), opt).Extract()
 		if err != nil {
 			return false, fmt.Errorf("error creating security group %v: %v", opt, err)
 		}
@@ -74,7 +74,7 @@ func (c *openstackCloud) ListSecurityGroupRules(opt sgr.ListOpts) ([]sgr.SecGrou
 	var rules []sgr.SecGroupRule
 
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		allPages, err := sgr.List(c.neutronClient, opt).AllPages()
+		allPages, err := sgr.List(c.NetworkingClient(), opt).AllPages()
 		if err != nil {
 			return false, fmt.Errorf("error listing security group rules %v: %v", opt, err)
 		}
@@ -99,7 +99,7 @@ func (c *openstackCloud) CreateSecurityGroupRule(opt sgr.CreateOptsBuilder) (*sg
 	var rule *sgr.SecGroupRule
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		r, err := sgr.Create(c.neutronClient, opt).Extract()
+		r, err := sgr.Create(c.NetworkingClient(), opt).Extract()
 		if err != nil {
 			return false, fmt.Errorf("error creating security group rule %v: %v", opt, err)
 		}
@@ -117,7 +117,7 @@ func (c *openstackCloud) CreateSecurityGroupRule(opt sgr.CreateOptsBuilder) (*sg
 
 func (c *openstackCloud) DeleteSecurityGroup(sgID string) error {
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		err := sg.Delete(c.neutronClient, sgID).ExtractErr()
+		err := sg.Delete(c.NetworkingClient(), sgID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting security group: %v", err)
 		}
@@ -134,7 +134,7 @@ func (c *openstackCloud) DeleteSecurityGroup(sgID string) error {
 
 func (c *openstackCloud) DeleteSecurityGroupRule(ruleID string) error {
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		err := sgr.Delete(c.neutronClient, ruleID).ExtractErr()
+		err := sgr.Delete(c.NetworkingClient(), ruleID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting security group rule: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/openstack/server_group.go
+++ b/upup/pkg/fi/cloudup/openstack/server_group.go
@@ -35,7 +35,7 @@ func (c *openstackCloud) CreateServerGroup(opt servergroups.CreateOptsBuilder) (
 	var i *servergroups.ServerGroup
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		v, err := servergroups.Create(c.novaClient, opt).Extract()
+		v, err := servergroups.Create(c.ComputeClient(), opt).Extract()
 		if err != nil {
 			return false, fmt.Errorf("error creating server group: %v", err)
 		}
@@ -55,7 +55,7 @@ func (c *openstackCloud) ListServerGroups() ([]servergroups.ServerGroup, error) 
 	var sgs []servergroups.ServerGroup
 
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		allPages, err := servergroups.List(c.novaClient).AllPages()
+		allPages, err := servergroups.List(c.ComputeClient()).AllPages()
 		if err != nil {
 			return false, fmt.Errorf("error listing server groups: %v", err)
 		}
@@ -136,7 +136,7 @@ func (c *openstackCloud) osBuildCloudInstanceGroup(cluster *kops.Cluster, ig *ko
 
 func (c *openstackCloud) DeleteServerGroup(groupID string) error {
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		err := servergroups.Delete(c.novaClient, groupID).ExtractErr()
+		err := servergroups.Delete(c.ComputeClient(), groupID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting server group: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/openstack/subnet.go
+++ b/upup/pkg/fi/cloudup/openstack/subnet.go
@@ -29,7 +29,7 @@ func (c *openstackCloud) ListSubnets(opt subnets.ListOptsBuilder) ([]subnets.Sub
 	var s []subnets.Subnet
 
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		allPages, err := subnets.List(c.neutronClient, opt).AllPages()
+		allPages, err := subnets.List(c.NetworkingClient(), opt).AllPages()
 		if err != nil {
 			return false, fmt.Errorf("error listing subnets: %v", err)
 		}
@@ -53,7 +53,7 @@ func (c *openstackCloud) ListSubnets(opt subnets.ListOptsBuilder) ([]subnets.Sub
 func (c *openstackCloud) GetSubnet(subnetID string) (*subnets.Subnet, error) {
 	var subnet *subnets.Subnet
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		sub, err := subnets.Get(c.neutronClient, subnetID).Extract()
+		sub, err := subnets.Get(c.NetworkingClient(), subnetID).Extract()
 		if err != nil {
 			return false, fmt.Errorf("error retrieving subnet: %v", err)
 		}
@@ -73,7 +73,7 @@ func (c *openstackCloud) CreateSubnet(opt subnets.CreateOptsBuilder) (*subnets.S
 	var s *subnets.Subnet
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		v, err := subnets.Create(c.neutronClient, opt).Extract()
+		v, err := subnets.Create(c.NetworkingClient(), opt).Extract()
 		if err != nil {
 			return false, fmt.Errorf("error creating subnet: %v", err)
 		}
@@ -91,7 +91,7 @@ func (c *openstackCloud) CreateSubnet(opt subnets.CreateOptsBuilder) (*subnets.S
 
 func (c *openstackCloud) DeleteSubnet(subnetID string) error {
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		err := subnets.Delete(c.neutronClient, subnetID).ExtractErr()
+		err := subnets.Delete(c.NetworkingClient(), subnetID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting subnet: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/openstack/volume.go
+++ b/upup/pkg/fi/cloudup/openstack/volume.go
@@ -30,7 +30,7 @@ func (c *openstackCloud) ListVolumes(opt cinder.ListOptsBuilder) ([]cinder.Volum
 	var volumes []cinder.Volume
 
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		allPages, err := cinder.List(c.cinderClient, opt).AllPages()
+		allPages, err := cinder.List(c.BlockStorageClient(), opt).AllPages()
 		if err != nil {
 			return false, fmt.Errorf("error listing volumes %v: %v", opt, err)
 		}
@@ -55,7 +55,7 @@ func (c *openstackCloud) CreateVolume(opt cinder.CreateOptsBuilder) (*cinder.Vol
 	var volume *cinder.Volume
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		v, err := cinder.Create(c.cinderClient, opt).Extract()
+		v, err := cinder.Create(c.BlockStorageClient(), opt).Extract()
 		if err != nil {
 			return false, fmt.Errorf("error creating volume %v: %v", opt, err)
 		}
@@ -100,7 +100,7 @@ func (c *openstackCloud) SetVolumeTags(id string, tags map[string]string) error 
 
 	opt := cinder.UpdateOpts{Metadata: tags}
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		_, err := cinder.Update(c.cinderClient, id, opt).Extract()
+		_, err := cinder.Update(c.BlockStorageClient(), id, opt).Extract()
 		if err != nil {
 			return false, fmt.Errorf("error setting tags to cinder volume %q: %v", id, err)
 		}
@@ -117,7 +117,7 @@ func (c *openstackCloud) SetVolumeTags(id string, tags map[string]string) error 
 
 func (c *openstackCloud) DeleteVolume(volumeID string) error {
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		err := cinder.Delete(c.cinderClient, volumeID, cinder.DeleteOpts{}).ExtractErr()
+		err := cinder.Delete(c.BlockStorageClient(), volumeID, cinder.DeleteOpts{}).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting volume: %v", err)
 		}


### PR DESCRIPTION
This is minor cleanup before refactoring the openstackCloud functions to make them more mockable, similar to AWSCloud.

This should effectively be a no-op

https://github.com/kubernetes/kops/blob/0bf54419abdc0aae39ca6fcf4402642e1c28041d/upup/pkg/fi/cloudup/openstack/cloud.go#L485-L503