### PR TITLE
remove nodeAffinity from typha

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -12233,14 +12233,6 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true
@@ -16226,14 +16218,6 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.16.yaml.template
@@ -531,14 +531,6 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3497,14 +3497,6 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true


### PR DESCRIPTION
This PR removes the unnecessary nodeAffinity from the Typha deployment in calico and canal manifests.

**Some background / history on how we got to this point:**
1. `nodeSelector: {kubernetes.io/role: master}` is added to Canal in https://github.com/kubernetes/kops/pull/7917/
1. This `nodeSelector` change is "copied" into the Calico manifest in #8104 .
1. @seh  points out that the node selector "makes it much harder to run more than three Typha replicas. It would be better to have node affinity that expresses a preference, but not a requirement for Typha pods to run on the masters." https://github.com/kubernetes/kops/pull/8104#discussion_r458153054, and raises https://github.com/kubernetes/kops/issues/9608 to track.
1. Nodeselector is converted to an Affinity as part of https://github.com/kubernetes/kops/pull/9609

**Why it was added in the first place**

I believe that the nodeSelector should never have been added in the first place. @tmjd has been asking questions on those threads and as best as we can tell, the node affinity / selectors were added to mitigate an issue where Typha was not being evicted from a node when the node group was being scaled down to zero. As per @seh:

>I've seen cases where the cluster autoscaler can't drop a worker node because a Typha pod is running on it. That Typha pod could run on one of the master nodes that are not subject to the autoscaler's control. The safe-to-evict annotation didn't work as expected. We wound up paying to run that worker node unnecessarily. [Note that] I wasn't using kops when I saw that problem with the cluster autoscaler failing to evict Typha's pods.
>Source:  https://github.com/kubernetes/kops/issues/9608#issuecomment-676520700

As per @KashifSaadat 
>I vaguely recall this was more specific to how we performed Kops node rolling upgrades and manifest updates. I believe as part of a Kops upgrade from v1.14 to v1.15 (including both Kubernetes and the Canal manifest update), after rolling the first master nodes the new Canal manifest was applied and Typha enabled (if specified in the cni spec), but Typha couldn't be scheduled on the old v1.14 nodes. At this point the canal pods have also begun rolling (as the new manifest was applied) and would fail to start because the Typha service is unavailable.
>I'd have to re-run the upgrade path to confirm the exact issue I encountered, but fairly certain the nodeSelector should no longer be required any more so we can look to remove it in a future update.
>Source: https://github.com/kubernetes/kops/pull/7917#issuecomment-677776726

I don't disagree that something may have been funky with evictions. But I do disagree with using affinity to avoid it. We should fix that eviction issue instead! Even after pouring through these issues, It's not clear to me what the eviction problem is, though it sounds like we might not be expecting it anymore?