### PR TITLE
Use all kops mirrors to determine artifacts hashes

### DIFF
--- a/hack/.packages
+++ b/hack/.packages
@@ -202,6 +202,7 @@ k8s.io/kops/util/pkg/env
 k8s.io/kops/util/pkg/exec
 k8s.io/kops/util/pkg/hashing
 k8s.io/kops/util/pkg/maps
+k8s.io/kops/util/pkg/mirrors
 k8s.io/kops/util/pkg/proxy
 k8s.io/kops/util/pkg/reflectutils
 k8s.io/kops/util/pkg/slice

--- a/pkg/assets/BUILD.bazel
+++ b/pkg/assets/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/kubemanifest:go_default_library",
         "//pkg/values:go_default_library",
         "//util/pkg/hashing:go_default_library",
+        "//util/pkg/mirrors:go_default_library",
         "//util/pkg/vfs:go_default_library",
         "//vendor/github.com/blang/semver/v4:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -318,11 +318,7 @@ func (a *AssetBuilder) findHash(file *FileAsset) (*hashing.Hash, error) {
 				b, err := vfs.Context.ReadFile(hashURL, vfs.WithBackoff(backoff))
 				if err != nil {
 					// Try to log without being too alarming - issue #7550
-					if ext == ".sha256" {
-						klog.V(2).Infof("Unable to read new sha256 hash file (is this an older/unsupported kubernetes release?) %q: %v", hashURL, err)
-					} else {
-						klog.V(2).Infof("Unable to read hash file %q: %v", hashURL, err)
-					}
+					klog.V(2).Infof("Unable to read hash file %q: %v", hashURL, err)
 					continue
 				}
 				hashString := strings.TrimSpace(string(b))
@@ -335,6 +331,9 @@ func (a *AssetBuilder) findHash(file *FileAsset) (*hashing.Hash, error) {
 					continue
 				}
 				return hashing.FromString(fields[0])
+			}
+			if ext == ".sha256" {
+				klog.V(2).Infof("Unable to read new sha256 hash file (is this an older/unsupported kubernetes release?)")
 			}
 		}
 	}

--- a/upup/pkg/fi/cloudup/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/BUILD.bazel
@@ -78,6 +78,7 @@ go_library(
         "//util/pkg/architectures:go_default_library",
         "//util/pkg/env:go_default_library",
         "//util/pkg/hashing:go_default_library",
+        "//util/pkg/mirrors:go_default_library",
         "//util/pkg/reflectutils:go_default_library",
         "//util/pkg/vfs:go_default_library",
         "//vendor/github.com/Masterminds/sprig:go_default_library",

--- a/util/pkg/mirrors/BUILD.bazel
+++ b/util/pkg/mirrors/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["mirrors.go"],
+    importpath = "k8s.io/kops/util/pkg/mirrors",
+    visibility = ["//visibility:public"],
+    deps = ["//:go_default_library"],
+)

--- a/util/pkg/mirrors/mirrors.go
+++ b/util/pkg/mirrors/mirrors.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mirrors
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/kops"
+)
+
+const (
+	defaultKopsMirrorBase    = "https://kubeupv2.s3.amazonaws.com/kops/%s/"
+	githubKopsMirrorBase     = "https://github.com/kubernetes/kops/releases/download/v%s/"
+	kubernetesKopsMirrorBase = "https://artifacts.k8s.io/binaries/kops/%s/"
+)
+
+func FindUrlMirrors(u string) []string {
+	// Use the mirrors to also find hashes.
+	baseURLString := fmt.Sprintf(defaultKopsMirrorBase, kops.Version)
+	if !strings.HasSuffix(baseURLString, "/") {
+		baseURLString += "/"
+	}
+
+	var mirrors []string
+	if strings.HasPrefix(u, baseURLString) {
+		suffix := strings.TrimPrefix(u, baseURLString)
+		// artifacts.k8s.io is the official and preferred mirror.
+		mirrors = append(mirrors, fmt.Sprintf(kubernetesKopsMirrorBase, kops.Version)+suffix)
+		// GitHub artifact names are quite different, because the suffix path is collapsed.
+		githubSuffix := strings.ReplaceAll(suffix, "/", "-")
+		githubSuffix = strings.ReplaceAll(githubSuffix, "linux-amd64-nodeup", "nodeup-linux-amd64")
+		githubSuffix = strings.ReplaceAll(githubSuffix, "linux-arm64-nodeup", "nodeup-linux-arm64")
+		mirrors = append(mirrors, fmt.Sprintf(githubKopsMirrorBase, kops.Version)+githubSuffix)
+	}
+	// Finally append the original URL to the list of mirrored URLs.
+	// In case this is a custom URL, there won't be any mirrors before it,
+	// otherwise it will be the last mirror URL, because it's now a legacy location.
+	mirrors = append(mirrors, u)
+
+	return mirrors
+}

--- a/util/pkg/vfs/context.go
+++ b/util/pkg/vfs/context.go
@@ -280,7 +280,7 @@ func RetryWithBackoff(backoff wait.Backoff, condition func() (bool, error)) (boo
 		}
 
 		if noMoreRetries {
-			klog.Infof("hit maximum retries %d with error %v", i, err)
+			klog.V(2).Infof("hit maximum retries %d with error %v", i, err)
 			return done, err
 		}
 	}


### PR DESCRIPTION
Current implementation only looks for hash files in the S3 mirror and, if that is down, kops commands will fail with:
```
cannot determine hash for "https://kubeupv2.s3.amazonaws.com/kops/1.19.0-alpha.4/linux/amd64/nodeup"
(have you specified a valid file location?)
```

The code in the assets remapping and mirroring is quite complex and even if this looks a bit less elegant than I would like, it works pretty well.

Fixes: #9951