### PR TITLE
Automated cherry pick of #9867: only apply external policy tasks on non-shared iam #9924: Only add additional policies to kops managed IAMRoles

### DIFF
--- a/pkg/model/iam.go
+++ b/pkg/model/iam.go
@@ -187,7 +187,7 @@ func (b *IAMModelBuilder) buildIAMTasks(igRole kops.InstanceGroupRole, iamName s
 		}
 
 		// Generate additional policies if needed, and attach to existing role
-		{
+		if !shared {
 			additionalPolicy := ""
 			if b.Cluster.Spec.AdditionalPolicies != nil {
 				additionalPolicies := *(b.Cluster.Spec.AdditionalPolicies)

--- a/pkg/model/iam.go
+++ b/pkg/model/iam.go
@@ -166,7 +166,7 @@ func (b *IAMModelBuilder) buildIAMTasks(igRole kops.InstanceGroupRole, iamName s
 		}
 
 		// Create External Policy tasks
-		{
+		if !shared {
 			var externalPolicies []string
 
 			if b.Cluster.Spec.ExternalPolicies != nil {


### PR DESCRIPTION
Cherry pick of #9867 #9924 on release-1.18.

#9867: only apply external policy tasks on non-shared iam
#9924: Only add additional policies to kops managed IAMRoles

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.