### PR TITLE
Populate cloudinstances data on openstack

### DIFF
--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -386,6 +386,8 @@ func NewOpenstackCloud(tags map[string]string, spec *kops.ClusterSpec) (Openstac
 	if err != nil {
 		return nil, fmt.Errorf("error building nova client: %v", err)
 	}
+	// 2.47 is the minimum version where the compute API /server/details returns flavor names
+	novaClient.Microversion = "2.47"
 
 	glanceClient, err := os.NewImageServiceV2(provider, gophercloud.EndpointOpts{
 		Type:   "image",


### PR DESCRIPTION
This will populate the data later displayed by `kops get instances` once #9762 has merged.