### PR TITLE
Refactor networking assets finder

### DIFF
--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -210,7 +210,7 @@ func (a *AssetBuilder) RemapImage(image string) (string, error) {
 	return image, nil
 }
 
-// RemapFileAndSHA returns a remapped url for the file, if AssetsLocation is defined.
+// RemapFileAndSHA returns a remapped URL for the file, if AssetsLocation is defined.
 // It also returns the SHA hash of the file.
 func (a *AssetBuilder) RemapFileAndSHA(fileURL *url.URL) (*url.URL, *hashing.Hash, error) {
 	if fileURL == nil {
@@ -240,15 +240,13 @@ func (a *AssetBuilder) RemapFileAndSHA(fileURL *url.URL) (*url.URL, *hashing.Has
 	}
 	fileAsset.SHAValue = h.Hex()
 
-	a.FileAssets = append(a.FileAssets, fileAsset)
 	klog.V(8).Infof("adding file: %+v", fileAsset)
+	a.FileAssets = append(a.FileAssets, fileAsset)
 
 	return fileAsset.DownloadURL, h, nil
 }
 
-// TODO - remove this method as CNI does now have a SHA file
-
-// RemapFileAndSHAValue is used exclusively to remap the cni tarball, as the tarball does not have a sha file in object storage.
+// RemapFileAndSHAValue returns a remapped URL for the file without a SHA file in object storage, if AssetsLocation is defined.
 func (a *AssetBuilder) RemapFileAndSHAValue(fileURL *url.URL, shaValue string) (*url.URL, error) {
 	if fileURL == nil {
 		return nil, fmt.Errorf("unable to remap a nil URL")
@@ -271,6 +269,7 @@ func (a *AssetBuilder) RemapFileAndSHAValue(fileURL *url.URL, shaValue string) (
 		klog.V(4).Infof("adding remapped file: %q", fileAsset.DownloadURL.String())
 	}
 
+	klog.V(8).Infof("adding file: %+v", fileAsset)
 	a.FileAssets = append(a.FileAssets, fileAsset)
 
 	return fileAsset.DownloadURL, nil

--- a/upup/pkg/fi/cloudup/networking_test.go
+++ b/upup/pkg/fi/cloudup/networking_test.go
@@ -28,26 +28,109 @@ import (
 func Test_FindCNIAssetFromEnvironmentVariable(t *testing.T) {
 
 	desiredCNIVersion := "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-TEST-VERSION.tar.gz"
-	os.Setenv(ENV_VAR_CNI_VERSION_URL, desiredCNIVersion)
+	desiredCNIVersionHash := "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+	os.Setenv(ENV_VAR_CNI_ASSET_URL, desiredCNIVersion)
+	os.Setenv(ENV_VAR_CNI_ASSET_HASH, desiredCNIVersionHash)
 	defer func() {
-		os.Unsetenv(ENV_VAR_CNI_VERSION_URL)
+		os.Unsetenv(ENV_VAR_CNI_ASSET_URL)
+		os.Unsetenv(ENV_VAR_CNI_ASSET_HASH)
 	}()
 
 	cluster := &api.Cluster{}
-	cluster.Spec.KubernetesVersion = "v1.9.0"
+	cluster.Spec.KubernetesVersion = "v1.18.0"
 
 	assetBuilder := assets.NewAssetBuilder(cluster, "")
 	cniAsset, cniAssetHash, err := findCNIAssets(cluster, assetBuilder, architectures.ArchitectureAmd64)
 
 	if err != nil {
-		t.Errorf("Unable to parse k8s version %s", err)
+		t.Errorf("Unable to parse CNI version %s", err)
 	}
 
 	if cniAsset.String() != desiredCNIVersion {
-		t.Errorf("Expected CNI version from Environment variable %q, but got %q instead", desiredCNIVersion, cniAsset)
+		t.Errorf("Expected CNI version from env var %q, but got %q instead", desiredCNIVersion, cniAsset)
 	}
 
-	if cniAssetHash != nil {
-		t.Errorf("Expected Empty CNI Version Hash String, but got %v instead", cniAssetHash)
+	if cniAssetHash.String() != desiredCNIVersionHash {
+		t.Errorf("Expected empty CNI version hash, but got %v instead", cniAssetHash)
+	}
+}
+
+func Test_FindCNIAssetFromDefaults(t *testing.T) {
+
+	desiredCNIVersion := "https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz"
+	desiredCNIVersionHash := "sha256:994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5"
+
+	cluster := &api.Cluster{}
+	cluster.Spec.KubernetesVersion = "v1.18.0"
+
+	assetBuilder := assets.NewAssetBuilder(cluster, "")
+	cniAsset, cniAssetHash, err := findCNIAssets(cluster, assetBuilder, architectures.ArchitectureAmd64)
+
+	if err != nil {
+		t.Errorf("Unable to parse CNI version %s", err)
+	}
+
+	if cniAsset.String() != desiredCNIVersion {
+		t.Errorf("Expected default CNI version %q, but got %q instead", desiredCNIVersion, cniAsset)
+	}
+
+	if cniAssetHash.String() != desiredCNIVersionHash {
+		t.Errorf("Expected default CNI version hash %q, but got %q instead", desiredCNIVersionHash, cniAssetHash)
+	}
+}
+
+func Test_FindLyftAssetFromEnvironmentVariable(t *testing.T) {
+
+	desiredLyftVersion := "https://github.com/lyft/cni-ipvlan-vpc-k8s/releases/download/TEST-VERSION/cni-TEST-VERSION.tar.gz"
+	desiredLyftVersionHash := "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+	os.Setenv(ENV_VAR_LYFT_VPC_ASSET_URL, desiredLyftVersion)
+	os.Setenv(ENV_VAR_LYFT_VPC_ASSET_HASH, desiredLyftVersionHash)
+	defer func() {
+		os.Unsetenv(ENV_VAR_LYFT_VPC_ASSET_URL)
+		os.Unsetenv(ENV_VAR_LYFT_VPC_ASSET_HASH)
+	}()
+
+	cluster := &api.Cluster{}
+	cluster.Spec.KubernetesVersion = "v1.18.0"
+
+	assetBuilder := assets.NewAssetBuilder(cluster, "")
+	lyftAsset, lyftAssetHash, err := findLyftVPCAssets(cluster, assetBuilder, architectures.ArchitectureAmd64)
+
+	if err != nil {
+		t.Errorf("Unable to parse Lyft version %s", err)
+	}
+
+	if lyftAsset.String() != desiredLyftVersion {
+		t.Errorf("Expected Lyft version from env var %q, but got %q instead", desiredLyftVersion, lyftAsset)
+	}
+
+	if lyftAssetHash.String() != desiredLyftVersionHash {
+		t.Errorf("Expected Lyft version hash from env var %q, but got %q instead", desiredLyftVersionHash, lyftAssetHash)
+	}
+}
+
+func Test_FindLyftAssetFromDefaults(t *testing.T) {
+
+	desiredLyftVersion := "https://github.com/lyft/cni-ipvlan-vpc-k8s/releases/download/v0.6.0/cni-ipvlan-vpc-k8s-amd64-v0.6.0.tar.gz"
+	desiredLyftVersionHash := "sha256:871757d381035f64020a523e7a3e139b6177b98eb7a61b547813ff25957fc566"
+
+	cluster := &api.Cluster{}
+	cluster.Spec.KubernetesVersion = "v1.18.0"
+
+	assetBuilder := assets.NewAssetBuilder(cluster, "")
+	lyftAsset, lyftAssetHash, err := findLyftVPCAssets(cluster, assetBuilder, architectures.ArchitectureAmd64)
+
+	if err != nil {
+		t.Errorf("Unable to parse Lyft version %s", err)
+	}
+
+	if lyftAsset.String() != desiredLyftVersion {
+		t.Errorf("Expected default Lyft version %q, but got %q instead", desiredLyftVersion, lyftAsset)
+	}
+
+	if lyftAssetHash.String() != desiredLyftVersionHash {
+		t.Errorf("Expected default Lyft version hash %q, but got %q instead", desiredLyftVersionHash, lyftAssetHash)
 	}
 }


### PR DESCRIPTION
Most notable changes are:
* extract the LyftVPC assets finder to separate function (similar to the CNI one)
* add test for the new function and update previous ones
* use SHA from repo for the CNI asset finder (similar to the kubelet one)
https://github.com/kubernetes/kops/blob/781279e268847579b47a87600380675317233b58/pkg/assets/builder.go#L249

Note: All file assets can be remapped using `Spec.Assets.FileRepository`, so maybe we should remove some of these env vars like `CNI_VERSION_URL` and `LYFT_VPC_DOWNLOAD_URL `.