### PR TITLE
Don't disassociate additional CIDR blocks with shared VPCs

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -202,7 +202,7 @@ func (_ *VPC) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *VPC) error {
 }
 
 func (e *VPC) FindDeletions(c *fi.Context) ([]fi.Deletion, error) {
-	if fi.StringValue(e.ID) == "" {
+	if fi.IsNilOrEmpty(e.ID) || fi.BoolValue(e.Shared) {
 		return nil, nil
 	}
 

--- a/upup/pkg/fi/cloudup/awstasks/vpc_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc_test.go
@@ -129,3 +129,94 @@ func Test4758(t *testing.T) {
 		t.Errorf("unexpected changes: +%v", changes)
 	}
 }
+
+func TestSharedVPCAdditionalCIDR(t *testing.T) {
+	cloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
+	c := &mockec2.MockEC2{}
+	c.CreateVpcWithId(&ec2.CreateVpcInput{
+		CidrBlock: s("172.21.0.0/16"),
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: s(ec2.ResourceTypeVpc),
+				Tags: []*ec2.Tag{
+					{
+						Key:   s("Name"),
+						Value: s("vpc-1"),
+					},
+				},
+			},
+		},
+	}, "vpc-1")
+	c.AssociateVpcCidrBlock(&ec2.AssociateVpcCidrBlockInput{
+		VpcId:     s("vpc-1"),
+		CidrBlock: s("172.22.0.0/16"),
+	})
+
+	cloud.MockEC2 = c
+
+	// We define a function so we can rebuild the tasks, because we modify in-place when running
+	buildTasks := func() map[string]fi.Task {
+		vpc1 := &VPC{
+			Name:   s("vpc-1"),
+			CIDR:   s("172.21.0.0/16"),
+			Tags:   map[string]string{"Name": "vpc-1"},
+			Shared: fi.Bool(true),
+		}
+		return map[string]fi.Task{
+			"vpc-1": vpc1,
+		}
+	}
+
+	{
+		allTasks := buildTasks()
+		vpc1 := allTasks["vpc-1"].(*VPC)
+
+		target := &awsup.AWSAPITarget{
+			Cloud: cloud,
+		}
+
+		context, err := fi.NewContext(target, nil, cloud, nil, nil, nil, true, allTasks)
+		if err != nil {
+			t.Fatalf("error building context: %v", err)
+		}
+		defer context.Close()
+
+		if err := context.RunTasks(testRunTasksOptions); err != nil {
+			t.Fatalf("unexpected error during Run: %v", err)
+		}
+
+		if fi.StringValue(vpc1.ID) == "" {
+			t.Fatalf("ID not set")
+		}
+
+		if len(c.Vpcs) != 1 {
+			t.Fatalf("Expected exactly one Vpc; found %v", c.Vpcs)
+		}
+
+		expected := &ec2.Vpc{
+			CidrBlock: s("172.21.0.0/16"),
+			IsDefault: fi.Bool(false),
+			VpcId:     vpc1.ID,
+			Tags: buildTags(map[string]string{
+				"Name": "vpc-1",
+			}),
+			CidrBlockAssociationSet: []*ec2.VpcCidrBlockAssociation{
+				{
+					AssociationId: s("vpc-1-0"),
+					CidrBlock:     s("172.22.0.0/16"),
+					CidrBlockState: &ec2.VpcCidrBlockState{
+						State: s(ec2.VpcCidrBlockStateCodeAssociated),
+					},
+				},
+			},
+		}
+		actual := c.FindVpc(*vpc1.ID)
+		if actual == nil {
+			t.Fatalf("VPC no longer exists")
+		}
+		if !reflect.DeepEqual(actual, expected) {
+			t.Fatalf("Unexpected VPC: expected=%v actual=%v", expected, actual)
+		}
+	}
+
+}


### PR DESCRIPTION
/cc @codablock

without the fix, the test fails with:

```
--- FAIL: TestSharedVPCAdditionalCIDR (0.00s)
   kops/upup/pkg/fi/cloudup/awstasks/vpc_test.go:218: Unexpected VPC: expected={
          CidrBlock: "172.21.0.0/16",
          CidrBlockAssociationSet: [{
              AssociationId: "vpc-1-0",
              CidrBlock: "172.22.0.0/16",
              CidrBlockState: {
                State: "associated"
              }
            }],
          IsDefault: false,
          Tags: [{
              Key: "Name",
              Value: "vpc-1"
            }],
          VpcId: "vpc-1"
        } actual={
          CidrBlock: "172.21.0.0/16",
          CidrBlockAssociationSet: [{
              AssociationId: "vpc-1-0",
              CidrBlock: "172.22.0.0/16",
              CidrBlockState: {
                State: "disassociated"
              }
            }],
          IsDefault: false,
          Tags: [{
              Key: "Name",
              Value: "vpc-1"
            }],
          VpcId: "vpc-1"
        }
FAIL
FAIL	k8s.io/kops/upup/pkg/fi/cloudup/awstasks	0.627s
```