### PR TITLE
Remove force_tcp flag for nodelocalcache dot zone

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -18594,9 +18594,7 @@ data:
         reload
         loop
         bind {{ KubeDNS.NodeLocalDNS.LocalIP }}{{ if NodeLocalDNSServerIP }} {{ NodeLocalDNSServerIP }}{{ end }}
-        forward . __PILLAR__UPSTREAM__SERVERS__ {
-          force_tcp
-        }
+        forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
     }
 ---

--- a/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
@@ -85,9 +85,7 @@ data:
         reload
         loop
         bind {{ KubeDNS.NodeLocalDNS.LocalIP }}{{ if NodeLocalDNSServerIP }} {{ NodeLocalDNSServerIP }}{{ end }}
-        forward . __PILLAR__UPSTREAM__SERVERS__ {
-          force_tcp
-        }
+        forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
     }
 ---


### PR DESCRIPTION
This PR is proposing a change in the nodelocalcache confimap. 
The change is removing the `force_tcp` flag from the `.` zone that handles all external DNS requests.
Using the current nodelocalcache configuration we have experienced increased latencies for our DNS requests that needs to go to our upstream DNS server (which in our case is AWS VPC's DNS servers).
Forcing all DNS communication go through TCP can lead to increased latency and slower DNS responses since a lot of upstream DNS servers are not optimized for TCP traffic.
An example is AWS's VPC DNS server that sending all the DNS traffic through TCP cause it to increase the latencies for this requests.
The kubernetes version has already changed this configmap to skip `force_tcp` flag for the . zone, so it might make sense to follow their example.

Reference https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml#L100