### PR TITLE
Automated cherry pick of #9656: Update Calico to v3.15.1 for k8s 1.16+

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -11436,7 +11436,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.15.0
+      - image: calico/typha:v3.15.1
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -11548,7 +11548,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.15.0
+          image: calico/cni:v3.15.1
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -11570,7 +11570,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.15.0
+          image: calico/cni:v3.15.1
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -11606,7 +11606,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.15.0
+          image: calico/pod2daemon-flexvol:v3.15.1
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -11617,7 +11617,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.15.0
+          image: calico/node:v3.15.1
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -11833,7 +11833,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.15.0
+          image: calico/kube-controllers:v3.15.1
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3522,7 +3522,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.15.0
+      - image: calico/typha:v3.15.1
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -3634,7 +3634,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.15.0
+          image: calico/cni:v3.15.1
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -3656,7 +3656,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.15.0
+          image: calico/cni:v3.15.1
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -3692,7 +3692,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.15.0
+          image: calico/pod2daemon-flexvol:v3.15.1
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -3703,7 +3703,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.15.0
+          image: calico/node:v3.15.1
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -3919,7 +3919,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.15.0
+          image: calico/kube-controllers:v3.15.1
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -726,7 +726,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.7":    "2.6.12-kops.1",
 			"k8s-1.7-v3": "3.8.0-kops.2",
 			"k8s-1.12":   "3.9.6-kops.1",
-			"k8s-1.16":   "3.15.0-kops.3",
+			"k8s-1.16":   "3.15.1-kops.1",
 		}
 
 		{


### PR DESCRIPTION
Cherry pick of #9656 on release-1.18.

#9656: Update Calico to v3.15.1 for k8s 1.16+

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.