### PR TITLE
Add nil support for setting fields via reflection

### DIFF
--- a/pkg/commands/set_cluster_test.go
+++ b/pkg/commands/set_cluster_test.go
@@ -296,6 +296,55 @@ func TestSetClusterFields(t *testing.T) {
 				},
 			},
 		},
+		{
+			Fields: []string{
+				"spec.docker.userNamespaceRemap=",
+			},
+			Input: kops.Cluster{
+				Spec: kops.ClusterSpec{
+					Docker: &kops.DockerConfig{
+						UserNamespaceRemap: "testuser:testuser",
+					},
+				},
+			},
+			Output: kops.Cluster{
+				Spec: kops.ClusterSpec{
+					Docker: &kops.DockerConfig{},
+				},
+			},
+		},
+		{
+			Fields: []string{
+				"spec.kubeScheduler.maxPersistentVolumes=",
+			},
+			Input: kops.Cluster{
+				Spec: kops.ClusterSpec{
+					KubeScheduler: &kops.KubeSchedulerConfig{
+						MaxPersistentVolumes: fi.Int32(1),
+					},
+				},
+			},
+			Output: kops.Cluster{
+				Spec: kops.ClusterSpec{
+					KubeScheduler: &kops.KubeSchedulerConfig{},
+				},
+			},
+		},
+		{
+			Fields: []string{
+				"spec.docker=",
+			},
+			Input: kops.Cluster{
+				Spec: kops.ClusterSpec{
+					Docker: &kops.DockerConfig{
+						RegistryMirrors: []string{"localhost"},
+					},
+				},
+			},
+			Output: kops.Cluster{
+				Spec: kops.ClusterSpec{},
+			},
+		},
 	}
 
 	for _, g := range grid {

--- a/util/pkg/reflectutils/access.go
+++ b/util/pkg/reflectutils/access.go
@@ -102,6 +102,11 @@ func setPrimitive(v reflect.Value, newValue string) error {
 	}
 
 	if v.Type().Kind() == reflect.Ptr {
+		if newValue == "" {
+			val := reflect.Zero(v.Type())
+			v.Set(val)
+			return nil
+		}
 		val := reflect.New(v.Type().Elem())
 		if err := setPrimitive(val.Elem(), newValue); err != nil {
 			return err

--- a/util/pkg/reflectutils/access_test.go
+++ b/util/pkg/reflectutils/access_test.go
@@ -52,9 +52,9 @@ type fakeObjectContainers struct {
 	Int32Pointer *int32 `json:"int32Pointer"`
 	Int64Pointer *int64 `json:"int64Pointer"`
 
-	Int   *int32 `json:"int"`
-	Int32 *int32 `json:"int32"`
-	Int64 *int64 `json:"int64"`
+	Int   int32 `json:"int"`
+	Int32 int32 `json:"int32"`
+	Int64 int64 `json:"int64"`
 
 	Enum      fakeEnum   `json:"enum"`
 	EnumSlice []fakeEnum `json:"enumSlice"`
@@ -163,6 +163,21 @@ func TestSet(t *testing.T) {
 			Path:     "spec.containers[0].enumSlice",
 			Value:    "ABC,DEF",
 		},
+		{
+			Name:     "unset int pointer",
+			Input:    "{ 'spec': { 'containers': [ { 'int64Pointer': 123 } ] } }",
+			Expected: "{ 'spec': { 'containers': [ { } ] } }",
+			Path:     "spec.containers[0].int64Pointer",
+			Value:    "",
+		},
+		{
+			Name:     "unset struct pointer",
+			Input:    "{ 'spec': { 'containers': [ { 'resources': { 'limits': { 'cpu': 1 } } } ] } }",
+			Expected: "{ 'spec': { 'containers': [ { } ] } }",
+			Path:     "spec.containers[0].resources",
+			Value:    "",
+		},
+
 		// Not sure if we should do this...
 		// {
 		// 	Name:     "creating missing array elements",


### PR DESCRIPTION
Extends #8896

This has an unfortunate side-effect of being unable to set `*string` fields to `""` since the pointer would instead be set to `nil`. If we think setting an empty string could be desirable we could instead have a special string, perhaps `"nil"` or `"null"`.

/hold for comment