### PR TITLE
Allow upgrades when IG image is Ubuntu 20.04

### DIFF
--- a/cmd/kops/upgrade_cluster.go
+++ b/cmd/kops/upgrade_cluster.go
@@ -181,7 +181,7 @@ func (c *UpgradeClusterCmd) Run(ctx context.Context, args []string) error {
 			klog.Warningf("No matching images specified in channel; cannot prompt for upgrade")
 		} else {
 			for _, ig := range instanceGroups {
-				if strings.Contains(ig.Spec.Image, "kope.io") {
+				if strings.HasPrefix(ig.Spec.Image, "kope.io/k8s-") || strings.HasPrefix(ig.Spec.Image, "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-") {
 					if ig.Spec.Image != image.Name {
 						target := ig
 						actions = append(actions, &upgradeAction{


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kops/issues/10021
/cc @rifelpet @justinsb 