### PR TITLE
Nodelocalcache configure resources

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -577,12 +577,16 @@ spec:
 
 NodeLocal DNSCache can be enabled if you are using CoreDNS. It is used to improve the Cluster DNS performance by running a dns caching agent on cluster nodes as a DaemonSet.
 
+`memoryRequest` and `cpuRequest` for the `node-local-dns` pods can also be configured. If not set, they will be configured by default to `5Mi` and `25m` respectively.
+
 ```yaml
 spec:
   kubeDNS:
     provider: CoreDNS
     nodeLocalDNS:
       enabled: true
+      memoryRequest: 5Mi
+      cpuRequest: 25m
 ```
 
 ## kubeControllerManager

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1345,12 +1345,26 @@ spec:
                   nodeLocalDNS:
                     description: NodeLocalDNS specifies the configuration for the node-local-dns addon
                     properties:
+                      cpuRequest:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: CPURequest specifies the cpu requests of each node-local-dns container in the daemonset. Default 25m.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
                       enabled:
                         description: Enabled activates the node-local-dns addon
                         type: boolean
                       localIP:
                         description: Local listen IP address. It can be any IP in the 169.254.20.0/16 space or any other IP address that can be guaranteed to not collide with any existing IP.
                         type: string
+                      memoryRequest:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: MemoryRequest specifies the memory requests of each node-local-dns container in the daemonset. Default 5Mi.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
                     type: object
                   provider:
                     description: Provider indicates whether CoreDNS or kube-dns will be the default service discovery.

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -413,6 +413,10 @@ type NodeLocalDNSConfig struct {
 	Enabled *bool `json:"enabled,omitempty"`
 	// Local listen IP address. It can be any IP in the 169.254.20.0/16 space or any other IP address that can be guaranteed to not collide with any existing IP.
 	LocalIP string `json:"localIP,omitempty"`
+	// MemoryRequest specifies the memory requests of each node-local-dns container in the daemonset. Default 5Mi.
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest specifies the cpu requests of each node-local-dns container in the daemonset. Default 25m.
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 }
 
 // ExternalDNSConfig are options of the dns-controller

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -414,6 +414,10 @@ type NodeLocalDNSConfig struct {
 	Enabled *bool `json:"enabled,omitempty"`
 	// Local listen IP address. It can be any IP in the 169.254.20.0/16 space or any other IP address that can be guaranteed to not collide with any existing IP.
 	LocalIP string `json:"localIP,omitempty"`
+	// MemoryRequest specifies the memory requests of each node-local-dns container in the daemonset. Default 5Mi.
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest specifies the cpu requests of each node-local-dns container in the daemonset. Default 25m.
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 }
 
 // ExternalDNSConfig are options of the dns-controller

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5031,6 +5031,8 @@ func Convert_kops_NodeAuthorizerSpec_To_v1alpha2_NodeAuthorizerSpec(in *kops.Nod
 func autoConvert_v1alpha2_NodeLocalDNSConfig_To_kops_NodeLocalDNSConfig(in *NodeLocalDNSConfig, out *kops.NodeLocalDNSConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
 	out.LocalIP = in.LocalIP
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
 	return nil
 }
 
@@ -5042,6 +5044,8 @@ func Convert_v1alpha2_NodeLocalDNSConfig_To_kops_NodeLocalDNSConfig(in *NodeLoca
 func autoConvert_kops_NodeLocalDNSConfig_To_v1alpha2_NodeLocalDNSConfig(in *kops.NodeLocalDNSConfig, out *NodeLocalDNSConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
 	out.LocalIP = in.LocalIP
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3357,6 +3357,16 @@ func (in *NodeLocalDNSConfig) DeepCopyInto(out *NodeLocalDNSConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3555,6 +3555,16 @@ func (in *NodeLocalDNSConfig) DeepCopyInto(out *NodeLocalDNSConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -87,5 +87,15 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 		nodeLocalDNS.LocalIP = "169.254.20.10"
 	}
 
+	if nodeLocalDNS.MemoryRequest == nil || nodeLocalDNS.MemoryRequest.IsZero() {
+		defaultMemoryRequest := resource.MustParse("5Mi")
+		nodeLocalDNS.MemoryRequest = &defaultMemoryRequest
+	}
+
+	if nodeLocalDNS.CPURequest == nil || nodeLocalDNS.CPURequest.IsZero() {
+		defaultCPURequest := resource.MustParse("25m")
+		nodeLocalDNS.CPURequest = &defaultCPURequest
+	}
+
 	return nil
 }

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -18640,8 +18640,8 @@ spec:
         image: k8s.gcr.io/k8s-dns-node-cache:1.15.10
         resources:
           requests:
-            cpu: 25m
-            memory: 5Mi
+            cpu: {{ KubeDNS.NodeLocalDNS.CPURequest }}
+            memory: {{ KubeDNS.NodeLocalDNS.MemoryRequest }}
         {{ if NodeLocalDNSServerIP }}
         args: [ "-localip", "{{ .KubeDNS.NodeLocalDNS.LocalIP }},{{ NodeLocalDNSServerIP }}", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream" ]
         {{ else }}

--- a/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
@@ -131,8 +131,8 @@ spec:
         image: k8s.gcr.io/k8s-dns-node-cache:1.15.10
         resources:
           requests:
-            cpu: 25m
-            memory: 5Mi
+            cpu: {{ KubeDNS.NodeLocalDNS.CPURequest }}
+            memory: {{ KubeDNS.NodeLocalDNS.MemoryRequest }}
         {{ if NodeLocalDNSServerIP }}
         args: [ "-localip", "{{ .KubeDNS.NodeLocalDNS.LocalIP }},{{ NodeLocalDNSServerIP }}", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream" ]
         {{ else }}


### PR DESCRIPTION
In this PR the `NodeLocalDNSConfig` is updated to hold `MemoryRequest` and `CPURequest` (as it is done in the `KubeDNSConfig`).

We end up with the following new cluster_spec (as updated in the documentation):
```
    nodeLocalDNS:
      enabled: true
      memoryRequest: 5Mi
      cpuRequest: 25m
```

`5Mi` and `25m` were chosen as they are the current defaults.

The reasoning behind this is that we would like to avoid patching the daemonset once kops has it deployed and be able to configure everything in the cluster spec config.

I am by no means an expert neither in go nor in contributing to the kops repo, so if I have forgotten anything please feel free to fire away any comments, additions, requirements or anything else that I may have overseen.