### PR TITLE
Automated cherry pick of #9376: NodeLocalDNS config population: small tweaks #9901: Update NodeLocalDNSConfig with Mem/CPU requests

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -585,12 +585,16 @@ spec:
 
 If you are using CoreDNS, you can enable NodeLocal DNSCache. It is used to improve the Cluster DNS performance by running a dns caching agent on cluster nodes as a DaemonSet.
 
+`memoryRequest` and `cpuRequest` for the `node-local-dns` pods can also be configured. If not set, they will be configured by default to `5Mi` and `25m` respectively.
+
 ```yaml
 spec:
   kubeDNS:
     provider: CoreDNS
     nodeLocalDNS:
       enabled: true
+      memoryRequest: 5Mi
+      cpuRequest: 25m
 ```
 
 ## kubeControllerManager

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1650,7 +1650,8 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: CPURequest specifies the cpu requests of each node-local-dns container in the daemonset. Default 25m.
+                        description: CPURequest specifies the cpu requests of each
+                          node-local-dns container in the daemonset. Default 25m.
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       enabled:
@@ -1665,7 +1666,9 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: MemoryRequest specifies the memory requests of each node-local-dns container in the daemonset. Default 5Mi.
+                        description: MemoryRequest specifies the memory requests of
+                          each node-local-dns container in the daemonset. Default
+                          5Mi.
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1646,6 +1646,13 @@ spec:
                     description: NodeLocalDNS specifies the configuration for the
                       node-local-dns addon
                     properties:
+                      cpuRequest:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: CPURequest specifies the cpu requests of each node-local-dns container in the daemonset. Default 25m.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
                       enabled:
                         description: Enabled activates the node-local-dns addon
                         type: boolean
@@ -1654,6 +1661,13 @@ spec:
                           the 169.254.20.0/16 space or any other IP address that can
                           be guaranteed to not collide with any existing IP.
                         type: string
