### PR TITLE
Build cloud outside of PerformAssignments

### DIFF
--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -144,9 +144,14 @@ func RunCreate(ctx context.Context, f *util.Factory, out io.Writer, c *CreateOpt
 
 			switch v := o.(type) {
 			case *kopsapi.Cluster:
+				cloud, err := cloudup.BuildCloud(v)
+				if err != nil {
+					return err
+				}
+
 				// Adding a PerformAssignments() call here as the user might be trying to use
 				// the new `-f` feature, with an old cluster definition.
-				err = cloudup.PerformAssignments(v)
+				err = cloudup.PerformAssignments(v, cloud)
 				if err != nil {
 					return fmt.Errorf("error populating configuration: %v", err)
 				}

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -493,7 +493,12 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 		return err
 	}
 
-	err = cloudup.PerformAssignments(cluster)
+	cloud, err := cloudup.BuildCloud(cluster)
+	if err != nil {
+		return err
+	}
+
+	err = cloudup.PerformAssignments(cluster, cloud)
 	if err != nil {
 		return fmt.Errorf("error populating configuration: %v", err)
 	}

--- a/cmd/kops/edit_cluster.go
+++ b/cmd/kops/edit_cluster.go
@@ -206,7 +206,12 @@ func RunEditCluster(ctx context.Context, f *util.Factory, cmd *cobra.Command, ar
 			continue
 		}
 
-		err = cloudup.PerformAssignments(newCluster)
+		cloud, err := cloudup.BuildCloud(newCluster)
+		if err != nil {
+			return err
+		}
+
+		err = cloudup.PerformAssignments(newCluster, cloud)
 		if err != nil {
 			return preservedFile(fmt.Errorf("error populating configuration: %v", err), file, out)
 		}
@@ -220,11 +225,6 @@ func RunEditCluster(ctx context.Context, f *util.Factory, cmd *cobra.Command, ar
 			results.header.addError(fmt.Sprintf("error populating cluster spec: %s", err))
 			containsError = true
 			continue
-		}
-
-		cloud, err := cloudup.BuildCloud(fullCluster)
-		if err != nil {
-			return err
 		}
 
 		err = validation.DeepValidate(fullCluster, instanceGroups, true, cloud)

--- a/cmd/kops/edit_instancegroup.go
+++ b/cmd/kops/edit_instancegroup.go
@@ -160,20 +160,20 @@ func RunEditInstanceGroup(ctx context.Context, f *util.Factory, cmd *cobra.Comma
 		return err
 	}
 
+	cloud, err := cloudup.BuildCloud(cluster)
+	if err != nil {
+		return err
+	}
+
 	// We need the full cluster spec to perform deep validation
 	// Note that we don't write it back though
-	err = cloudup.PerformAssignments(cluster)
+	err = cloudup.PerformAssignments(cluster, cloud)
 	if err != nil {
 		return fmt.Errorf("error populating configuration: %v", err)
 	}
 
 	assetBuilder := assets.NewAssetBuilder(cluster, "")
 	fullCluster, err := cloudup.PopulateClusterSpec(clientset, cluster, assetBuilder)
-	if err != nil {
-		return err
-	}
-
-	cloud, err := cloudup.BuildCloud(fullCluster)
 	if err != nil {
 		return err
 	}

--- a/examples/kops-api-example/up.go
+++ b/examples/kops-api-example/up.go
@@ -65,11 +65,16 @@ func up(ctx context.Context) error {
 		cluster.Spec.EtcdClusters = append(cluster.Spec.EtcdClusters, etcdCluster)
 	}
 
-	if err := cloudup.PerformAssignments(cluster); err != nil {
+	cloud, err := cloudup.BuildCloud(cluster)
+	if err != nil {
 		return err
 	}
 
-	_, err := clientset.CreateCluster(ctx, cluster)
+	if err := cloudup.PerformAssignments(cluster, cloud); err != nil {
+		return err
+	}
+
+	_, err = clientset.CreateCluster(ctx, cluster)
 	if err != nil {
 		return err
 	}

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -296,8 +296,13 @@ func RunGoldenTest(t *testing.T, basedir string, key string, builder func(*Nodeu
 	nodeupModelContext.KeyStore = keystore
 
 	// Populate the cluster
+	cloud, err := cloudup.BuildCloud(nodeupModelContext.Cluster)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
+
 	{
-		err := cloudup.PerformAssignments(nodeupModelContext.Cluster)
+		err := cloudup.PerformAssignments(nodeupModelContext.Cluster, cloud)
 		if err != nil {
 			t.Fatalf("error from PerformAssignments: %v", err)
 		}

--- a/pkg/commands/helpers_readwrite.go
+++ b/pkg/commands/helpers_readwrite.go
@@ -30,7 +30,12 @@ import (
 
 // UpdateCluster writes the updated cluster to the state store, after performing validation
 func UpdateCluster(ctx context.Context, clientset simple.Clientset, cluster *kops.Cluster, instanceGroups []*kops.InstanceGroup) error {
-	err := cloudup.PerformAssignments(cluster)
+	cloud, err := cloudup.BuildCloud(cluster)
+	if err != nil {
+		return err
+	}
+
+	err = cloudup.PerformAssignments(cluster, cloud)
 	if err != nil {
 		return fmt.Errorf("error populating configuration: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
@@ -79,7 +79,12 @@ func runChannelBuilderTest(t *testing.T, key string, addonManifests []string) {
 	}
 	cluster := obj.(*kopsapi.Cluster)
 
-	if err := PerformAssignments(cluster); err != nil {
+	cloud, err := BuildCloud(cluster)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
+
+	if err := PerformAssignments(cluster, cloud); err != nil {
 		t.Fatalf("error from PerformAssignments for %q: %v", key, err)
 	}
 

--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -98,7 +98,12 @@ func (c *populateClusterSpec) run(clientset simple.Clientset) error {
 		return err
 	}
 
-	err = PerformAssignments(cluster)
+	cloud, err := BuildCloud(cluster)
+	if err != nil {
+		return err
+	}
+
+	err = PerformAssignments(cluster, cloud)
 	if err != nil {
 		return err
 	}
@@ -219,11 +224,6 @@ func (c *populateClusterSpec) run(clientset simple.Clientset) error {
 		klog.V(2).Infof("Normalizing kubernetes version: %q -> %q", cluster.Spec.KubernetesVersion, versionWithoutV)
 		cluster.Spec.KubernetesVersion = versionWithoutV
 	}
-	cloud, err := BuildCloud(cluster)
-	if err != nil {
-		return err
-	}
-
 	if cluster.Spec.DNSZone == "" && !dns.IsGossipHostname(cluster.ObjectMeta.Name) {
 		dns, err := cloud.DNS()
 		if err != nil {

--- a/upup/pkg/fi/cloudup/populatecluster_test.go
+++ b/upup/pkg/fi/cloudup/populatecluster_test.go
@@ -88,8 +88,12 @@ func addEtcdClusters(c *kopsapi.Cluster) {
 
 func TestPopulateCluster_Default_NoError(t *testing.T) {
 	c := buildMinimalCluster()
+	cloud, err := BuildCloud(c)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
 
-	err := PerformAssignments(c)
+	err = PerformAssignments(c, cloud)
 	if err != nil {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}
@@ -123,8 +127,12 @@ func TestPopulateCluster_Docker_Spec(t *testing.T) {
 		RegistryMirrors:    []string{"https://registry.example.com"},
 		LogOpt:             []string{"env=FOO"},
 	}
+	cloud, err := BuildCloud(c)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
 
-	err := PerformAssignments(c)
+	err = PerformAssignments(c, cloud)
 	if err != nil {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}
@@ -159,7 +167,12 @@ func TestPopulateCluster_Docker_Spec(t *testing.T) {
 
 func TestPopulateCluster_StorageDefault(t *testing.T) {
 	c := buildMinimalCluster()
-	err := PerformAssignments(c)
+	cloud, err := BuildCloud(c)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
+
+	err = PerformAssignments(c, cloud)
 	if err != nil {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}
@@ -177,7 +190,12 @@ func TestPopulateCluster_StorageDefault(t *testing.T) {
 }
 
 func build(c *kopsapi.Cluster) (*kopsapi.Cluster, error) {
-	err := PerformAssignments(c)
+	cloud, err := BuildCloud(c)
+	if err != nil {
+		return nil, fmt.Errorf("error from BuildCloud: %v", err)
+	}
+
+	err = PerformAssignments(c, cloud)
 	if err != nil {
 		return nil, fmt.Errorf("error from PerformAssignments: %v", err)
 	}
@@ -245,7 +263,12 @@ func TestPopulateCluster_Custom_CIDR(t *testing.T) {
 		{Name: "subnet-us-mock-1c", Zone: "us-mock-1c", CIDR: "172.20.2.64/27"},
 	}
 
-	err := PerformAssignments(c)
+	cloud, err := BuildCloud(c)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
+
+	err = PerformAssignments(c, cloud)
 	if err != nil {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}
@@ -264,8 +287,12 @@ func TestPopulateCluster_Custom_CIDR(t *testing.T) {
 func TestPopulateCluster_IsolateMasters(t *testing.T) {
 	c := buildMinimalCluster()
 	c.Spec.IsolateMasters = fi.Bool(true)
+	cloud, err := BuildCloud(c)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
 
-	err := PerformAssignments(c)
+	err = PerformAssignments(c, cloud)
 	if err != nil {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}
@@ -288,7 +315,12 @@ func TestPopulateCluster_IsolateMastersFalse(t *testing.T) {
 	c := buildMinimalCluster()
 	// default: c.Spec.IsolateMasters = fi.Bool(false)
 
-	err := PerformAssignments(c)
+	cloud, err := BuildCloud(c)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
+
+	err = PerformAssignments(c, cloud)
 	if err != nil {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}
@@ -410,7 +442,12 @@ func TestPopulateCluster_AnonymousAuth(t *testing.T) {
 	c := buildMinimalCluster()
 	c.Spec.KubernetesVersion = "1.15.0"
 
-	err := PerformAssignments(c)
+	cloud, err := BuildCloud(c)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
+
+	err = PerformAssignments(c, cloud)
 	if err != nil {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}
@@ -477,7 +514,12 @@ func TestPopulateCluster_KubeController_High_Enough_Version(t *testing.T) {
 	c := buildMinimalCluster()
 	c.Spec.KubernetesVersion = "v1.9.0"
 
-	err := PerformAssignments(c)
+	cloud, err := BuildCloud(c)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
+
+	err = PerformAssignments(c, cloud)
 	if err != nil {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/validation_test.go
+++ b/upup/pkg/fi/cloudup/validation_test.go
@@ -32,7 +32,12 @@ const MockAWSRegion = "us-mock-1"
 func buildDefaultCluster(t *testing.T) *api.Cluster {
 	c := buildMinimalCluster()
 
-	err := PerformAssignments(c)
+	cloud, err := BuildCloud(c)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
+
+	err = PerformAssignments(c, cloud)
 	if err != nil {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}

--- a/upup/pkg/kutil/convert_kubeup_cluster.go
+++ b/upup/pkg/kutil/convert_kubeup_cluster.go
@@ -97,7 +97,7 @@ func (x *ConvertKubeupCluster) Upgrade(ctx context.Context) error {
 		}
 	}
 
-	err = cloudup.PerformAssignments(cluster)
+	err = cloudup.PerformAssignments(cluster, awsCloud)
 	if err != nil {
 		return fmt.Errorf("error populating cluster defaults: %v", err)
 	}


### PR DESCRIPTION
We tend to build cloud, call some method, and then build cloud over
again. It would be easier to just pass the first one along.

Passing along cloud would also make it easier to mock cloud.