### PR TITLE
Support writing a full certificate chain

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -446,7 +446,6 @@ func (c *NodeupModelContext) BuildCertificateTask(ctx *fi.ModelBuilderContext, n
 	if err != nil {
 		return err
 	}
-
 	p := filename
 	if !filepath.IsAbs(p) {
 		p = filepath.Join(c.PathSrvKubernetes(), filename)

--- a/nodeup/pkg/model/secrets.go
+++ b/nodeup/pkg/model/secrets.go
@@ -120,6 +120,10 @@ func (b *SecretBuilder) Build(c *fi.ModelBuilderContext) error {
 			Subject:        nodetasks.PKIXName{CommonName: "kubernetes-master"},
 			AlternateNames: alternateNames,
 		}
+
+		// Including the CA certificate is more correct, and is needed for e.g. AWS WebIdentity federation
+		issueCert.IncludeRootCertificate = true
+
 		c.AddTask(issueCert)
 		err := issueCert.AddFileTasks(c, b.PathSrvKubernetes(), "server", "", nil)
 		if err != nil {

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-secret.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-secret.yaml
@@ -70,6 +70,7 @@ contents:
     - api.internal.minimal.example.com
     - 100.64.0.1
     - 127.0.0.1
+    includeRootCertificate: true
     signer: ca
     subject:
       CommonName: kubernetes-master
@@ -90,6 +91,7 @@ contents:
     - api.internal.minimal.example.com
     - 100.64.0.1
     - 127.0.0.1
+    includeRootCertificate: true
     signer: ca
     subject:
       CommonName: kubernetes-master
@@ -146,6 +148,7 @@ alternateNames:
 - api.internal.minimal.example.com
 - 100.64.0.1
 - 127.0.0.1
+includeRootCertificate: true
 signer: ca
 subject:
   CommonName: kubernetes-master


### PR DESCRIPTION
This means that our https endpoint will serve the ca.crt as well.