### PR TITLE
Spotinst: Upgrade the Spot Cluster Controller to version 1.0.64

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -19377,12 +19377,21 @@ spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
         imagePullPolicy: Always
-        image: spotinst/kubernetes-cluster-controller:1.0.63
+        image: spotinst/kubernetes-cluster-controller:1.0.64
         livenessProbe:
           httpGet:
             path: /healthcheck
             port: 4401
           initialDelaySeconds: 300
+          periodSeconds: 20
+          timeoutSeconds: 2
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 4401
+          initialDelaySeconds: 20
           periodSeconds: 20
           timeoutSeconds: 2
           successThreshold: 1

--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
@@ -171,12 +171,21 @@ spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
         imagePullPolicy: Always
-        image: spotinst/kubernetes-cluster-controller:1.0.63
+        image: spotinst/kubernetes-cluster-controller:1.0.64
         livenessProbe:
           httpGet:
             path: /healthcheck
             port: 4401
           initialDelaySeconds: 300
+          periodSeconds: 20
+          timeoutSeconds: 2
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 4401
+          initialDelaySeconds: 20
           periodSeconds: 20
           timeoutSeconds: 2
           successThreshold: 1

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -610,7 +610,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		{
 			id := "v1.14.0"
 			location := key + "/" + id + ".yaml"
-			version := "1.0.63"
+			version := "1.0.64"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),


### PR DESCRIPTION
This PR upgrade the Spot Cluster Controller to version 1.0.64.