### PR TITLE
Only add additional policies to kops managed IAMRoles

### DIFF
--- a/pkg/model/iam.go
+++ b/pkg/model/iam.go
@@ -263,7 +263,7 @@ func (b *IAMModelBuilder) buildIAMTasks(role iam.Subject, iamName string, c *fi.
 		}
 
 		// Generate additional policies if needed, and attach to existing role
-		{
+		if !shared {
 			additionalPolicy := ""
 			if b.Cluster.Spec.AdditionalPolicies != nil {
 				additionalPolicies := *(b.Cluster.Spec.AdditionalPolicies)


### PR DESCRIPTION
While reviewing https://github.com/kubernetes/kops/pull/9867 I noticed that kops modifies existing/shared IAM instance profiles when setting additional policies.

In my opinion, kops should only modify the resources it creates. If changes are applied on external resources shared between multiple clusters, the consequences would be unpredictable.