### PR TITLE
Update installation

### DIFF
--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -3,7 +3,7 @@
 `kubectl` is required, see [here](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
 
-## OSX From Homebrew
+## macOS and Linux From Homebrew
 
 ```shell
 brew update && brew install kops
@@ -12,12 +12,22 @@ brew update && brew install kops
 The `kops` binary is also available via our [releases](https://github.com/kubernetes/kops/releases/latest).
 
 
-## Linux
+## GitHub Releases
+
+### Linux
 
 ```shell
 curl -LO https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-linux-amd64
 chmod +x kops-linux-amd64
 sudo mv kops-linux-amd64 /usr/local/bin/kops
+```
+
+### macOS
+
+```shell
+curl -LO https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-darwin-amd64
+chmod +x kops-darwin-amd64
+sudo mv kops-darwin-amd64 /usr/local/bin/kops
 ```
 
 ## Windows


### PR DESCRIPTION
- OSX was renamed to macOS a long time ago
- Homebrew has supported Linux for a long time
- brew install is much easier and better for version management on Linux too