### PR TITLE
Upgrade k8s-dns-dnsmasq-nanny to match KubeDNS

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -2823,7 +2823,7 @@ spec:
           mountPath: /kube-dns-config
 
       - name: dnsmasq
-        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-{{Arch}}:1.14.13
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-{{Arch}}:1.15.13
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
@@ -182,7 +182,7 @@ spec:
           mountPath: /kube-dns-config
 
       - name: dnsmasq
-        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-{{Arch}}:1.14.13
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-{{Arch}}:1.15.13
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -240,7 +240,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 
 		{
 			key := "kube-dns.addons.k8s.io"
-			version := "1.15.13-kops.1"
+			version := "1.15.13-kops.2"
 
 			{
 				location := key + "/k8s-1.6.yaml"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -25,15 +25,15 @@ spec:
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.15.13-kops.1
+    version: 1.15.13-kops.2
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 42ba17717415e9c2e3c9a2142654c2a48a915318
+    manifestHash: 63978a5d4cba2256f5e80381a2c41d9ae9a14d4e
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.15.13-kops.1
+    version: 1.15.13-kops.2
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
     manifestHash: 5d53ce7b920cd1e8d65d2306d80a041420711914

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -25,15 +25,15 @@ spec:
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.15.13-kops.1
+    version: 1.15.13-kops.2
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 42ba17717415e9c2e3c9a2142654c2a48a915318
+    manifestHash: 63978a5d4cba2256f5e80381a2c41d9ae9a14d4e
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.15.13-kops.1
+    version: 1.15.13-kops.2
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
     manifestHash: 5d53ce7b920cd1e8d65d2306d80a041420711914

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -25,15 +25,15 @@ spec:
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.15.13-kops.1
+    version: 1.15.13-kops.2
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 42ba17717415e9c2e3c9a2142654c2a48a915318
+    manifestHash: 63978a5d4cba2256f5e80381a2c41d9ae9a14d4e
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.15.13-kops.1
+    version: 1.15.13-kops.2
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
     manifestHash: 5d53ce7b920cd1e8d65d2306d80a041420711914

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -25,15 +25,15 @@ spec:
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.15.13-kops.1
+    version: 1.15.13-kops.2
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 42ba17717415e9c2e3c9a2142654c2a48a915318
+    manifestHash: 63978a5d4cba2256f5e80381a2c41d9ae9a14d4e
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
-    version: 1.15.13-kops.1
+    version: 1.15.13-kops.2
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
     manifestHash: 5d53ce7b920cd1e8d65d2306d80a041420711914


### PR DESCRIPTION
#9462 missed upgrading k8s-dns-dnsmasq-nanny in the 1.12 manifest to match KubeDNS. It was thus missed in the #9485 backport. It has since been fixed in master branch.
