### PR TITLE
Move kops-controller serving port out of conflict

### DIFF
--- a/docs/development/ports.md
+++ b/docs/development/ports.md
@@ -13,7 +13,7 @@ See also pkg/wellknownports/wellknownports.go
 | 179  | Calico                                   |
 | 2380 | etcd main peering                        |
 | 2381 | etcd events peering                      |
-| 3992 | dns gossip - protokube - memberlist      |
+| 3988 | dns gossip - protokube - memberlist      |
 | 3993 | dns gossip - dns-controller - memberlist |
 | 3994 | etcd-manager - main - quarantined        |
 | 3995 | etcd-manager - events - quarantined      |

--- a/pkg/wellknownports/wellknownports.go
+++ b/pkg/wellknownports/wellknownports.go
@@ -45,7 +45,7 @@ const (
 	DNSControllerGossipMemberlist = 3993
 
 	// KopsControllerPort is the port where kops-controller listens.
-	KopsControllerPort = 3992
+	KopsControllerPort = 3988
 
 	// 4001 is etcd main, 4002 is etcd events, 4003 is etcd cilium
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: db684c93db61d505f87af71577409945bc290fc1
+    manifestHash: 95b29a87c7e7204fd7f36716d7f9f3187985c2af
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3992","provider":{"aws":{"nodesRoles":["kops-custom-node-role","nodes.minimal.example.com"],"Region":"us-east-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["ca"],"certNames":["kubelet","kube-proxy"]}}
+    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role","nodes.minimal.example.com"],"Region":"us-east-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["ca"],"certNames":["kubelet","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   labels:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: db684c93db61d505f87af71577409945bc290fc1
+    manifestHash: 95b29a87c7e7204fd7f36716d7f9f3187985c2af
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io


### PR DESCRIPTION
The new kops-controller port conflicts with Cilium etcd's port.