### PR TITLE
Only apply external policies when these are defined

### DIFF
--- a/pkg/model/iam.go
+++ b/pkg/model/iam.go
@@ -242,7 +242,7 @@ func (b *IAMModelBuilder) buildIAMTasks(role iam.Subject, iamName string, c *fi.
 		}
 
 		// Create External Policy tasks
-		{
+		if !shared {
 			var externalPolicies []string
 
 			if b.Cluster.Spec.ExternalPolicies != nil {


### PR DESCRIPTION
We experience fatal errors with this new feature (that we are not using) because some of the instance groups in our clusters include `spec.iam.profile` while others use the managed `nodes` role/profile. The `ExternalPolicies` feature is broken, and this makes it go away when not specifically asked for in the cluster configuration.

At the moment, without this patch, the `kops update cluster` operation results in -

```
F0903 17:45:44.372520   48506 task.go:59] found duplicate tasks with name "IAMRolePolicy/node-policyoverride": *awstasks.IAMRolePolicy {"ID":null,"Lifecycle":"Sync","Name":"node-policyoverride","Role":{"ID":null,"Lifecycle":"Sync","Name":"nodes.mycluster.domain.com","RolePolicyDocument":{"Name":"","Resource":{}},"ExportWithID":"nodes"},"PolicyDocument":null,"ExternalPolicies":null,"Managed":true} and *awstasks.IAMRolePolicy {"ID":null,"Lifecycle":"Sync","Name":"node-policyoverride","Role":{"ID":null,"Lifecycle":"Sync","Name":"secondgroup.mycluster.domain.com","RolePolicyDocument":{"Name":"","Resource":{}},"ExportWithID":"nodes"},"PolicyDocument":null,"ExternalPolicies":null,"Managed":true}
```

With this patch, everything works correctly without fatal errors.