### PR TITLE
Upgrade CI jobs to go 1.15.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.0-rc2
-          stable: false
+          go-version: 1.15.0
 
       - uses: actions/checkout@v2
         with:
@@ -34,8 +33,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.0-rc2
-        stable: false
+        go-version: 1.15.0
 
     - uses: actions/checkout@v2
       with:
@@ -52,8 +50,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.0-rc2
-        stable: false
+        go-version: 1.15.0
 
     - uses: actions/checkout@v2
       with:
@@ -70,8 +67,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.0-rc2
-          stable: false
+          go-version: 1.15.0
 
       - uses: actions/checkout@v2
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ arch:
   - arm64
 os: linux
 dist: focal
-go: 1.15rc2
+go: 1.15
 
 go_import_path: k8s.io/kops
 


### PR DESCRIPTION
These were failing, apparently the RC is no longer available once the stable release lands.
We can bump bazel rules_go once it is released.