### PR TITLE
Update containerd to v1.4.1

### DIFF
--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -103,13 +103,13 @@ var containerdVersions = []packageVersion{
 		},
 	},
 
-	// 1.4.0 - Linux Generic AMD64
+	// 1.4.1 - Linux Generic AMD64
 	{
-		PackageVersion: "1.4.0",
+		PackageVersion: "1.4.1",
 		PlainBinary:    true,
 		Architectures:  []architectures.Architecture{architectures.ArchitectureAmd64},
-		Source:         "https://github.com/containerd/containerd/releases/download/v1.4.0/cri-containerd-cni-1.4.0-linux-amd64.tar.gz",
-		Hash:           "b379f29417efd583f77e095173d4d0bd6bb001f0081b2a63d152ee7aef653ce1",
+		Source:         "https://github.com/containerd/containerd/releases/download/v1.4.1/cri-containerd-cni-1.4.1-linux-amd64.tar.gz",
+		Hash:           "757efb93a4f3161efc447a943317503d8a7ded5cb4cc0cba3f3318d7ce1542ed",
 		MapFiles: map[string]string{
 			"usr/local/bin":  "/usr",
 			"usr/local/sbin": "/usr",

--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -51,7 +51,7 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 		// Set containerd based on Kubernetes version
 		if fi.StringValue(containerd.Version) == "" {
 			if b.IsKubernetesGTE("1.19") {
-				containerd.Version = fi.String("1.4.0")
+				containerd.Version = fi.String("1.4.1")
 			} else if b.IsKubernetesGTE("1.18") {
 				containerd.Version = fi.String("1.3.4")
 			} else {


### PR DESCRIPTION
https://github.com/containerd/containerd/releases/tag/v1.4.1

v1.4.0 was never released so we can just replace it.