### PR TITLE
Setup a second ELB listener when an AWS ACM certificate is used 

### DIFF
--- a/nodeup/pkg/model/kube_apiserver_test.go
+++ b/nodeup/pkg/model/kube_apiserver_test.go
@@ -199,6 +199,13 @@ func TestAwsIamAuthenticator(t *testing.T) {
 	})
 }
 
+func TestAwsACMCertificate(t *testing.T) {
+	RunGoldenTest(t, "tests/golden/awsacm", "kube-apiserver", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+		builder := KubeAPIServerBuilder{NodeupModelContext: nodeupModelContext}
+		return builder.Build(target)
+	})
+}
+
 func TestKubeAPIServerBuilderAMD64(t *testing.T) {
 	RunGoldenTest(t, "tests/golden/side-loading", "kube-apiserver-amd64", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
 		builder := KubeAPIServerBuilder{NodeupModelContext: nodeupModelContext}

--- a/nodeup/pkg/model/tests/golden/awsacm/cluster.yaml
+++ b/nodeup/pkg/model/tests/golden/awsacm/cluster.yaml
@@ -1,0 +1,70 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  name: minimal.example.com
+spec:
+  api:
+    loadBalancer:
+      sslCertificate: arn:aws:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  etcdClusters:
+  - cpuRequest: 200m
+    etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: us-test-1a
+    memoryRequest: 100Mi
+    name: main
+    provider: Manager
+    backups:
+      backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd-main
+  - cpuRequest: 100m
+    etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: us-test-1a
+    memoryRequest: 100Mi
+    name: events
+    provider: Manager
+    backups:
+      backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
+  iam: {}
+  kubelet:
+    anonymousAuth: false
+  kubernetesVersion: v1.18.0
+  masterInternalName: api.internal.minimal.example.com
+  masterPublicName: api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+    - 0.0.0.0/0
+  topology:
+    masters: public
+    nodes: public
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  name: master-us-test-1a
+  labels:
+    kops.k8s.io/cluster: minimal.example.com
+spec:
+  associatePublicIp: true
+  image: ami-1234
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test-1a

--- a/nodeup/pkg/model/tests/golden/awsacm/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/awsacm/tasks-kube-apiserver.yaml
@@ -1,0 +1,197 @@
+contents: |
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      dns.alpha.kubernetes.io/internal: api.internal.minimal.example.com
+      scheduler.alpha.kubernetes.io/critical-pod: ""
+    creationTimestamp: null
+    labels:
+      k8s-app: kube-apiserver
+    name: kube-apiserver
+    namespace: kube-system
+  spec:
+    containers:
+    - args:
+      - --allow-privileged=true
+      - --anonymous-auth=false
+      - --apiserver-count=1
+      - --authorization-mode=AlwaysAllow
+      - --bind-address=0.0.0.0
+      - --client-ca-file=/srv/kubernetes/ca.crt
+      - --cloud-provider=aws
+      - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,NodeRestriction,ResourceQuota
+      - --etcd-cafile=/etc/kubernetes/pki/kube-apiserver/etcd-ca.crt
+      - --etcd-certfile=/etc/kubernetes/pki/kube-apiserver/etcd-client.crt
+      - --etcd-keyfile=/etc/kubernetes/pki/kube-apiserver/etcd-client.key
+      - --etcd-servers-overrides=/events#https://127.0.0.1:4002
+      - --etcd-servers=https://127.0.0.1:4001
+      - --insecure-bind-address=127.0.0.1
+      - --insecure-port=0
+      - --kubelet-client-certificate=/srv/kubernetes/kubelet-api.crt
+      - --kubelet-client-key=/srv/kubernetes/kubelet-api.key
+      - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
+      - --proxy-client-cert-file=/srv/kubernetes/apiserver-aggregator.crt
+      - --proxy-client-key-file=/srv/kubernetes/apiserver-aggregator.key
+      - --requestheader-allowed-names=aggregator
+      - --requestheader-client-ca-file=/srv/kubernetes/apiserver-aggregator-ca.crt
+      - --requestheader-extra-headers-prefix=X-Remote-Extra-
+      - --requestheader-group-headers=X-Remote-Group
+      - --requestheader-username-headers=X-Remote-User
+      - --secure-port=443
+      - --service-account-key-file=/srv/kubernetes/service-account.key
+      - --service-cluster-ip-range=100.64.0.0/13
+      - --storage-backend=etcd3
+      - --tls-cert-file=/srv/kubernetes/server.crt
+      - --tls-private-key-file=/srv/kubernetes/server.key
+      - --v=2
+      - --logtostderr=false
+      - --alsologtostderr
+      - --log-file=/var/log/kube-apiserver.log
+      command:
+      - /usr/local/bin/kube-apiserver
+      image: k8s.gcr.io/kube-apiserver:v1.18.0
+      livenessProbe:
+        httpGet:
+          host: 127.0.0.1
+          path: /healthz
+          port: 443
+          scheme: HTTPS
+        initialDelaySeconds: 45
+        timeoutSeconds: 15
+      name: kube-apiserver
+      ports:
+      - containerPort: 443
+        hostPort: 443
+        name: https
+      - containerPort: 443
+        hostPort: 8443
+        name: tcp
+      resources:
+        requests:
+          cpu: 150m
+      volumeMounts:
+      - mountPath: /var/log/kube-apiserver.log
+        name: logfile
+      - mountPath: /etc/ssl
+        name: etcssl
+        readOnly: true
+      - mountPath: /etc/pki/tls
+        name: etcpkitls
+        readOnly: true
+      - mountPath: /etc/pki/ca-trust
+        name: etcpkica-trust
+        readOnly: true
+      - mountPath: /usr/share/ssl
+        name: usrsharessl
+        readOnly: true
+      - mountPath: /usr/ssl
+        name: usrssl
+        readOnly: true
+      - mountPath: /usr/lib/ssl
+        name: usrlibssl
+        readOnly: true
+      - mountPath: /usr/local/openssl
+        name: usrlocalopenssl
+        readOnly: true
+      - mountPath: /var/ssl
+        name: varssl
+        readOnly: true
+      - mountPath: /etc/openssl
+        name: etcopenssl
+        readOnly: true
+      - mountPath: /etc/kubernetes/pki/kube-apiserver
+        name: pki
+      - mountPath: /srv/kubernetes
+        name: srvkube
+        readOnly: true
+      - mountPath: /srv/sshproxy
+        name: srvsshproxy
+        readOnly: true
+    hostNetwork: true
+    priorityClassName: system-cluster-critical
+    tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+    volumes:
+    - hostPath:
+        path: /var/log/kube-apiserver.log
+      name: logfile
+    - hostPath:
+        path: /etc/ssl
+      name: etcssl
+    - hostPath:
+        path: /etc/pki/tls
+      name: etcpkitls
+    - hostPath:
+        path: /etc/pki/ca-trust
+      name: etcpkica-trust
+    - hostPath:
+        path: /usr/share/ssl
+      name: usrsharessl
+    - hostPath:
+        path: /usr/ssl
+      name: usrssl
+    - hostPath:
+        path: /usr/lib/ssl
+      name: usrlibssl
+    - hostPath:
+        path: /usr/local/openssl
+      name: usrlocalopenssl
+    - hostPath:
+        path: /var/ssl
+      name: varssl
+    - hostPath:
+        path: /etc/openssl
+      name: etcopenssl
+    - hostPath:
+        path: /etc/kubernetes/pki/kube-apiserver
+        type: DirectoryOrCreate
+      name: pki
+    - hostPath:
+        path: /srv/kubernetes
+      name: srvkube
+    - hostPath:
+        path: /srv/sshproxy
+      name: srvsshproxy
+  status: {}
+path: /etc/kubernetes/manifests/kube-apiserver.manifest
+type: file
+---
+mode: "0755"
+path: /srv/kubernetes
+type: directory
+---
+contents:
+  task:
+    Name: kubelet-api
+    signer: ca
+    subject:
+      CommonName: kubelet-api
+    type: client
+mode: "0644"
+path: /srv/kubernetes/kubelet-api.crt
+type: file
+---
+contents:
+  task:
+    Name: kubelet-api
+    signer: ca
+    subject:
+      CommonName: kubelet-api
+    type: client
+mode: "0600"
+path: /srv/kubernetes/kubelet-api.key
+type: file
+---
+contents: ""
+ifNotExists: true
+mode: "0400"
+path: /var/log/kube-apiserver.log
+type: file
+---
+Name: kubelet-api
+signer: ca
+subject:
+  CommonName: kubelet-api
+type: client

--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -111,7 +111,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 
 		if lbSpec.SSLCertificate != "" {
 			listeners["443"] = &awstasks.LoadBalancerListener{InstancePort: 443, SSLCertificateID: lbSpec.SSLCertificate}
-			listeners["8443"] = &awstasks.LoadBalancerListener{InstancePort: 443}
+			listeners["8443"] = &awstasks.LoadBalancerListener{InstancePort: 8443}
 		}
 
 		if lbSpec.SecurityGroupOverride != nil {
@@ -278,6 +278,17 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 				SourceGroup:   lbSG,
 				ToPort:        fi.Int64(443),
 			})
+			if lbSpec.SSLCertificate != "" {
+				c.AddTask(&awstasks.SecurityGroupRule{
+					Name:          fi.String(fmt.Sprintf("tcp-elb-to-master%s", suffix)),
+					Lifecycle:     b.SecurityLifecycle,
+					FromPort:      fi.Int64(8443),
+					Protocol:      fi.String("tcp"),
+					SecurityGroup: masterGroup.Task,
+					SourceGroup:   lbSG,
+					ToPort:        fi.Int64(8443),
+				})
+			}
 		}
 	}
 

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -857,6 +857,20 @@
         "CidrIp": "2001:0:8500::/40"
       }
     },
