### PR TITLE
Don't use nova for glance mocks

### DIFF
--- a/cloudmock/openstack/mockcompute/BUILD.bazel
+++ b/cloudmock/openstack/mockcompute/BUILD.bazel
@@ -5,7 +5,6 @@ go_library(
     srcs = [
         "api.go",
         "flavors.go",
-        "images.go",
         "keypairs.go",
         "servergroups.go",
         "servers.go",

--- a/cloudmock/openstack/mockimage/BUILD.bazel
+++ b/cloudmock/openstack/mockimage/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "api.go",
+        "images.go",
+    ],
+    importpath = "k8s.io/kops/cloudmock/openstack/mockimage",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cloudmock/openstack:go_default_library",
+        "//vendor/github.com/google/uuid:go_default_library",
+        "//vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images:go_default_library",
+    ],
+)

--- a/cloudmock/openstack/mockimage/api.go
+++ b/cloudmock/openstack/mockimage/api.go
@@ -14,16 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mockcompute
+package mockimage
 
 import (
 	"net/http/httptest"
 	"sync"
 
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 	"k8s.io/kops/cloudmock/openstack"
 )
@@ -33,11 +29,7 @@ type MockClient struct {
 	openstack.MockOpenstackServer
 	mutex sync.Mutex
 
-	serverGroups map[string]servergroups.ServerGroup
-	servers      map[string]servers.Server
-	keyPairs     map[string]keypairs.KeyPair
-	images       map[string]images.Image
-	flavors      map[string]flavors.Flavor
+	images map[string]images.Image
 }
 
 // CreateClient will create a new mock networking client
