### PR TITLE
Automated cherry pick of #9793: Add flag for root volume encryption #9872: Use root volume encryption flag for LaunchConfiguration

### DIFF
--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -695,6 +695,10 @@ spec:
                   NOTE: This setting applies only to the Launch Configuration and
                   does not affect Launch Templates.'
                 type: boolean
+              rootVolumeEncryption:
+                description: RootVolumeEncryption enables EBS root volume encryption
+                  for an instance
+                type: boolean
               rootVolumeIops:
                 description: If volume type is io1, then we need to specify the number
                   of Iops.

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -108,6 +108,8 @@ type InstanceGroupSpec struct {
 	// The root volume is deleted by default. Cluster deletion does not remove retained root volumes.
 	// NOTE: This setting applies only to the Launch Configuration and does not affect Launch Templates.
 	RootVolumeDeleteOnTermination *bool `json:"rootVolumeDeleteOnTermination,omitempty"`
+	// RootVolumeEncryption enables EBS root volume encryption for an instance
+	RootVolumeEncryption *bool `json:"rootVolumeEncryption,omitempty"`
 	// Volumes is a collection of additional volumes to create for instances within this InstanceGroup
 	Volumes []*VolumeSpec `json:"volumes,omitempty"`
 	// VolumeMounts a collection of volume mounts

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -103,6 +103,8 @@ type InstanceGroupSpec struct {
 	// The root volume is deleted by default. Cluster deletion does not remove retained root volumes.
 	// NOTE: This setting applies only to the Launch Configuration and does not affect Launch Templates.
 	RootVolumeDeleteOnTermination *bool `json:"rootVolumeDeleteOnTermination,omitempty"`
+	// RootVolumeEncryption enables EBS root volume encryption for an instance
+	RootVolumeEncryption *bool `json:"rootVolumeEncryption,omitempty"`
 	// Volumes is a collection of additional volumes to create for instances within this InstanceGroup
 	Volumes []*VolumeSpec `json:"volumes,omitempty"`
 	// VolumeMounts a collection of volume mounts

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3255,6 +3255,7 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	out.RootVolumeIops = in.RootVolumeIops
 	out.RootVolumeOptimization = in.RootVolumeOptimization
 	out.RootVolumeDeleteOnTermination = in.RootVolumeDeleteOnTermination
+	out.RootVolumeEncryption = in.RootVolumeEncryption
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]*kops.VolumeSpec, len(*in))
@@ -3394,6 +3395,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	out.RootVolumeIops = in.RootVolumeIops
 	out.RootVolumeOptimization = in.RootVolumeOptimization
 	out.RootVolumeDeleteOnTermination = in.RootVolumeDeleteOnTermination
+	out.RootVolumeEncryption = in.RootVolumeEncryption
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]*VolumeSpec, len(*in))

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1655,6 +1655,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RootVolumeEncryption != nil {
+		in, out := &in.RootVolumeEncryption, &out.RootVolumeEncryption
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]*VolumeSpec, len(*in))

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -1821,6 +1821,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RootVolumeEncryption != nil {
+		in, out := &in.RootVolumeEncryption, &out.RootVolumeEncryption
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]*VolumeSpec, len(*in))

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -128,6 +128,7 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateTask(c *fi.ModelBuilde
 		RootVolumeSize:         lc.RootVolumeSize,
 		RootVolumeIops:         lc.RootVolumeIops,
 		RootVolumeType:         lc.RootVolumeType,
+		RootVolumeEncryption:   lc.RootVolumeEncryption,
 		SSHKey:                 lc.SSHKey,
 		SecurityGroups:         lc.SecurityGroups,
 		Tags:                   tags,
@@ -199,6 +200,7 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchConfigurationTask(c *fi.ModelB
 		RootVolumeOptimization:        ig.Spec.RootVolumeOptimization,
 		RootVolumeSize:                fi.Int64(int64(volumeSize)),
 		RootVolumeType:                fi.String(volumeType),
+		RootVolumeEncryption:          ig.Spec.RootVolumeEncryption,
 		SecurityGroups:                []*awstasks.SecurityGroup{sgLink},
 	}
 

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -151,7 +151,8 @@
             "Ebs": {
               "VolumeType": "gp2",
               "VolumeSize": 64,
-              "DeleteOnTermination": true
+              "DeleteOnTermination": true,
+              "Encrypted": true
             }
           },
           {
@@ -184,7 +185,8 @@
             "Ebs": {
               "VolumeType": "gp2",
               "VolumeSize": 128,
-              "DeleteOnTermination": false
+              "DeleteOnTermination": false,
+              "Encrypted": true
             }
           },
           {

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -78,6 +78,7 @@ spec:
   - us-test-1a
   detailedInstanceMonitoring: true
   rootVolumeDeleteOnTermination: false
+  rootVolumeEncryption: true
   volumes:
   - device: /dev/xvdd
     deleteOnTermination: false
@@ -100,5 +101,6 @@ spec:
   maxSize: 1
   minSize: 1
   role: Master
+  rootVolumeEncryption: true
   subnets:
   - us-test-1a

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -78,6 +78,7 @@ spec:
   - us-test-1a
   detailedInstanceMonitoring: true
   rootVolumeDeleteOnTermination: false
+  rootVolumeEncryption: true
   volumes:
   - device: /dev/xvdd
     deleteOnTermination: false
@@ -100,5 +101,6 @@ spec:
   maxSize: 1
   minSize: 1
   role: Master
+  rootVolumeEncryption: true
   subnets:
   - us-test-1a

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -302,6 +302,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-complex-example-c
   name_prefix = "master-us-test-1a.masters.complex.example.com-"
   root_block_device {
     delete_on_termination = true
+    encrypted             = true
     volume_size           = 64
     volume_type           = "gp2"
   }
@@ -328,6 +329,7 @@ resource "aws_launch_configuration" "nodes-complex-example-com" {
   name_prefix = "nodes.complex.example.com-"
   root_block_device {
     delete_on_termination = false
+    encrypted             = true
     volume_size           = 128
     volume_type           = "gp2"
   }

--- a/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
@@ -510,6 +510,7 @@ func (_ *LaunchConfiguration) RenderTerraform(t *terraform.TerraformTarget, a, e
 					VolumeType:          bdm.EbsVolumeType,
 					VolumeSize:          bdm.EbsVolumeSize,
 					Iops:                bdm.EbsVolumeIops,
+					Encrypted:           bdm.EbsEncrypted,
 					DeleteOnTermination: bdm.EbsDeleteOnTermination,
 				}
 			}
@@ -670,6 +671,7 @@ func (_ *LaunchConfiguration) RenderCloudformation(t *cloudformation.Cloudformat
 						VolumeType:          bdm.EbsVolumeType,
 						VolumeSize:          bdm.EbsVolumeSize,
 						Iops:                bdm.EbsVolumeIops,
+						Encrypted:           bdm.EbsEncrypted,
 						DeleteOnTermination: bdm.EbsDeleteOnTermination,
 					},
 				}

