### PR TITLE
Automated cherry pick of #9663: Prefer nodes with "master" role for Canal Typha pods

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -15400,15 +15400,22 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
-        kubernetes.io/role: master
       hostNetwork: true
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: "node-role.kubernetes.io/master"
+        - key: node-role.kubernetes.io/master
           effect: NoSchedule
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.16.yaml.template
@@ -531,15 +531,22 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
-        kubernetes.io/role: master
       hostNetwork: true
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: "node-role.kubernetes.io/master"
+        - key: node-role.kubernetes.io/master
           effect: NoSchedule
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -794,7 +794,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.9":  "3.2.3-kops.1",
 			"k8s-1.12": "3.7.5-kops.2",
 			"k8s-1.15": "3.12.2-kops.1",
-			"k8s-1.16": "3.13.4-kops.1",
+			"k8s-1.16": "3.13.4-kops.2",
 		}
 		{
 			id := "k8s-1.9"


### PR DESCRIPTION
Cherry pick of #9663 on release-1.18.

#9663: Prefer nodes with "master" role for Canal Typha pods

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.