### PR TITLE
WIP Improve API ELB Healthchecking

### DIFF
--- a/nodeup/pkg/model/tests/golden/awsiam/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/awsiam/tasks-kube-apiserver.yaml
@@ -64,6 +64,7 @@ contents: |
       - --secure-port=443
       - --service-account-key-file=/srv/kubernetes/service-account.key
       - --service-cluster-ip-range=100.64.0.0/13
+      - --shutdown-delay-duration=30s
       - --storage-backend=etcd3
       - --tls-cert-file=/srv/kubernetes/server.crt
       - --tls-private-key-file=/srv/kubernetes/server.key
@@ -77,7 +78,7 @@ contents: |
       livenessProbe:
         httpGet:
           host: 127.0.0.1
-          path: /healthz
+          path: /livez
           port: 443
           scheme: HTTPS
         initialDelaySeconds: 45
@@ -133,6 +134,7 @@ contents: |
         readOnly: true
     hostNetwork: true
     priorityClassName: system-cluster-critical
+    terminationGracePeriodSeconds: 35
     tolerations:
     - key: CriticalAddonsOnly
       operator: Exists

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
@@ -42,6 +42,7 @@ contents: |
       - --secure-port=443
       - --service-account-key-file=/srv/kubernetes/service-account.key
       - --service-cluster-ip-range=100.64.0.0/13
+      - --shutdown-delay-duration=30s
       - --storage-backend=etcd3
       - --tls-cert-file=/srv/kubernetes/server.crt
       - --tls-private-key-file=/srv/kubernetes/server.key
@@ -55,7 +56,7 @@ contents: |
       livenessProbe:
         httpGet:
           host: 127.0.0.1
-          path: /healthz
+          path: /livez
           port: 443
           scheme: HTTPS
         initialDelaySeconds: 45
@@ -108,6 +109,7 @@ contents: |
         readOnly: true
     hostNetwork: true
     priorityClassName: system-cluster-critical
+    terminationGracePeriodSeconds: 35
     tolerations:
     - key: CriticalAddonsOnly
       operator: Exists

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-amd64.yaml
@@ -42,6 +42,7 @@ contents: |
       - --secure-port=443
       - --service-account-key-file=/srv/kubernetes/service-account.key
       - --service-cluster-ip-range=100.64.0.0/13
+      - --shutdown-delay-duration=30s
       - --storage-backend=etcd3
       - --tls-cert-file=/srv/kubernetes/server.crt
       - --tls-private-key-file=/srv/kubernetes/server.key
@@ -55,7 +56,7 @@ contents: |
       livenessProbe:
         httpGet:
           host: 127.0.0.1
-          path: /healthz
+          path: /livez
           port: 443
           scheme: HTTPS
         initialDelaySeconds: 45
@@ -108,6 +109,7 @@ contents: |
         readOnly: true
     hostNetwork: true
     priorityClassName: system-cluster-critical
+    terminationGracePeriodSeconds: 35
     tolerations:
     - key: CriticalAddonsOnly
       operator: Exists

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-arm64.yaml
@@ -42,6 +42,7 @@ contents: |
       - --secure-port=443
       - --service-account-key-file=/srv/kubernetes/service-account.key
       - --service-cluster-ip-range=100.64.0.0/13
+      - --shutdown-delay-duration=30s
       - --storage-backend=etcd3
       - --tls-cert-file=/srv/kubernetes/server.crt
       - --tls-private-key-file=/srv/kubernetes/server.key
@@ -55,7 +56,7 @@ contents: |
       livenessProbe:
         httpGet:
           host: 127.0.0.1
-          path: /healthz
+          path: /livez
           port: 443
           scheme: HTTPS
         initialDelaySeconds: 45
@@ -108,6 +109,7 @@ contents: |
         readOnly: true
     hostNetwork: true
     priorityClassName: system-cluster-critical
+    terminationGracePeriodSeconds: 35
     tolerations:
     - key: CriticalAddonsOnly
       operator: Exists

