### PR TITLE
Update API slice fields to not use pointers

### DIFF
--- a/examples/kops-api-example/up.go
+++ b/examples/kops-api-example/up.go
@@ -52,11 +52,11 @@ func up(ctx context.Context) error {
 	}
 
 	for _, etcdClusterName := range cloudup.EtcdClusters {
-		etcdCluster := &api.EtcdClusterSpec{
+		etcdCluster := api.EtcdClusterSpec{
 			Name: etcdClusterName,
 		}
 		for _, masterZone := range masterZones {
-			etcdMember := &api.EtcdMemberSpec{
+			etcdMember := api.EtcdMemberSpec{
 				Name:          masterZone,
 				InstanceGroup: fi.String(masterZone),
 			}

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -143,7 +143,7 @@ type ClusterSpec struct {
 	// A collection of files assets for deployed cluster wide
 	FileAssets []FileAssetSpec `json:"fileAssets,omitempty"`
 	// EtcdClusters stores the configuration for each cluster
-	EtcdClusters []*EtcdClusterSpec `json:"etcdClusters,omitempty"`
+	EtcdClusters []EtcdClusterSpec `json:"etcdClusters,omitempty"`
 	// Component configurations
 	Containerd                     *ContainerdConfig             `json:"containerd,omitempty"`
 	Docker                         *DockerConfig                 `json:"docker,omitempty"`
@@ -204,7 +204,7 @@ type NodeAuthorizerSpec struct {
 	// Authorizer is the authorizer to use
 	Authorizer string `json:"authorizer,omitempty"`
 	// Features is a series of authorizer features to enable or disable
-	Features *[]string `json:"features,omitempty"`
+	Features []string `json:"features,omitempty"`
 	// Image is the location of container
 	Image string `json:"image,omitempty"`
 	// NodeURL is the node authorization service url
@@ -443,7 +443,7 @@ type EtcdClusterSpec struct {
 	// We default to manager for kubernetes 1.11 or if the manager is configured; otherwise standalone.
 	Provider EtcdProviderType `json:"provider,omitempty"`
 	// Members stores the configurations for each member of the cluster (including the data volume)
-	Members []*EtcdMemberSpec `json:"etcdMembers,omitempty"`
+	Members []EtcdMemberSpec `json:"etcdMembers,omitempty"`
 	// EnableEtcdTLS indicates the etcd service should use TLS between peers and clients
 	EnableEtcdTLS bool `json:"enableEtcdTLS,omitempty"`
 	// EnableTLSAuth indicates client and peer TLS auth should be enforced

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -109,9 +109,9 @@ type InstanceGroupSpec struct {
 	// RootVolumeEncryption enables EBS root volume encryption for an instance
 	RootVolumeEncryption *bool `json:"rootVolumeEncryption,omitempty"`
 	// Volumes is a collection of additional volumes to create for instances within this InstanceGroup
-	Volumes []*VolumeSpec `json:"volumes,omitempty"`
+	Volumes []VolumeSpec `json:"volumes,omitempty"`
 	// VolumeMounts a collection of volume mounts
-	VolumeMounts []*VolumeMountSpec `json:"volumeMounts,omitempty"`
+	VolumeMounts []VolumeMountSpec `json:"volumeMounts,omitempty"`
 	// Subnets is the names of the Subnets (as specified in the Cluster) where machines in this instance group should be placed
 	Subnets []string `json:"subnets,omitempty"`
 	// Zones is the names of the Zones where machines in this instance group should be placed

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -142,7 +142,7 @@ type ClusterSpec struct {
 	// A collection of files assets for deployed cluster wide
 	FileAssets []FileAssetSpec `json:"fileAssets,omitempty"`
 	// EtcdClusters stores the configuration for each cluster
-	EtcdClusters []*EtcdClusterSpec `json:"etcdClusters,omitempty"`
+	EtcdClusters []EtcdClusterSpec `json:"etcdClusters,omitempty"`
 	// Component configurations
 	Containerd                     *ContainerdConfig             `json:"containerd,omitempty"`
 	Docker                         *DockerConfig                 `json:"docker,omitempty"`
@@ -202,7 +202,7 @@ type NodeAuthorizerSpec struct {
 	// Authorizer is the authorizer to use
 	Authorizer string `json:"authorizer,omitempty"`
 	// Features is a series of authorizer features to enable or disable
-	Features *[]string `json:"features,omitempty"`
+	Features []string `json:"features,omitempty"`
 	// Image is the location of container
 	Image string `json:"image,omitempty"`
 	// NodeURL is the node authorization service url
@@ -439,7 +439,7 @@ type EtcdClusterSpec struct {
 	// We default to manager for kubernetes 1.11 or if the manager is configured; otherwise standalone.
 	Provider EtcdProviderType `json:"provider,omitempty"`
 	// Members stores the configurations for each member of the cluster (including the data volume)
-	Members []*EtcdMemberSpec `json:"etcdMembers,omitempty"`
+	Members []EtcdMemberSpec `json:"etcdMembers,omitempty"`
 	// EnableEtcdTLS indicates the etcd service should use TLS between peers and clients
 	EnableEtcdTLS bool `json:"enableEtcdTLS,omitempty"`
 	// EnableTLSAuth indicates client and peer TLS auth should be enforced

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -106,9 +106,9 @@ type InstanceGroupSpec struct {
 	// RootVolumeEncryption enables EBS root volume encryption for an instance
 	RootVolumeEncryption *bool `json:"rootVolumeEncryption,omitempty"`
 	// Volumes is a collection of additional volumes to create for instances within this InstanceGroup
-	Volumes []*VolumeSpec `json:"volumes,omitempty"`
+	Volumes []VolumeSpec `json:"volumes,omitempty"`
 	// VolumeMounts a collection of volume mounts
-	VolumeMounts []*VolumeMountSpec `json:"volumeMounts,omitempty"`
+	VolumeMounts []VolumeMountSpec `json:"volumeMounts,omitempty"`
 	// Subnets is the names of the Subnets (as specified in the Cluster) where machines in this instance group should be placed
 	Subnets []string `json:"subnets,omitempty"`
 	// Zones is the names of the Zones where machines in this instance group should be placed

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1872,10 +1872,9 @@ func autoConvert_v1alpha2_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 	}
 	if in.EtcdClusters != nil {
 		in, out := &in.EtcdClusters, &out.EtcdClusters
-		*out = make([]*kops.EtcdClusterSpec, len(*in))
+		*out = make([]kops.EtcdClusterSpec, len(*in))
 		for i := range *in {
-			// TODO: Inefficient conversion - can we improve it?
-			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+			if err := Convert_v1alpha2_EtcdClusterSpec_To_kops_EtcdClusterSpec(&(*in)[i], &(*out)[i], s); err != nil {
 				return err
 			}
 		}
@@ -2195,10 +2194,9 @@ func autoConvert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, 
 	}
 	if in.EtcdClusters != nil {
 		in, out := &in.EtcdClusters, &out.EtcdClusters
-		*out = make([]*EtcdClusterSpec, len(*in))
+		*out = make([]EtcdClusterSpec, len(*in))
 		for i := range *in {
-			// TODO: Inefficient conversion - can we improve it?
-			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+			if err := Convert_kops_EtcdClusterSpec_To_v1alpha2_EtcdClusterSpec(&(*in)[i], &(*out)[i], s); err != nil {
 				return err
 			}
 		}
@@ -2713,10 +2711,9 @@ func autoConvert_v1alpha2_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdCluste
 	out.Provider = kops.EtcdProviderType(in.Provider)
 	if in.Members != nil {
 		in, out := &in.Members, &out.Members
-		*out = make([]*kops.EtcdMemberSpec, len(*in))
+		*out = make([]kops.EtcdMemberSpec, len(*in))
 		for i := range *in {
-			// TODO: Inefficient conversion - can we improve it?
-			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+			if err := Convert_v1alpha2_EtcdMemberSpec_To_kops_EtcdMemberSpec(&(*in)[i], &(*out)[i], s); err != nil {
 				return err
 			}
 		}
@@ -2762,10 +2759,9 @@ func autoConvert_kops_EtcdClusterSpec_To_v1alpha2_EtcdClusterSpec(in *kops.EtcdC
 	out.Provider = EtcdProviderType(in.Provider)
 	if in.Members != nil {
 		in, out := &in.Members, &out.Members
-		*out = make([]*EtcdMemberSpec, len(*in))
+		*out = make([]EtcdMemberSpec, len(*in))
 		for i := range *in {
-			// TODO: Inefficient conversion - can we improve it?
-			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+			if err := Convert_kops_EtcdMemberSpec_To_v1alpha2_EtcdMemberSpec(&(*in)[i], &(*out)[i], s); err != nil {
 				return err
 			}
 		}
@@ -3310,10 +3306,9 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	out.RootVolumeEncryption = in.RootVolumeEncryption
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
-		*out = make([]*kops.VolumeSpec, len(*in))
+		*out = make([]kops.VolumeSpec, len(*in))
 		for i := range *in {
-			// TODO: Inefficient conversion - can we improve it?
-			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+			if err := Convert_v1alpha2_VolumeSpec_To_kops_VolumeSpec(&(*in)[i], &(*out)[i], s); err != nil {
 				return err
 			}
 		}
@@ -3322,10 +3317,9 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	}
 	if in.VolumeMounts != nil {
 		in, out := &in.VolumeMounts, &out.VolumeMounts
-		*out = make([]*kops.VolumeMountSpec, len(*in))
+		*out = make([]kops.VolumeMountSpec, len(*in))
 		for i := range *in {
-			// TODO: Inefficient conversion - can we improve it?
-			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+			if err := Convert_v1alpha2_VolumeMountSpec_To_kops_VolumeMountSpec(&(*in)[i], &(*out)[i], s); err != nil {
 				return err
 			}
 		}
@@ -3450,10 +3444,9 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	out.RootVolumeEncryption = in.RootVolumeEncryption
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
-		*out = make([]*VolumeSpec, len(*in))
+		*out = make([]VolumeSpec, len(*in))
 		for i := range *in {
-			// TODO: Inefficient conversion - can we improve it?
-			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+			if err := Convert_kops_VolumeSpec_To_v1alpha2_VolumeSpec(&(*in)[i], &(*out)[i], s); err != nil {
 				return err
 			}
 		}
@@ -3462,10 +3455,9 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	}
 	if in.VolumeMounts != nil {
 		in, out := &in.VolumeMounts, &out.VolumeMounts
-		*out = make([]*VolumeMountSpec, len(*in))
+		*out = make([]VolumeMountSpec, len(*in))
 		for i := range *in {
-			// TODO: Inefficient conversion - can we improve it?
-			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+			if err := Convert_kops_VolumeMountSpec_To_v1alpha2_VolumeMountSpec(&(*in)[i], &(*out)[i], s); err != nil {
 				return err
 			}
 		}

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -720,13 +720,9 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 	}
 	if in.EtcdClusters != nil {
 		in, out := &in.EtcdClusters, &out.EtcdClusters
-		*out = make([]*EtcdClusterSpec, len(*in))
+		*out = make([]EtcdClusterSpec, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(EtcdClusterSpec)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Containerd != nil {
@@ -1201,13 +1197,9 @@ func (in *EtcdClusterSpec) DeepCopyInto(out *EtcdClusterSpec) {
 	*out = *in
 	if in.Members != nil {
 		in, out := &in.Members, &out.Members
-		*out = make([]*EtcdMemberSpec, len(*in))
+		*out = make([]EtcdMemberSpec, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(EtcdMemberSpec)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.LeaderElectionTimeout != nil {
@@ -1704,24 +1696,16 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
-		*out = make([]*VolumeSpec, len(*in))
+		*out = make([]VolumeSpec, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(VolumeSpec)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.VolumeMounts != nil {
 		in, out := &in.VolumeMounts, &out.VolumeMounts
-		*out = make([]*VolumeMountSpec, len(*in))
+		*out = make([]VolumeMountSpec, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(VolumeMountSpec)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Subnets != nil {
@@ -3273,12 +3257,8 @@ func (in *NodeAuthorizerSpec) DeepCopyInto(out *NodeAuthorizerSpec) {
 	*out = *in
 	if in.Features != nil {
 		in, out := &in.Features, &out.Features
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.Interval != nil {
 		in, out := &in.Interval, &out.Interval

--- a/pkg/apis/kops/validation/cluster_test.go
+++ b/pkg/apis/kops/validation/cluster_test.go
@@ -26,15 +26,15 @@ import (
 
 func TestValidEtcdChanges(t *testing.T) {
 	grid := []struct {
-		OldSpec *kops.EtcdClusterSpec
-		NewSpec *kops.EtcdClusterSpec
+		OldSpec kops.EtcdClusterSpec
+		NewSpec kops.EtcdClusterSpec
 		Status  *kops.ClusterStatus
 		Details string
 	}{
 		{
-			OldSpec: &kops.EtcdClusterSpec{
+			OldSpec: kops.EtcdClusterSpec{
 				Name: "main",
-				Members: []*kops.EtcdMemberSpec{
+				Members: []kops.EtcdMemberSpec{
 					{
 						Name:          "a",
 						InstanceGroup: fi.String("eu-central-1a"),
@@ -50,9 +50,9 @@ func TestValidEtcdChanges(t *testing.T) {
 				},
 			},
 
-			NewSpec: &kops.EtcdClusterSpec{
+			NewSpec: kops.EtcdClusterSpec{
 				Name: "main",
-				Members: []*kops.EtcdMemberSpec{
+				Members: []kops.EtcdMemberSpec{
 					{
 						Name:          "a",
 						InstanceGroup: fi.String("eu-central-1a"),
@@ -80,9 +80,9 @@ func TestValidEtcdChanges(t *testing.T) {
 		},
 
 		{
-			OldSpec: &kops.EtcdClusterSpec{
+			OldSpec: kops.EtcdClusterSpec{
 				Name: "main",
-				Members: []*kops.EtcdMemberSpec{
+				Members: []kops.EtcdMemberSpec{
 					{
 						Name:          "a",
 						InstanceGroup: fi.String("eu-central-1a"),
@@ -90,9 +90,9 @@ func TestValidEtcdChanges(t *testing.T) {
 				},
 			},
 
-			NewSpec: &kops.EtcdClusterSpec{
+			NewSpec: kops.EtcdClusterSpec{
 				Name: "main",
-				Members: []*kops.EtcdMemberSpec{
+				Members: []kops.EtcdMemberSpec{
 					{
 						Name:          "a",
 						InstanceGroup: fi.String("eu-central-1a"),
@@ -120,9 +120,9 @@ func TestValidEtcdChanges(t *testing.T) {
 		},
 
 		{
-			OldSpec: &kops.EtcdClusterSpec{
+			OldSpec: kops.EtcdClusterSpec{
 				Name: "main",
-				Members: []*kops.EtcdMemberSpec{
+				Members: []kops.EtcdMemberSpec{
 					{
 						Name:          "a",
 						InstanceGroup: fi.String("eu-central-1a"),
@@ -130,9 +130,9 @@ func TestValidEtcdChanges(t *testing.T) {
 				},
 			},
 
-			NewSpec: &kops.EtcdClusterSpec{
+			NewSpec: kops.EtcdClusterSpec{
 				Name: "main",
-				Members: []*kops.EtcdMemberSpec{
+				Members: []kops.EtcdMemberSpec{
 					{
 						Name:          "a",
 						InstanceGroup: fi.String("eu-central-1a"),

--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -123,7 +123,7 @@ func ValidateInstanceGroup(g *kops.InstanceGroup, cloud fi.Cloud) field.ErrorLis
 }
 
 // validateVolumeSpec is responsible for checking a volume spec is ok
-func validateVolumeSpec(path *field.Path, v *kops.VolumeSpec) field.ErrorList {
+func validateVolumeSpec(path *field.Path, v kops.VolumeSpec) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if v.Device == "" {
@@ -137,7 +137,7 @@ func validateVolumeSpec(path *field.Path, v *kops.VolumeSpec) field.ErrorList {
 }
 
 // validateVolumeMountSpec is responsible for checking the volume mount is ok
-func validateVolumeMountSpec(path *field.Path, spec *kops.VolumeMountSpec) field.ErrorList {
+func validateVolumeMountSpec(path *field.Path, spec kops.VolumeMountSpec) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if spec.Device == "" {

--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -102,10 +102,10 @@ func TestValidMasterInstanceGroup(t *testing.T) {
 		{
 			Cluster: &kops.Cluster{
 				Spec: kops.ClusterSpec{
-					EtcdClusters: []*kops.EtcdClusterSpec{
+					EtcdClusters: []kops.EtcdClusterSpec{
 						{
 							Name: "main",
-							Members: []*kops.EtcdMemberSpec{
+							Members: []kops.EtcdMemberSpec{
 								{
 									Name:          "a",
 									InstanceGroup: fi.String("eu-central-1a"),
@@ -137,10 +137,10 @@ func TestValidMasterInstanceGroup(t *testing.T) {
 		{
 			Cluster: &kops.Cluster{
 				Spec: kops.ClusterSpec{
-					EtcdClusters: []*kops.EtcdClusterSpec{
+					EtcdClusters: []kops.EtcdClusterSpec{
 						{
 							Name: "main",
-							Members: []*kops.EtcdMemberSpec{
+							Members: []kops.EtcdMemberSpec{
 								{
 									Name:          "a",
 									InstanceGroup: fi.String("eu-central-1a"),

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -795,7 +795,7 @@ func validateAdditionalPolicy(role string, policy string, fldPath *field.Path) f
 	return errs
 }
 
-func validateEtcdClusterSpec(spec *kops.EtcdClusterSpec, c *kops.Cluster, fieldPath *field.Path) field.ErrorList {
+func validateEtcdClusterSpec(spec kops.EtcdClusterSpec, c *kops.Cluster, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if spec.Name == "" {
@@ -823,7 +823,7 @@ func validateEtcdClusterSpec(spec *kops.EtcdClusterSpec, c *kops.Cluster, fieldP
 }
 
 // validateEtcdBackupStore checks that the etcd clusters backupStore path is unique.
-func validateEtcdBackupStore(specs []*kops.EtcdClusterSpec, fieldPath *field.Path) field.ErrorList {
+func validateEtcdBackupStore(specs []kops.EtcdClusterSpec, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	etcdBackupStore := make(map[string]bool)
 	for _, x := range specs {
@@ -837,7 +837,7 @@ func validateEtcdBackupStore(specs []*kops.EtcdClusterSpec, fieldPath *field.Pat
 }
 
 // validateEtcdTLS checks the TLS settings for etcd are valid
-func validateEtcdTLS(specs []*kops.EtcdClusterSpec, fieldPath *field.Path) field.ErrorList {
+func validateEtcdTLS(specs []kops.EtcdClusterSpec, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	var usingTLS int
 	for _, x := range specs {
@@ -854,7 +854,7 @@ func validateEtcdTLS(specs []*kops.EtcdClusterSpec, fieldPath *field.Path) field
 }
 
 // validateEtcdStorage is responsible for checking versions are identical.
-func validateEtcdStorage(specs []*kops.EtcdClusterSpec, fieldPath *field.Path) field.ErrorList {
+func validateEtcdStorage(specs []kops.EtcdClusterSpec, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	version := specs[0].Version
 	for i, x := range specs {
@@ -868,7 +868,7 @@ func validateEtcdStorage(specs []*kops.EtcdClusterSpec, fieldPath *field.Path) f
 
 // validateEtcdVersion is responsible for validating the storage version of etcd
 // @TODO semvar package doesn't appear to ignore a 'v' in v1.1.1; could be a problem later down the line
-func validateEtcdVersion(spec *kops.EtcdClusterSpec, fieldPath *field.Path, minimalVersion *semver.Version) field.ErrorList {
+func validateEtcdVersion(spec kops.EtcdClusterSpec, fieldPath *field.Path, minimalVersion *semver.Version) field.ErrorList {
 	// @check if the storage is specified that it's valid
 
 	if minimalVersion == nil {
@@ -898,7 +898,7 @@ func validateEtcdVersion(spec *kops.EtcdClusterSpec, fieldPath *field.Path, mini
 }
 
 // validateEtcdMemberSpec is responsible for validate the cluster member
-func validateEtcdMemberSpec(spec *kops.EtcdMemberSpec, fieldPath *field.Path) field.ErrorList {
+func validateEtcdMemberSpec(spec kops.EtcdMemberSpec, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if spec.Name == "" {
 		allErrs = append(allErrs, field.Required(fieldPath.Child("name"), "etcdMember did not have name"))
@@ -911,7 +911,7 @@ func validateEtcdMemberSpec(spec *kops.EtcdMemberSpec, fieldPath *field.Path) fi
 	return allErrs
 }
 
-func ValidateEtcdVersionForCalicoV3(e *kops.EtcdClusterSpec, majorVersion string, fldPath *field.Path) field.ErrorList {
+func ValidateEtcdVersionForCalicoV3(e kops.EtcdClusterSpec, majorVersion string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if e.Version == "" {
@@ -932,7 +932,7 @@ func ValidateEtcdVersionForCalicoV3(e *kops.EtcdClusterSpec, majorVersion string
 	return allErrs
 }
 
-func validateNetworkingCalico(v *kops.CalicoNetworkingSpec, e *kops.EtcdClusterSpec, fldPath *field.Path) field.ErrorList {
+func validateNetworkingCalico(v *kops.CalicoNetworkingSpec, e kops.EtcdClusterSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if v.TyphaReplicas < 0 {

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -342,10 +342,10 @@ func Test_Validate_AdditionalPolicies(t *testing.T) {
 			Subnets: []kops.ClusterSubnetSpec{
 				{Name: "subnet1"},
 			},
-			EtcdClusters: []*kops.EtcdClusterSpec{
+			EtcdClusters: []kops.EtcdClusterSpec{
 				{
 					Name: "main",
-					Members: []*kops.EtcdMemberSpec{
+					Members: []kops.EtcdMemberSpec{
 						{
 							Name:          "us-test-1a",
 							InstanceGroup: fi.String("master-us-test-1a"),
@@ -362,7 +362,7 @@ func Test_Validate_AdditionalPolicies(t *testing.T) {
 
 type caliInput struct {
 	Calico *kops.CalicoNetworkingSpec
-	Etcd   *kops.EtcdClusterSpec
+	Etcd   kops.EtcdClusterSpec
 }
 
 func Test_Validate_Calico(t *testing.T) {
@@ -373,7 +373,7 @@ func Test_Validate_Calico(t *testing.T) {
 		{
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{},
-				Etcd:   &kops.EtcdClusterSpec{},
+				Etcd:   kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -381,7 +381,7 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					TyphaReplicas: 3,
 				},
-				Etcd: &kops.EtcdClusterSpec{},
+				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -389,7 +389,7 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					TyphaReplicas: -1,
 				},
-				Etcd: &kops.EtcdClusterSpec{},
+				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{"Invalid value::calico.typhaReplicas"},
 		},
@@ -398,7 +398,7 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					MajorVersion: "v3",
 				},
-				Etcd: &kops.EtcdClusterSpec{
+				Etcd: kops.EtcdClusterSpec{
 					Version: "3.2.18",
 				},
 			},
@@ -408,7 +408,7 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					MajorVersion: "v3",
 				},
-				Etcd: &kops.EtcdClusterSpec{
+				Etcd: kops.EtcdClusterSpec{
 					Version: "2.2.18",
 				},
 			},
@@ -419,7 +419,7 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "first-found",
 				},
-				Etcd: &kops.EtcdClusterSpec{},
+				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -427,7 +427,7 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv6AutoDetectionMethod: "first-found",
 				},
-				Etcd: &kops.EtcdClusterSpec{},
+				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -435,7 +435,7 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "can-reach=8.8.8.8",
 				},
-				Etcd: &kops.EtcdClusterSpec{},
+				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -443,7 +443,7 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv6AutoDetectionMethod: "can-reach=2001:4860:4860::8888",
 				},
-				Etcd: &kops.EtcdClusterSpec{},
+				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -451,7 +451,7 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "bogus",
 				},
-				Etcd: &kops.EtcdClusterSpec{},
+				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
 		},
@@ -460,7 +460,7 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv6AutoDetectionMethod: "bogus",
 				},
-				Etcd: &kops.EtcdClusterSpec{},
+				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{"Invalid value::calico.ipv6AutoDetectionMethod"},
 		},
@@ -469,7 +469,7 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv6AutoDetectionMethod: "interface=",
 				},
-				Etcd: &kops.EtcdClusterSpec{},
+				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{"Invalid value::calico.ipv6AutoDetectionMethod"},
 		},
@@ -478,7 +478,7 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "interface=en.*,eth0",
 				},
-				Etcd: &kops.EtcdClusterSpec{},
+				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -486,7 +486,7 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv6AutoDetectionMethod: "skip-interface=en.*,eth0",
 				},
-				Etcd: &kops.EtcdClusterSpec{},
+				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -494,7 +494,7 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "interface=(,en1",
 				},
-				Etcd: &kops.EtcdClusterSpec{},
+				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
 		},
@@ -503,7 +503,7 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "interface=foo=bar",
 				},
-				Etcd: &kops.EtcdClusterSpec{},
+				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
 		},
@@ -512,7 +512,7 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "=en0,eth.*",
 				},
-				Etcd: &kops.EtcdClusterSpec{},
+				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
 		},

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -820,13 +820,9 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 	}
 	if in.EtcdClusters != nil {
 		in, out := &in.EtcdClusters, &out.EtcdClusters
-		*out = make([]*EtcdClusterSpec, len(*in))
+		*out = make([]EtcdClusterSpec, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(EtcdClusterSpec)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Containerd != nil {
@@ -1324,13 +1320,9 @@ func (in *EtcdClusterSpec) DeepCopyInto(out *EtcdClusterSpec) {
 	*out = *in
 	if in.Members != nil {
 		in, out := &in.Members, &out.Members
-		*out = make([]*EtcdMemberSpec, len(*in))
+		*out = make([]EtcdMemberSpec, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(EtcdMemberSpec)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.LeaderElectionTimeout != nil {
@@ -1870,24 +1862,16 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
-		*out = make([]*VolumeSpec, len(*in))
+		*out = make([]VolumeSpec, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(VolumeSpec)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.VolumeMounts != nil {
 		in, out := &in.VolumeMounts, &out.VolumeMounts
-		*out = make([]*VolumeMountSpec, len(*in))
+		*out = make([]VolumeMountSpec, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(VolumeMountSpec)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Subnets != nil {
@@ -3471,12 +3455,8 @@ func (in *NodeAuthorizerSpec) DeepCopyInto(out *NodeAuthorizerSpec) {
 	*out = *in
 	if in.Features != nil {
 		in, out := &in.Features, &out.Features
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.Interval != nil {
 		in, out := &in.Interval, &out.Interval

--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -65,7 +65,7 @@ type Config struct {
 	// it would appear in sysctl.conf.
 	SysctlParameters []string `json:",omitempty"`
 	// VolumeMounts are a collection of volume mounts.
-	VolumeMounts []*kops.VolumeMountSpec `json:",omitempty"`
+	VolumeMounts []kops.VolumeMountSpec `json:",omitempty"`
 }
 
 // Image is a docker image we should pre-load

--- a/pkg/commands/set_cluster.go
+++ b/pkg/commands/set_cluster.go
@@ -116,31 +116,32 @@ func SetClusterFields(fields []string, cluster *api.Cluster, instanceGroups []*a
 			if err != nil {
 				return fmt.Errorf("unknown boolean value: %q", kv[1])
 			}
-			for _, c := range cluster.Spec.EtcdClusters {
-				c.EnableEtcdTLS = v
+			for i := range cluster.Spec.EtcdClusters {
+				cluster.Spec.EtcdClusters[i].EnableEtcdTLS = v
 			}
 		case "cluster.spec.etcdClusters[*].enableTLSAuth":
 			v, err := strconv.ParseBool(kv[1])
 			if err != nil {
 				return fmt.Errorf("unknown boolean value: %q", kv[1])
 			}
-			for _, c := range cluster.Spec.EtcdClusters {
-				c.EnableTLSAuth = v
+			for i := range cluster.Spec.EtcdClusters {
+				cluster.Spec.EtcdClusters[i].EnableTLSAuth = v
 			}
 		case "cluster.spec.etcdClusters[*].version":
-			for _, c := range cluster.Spec.EtcdClusters {
-				c.Version = kv[1]
+			for i := range cluster.Spec.EtcdClusters {
+				cluster.Spec.EtcdClusters[i].Version = kv[1]
 			}
 		case "cluster.spec.etcdClusters[*].provider":
 			p, err := toEtcdProviderType(kv[1])
 			if err != nil {
 				return err
 			}
-			for _, etcd := range cluster.Spec.EtcdClusters {
-				etcd.Provider = p
+			for i := range cluster.Spec.EtcdClusters {
+				cluster.Spec.EtcdClusters[i].Provider = p
 			}
 		case "cluster.spec.etcdClusters[*].manager.image":
-			for _, etcd := range cluster.Spec.EtcdClusters {
+			for i := range cluster.Spec.EtcdClusters {
+				etcd := &cluster.Spec.EtcdClusters[i]
 				if etcd.Manager == nil {
 					etcd.Manager = &api.EtcdManagerSpec{}
 				}

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -231,7 +231,8 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchConfigurationTask(c *fi.ModelB
 	}
 
 	// @step: add any additional block devices to the launch configuration
-	for _, x := range ig.Spec.Volumes {
+	for i := range ig.Spec.Volumes {
+		x := &ig.Spec.Volumes[i]
 		if x.Type == "" {
 			x.Type = DefaultVolumeType
 		}

--- a/pkg/model/bootstrapscript_test.go
+++ b/pkg/model/bootstrapscript_test.go
@@ -169,10 +169,10 @@ func makeTestCluster(hookSpecRoles []kops.InstanceGroupRole, fileAssetSpecRoles 
 				{Name: "test", Zone: "eu-west-1a"},
 			},
 			NonMasqueradeCIDR: "10.100.0.0/16",
-			EtcdClusters: []*kops.EtcdClusterSpec{
+			EtcdClusters: []kops.EtcdClusterSpec{
 				{
 					Name: "main",
-					Members: []*kops.EtcdMemberSpec{
+					Members: []kops.EtcdMemberSpec{
 						{
 							Name:          "test",
 							InstanceGroup: s("ig-1"),
@@ -182,7 +182,7 @@ func makeTestCluster(hookSpecRoles []kops.InstanceGroupRole, fileAssetSpecRoles 
 				},
 				{
 					Name: "events",
-					Members: []*kops.EtcdMemberSpec{
+					Members: []kops.EtcdMemberSpec{
 						{
 							Name:          "test",
 							InstanceGroup: s("ig-1"),

--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -50,7 +50,8 @@ const (
 func (b *EtcdOptionsBuilder) BuildOptions(o interface{}) error {
 	spec := o.(*kops.ClusterSpec)
 
-	for _, c := range spec.EtcdClusters {
+	for i := range spec.EtcdClusters {
+		c := &spec.EtcdClusters[i]
 		if c.Provider == "" {
 			if b.IsKubernetesGTE("1.12") {
 				c.Provider = kops.EtcdProviderTypeManager
@@ -110,11 +111,8 @@ func (b *EtcdOptionsBuilder) BuildOptions(o interface{}) error {
 				c.EnableTLSAuth = true
 			}
 		}
-	}
 
-	// Remap the well known images
-	for _, c := range spec.EtcdClusters {
-
+		// Remap the well known images
 		// We remap the etcd manager image when we build the manifest,
 		// but we need to map the standalone images here because protokube launches them
 

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -157,7 +157,7 @@ type etcdClusterSpec struct {
 	EtcdVersion string `json:"etcdVersion,omitempty"`
 }
 
-func (b *EtcdManagerBuilder) buildManifest(etcdCluster *kops.EtcdClusterSpec) (*v1.Pod, error) {
+func (b *EtcdManagerBuilder) buildManifest(etcdCluster kops.EtcdClusterSpec) (*v1.Pod, error) {
 	return b.buildPod(etcdCluster)
 }
 
@@ -199,7 +199,7 @@ spec:
 `
 
 // buildPod creates the pod spec, based on the EtcdClusterSpec
-func (b *EtcdManagerBuilder) buildPod(etcdCluster *kops.EtcdClusterSpec) (*v1.Pod, error) {
+func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec) (*v1.Pod, error) {
 	var pod *v1.Pod
 	var container *v1.Container
 

--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -39,7 +39,8 @@ var _ loader.OptionsBuilder = &EtcdManagerOptionsBuilder{}
 func (b *EtcdManagerOptionsBuilder) BuildOptions(o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 
-	for _, etcdCluster := range clusterSpec.EtcdClusters {
+	for i := range clusterSpec.EtcdClusters {
+		etcdCluster := &clusterSpec.EtcdClusters[i]
 		if etcdCluster.Provider != kops.EtcdProviderTypeManager {
 			continue
 		}

--- a/pkg/model/components/node-authorizer/options.go
+++ b/pkg/model/components/node-authorizer/options.go
@@ -86,7 +86,7 @@ func (b *OptionsBuilder) BuildOptions(o interface{}) error {
 				case kops.CloudProviderAWS:
 					features = append(features, "verify-signature")
 				}
-				na.NodeAuthorizer.Features = &features
+				na.NodeAuthorizer.Features = features
 			}
 		}
 	}

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -144,9 +144,9 @@ func TestPolicyGeneration(t *testing.T) {
 						Legacy:                 x.LegacyIAM,
 						AllowContainerRegistry: x.AllowContainerRegistry,
 					},
-					EtcdClusters: []*kops.EtcdClusterSpec{
+					EtcdClusters: []kops.EtcdClusterSpec{
 						{
-							Members: []*kops.EtcdMemberSpec{
+							Members: []kops.EtcdMemberSpec{
 								{
 									KmsKeyId: aws.String("key-id-1"),
 								},
@@ -156,10 +156,10 @@ func TestPolicyGeneration(t *testing.T) {
 							},
 						},
 						{
-							Members: []*kops.EtcdMemberSpec{},
+							Members: []kops.EtcdMemberSpec{},
 						},
 						{
-							Members: []*kops.EtcdMemberSpec{
+							Members: []kops.EtcdMemberSpec{
 								{
 									KmsKeyId: aws.String("key-id-3"),
 								},

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -115,7 +115,7 @@ func (b *MasterVolumeBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-func (b *MasterVolumeBuilder) addAWSVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) error {
+func (b *MasterVolumeBuilder) addAWSVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) error {
 	volumeType := fi.StringValue(m.VolumeType)
 	volumeIops := fi.Int32Value(m.VolumeIops)
 	switch volumeType {
@@ -171,7 +171,7 @@ func (b *MasterVolumeBuilder) addAWSVolume(c *fi.ModelBuilderContext, name strin
 	return nil
 }
 
-func (b *MasterVolumeBuilder) addDOVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) {
+func (b *MasterVolumeBuilder) addDOVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) {
 	// required that names start with a lower case and only contains letters, numbers and hyphens
 	name = "kops-" + do.SafeClusterName(name)
 
@@ -198,7 +198,7 @@ func (b *MasterVolumeBuilder) addDOVolume(c *fi.ModelBuilderContext, name string
 	c.AddTask(t)
 }
 
-func (b *MasterVolumeBuilder) addGCEVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) {
+func (b *MasterVolumeBuilder) addGCEVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) {
 	volumeType := fi.StringValue(m.VolumeType)
 	if volumeType == "" {
 		volumeType = DefaultGCEEtcdVolumeType
@@ -245,7 +245,7 @@ func (b *MasterVolumeBuilder) addGCEVolume(c *fi.ModelBuilderContext, name strin
 	c.AddTask(t)
 }
 
-func (b *MasterVolumeBuilder) addOpenstackVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) error {
+func (b *MasterVolumeBuilder) addOpenstackVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) error {
 	volumeType := fi.StringValue(m.VolumeType)
 	if volumeType == "" {
 		return fmt.Errorf("must set ETCDMemberSpec.VolumeType on Openstack platform")
@@ -279,7 +279,7 @@ func (b *MasterVolumeBuilder) addOpenstackVolume(c *fi.ModelBuilderContext, name
 	return nil
 }
 
-func (b *MasterVolumeBuilder) addALIVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) {
+func (b *MasterVolumeBuilder) addALIVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) {
 	//Alicloud does not support volumeName starts with number
 	name = "v" + name
 	volumeType := fi.StringValue(m.VolumeType)

--- a/upup/pkg/fi/cloudup/deepvalidate_test.go
+++ b/upup/pkg/fi/cloudup/deepvalidate_test.go
@@ -128,10 +128,10 @@ func TestDeepValidate_ExtraMasterZone(t *testing.T) {
 
 func TestDeepValidate_EvenEtcdClusterSize(t *testing.T) {
 	c := buildDefaultCluster(t)
-	c.Spec.EtcdClusters = []*kopsapi.EtcdClusterSpec{
+	c.Spec.EtcdClusters = []kopsapi.EtcdClusterSpec{
 		{
 			Name: "main",
-			Members: []*kopsapi.EtcdMemberSpec{
+			Members: []kopsapi.EtcdMemberSpec{
 				{Name: "us-mock-1a", InstanceGroup: fi.String("us-mock-1a")},
 				{Name: "us-mock-1b", InstanceGroup: fi.String("us-mock-1b")},
 			},
@@ -150,10 +150,10 @@ func TestDeepValidate_EvenEtcdClusterSize(t *testing.T) {
 
 func TestDeepValidate_MissingEtcdMember(t *testing.T) {
 	c := buildDefaultCluster(t)
-	c.Spec.EtcdClusters = []*kopsapi.EtcdClusterSpec{
+	c.Spec.EtcdClusters = []kopsapi.EtcdClusterSpec{
 		{
 			Name: "main",
-			Members: []*kopsapi.EtcdMemberSpec{
+			Members: []kopsapi.EtcdMemberSpec{
 				{Name: "us-mock-1a", InstanceGroup: fi.String("us-mock-1a")},
 				{Name: "us-mock-1b", InstanceGroup: fi.String("us-mock-1b")},
 				{Name: "us-mock-1c", InstanceGroup: fi.String("us-mock-1c")},

--- a/upup/pkg/fi/cloudup/dns_test.go
+++ b/upup/pkg/fi/cloudup/dns_test.go
@@ -29,10 +29,10 @@ func TestPrecreateDNSNames(t *testing.T) {
 	cluster.ObjectMeta.Name = "cluster1.example.com"
 	cluster.Spec.MasterPublicName = "api." + cluster.ObjectMeta.Name
 	cluster.Spec.MasterInternalName = "api.internal." + cluster.ObjectMeta.Name
-	cluster.Spec.EtcdClusters = []*kops.EtcdClusterSpec{
+	cluster.Spec.EtcdClusters = []kops.EtcdClusterSpec{
 		{
 			Name: "main",
-			Members: []*kops.EtcdMemberSpec{
+			Members: []kops.EtcdMemberSpec{
 				{Name: "zone1"},
 				{Name: "zone2"},
 				{Name: "zone3"},
@@ -40,7 +40,7 @@ func TestPrecreateDNSNames(t *testing.T) {
 		},
 		{
 			Name: "events",
-			Members: []*kops.EtcdMemberSpec{
+			Members: []kops.EtcdMemberSpec{
 				{Name: "zonea"},
 				{Name: "zoneb"},
 				{Name: "zonec"},

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -961,8 +961,8 @@ func initializeOpenstackAPI(opt *NewClusterOptions, cluster *api.Cluster) {
 	}
 }
 
-func createEtcdCluster(etcdCluster string, masters []*api.InstanceGroup, encryptEtcdStorage bool, etcdStorageType string) *api.EtcdClusterSpec {
-	etcd := &api.EtcdClusterSpec{}
+func createEtcdCluster(etcdCluster string, masters []*api.InstanceGroup, encryptEtcdStorage bool, etcdStorageType string) api.EtcdClusterSpec {
+	etcd := api.EtcdClusterSpec{}
 	etcd.Name = etcdCluster
 
 	// if this is the main cluster, we use 200 millicores by default.
@@ -991,7 +991,7 @@ func createEtcdCluster(etcdCluster string, masters []*api.InstanceGroup, encrypt
 	names = trimCommonPrefix(names)
 
 	for i, ig := range masters {
-		m := &api.EtcdMemberSpec{}
+		m := api.EtcdMemberSpec{}
 		if encryptEtcdStorage {
 			m.EncryptedVolume = &encryptEtcdStorage
 		}

--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -138,17 +138,17 @@ func (c *populateClusterSpec) run(clientset simple.Clientset) error {
 					}
 				}
 
-				etcdInstanceGroups := make(map[string]*kopsapi.EtcdMemberSpec)
-				etcdNames := make(map[string]*kopsapi.EtcdMemberSpec)
+				etcdInstanceGroups := make(map[string]kopsapi.EtcdMemberSpec)
+				etcdNames := make(map[string]kopsapi.EtcdMemberSpec)
 
 				for _, m := range etcd.Members {
-					if etcdNames[m.Name] != nil {
+					if _, ok := etcdNames[m.Name]; ok {
 						return fmt.Errorf("EtcdMembers found with same name %q in etcd-cluster %q", m.Name, etcd.Name)
 					}
 
 					instanceGroupName := fi.StringValue(m.InstanceGroup)
 
-					if etcdInstanceGroups[instanceGroupName] != nil {
+					if _, ok := etcdInstanceGroups[instanceGroupName]; ok {
 						klog.Warningf("EtcdMembers are in the same InstanceGroup %q in etcd-cluster %q (fault-tolerance may be reduced)", instanceGroupName, etcd.Name)
 					}
 

--- a/upup/pkg/fi/cloudup/populatecluster_test.go
+++ b/upup/pkg/fi/cloudup/populatecluster_test.go
@@ -74,10 +74,10 @@ func addEtcdClusters(c *kopsapi.Cluster) {
 	etcdZones := subnetNames.List()
 
 	for _, etcdCluster := range EtcdClusters {
-		etcd := &kopsapi.EtcdClusterSpec{}
+		etcd := kopsapi.EtcdClusterSpec{}
 		etcd.Name = etcdCluster
 		for _, zone := range etcdZones {
-			m := &kopsapi.EtcdMemberSpec{}
+			m := kopsapi.EtcdMemberSpec{}
 			m.Name = zone
 			m.InstanceGroup = fi.String(zone)
 			etcd.Members = append(etcd.Members, m)

--- a/upup/pkg/fi/cloudup/validation_test.go
+++ b/upup/pkg/fi/cloudup/validation_test.go
@@ -41,10 +41,10 @@ func buildDefaultCluster(t *testing.T) *api.Cluster {
 
 		for _, etcdCluster := range EtcdClusters {
 
-			etcd := &api.EtcdClusterSpec{}
+			etcd := api.EtcdClusterSpec{}
 			etcd.Name = etcdCluster
 			for _, subnet := range c.Spec.Subnets {
-				m := &api.EtcdMemberSpec{}
+				m := api.EtcdMemberSpec{}
 				m.Name = subnet.Zone
 				m.InstanceGroup = fi.String("master-" + subnet.Name)
 				etcd.Members = append(etcd.Members, m)

--- a/upup/pkg/kutil/import_cluster.go
+++ b/upup/pkg/kutil/import_cluster.go
@@ -357,12 +357,12 @@ func (x *ImportCluster) ImportAWSCluster(ctx context.Context) error {
 	// }
 
 	for _, etcdClusterName := range []string{"main", "events"} {
-		etcdCluster := &kops.EtcdClusterSpec{
+		etcdCluster := kops.EtcdClusterSpec{
 			Name: etcdClusterName,
 		}
 
 		for _, ig := range masterInstanceGroups {
-			member := &kops.EtcdMemberSpec{
+			member := kops.EtcdMemberSpec{
 				InstanceGroup: fi.String(ig.ObjectMeta.Name),
 			}
 


### PR DESCRIPTION
A slice of pointers causes problems with the Kubernetes 1.19 code-generator.

A nil entry in these slices isn't valid anyways, so this should have no impact short of being a breaking change for anyone importing these API types.