### PR TITLE
Remove embedded structs from spotinst terraform types

### DIFF
--- a/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
@@ -1281,33 +1281,20 @@ type terraformElastigroup struct {
 	Tags                 []*terraformKV                          `json:"tags,omitempty" cty:"tags"`
 	Lifecycle            *terraformLifecycle                     `json:"lifecycle,omitempty" cty:"lifecycle"`
 
-	*terraformElastigroupCapacity
-	*terraformElastigroupStrategy
-	*terraformElastigroupInstanceTypes
-	*terraformElastigroupLaunchSpec
-}
-
-type terraformElastigroupCapacity struct {
 	MinSize         *int64  `json:"min_size,omitempty" cty:"min_size"`
 	MaxSize         *int64  `json:"max_size,omitempty" cty:"max_size"`
 	DesiredCapacity *int64  `json:"desired_capacity,omitempty" cty:"desired_capacity"`
 	CapacityUnit    *string `json:"capacity_unit,omitempty" cty:"capacity_unit"`
-}
 
-type terraformElastigroupStrategy struct {
 	SpotPercentage           *float64 `json:"spot_percentage,omitempty" cty:"spot_percentage"`
 	Orientation              *string  `json:"orientation,omitempty" cty:"orientation"`
 	FallbackToOnDemand       *bool    `json:"fallback_to_ondemand,omitempty" cty:"fallback_to_ondemand"`
 	UtilizeReservedInstances *bool    `json:"utilize_reserved_instances,omitempty" cty:"utilize_reserved_instances"`
 	DrainingTimeout          *int64   `json:"draining_timeout,omitempty" cty:"draining_timeout"`
-}
 
-type terraformElastigroupInstanceTypes struct {
 	OnDemand *string  `json:"instance_types_ondemand,omitempty" cty:"instance_types_ondemand"`
 	Spot     []string `json:"instance_types_spot,omitempty" cty:"instance_types_spot"`
-}
 
