### PR TITLE
Add label to prevent kops-controller from running on old nodes

### DIFF
--- a/protokube/pkg/protokube/labeler.go
+++ b/protokube/pkg/protokube/labeler.go
@@ -40,7 +40,8 @@ func bootstrapMasterNodeLabels(ctx context.Context, kubeContext *KubernetesConte
 	}
 
 	labels := map[string]string{
-		"node-role.kubernetes.io/master": "",
+		"node-role.kubernetes.io/master":  "",
+		"kops.k8s.io/kops-controller-pki": "",
 	}
 
 	shouldPatch := false

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -2751,6 +2751,7 @@ spec:
         operator: Exists
       nodeSelector:
         node-role.kubernetes.io/master: ""
+        kops.k8s.io/kops-controller-pki: ""
       dnsPolicy: Default  # Don't use cluster DNS (we are likely running before kube-dns)
       hostNetwork: true
       serviceAccount: kops-controller

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -41,6 +41,7 @@ spec:
         operator: Exists
       nodeSelector:
         node-role.kubernetes.io/master: ""
+        kops.k8s.io/kops-controller-pki: ""
       dnsPolicy: Default  # Don't use cluster DNS (we are likely running before kube-dns)
       hostNetwork: true
       serviceAccount: kops-controller

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b047de23df3b0caff3784aaa89ae0c967e866c95
+    manifestHash: 00457a1b369f839820f5fc094c5610e2065da388
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3c73d81e8c87bf4f409323ca904d22ee9c375284
+    manifestHash: db684c93db61d505f87af71577409945bc290fc1
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -52,6 +52,7 @@ spec:
       dnsPolicy: Default
       hostNetwork: true
       nodeSelector:
+        kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
       priorityClassName: system-node-critical
       serviceAccount: kops-controller

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b047de23df3b0caff3784aaa89ae0c967e866c95
+    manifestHash: 00457a1b369f839820f5fc094c5610e2065da388
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -52,6 +52,7 @@ spec:
       dnsPolicy: Default
       hostNetwork: true
       nodeSelector:
+        kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
       priorityClassName: system-node-critical
       serviceAccount: kops-controller

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b047de23df3b0caff3784aaa89ae0c967e866c95
+    manifestHash: 00457a1b369f839820f5fc094c5610e2065da388
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -52,6 +52,7 @@ spec:
       dnsPolicy: Default
       hostNetwork: true
       nodeSelector:
+        kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
       priorityClassName: system-node-critical
       serviceAccount: kops-controller

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3c73d81e8c87bf4f409323ca904d22ee9c375284
+    manifestHash: db684c93db61d505f87af71577409945bc290fc1
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b047de23df3b0caff3784aaa89ae0c967e866c95
+    manifestHash: 00457a1b369f839820f5fc094c5610e2065da388
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io


### PR DESCRIPTION
Adds a label and nodeSelector to prevent kops-controller from running on nodes that were created with an older version of kops (and thus don't have the necessary PKI files provisioned by nodeup).

Fixes #9953 

Upgrading a 3-node control plane from kops 1.18.1 appears to be working.