### PR TITLE
Add --internal flag for export kubecfg that targets the internal dns name

### DIFF
--- a/cmd/kops/export_kubecfg.go
+++ b/cmd/kops/export_kubecfg.go
@@ -46,6 +46,9 @@ var (
 
 	# export using a user already existing in the kubeconfig file
 	kops export kubecfg kubernetes-cluster.example.com --user my-oidc-user
+
+	# export using the internal DNS name, bypassing the cloud load balancer
+	kops export kubecfg kubernetes-cluster.example.com --internal
 		`))
 
 	exportKubecfgShort = i18n.T(`Export kubecfg.`)
@@ -56,6 +59,7 @@ type ExportKubecfgOptions struct {
 	all            bool
 	admin          time.Duration
 	user           string
+	internal       bool
 }
 
 func NewCmdExportKubecfg(f *util.Factory, out io.Writer) *cobra.Command {
@@ -80,6 +84,7 @@ func NewCmdExportKubecfg(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().DurationVar(&options.admin, "admin", options.admin, "export a cluster admin user credential with the given lifetime and add it to the cluster context")
 	cmd.Flags().Lookup("admin").NoOptDefVal = kubeconfig.DefaultKubecfgAdminLifetime.String()
 	cmd.Flags().StringVar(&options.user, "user", options.user, "add an existing user to the cluster context")
+	cmd.Flags().BoolVar(&options.internal, "internal", options.internal, "use the cluster's internal DNS name")
 
 	return cmd
 }
@@ -130,7 +135,7 @@ func RunExportKubecfg(ctx context.Context, f *util.Factory, out io.Writer, optio
 			return err
 		}
 
-		conf, err := kubeconfig.BuildKubecfg(cluster, keyStore, secretStore, &commands.CloudDiscoveryStatusStore{}, buildPathOptions(options), options.admin, options.user)
+		conf, err := kubeconfig.BuildKubecfg(cluster, keyStore, secretStore, &commands.CloudDiscoveryStatusStore{}, buildPathOptions(options), options.admin, options.user, options.internal)
 		if err != nil {
 			return err
 		}

--- a/docs/cli/kops_export_kubecfg.md
+++ b/docs/cli/kops_export_kubecfg.md
@@ -21,6 +21,9 @@ kops export kubecfg CLUSTERNAME [flags]
   
   # export using a user already existing in the kubeconfig file
   kops export kubecfg kubernetes-cluster.example.com --user my-oidc-user
+  
+  # export using the internal DNS name, bypassing the cloud load balancer
+  kops export kubecfg kubernetes-cluster.example.com --internal
 ```
 
 ### Options
@@ -29,6 +32,7 @@ kops export kubecfg CLUSTERNAME [flags]
       --admin duration[=18h0m0s]   export a cluster admin user credential with the given lifetime and add it to the cluster context
       --all                        export all clusters from the kops state store
   -h, --help                       help for kubecfg
+      --internal                   use the cluster's internal DNS name
       --kubeconfig string          the location of the kubeconfig file to create.
       --user string                add an existing user to the cluster context
 ```

--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -29,6 +29,7 @@ kops update cluster [flags]
       --allow-kops-downgrade          Allow an older version of kops to update the cluster than last used
       --create-kube-config            Will control automatically creating the kube config file on your local filesystem
   -h, --help                          help for cluster
+      --internal                      Use the cluster's internal DNS name. Implies --create-kube-config
       --lifecycle-overrides strings   comma separated list of phase overrides, example: SecurityGroups=Ignore,InternetGateway=ExistsAndWarnIfChanges
       --out string                    Path to write any local output
       --phase string                  Subset of tasks to run: assets, cluster, network, security

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -48,7 +48,9 @@ spec:
       idleTimeoutSeconds: 300
 ```
 
-You can use a valid SSL Certificate for your API Server Load Balancer. Currently, only AWS is supported:
+You can use a valid SSL Certificate for your API Server Load Balancer. Currently, only AWS is supported.
+
+Note that when using `sslCertificate`, client certificate authentication, such as with the credentials generated via `kops export kubecfg`, will not work through the load balancer. As of Kops 1.19, a `kubecfg` that bypasses the load balancer may be created with the `--internal` flag to `kops update cluster` or `kops export kubecfg`. Security groups may need to be opened to allow access from the clients to the master instances' port TCP/443, for example by using the `additionalSecurityGroups` field on the master instance groups.
 
 ```yaml
 spec:


### PR DESCRIPTION
Kops creates an "api.internal.$clustername" dns A record that points to the master IP(s)

This adds a flag that will use that name and force the CA cert to be included.
This is a workaround for client certificate authentication not working on API ELBs with ACM certificates.
The ELB has a TLS listener rather than TCP, so the client certificate is not passed through to the apiserver.
Using --internal will bypass the API ELB so that the client certificate will be passed directly to the apiserver.

This also requires that the masters' security groups allow 443 access from the client which this does not handle automatically. I suppose if sslCertificateId is set, kops could automatically open 443 on the masters to the same sources that the ELB's 443 allows but I could see that being frowned upon for security reasons.


Fixes #800
(wow)

/hold for comment