### PR TITLE
Automated cherry pick of #9647: Calico: upgrade "k8s-ec2-srcdst" to version v0.3.0

### DIFF
--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -136,7 +136,7 @@ func makeGroup(groups map[string]*cloudinstances.CloudInstanceGroup, k8sClient k
 
 	var instanceIds []*string
 	for i := 0; i < count; i++ {
-		id := name + string('a'+i)
+		id := name + string(rune('a'+i))
 		var node *v1.Node
 		if role != kopsapi.InstanceGroupRoleBastion {
 			node = &v1.Node{

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -11857,8 +11857,16 @@ metadata:
     role.kubernetes.io/networking: "1"
 
 {{ if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}
-# This manifest installs the k8s-ec2-srcdst container, which disables
-# src/dst ip checks to allow BGP to function for calico for hosts within subnets
+# This manifest installs the "k8s-ec2-srcdst" container, which
+# disables source/destination IP address checks for ENIs attached to
+# EC2 instances hosting Kubernetes nodes.
+#
+# Disabling these checks allows Calico to send unencapsulated packets
+# to and from pods within the same VPC subnet, where either a given
+# packet's source address (originating from a pod) may not match the
+# sending machine's address or the destination address (heading to a
+# pod) may not match the receiving machine's address.
+#
 # This only applies for AWS environments.
 ---
 
@@ -11936,7 +11944,7 @@ spec:
       serviceAccountName: k8s-ec2-srcdst
       priorityClassName: system-cluster-critical
       containers:
-        - image: ottoyiu/k8s-ec2-srcdst:v0.2.2
+        - image: ottoyiu/k8s-ec2-srcdst:v0.3.0
           name: k8s-ec2-srcdst
           resources:
             requests:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3943,8 +3943,16 @@ metadata:
     role.kubernetes.io/networking: "1"
 
 {{ if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}
-# This manifest installs the k8s-ec2-srcdst container, which disables
-# src/dst ip checks to allow BGP to function for calico for hosts within subnets
+# This manifest installs the "k8s-ec2-srcdst" container, which
+# disables source/destination IP address checks for ENIs attached to
+# EC2 instances hosting Kubernetes nodes.
+#
+# Disabling these checks allows Calico to send unencapsulated packets
+# to and from pods within the same VPC subnet, where either a given
+# packet's source address (originating from a pod) may not match the
+# sending machine's address or the destination address (heading to a
+# pod) may not match the receiving machine's address.
+#
 # This only applies for AWS environments.
 ---
 
@@ -4022,7 +4030,7 @@ spec:
       serviceAccountName: k8s-ec2-srcdst
       priorityClassName: system-cluster-critical
       containers:
-        - image: ottoyiu/k8s-ec2-srcdst:v0.2.2
+        - image: ottoyiu/k8s-ec2-srcdst:v0.3.0
           name: k8s-ec2-srcdst
           resources:
             requests:

--- a/upup/pkg/fi/cloudup/awsup/machine_types.go
+++ b/upup/pkg/fi/cloudup/awsup/machine_types.go
@@ -50,7 +50,7 @@ func (m *AWSMachineTypeInfo) EphemeralDevices() []*EphemeralDevice {
 			// TODO: What drive letters do we use?
 			klog.Fatalf("ephemeral devices for > 20 not yet implemented")
 		}
-		d.DeviceName = "/dev/sd" + string('c'+i)
+		d.DeviceName = fmt.Sprintf("/dev/sd%c", 'c'+i)
 		d.VirtualName = fmt.Sprintf("ephemeral%d", i)
 
 		disks = append(disks, d)

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -726,7 +726,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.7":    "2.6.12-kops.1",
 			"k8s-1.7-v3": "3.8.0-kops.2",
 			"k8s-1.12":   "3.9.6-kops.1",
-			"k8s-1.16":   "3.15.0-kops.2",
+			"k8s-1.16":   "3.15.0-kops.3",
 		}
 
 		{


### PR DESCRIPTION
Cherry pick of #9647 on release-1.18.

#9647: Calico: upgrade "k8s-ec2-srcdst" to version v0.3.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.