### PR TITLE
Allow caching of Nodeidentity Info in kops-controller for AWS.

### DIFF
--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -150,7 +150,7 @@ func addNodeController(mgr manager.Manager, opt *config.Options) error {
 	var err error
 	switch opt.Cloud {
 	case "aws":
-		identifier, err = nodeidentityaws.New()
+		identifier, err = nodeidentityaws.New(opt.CacheNodeidentityInfo)
 		if err != nil {
 			return fmt.Errorf("error building identifier: %v", err)
 		}

--- a/cmd/kops-controller/pkg/config/options.go
+++ b/cmd/kops-controller/pkg/config/options.go
@@ -19,9 +19,10 @@ package config
 import "k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 
 type Options struct {
-	Cloud      string         `json:"cloud,omitempty"`
-	ConfigBase string         `json:"configBase,omitempty"`
-	Server     *ServerOptions `json:"server,omitempty"`
+	Cloud                 string         `json:"cloud,omitempty"`
+	ConfigBase            string         `json:"configBase,omitempty"`
+	Server                *ServerOptions `json:"server,omitempty"`
+	CacheNodeidentityInfo bool           `json:"cacheNodeidentityInfo,omitempty"`
 }
 
 func (o *Options) PopulateDefaults() {

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -47,6 +47,9 @@ var (
 )
 
 var (
+	// CacheNodeidentityInfo enables NodeidentityInfo caching
+	// in order to reduce the number of EC2 DescribeInstance calls.
+	CacheNodeidentityInfo = New("CacheNodeidentityInfo", Bool(false))
 	// DNSPreCreate controls whether we pre-create DNS records.
 	DNSPreCreate = New("DNSPreCreate", Bool(true))
 	// EnableLaunchTemplates indicates we wish to switch to using launch templates rather than launchconfigurations

--- a/pkg/nodeidentity/aws/BUILD.bazel
+++ b/pkg/nodeidentity/aws/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2/ec2iface:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/pkg/nodeidentity/aws/identify.go
+++ b/pkg/nodeidentity/aws/identify.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
@@ -28,22 +29,33 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	corev1 "k8s.io/api/core/v1"
+	expirationcache "k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/nodeidentity"
 )
 
-// CloudTagInstanceGroupName is a cloud tag that defines the instance group name
-// This is used by the aws nodeidentifier to securely identify the node instancegroup
-const CloudTagInstanceGroupName = "kops.k8s.io/instancegroup"
+const (
+	// CloudTagInstanceGroupName is a cloud tag that defines the instance group name
+	// This is used by the aws nodeidentifier to securely identify the node instancegroup
+	CloudTagInstanceGroupName = "kops.k8s.io/instancegroup"
+
+	// The expiration time of nodeidentity.Info cache.
+	cacheTTL = 60 * time.Minute
+)
 
 // nodeIdentifier identifies a node from EC2
 type nodeIdentifier struct {
 	// client is the ec2 interface
 	ec2Client ec2iface.EC2API
+
+	// cache is a cache of nodeidentity.Info
+	cache expirationcache.Store
+	// cacheEnabled indicates if caching should be used
+	cacheEnabled bool
 }
 
 // New creates and returns a nodeidentity.Identifier for Nodes running on AWS
-func New() (nodeidentity.Identifier, error) {
+func New(CacheNodeidentityInfo bool) (nodeidentity.Identifier, error) {
 	config := aws.NewConfig()
 	config = config.WithCredentialsChainVerboseErrors(true)
 
@@ -66,8 +78,16 @@ func New() (nodeidentity.Identifier, error) {
 	ec2Client := ec2.New(s, config.WithRegion(region))
 
 	return &nodeIdentifier{
-		ec2Client: ec2Client,
+		ec2Client:    ec2Client,
+		cache:        expirationcache.NewTTLStore(stringKeyFunc, cacheTTL),
+		cacheEnabled: CacheNodeidentityInfo,
 	}, nil
+}
+
+// stringKeyFunc is a string as cache key function
+func stringKeyFunc(obj interface{}) (string, error) {
+	key := obj.(*nodeidentity.Info).InstanceID
+	return key, nil
 }
 
 // IdentifyNode queries AWS for the node identity information
@@ -87,6 +107,18 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 
 	//zone := tokens[1]
 	instanceID := tokens[2]
+
+	// If caching is enabled try pulling nodeidentity.Info from cache before
+	// doing a EC2 API call.
+	if i.cacheEnabled {
+		obj, exists, err := i.cache.GetByKey(instanceID)
+		if err != nil {
+			klog.Warningf("Nodeidentity info cache lookup failure: %v", err)
+		}
+		if exists {
+			return obj.(*nodeidentity.Info), nil
+		}
+	}
 
 	// Based on node-authorizer code
 	instance, err := i.getInstance(instanceID)
@@ -114,8 +146,17 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 	}
 
 	info := &nodeidentity.Info{}
+	info.InstanceID = instanceID
 	info.InstanceGroup = igName
 	info.InstanceLifecycle = lifecycle
+
+	// If caching is enabled add the nodeidentity.Info to cache.
+	if i.cacheEnabled {
+		err = i.cache.Add(info)
+		if err != nil {
+			klog.Warningf("Failed to add node identity info to cache: %v", err)
+		}
+	}
 
 	return info, nil
 }

--- a/pkg/nodeidentity/interfaces.go
+++ b/pkg/nodeidentity/interfaces.go
@@ -27,6 +27,7 @@ type Identifier interface {
 }
 
 type Info struct {
+	InstanceID        string
 	InstanceGroup     string
 	InstanceLifecycle string
 }

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -383,6 +383,10 @@ func (tf *TemplateFunctions) KopsControllerConfig() (string, error) {
 		ConfigBase: cluster.Spec.ConfigBase,
 	}
 
+	if featureflag.CacheNodeidentityInfo.Enabled() {
+		config.CacheNodeidentityInfo = true
+	}
+
 	if tf.UseKopsControllerForNodeBootstrap() {
 		certNames := []string{"kubelet"}
 		signingCAs := []string{fi.CertificateIDCA}


### PR DESCRIPTION
Allow caching of Nodeidentity Info in kops-controller for AWS to reduce the number of DescribeInstances API calls.

We've recently been hitting the AWS API rate limit for DescribeInstances very often. Upon further investigation we've discovered that this was due to kops-controller making calls to AWS in order to pull instances info. Given that the information being looked up should never change I implemented caching to help alleviate this issue.

This is behind a feature flag for the time being.