### PR TITLE
Don't write application credentials to cloud config unless external CCM is enabled

### DIFF
--- a/nodeup/pkg/model/cloudconfig.go
+++ b/nodeup/pkg/model/cloudconfig.go
@@ -92,8 +92,16 @@ func (b *CloudConfigBuilder) Build(c *fi.ModelBuilderContext) error {
 			fmt.Sprintf("tenant-name=\"%s\"", tenantName),
 			fmt.Sprintf("domain-name=\"%s\"", os.Getenv("OS_DOMAIN_NAME")),
 			fmt.Sprintf("domain-id=\"%s\"", os.Getenv("OS_DOMAIN_ID")),
-			fmt.Sprintf("application-credential-id=\"%s\"", os.Getenv("OS_APPLICATION_CREDENTIAL_ID")),
-			fmt.Sprintf("application-credential-secret=\"%s\"", os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET")),
+		)
+		if b.Cluster.Spec.ExternalCloudControllerManager != nil {
+			lines = append(lines,
+				fmt.Sprintf("application-credential-id=\"%s\"", os.Getenv("OS_APPLICATION_CREDENTIAL_ID")),
+				fmt.Sprintf("application-credential-secret=\"%s\"", os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET")),
+			)
+
+		}
+
+		lines = append(lines,
 			"",
 		)
 

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -118,7 +118,13 @@ func (b *BootstrapScript) buildEnvironmentVariables(cluster *kops.Cluster) (map[
 			"OS_REGION_NAME",
 		}
 
-		if os.Getenv("OS_APPLICATION_CREDENTIAL_ID") != "" && os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET") != "" {
+		hasCCM := cluster.Spec.ExternalCloudControllerManager != nil
+		appCreds := os.Getenv("OS_APPLICATION_CREDENTIAL_ID") != "" && os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET") != ""
+		if !hasCCM && appCreds {
+			klog.Warning("application credentials only supported when using external cloud controller manager. Continuing with passwords.")
+		}
+
+		if hasCCM && appCreds {
 			osEnvs = append(osEnvs,
 				"OS_APPLICATION_CREDENTIAL_ID",
 				"OS_APPLICATION_CREDENTIAL_SECRET",


### PR DESCRIPTION
Looks like the in-tree CCM gets confused over these params.

fixes #9928 