--- a/pkg/model/awsmodel/BUILD.bazel
+++ b/pkg/model/awsmodel/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/model:go_default_library",
         "//pkg/model/defaults:go_default_library",
         "//pkg/model/spotinstmodel:go_default_library",
+        "//pkg/wellknownports:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awstasks:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",

--- a/pkg/model/components/etcdmanager/tests/minimal/cluster.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/cluster.yaml
@@ -28,7 +28,7 @@ spec:
     provider: Manager
     backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
-  kubernetesVersion: v1.17.0
+  kubernetesVersion: v1.19.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -81,6 +81,11 @@ Contents:
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3997 --insecure=false --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
         image: kopeio/etcd-manager:3.0.20200531
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sleep 35
         name: etcd-manager
         resources:
           requests:
@@ -98,6 +103,7 @@ Contents:
       hostNetwork: true
       hostPID: true
       priorityClassName: system-cluster-critical
+      terminationGracePeriodSeconds: 40
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
@@ -140,6 +146,11 @@ Contents:
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3996 --insecure=false --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
         image: kopeio/etcd-manager:3.0.20200531
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sleep 35
         name: etcd-manager
         resources:
           requests:
@@ -157,6 +168,7 @@ Contents:
       hostNetwork: true
       hostPID: true
       priorityClassName: system-cluster-critical
+      terminationGracePeriodSeconds: 40
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -84,6 +84,11 @@ Contents:
         - name: ETCD_QUOTA_BACKEND_BYTES
           value: "10737418240"
         image: kopeio/etcd-manager:3.0.20200531
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sleep 35
         name: etcd-manager
         resources:
           requests:
@@ -101,6 +106,7 @@ Contents:
       hostNetwork: true
       hostPID: true
       priorityClassName: system-cluster-critical
+      terminationGracePeriodSeconds: 40
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
@@ -146,6 +152,11 @@ Contents:
         - name: ETCD_QUOTA_BACKEND_BYTES
           value: "10737418240"
         image: kopeio/etcd-manager:3.0.20200531
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sleep 35
         name: etcd-manager
         resources:
           requests:
@@ -163,6 +174,7 @@ Contents:
       hostNetwork: true
       hostPID: true
       priorityClassName: system-cluster-critical
+      terminationGracePeriodSeconds: 40
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/pkg/model/components/kubeapiserver/model.go
+++ b/pkg/model/components/kubeapiserver/model.go
@@ -146,7 +146,7 @@ func (b *KubeApiserverBuilder) buildHealthcheckSidecar() (*corev1.Pod, error) {
 		}
 
 		if len(pod.Spec.Containers) != 1 {
-			return nil, fmt.Errorf("expected exactly one container in etcd-manager Pod, found %d", len(pod.Spec.Containers))
+			return nil, fmt.Errorf("expected exactly one container in kube-apiserver Pod, found %d", len(pod.Spec.Containers))
 		}
 		container = &pod.Spec.Containers[0]
 	}

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -567,6 +567,20 @@
         "IpProtocol": "-1"
       }
     },
+    "AWSEC2SecurityGroupIngresshealthcheckelbtomaster": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
+        },
+        "SourceSecurityGroupId": {
+          "Ref": "AWSEC2SecurityGroupapielbcomplexexamplecom"
+        },
+        "FromPort": 3990,
+        "ToPort": 3990,
+        "IpProtocol": "tcp"
+      }
+    },
     "AWSEC2SecurityGroupIngresshttpsapielb111024": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
