### PR TITLE
Automated cherry pick of #9879: Add kubelet cgroup driver property

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1905,7 +1905,8 @@ spec:
                       that will be used to get client certificate for kubelet
                     type: string
                   cgroupDriver:
-                    description: CgroupDriver allows the explicit setting of the kubelet cgroup driver. If omitted, defaults to cgroupfs.
+                    description: CgroupDriver allows the explicit setting of the kubelet
+                      cgroup driver. If omitted, defaults to cgroupfs.
                     type: string
                   cgroupRoot:
                     description: cgroupRoot is the root cgroup to use for pods. This
@@ -2281,7 +2282,8 @@ spec:
                       that will be used to get client certificate for kubelet
                     type: string
                   cgroupDriver:
-                    description: CgroupDriver allows the explicit setting of the kubelet cgroup driver. If omitted, defaults to cgroupfs.
+                    description: CgroupDriver allows the explicit setting of the kubelet
+                      cgroup driver. If omitted, defaults to cgroupfs.
                     type: string
                   cgroupRoot:
                     description: cgroupRoot is the root cgroup to use for pods. This

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1904,6 +1904,9 @@ spec:
                     description: BootstrapKubeconfig is the path to a kubeconfig file
                       that will be used to get client certificate for kubelet
                     type: string
+                  cgroupDriver:
+                    description: CgroupDriver allows the explicit setting of the kubelet cgroup driver. If omitted, defaults to cgroupfs.
+                    type: string
                   cgroupRoot:
                     description: cgroupRoot is the root cgroup to use for pods. This
                       is handled by the container runtime on a best effort basis.
@@ -2276,6 +2279,9 @@ spec:
                   bootstrapKubeconfig:
                     description: BootstrapKubeconfig is the path to a kubeconfig file
                       that will be used to get client certificate for kubelet
+                    type: string
+                  cgroupDriver:
+                    description: CgroupDriver allows the explicit setting of the kubelet cgroup driver. If omitted, defaults to cgroupfs.
                     type: string
                   cgroupRoot:
                     description: cgroupRoot is the root cgroup to use for pods. This

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -268,7 +268,8 @@ spec:
                       that will be used to get client certificate for kubelet
                     type: string
                   cgroupDriver:
-                    description: CgroupDriver allows the explicit setting of the kubelet cgroup driver. If omitted, defaults to cgroupfs.
+                    description: CgroupDriver allows the explicit setting of the kubelet
+                      cgroup driver. If omitted, defaults to cgroupfs.
                     type: string
                   cgroupRoot:
                     description: cgroupRoot is the root cgroup to use for pods. This

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -267,6 +267,9 @@ spec:
                     description: BootstrapKubeconfig is the path to a kubeconfig file
                       that will be used to get client certificate for kubelet
                     type: string
+                  cgroupDriver:
+                    description: CgroupDriver allows the explicit setting of the kubelet cgroup driver. If omitted, defaults to cgroupfs.
+                    type: string
                   cgroupRoot:
                     description: cgroupRoot is the root cgroup to use for pods. This
                       is handled by the container runtime on a best effort basis.

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -198,13 +198,13 @@ type KubeletConfigSpec struct {
 	RegistryBurst *int32 `json:"registryBurst,omitempty" flag:"registry-burst"`
 	//TopologyManagerPolicy determines the allocation policy for the topology manager.
 	TopologyManagerPolicy string `json:"topologyManagerPolicy,omitempty" flag:"topology-manager-policy"`
-
 	// rotateCertificates enables client certificate rotation.
 	RotateCertificates *bool `json:"rotateCertificates,omitempty" flag:"rotate-certificates"`
-
 	// Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.
 	// (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag.
 	ProtectKernelDefaults *bool `json:"protectKernelDefaults,omitempty" flag:"protect-kernel-defaults"`
+	// CgroupDriver allows the explicit setting of the kubelet cgroup driver. If omitted, defaults to cgroupfs.
+	CgroupDriver string `json:"cgroupDriver,omitempty" flag:"cgroup-driver"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -198,13 +198,13 @@ type KubeletConfigSpec struct {
 	RegistryBurst *int32 `json:"registryBurst,omitempty" flag:"registry-burst"`
 	//TopologyManagerPolicy determines the allocation policy for the topology manager.
 	TopologyManagerPolicy string `json:"topologyManagerPolicy,omitempty" flag:"topology-manager-policy"`
-
 	// rotateCertificates enables client certificate rotation.
 	RotateCertificates *bool `json:"rotateCertificates,omitempty" flag:"rotate-certificates"`
-
 	// Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.
 	// (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag.
 	ProtectKernelDefaults *bool `json:"protectKernelDefaults,omitempty" flag:"protect-kernel-defaults"`
+	// CgroupDriver allows the explicit setting of the kubelet cgroup driver. If omitted, defaults to cgroupfs.
+	CgroupDriver string `json:"cgroupDriver,omitempty" flag:"cgroup-driver"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4281,6 +4281,7 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.TopologyManagerPolicy = in.TopologyManagerPolicy
 	out.RotateCertificates = in.RotateCertificates
 	out.ProtectKernelDefaults = in.ProtectKernelDefaults
+	out.CgroupDriver = in.CgroupDriver
 	return nil
 }
 
@@ -4368,6 +4369,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.TopologyManagerPolicy = in.TopologyManagerPolicy
 	out.RotateCertificates = in.RotateCertificates
 	out.ProtectKernelDefaults = in.ProtectKernelDefaults
+	out.CgroupDriver = in.CgroupDriver
 	return nil
 }
 


### PR DESCRIPTION
Cherry pick of #9879 on release-1.18.

#9879: Add kubelet cgroup driver property

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.