### PR TITLE
Use root volume encryption flag for LaunchConfiguration with TF and CF

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
@@ -490,6 +490,7 @@ func (_ *LaunchConfiguration) RenderTerraform(t *terraform.TerraformTarget, a, e
 					VolumeType:          bdm.EbsVolumeType,
 					VolumeSize:          bdm.EbsVolumeSize,
 					Iops:                bdm.EbsVolumeIops,
+					Encrypted:           bdm.EbsEncrypted,
 					DeleteOnTermination: bdm.EbsDeleteOnTermination,
 				}
 			}
@@ -650,6 +651,7 @@ func (_ *LaunchConfiguration) RenderCloudformation(t *cloudformation.Cloudformat
 						VolumeType:          bdm.EbsVolumeType,
 						VolumeSize:          bdm.EbsVolumeSize,
 						Iops:                bdm.EbsVolumeIops,
+						Encrypted:           bdm.EbsEncrypted,
 						DeleteOnTermination: bdm.EbsDeleteOnTermination,
 					},
 				}


### PR DESCRIPTION
#9793 missed the config flags for LaunchConfiguration with Terraform and CloudFormation.
This will be useful in kops 1.18.1.