### PR TITLE
Fix small typo in create cluster help output

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -148,7 +148,7 @@ var (
 		--yes
 
 	# Generate a cluster spec to apply later.
-	# Run the following, then: kops create -f filename.yamlh
+	# Run the following, then: kops create -f filename.yaml
 	kops create cluster --name=kubernetes-cluster.example.com \
 		--state=s3://kops-state-1234 \
 		--zones=eu-west-1a \

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -53,7 +53,7 @@ kops create cluster [flags]
   --yes
   
   # Generate a cluster spec to apply later.
-  # Run the following, then: kops create -f filename.yamlh
+  # Run the following, then: kops create -f filename.yaml
   kops create cluster --name=kubernetes-cluster.example.com \
   --state=s3://kops-state-1234 \
   --zones=eu-west-1a \


### PR DESCRIPTION
Fixes typo in cmd/kops/create_cluster.go and
docs/cli/kops_create_cluster.md where example output had filename.yamlh,
changed to filename.yaml

Resolves https://github.com/kubernetes/kops/issues/9994