### PR TITLE
Fix GCE cluster creation with private topology

### DIFF
--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -856,9 +856,10 @@ func setupTopology(opt *NewClusterOptions, cluster *api.Cluster, allZones sets.S
 				continue
 			}
 			subnet := api.ClusterSubnetSpec{
-				Name: "utility-" + s.Name,
-				Zone: s.Zone,
-				Type: api.SubnetTypeUtility,
+				Name:   "utility-" + s.Name,
+				Zone:   s.Zone,
+				Type:   api.SubnetTypeUtility,
+				Region: s.Region,
 			}
 			if subnetID, ok := zoneToSubnetProviderID[s.Zone]; ok {
 				subnet.ProviderID = subnetID


### PR DESCRIPTION
This was later failing api validation with:

`spec.subnets[1].region: Required value: region must be specified for GCE subnets`

So now we copy the region value from the equivalent non-utility subnet when creating utility subnets.

While the value is only set and referenced in GCE, it should be safe to copy the zero-value for other cloud providers.

ref: https://github.com/kubernetes/kops/issues/8626#issuecomment-680242593