### PR TITLE
Add WireGuard support for Calico CNI 

### DIFF
--- a/docs/networking/calico.md
+++ b/docs/networking/calico.md
@@ -56,7 +56,7 @@ To enable this mode in a cluster, add the following to the cluster spec:
       crossSubnet: true
 ```
 In the case of AWS, EC2 instances have source/destination checks enabled by default.
-When you enable cross-subnet mode in kops 1.19+, it is equivalent to: 
+When you enable cross-subnet mode in kops 1.19+, it is equivalent to:
 ```yaml
   networking:
     calico:
@@ -91,6 +91,19 @@ It is possible to configure Calico to use Typha by editing a cluster and adding 
   networking:
     calico:
       typhaReplicas: 3
+```
+
+### Configuring WireGuard
+{{ kops_feature_table(kops_added_default='1.19', k8s_min='1.16') }}
+
+Calico supports WireGuard to encrypt pod-to-pod traffic. If you enable this options, WireGuard encryption is automatically enabled for all nodes. At the moment, kops installs WireGuard automatically only when the host OS is *Ubuntu*. For other OSes, WireGuard has to be part of the base image or installed via a hook.
+
+For more details of Calico WireGuard please refer the [Calico Docs](https://docs.projectcalico.org/security/encrypt-cluster-pod-traffic).
+
+```yaml
+  networking:
+    calico:
+      wireguardEnabled: true
 ```
 
 ## Getting help

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2194,6 +2194,9 @@ spec:
                         description: TyphaReplicas is the number of replicas of Typha to deploy
                         format: int32
                         type: integer
+                      wireguardEnabled:
+                        description: 'WireguardEnabled enables WireGuard encryption for all on-the-wire pod-to-pod traffic (default: false)'
+                        type: boolean
                     type: object
                   canal:
                     description: CanalNetworkingSpec declares that we want Canal networking

--- a/nodeup/pkg/model/networking/calico.go
+++ b/nodeup/pkg/model/networking/calico.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/kops/nodeup/pkg/model"
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 )
 
 // CalicoBuilder configures the etcd TLS support for Calico
@@ -36,6 +37,10 @@ func (b *CalicoBuilder) Build(c *fi.ModelBuilderContext) error {
 
 	if networking.Calico == nil {
 		return nil
+	}
+
+	if b.Distribution.IsUbuntu() {
+		c.AddTask(&nodetasks.Package{Name: "wireguard"})
 	}
 
 	// @check if tls is enabled and if so, we need to download the client certificates

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -152,6 +152,9 @@ type CalicoNetworkingSpec struct {
 	TyphaPrometheusMetricsPort int32 `json:"typhaPrometheusMetricsPort,omitempty"`
 	// TyphaReplicas is the number of replicas of Typha to deploy
 	TyphaReplicas int32 `json:"typhaReplicas,omitempty"`
+	// WireguardEnabled enables WireGuard encryption for all on-the-wire pod-to-pod traffic
+	// (default: false)
+	WireguardEnabled bool `json:"wireguardEnabled,omitempty"`
 }
 
 // CanalNetworkingSpec declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -152,6 +152,9 @@ type CalicoNetworkingSpec struct {
 	TyphaPrometheusMetricsPort int32 `json:"typhaPrometheusMetricsPort,omitempty"`
 	// TyphaReplicas is the number of replicas of Typha to deploy
 	TyphaReplicas int32 `json:"typhaReplicas,omitempty"`
+	// WireguardEnabled enables WireGuard encryption for all on-the-wire pod-to-pod traffic
+	// (default: false)
+	WireguardEnabled bool `json:"wireguardEnabled,omitempty"`
 }
 
 // CanalNetworkingSpec declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1343,6 +1343,7 @@ func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.TyphaPrometheusMetricsEnabled = in.TyphaPrometheusMetricsEnabled
 	out.TyphaPrometheusMetricsPort = in.TyphaPrometheusMetricsPort
 	out.TyphaReplicas = in.TyphaReplicas
+	out.WireguardEnabled = in.WireguardEnabled
 	return nil
 }
 
@@ -1370,6 +1371,7 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *
 	out.TyphaPrometheusMetricsEnabled = in.TyphaPrometheusMetricsEnabled
 	out.TyphaPrometheusMetricsPort = in.TyphaPrometheusMetricsPort
 	out.TyphaReplicas = in.TyphaReplicas
+	out.WireguardEnabled = in.WireguardEnabled
 	return nil
 }
 

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -13100,6 +13100,9 @@ spec:
             # Enable / Disable source/destination checks in AWS
             - name: FELIX_AWSSRCDSTCHECK
               value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}Disable{{- else -}} {{- or .Networking.Calico.AwsSrcDstCheck "DoNothing" -}} {{- end -}}"
+            # Enable WireGuard encryption for all on-the-wire pod-to-pod traffic
+            - name: FELIX_WIREGUARDENABLED
+              value: "{{ .Networking.Calico.WireguardEnabled }}"
           securityContext:
             privileged: true
           resources:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3937,6 +3937,9 @@ spec:
             # Enable / Disable source/destination checks in AWS
             - name: FELIX_AWSSRCDSTCHECK
               value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}Disable{{- else -}} {{- or .Networking.Calico.AwsSrcDstCheck "DoNothing" -}} {{- end -}}"
+            # Enable WireGuard encryption for all on-the-wire pod-to-pod traffic
+            - name: FELIX_WIREGUARDENABLED
+              value: "{{ .Networking.Calico.WireguardEnabled }}"
           securityContext:
             privileged: true
           resources:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -858,7 +858,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 			"k8s-1.7":    "2.6.12-kops.1",
 			"k8s-1.7-v3": "3.8.0-kops.2",
 			"k8s-1.12":   "3.9.6-kops.1",
-			"k8s-1.16":   "3.16.3-kops.1",
+			"k8s-1.16":   "3.16.3-kops.2",
 		}
 
 		{


### PR DESCRIPTION
Refs: https://github.com/kubernetes/kops/issues/9753

I add new option to enable WireGuard on Calico.

**Sample Configuration**
```yaml
  networking:
    calico:
      wireguardEnabled: true