@@ -1089,7 +1103,7 @@
           }
         ],
         "HealthCheck": {
-          "Target": "SSL:443",
+          "Target": "HTTP:3990/readyz",
           "HealthyThreshold": 2,
           "UnhealthyThreshold": 2,
           "Interval": 10,

--- a/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
@@ -160,7 +160,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscomplexexamplecom.Properties.
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    skipInstall: true
+    configOverride: |
+      disabled_plugins = ["cri"]
+    logLevel: info
+    version: 1.2.13
   docker:
     ipMasq: false
     ipTables: false
@@ -170,13 +173,13 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscomplexexamplecom.Properties.
     - max-size=10m
     - max-file=5
     storage: overlay2,overlay,aufs
-    version: 18.06.3
+    version: 19.03.11
   encryptionConfig: null
   etcdClusters:
     events:
-      version: 3.3.10
+      version: 3.4.3
     main:
-      version: 3.3.10
+      version: 3.4.3
   kubeAPIServer:
     allowPrivileged: true
     anonymousAuth: false
@@ -200,9 +203,8 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscomplexexamplecom.Properties.
     - http://127.0.0.1:4001
     etcdServersOverrides:
     - /events#http://127.0.0.1:4002
-    image: k8s.gcr.io/kube-apiserver:v1.14.0
+    image: k8s.gcr.io/kube-apiserver:v1.19.0
     insecureBindAddress: 127.0.0.1
-    insecurePort: 8080
     kubeletPreferredAddressTypes:
     - InternalIP
     - Hostname
@@ -227,7 +229,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscomplexexamplecom.Properties.
     clusterCIDR: 100.96.0.0/11
     clusterName: complex.example.com
     configureCloudRoutes: true
-    image: k8s.gcr.io/kube-controller-manager:v1.14.0
+    image: k8s.gcr.io/kube-controller-manager:v1.19.0
     leaderElection:
       leaderElect: true
     logLevel: 2
@@ -236,10 +238,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscomplexexamplecom.Properties.
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
     hostnameOverride: '@aws'
-    image: k8s.gcr.io/kube-proxy:v1.14.0
+    image: k8s.gcr.io/kube-proxy:v1.19.0
     logLevel: 2
   kubeScheduler:
-    image: k8s.gcr.io/kube-scheduler:v1.14.0
+    image: k8s.gcr.io/kube-scheduler:v1.19.0
     leaderElection:
       leaderElect: true
     logLevel: 2
@@ -251,8 +253,6 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscomplexexamplecom.Properties.
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
@@ -269,8 +269,6 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscomplexexamplecom.Properties.
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
@@ -291,13 +289,13 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscomplexexamplecom.Properties.
   cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
     amd64:
-    - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
-    - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
-    - 3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
+    - 3f03e5c160a8b658d30b34824a1c00abadbac96e62c4d01bf5c9271a2debc3ab@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubelet
+    - 79bb0d2f05487ff533999a639c075043c70a0a1ba25c1629eb1eef6ebe3ba70f@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubectl
+    - 994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz
     arm64:
-    - df38e04576026393055ccc77c0dce73612996561@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/arm64/kubelet
-    - 01c2b6b43d36b6bfafc80a3737391c19ebfb8ad5@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/arm64/kubectl
-    - 7fec91af78e9548df306f0ec43bea527c8c10cc3a9682c33e971c8522a7fcded@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-arm64-v0.7.5.tgz
+    - d8fa5a9739ecc387dfcc55afa91ac6f4b0ccd01f1423c423dbd312d787bbb6bf@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/arm64/kubelet
+    - d4adf1b6b97252025cb2f7febf55daa3f42dc305822e3da133f77fd33071ec2f@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/arm64/kubectl
+    - 43fbf750c5eccb10accffeeb092693c32b236fb25d919cf058c91a677822c999@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.6/cni-plugins-linux-arm64-v0.8.6.tgz
   ClusterName: complex.example.com
   ConfigBase: memfs://clusters.example.com/complex.example.com
   InstanceGroupName: master-us-test-1a
@@ -310,8 +308,6 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscomplexexamplecom.Properties.
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
@@ -329,6 +325,9 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscomplexexamplecom.Properties.
   etcdManifests:
   - memfs://clusters.example.com/complex.example.com/manifests/etcd/main.yaml
   - memfs://clusters.example.com/complex.example.com/manifests/etcd/events.yaml
+  staticManifests:
+  - key: kube-apiserver-healthcheck
+    path: manifests/static/kube-apiserver-healthcheck.yaml
 
   __EOF_KUBE_ENV
 
@@ -507,7 +506,10 @@ Resources.AWSEC2LaunchTemplatenodescomplexexamplecom.Properties.LaunchTemplateDa
   cloudConfig: null
   containerRuntime: docker
   containerd:
-    skipInstall: true
+    configOverride: |
+      disabled_plugins = ["cri"]
+    logLevel: info
+    version: 1.2.13
   docker:
     ipMasq: false
     ipTables: false
@@ -517,12 +519,12 @@ Resources.AWSEC2LaunchTemplatenodescomplexexamplecom.Properties.LaunchTemplateDa
     - max-size=10m
     - max-file=5
     storage: overlay2,overlay,aufs
-    version: 18.06.3
+    version: 19.03.11
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
     hostnameOverride: '@aws'
-    image: k8s.gcr.io/kube-proxy:v1.14.0
+    image: k8s.gcr.io/kube-proxy:v1.19.0
     logLevel: 2
   kubelet:
     anonymousAuth: false
@@ -532,8 +534,6 @@ Resources.AWSEC2LaunchTemplatenodescomplexexamplecom.Properties.LaunchTemplateDa
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
@@ -553,13 +553,13 @@ Resources.AWSEC2LaunchTemplatenodescomplexexamplecom.Properties.LaunchTemplateDa
   cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
     amd64:
-    - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
-    - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
-    - 3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
+    - 3f03e5c160a8b658d30b34824a1c00abadbac96e62c4d01bf5c9271a2debc3ab@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubelet
+    - 79bb0d2f05487ff533999a639c075043c70a0a1ba25c1629eb1eef6ebe3ba70f@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubectl
+    - 994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz
     arm64:
-    - df38e04576026393055ccc77c0dce73612996561@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/arm64/kubelet
-    - 01c2b6b43d36b6bfafc80a3737391c19ebfb8ad5@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/arm64/kubectl
-    - 7fec91af78e9548df306f0ec43bea527c8c10cc3a9682c33e971c8522a7fcded@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-arm64-v0.7.5.tgz
+    - d8fa5a9739ecc387dfcc55afa91ac6f4b0ccd01f1423c423dbd312d787bbb6bf@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/arm64/kubelet
+    - d4adf1b6b97252025cb2f7febf55daa3f42dc305822e3da133f77fd33071ec2f@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/arm64/kubectl
+    - 43fbf750c5eccb10accffeeb092693c32b236fb25d919cf058c91a677822c999@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.6/cni-plugins-linux-arm64-v0.8.6.tgz
   ClusterName: complex.example.com
   ConfigBase: memfs://clusters.example.com/complex.example.com
   InstanceGroupName: nodes
@@ -572,8 +572,6 @@ Resources.AWSEC2LaunchTemplatenodescomplexexamplecom.Properties.LaunchTemplateDa
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
@@ -159,7 +159,10 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig: null
 containerRuntime: docker
 containerd:
-  skipInstall: true
+  configOverride: |
+    disabled_plugins = ["cri"]
+  logLevel: info
+  version: 1.2.13
 docker:
   ipMasq: false
   ipTables: false
@@ -169,13 +172,13 @@ docker:
   - max-size=10m
   - max-file=5
   storage: overlay2,overlay,aufs
-  version: 18.06.3
+  version: 19.03.11
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.3.10
+    version: 3.4.3
   main:
-    version: 3.3.10
+    version: 3.4.3
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false
@@ -199,9 +202,8 @@ kubeAPIServer:
   - http://127.0.0.1:4001
   etcdServersOverrides:
   - /events#http://127.0.0.1:4002
-  image: k8s.gcr.io/kube-apiserver:v1.14.0
+  image: k8s.gcr.io/kube-apiserver:v1.19.0
   insecureBindAddress: 127.0.0.1
-  insecurePort: 8080
   kubeletPreferredAddressTypes:
   - InternalIP
   - Hostname
@@ -226,7 +228,7 @@ kubeControllerManager:
   clusterCIDR: 100.96.0.0/11
   clusterName: complex.example.com
   configureCloudRoutes: true
-  image: k8s.gcr.io/kube-controller-manager:v1.14.0
+  image: k8s.gcr.io/kube-controller-manager:v1.19.0
   leaderElection:
     leaderElect: true
   logLevel: 2
@@ -235,10 +237,10 @@ kubeProxy:
   clusterCIDR: 100.96.0.0/11
   cpuRequest: 100m
   hostnameOverride: '@aws'
-  image: k8s.gcr.io/kube-proxy:v1.14.0
+  image: k8s.gcr.io/kube-proxy:v1.19.0
   logLevel: 2
 kubeScheduler:
-  image: k8s.gcr.io/kube-scheduler:v1.14.0
+  image: k8s.gcr.io/kube-scheduler:v1.19.0
   leaderElection:
     leaderElect: true
   logLevel: 2
@@ -250,8 +252,6 @@ kubelet:
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-  featureGates:
-    ExperimentalCriticalPodAnnotation: "true"
   hostnameOverride: '@aws'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
@@ -268,8 +268,6 @@ masterKubelet:
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-  featureGates:
-    ExperimentalCriticalPodAnnotation: "true"
   hostnameOverride: '@aws'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
@@ -290,13 +288,13 @@ __EOF_IG_SPEC
 cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 Assets:
   amd64:
-  - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
-  - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
-  - 3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
+  - 3f03e5c160a8b658d30b34824a1c00abadbac96e62c4d01bf5c9271a2debc3ab@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubelet
+  - 79bb0d2f05487ff533999a639c075043c70a0a1ba25c1629eb1eef6ebe3ba70f@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubectl
+  - 994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz
   arm64:
-  - df38e04576026393055ccc77c0dce73612996561@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/arm64/kubelet
-  - 01c2b6b43d36b6bfafc80a3737391c19ebfb8ad5@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/arm64/kubectl
-  - 7fec91af78e9548df306f0ec43bea527c8c10cc3a9682c33e971c8522a7fcded@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-arm64-v0.7.5.tgz
+  - d8fa5a9739ecc387dfcc55afa91ac6f4b0ccd01f1423c423dbd312d787bbb6bf@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/arm64/kubelet
+  - d4adf1b6b97252025cb2f7febf55daa3f42dc305822e3da133f77fd33071ec2f@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/arm64/kubectl
+  - 43fbf750c5eccb10accffeeb092693c32b236fb25d919cf058c91a677822c999@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.6/cni-plugins-linux-arm64-v0.8.6.tgz
 ClusterName: complex.example.com
 ConfigBase: memfs://clusters.example.com/complex.example.com
 InstanceGroupName: master-us-test-1a
@@ -309,8 +307,6 @@ KubeletConfig:
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-  featureGates:
-    ExperimentalCriticalPodAnnotation: "true"
   hostnameOverride: '@aws'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
@@ -328,6 +324,9 @@ channels:
 etcdManifests:
 - memfs://clusters.example.com/complex.example.com/manifests/etcd/main.yaml
 - memfs://clusters.example.com/complex.example.com/manifests/etcd/events.yaml
+staticManifests:
+- key: kube-apiserver-healthcheck
+  path: manifests/static/kube-apiserver-healthcheck.yaml
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
@@ -159,7 +159,10 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig: null
 containerRuntime: docker
 containerd:
-  skipInstall: true
+  configOverride: |
+    disabled_plugins = ["cri"]
+  logLevel: info
+  version: 1.2.13
 docker:
   ipMasq: false
   ipTables: false
@@ -169,12 +172,12 @@ docker:
   - max-size=10m
   - max-file=5
   storage: overlay2,overlay,aufs
-  version: 18.06.3
+  version: 19.03.11
 kubeProxy:
   clusterCIDR: 100.96.0.0/11
   cpuRequest: 100m
   hostnameOverride: '@aws'
-  image: k8s.gcr.io/kube-proxy:v1.14.0
+  image: k8s.gcr.io/kube-proxy:v1.19.0
   logLevel: 2
 kubelet:
   anonymousAuth: false
@@ -184,8 +187,6 @@ kubelet:
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-  featureGates:
-    ExperimentalCriticalPodAnnotation: "true"
   hostnameOverride: '@aws'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
@@ -205,13 +206,13 @@ __EOF_IG_SPEC
 cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 Assets:
   amd64:
-  - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
-  - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
-  - 3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
+  - 3f03e5c160a8b658d30b34824a1c00abadbac96e62c4d01bf5c9271a2debc3ab@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubelet
+  - 79bb0d2f05487ff533999a639c075043c70a0a1ba25c1629eb1eef6ebe3ba70f@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubectl
+  - 994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz
   arm64:
-  - df38e04576026393055ccc77c0dce73612996561@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/arm64/kubelet
-  - 01c2b6b43d36b6bfafc80a3737391c19ebfb8ad5@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/arm64/kubectl
-  - 7fec91af78e9548df306f0ec43bea527c8c10cc3a9682c33e971c8522a7fcded@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-arm64-v0.7.5.tgz
+  - d8fa5a9739ecc387dfcc55afa91ac6f4b0ccd01f1423c423dbd312d787bbb6bf@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/arm64/kubelet
+  - d4adf1b6b97252025cb2f7febf55daa3f42dc305822e3da133f77fd33071ec2f@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/arm64/kubectl
+  - 43fbf750c5eccb10accffeeb092693c32b236fb25d919cf058c91a677822c999@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.6/cni-plugins-linux-arm64-v0.8.6.tgz
 ClusterName: complex.example.com
 ConfigBase: memfs://clusters.example.com/complex.example.com
 InstanceGroupName: nodes
@@ -224,8 +225,6 @@ KubeletConfig:
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-  featureGates:
-    ExperimentalCriticalPodAnnotation: "true"
   hostnameOverride: '@aws'
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -36,7 +36,7 @@ spec:
     auditWebhookBatchThrottleQps: 3.14
   kubelet:
     anonymousAuth: false
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.19.0
   masterInternalName: api.internal.complex.example.com
   masterPublicName: api.complex.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -36,7 +36,7 @@ spec:
     auditWebhookBatchThrottleQps: 3.14
   kubelet:
     anonymousAuth: false
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.19.0
   masterInternalName: api.internal.complex.example.com
   masterPublicName: api.complex.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -219,7 +219,7 @@ resource "aws_elb" "api-complex-example-com" {
   health_check {
     healthy_threshold   = 2
     interval            = 10
-    target              = "SSL:443"
+    target              = "HTTP:3990/readyz"
     timeout             = 5
     unhealthy_threshold = 2
   }
@@ -488,6 +488,15 @@ resource "aws_security_group_rule" "api-elb-egress" {
   security_group_id = aws_security_group.api-elb-complex-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "healthcheck-elb-to-master" {
+  from_port                = 3990
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-complex-example-com.id
+  source_security_group_id = aws_security_group.api-elb-complex-example-com.id
+  to_port                  = 3990
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "https-api-elb-1-1-1-0--24" {


### PR DESCRIPTION
This is untested and still WIP but I'd like to get others views on this general change.
As of k8s 1.17 we now have a healthcheck container that proxies HTTP requests for the healthcheck endpoints to authenticated HTTPS requests to kube-apiserver. This PR extends that functionality to also be used by the API ELB for a more accurate healthcheck.

[These docs](https://kubernetes.io/docs/reference/using-api/health-checks/#api-endpoints-for-health) mention that `/healthz` is deprecated in 1.16 so the livenessProbe now uses `/livez` and the ELB healthcheck uses `/readyz`. While in the apiserver docs I noticed a [--shutdown-delay-duration](https://github.com/kubernetes/kubernetes/pull/74416/files) flag that was also introduced in 1.16 which will fail the `/readyz` endpoint for a period of time between the SIGINT and SIGKILL. This seems beneficial for rolling updates to reduce lost requests while a master is being replaced. I chose 30s because it matches the default `terminationGracePeriodSeconds` value and aligns with the ELB's health check settings of `unhealthyThreshold=2` and `Interval=10s`.

Does the shutdown delay make sense?  Maybe we add an equivalent sleep in the etcd preStop lifecycle so that etcd is available for as long as apiserver stays up. I'm also wondering exactly how etcd and apiserver are shutdown during the drain and terminate steps and if they will be able to have this additional time to shutdown gracefully.

Fixes https://github.com/kubernetes/kops/issues/1647