### PR TITLE
add kube-system psp to system:nodes

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -19376,11 +19376,9 @@ subjects:
 - kind: User
   name: kubelet
   apiGroup: rbac.authorization.k8s.io
-{{- if UseBootstrapTokens }}
 - kind: Group
   name: system:nodes
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/upup/models/cloudup/resources/addons/podsecuritypolicy.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/podsecuritypolicy.addons.k8s.io/k8s-1.12.yaml.template
@@ -58,11 +58,9 @@ subjects:
 - kind: User
   name: kubelet
   apiGroup: rbac.authorization.k8s.io
-{{- if UseBootstrapTokens }}
 - kind: Group
   name: system:nodes
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
fixes #9937 

This is quite good page to read through https://octetz.com/docs/2019/2019-10-12-static-pods/

When we are deploying apiserver, controller-manager, scheduler, etcds with static pods. It means that those are running in docker and we cannot shutdown those using kubernetes api. However, when kubelet will try to add those "mirror pods" to kubernetes API the PSPs are applied. Kubelet cannot add these pods to K8s api without this permission
