### PR TITLE
kops/cmd: add sshAccess to be recognized for the kops set cluster command

### DIFF
--- a/pkg/commands/set_cluster.go
+++ b/pkg/commands/set_cluster.go
@@ -101,6 +101,8 @@ func SetClusterFields(fields []string, cluster *api.Cluster, instanceGroups []*a
 				cluster.Spec.KubeDNS = &api.KubeDNSConfig{}
 			}
 			cluster.Spec.KubeDNS.Provider = kv[1]
+		case "spec.sshAccess":
+			cluster.Spec.SSHAccess = strings.Split(kv[1], ",")
 		case "cluster.spec.etcdClusters[*].enableEtcdTLS":
 			v, err := strconv.ParseBool(kv[1])
 			if err != nil {

--- a/pkg/commands/set_cluster_test.go
+++ b/pkg/commands/set_cluster_test.go
@@ -35,6 +35,7 @@ func TestSetClusterFields(t *testing.T) {
 				"spec.kubernetesVersion=1.8.2",
 				"spec.kubelet.authorizationMode=Webhook",
 				"spec.kubelet.authenticationTokenWebhook=true",
+				"spec.sshAccess=1.2.3.4/5,9.9.9.9/9",
 			},
 			Input: kops.Cluster{
 				Spec: kops.ClusterSpec{
@@ -48,6 +49,7 @@ func TestSetClusterFields(t *testing.T) {
 						AuthorizationMode:          "Webhook",
 						AuthenticationTokenWebhook: fi.Bool(true),
 					},
+					SSHAccess: []string{"1.2.3.4/5", "9.9.9.9/9"},
 				},
 			},
 		},


### PR DESCRIPTION
Some fields you cannot change using the `kops set cluster` command because the validation only parses a few.

Adding the `sshAccess` to be in the list for the release-1.18 branch.
On the main branch this is fixed and you can change all the fields, but I cannot use master right now for some cases :)

I propose to add this tiny change and I'm willing to add more in this PR if needed.
I know that might have another release for this branch so will be good to have this.

thanks!

/cc @hakman 