### PR TITLE
Add missing cli options for kube-controller-manager and kube-scheduler

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1145,6 +1145,7 @@ k8s.io/cloud-provider v0.18.6/go.mod h1:QnPLLdFkvtx1dEyVMaPUdzVWB+ECzEf+PA3DXwIr
 k8s.io/cloud-provider-openstack v1.17.0 h1:n6hkiJSekJEa2LIlu+1uGfMt5jwIvPO2qnx5tcJtlYo=
 k8s.io/cloud-provider-openstack v1.17.0/go.mod h1:0pc0EbtR72bEHmhjKwzrY60oeiQzlCONjZeDe8DEgN8=
 k8s.io/cluster-bootstrap v0.18.6/go.mod h1:lnM1CXtPImlEBTh5874ZI+ofZzdIy1t2JV9Y+NxvojU=
+k8s.io/code-generator v0.18.6 h1:QdfvGfs4gUCS1dru+rLbCKIFxYEV0IRfF8MXwY/ozLk=
 k8s.io/code-generator v0.18.6/go.mod h1:TgNEVx9hCyPGpdtCWA34olQYLkh3ok9ar7XfSsr8b6c=
 k8s.io/component-base v0.18.6 h1:Wd6cHGwJN2qpufnirVOB3oMhyhbioGsKEi5HeDBsV+s=
 k8s.io/component-base v0.18.6/go.mod h1:knSVsibPR5K6EW2XOjEHik6sdU5nCvKMrzMt2D4In14=

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1361,6 +1361,14 @@ spec:
                       reconciler sync states loop wait between successive executions.
                       Is set to 1 min by kops by default
                     type: string
+                  authenticationKubeconfig:
+                    description: AuthenticationKubeconfig is the path to an Authentication
+                      Kubeconfig
+                    type: string
+                  authorizationKubeconfig:
+                    description: AuthorizationKubeconfig is the path to an Authorization
+                      Kubeconfig
+                    type: string
                   cidrAllocatorType:
                     description: CIDRAllocatorType specifies the type of CIDR allocator
                       to use.
@@ -1783,6 +1791,14 @@ spec:
               kubeScheduler:
                 description: KubeSchedulerConfig is the configuration for the kube-scheduler
                 properties:
+                  authenticationKubeconfig:
+                    description: AuthenticationKubeconfig is the path to an Authentication
+                      Kubeconfig
+                    type: string
+                  authorizationKubeconfig:
+                    description: AuthorizationKubeconfig is the path to an Authorization
+                      Kubeconfig
+                    type: string
                   burst:
                     description: Burst sets the maximum qps to send to apiserver after
                       the burst quota is exhausted

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1365,6 +1365,12 @@ spec:
                     description: AuthenticationKubeconfig is the path to an Authentication
                       Kubeconfig
                     type: string
+                  authorizationAlwaysAllowPaths:
+                    description: AuthorizationAlwaysAllowPaths is the list of HTTP
+                      paths to skip during authorization
+                    items:
+                      type: string
+                    type: array
                   authorizationKubeconfig:
                     description: AuthorizationKubeconfig is the path to an Authorization
                       Kubeconfig
@@ -1795,6 +1801,12 @@ spec:
                     description: AuthenticationKubeconfig is the path to an Authentication
                       Kubeconfig
                     type: string
