### PR TITLE
Add missing `selector` for deployment in calico manifest. Fixes #9723

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -9974,6 +9974,9 @@ spec:
   replicas: 0
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      k8s-app: calico-policy
   template:
     metadata:
       name: calico-policy-controller

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.7.yaml.template
@@ -398,6 +398,9 @@ spec:
   replicas: 0
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      k8s-app: calico-policy
   template:
     metadata:
       name: calico-policy-controller


### PR DESCRIPTION
Fixes issue in #9723 

```
Aug 10 22:37:44 ip-10-53-1-16 docker[8000]: I0810 22:37:44.376595    8337 apply.go:70] error running kubectl apply -f /tmp/channel784648579/manifest.yaml                                                                     
Aug 10 22:37:44 ip-10-53-1-16 docker[8000]: I0810 22:37:44.376621    8337 apply.go:71] configmap "calico-config" unchanged                
Aug 10 22:37:44 ip-10-53-1-16 docker[8000]: clusterrole "calico" configured                                                            
Aug 10 22:37:44 ip-10-53-1-16 docker[8000]: serviceaccount "calico" unchanged                                                     
Aug 10 22:37:44 ip-10-53-1-16 docker[8000]: clusterrolebinding "calico" configured                                                           
Aug 10 22:37:44 ip-10-53-1-16 docker[8000]: daemonset "calico-node" configured                                                     
Aug 10 22:37:44 ip-10-53-1-16 docker[8000]: deployment "calico-kube-controllers" unchanged                                                                                                                                                                                                                   
Aug 10 22:37:44 ip-10-53-1-16 docker[8000]: The Deployment "calico-policy-controller" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"k8s-app":"calico-policy"}: `selector` does not match template `labels`         
```