### PR TITLE
Validate labels

### DIFF
--- a/pkg/apis/kops/validation/BUILD.bazel
+++ b/pkg/apis/kops/validation/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/featureflag:go_default_library",
         "//pkg/model/components:go_default_library",
         "//pkg/model/iam:go_default_library",
+        "//pkg/nodeidentity/aws:go_default_library",
         "//pkg/util/subnet:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
@@ -48,6 +49,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/kops:go_default_library",
+        "//pkg/nodeidentity/aws:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",


### PR DESCRIPTION
This fixes a couple of issues with labels reported by users:
* A mixup between cloudLabels (which allows many /) and nodeLabels (which don't) ended up in issues with kops-controller who couldn't set labels with a bad value
* Someone setting the kops IG node cloud label manually to something else than the IG name ended up in issues with node identity.

We should validate more, but that can come as future PRs.