### PR TITLE
GCE: Fix spurious comparison failures on adddress & InstanceTemplate

### DIFF
--- a/upup/pkg/fi/cloudup/gcetasks/address.go
+++ b/upup/pkg/fi/cloudup/gcetasks/address.go
@@ -35,12 +35,22 @@ type Address struct {
 	ForAPIServer bool
 }
 
+var _ fi.CompareWithID = &ForwardingRule{}
+
+func (e *Address) CompareWithID() *string {
+	return e.Name
+}
+
 func (e *Address) Find(c *fi.Context) (*Address, error) {
 	actual, err := e.find(c.Cloud.(gce.GCECloud))
 	if actual != nil && err == nil {
 		if e.IPAddress == nil {
 			e.IPAddress = actual.IPAddress
 		}
+
+		// Ignore system fields
+		actual.Lifecycle = e.Lifecycle
+		actual.ForAPIServer = e.ForAPIServer
 	}
 	return actual, err
 }

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -139,6 +139,7 @@ func (e *InstanceTemplate) Find(c *fi.Context) (*InstanceTemplate, error) {
 			for _, scope := range serviceAccount.Scopes {
 				actual.Scopes = append(actual.Scopes, scopeToShortForm(scope))
 			}
+			actual.ServiceAccounts = append(actual.ServiceAccounts, serviceAccount.Email)
 		}
 
 		// When we deal with additional disks (local disks), we'll need to map them like this...


### PR DESCRIPTION
Spruce up the find logic to avoid detecting changes that aren't there.