### PR TITLE
Map --config flag in KubeletConfigSpec

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -198,13 +198,13 @@ type KubeletConfigSpec struct {
 	RegistryBurst *int32 `json:"registryBurst,omitempty" flag:"registry-burst"`
 	//TopologyManagerPolicy determines the allocation policy for the topology manager.
 	TopologyManagerPolicy string `json:"topologyManagerPolicy,omitempty" flag:"topology-manager-policy"`
-
 	// rotateCertificates enables client certificate rotation.
 	RotateCertificates *bool `json:"rotateCertificates,omitempty" flag:"rotate-certificates"`
-
 	// Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.
 	// (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag.
 	ProtectKernelDefaults *bool `json:"protectKernelDefaults,omitempty" flag:"protect-kernel-defaults"`
+	// Kubelet config file from file system. Command line flags which target the same value as a config file will override that value.
+	Config string `json:"config,omitempty" flag:"config"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -198,13 +198,13 @@ type KubeletConfigSpec struct {
 	RegistryBurst *int32 `json:"registryBurst,omitempty" flag:"registry-burst"`
 	//TopologyManagerPolicy determines the allocation policy for the topology manager.
 	TopologyManagerPolicy string `json:"topologyManagerPolicy,omitempty" flag:"topology-manager-policy"`
-
 	// rotateCertificates enables client certificate rotation.
 	RotateCertificates *bool `json:"rotateCertificates,omitempty" flag:"rotate-certificates"`
-
 	// Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.
 	// (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag.
 	ProtectKernelDefaults *bool `json:"protectKernelDefaults,omitempty" flag:"protect-kernel-defaults"`
+	// Kubelet config file from file system. Command line flags which target the same value as a config file will override that value.
+	Config string `json:"config,omitempty" flag:"config"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy


### PR DESCRIPTION
Most config parameters passed as flags on the kubelet has been deprecated in favor of the `--config` parameter which expects a file as input. (https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/)

I read issue #5070 that the suggestion is to migrate away from the old style of migrating configuration to the kubelet, so I think this would be a good first step to just expose the flag. That way users can start migrating configuration to file before they are forced to do so.