### PR TITLE
Always use OpenStack Swift reauthentication

### DIFF
--- a/util/pkg/vfs/swiftfs.go
+++ b/util/pkg/vfs/swiftfs.go
@@ -51,6 +51,8 @@ func NewSwiftClient() (*gophercloud.ServiceClient, error) {
 		return nil, err
 	}
 
+	authOption.AllowReauth = true
+
 	pc, err := openstack.NewClient(authOption.IdentityEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("error building openstack provider client: %v", err)


### PR DESCRIPTION
If we were using credentials from env vars, we would not do
reauthentication with Swift.