### PR TITLE
Support for using hostPort when using kube-router

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -7235,6 +7235,7 @@ spec:
         - --run-router=true
         - --run-firewall=true
         - --run-service-proxy=true
+        - --bgp-graceful-restart=true
         - --kubeconfig=/var/lib/kube-router/kubeconfig
         - --metrics-port=12013
         env:

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -7196,6 +7196,13 @@ data:
              "ipam":{
                 "type":"host-local"
              }
+          },
+          {
+             "type": "portmap",
+             "capabilities": {
+                "snat": true,
+                "portMappings": true
+             }
           }
        ]
     }

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -61,6 +61,7 @@ spec:
         - --run-router=true
         - --run-firewall=true
         - --run-service-proxy=true
+        - --bgp-graceful-restart=true
         - --kubeconfig=/var/lib/kube-router/kubeconfig
         - --metrics-port=12013
         env:

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -22,6 +22,13 @@ data:
              "ipam":{
                 "type":"host-local"
              }
+          },
+          {
+             "type": "portmap",
+             "capabilities": {
+                "snat": true,
+                "portMappings": true
+             }
           }
        ]
     }

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -842,7 +842,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		key := "networking.kuberouter"
 		versions := map[string]string{
 			"k8s-1.6":  "0.3.1-kops.4",
-			"k8s-1.12": "1.0.0-kops.2",
+			"k8s-1.12": "1.0.0-kops.3",
 		}
 
 		{


### PR DESCRIPTION
Enable portmap plugin in the kube-router cni config to support hostPort.  
Similar to #7295 (flannel), #4063 (canal), and #3206 (calico).