### PR TITLE
Automated cherry pick of #9836: Always use OpenStack Swift reauthentication

### DIFF
--- a/util/pkg/vfs/swiftfs.go
+++ b/util/pkg/vfs/swiftfs.go
@@ -51,6 +51,8 @@ func NewSwiftClient() (*gophercloud.ServiceClient, error) {
 		return nil, err
 	}
 
+	authOption.AllowReauth = true
+
 	pc, err := openstack.NewClient(authOption.IdentityEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("error building openstack provider client: %v", err)


### PR DESCRIPTION
Cherry pick of #9836 on release-1.18.

#9836: Always use OpenStack Swift reauthentication

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.