### PR TITLE
Update Calico to v3.15.1 for k8s 1.16+

### DIFF
--- a/docs/releases/1.18-NOTES.md
+++ b/docs/releases/1.18-NOTES.md
@@ -9,7 +9,7 @@
 * To address the [issue](https://github.com/kubernetes/kubernetes/issues/91507) of IPv4 only clusters being susceptible to MitM attacks via IPv6 rogue router advertisements, the affected components have been upgraded as follows:
     * Docker version 19.03.11 - [CVE-2020-13401](https://github.com/docker/docker-ce/releases/v19.03.11)
     * CNI plugins 0.8.6 - [CVE-2020-10749](https://github.com/containernetworking/plugins/releases/tag/v0.8.6)
-    * Calico 3.13.4 - [CVE-2020-13597](https://www.projectcalico.org/security-bulletins/)
+    * Calico 3.15.1 - [CVE-2020-13597](https://www.projectcalico.org/security-bulletins/)
     * Weave Net 2.6.5 - [CVE-2020-11091](https://github.com/weaveworks/weave/security/advisories/GHSA-59qg-grp7-5r73)
 
 * Support for [RHEL 8](../operations/images.md#rhel-8) and [CentOS 8](../operations/images.md#centos-8) has been added.

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -12195,7 +12195,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.15.0
+      - image: calico/typha:v3.15.1
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -12307,7 +12307,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.15.0
+          image: calico/cni:v3.15.1
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -12329,7 +12329,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.15.0
+          image: calico/cni:v3.15.1
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -12365,7 +12365,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.15.0
+          image: calico/pod2daemon-flexvol:v3.15.1
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -12376,7 +12376,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.15.0
+          image: calico/node:v3.15.1
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -12596,7 +12596,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.15.0
+          image: calico/kube-controllers:v3.15.1
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3522,7 +3522,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.15.0
+      - image: calico/typha:v3.15.1
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -3634,7 +3634,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.15.0
+          image: calico/cni:v3.15.1
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -3656,7 +3656,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.15.0
+          image: calico/cni:v3.15.1
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -3692,7 +3692,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.15.0
+          image: calico/pod2daemon-flexvol:v3.15.1
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -3703,7 +3703,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.15.0
+          image: calico/node:v3.15.1
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -3923,7 +3923,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.15.0
+          image: calico/kube-controllers:v3.15.1
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -714,7 +714,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.7":    "2.6.12-kops.1",
 			"k8s-1.7-v3": "3.8.0-kops.2",
 			"k8s-1.12":   "3.9.6-kops.1",
-			"k8s-1.16":   "3.15.0-kops.3",
+			"k8s-1.16":   "3.15.1-kops.1",
 		}
 
 		{


### PR DESCRIPTION
https://github.com/projectcalico/calico/releases/tag/v3.15.1
https://github.com/projectcalico/confd/pull/337
```
Fix critical issue with service IP advertisement breaking host service connectivity
```