--- a/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
@@ -81,6 +81,8 @@ type LaunchConfiguration struct {
 	RootVolumeSize *int64
 	// RootVolumeType is the type of the EBS root volume to use (e.g. gp2)
 	RootVolumeType *string
+	// RootVolumeEncryption enables EBS root volume encryption for an instance
+	RootVolumeEncryption *bool
 	// SSHKey is the ssh key for the instances
 	SSHKey *SSHKey
 	// SecurityGroups is a list of security group associated
@@ -203,6 +205,7 @@ func (e *LaunchConfiguration) Find(c *fi.Context) (*LaunchConfiguration, error) 
 			actual.RootVolumeSize = b.Ebs.VolumeSize
 			actual.RootVolumeType = b.Ebs.VolumeType
 			actual.RootVolumeIops = b.Ebs.Iops
+			actual.RootVolumeEncryption = b.Ebs.Encrypted
 			actual.RootVolumeDeleteOnTermination = b.Ebs.DeleteOnTermination
 		} else {
 			_, d := BlockDeviceMappingFromAutoscaling(b)
@@ -406,6 +409,7 @@ func (t *LaunchConfiguration) buildRootDevice(cloud awsup.AWSCloud) (map[string]
 		EbsVolumeSize:          t.RootVolumeSize,
 		EbsVolumeType:          t.RootVolumeType,
 		EbsVolumeIops:          t.RootVolumeIops,
+		EbsEncrypted:           t.RootVolumeEncryption,
 	}
 
 	return bm, nil

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
@@ -56,6 +56,8 @@ type LaunchTemplate struct {
 	RootVolumeSize *int64
 	// RootVolumeType is the type of the EBS root volume to use (e.g. gp2)
 	RootVolumeType *string
+	// RootVolumeEncryption enables EBS root volume encryption for an instance
+	RootVolumeEncryption *bool
 	// SSHKey is the ssh key for the instances
 	SSHKey *SSHKey
 	// SecurityGroups is a list of security group associated
@@ -112,6 +114,7 @@ func (t *LaunchTemplate) buildRootDevice(cloud awsup.AWSCloud) (map[string]*Bloc
 		EbsVolumeSize:          t.RootVolumeSize,
 		EbsVolumeType:          t.RootVolumeType,
 		EbsVolumeIops:          t.RootVolumeIops,
+		EbsEncrypted:           t.RootVolumeEncryption,
 	}
 
 	return bm, nil

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -251,6 +251,7 @@ func (t *LaunchTemplate) Find(c *fi.Context) (*LaunchTemplate, error) {
 			actual.RootVolumeSize = b.Ebs.VolumeSize
 			actual.RootVolumeType = b.Ebs.VolumeType
 			actual.RootVolumeIops = b.Ebs.Iops
+			actual.RootVolumeEncryption = b.Ebs.Encrypted
 		} else {
 			_, d := BlockDeviceMappingFromLaunchTemplateBootDeviceRequest(b)
 			actual.BlockDeviceMappings = append(actual.BlockDeviceMappings, d)

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation.go
@@ -234,6 +234,7 @@ func (t *LaunchTemplate) RenderCloudformation(target *cloudformation.Cloudformat
 				IOPS:                x.EbsVolumeIops,
 				VolumeSize:          x.EbsVolumeSize,
 				VolumeType:          x.EbsVolumeType,
+				Encrypted:           x.EbsEncrypted,
 			},
 		})
 	}

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -232,6 +232,7 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 			EBS: []*terraformLaunchTemplateBlockDeviceEBS{
 				{
 					DeleteOnTermination: fi.Bool(true),
+					Encrypted:           x.EbsEncrypted,
 					IOPS:                x.EbsVolumeIops,
 					VolumeSize:          x.EbsVolumeSize,
 					VolumeType:          x.EbsVolumeType,


### PR DESCRIPTION
Cherry pick of #9793 #9872 on release-1.18.

#9793: Add flag for root volume encryption
#9872: Use root volume encryption flag for LaunchConfiguration

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.