### PR TITLE
Make ARM64 job blocking with TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ arch:
 os:
   - linux
   - osx
+dist: focal
 go: 1.14.x
 
 go_import_path: k8s.io/kops
@@ -17,6 +18,7 @@ jobs:
     - name: Verify
       arch: amd64
       os: linux
+      dist: focal
       go: 1.14.x
       script:
         - GOPROXY=https://proxy.golang.org make travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ arch:
 os:
   - linux
   - osx
-go:
-  - 1.13.x
-  - 1.14.x
+go: 1.14.x
 
 go_import_path: k8s.io/kops
 
@@ -15,16 +13,6 @@ script:
   - GOPROXY=https://proxy.golang.org travis_wait 30 make nodeup examples test
 
 jobs:
-  allow_failures:
-    - arch: arm64
-
-  exclude:
-    - os: osx
-      go: 1.13.x
-    - os: linux
-      go: 1.13.x
-      arch: arm64
-
   include:
     - name: Verify
       arch: amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ go: 1.14.x
 go_import_path: k8s.io/kops
 
 script:
-  - GOPROXY=https://proxy.golang.org travis_wait 30 make nodeup examples test
+  - GOPROXY=https://proxy.golang.org travis_wait 30 make all examples test
 
 jobs:
   include:

--- a/nodeup/pkg/model/containerd_test.go
+++ b/nodeup/pkg/model/containerd_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"k8s.io/kops/nodeup/pkg/distros"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/flagbuilder"
 	"k8s.io/kops/pkg/testutils"
@@ -153,6 +154,7 @@ func runContainerdBuilderTest(t *testing.T, key string) {
 	basedir := path.Join("tests/containerdbuilder/", key)
 
 	nodeUpModelContext, err := BuildNodeupModelContext(basedir)
+	nodeUpModelContext.Distribution = distros.DistributionXenial
 	if err != nil {
 		t.Fatalf("error parsing cluster yaml %q: %v", basedir, err)
 		return

--- a/nodeup/pkg/model/docker_test.go
+++ b/nodeup/pkg/model/docker_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/kops/nodeup/pkg/distros"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/flagbuilder"
 	"k8s.io/kops/pkg/testutils"
@@ -249,6 +250,7 @@ func runDockerBuilderTest(t *testing.T, key string) {
 	basedir := path.Join("tests/dockerbuilder/", key)
 
 	nodeUpModelContext, err := BuildNodeupModelContext(basedir)
+	nodeUpModelContext.Distribution = distros.DistributionXenial
 	if err != nil {
 		t.Fatalf("error parsing cluster yaml %q: %v", basedir, err)
 		return

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"k8s.io/klog"
-	"k8s.io/kops/nodeup/pkg/distros"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/nodeup"
 	"k8s.io/kops/pkg/assets"
@@ -208,7 +207,6 @@ func BuildNodeupModelContext(basedir string) (*NodeupModelContext, error) {
 	nodeUpModelContext := &NodeupModelContext{
 		Cluster:      model.Cluster,
 		Architecture: "amd64",
-		Distribution: distros.DistributionXenial,
 		NodeupConfig: &nodeup.Config{},
 	}
 


### PR DESCRIPTION
The ARM64 job seems to be faster with latest ubuntu and more stable with latest Ubuntu. Time to try to make it blocking.