+                      memoryRequest:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: MemoryRequest specifies the memory requests of each node-local-dns container in the daemonset. Default 5Mi.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
                     type: object
                   provider:
                     description: Provider indicates whether CoreDNS or kube-dns will

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -408,6 +408,10 @@ type NodeLocalDNSConfig struct {
 	Enabled *bool `json:"enabled,omitempty"`
 	// Local listen IP address. It can be any IP in the 169.254.20.0/16 space or any other IP address that can be guaranteed to not collide with any existing IP.
 	LocalIP string `json:"localIP,omitempty"`
+	// MemoryRequest specifies the memory requests of each node-local-dns container in the daemonset. Default 5Mi.
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest specifies the cpu requests of each node-local-dns container in the daemonset. Default 25m.
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 }
 
 // ExternalDNSConfig are options of the dns-controller

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -406,6 +406,10 @@ type NodeLocalDNSConfig struct {
 	Enabled *bool `json:"enabled,omitempty"`
 	// Local listen IP address. It can be any IP in the 169.254.20.0/16 space or any other IP address that can be guaranteed to not collide with any existing IP.
 	LocalIP string `json:"localIP,omitempty"`
+	// MemoryRequest specifies the memory requests of each node-local-dns container in the daemonset. Default 5Mi.
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest specifies the cpu requests of each node-local-dns container in the daemonset. Default 25m.
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 }
 
 // ExternalDNSConfig are options of the dns-controller

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4913,6 +4913,8 @@ func Convert_kops_NodeAuthorizerSpec_To_v1alpha2_NodeAuthorizerSpec(in *kops.Nod
 func autoConvert_v1alpha2_NodeLocalDNSConfig_To_kops_NodeLocalDNSConfig(in *NodeLocalDNSConfig, out *kops.NodeLocalDNSConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
 	out.LocalIP = in.LocalIP
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
 	return nil
 }
 
@@ -4924,6 +4926,8 @@ func Convert_v1alpha2_NodeLocalDNSConfig_To_kops_NodeLocalDNSConfig(in *NodeLoca
 func autoConvert_kops_NodeLocalDNSConfig_To_v1alpha2_NodeLocalDNSConfig(in *kops.NodeLocalDNSConfig, out *NodeLocalDNSConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
 	out.LocalIP = in.LocalIP
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3264,6 +3264,16 @@ func (in *NodeLocalDNSConfig) DeepCopyInto(out *NodeLocalDNSConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3462,6 +3462,16 @@ func (in *NodeLocalDNSConfig) DeepCopyInto(out *NodeLocalDNSConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -87,5 +87,15 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 		nodeLocalDNS.LocalIP = "169.254.20.10"
 	}
 
+	if nodeLocalDNS.MemoryRequest == nil || nodeLocalDNS.MemoryRequest.IsZero() {
+		defaultMemoryRequest := resource.MustParse("5Mi")
+		nodeLocalDNS.MemoryRequest = &defaultMemoryRequest
+	}
+
+	if nodeLocalDNS.CPURequest == nil || nodeLocalDNS.CPURequest.IsZero() {
+		defaultCPURequest := resource.MustParse("25m")
+		nodeLocalDNS.CPURequest = &defaultCPURequest
+	}
+
 	return nil
 }

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -75,12 +75,16 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.KubeDNS.MemoryLimit = &defaultMemoryLimit
 	}
 
-	NodeLocalDNS := clusterSpec.KubeDNS.NodeLocalDNS
-	if NodeLocalDNS == nil {
-		NodeLocalDNS = &kops.NodeLocalDNSConfig{}
-		NodeLocalDNS.Enabled = fi.Bool(false)
-	} else if fi.BoolValue(NodeLocalDNS.Enabled) && NodeLocalDNS.LocalIP == "" {
-		NodeLocalDNS.LocalIP = "169.254.20.10"
+	nodeLocalDNS := clusterSpec.KubeDNS.NodeLocalDNS
+	if nodeLocalDNS == nil {
+		nodeLocalDNS = &kops.NodeLocalDNSConfig{}
+		clusterSpec.KubeDNS.NodeLocalDNS = nodeLocalDNS
+	}
+	if nodeLocalDNS.Enabled == nil {
+		nodeLocalDNS.Enabled = fi.Bool(false)
+	}
+	if fi.BoolValue(nodeLocalDNS.Enabled) && nodeLocalDNS.LocalIP == "" {
+		nodeLocalDNS.LocalIP = "169.254.20.10"
 	}
 
 	return nil

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -18260,8 +18260,8 @@ spec:
         image: k8s.gcr.io/k8s-dns-node-cache:1.15.10
         resources:
           requests:
-            cpu: 25m
-            memory: 5Mi
+            cpu: {{ KubeDNS.NodeLocalDNS.CPURequest }}
+            memory: {{ KubeDNS.NodeLocalDNS.MemoryRequest }}
         {{ if NodeLocalDNSServerIP }}
         args: [ "-localip", "{{ .KubeDNS.NodeLocalDNS.LocalIP }},{{ NodeLocalDNSServerIP }}", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream" ]
         {{ else }}

--- a/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
@@ -131,8 +131,8 @@ spec:
         image: k8s.gcr.io/k8s-dns-node-cache:1.15.10
         resources:
           requests:
-            cpu: 25m
-            memory: 5Mi
+            cpu: {{ KubeDNS.NodeLocalDNS.CPURequest }}
+            memory: {{ KubeDNS.NodeLocalDNS.MemoryRequest }}
         {{ if NodeLocalDNSServerIP }}
         args: [ "-localip", "{{ .KubeDNS.NodeLocalDNS.LocalIP }},{{ NodeLocalDNSServerIP }}", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream" ]
         {{ else }}


### PR DESCRIPTION
Cherry pick of #9376 #9901 on release-1.18.

#9376: NodeLocalDNS config population: small tweaks
#9901: Update NodeLocalDNSConfig with Mem/CPU requests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.