### PR TITLE
Add support for KubeAPIServer --request-timeout flag

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -2,7 +2,7 @@
 
 The `Cluster` resource contains the specification of the cluster itself.
 
-The complete list of keys can be found at the [Cluster](https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#ClusterSpec) reference page. 
+The complete list of keys can be found at the [Cluster](https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#ClusterSpec) reference page.
 
 On this page, we will expand on the more important configuration keys.
 
@@ -322,6 +322,19 @@ spec:
   kubeAPIServer:
     maxMutatingRequestsInflight: 450
 ```
+
+### Request Timeout
+{{ kops_feature_table(kops_added_default='1.19') }}
+
+The duration a handler must keep a request open before timing it out and can be overridden by other flags for specific types of requests.
+Note that you must fill empty units of time with zeros. (default 1m0s)
+
+```yaml
+spec:
+  kubeAPIServer:
+    requestTimeout: 3m0s
+```
+
 ### Profiling
 {{ kops_feature_table(kops_added_default='1.18') }}
 
@@ -915,7 +928,7 @@ docker:
   ipMasq: true
   ipTables: true
 ```
- 
+
 ## sshKeyName
 
 In some cases, it may be desirable to use an existing AWS SSH key instead of allowing kops to create a new one.

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1031,6 +1031,9 @@ spec:
                   proxyClientKeyFile:
                     description: The apiserver's client key used for outbound requests.
                     type: string
+                  requestTimeout:
+                    description: RequestTimeout configures the duration a handler must keep a request open before timing it out. (default 1m0s)
+                    type: string
                   requestheaderAllowedNames:
                     description: List of client certificate common names to allow to provide usernames in headers specified by --requestheader-username-headers. If empty, any client certificate validated by the authorities in --requestheader-client-ca-file is allowed.
                     items:

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -437,6 +437,9 @@ type KubeAPIServerConfig struct {
 	// EtcdQuorumRead configures the etcd-quorum-read flag, which forces consistent reads from etcd
 	EtcdQuorumRead *bool `json:"etcdQuorumRead,omitempty" flag:"etcd-quorum-read"`
 
+	// RequestTimeout configures the duration a handler must keep a request open before timing it out. (default 1m0s)
+	RequestTimeout *metav1.Duration `json:"requestTimeout,omitempty" flag:"request-timeout"`
+
 	// MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out.
 	// Currently only honored by the watch request handler
 	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -437,6 +437,9 @@ type KubeAPIServerConfig struct {
 	// EtcdQuorumRead configures the etcd-quorum-read flag, which forces consistent reads from etcd
 	EtcdQuorumRead *bool `json:"etcdQuorumRead,omitempty" flag:"etcd-quorum-read"`
 
+	// RequestTimeout configures the duration a handler must keep a request open before timing it out. (default 1m0s)
+	RequestTimeout *metav1.Duration `json:"requestTimeout,omitempty" flag:"request-timeout"`
+
 	// MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out.
 	// Currently only honored by the watch request handler
 	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3932,6 +3932,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.MaxMutatingRequestsInflight = in.MaxMutatingRequestsInflight
 	out.HTTP2MaxStreamsPerConnection = in.HTTP2MaxStreamsPerConnection
 	out.EtcdQuorumRead = in.EtcdQuorumRead
+	out.RequestTimeout = in.RequestTimeout
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.TargetRamMb = in.TargetRamMb
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
@@ -4036,6 +4037,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.MaxMutatingRequestsInflight = in.MaxMutatingRequestsInflight
 	out.HTTP2MaxStreamsPerConnection = in.HTTP2MaxStreamsPerConnection
 	out.EtcdQuorumRead = in.EtcdQuorumRead
+	out.RequestTimeout = in.RequestTimeout
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.TargetRamMb = in.TargetRamMb
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2329,6 +2329,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RequestTimeout != nil {
+		in, out := &in.RequestTimeout, &out.RequestTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.MinRequestTimeout != nil {
 		in, out := &in.MinRequestTimeout, &out.MinRequestTimeout
 		*out = new(int32)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2511,6 +2511,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RequestTimeout != nil {
+		in, out := &in.RequestTimeout, &out.RequestTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.MinRequestTimeout != nil {
 		in, out := &in.MinRequestTimeout, &out.MinRequestTimeout
 		*out = new(int32)


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it:**
Add support for kops to declare `--request-timeout` flag from kube-apiserver

**Which issue(s) this PR fixes:**
Addresses #10026

**Does this PR introduce a user-facing change?:**

Enable users to set timeout value for all kinds of handlers via `request-timeout` flag on kube-apiserver

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**

```yaml
kind: Cluster
spec:
    kubeAPIServer:
      requestTimeout: "180s"
```