### PR TITLE
Spotinst: Upgrade the Spot Cluster Controller to version 1.0.63

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -19278,7 +19278,7 @@ spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
         imagePullPolicy: Always
-        image: spotinst/kubernetes-cluster-controller:1.0.62
+        image: spotinst/kubernetes-cluster-controller:1.0.63
         livenessProbe:
           httpGet:
             path: /healthcheck

--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
@@ -171,7 +171,7 @@ spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
         imagePullPolicy: Always
-        image: spotinst/kubernetes-cluster-controller:1.0.62
+        image: spotinst/kubernetes-cluster-controller:1.0.63
         livenessProbe:
           httpGet:
             path: /healthcheck

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -551,7 +551,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		{
 			id := "v1.14.0"
 			location := key + "/" + id + ".yaml"
-			version := "1.0.62"
+			version := "1.0.63"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),


### PR DESCRIPTION
This PR upgrade the Spot Cluster Controller to version 1.0.63.