### PR TITLE
Move cluster-proportional-autoscaler to worker nodes

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -1320,14 +1320,10 @@ spec:
           - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
           - --logtostderr=true
           - --v=2
-      nodeSelector:
-        kubernetes.io/role: master
       priorityClassName: system-cluster-critical
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
-      - key: node-role.kubernetes.io/master
-        operator: Exists
       serviceAccountName: coredns-autoscaler
 ---
 apiVersion: apps/v1
@@ -2748,14 +2744,10 @@ spec:
           - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
           - --logtostderr=true
           - --v=2
-      nodeSelector:
-        kubernetes.io/role: master
       priorityClassName: system-cluster-critical
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
-      - key: node-role.kubernetes.io/master
-        operator: Exists
       serviceAccountName: kube-dns-autoscaler
 
 ---
@@ -3108,13 +3100,9 @@ spec:
           - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
           - --logtostderr=true
           - --v=2
-      nodeSelector:
-        kubernetes.io/role: master
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
-      - key: node-role.kubernetes.io/master
-        operator: Exists
       serviceAccountName: kube-dns-autoscaler
 
 ---

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -119,14 +119,10 @@ spec:
           - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
           - --logtostderr=true
           - --v=2
-      nodeSelector:
-        kubernetes.io/role: master
       priorityClassName: system-cluster-critical
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
-      - key: node-role.kubernetes.io/master
-        operator: Exists
       serviceAccountName: coredns-autoscaler
 ---
 apiVersion: apps/v1

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
@@ -69,14 +69,10 @@ spec:
           - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
           - --logtostderr=true
           - --v=2
-      nodeSelector:
-        kubernetes.io/role: master
       priorityClassName: system-cluster-critical
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
-      - key: node-role.kubernetes.io/master
-        operator: Exists
       serviceAccountName: kube-dns-autoscaler
 
 ---

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template
@@ -68,13 +68,9 @@ spec:
           - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
           - --logtostderr=true
           - --v=2
-      nodeSelector:
-        kubernetes.io/role: master
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
-      - key: node-role.kubernetes.io/master
-        operator: Exists
       serviceAccountName: kube-dns-autoscaler
 
 ---

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -21,7 +21,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 92638799b10064ffc74907b096407658074b0f71
+    manifestHash: 622cc4a17d2d0258d6e364294dcef983730e9f7e
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -29,7 +29,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 041cc42d4f2cccc9a9d4ac0ab089b20c1f27a6c4
+    manifestHash: 66f284c5d8a4b3fdbc385b84b21d013a55eec4cd
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -21,7 +21,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 92638799b10064ffc74907b096407658074b0f71
+    manifestHash: 622cc4a17d2d0258d6e364294dcef983730e9f7e
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -29,7 +29,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 041cc42d4f2cccc9a9d4ac0ab089b20c1f27a6c4
+    manifestHash: 66f284c5d8a4b3fdbc385b84b21d013a55eec4cd
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -21,7 +21,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 92638799b10064ffc74907b096407658074b0f71
+    manifestHash: 622cc4a17d2d0258d6e364294dcef983730e9f7e
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -29,7 +29,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 041cc42d4f2cccc9a9d4ac0ab089b20c1f27a6c4
+    manifestHash: 66f284c5d8a4b3fdbc385b84b21d013a55eec4cd
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -21,7 +21,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: kube-dns.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 92638799b10064ffc74907b096407658074b0f71
+    manifestHash: 622cc4a17d2d0258d6e364294dcef983730e9f7e
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
@@ -29,7 +29,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 041cc42d4f2cccc9a9d4ac0ab089b20c1f27a6c4
+    manifestHash: 66f284c5d8a4b3fdbc385b84b21d013a55eec4cd
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io


### PR DESCRIPTION
Now that https://github.com/kubernetes/kops/pull/9674 was merged, there is no need for CPA to run on control-plane nodes.
Basically, this reverts parts of https://github.com/kubernetes/kops/pull/9418 and https://github.com/kubernetes/kops/pull/9431.

/cc @olemarkus @johngmyers 