### PR TITLE
WIP Add support for compressed files for slower networks/links

### DIFF
--- a/pkg/model/tests/data/bootstrapscript_0.txt
+++ b/pkg/model/tests/data/bootstrapscript_0.txt
@@ -75,16 +75,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/pkg/model/tests/data/bootstrapscript_1.txt
+++ b/pkg/model/tests/data/bootstrapscript_1.txt
@@ -75,16 +75,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/pkg/model/tests/data/bootstrapscript_2.txt
+++ b/pkg/model/tests/data/bootstrapscript_2.txt
@@ -75,16 +75,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/pkg/model/tests/data/bootstrapscript_3.txt
+++ b/pkg/model/tests/data/bootstrapscript_3.txt
@@ -75,16 +75,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/pkg/model/tests/data/bootstrapscript_4.txt
+++ b/pkg/model/tests/data/bootstrapscript_4.txt
@@ -75,16 +75,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/pkg/model/tests/data/bootstrapscript_5.txt
+++ b/pkg/model/tests/data/bootstrapscript_5.txt
@@ -75,16 +75,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_nodes.bastionuserdata.example.com_user_data
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_nodes.bastionuserdata.example.com_user_data
@@ -68,16 +68,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
@@ -69,17 +69,26 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscomplexexamplecom.Properties.
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
+          if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
-            else
-              echo "== Downloaded ${url} =="
-            fi
-            return
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
+        else
+          echo "== Downloaded ${url} =="
+        fi
         done
       done
 
@@ -416,16 +425,25 @@ Resources.AWSEC2LaunchTemplatenodescomplexexamplecom.Properties.LaunchTemplateDa
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
@@ -68,16 +68,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
@@ -68,16 +68,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
@@ -60,16 +60,25 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -375,16 +384,25 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_nodes.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_nodes.existing-iam.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -60,16 +60,25 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -385,16 +394,25 @@ Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateDa
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_nodes.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_nodes.existingsg.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -60,16 +60,25 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersexternallbexamplecom.Properti
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -385,16 +394,25 @@ Resources.AWSEC2LaunchTemplatenodesexternallbexamplecom.Properties.LaunchTemplat
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done

--- a/tests/integration/update_cluster/externallb/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data
+++ b/tests/integration/update_cluster/externallb/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/externallb/data/aws_launch_template_nodes.externallb.example.com_user_data
+++ b/tests/integration/update_cluster/externallb/data/aws_launch_template_nodes.externallb.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_nodes.externalpolicies.example.com_user_data
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_nodes.externalpolicies.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_nodes.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_nodes.ha.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_startup-script
@@ -58,16 +58,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_startup-script
@@ -58,16 +58,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_startup-script
@@ -58,16 +58,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_startup-script
@@ -58,16 +58,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/launch_templates/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/launch_templates/cloudformation.json.extracted.yaml
@@ -60,16 +60,25 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1amasterslaunchtemplatese
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -388,16 +397,25 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1bmasterslaunchtemplatese
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -716,16 +734,25 @@ Resources.AWSAutoScalingLaunchConfigurationmasterustest1cmasterslaunchtemplatese
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -1044,16 +1071,25 @@ Resources.AWSAutoScalingLaunchConfigurationnodeslaunchtemplatesexamplecom.Proper
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done

--- a/tests/integration/update_cluster/launch_templates/data/aws_launch_configuration_master-us-test-1a.masters.launchtemplates.example.com_user_data
+++ b/tests/integration/update_cluster/launch_templates/data/aws_launch_configuration_master-us-test-1a.masters.launchtemplates.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/launch_templates/data/aws_launch_configuration_master-us-test-1b.masters.launchtemplates.example.com_user_data
+++ b/tests/integration/update_cluster/launch_templates/data/aws_launch_configuration_master-us-test-1b.masters.launchtemplates.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/launch_templates/data/aws_launch_configuration_master-us-test-1c.masters.launchtemplates.example.com_user_data
+++ b/tests/integration/update_cluster/launch_templates/data/aws_launch_configuration_master-us-test-1c.masters.launchtemplates.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/launch_templates/data/aws_launch_configuration_nodes.launchtemplates.example.com_user_data
+++ b/tests/integration/update_cluster/launch_templates/data/aws_launch_configuration_nodes.launchtemplates.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json.extracted.yaml
@@ -60,16 +60,25 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -385,16 +394,25 @@ Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateDa
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done