@@ -45,31 +37,21 @@ func CreateClient() *MockClient {
 	m := &MockClient{}
 	m.SetupMux()
 	m.Reset()
-	m.mockServerGroups()
-	m.mockServers()
-	m.mockKeyPairs()
-	m.mockFlavors()
+	m.mockImages()
 	m.Server = httptest.NewServer(m.Mux)
 	return m
 }
 
 // Reset will empty the state of the mock data
 func (m *MockClient) Reset() {
-	m.serverGroups = make(map[string]servergroups.ServerGroup)
-	m.servers = make(map[string]servers.Server)
-	m.keyPairs = make(map[string]keypairs.KeyPair)
 	m.images = make(map[string]images.Image)
-	m.flavors = make(map[string]flavors.Flavor)
 }
 
 // All returns a map of all resource IDs to their resources
 func (m *MockClient) All() map[string]interface{} {
 	all := make(map[string]interface{})
-	for id, sg := range m.serverGroups {
-		all[id] = sg
-	}
-	for id, kp := range m.keyPairs {
-		all[id] = kp
+	for id, i := range m.images {
+		all[id] = i
 	}
 	return all
 }

--- a/cloudmock/openstack/mockimage/images.go
+++ b/cloudmock/openstack/mockimage/images.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mockcompute
+package mockimage
 
 import (
 	"encoding/json"
@@ -46,7 +46,7 @@ func (m *MockClient) mockImages() {
 		imageID := re.ReplaceAllString(r.URL.Path, "")
 		switch r.Method {
 		case http.MethodGet:
-			if imageID == "detail" {
+			if imageID == "" {
 				m.listImages(w)
 			} else {
 				m.getImage(w, imageID)
@@ -127,7 +127,6 @@ func (m *MockClient) createImage(w http.ResponseWriter, r *http.Request) {
 		MinDiskGigabytes: create.MinDisk,
 	}
 	m.images[image.ID] = image
-
 	resp := imageGetResponse{
 		Image: image,
 	}

--- a/hack/.packages
+++ b/hack/.packages
@@ -13,6 +13,7 @@ k8s.io/kops/cloudmock/openstack
 k8s.io/kops/cloudmock/openstack/mockblockstorage
 k8s.io/kops/cloudmock/openstack/mockcompute
 k8s.io/kops/cloudmock/openstack/mockdns
+k8s.io/kops/cloudmock/openstack/mockimage
 k8s.io/kops/cloudmock/openstack/mockloadbalancer
 k8s.io/kops/cloudmock/openstack/mocknetworking
 k8s.io/kops/cmd/kops

--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//cloudmock/openstack/mockblockstorage:go_default_library",
         "//cloudmock/openstack/mockcompute:go_default_library",
         "//cloudmock/openstack/mockdns:go_default_library",
+        "//cloudmock/openstack/mockimage:go_default_library",
         "//cloudmock/openstack/mockloadbalancer:go_default_library",
         "//cloudmock/openstack/mocknetworking:go_default_library",
         "//pkg/apis/kops:go_default_library",

--- a/pkg/testutils/integrationtestharness.go
+++ b/pkg/testutils/integrationtestharness.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/kops/cloudmock/openstack/mockblockstorage"
 	"k8s.io/kops/cloudmock/openstack/mockcompute"
 	"k8s.io/kops/cloudmock/openstack/mockdns"
+	"k8s.io/kops/cloudmock/openstack/mockimage"
 	"k8s.io/kops/cloudmock/openstack/mockloadbalancer"
 	"k8s.io/kops/cloudmock/openstack/mocknetworking"
 	"k8s.io/kops/pkg/apis/kops"
@@ -264,6 +265,8 @@ func (h *IntegrationTestHarness) SetupMockOpenstack() *openstack.MockCloud {
 
 	c.MockDNSClient = mockdns.CreateClient()
 
+	c.MockImageClient = mockimage.CreateClient()
+
 	extNetworkName := "external"
 	networkCreateOpts := networks.CreateOpts{
 		Name:         extNetworkName,
@@ -286,7 +289,7 @@ func (h *IntegrationTestHarness) SetupMockOpenstack() *openstack.MockCloud {
 	c.CreateSubnet(extSubnet)
 	c.SetExternalSubnet(fi.String(extSubnetName))
 	c.SetLBFloatingSubnet(fi.String(extSubnetName))
-	images.Create(c.MockNovaClient.ServiceClient(), images.CreateOpts{
+	images.Create(c.MockImageClient.ServiceClient(), images.CreateOpts{
 		Name:    "Ubuntu-20.04",
 		MinDisk: 12,
 	})

--- a/upup/pkg/fi/cloudup/openstack/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/openstack/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//cloudmock/openstack/mockblockstorage:go_default_library",
         "//cloudmock/openstack/mockcompute:go_default_library",
         "//cloudmock/openstack/mockdns:go_default_library",
+        "//cloudmock/openstack/mockimage:go_default_library",
         "//cloudmock/openstack/mockloadbalancer:go_default_library",
         "//cloudmock/openstack/mocknetworking:go_default_library",
         "//dnsprovider/pkg/dnsprovider:go_default_library",

--- a/upup/pkg/fi/cloudup/openstack/mock_cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/mock_cloud.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/kops/cloudmock/openstack/mockblockstorage"
 	"k8s.io/kops/cloudmock/openstack/mockcompute"
 	"k8s.io/kops/cloudmock/openstack/mockdns"
+	"k8s.io/kops/cloudmock/openstack/mockimage"
 	"k8s.io/kops/cloudmock/openstack/mockloadbalancer"
 	"k8s.io/kops/cloudmock/openstack/mocknetworking"
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider"
@@ -60,7 +61,7 @@ type MockCloud struct {
 	MockNovaClient    *mockcompute.MockClient
 	MockDNSClient     *mockdns.MockClient
 	MockLBClient      *mockloadbalancer.MockClient
-	MockGlanceClient  *mockcompute.MockClient
+	MockImageClient   *mockimage.MockClient
 	region            string
 	tags              map[string]string
 	useOctavia        bool
@@ -115,9 +116,7 @@ func (c *MockCloud) DNSClient() *gophercloud.ServiceClient {
 }
 
 func (c *MockCloud) ImageClient() *gophercloud.ServiceClient {
-	// Some compute endpoints implicitly call image endpoints
-	// so it is easiest to share the same mock client
-	client := c.MockNovaClient.ServiceClient()
+	client := c.MockImageClient.ServiceClient()
 	client.UserAgent.Prepend("image")
 	return client
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/openstacktasks/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "//vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers:go_default_library",
+        "//vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools:go_default_library",


### PR DESCRIPTION
Fetching images through nova is deprecated and removed in newer versions
of the compute API. Mocks now reflect this behavior.