### PR TITLE
Add deprecation notice for support of Terraform v0.11

### DIFF
--- a/docs/releases/1.19-NOTES.md
+++ b/docs/releases/1.19-NOTES.md
@@ -58,6 +58,10 @@ The expiration times vary randomly so that nodes are likely to have their certs 
 
 * Support for Kubernetes versions 1.11 and 1.12 are deprecated and will be removed in kops 1.20.
 
+* Support for Terraform version 0.11 has been deprecated and will be removed in kops 1.20.
+
+* Support for feature flag `Terraform-0.12` has been deprecated and will be removed in kops 1.20. All generated Terraform HCL2/JSON files will support versions `0.12.26+` and `0.13.0+`.
+
 # Full change list since 1.18.0 release
 
 ## v1.18.0-alpha.3 to v1.19.0-alpha.1


### PR DESCRIPTION
As of Nov 9th 2019, HashiCorp is starting a phased approach to deprecate support of Terraform v0.11 in Terraform providers.

https://www.hashicorp.com/blog/deprecating-terraform-0-11-support-in-terraform-providers

This deprecation notice should be merged in kops v1.19 prior to the merge of PR #9940 in kops v1.20.