### PR TITLE
Default kubelet authenticationTokenWebhook to true for k8s 1.19+

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -517,6 +517,10 @@ func (b *KubeletBuilder) buildKubeletConfigSpec() (*kops.KubeletConfigSpec, erro
 		c.AuthorizationMode = "Webhook"
 	}
 
+	if c.AuthenticationTokenWebhook == nil && b.Cluster.IsKubernetesGTE("1.19") {
+		c.AuthenticationTokenWebhook = fi.Bool(true)
+	}
+
 	return &c, nil
 }
 


### PR DESCRIPTION
As discussed in Office Hours.

Fixes #7200 