--- a/tests/integration/update_cluster/minimal/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/minimal/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
@@ -58,16 +58,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
@@ -58,16 +58,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
@@ -60,16 +60,25 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersmixedinstancesexamplecom.Prop
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -388,16 +397,25 @@ Resources.AWSEC2LaunchTemplatemasterustest1bmastersmixedinstancesexamplecom.Prop
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -716,16 +734,25 @@ Resources.AWSEC2LaunchTemplatemasterustest1cmastersmixedinstancesexamplecom.Prop
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -1044,16 +1071,25 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
@@ -60,16 +60,25 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersmixedinstancesexamplecom.Prop
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -388,16 +397,25 @@ Resources.AWSEC2LaunchTemplatemasterustest1bmastersmixedinstancesexamplecom.Prop
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -716,16 +734,25 @@ Resources.AWSEC2LaunchTemplatemasterustest1cmastersmixedinstancesexamplecom.Prop
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -1044,16 +1071,25 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_nodes.private-shared-subnet.example.com_user_data
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_nodes.private-shared-subnet.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
@@ -61,16 +61,25 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivatecalicoexamplecom.Prope
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -383,16 +392,25 @@ Resources.AWSEC2LaunchTemplatenodesprivatecalicoexamplecom.Properties.LaunchTemp
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done

--- a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
+++ b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_nodes.privatecalico.example.com_user_data
+++ b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_nodes.privatecalico.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privatecanal/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data
+++ b/tests/integration/update_cluster/privatecanal/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privatecanal/data/aws_launch_template_nodes.privatecanal.example.com_user_data
+++ b/tests/integration/update_cluster/privatecanal/data/aws_launch_template_nodes.privatecanal.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json.extracted.yaml
@@ -61,16 +61,25 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumexamplecom.Prope
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -383,16 +392,25 @@ Resources.AWSEC2LaunchTemplatenodesprivateciliumexamplecom.Properties.LaunchTemp
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done

--- a/tests/integration/update_cluster/privatecilium/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privatecilium/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium/data/aws_launch_template_nodes.privatecilium.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json.extracted.yaml
@@ -61,16 +61,25 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumexamplecom.Prope
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -383,16 +392,25 @@ Resources.AWSEC2LaunchTemplatenodesprivateciliumexamplecom.Properties.LaunchTemp
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done

--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json.extracted.yaml
@@ -61,16 +61,25 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumadvancedexamplec
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done
@@ -387,16 +396,25 @@ Resources.AWSEC2LaunchTemplatenodesprivateciliumadvancedexamplecom.Properties.La
             echo "== Download failed with ${cmd} =="
             continue
           fi
-          if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            if [[ -n "${hash}" ]]; then
-              echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          if [[ -n "${hash}" ]]; then
+            if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+            elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             else
-              echo "== Downloaded ${url} =="
+              kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+              echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
             fi
-            return
+          else
+            echo "== Downloaded ${url} =="
           fi
         done
       done

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privatedns1/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns1/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privatedns1/data/aws_launch_template_nodes.privatedns1.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns1/data/aws_launch_template_nodes.privatedns1.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privatedns2/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns2/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privatedns2/data/aws_launch_template_nodes.privatedns2.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns2/data/aws_launch_template_nodes.privatedns2.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
+++ b/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privateflannel/data/aws_launch_template_nodes.privateflannel.example.com_user_data
+++ b/tests/integration/update_cluster/privateflannel/data/aws_launch_template_nodes.privateflannel.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_nodes.privatekopeio.example.com_user_data
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_nodes.privatekopeio.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privateweave/data/aws_launch_template_master-us-test-1a.masters.privateweave.example.com_user_data
+++ b/tests/integration/update_cluster/privateweave/data/aws_launch_template_master-us-test-1a.masters.privateweave.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/privateweave/data/aws_launch_template_nodes.privateweave.example.com_user_data
+++ b/tests/integration/update_cluster/privateweave/data/aws_launch_template_nodes.privateweave.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_nodes.sharedvpc.example.com_user_data
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_nodes.sharedvpc.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/unmanaged/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data
+++ b/tests/integration/update_cluster/unmanaged/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done

--- a/tests/integration/update_cluster/unmanaged/data/aws_launch_template_nodes.unmanaged.example.com_user_data
+++ b/tests/integration/update_cluster/unmanaged/data/aws_launch_template_nodes.unmanaged.example.com_user_data
@@ -59,16 +59,25 @@ download-or-bust() {
           echo "== Download failed with ${cmd} =="
           continue
         fi
-        if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          if [[ -n "${hash}" ]]; then
-            echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+        if [[ -n "${hash}" ]]; then
+          if [[ ${url} =~ \.gz$ ]] && command -v gunzip; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.gz" && gunzip "${file}.gz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.bz2$ ]] && command -v bunzip2; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.bz2" && bunzip2 "${file}.bz2" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
+          elif [[ ${url} =~ \.xz$ ]] && command -v xz; then
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            mv "${file}" "${file}.xz" && xz -d "${file}.xz" && kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           else
-            echo "== Downloaded ${url} =="
+            kops::validate-hash "${file}" "${hash}" && { echo "== Downloaded ${url} (SHA1 = ${hash}) =="; return; }
+            echo "== Hash validation of ${url} failed. Retrying. ==" && rm -f "${file}";
           fi
