### PR TITLE
Errors when encryptionConfig is enabled, but no encryptionconfig secret

### DIFF
--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -71,8 +71,8 @@ func (b *KubeAPIServerBuilder) Build(c *fi.ModelBuilderContext) error {
 			}
 
 			key := "encryptionconfig"
-			encryptioncfg, _ := b.SecretStore.Secret(key)
-			if encryptioncfg != nil {
+			encryptioncfg, err := b.SecretStore.Secret(key)
+			if err == nil {
 				contents := string(encryptioncfg.Data)
 				t := &nodetasks.File{
 					Path:     *encryptionConfigPath,
@@ -81,6 +81,8 @@ func (b *KubeAPIServerBuilder) Build(c *fi.ModelBuilderContext) error {
 					Type:     nodetasks.FileType_File,
 				}
 				c.AddTask(t)
+			} else {
+				return fmt.Errorf("encryptionConfig enabled, but could not load encryptionconfig secret: %v", err)
 			}
 		}
 	}

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -331,6 +331,19 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 		}
 	}
 
+	if fi.BoolValue(c.Cluster.Spec.EncryptionConfig) {
+		secret, err := secretStore.FindSecret("encryptionconfig")
+		if err != nil {
+			return fmt.Errorf("could not load encryptionconfig secret: %v", err)
+		}
+		if secret == nil {
+			fmt.Println("")
+			fmt.Println("You have encryptionConfig enabled, but no encryptionconfig secret has been set.")
+			fmt.Println("See `kops create secret encryptionconfig -h` and https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/")
+			return fmt.Errorf("could not find encryptionconfig secret")
+		}
+	}
+
 	if err := c.addFileAssets(assetBuilder); err != nil {
 		return err
 	}


### PR DESCRIPTION
When encryptionConfig is enabled, but the secret is missing, there is no visible errors anywhere. kube-apiserver just goes into a crashloop without any complains. This PR adds warnings both on the client side and through nodeup.