### PR TITLE
Add missing permissions for cilium-operator

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -4735,6 +4735,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -5640,6 +5648,14 @@ rules:
   - ciliumidentities/status
   verbs:
   - '*'
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
@@ -349,6 +349,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12.yaml.template
@@ -327,6 +327,14 @@ rules:
   - ciliumidentities/status
   verbs:
   - '*'
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -89,7 +89,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12-v1.8.yaml
-    manifestHash: 91d442758bc9678f9be8e1b08ef393bb7d2066a0
+    manifestHash: 0d0cb351894e81048b6c7046e15bd3a0c02c0ee9
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
These became required a few cilium versions ago.

This basically fixes the same as reported in kubespray: https://github.com/kubernetes-sigs/kubespray/issues/6681, which was fixed in https://github.com/kubernetes-sigs/kubespray/pull/6683

I encountered exactly the same error with kops and cilium. A follow up error is that the cilium agents fail and keep restarting due to the cilium-operator not starting up and not issuing heart beats.

EDIT: I'm not sure I understand the folder structure in `upup/models/cloudup/resources/addons/networking.cilium.io`. I already figured out that I have to run a local build first to update bindata.go...but I don't understand which of the 3 templates needs the changes.