### PR TITLE
fixes(openstack): auth problem for kops-controller

### DIFF
--- a/pkg/nodeidentity/openstack/identify.go
+++ b/pkg/nodeidentity/openstack/identify.go
@@ -50,6 +50,9 @@ func New() (nodeidentity.Identifier, error) {
 	if err != nil {
 		return nil, err
 	}
+	
+	// node-controller should be able to renew it tokens against OpenStack API
+	env.AllowReauth = true
 
 	err = openstack.Authenticate(provider, env)
 	if err != nil {

--- a/pkg/nodeidentity/openstack/identify.go
+++ b/pkg/nodeidentity/openstack/identify.go
@@ -50,7 +50,7 @@ func New() (nodeidentity.Identifier, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// node-controller should be able to renew it tokens against OpenStack API
 	env.AllowReauth = true
 


### PR DESCRIPTION
A backport from https://github.com/kubernetes/kops/pull/8862 to be used in 1.17