### PR TITLE
upgrade-cluster: Use correct test mechanism when auto-updating image name

### DIFF
--- a/cmd/kops/upgrade_cluster.go
+++ b/cmd/kops/upgrade_cluster.go
@@ -181,7 +181,7 @@ func (c *UpgradeClusterCmd) Run(ctx context.Context, args []string) error {
 			klog.Warningf("No matching images specified in channel; cannot prompt for upgrade")
 		} else {
 			for _, ig := range instanceGroups {
-				if strings.Contains(ig.Spec.Image, "kope.io") {
+				if strings.Contains(ig.Spec.Image, "kope.io") || strings.Contains(ig.Spec.Image, "099720109477/ubuntu") {
 					if ig.Spec.Image != image.Name {
 						target := ig
 						actions = append(actions, &upgradeAction{


### PR DESCRIPTION
When automatically managing image name of cluster, make sure we check that the image name is in the channel list instead of verifying that kope.io is in the name.

Fixes #10021

**Sample output BEFORE this patch**
```
$ kops upgrade cluster
Using cluster from kubectl context: test

I1008 00:38:57.241945   25556 upgrade_cluster.go:198] Custom image (099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907) has been provided for Instance Group "backups"; not updating image
I1008 00:38:57.242064   25556 upgrade_cluster.go:198] Custom image (099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907) has been provided for Instance Group "datagateways"; not updating image
I1008 00:38:57.242085   25556 upgrade_cluster.go:198] Custom image (099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907) has been provided for Instance Group "master-ca-central-1a"; not updating image
I1008 00:38:57.242100   25556 upgrade_cluster.go:198] Custom image (099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907) has been provided for Instance Group "nodes"; not updating image
I1008 00:38:57.242118   25556 upgrade_cluster.go:198] Custom image (099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907) has been provided for Instance Group "ops"; not updating image
I1008 00:38:57.242144   25556 upgrade_cluster.go:198] Custom image (099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907) has been provided for Instance Group "workers"; not updating image
ITEM	PROPERTY		OLD	NEW
Cluster	KubernetesVersion	1.18.9	1.19.2

Must specify --yes to perform upgrade
```

**Sample output BEFORE this patch**
```
$ kops upgrade cluster
Using cluster from kubectl context: ca-accp.k8s.equisoft.io

ITEM	PROPERTY		OLD	NEW
Cluster	KubernetesVersion	1.18.9	1.19.2

Must specify --yes to perform upgrade

```

The image  `099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907` is part of the channel.yaml and should not be considered a custom image but a supported image that needs to be auto-updated on cluster upgrade.