### PR TITLE
Bump stable versions from alpha

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -59,13 +59,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.18.0"
-    recommendedVersion: 1.18.6
+    recommendedVersion: 1.18.8
     requiredVersion: 1.18.0
   - range: ">=1.17.0"
-    recommendedVersion: 1.17.9
+    recommendedVersion: 1.17.11
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
-    recommendedVersion: 1.16.13
+    recommendedVersion: 1.16.14
     requiredVersion: 1.16.0
   - range: ">=1.15.0"
     recommendedVersion: 1.15.12
@@ -93,15 +93,15 @@ spec:
   - range: ">=1.18.0-alpha.1"
     recommendedVersion: "1.18.0"
     #requiredVersion: 1.18.0
-    kubernetesVersion: 1.18.6
+    kubernetesVersion: 1.18.8
   - range: ">=1.17.0-alpha.1"
     recommendedVersion: "1.17.1"
     #requiredVersion: 1.17.0
-    kubernetesVersion: 1.17.9
+    kubernetesVersion: 1.17.11
   - range: ">=1.16.0-alpha.1"
     recommendedVersion: "1.16.4"
     #requiredVersion: 1.16.0
-    kubernetesVersion: 1.16.13
+    kubernetesVersion: 1.16.14
   - range: ">=1.15.0-alpha.1"
     recommendedVersion: "1.15.3"
     #requiredVersion: 1.15.0


### PR DESCRIPTION
11 days have passed since these version were pushed to alpha ([ref](https://github.com/kubernetes/kops/commit/9f768c127511b30c0094d2f2a7df3fd7da688ae7#diff-37c59376fa8938637370b21d9540af69)).
We should be good bumping to stable at this point.