### PR TITLE
Automated cherry pick of #9689: Support for using hostPort when using kube-router #9818: Update kube-router to v1.0.1

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -6429,7 +6429,7 @@ func cloudupResourcesAddonsNetworkingKopeIoK8s16Yaml() (*asset, error) {
 	return a, nil
 }
 
-var _cloudupResourcesAddonsNetworkingKuberouterK8s112YamlTemplate = []byte(`# Pulled and modified from https://raw.githubusercontent.com/cloudnativelabs/kube-router/v1.0.0/daemonset/kubeadm-kuberouter.yaml
+var _cloudupResourcesAddonsNetworkingKuberouterK8s112YamlTemplate = []byte(`# Pulled and modified from https://raw.githubusercontent.com/cloudnativelabs/kube-router/v1.0.1/daemonset/kubeadm-kuberouter.yaml
 
 apiVersion: v1
 kind: ConfigMap
@@ -6487,7 +6487,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: docker.io/cloudnativelabs/kube-router:v1.0.0
+        image: docker.io/cloudnativelabs/kube-router:v1.0.1
         args:
         - --run-router=true
         - --run-firewall=true
@@ -6528,7 +6528,7 @@ spec:
           readOnly: false
       initContainers:
       - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router:v1.0.0
+        image: docker.io/cloudnativelabs/kube-router:v1.0.1
         command:
         - /bin/sh
         - -c

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -6453,6 +6453,13 @@ data:
              "ipam":{
                 "type":"host-local"
              }
+          },
+          {
+             "type": "portmap",
+             "capabilities": {
+                "snat": true,
+                "portMappings": true
+             }
           }
        ]
     }

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -6492,6 +6492,7 @@ spec:
         - --run-router=true
         - --run-firewall=true
         - --run-service-proxy=true
+        - --bgp-graceful-restart=true
         - --kubeconfig=/var/lib/kube-router/kubeconfig
         - --metrics-port=12013
         env:

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -1,4 +1,4 @@
-# Pulled and modified from https://raw.githubusercontent.com/cloudnativelabs/kube-router/v1.0.0/daemonset/kubeadm-kuberouter.yaml
+# Pulled and modified from https://raw.githubusercontent.com/cloudnativelabs/kube-router/v1.0.1/daemonset/kubeadm-kuberouter.yaml
 
 apiVersion: v1
 kind: ConfigMap
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: docker.io/cloudnativelabs/kube-router:v1.0.0
+        image: docker.io/cloudnativelabs/kube-router:v1.0.1
         args:
         - --run-router=true
         - --run-firewall=true
@@ -97,7 +97,7 @@ spec:
           readOnly: false
       initContainers:
       - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router:v1.0.0
+        image: docker.io/cloudnativelabs/kube-router:v1.0.1
         command:
         - /bin/sh
         - -c

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -61,6 +61,7 @@ spec:
         - --run-router=true
         - --run-firewall=true
         - --run-service-proxy=true
+        - --bgp-graceful-restart=true
         - --kubeconfig=/var/lib/kube-router/kubeconfig
         - --metrics-port=12013
         env:

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -22,6 +22,13 @@ data:
              "ipam":{
                 "type":"host-local"
              }
+          },
+          {
+             "type": "portmap",
+             "capabilities": {
+                "snat": true,
+                "portMappings": true
+             }
           }
        ]
     }

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -854,7 +854,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		key := "networking.kuberouter"
 		versions := map[string]string{
 			"k8s-1.6":  "0.3.1-kops.4",
-			"k8s-1.12": "1.0.0-kops.2",
+			"k8s-1.12": "1.0.0-kops.3",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -854,7 +854,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		key := "networking.kuberouter"
 		versions := map[string]string{
 			"k8s-1.6":  "0.3.1-kops.4",
-			"k8s-1.12": "1.0.0-kops.3",
+			"k8s-1.12": "1.0.1-kops.1",
 		}
 
 		{


### PR DESCRIPTION
Cherry pick of #9689 #9818 on release-1.18.

#9689: Support for using hostPort when using kube-router
#9818: Update kube-router to v1.0.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.