### PR TITLE
Add instance groups and k8s 1.19 to bootstrapchannelbuilder tests

### DIFF
--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
@@ -106,21 +106,39 @@ func runChannelBuilderTest(t *testing.T, key string, addonManifests []string) {
 	if err != nil {
 		t.Error(err)
 	}
+	role := "arn:aws:iam::1234567890108:instance-profile/kops-custom-node-role"
+	kopsModel := model.KopsModelContext{
+		IAMModelContext: iam.IAMModelContext{
+			Cluster:      cluster,
+			AWSAccountID: "123456789012",
+		},
+		Region: "us-east-1",
+		InstanceGroups: []*kopsapi.InstanceGroup{
+			{
+				Spec: kopsapi.InstanceGroupSpec{
+					IAM: &kopsapi.IAMProfileSpec{
+						Profile: &role,
+					},
+					Role: kopsapi.InstanceGroupRoleNode,
+				},
+			},
+			{
+				Spec: kopsapi.InstanceGroupSpec{
+					Role: kopsapi.InstanceGroupRoleNode,
+				},
+			},
+		},
+	}
 
 	tf := &TemplateFunctions{
-		KopsModelContext: model.KopsModelContext{
-			IAMModelContext: iam.IAMModelContext{Cluster: cluster},
-			Region:          "us-east-1",
-		},
+		KopsModelContext: kopsModel,
 	}
 	tf.AddTo(templates.TemplateFunctions, secretStore)
 
 	bcb := BootstrapChannelBuilder{
-		KopsModelContext: &model.KopsModelContext{
-			IAMModelContext: iam.IAMModelContext{Cluster: cluster},
-		},
-		templates:    templates,
-		assetBuilder: assets.NewAssetBuilder(cluster, ""),
+		KopsModelContext: &kopsModel,
+		templates:        templates,
+		assetBuilder:     assets.NewAssetBuilder(cluster, ""),
 	}
 
 	context := &fi.ModelBuilderContext{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/cluster.yaml
@@ -25,7 +25,7 @@ spec:
       name: master-us-test-1a
     name: events
   iam: {}
-  kubernetesVersion: v1.14.6
+  kubernetesVersion: v1.19.2
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   additionalSans:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b047de23df3b0caff3784aaa89ae0c967e866c95
+    manifestHash: 3c73d81e8c87bf4f409323ca904d22ee9c375284
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
@@ -34,13 +34,6 @@ spec:
     selector:
       k8s-addon: kube-dns.addons.k8s.io
     version: 1.15.13-kops.3
-  - id: k8s-1.8
-    manifest: rbac.addons.k8s.io/k8s-1.8.yaml
-    manifestHash: 5d53ce7b920cd1e8d65d2306d80a041420711914
-    name: rbac.addons.k8s.io
-    selector:
-      k8s-addon: rbac.addons.k8s.io
-    version: 1.8.0
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
     manifestHash: e1508d77cb4e527d7a2939babe36dc350dd83745

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -35,7 +35,7 @@ spec:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
         - name: AWS_ROLE_ARN
-          value: arn:aws:iam:::role/dns-controller.kube-system.sa.minimal.example.com
+          value: arn:aws:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
         image: k8s.gcr.io/kops/dns-controller:1.19.0-alpha.4

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/manifest.yaml
@@ -73,7 +73,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 767e92b277dad99d830ddfa0dfc37f15731f4b8e
+    manifestHash: ec9465805a830d1029d3fb7a181202a1f9266b8e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/cluster.yaml
@@ -21,7 +21,7 @@ spec:
       name: master-us-test-1a
     name: events
   iam: {}
-  kubernetesVersion: v1.14.6
+  kubernetesVersion: v1.19.2
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   additionalSans:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com"}
+    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3992","provider":{"aws":{"nodesRoles":["kops-custom-node-role","nodes.minimal.example.com"],"Region":"us-east-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["ca"],"certNames":["kubelet","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   labels:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b047de23df3b0caff3784aaa89ae0c967e866c95
+    manifestHash: 3c73d81e8c87bf4f409323ca904d22ee9c375284
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
@@ -34,13 +34,6 @@ spec:
     selector:
       k8s-addon: kube-dns.addons.k8s.io
     version: 1.15.13-kops.3
-  - id: k8s-1.8
-    manifest: rbac.addons.k8s.io/k8s-1.8.yaml
-    manifestHash: 5d53ce7b920cd1e8d65d2306d80a041420711914
-    name: rbac.addons.k8s.io
-    selector:
-      k8s-addon: rbac.addons.k8s.io
-    version: 1.8.0
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
     manifestHash: e1508d77cb4e527d7a2939babe36dc350dd83745


### PR DESCRIPTION
This now exercises the kops-controller node bootstrapping logic

minor improvements as a part of #9855