### PR TITLE
fix "unbound variable" issue

### DIFF
--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -47,7 +47,7 @@ export IFS=','; checks="${CHECKS[*]}"; unset IFS
 # add it to the .staticcheck_failures blacklist
 IGNORE=(
 )
-export IFS='|'; ignore_pattern="^(${IGNORE[*]})\$"; unset IFS
+export IFS='|'; ignore_pattern="^(${IGNORE[*]-})\$"; unset IFS
 
 # Ensure that we find the binaries we build before anything else.
 export GOBIN="${KOPS_ROOT}/_output/bin"


### PR DESCRIPTION
IGNORE is an empty array, it throws error when make verify-staticcheck
$ make verify-staticcheck
hack/verify-staticcheck.sh
hack/verify-staticcheck.sh: line 50: IGNORE[*]: unbound variable
make: *** [verify-staticcheck] Error 1

Signed-off-by: Ma Xinjian <maxj.fnst@cn.fujitsu.com>