### PR TITLE
enable kubelet --housekeeping-interval flag

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -499,6 +499,17 @@ spec:
     protectKernelDefaults: true
 ```
 
+### Housekeeping Interval
+{{ kops_feature_table(kops_added_default='1.19', k8s_min='1.2') }}
+
+The interval between container housekeepings defaults to `10s`. This can be too small or too high for some use cases and can be modified with the following addition to the kubelet spec.
+
+```yaml
+spec:
+  kubelet:
+    housekeepingInterval: 30s
+```
+
 ## kubeScheduler
 
 This block contains configurations for `kube-scheduler`.  See https://kubernetes.io/docs/admin/kube-scheduler/

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1646,6 +1646,9 @@ spec:
                   hostnameOverride:
                     description: HostnameOverride is the hostname used to identify the kubelet instead of the actual hostname.
                     type: string
+                  housekeepingInterval:
+                    description: HousekeepingInterval allows to specify interval between container housekeepings.
+                    type: string
                   imageGCHighThresholdPercent:
                     description: ImageGCHighThresholdPercent is the percent of disk usage after which image garbage collection is always run.
                     format: int32
@@ -1923,6 +1926,9 @@ spec:
                     type: string
                   hostnameOverride:
                     description: HostnameOverride is the hostname used to identify the kubelet instead of the actual hostname.
+                    type: string
+                  housekeepingInterval:
+                    description: HousekeepingInterval allows to specify interval between container housekeepings.
                     type: string
                   imageGCHighThresholdPercent:
                     description: ImageGCHighThresholdPercent is the percent of disk usage after which image garbage collection is always run.

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -305,6 +305,9 @@ spec:
                   hostnameOverride:
                     description: HostnameOverride is the hostname used to identify the kubelet instead of the actual hostname.
                     type: string
+                  housekeepingInterval:
+                    description: HousekeepingInterval allows to specify interval between container housekeepings.
+                    type: string
                   imageGCHighThresholdPercent:
                     description: ImageGCHighThresholdPercent is the percent of disk usage after which image garbage collection is always run.
                     format: int32

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -205,6 +205,8 @@ type KubeletConfigSpec struct {
 	ProtectKernelDefaults *bool `json:"protectKernelDefaults,omitempty" flag:"protect-kernel-defaults"`
 	// CgroupDriver allows the explicit setting of the kubelet cgroup driver. If omitted, defaults to cgroupfs.
 	CgroupDriver string `json:"cgroupDriver,omitempty" flag:"cgroup-driver"`
+	// HousekeepingInterval allows to specify interval between container housekeepings.
+	HousekeepingInterval *metav1.Duration `json:"housekeepingInterval,omitempty" flag:"housekeeping-interval"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -205,6 +205,8 @@ type KubeletConfigSpec struct {
 	ProtectKernelDefaults *bool `json:"protectKernelDefaults,omitempty" flag:"protect-kernel-defaults"`
 	// CgroupDriver allows the explicit setting of the kubelet cgroup driver. If omitted, defaults to cgroupfs.
 	CgroupDriver string `json:"cgroupDriver,omitempty" flag:"cgroup-driver"`
+	// HousekeepingInterval allows to specify interval between container housekeepings.
+	HousekeepingInterval *metav1.Duration `json:"housekeepingInterval,omitempty" flag:"housekeeping-interval"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4444,6 +4444,7 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.RotateCertificates = in.RotateCertificates
 	out.ProtectKernelDefaults = in.ProtectKernelDefaults
 	out.CgroupDriver = in.CgroupDriver
+	out.HousekeepingInterval = in.HousekeepingInterval
 	return nil
 }
 
@@ -4532,6 +4533,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.RotateCertificates = in.RotateCertificates
 	out.ProtectKernelDefaults = in.ProtectKernelDefaults
 	out.CgroupDriver = in.CgroupDriver
+	out.HousekeepingInterval = in.HousekeepingInterval
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2983,6 +2983,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.HousekeepingInterval != nil {
+		in, out := &in.HousekeepingInterval, &out.HousekeepingInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3165,6 +3165,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.HousekeepingInterval != nil {
+		in, out := &in.HousekeepingInterval, &out.HousekeepingInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
#6356 Enable kubelet `--housekeeping-interval` flag.

**Testing Completed**
- Create a cluster with `kubelet` option `housekeepingInterval`
- Verify `kubelet` process has argument ` --housekeeping-interval`