+    "AWSEC2SecurityGroupIngresstcpelbtomaster": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
+        },
+        "SourceSecurityGroupId": {
+          "Ref": "AWSEC2SecurityGroupapielbcomplexexamplecom"
+        },
+        "FromPort": 8443,
+        "ToPort": 8443,
+        "IpProtocol": "tcp"
+      }
+    },
     "AWSEC2SecurityGroupapielbcomplexexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
@@ -1161,7 +1175,7 @@
             "Protocol": "TCP"
           },
           {
-            "InstancePort": "443",
+            "InstancePort": "8443",
             "InstanceProtocol": "TCP",
             "LoadBalancerPort": "8443",
             "Protocol": "TCP"

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -833,6 +833,30 @@
         "CidrIp": "2001:0:85a3::/48"
       }
     },
+    "AWSEC2SecurityGroupIngresstcpapielb111024": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupapielbcomplexexamplecom"
+        },
+        "FromPort": 8443,
+        "ToPort": 8443,
+        "IpProtocol": "tcp",
+        "CidrIp": "1.1.1.0/24"
+      }
+    },
+    "AWSEC2SecurityGroupIngresstcpapielb20010850040": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupapielbcomplexexamplecom"
+        },
+        "FromPort": 8443,
+        "ToPort": 8443,
+        "IpProtocol": "tcp",
+        "CidrIp": "2001:0:8500::/40"
+      }
+    },
     "AWSEC2SecurityGroupapielbcomplexexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