+                  authorizationAlwaysAllowPaths:
+                    description: AuthorizationAlwaysAllowPaths is the list of HTTP
+                      paths to skip during authorization
+                    items:
+                      type: string
+                    type: array
                   authorizationKubeconfig:
                     description: AuthorizationKubeconfig is the path to an Authorization
                       Kubeconfig

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -585,6 +585,8 @@ type KubeControllerManagerConfig struct {
 	AuthenticationKubeconfig string `json:"authenticationKubeconfig,omitempty" flag:"authentication-kubeconfig"`
 	// AuthorizationKubeconfig is the path to an Authorization Kubeconfig
 	AuthorizationKubeconfig string `json:"authorizationKubeconfig,omitempty" flag:"authorization-kubeconfig"`
+	// AuthorizationAlwaysAllowPaths is the list of HTTP paths to skip during authorization
+	AuthorizationAlwaysAllowPaths []string `json:"authorizationAlwaysAllowPaths,omitempty" flag:"authorization-always-allow-paths"`
 
 	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
@@ -644,6 +646,8 @@ type KubeSchedulerConfig struct {
 	AuthenticationKubeconfig string `json:"authenticationKubeconfig,omitempty" flag:"authentication-kubeconfig"`
 	// AuthorizationKubeconfig is the path to an Authorization Kubeconfig
 	AuthorizationKubeconfig string `json:"authorizationKubeconfig,omitempty" flag:"authorization-kubeconfig"`
+	// AuthorizationAlwaysAllowPaths is the list of HTTP paths to skip during authorization
+	AuthorizationAlwaysAllowPaths []string `json:"authorizationAlwaysAllowPaths,omitempty" flag:"authorization-always-allow-paths"`
 
 	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -581,6 +581,10 @@ type KubeControllerManagerConfig struct {
 	ConcurrentServiceaccountTokenSyncs *int32 `json:"concurrentServiceaccountTokenSyncs,omitempty" flag:"concurrent-serviceaccount-token-syncs"`
 	// The number of replicationcontroller objects that are allowed to sync concurrently.
 	ConcurrentRcSyncs *int32 `json:"concurrentRcSyncs,omitempty" flag:"concurrent-rc-syncs"`
+	// AuthenticationKubeconfig is the path to an Authentication Kubeconfig
+	AuthenticationKubeconfig string `json:"authenticationKubeconfig,omitempty" flag:"authentication-kubeconfig"`
+	// AuthorizationKubeconfig is the path to an Authorization Kubeconfig
+	AuthorizationKubeconfig string `json:"authorizationKubeconfig,omitempty" flag:"authorization-kubeconfig"`
 
 	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
@@ -636,6 +640,10 @@ type KubeSchedulerConfig struct {
 	Qps *resource.Quantity `json:"qps,omitempty" configfile:"ClientConnection.QPS"`
 	// Burst sets the maximum qps to send to apiserver after the burst quota is exhausted
 	Burst int32 `json:"burst,omitempty" configfile:"ClientConnection.Burst"`
+	// AuthenticationKubeconfig is the path to an Authentication Kubeconfig
+	AuthenticationKubeconfig string `json:"authenticationKubeconfig,omitempty" flag:"authentication-kubeconfig"`
+	// AuthorizationKubeconfig is the path to an Authorization Kubeconfig
+	AuthorizationKubeconfig string `json:"authorizationKubeconfig,omitempty" flag:"authorization-kubeconfig"`
 
 	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -586,6 +586,8 @@ type KubeControllerManagerConfig struct {
 	AuthenticationKubeconfig string `json:"authenticationKubeconfig,omitempty" flag:"authentication-kubeconfig"`
 	// AuthorizationKubeconfig is the path to an Authorization Kubeconfig
 	AuthorizationKubeconfig string `json:"authorizationKubeconfig,omitempty" flag:"authorization-kubeconfig"`
+	// AuthorizationAlwaysAllowPaths is the list of HTTP paths to skip during authorization
+	AuthorizationAlwaysAllowPaths []string `json:"authorizationAlwaysAllowPaths,omitempty" flag:"authorization-always-allow-paths"`
 
 	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
@@ -645,6 +647,8 @@ type KubeSchedulerConfig struct {
 	AuthenticationKubeconfig string `json:"authenticationKubeconfig,omitempty" flag:"authentication-kubeconfig"`
 	// AuthorizationKubeconfig is the path to an Authorization Kubeconfig
 	AuthorizationKubeconfig string `json:"authorizationKubeconfig,omitempty" flag:"authorization-kubeconfig"`
+	// AuthorizationAlwaysAllowPaths is the list of HTTP paths to skip during authorization
+	AuthorizationAlwaysAllowPaths []string `json:"authorizationAlwaysAllowPaths,omitempty" flag:"authorization-always-allow-paths"`
 
 	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -582,6 +582,10 @@ type KubeControllerManagerConfig struct {
 	// The number of replicationcontroller objects that are allowed to sync concurrently.
 	// This only works on kubernetes >= 1.14
 	ConcurrentRcSyncs *int32 `json:"concurrentRcSyncs,omitempty" flag:"concurrent-rc-syncs"`
+	// AuthenticationKubeconfig is the path to an Authentication Kubeconfig
+	AuthenticationKubeconfig string `json:"authenticationKubeconfig,omitempty" flag:"authentication-kubeconfig"`
+	// AuthorizationKubeconfig is the path to an Authorization Kubeconfig
+	AuthorizationKubeconfig string `json:"authorizationKubeconfig,omitempty" flag:"authorization-kubeconfig"`
 
 	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
@@ -637,6 +641,10 @@ type KubeSchedulerConfig struct {
 	Qps *resource.Quantity `json:"qps,omitempty"`
 	// Burst sets the maximum qps to send to apiserver after the burst quota is exhausted
 	Burst int32 `json:"burst,omitempty"`
+	// AuthenticationKubeconfig is the path to an Authentication Kubeconfig
+	AuthenticationKubeconfig string `json:"authenticationKubeconfig,omitempty" flag:"authentication-kubeconfig"`
+	// AuthorizationKubeconfig is the path to an Authorization Kubeconfig
+	AuthorizationKubeconfig string `json:"authorizationKubeconfig,omitempty" flag:"authorization-kubeconfig"`
 
 	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4005,6 +4005,7 @@ func autoConvert_v1alpha2_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.ConcurrentRcSyncs = in.ConcurrentRcSyncs
 	out.AuthenticationKubeconfig = in.AuthenticationKubeconfig
 	out.AuthorizationKubeconfig = in.AuthorizationKubeconfig
+	out.AuthorizationAlwaysAllowPaths = in.AuthorizationAlwaysAllowPaths
 	out.EnableProfiling = in.EnableProfiling
 	return nil
 }
@@ -4067,6 +4068,7 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha2_KubeControllerMana
 	out.ConcurrentRcSyncs = in.ConcurrentRcSyncs
 	out.AuthenticationKubeconfig = in.AuthenticationKubeconfig
 	out.AuthorizationKubeconfig = in.AuthorizationKubeconfig
+	out.AuthorizationAlwaysAllowPaths = in.AuthorizationAlwaysAllowPaths
 	out.EnableProfiling = in.EnableProfiling
 	return nil
 }
@@ -4218,6 +4220,7 @@ func autoConvert_v1alpha2_KubeSchedulerConfig_To_kops_KubeSchedulerConfig(in *Ku
 	out.Burst = in.Burst
 	out.AuthenticationKubeconfig = in.AuthenticationKubeconfig
 	out.AuthorizationKubeconfig = in.AuthorizationKubeconfig
+	out.AuthorizationAlwaysAllowPaths = in.AuthorizationAlwaysAllowPaths
 	out.EnableProfiling = in.EnableProfiling
 	return nil
 }
@@ -4247,6 +4250,7 @@ func autoConvert_kops_KubeSchedulerConfig_To_v1alpha2_KubeSchedulerConfig(in *ko
 	out.Burst = in.Burst
 	out.AuthenticationKubeconfig = in.AuthenticationKubeconfig
 	out.AuthorizationKubeconfig = in.AuthorizationKubeconfig
+	out.AuthorizationAlwaysAllowPaths = in.AuthorizationAlwaysAllowPaths
 	out.EnableProfiling = in.EnableProfiling
 	return nil
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4003,6 +4003,8 @@ func autoConvert_v1alpha2_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.ConcurrentResourceQuotaSyncs = in.ConcurrentResourceQuotaSyncs
 	out.ConcurrentServiceaccountTokenSyncs = in.ConcurrentServiceaccountTokenSyncs
 	out.ConcurrentRcSyncs = in.ConcurrentRcSyncs
+	out.AuthenticationKubeconfig = in.AuthenticationKubeconfig
+	out.AuthorizationKubeconfig = in.AuthorizationKubeconfig
 	out.EnableProfiling = in.EnableProfiling
 	return nil
 }
@@ -4063,6 +4065,8 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha2_KubeControllerMana
 	out.ConcurrentResourceQuotaSyncs = in.ConcurrentResourceQuotaSyncs
 	out.ConcurrentServiceaccountTokenSyncs = in.ConcurrentServiceaccountTokenSyncs
 	out.ConcurrentRcSyncs = in.ConcurrentRcSyncs
+	out.AuthenticationKubeconfig = in.AuthenticationKubeconfig
+	out.AuthorizationKubeconfig = in.AuthorizationKubeconfig
 	out.EnableProfiling = in.EnableProfiling
 	return nil
 }
@@ -4212,6 +4216,8 @@ func autoConvert_v1alpha2_KubeSchedulerConfig_To_kops_KubeSchedulerConfig(in *Ku
 	out.MaxPersistentVolumes = in.MaxPersistentVolumes
 	out.Qps = in.Qps
 	out.Burst = in.Burst
+	out.AuthenticationKubeconfig = in.AuthenticationKubeconfig
+	out.AuthorizationKubeconfig = in.AuthorizationKubeconfig
 	out.EnableProfiling = in.EnableProfiling
 	return nil
 }
@@ -4239,6 +4245,8 @@ func autoConvert_kops_KubeSchedulerConfig_To_v1alpha2_KubeSchedulerConfig(in *ko
 	out.MaxPersistentVolumes = in.MaxPersistentVolumes
 	out.Qps = in.Qps
 	out.Burst = in.Burst
+	out.AuthenticationKubeconfig = in.AuthenticationKubeconfig
+	out.AuthorizationKubeconfig = in.AuthorizationKubeconfig
 	out.EnableProfiling = in.EnableProfiling
 	return nil
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2493,6 +2493,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(int32)
 		**out = **in
 	}
+	if in.AuthorizationAlwaysAllowPaths != nil {
+		in, out := &in.AuthorizationAlwaysAllowPaths, &out.AuthorizationAlwaysAllowPaths
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.EnableProfiling != nil {
 		in, out := &in.EnableProfiling, &out.EnableProfiling
 		*out = new(bool)
@@ -2659,6 +2664,11 @@ func (in *KubeSchedulerConfig) DeepCopyInto(out *KubeSchedulerConfig) {
 		in, out := &in.Qps, &out.Qps
 		x := (*in).DeepCopy()
 		*out = &x
+	}
+	if in.AuthorizationAlwaysAllowPaths != nil {
+		in, out := &in.AuthorizationAlwaysAllowPaths, &out.AuthorizationAlwaysAllowPaths
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.EnableProfiling != nil {
 		in, out := &in.EnableProfiling, &out.EnableProfiling

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2675,6 +2675,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(int32)
 		**out = **in
 	}
+	if in.AuthorizationAlwaysAllowPaths != nil {
+		in, out := &in.AuthorizationAlwaysAllowPaths, &out.AuthorizationAlwaysAllowPaths
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.EnableProfiling != nil {
 		in, out := &in.EnableProfiling, &out.EnableProfiling
 		*out = new(bool)
@@ -2841,6 +2846,11 @@ func (in *KubeSchedulerConfig) DeepCopyInto(out *KubeSchedulerConfig) {
 		in, out := &in.Qps, &out.Qps
 		x := (*in).DeepCopy()
 		*out = &x
+	}
+	if in.AuthorizationAlwaysAllowPaths != nil {
+		in, out := &in.AuthorizationAlwaysAllowPaths, &out.AuthorizationAlwaysAllowPaths
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.EnableProfiling != nil {
 		in, out := &in.EnableProfiling, &out.EnableProfiling

--- a/protokube/pkg/gossip/mesh/mesh.pb.go
+++ b/protokube/pkg/gossip/mesh/mesh.pb.go
@@ -21,14 +21,15 @@ package mesh
 
 import (
 	fmt "fmt"
-	_ "github.com/gogo/protobuf/gogoproto"
-	proto "github.com/gogo/protobuf/proto"
-	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 	io "io"
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
+
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
+	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
PR Summary:
- Adds missing cli options for kube-controller-manager and kube-scheduler
- Fixes https://github.com/kubernetes/kops/issues/9695