### PR TITLE
Stop trying to pull the Protokube image

### DIFF
--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -119,10 +119,6 @@ func (t *ProtokubeBuilder) buildSystemdService() (*nodetasks.Service, error) {
 		return nil, err
 	}
 
-	protokubeImagePullCommand, err := t.ProtokubeImagePullCommand()
-	if err != nil {
-		return nil, err
-	}
 	protokubeContainerStopCommand, err := t.ProtokubeContainerStopCommand()
 	if err != nil {
 		return nil, err
@@ -143,10 +139,9 @@ func (t *ProtokubeBuilder) buildSystemdService() (*nodetasks.Service, error) {
 	// @step: let need a dependency for any volumes to be mounted first
 	manifest.Set("Service", "ExecStartPre", protokubeContainerStopCommand)
 	manifest.Set("Service", "ExecStartPre", protokubeContainerRemoveCommand)
-	manifest.Set("Service", "ExecStartPre", protokubeImagePullCommand)
 	manifest.Set("Service", "ExecStart", protokubeContainerRunCommand+" "+protokubeRunArgs)
 	manifest.Set("Service", "Restart", "always")
-	manifest.Set("Service", "RestartSec", "2s")
+	manifest.Set("Service", "RestartSec", "3s")
 	manifest.Set("Service", "StartLimitInterval", "0")
 	manifest.Set("Install", "WantedBy", "multi-user.target")
 
@@ -174,32 +169,6 @@ func (t *ProtokubeBuilder) ProtokubeImageName() string {
 		name = kopsbase.DefaultProtokubeImageName()
 	}
 	return name
-}
-
-// ProtokubeImagePullCommand returns the command to pull the image
-func (t *ProtokubeBuilder) ProtokubeImagePullCommand() (string, error) {
-	var sources []string
-	if t.NodeupConfig.ProtokubeImage[t.Architecture] != nil {
-		sources = t.NodeupConfig.ProtokubeImage[t.Architecture].Sources
-	}
-	if len(sources) == 0 {
-		// Nothing to pull; return dummy value
-		return "/bin/true", nil
-	}
-	if strings.HasPrefix(sources[0], "http:") || strings.HasPrefix(sources[0], "https:") || strings.HasPrefix(sources[0], "s3:") {
-		// We preloaded the image; return a dummy value
-		return "/bin/true", nil
-	}
-
-	var protokubeImagePullCommand string
-	if t.Cluster.Spec.ContainerRuntime == "docker" {
-		protokubeImagePullCommand = "-/usr/bin/docker pull " + sources[0]
-	} else if t.Cluster.Spec.ContainerRuntime == "containerd" {
-		protokubeImagePullCommand = "-/usr/bin/ctr --namespace k8s.io images pull docker.io/" + sources[0]
-	} else {
-		return "", fmt.Errorf("unable to create protokube image pull command for unsupported runtime %q", t.Cluster.Spec.ContainerRuntime)
-	}
-	return protokubeImagePullCommand, nil
 }
 
 // ProtokubeContainerStopCommand returns the command that stops the Protokube container, before being removed

--- a/nodeup/pkg/model/tests/protokube/containerd/tasks-protokube.yaml
+++ b/nodeup/pkg/model/tests/protokube/containerd/tasks-protokube.yaml
@@ -85,10 +85,9 @@ definition: |
   [Service]
   ExecStartPre=/bin/true
   ExecStartPre=-/usr/bin/ctr --namespace k8s.io container rm protokube
-  ExecStartPre=/bin/true
   ExecStart=/usr/bin/ctr --namespace k8s.io run --net-host --with-ns pid:/proc/1/ns/pid --privileged --mount type=bind,src=/,dst=/rootfs,options=rbind:rslave --env KUBECONFIG=/rootfs/var/lib/kops/kubeconfig --mount type=bind,src=/bin,dst=/bin,options=rbind:ro:rprivate --mount type=bind,src=/lib,dst=/lib,options=rbind:ro:rprivate --mount type=bind,src=/lib64,dst=/lib64,options=rbind:ro:rprivate --mount type=bind,src=/sbin,dst=/sbin,options=rbind:ro:rprivate --mount type=bind,src=/usr/bin,dst=/usr/bin,options=rbind:ro:rprivate --mount type=bind,src=/var/run/dbus,dst=/var/run/dbus,options=rbind:rprivate --mount type=bind,src=/run/systemd,dst=/run/systemd,options=rbind:rprivate --mount type=bind,src=/usr/local/bin,dst=/opt/kops/bin,options=rbind:ro:rprivate --env PATH=/opt/kops/bin:/usr/bin:/sbin:/bin docker.io/library/protokube image name protokube /protokube --bootstrap-master-node-labels=true --cloud=aws --containerized=true --dns-internal-suffix=.internal.minimal.example.com --dns=aws-route53 --etcd-backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main --etcd-image=k8s.gcr.io/etcd:3.4.3 --initialize-rbac=true --manage-etcd=true --master=true --node-name=master.hostname.invalid --peer-ca=/srv/kubernetes/ca.crt --peer-cert=/srv/kubernetes/etcd-peer.pem --peer-key=/srv/kubernetes/etcd-peer-key.pem --tls-auth=true --tls-ca=/srv/kubernetes/ca.crt --tls-cert=/srv/kubernetes/etcd.pem --tls-key=/srv/kubernetes/etcd-key.pem --v=4 --zone=*/Z1AFAKE1ZON3YO
   Restart=always
-  RestartSec=2s
+  RestartSec=3s
   StartLimitInterval=0
 
   [Install]

--- a/nodeup/pkg/model/tests/protokube/docker/tasks-protokube.yaml
+++ b/nodeup/pkg/model/tests/protokube/docker/tasks-protokube.yaml
@@ -85,10 +85,9 @@ definition: |
   [Service]
   ExecStartPre=-/usr/bin/docker stop protokube
   ExecStartPre=-/usr/bin/docker rm protokube
-  ExecStartPre=/bin/true
   ExecStart=/usr/bin/docker run --net=host --pid=host --privileged --volume /:/rootfs --env KUBECONFIG=/rootfs/var/lib/kops/kubeconfig --volume /bin:/bin:ro --volume /lib:/lib:ro --volume /lib64:/lib64:ro --volume /sbin:/sbin:ro --volume /usr/bin:/usr/bin:ro --volume /var/run/dbus:/var/run/dbus --volume /run/systemd:/run/systemd --volume /usr/local/bin:/opt/kops/bin:ro --env PATH=/opt/kops/bin:/usr/bin:/sbin:/bin --name protokube protokube image name /protokube --bootstrap-master-node-labels=true --cloud=aws --containerized=true --dns-internal-suffix=internal.minimal.k8s.local --dns=gossip --etcd-backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main --etcd-image=k8s.gcr.io/etcd:3.4.3 --initialize-rbac=true --manage-etcd=true --master=true --node-name=master.override.invalid --peer-ca=/srv/kubernetes/ca.crt --peer-cert=/srv/kubernetes/etcd-peer.pem --peer-key=/srv/kubernetes/etcd-peer-key.pem --tls-auth=true --tls-ca=/srv/kubernetes/ca.crt --tls-cert=/srv/kubernetes/etcd.pem --tls-key=/srv/kubernetes/etcd-key.pem --v=4 --zone=*/Z1AFAKE1ZON3YO
   Restart=always
-  RestartSec=2s
+  RestartSec=3s
   StartLimitInterval=0
 
   [Install]


### PR DESCRIPTION
Protokube is always side-loaded. It is never pushed to a Docker registry, so there is no reason to pull it.
```yaml
protokubeImage:
  hash: 8f09e5b87f6df65e1579c56775f7c9c6ddac315579f367129c0ed297c46840f5
  name: protokube:1.18.0
  sources:
  - https://artifacts.k8s.io/binaries/kops/1.18.0/images/protokube.tar.gz
  - https://github.com/kubernetes/kops/releases/download/v1.18.0/images-protokube.tar.gz
  - https://kubeupv2.s3.amazonaws.com/kops/1.18.0/images/protokube.tar.gz
```