@@ -1134,6 +1158,12 @@
             "InstancePort": "443",
             "InstanceProtocol": "TCP",
             "LoadBalancerPort": "443",
+            "Protocol": "TCP"
+          },
+          {
+            "InstancePort": "443",
+            "InstanceProtocol": "TCP",
+            "LoadBalancerPort": "8443",
             "Protocol": "TCP"
           }
         ],

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -11,6 +11,7 @@ spec:
       - sg-exampleid3
       - sg-exampleid4
       crossZoneLoadBalancing: true
+      sslCertificate: arn:aws:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678
   kubernetesApiAccess:
   - 1.1.1.0/24
   - 2001:0:8500::/40

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -11,6 +11,7 @@ spec:
       - sg-exampleid3
       - sg-exampleid4
       crossZoneLoadBalancing: true
+      sslCertificate: arn:aws:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678
   kubernetesApiAccess:
   - 1.1.1.0/24
   - 2001:0:8500::/40

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -245,9 +245,16 @@ resource "aws_elb" "api-complex-example-com" {
   }
   idle_timeout = 300
   listener {
+    instance_port      = 443
+    instance_protocol  = "SSL"
+    lb_port            = 443
+    lb_protocol        = "SSL"
+    ssl_certificate_id = "arn:aws:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678"
+  }
+  listener {
     instance_port     = 443
     instance_protocol = "TCP"
-    lb_port           = 443
+    lb_port           = 8443
     lb_protocol       = "TCP"
   }
   name            = "api-complex-example-com-vd3t5n"
