### PR TITLE
Calico: Upgrade the "k8s-ec2-srcdst" controller to version v0.3.0

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -12620,8 +12620,16 @@ metadata:
     role.kubernetes.io/networking: "1"
 
 {{ if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}
-# This manifest installs the k8s-ec2-srcdst container, which disables
-# src/dst ip checks to allow BGP to function for calico for hosts within subnets
+# This manifest installs the "k8s-ec2-srcdst" container, which
+# disables source/destination IP address checks for ENIs attached to
+# EC2 instances hosting Kubernetes nodes.
+#
+# Disabling these checks allows Calico to send unencapsulated packets
+# to and from pods within the same VPC subnet, where either a given
+# packet's source address (originating from a pod) may not match the
+# sending machine's address or the destination address (heading to a
+# pod) may not match the receiving machine's address.
+#
 # This only applies for AWS environments.
 ---
 
@@ -12699,7 +12707,7 @@ spec:
       serviceAccountName: k8s-ec2-srcdst
       priorityClassName: system-cluster-critical
       containers:
-        - image: ottoyiu/k8s-ec2-srcdst:v0.2.2
+        - image: ottoyiu/k8s-ec2-srcdst:v0.3.0
           name: k8s-ec2-srcdst
           resources:
             requests:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3947,8 +3947,16 @@ metadata:
     role.kubernetes.io/networking: "1"
 
 {{ if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}
-# This manifest installs the k8s-ec2-srcdst container, which disables
-# src/dst ip checks to allow BGP to function for calico for hosts within subnets
+# This manifest installs the "k8s-ec2-srcdst" container, which
+# disables source/destination IP address checks for ENIs attached to
+# EC2 instances hosting Kubernetes nodes.
+#
+# Disabling these checks allows Calico to send unencapsulated packets
+# to and from pods within the same VPC subnet, where either a given
+# packet's source address (originating from a pod) may not match the
+# sending machine's address or the destination address (heading to a
+# pod) may not match the receiving machine's address.
+#
 # This only applies for AWS environments.
 ---
 
@@ -4026,7 +4034,7 @@ spec:
       serviceAccountName: k8s-ec2-srcdst
       priorityClassName: system-cluster-critical
       containers:
-        - image: ottoyiu/k8s-ec2-srcdst:v0.2.2
+        - image: ottoyiu/k8s-ec2-srcdst:v0.3.0
           name: k8s-ec2-srcdst
           resources:
             requests:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -714,7 +714,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.7":    "2.6.12-kops.1",
 			"k8s-1.7-v3": "3.8.0-kops.2",
 			"k8s-1.12":   "3.9.6-kops.1",
-			"k8s-1.16":   "3.15.0-kops.2",
+			"k8s-1.16":   "3.15.0-kops.3",
 		}
 
 		{


### PR DESCRIPTION
Upgrading [the _k8s-ec2-srcdst_ controller](https://github.com/ottoyiu/k8s-ec2-srcdst/) to [this latest version](https://github.com/ottoyiu/k8s-ec2-srcdst/releases/tag/v0.3.0) allows it to work correctly with the objects containing the new "metadata.managedFields" field [introduced in Kubernetes version 1.18.0](https://kubernetes.io/blog/2020/04/01/kubernetes-1.18-feature-server-side-apply-beta-2/#how-does-it-work-what-s-managedfields), per ottoyiu/k8s-ec2-srcdst#17.

The previous container image versions used a version of the _client-go_ library that was too old to consume these fields
correctly, causing the controller to fail repeatedly when trying to read _Node_ objects retrieved from the Kubernetes API server.