-          return
+        else
+          echo "== Downloaded ${url} =="
         fi
       done
     done


### PR DESCRIPTION
On slower networks, downloading the bootstrap files can be very slow and the nodeup binary is 100Mb and compresses very well.

if the url is a compressed file (url extension), then it will download and try to verify the hash both before and after unzipping (so either the sha256 hash of the compressed or uncompressed file will work).    This should have no impact on anything currently running as it still supports uncompressed. 

```
100 MiB  Fri Aug 21 10:32:13 2020   nodeup
32 MiB  Fri Aug 21 10:32:43 2020   nodeup.bz2
34 MiB  Fri Aug 21 10:29:51 2020   nodeup.gz
28 MiB  Fri Aug 21 10:33:15 2020   nodeup.xz
```

No file compression - 34.189 seconds
```
Attempting download with: curl -f --ipv4 --compressed -Lo nodeup --connect-timeout 20 --retry 6 --retry-delay 10  {url}
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  100M  100  100M    0     0  3085k      0  0:00:33  0:00:33 --:--:-- 3194k
== Downloaded https://srv-file21.gofile.io/download/vkCyT2/nodeup (SHA1 = 8ba8592c06c1be849cbccd82890a2d7e502b6caee49fd812ad1855f4960e92be) ==
./test.sh  0.58s user 0.50s system 3% cpu 34.189 total
```

gzip compression - 12.725 seconds (with extraction)
```
Attempting download with: curl -f --ipv4 --compressed -Lo nodeup --connect-timeout 20 --retry 6 --retry-delay 10  {url}
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 34.6M  100 34.6M    0     0  3087k      0  0:00:11  0:00:11 --:--:-- 3125k
/usr/bin/gunzip
== nodeup corrupted, hash 9c86fad78588d49dc9d171cc89301b7d0dc4313cd13423c5fe4b10f18cce0fbd doesn't match expected 8ba8592c06c1be849cbccd82890a2d7e502b6caee49fd812ad1855f4960e92be ==
== Downloaded https://srv-file21.gofile.io/download/vkCyT2/nodeup.gz (SHA1 = 8ba8592c06c1be849cbccd82890a2d7e502b6caee49fd812ad1855f4960e92be) ==
./test.sh  0.89s user 0.40s system 10% cpu 12.725 total
```

bzip2 compression - 15.088 seconds (with extraction)
```
Attempting download with: curl -f --ipv4 --compressed -Lo nodeup --connect-timeout 20 --retry 6 --retry-delay 10  {url}
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 32.7M  100 32.7M    0     0  3119k      0  0:00:10  0:00:10 --:--:-- 3186k
/usr/bin/bunzip2
== nodeup corrupted, hash aed29eb1f9acab5861244dba2bf098e4851604ab2269817045fc0c4d0cdbe6d6 doesn't match expected 8ba8592c06c1be849cbccd82890a2d7e502b6caee49fd812ad1855f4960e92be ==
== Downloaded https://srv-file21.gofile.io/download/vkCyT2/nodeup.bz2 (SHA1 = 8ba8592c06c1be849cbccd82890a2d7e502b6caee49fd812ad1855f4960e92be) ==
./test.sh  3.82s user 0.56s system 29% cpu 15.088 total
```

XZ compression - 11.758 seconds (with extraction)
```
Attempting download with: curl -f --ipv4 --compressed -Lo nodeup --connect-timeout 20 --retry 6 --retry-delay 10  {url}
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 28.0M  100 28.0M    0     0  3082k      0  0:00:09  0:00:09 --:--:-- 3102k
/usr/local/bin/xz
== nodeup corrupted, hash 3875e05b0b0d3d12c2466375e120ea2203dd300cf7bd0bfe757f4df440aa170f doesn't match expected 8ba8592c06c1be849cbccd82890a2d7e502b6caee49fd812ad1855f4960e92be ==
== Downloaded https://srv-file21.gofile.io/download/vkCyT2/nodeup.xz (SHA1 = 8ba8592c06c1be849cbccd82890a2d7e502b6caee49fd812ad1855f4960e92be) ==
./test.sh  1.98s user 0.50s system 21% cpu 11.758 total
```