@@ -689,6 +696,24 @@ resource "aws_security_group_rule" "ssh-external-to-node-2001_0_85a3__--48" {
   protocol          = "tcp"
   security_group_id = aws_security_group.nodes-complex-example-com.id
   to_port           = 22
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "tcp-api-elb-1-1-1-0--24" {
+  cidr_blocks       = ["1.1.1.0/24"]
+  from_port         = 8443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.api-elb-complex-example-com.id
+  to_port           = 8443
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "tcp-api-elb-2001_0_8500__--40" {
+  cidr_blocks       = ["2001:0:8500::/40"]
+  from_port         = 8443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.api-elb-complex-example-com.id
+  to_port           = 8443
   type              = "ingress"
 }
 

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -252,7 +252,7 @@ resource "aws_elb" "api-complex-example-com" {
     ssl_certificate_id = "arn:aws:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678"
   }
   listener {
-    instance_port     = 443
+    instance_port     = 8443
     instance_protocol = "TCP"
     lb_port           = 8443
     lb_protocol       = "TCP"
@@ -715,6 +715,15 @@ resource "aws_security_group_rule" "tcp-api-elb-2001_0_8500__--40" {
   security_group_id = aws_security_group.api-elb-complex-example-com.id
   to_port           = 8443
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "tcp-elb-to-master" {
+  from_port                = 8443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-complex-example-com.id
+  source_security_group_id = aws_security_group.api-elb-complex-example-com.id
+  to_port                  = 8443
+  type                     = "ingress"
 }
 
 resource "aws_security_group" "api-elb-complex-example-com" {

--- a/upup/pkg/fi/cloudup/awstasks/load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/load_balancer.go
@@ -715,7 +715,13 @@ func (_ *LoadBalancer) RenderTerraform(t *terraform.TerraformTarget, a, e, chang
 	}
 	terraform.SortLiterals(tf.SecurityGroups)
 
-	for loadBalancerPort, listener := range e.Listeners {
+	listenerPorts := make([]string, 0)
+	for port := range e.Listeners {
+		listenerPorts = append(listenerPorts, port)
+	}
+	sort.Strings(listenerPorts)
+	for _, loadBalancerPort := range listenerPorts {
+		listener := e.Listeners[loadBalancerPort]
 		loadBalancerPortInt, err := strconv.ParseInt(loadBalancerPort, 10, 64)
 		if err != nil {
 			return fmt.Errorf("error parsing load balancer listener port: %q", loadBalancerPort)
@@ -855,7 +861,13 @@ func (_ *LoadBalancer) RenderCloudformation(t *cloudformation.CloudformationTarg
 		tf.SecurityGroups = append(tf.SecurityGroups, sg.CloudformationLink())
 	}
 
-	for loadBalancerPort, listener := range e.Listeners {
+	listenerPorts := make([]string, 0)
+	for port := range e.Listeners {
+		listenerPorts = append(listenerPorts, port)
+	}
+	sort.Strings(listenerPorts)
+	for _, loadBalancerPort := range listenerPorts {
+		listener := e.Listeners[loadBalancerPort]
 
 		tf.Listener = append(tf.Listener, &cloudformationLoadBalancerListener{
 			InstanceProtocol:     "TCP",


### PR DESCRIPTION
This is the alternative solution to #9756

When `sslCertificate` is set, the API ELB will also have a TCP listener on 8443 that will pass through the TLS session to the apiserver pods, allowing client certificate auth.

When `--admin` is specified in `kops update cluster` or `kops export kubecfg`, the kubeconfig file will use this port and will include the cluster's CA.

If anyone has a preference for port number other than 8443 I'm happy to change it.