### PR TITLE
Update Go to v1.15rc2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.0-rc1
+          go-version: 1.15.0-rc2
           stable: false
 
       - uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.0-rc1
+        go-version: 1.15.0-rc2
         stable: false
 
     - uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.0-rc1
+          go-version: 1.15.0-rc2
           stable: false
 
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
   - linux
   - osx
 dist: focal
-go: 1.15rc1
+go: 1.15rc2
 
 go_import_path: k8s.io/kops
 
@@ -19,6 +19,6 @@ jobs:
       arch: amd64
       os: linux
       dist: focal
-      go: 1.15rc1
+      go: 1.15rc2
       script:
         - GOPROXY=https://proxy.golang.org make travis-ci

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,8 +29,8 @@ go_rules_dependencies()
 go_download_sdk(
     name = "go_sdk",
     sdks = {
-        "darwin_amd64": ("go1.15rc1.darwin-amd64.tar.gz", "0572e053ed5fd6e8d6ed24f62832b747d46787288e146e8ba99b574b6e0d67b0"),
-        "linux_amd64": ("go1.15rc1.linux-amd64.tar.gz", "ac092ebb92f88366786063e68a9531d5eccac51371f9becb128f064721731b2e"),
+        "darwin_amd64": ("go1.15rc2.darwin-amd64.tar.gz", "c3b33843b6318c80a3d6e4007986aeeea7950f469a7bd6eed549b0633ba9e456"),
+        "linux_amd64": ("go1.15rc2.linux-amd64.tar.gz", "f41a08f630f018bc5d9fd100bd9899516e4965356c78165157eb0eda9a17ac09"),
     },
 )
 


### PR DESCRIPTION
At the moment GH jobs are broken because they cannot find the old Go rc1 anymore... 🤷 
Follow-up of https://github.com/kubernetes/kops/pull/9641.