### PR TITLE
Fix int to string conversions

### DIFF
--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -136,7 +136,7 @@ func makeGroup(groups map[string]*cloudinstances.CloudInstanceGroup, k8sClient k
 
 	var instanceIds []*string
 	for i := 0; i < count; i++ {
-		id := name + string('a'+i)
+		id := name + string(rune('a'+i))
 		var node *v1.Node
 		if role != kopsapi.InstanceGroupRoleBastion {
 			node = &v1.Node{

--- a/upup/pkg/fi/cloudup/awsup/machine_types.go
+++ b/upup/pkg/fi/cloudup/awsup/machine_types.go
@@ -58,7 +58,7 @@ func (m *AWSMachineTypeInfo) EphemeralDevices() []*EphemeralDevice {
 			// TODO: What drive letters do we use?
 			klog.Fatalf("ephemeral devices for > 20 not yet implemented")
 		}
-		d.DeviceName = "/dev/sd" + string('c'+i)
+		d.DeviceName = fmt.Sprintf("/dev/sd%c", 'c'+i)
 		d.VirtualName = fmt.Sprintf("ephemeral%d", i)
 
 		disks = append(disks, d)


### PR DESCRIPTION
Go 1.15 introduces some new restrictions:
https://tip.golang.org/doc/go1.15#vet
```
# k8s.io/kops/pkg/instancegroups
pkg/instancegroups/rollingupdate_test.go:139:16: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
FAIL	k8s.io/kops/pkg/instancegroups [build failed]

# k8s.io/kops/upup/pkg/fi/cloudup/awsup
upup/pkg/fi/cloudup/awsup/machine_types.go:61:30: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
FAIL	k8s.io/kops/upup/pkg/fi/cloudup/awsup [build failed]
```