```

**Result of this configuration**
```
$ calicoctl get node -o yaml
apiVersion: projectcalico.org/v3
items:
- apiVersion: projectcalico.org/v3
  kind: Node
  metadata:
    annotations:
      projectcalico.org/kube-labels: '{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"t2.medium","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"ap-northeast-1","failure-domain.beta.kubernetes.io/zone":"ap-northeast-1a","kops.k8s.io/instancegroup":"master-ap-northeast-1a","kops.k8s.io/kops-controller-pki":"","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"ip-172-16-1-104.ap-northeast-1.compute.internal","kubernetes.io/os":"linux","kubernetes.io/role":"master","node-role.kubernetes.io/master":"","node.kubernetes.io/instance-type":"t2.medium","topology.kubernetes.io/region":"ap-northeast-1","topology.kubernetes.io/zone":"ap-northeast-1a"}'
    creationTimestamp: "2020-10-10T04:51:21Z"
    labels:
      beta.kubernetes.io/arch: amd64
      beta.kubernetes.io/instance-type: t2.medium
      beta.kubernetes.io/os: linux
      failure-domain.beta.kubernetes.io/region: ap-northeast-1
      failure-domain.beta.kubernetes.io/zone: ap-northeast-1a
      kops.k8s.io/instancegroup: master-ap-northeast-1a
      kops.k8s.io/kops-controller-pki: ""
      kubernetes.io/arch: amd64
      kubernetes.io/hostname: ip-172-16-1-104.ap-northeast-1.compute.internal
      kubernetes.io/os: linux
      kubernetes.io/role: master
      node-role.kubernetes.io/master: ""
      node.kubernetes.io/instance-type: t2.medium
      topology.kubernetes.io/region: ap-northeast-1
      topology.kubernetes.io/zone: ap-northeast-1a
    name: ip-172-16-1-104.ap-northeast-1.compute.internal
    resourceVersion: "26468"
    uid: 93998838-f69d-4e3c-8be0-7ac7cba5f22f
  spec:
    bgp:
      ipv4Address: 172.16.1.104/20
      ipv4IPIPTunnelAddr: 100.118.28.192
    orchRefs:
    - nodeName: ip-172-16-1-104.ap-northeast-1.compute.internal
      orchestrator: k8s
    wireguard:
      interfaceIPv4Address: 100.118.28.194
  status:
    podCIDRs:
    - ""
    - 100.96.0.0/24
    wireguardPublicKey: BBa9VazbVUCB1VeHHABK9iznixnnvsJrlPAMO9Gc5y0=
- apiVersion: projectcalico.org/v3
  kind: Node
  metadata:
    annotations:
      projectcalico.org/kube-labels: '{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"t2.medium","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"ap-northeast-1","failure-domain.beta.kubernetes.io/zone":"ap-northeast-1a","kops.k8s.io/instancegroup":"nodes-ap-northeast-1a","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"ip-172-16-10-49.ap-northeast-1.compute.internal","kubernetes.io/os":"linux","kubernetes.io/role":"node","node-role.kubernetes.io/node":"","node.kubernetes.io/instance-type":"t2.medium","topology.kubernetes.io/region":"ap-northeast-1","topology.kubernetes.io/zone":"ap-northeast-1a"}'
    creationTimestamp: "2020-10-10T04:56:12Z"
    labels:
      beta.kubernetes.io/arch: amd64
      beta.kubernetes.io/instance-type: t2.medium
      beta.kubernetes.io/os: linux
      failure-domain.beta.kubernetes.io/region: ap-northeast-1
      failure-domain.beta.kubernetes.io/zone: ap-northeast-1a
      kops.k8s.io/instancegroup: nodes-ap-northeast-1a
      kubernetes.io/arch: amd64
      kubernetes.io/hostname: ip-172-16-10-49.ap-northeast-1.compute.internal
      kubernetes.io/os: linux
      kubernetes.io/role: node
      node-role.kubernetes.io/node: ""
      node.kubernetes.io/instance-type: t2.medium
      topology.kubernetes.io/region: ap-northeast-1
      topology.kubernetes.io/zone: ap-northeast-1a
    name: ip-172-16-10-49.ap-northeast-1.compute.internal
    resourceVersion: "26464"
    uid: 1cf3c2d9-288b-40bf-8718-0e60b5ccdd04
  spec:
    bgp:
      ipv4Address: 172.16.10.49/20
      ipv4IPIPTunnelAddr: 100.126.81.0
    orchRefs:
    - nodeName: ip-172-16-10-49.ap-northeast-1.compute.internal
      orchestrator: k8s
    wireguard:
      interfaceIPv4Address: 100.126.81.4
  status:
    podCIDRs:
    - ""
    - 100.96.1.0/24
    wireguardPublicKey: OBV1rEMKdG3rsUoj25dLUbGi5EpPj9C6Z627Eyc2pxQ=
kind: NodeList
metadata: {}
```
Each node contain a field with a WireGuard public key, so it is succeeded.