### PR TITLE
Backport #9803: Update validation for Calico to assume etcd3 as default

### DIFF
--- a/cmd/kops/BUILD.bazel
+++ b/cmd/kops/BUILD.bazel
@@ -77,7 +77,6 @@ go_library(
         "//pkg/k8sversion:go_default_library",
         "//pkg/kopscodecs:go_default_library",
         "//pkg/kubeconfig:go_default_library",
-        "//pkg/model/components:go_default_library",
         "//pkg/pki:go_default_library",
         "//pkg/pretty:go_default_library",
         "//pkg/resources:go_default_library",

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog"
 	"k8s.io/kops"
 	"k8s.io/kops/cmd/kops/util"
@@ -47,7 +46,6 @@ import (
 	"k8s.io/kops/pkg/dns"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/k8sversion"
-	"k8s.io/kops/pkg/model/components"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/aliup"
@@ -995,14 +993,6 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 	case "calico":
 		cluster.Spec.Networking.Calico = &api.CalicoNetworkingSpec{
 			MajorVersion: "v3",
-		}
-		// Validate to check if etcd clusters have an acceptable version
-		if errList := validation.ValidateEtcdVersionForCalicoV3(cluster.Spec.EtcdClusters[0], cluster.Spec.Networking.Calico.MajorVersion, field.NewPath("spec", "networking", "calico")); len(errList) != 0 {
-
-			// This is not a special version but simply of the 3 series
-			for _, etcd := range cluster.Spec.EtcdClusters {
-				etcd.Version = components.DefaultEtcd3Version_1_11
-			}
 		}
 	case "canal":
 		cluster.Spec.Networking.Canal = &api.CanalNetworkingSpec{}

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -668,25 +668,19 @@ func validateEtcdMemberSpec(spec *kops.EtcdMemberSpec, fieldPath *field.Path) fi
 func ValidateEtcdVersionForCalicoV3(e *kops.EtcdClusterSpec, majorVersion string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	version := e.Version
 	if e.Version == "" {
-		version = components.DefaultEtcd2Version
-	}
-	sem, err := semver.Parse(strings.TrimPrefix(version, "v"))
-	if err != nil {
-		allErrs = append(allErrs, field.InternalError(fldPath.Child("majorVersion"), fmt.Errorf("failed to parse Etcd version to check compatibility: %s", err)))
-	}
-
-	if sem.Major != 3 {
-		if e.Version == "" {
-			allErrs = append(allErrs,
-				field.Forbidden(fldPath.Child("majorVersion"),
-					fmt.Sprintf("Unable to use v3 when ETCD version for %s cluster is default(%s)",
-						e.Name, components.DefaultEtcd2Version)))
+		if majorVersion == "v3" {
+			return allErrs
 		} else {
-			allErrs = append(allErrs,
-				field.Forbidden(fldPath.Child("majorVersion"),
-					fmt.Sprintf("Unable to use v3 when ETCD version for %s cluster is %s", e.Name, e.Version)))
+			allErrs = append(allErrs, field.Required(fldPath.Child("majorVersion"), "majorVersion required when etcd version is not set explicitly"))
+		}
+	} else {
+		sem, err := semver.Parse(strings.TrimPrefix(e.Version, "v"))
+		if err != nil {
+			allErrs = append(allErrs, field.InternalError(fldPath.Child("majorVersion"), fmt.Errorf("failed to parse etcd version to check compatibility: %s", err)))
+		}
+		if majorVersion == "v3" && sem.Major != 3 {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("majorVersion"), fmt.Sprintf("unable to use v3 when etcd version for %s cluster is %s", e.Name, e.Version)))
 		}
 	}
 	return allErrs


### PR DESCRIPTION
Backporting just the fix from #9803, without updating tests.
/cc @olemarkus 