### PR TITLE
Spotinst: Upgrade the Spot Cluster Controller to version 1.0.67

### DIFF
--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
@@ -7,9 +7,20 @@ metadata:
   name: spotinst-kubernetes-cluster-controller-config
   namespace: kube-system
 data:
-  spotinst.token: {{ SpotinstToken }}
-  spotinst.account: {{ SpotinstAccount }}
   spotinst.cluster-identifier: {{ ClusterName }}
+---
+# ------------------------------------------------------------------------------
+# Secret
+# ------------------------------------------------------------------------------
+apiVersion: v1
+kind: Secret
+metadata:
+  name: spotinst-kubernetes-cluster-controller
+  namespace: kube-system
+type: Opaque
+data:
+  token: {{ SpotinstTokenBase64 }}
+  account: {{ SpotinstAccountBase64 }}
 ---
 # ------------------------------------------------------------------------------
 # Service Account
@@ -87,6 +98,10 @@ rules:
 - apiGroups: ["certificates.k8s.io"]
   resources: ["certificatesigningrequests/approval"]
   verbs: ["patch", "update"]
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["signers"]
+  resourceNames: ["kubernetes.io/kubelet-serving", "kubernetes.io/kube-apiserver-client-kubelet"]
+  verbs: ["approve"]
   # ----------------------------------------------------------------------------
   # Required by the Spotinst Auto Update feature.
   # ----------------------------------------------------------------------------
@@ -171,7 +186,7 @@ spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
         imagePullPolicy: Always
-        image: spotinst/kubernetes-cluster-controller:1.0.64
+        image: spotinst/kubernetes-cluster-controller:1.0.67
         livenessProbe:
           httpGet:
             path: /healthcheck
@@ -193,14 +208,28 @@ spec:
         env:
         - name: SPOTINST_TOKEN
           valueFrom:
+            secretKeyRef:
+              name: spotinst-kubernetes-cluster-controller
+              key: token
+              optional: true
+        - name: SPOTINST_ACCOUNT
+          valueFrom:
+            secretKeyRef:
+              name: spotinst-kubernetes-cluster-controller
+              key: account
+              optional: true
+        - name: SPOTINST_TOKEN_LEGACY
+          valueFrom:
             configMapKeyRef:
               name: spotinst-kubernetes-cluster-controller-config
               key: spotinst.token
-        - name: SPOTINST_ACCOUNT
+              optional: true
+        - name: SPOTINST_ACCOUNT_LEGACY
           valueFrom:
             configMapKeyRef:
               name: spotinst-kubernetes-cluster-controller-config
               key: spotinst.account
+              optional: true
         - name: CLUSTER_IDENTIFIER
           valueFrom:
             configMapKeyRef:

--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.9.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.9.0.yaml.template
@@ -12,16 +12,6 @@ data:
   spotinst.cluster-identifier: {{ ClusterName }}
 ---
 # ------------------------------------------
-# Secret
-# ------------------------------------------
-apiVersion: v1
-kind: Secret
-metadata:
-  name: spotinst-kubernetes-cluster-controller-certs
-  namespace: kube-system
-type: Opaque
----
-# ------------------------------------------
 # Service Account
 # ------------------------------------------
 apiVersion: v1
@@ -102,9 +92,6 @@ spec:
       - name: spotinst-kubernetes-cluster-controller
         imagePullPolicy: Always
         image: spotinst/kubernetes-cluster-controller:1.0.39
-        volumeMounts:
-        - name: spotinst-kubernetes-cluster-controller-certs
-          mountPath: /certs
         livenessProbe:
           httpGet:
             path: /healthcheck
@@ -127,10 +114,6 @@ spec:
             configMapKeyRef:
               name: spotinst-kubernetes-cluster-controller-config
               key: spotinst.cluster-identifier
-      volumes:
-      - name: spotinst-kubernetes-cluster-controller-certs
-        secret:
-          secretName: spotinst-kubernetes-cluster-controller-certs
       serviceAccountName: spotinst-kubernetes-cluster-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -674,7 +674,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 		{
 			id := "v1.14.0"
 			location := key + "/" + id + ".yaml"
-			version := "1.0.64"
+			version := "1.0.67"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -28,6 +28,7 @@ When defining a new function:
 package cloudup
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -139,6 +140,8 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 		if creds, err := spotinst.LoadCredentials(); err == nil {
 			dest["SpotinstToken"] = func() string { return creds.Token }
 			dest["SpotinstAccount"] = func() string { return creds.Account }
+			dest["SpotinstTokenBase64"] = func() string { return base64.StdEncoding.EncodeToString([]byte(creds.Token)) }
+			dest["SpotinstAccountBase64"] = func() string { return base64.StdEncoding.EncodeToString([]byte(creds.Account)) }
 		}
 	}
 


### PR DESCRIPTION
This PR upgrades the Spot Cluster Controller to version 1.0.67 and stores the user credentials in a `Secret` instead of a `ConfigMap`.