### PR TITLE
Bumping k8s versions and ubuntu AMI version from alpha to stable

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -44,7 +44,7 @@ spec:
     - name: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
       providerID: aws
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200817
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907
       providerID: aws
       kubernetesVersion: ">=1.18.0"
     - providerID: gce
@@ -59,10 +59,10 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.18.0"
-    recommendedVersion: 1.18.8
+    recommendedVersion: 1.18.9
     requiredVersion: 1.18.0
   - range: ">=1.17.0"
-    recommendedVersion: 1.17.11
+    recommendedVersion: 1.17.12
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
     recommendedVersion: 1.16.15
@@ -89,15 +89,15 @@ spec:
   - range: ">=1.19.0-alpha.1"
     #recommendedVersion: "1.19.0-alpha.1"
     #requiredVersion: 1.19.0
-    kubernetesVersion: 1.19.0-rc.1
+    kubernetesVersion: 1.19.2
   - range: ">=1.18.0-alpha.1"
     recommendedVersion: "1.18.0"
     #requiredVersion: 1.18.0
-    kubernetesVersion: 1.18.8
+    kubernetesVersion: 1.18.9
   - range: ">=1.17.0-alpha.1"
     recommendedVersion: "1.17.1"
     #requiredVersion: 1.17.0
-    kubernetesVersion: 1.17.11
+    kubernetesVersion: 1.17.12
   - range: ">=1.16.0-alpha.1"
     recommendedVersion: "1.16.4"
     #requiredVersion: 1.16.0


### PR DESCRIPTION
It's been a week since these versions were pushed to alpha, seems like it's ready for stable.