### PR TITLE
Continue if asg instance is unknown

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -778,6 +778,9 @@ func awsBuildCloudInstanceGroup(c AWSCloud, cluster *kops.Cluster, ig *kops.Inst
 			klog.Warningf("ignoring instance as it is terminating: %s in autoscaling group: %s", id, cg.HumanName)
 			continue
 		}
+		if instances[id] == nil {
+			continue
+		}
 		currentConfigName := findInstanceLaunchConfiguration(i)
 		status := cloudinstances.CloudInstanceStatusUpToDate
 		if newConfigName != currentConfigName {


### PR DESCRIPTION
Most likely this comes from ASG thinking the instance is inService, but it is terminating when we run describe from EC2.

`kops get instances` should maybe also show instance status: terminating at some point, but that would also require changes in the rolling update code as it now assumes we filter terminating/terminated nodes.