### PR TITLE
Upgrade to Terraform 0.13.0

### DIFF
--- a/hack/verify-terraform.sh
+++ b/hack/verify-terraform.sh
@@ -26,7 +26,7 @@ CLUSTERS_0_11=(
 )
 
 # Terraform versions
-TAG_0_13=0.13.0-beta2
+TAG_0_13=0.13.0
 TAG_0_11=0.11.14
 
 PROVIDER_CACHE="${KOPS_ROOT}/.cache/terraform"


### PR DESCRIPTION
https://www.hashicorp.com/blog/announcing-hashicorp-terraform-0-13/

This also now tests version 3.X of the AWS Provider which has a [breaking change related to launch templates](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_launch_template) but my local testing showed that our use of `aws_launch_template` is not impacted.