-type terraformElastigroupLaunchSpec struct {
 	Monitoring         *bool                `json:"enable_monitoring,omitempty" cty:"enable_monitoring"`
 	EBSOptimized       *bool                `json:"ebs_optimized,omitempty" cty:"ebs_optimized"`
 	ImageID            *string              `json:"image_id,omitempty" cty:"image_id"`
@@ -1337,7 +1324,12 @@ type terraformElastigroupIntegration struct {
 	IntegrationMode   *string `json:"integration_mode,omitempty" cty:"integration_mode"`
 	ClusterIdentifier *string `json:"cluster_identifier,omitempty" cty:"cluster_identifier"`
 
-	*terraformAutoScaler
+	Enabled    *bool                        `json:"autoscale_is_enabled,omitempty" cty:"autoscale_is_enabled"`
+	AutoConfig *bool                        `json:"autoscale_is_auto_config,omitempty" cty:"autoscale_is_auto_config"`
+	Cooldown   *int                         `json:"autoscale_cooldown,omitempty" cty:"autoscale_cooldown"`
+	Headroom   *terraformAutoScalerHeadroom `json:"autoscale_headroom,omitempty" cty:"autoscale_headroom"`
+	Down       *terraformAutoScalerDown     `json:"autoscale_down,omitempty" cty:"autoscale_down"`
+	Labels     []*terraformKV               `json:"autoscale_labels,omitempty" cty:"autoscale_labels"`
 }
 
 type terraformAutoScaler struct {
@@ -1379,24 +1371,20 @@ func (_ *Elastigroup) RenderTerraform(t *terraform.TerraformTarget, a, e, change
 		Description: e.Name,
 		Product:     e.Product,
 		Region:      fi.String(cloud.Region()),
-		terraformElastigroupCapacity: &terraformElastigroupCapacity{
-			DesiredCapacity: e.MinSize,
-			MinSize:         e.MinSize,
-			MaxSize:         e.MaxSize,
-			CapacityUnit:    fi.String("instance"),
-		},
-		terraformElastigroupStrategy: &terraformElastigroupStrategy{
-			SpotPercentage:           e.SpotPercentage,
-			Orientation:              fi.String(string(normalizeOrientation(e.Orientation))),
-			FallbackToOnDemand:       e.FallbackToOnDemand,
-			UtilizeReservedInstances: e.UtilizeReservedInstances,
-			DrainingTimeout:          e.DrainingTimeout,
-		},
-		terraformElastigroupInstanceTypes: &terraformElastigroupInstanceTypes{
-			OnDemand: e.OnDemandInstanceType,
-			Spot:     e.SpotInstanceTypes,
-		},
-		terraformElastigroupLaunchSpec: &terraformElastigroupLaunchSpec{},
+
+		DesiredCapacity: e.MinSize,
+		MinSize:         e.MinSize,
+		MaxSize:         e.MaxSize,
+		CapacityUnit:    fi.String("instance"),
+
+		SpotPercentage:           e.SpotPercentage,
+		Orientation:              fi.String(string(normalizeOrientation(e.Orientation))),
+		FallbackToOnDemand:       e.FallbackToOnDemand,
+		UtilizeReservedInstances: e.UtilizeReservedInstances,
+		DrainingTimeout:          e.DrainingTimeout,
+
+		OnDemand: e.OnDemandInstanceType,
+		Spot:     e.SpotInstanceTypes,
 	}
 
 	// Image.
@@ -1548,11 +1536,9 @@ func (_ *Elastigroup) RenderTerraform(t *terraform.TerraformTarget, a, e, change
 			}
 
 			if opts.Enabled != nil {
-				tf.Integration.terraformAutoScaler = &terraformAutoScaler{
-					Enabled:    opts.Enabled,
-					AutoConfig: fi.Bool(true),
-					Cooldown:   opts.Cooldown,
-				}
+				tf.Integration.Enabled = opts.Enabled
+				tf.Integration.AutoConfig = fi.Bool(true)
+				tf.Integration.Cooldown = opts.Cooldown
 
 				// Headroom.
 				if headroom := opts.Headroom; headroom != nil {

--- a/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
@@ -639,16 +639,28 @@ type terraformLaunchSpec struct {
 	Name    *string            `json:"name,omitempty" cty:"name"`
 	OceanID *terraform.Literal `json:"ocean_id,omitempty" cty:"ocean_id"`
 
-	*terraformOceanLaunchSpec
+	Monitoring               *bool                          `json:"monitoring,omitempty" cty:"monitoring"`
+	EBSOptimized             *bool                          `json:"ebs_optimized,omitempty" cty:"ebs_optimized"`
+	ImageID                  *string                        `json:"image_id,omitempty" cty:"image_id"`
+	AssociatePublicIPAddress *bool                          `json:"associate_public_ip_address,omitempty" cty:"associate_public_ip_address"`
+	RootVolumeSize           *int32                         `json:"root_volume_size,omitempty" cty:"root_volume_size"`
+	UserData                 *terraform.Literal             `json:"user_data,omitempty" cty:"user_data"`
+	IAMInstanceProfile       *terraform.Literal             `json:"iam_instance_profile,omitempty" cty:"iam_instance_profile"`
+	KeyName                  *terraform.Literal             `json:"key_name,omitempty" cty:"key_name"`
+	SubnetIDs                []*terraform.Literal           `json:"subnet_ids,omitempty" cty:"subnet_ids"`
+	SecurityGroups           []*terraform.Literal           `json:"security_groups,omitempty" cty:"security_groups"`
+	Taints                   []*corev1.Taint                `json:"taints,omitempty" cty:"taints"`
+	Labels                   []*terraformKV                 `json:"labels,omitempty" cty:"labels"`
+	Tags                     []*terraformKV                 `json:"tags,omitempty" cty:"tags"`
+	Headrooms                []*terraformAutoScalerHeadroom `json:"autoscale_headrooms,omitempty" cty:"autoscale_headrooms"`
 }
 
 func (_ *LaunchSpec) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *LaunchSpec) error {
 	cloud := t.Cloud.(awsup.AWSCloud)
 
 	tf := &terraformLaunchSpec{
-		Name:                     e.Name,
-		OceanID:                  e.Ocean.TerraformLink(),
-		terraformOceanLaunchSpec: &terraformOceanLaunchSpec{},
+		Name:    e.Name,
+		OceanID: e.Ocean.TerraformLink(),
 	}
 
 	// Image.

--- a/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
@@ -1006,26 +1006,16 @@ type terraformOcean struct {
 	Tags                   []*terraformKV       `json:"tags,omitempty" cty:"tags"`
 	Lifecycle              *terraformLifecycle  `json:"lifecycle,omitempty" cty:"lifecycle"`
 
-	*terraformOceanCapacity
-	*terraformOceanStrategy
-	*terraformOceanLaunchSpec
-}
-
-type terraformOceanCapacity struct {
 	MinSize         *int64 `json:"min_size,omitempty" cty:"min_size"`
 	MaxSize         *int64 `json:"max_size,omitempty" cty:"max_size"`
 	DesiredCapacity *int64 `json:"desired_capacity,omitempty" cty:"desired_capacity"`
-}
 
-type terraformOceanStrategy struct {
 	SpotPercentage           *float64 `json:"spot_percentage,omitempty" cty:"spot_percentage"`
 	FallbackToOnDemand       *bool    `json:"fallback_to_ondemand,omitempty" cty:"fallback_to_ondemand"`
 	UtilizeReservedInstances *bool    `json:"utilize_reserved_instances,omitempty" cty:"utilize_reserved_instances"`
 	DrainingTimeout          *int64   `json:"draining_timeout,omitempty" cty:"draining_timeout"`
 	GracePeriod              *int64   `json:"grace_period,omitempty" cty:"grace_period"`
-}
 
-type terraformOceanLaunchSpec struct {
 	Monitoring               *bool                          `json:"monitoring,omitempty" cty:"monitoring"`
 	EBSOptimized             *bool                          `json:"ebs_optimized,omitempty" cty:"ebs_optimized"`
 	ImageID                  *string                        `json:"image_id,omitempty" cty:"image_id"`
@@ -1034,11 +1024,9 @@ type terraformOceanLaunchSpec struct {
 	UserData                 *terraform.Literal             `json:"user_data,omitempty" cty:"user_data"`
 	IAMInstanceProfile       *terraform.Literal             `json:"iam_instance_profile,omitempty" cty:"iam_instance_profile"`
 	KeyName                  *terraform.Literal             `json:"key_name,omitempty" cty:"key_name"`
-	SubnetIDs                []*terraform.Literal           `json:"subnet_ids,omitempty" cty:"subnet_ids"`
 	SecurityGroups           []*terraform.Literal           `json:"security_groups,omitempty" cty:"security_groups"`
 	Taints                   []*corev1.Taint                `json:"taints,omitempty" cty:"taints"`
 	Labels                   []*terraformKV                 `json:"labels,omitempty" cty:"labels"`
-	Tags                     []*terraformKV                 `json:"tags,omitempty" cty:"tags"`
 	Headrooms                []*terraformAutoScalerHeadroom `json:"autoscale_headrooms,omitempty" cty:"autoscale_headrooms"`
 }
 
@@ -1049,19 +1037,16 @@ func (_ *Ocean) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Oce
 	tf := &terraformOcean{
 		Name:   e.Name,
 		Region: fi.String(cloud.Region()),
-		terraformOceanCapacity: &terraformOceanCapacity{
-			DesiredCapacity: e.MinSize,
-			MinSize:         e.MinSize,
-			MaxSize:         e.MaxSize,
-		},
-		terraformOceanStrategy: &terraformOceanStrategy{
-			SpotPercentage:           e.SpotPercentage,
-			FallbackToOnDemand:       e.FallbackToOnDemand,
-			UtilizeReservedInstances: e.UtilizeReservedInstances,
-			DrainingTimeout:          e.DrainingTimeout,
-			GracePeriod:              e.GracePeriod,
-		},
-		terraformOceanLaunchSpec: &terraformOceanLaunchSpec{},
+
+		DesiredCapacity: e.MinSize,
+		MinSize:         e.MinSize,
+		MaxSize:         e.MaxSize,
+
+		SpotPercentage:           e.SpotPercentage,
+		FallbackToOnDemand:       e.FallbackToOnDemand,
+		UtilizeReservedInstances: e.UtilizeReservedInstances,
+		DrainingTimeout:          e.DrainingTimeout,
+		GracePeriod:              e.GracePeriod,
 	}
 
 	// Image.


### PR DESCRIPTION
The HCL2 library doesn't handle embedded structs like json marshalling does, so this inlines the fields to match how terraform represents the resources.
There was only one type that was embedded in two places, so I just copied those fields.

fixes #9679 