### PR TITLE
Bump k8s versions and Ubuntu ami version to latest

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -44,7 +44,7 @@ spec:
     - name: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
       providerID: aws
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200817
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907
       providerID: aws
       kubernetesVersion: ">=1.18.0"
     - providerID: gce
@@ -59,10 +59,10 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.18.0"
-    recommendedVersion: 1.18.8
+    recommendedVersion: 1.18.9
     requiredVersion: 1.18.0
   - range: ">=1.17.0"
-    recommendedVersion: 1.17.11
+    recommendedVersion: 1.17.12
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
     recommendedVersion: 1.16.15
@@ -89,15 +89,15 @@ spec:
   - range: ">=1.19.0-alpha.1"
     #recommendedVersion: "1.19.0-alpha.1"
     #requiredVersion: 1.19.0
-    kubernetesVersion: 1.19.0-rc.1
+    kubernetesVersion: 1.19.2
   - range: ">=1.18.0-alpha.1"
     recommendedVersion: "1.18.0"
     #requiredVersion: 1.18.0
-    kubernetesVersion: 1.18.8
+    kubernetesVersion: 1.18.9
   - range: ">=1.17.0-alpha.1"
     recommendedVersion: "1.17.1"
     #requiredVersion: 1.17.0
-    kubernetesVersion: 1.17.11
+    kubernetesVersion: 1.17.12
   - range: ">=1.16.0-alpha.1"
     recommendedVersion: "1.16.4"
     #requiredVersion: 1.16.0

--- a/channels/stable
+++ b/channels/stable
@@ -44,7 +44,7 @@ spec:
     - name: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
       providerID: aws
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200716
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200817
       providerID: aws
       kubernetesVersion: ">=1.18.0"
     - providerID: gce
@@ -65,7 +65,7 @@ spec:
     recommendedVersion: 1.17.11
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
-    recommendedVersion: 1.16.14
+    recommendedVersion: 1.16.15
     requiredVersion: 1.16.0
   - range: ">=1.15.0"
     recommendedVersion: 1.15.12
@@ -101,7 +101,7 @@ spec:
   - range: ">=1.16.0-alpha.1"
     recommendedVersion: "1.16.4"
     #requiredVersion: 1.16.0
-    kubernetesVersion: 1.16.14
+    kubernetesVersion: 1.16.15
   - range: ">=1.15.0-alpha.1"
     recommendedVersion: "1.15.3"
     #requiredVersion: 1.15.0


### PR DESCRIPTION
# Stable changes: 
- Bump k8s 1.16.15 and Ubuntu image from August from `alpha` to `stable`
# Alpha changes:
- Bump k8s versions with releases from yesterday:
  - https://github.com/kubernetes/kubernetes/releases/tag/v1.19.2
  - https://github.com/kubernetes/kubernetes/releases/tag/v1.18.9
  - https://github.com/kubernetes/kubernetes/releases/tag/v1.17.12
- Bump ubuntu ami version to latest available - `ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907`