### PR TITLE
OpenStack: allow to specify storageClass creation to false

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -20353,7 +20353,7 @@ spec:
   - Persistent
   - Ephemeral
 
-{{ if .CloudConfig.Openstack.BlockStorage.CreateStorageClass }}
+{{ if WithDefaultBool .CloudConfig.Openstack.BlockStorage.CreateStorageClass true }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
@@ -517,7 +517,7 @@ spec:
   - Persistent
   - Ephemeral
 
-{{ if .CloudConfig.Openstack.BlockStorage.CreateStorageClass }}
+{{ if WithDefaultBool .CloudConfig.Openstack.BlockStorage.CreateStorageClass true }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass


### PR DESCRIPTION
The current problem is following: https://play.golang.org/p/6rglepaQ9r8

Because `CreateStorageClass` is `*bool` it will be marked always as `True` if defined. And because https://github.com/kubernetes/kops/blob/master/pkg/model/components/openstack.go#L51-L53 makes sure that this will be always true.

/kind bug