### PR TITLE
Open etcd port only when Calico uses "etcd" datastore

### DIFF
--- a/nodeup/pkg/model/networking/calico.go
+++ b/nodeup/pkg/model/networking/calico.go
@@ -39,7 +39,7 @@ func (b *CalicoBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 
 	// @check if tls is enabled and if so, we need to download the client certificates
-	if !b.UseEtcdManager() && b.UseEtcdTLS() {
+	if b.IsKubernetesLT("1.12") && !b.UseEtcdManager() && b.UseEtcdTLS() {
 		name := "calico-client"
 		dirname := "calico"
 		ca := filepath.Join(dirname, "ca.pem")

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -674,6 +674,12 @@ func (c *Cluster) IsKubernetesGTE(version string) bool {
 	return clusterVersion.GTE(*parsedVersion)
 }
 
+// IsKubernetesLT checks if the version is < the specified version.
+// It panics if the kubernetes version in the cluster is invalid, or if the version is invalid.
+func (c *Cluster) IsKubernetesLT(version string) bool {
+	return !c.IsKubernetesGTE(version)
+}
+
 // EnvVar represents an environment variable present in a Container.
 type EnvVar struct {
 	// Name of the environment variable. Must be a C_IDENTIFIER.

--- a/pkg/model/firewall.go
+++ b/pkg/model/firewall.go
@@ -250,10 +250,12 @@ func (b *FirewallModelBuilder) applyNodeToMasterBlockSpecificPorts(c *fi.ModelBu
 	}
 
 	if b.Cluster.Spec.Networking.Calico != nil {
-		// Calico needs to access etcd
-		// TODO: Remove, replace with etcd in calico manifest
-		klog.Warningf("Opening etcd port on masters for access from the nodes, for calico.  This is unsafe in untrusted environments.")
-		tcpBlocked[4001] = false
+		if b.IsKubernetesLT("1.12") {
+			// Calico needs to access etcd
+			// TODO: Remove, replace with etcd in calico manifest
+			klog.Warningf("Opening etcd port on masters for access from the nodes, for calico.  This is unsafe in untrusted environments.")
+			tcpBlocked[4001] = false
+		}
 		protocols = append(protocols, ProtocolIPIP)
 	}
 

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -570,7 +570,7 @@ func ReadableStatePaths(cluster *kops.Cluster, role Subject) ([]string, error) {
 				}
 
 				// @check if calico is enabled as the CNI provider and permit access to the client TLS certificate by default
-				if networkingSpec.Calico != nil {
+				if cluster.IsKubernetesLT("1.12") && networkingSpec.Calico != nil {
 					calicoClientCert := false
 					for _, x := range cluster.Spec.EtcdClusters {
 						if x.Provider == kops.EtcdProviderTypeManager {

--- a/pkg/model/pki.go
+++ b/pkg/model/pki.go
@@ -129,7 +129,7 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		})
 
 		// @check if calico is enabled as the CNI provider
-		if b.KopsModelContext.Cluster.Spec.Networking.Calico != nil {
+		if b.IsKubernetesLT("1.12") && b.KopsModelContext.Cluster.Spec.Networking.Calico != nil {
 			c.AddTask(&fitasks.Keypair{
 				Name:      fi.String("calico-client"),
 				Lifecycle: b.Lifecycle,

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -753,12 +753,12 @@ resource "aws_security_group_rule" "node-to-master-tcp-1-2379" {
   type                     = "ingress"
 }
 
-resource "aws_security_group_rule" "node-to-master-tcp-2382-4001" {
+resource "aws_security_group_rule" "node-to-master-tcp-2382-4000" {
   from_port                = 2382
   protocol                 = "tcp"
   security_group_id        = aws_security_group.masters-bastionuserdata-example-com.id
   source_security_group_id = aws_security_group.nodes-bastionuserdata-example-com.id
-  to_port                  = 4001
+  to_port                  = 4000
   type                     = "ingress"
 }
 

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -847,7 +847,7 @@
         "IpProtocol": "tcp"
       }
     },
-    "AWSEC2SecurityGroupIngressnodetomastertcp23824001": {
+    "AWSEC2SecurityGroupIngressnodetomastertcp23824000": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
         "GroupId": {
@@ -857,7 +857,7 @@
           "Ref": "AWSEC2SecurityGroupnodesprivatecalicoexamplecom"
         },
         "FromPort": 2382,
-        "ToPort": 4001,
+        "ToPort": 4000,
         "IpProtocol": "tcp"
       }
     },

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -752,12 +752,12 @@ resource "aws_security_group_rule" "node-to-master-tcp-1-2379" {
   type                     = "ingress"
 }
 
-resource "aws_security_group_rule" "node-to-master-tcp-2382-4001" {
+resource "aws_security_group_rule" "node-to-master-tcp-2382-4000" {
   from_port                = 2382
   protocol                 = "tcp"
   security_group_id        = aws_security_group.masters-privatecalico-example-com.id
   source_security_group_id = aws_security_group.nodes-privatecalico-example-com.id
-  to_port                  = 4001
+  to_port                  = 4000
   type                     = "ingress"
 }
 


### PR DESCRIPTION
For _kubernetes_ 1.12+, _kops_ hardcodes `DATASTORE_TYPE` to "kubernetes".
https://github.com/kubernetes/kops/blob/5cc1b5ad8ef074b86a61db80a8b24aca1f6dbb53/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template#L36
https://github.com/kubernetes/kops/blob/5cc1b5ad8ef074b86a61db80a8b24aca1f6dbb53/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template#L763-L764