### PR TITLE
Adds support for using OS application credentials

### DIFF
--- a/nodeup/pkg/bootstrap/install.go
+++ b/nodeup/pkg/bootstrap/install.go
@@ -150,6 +150,8 @@ func (i *Installation) buildSystemdJob() *nodetasks.Service {
 			"OS_PASSWORD",
 			"OS_AUTH_URL",
 			"OS_REGION_NAME",
+			"OS_APPLICATION_CREDENTIAL_ID",
+			"OS_APPLICATION_CREDENTIAL_SECRET",
 		} {
 			buffer.WriteString("'")
 			buffer.WriteString(envVar)

--- a/nodeup/pkg/model/cloudconfig.go
+++ b/nodeup/pkg/model/cloudconfig.go
@@ -92,6 +92,8 @@ func (b *CloudConfigBuilder) Build(c *fi.ModelBuilderContext) error {
 			fmt.Sprintf("tenant-name=\"%s\"", tenantName),
 			fmt.Sprintf("domain-name=\"%s\"", os.Getenv("OS_DOMAIN_NAME")),
 			fmt.Sprintf("domain-id=\"%s\"", os.Getenv("OS_DOMAIN_ID")),
+			fmt.Sprintf("application-credential-id=\"%s\"", os.Getenv("OS_APPLICATION_CREDENTIAL_ID")),
+			fmt.Sprintf("application-credential-secret=\"%s\"", os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET")),
 			"",
 		)
 

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -614,6 +614,8 @@ func (t *ProtokubeBuilder) ProtokubeEnvironmentVariables() string {
 			"OS_PASSWORD",
 			"OS_AUTH_URL",
 			"OS_REGION_NAME",
+			"OS_APPLICATION_CREDENTIAL_ID",
+			"OS_APPLICATION_CREDENTIAL_SECRET",
 		} {
 			buffer.WriteString(" --env '")
 			buffer.WriteString(envVar)

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -108,17 +108,30 @@ func (b *BootstrapScript) buildEnvironmentVariables(cluster *kops.Cluster) (map[
 		env["S3_SECRET_ACCESS_KEY"] = os.Getenv("S3_SECRET_ACCESS_KEY")
 	}
 
-	// Pass in required credentials when using user-defined swift endpoint
-	if os.Getenv("OS_AUTH_URL") != "" {
-		for _, envVar := range []string{
-			"OS_TENANT_ID", "OS_TENANT_NAME", "OS_PROJECT_ID", "OS_PROJECT_NAME",
-			"OS_PROJECT_DOMAIN_NAME", "OS_PROJECT_DOMAIN_ID",
-			"OS_DOMAIN_NAME", "OS_DOMAIN_ID",
+	osEnvs := []string{
+		"OS_TENANT_ID", "OS_TENANT_NAME", "OS_PROJECT_ID", "OS_PROJECT_NAME",
+		"OS_PROJECT_DOMAIN_NAME", "OS_PROJECT_DOMAIN_ID",
+		"OS_DOMAIN_NAME", "OS_DOMAIN_ID",
+		"OS_AUTH_URL",
+		"OS_REGION_NAME",
+	}
+
+	if os.Getenv("OS_APPLICATION_CREDENTIAL_ID") != "" && os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET") != "" {
+		osEnvs = append(osEnvs,
+			"OS_APPLICATION_CREDENTIAL_ID",
+			"OS_APPLICATION_CREDENTIAL_SECRET",
+		)
+	} else {
+		klog.Warning("exporting username and password. Consider using application credentials instead.")
+		osEnvs = append(osEnvs,
 			"OS_USERNAME",
 			"OS_PASSWORD",
-			"OS_AUTH_URL",
-			"OS_REGION_NAME",
-		} {
+		)
+	}
+
+	// Pass in required credentials when using user-defined swift endpoint
+	if os.Getenv("OS_AUTH_URL") != "" {
+		for _, envVar := range osEnvs {
 			env[envVar] = fmt.Sprintf("'%s'", os.Getenv(envVar))
 		}
 	}

--- a/util/pkg/env/standard.go
+++ b/util/pkg/env/standard.go
@@ -60,6 +60,8 @@ func BuildSystemComponentEnvVars(spec *kops.ClusterSpec) EnvVars {
 	vars.addEnvVariableIfExist("OS_PASSWORD")
 	vars.addEnvVariableIfExist("OS_AUTH_URL")
 	vars.addEnvVariableIfExist("OS_REGION_NAME")
+	vars.addEnvVariableIfExist("OS_APPLICATION_CREDENTIAL_ID")
+	vars.addEnvVariableIfExist("OS_APPLICATION_CREDENTIAL_SECRET")
 
 	// Digital Ocean related values.
 	vars.addEnvVariableIfExist("DIGITALOCEAN_ACCESS_TOKEN")

--- a/util/pkg/vfs/swiftfs.go
+++ b/util/pkg/vfs/swiftfs.go
@@ -139,6 +139,10 @@ func (oc OpenstackConfig) GetCredential() (gophercloud.AuthOptions, error) {
 		// fallback to config file
 		return oc.getCredentialFromFile()
 	}
+
+	if env.ApplicationCredentialID != "" && env.Username == "" {
+		env.Scope = &gophercloud.AuthScope{}
+	}
 	return env, nil
 
 }


### PR DESCRIPTION
Application credentials allows you to export a purpose-specific set of
credentials for a user instead of exposing user login credentials.
Especially useful when using LDAP or similar for Openstack users.
Also lets you rotate credentials more easily since multiple application
credentials can be provisioned per user.

Depends on https://github.com/kopeio/etcd-manager/pull/336 as well.