### PR TITLE
Automated cherry pick of #10037: Add WireGuard support for Calico CNI

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2737,6 +2737,10 @@ spec:
                           to deploy
                         format: int32
                         type: integer
+                      wireguardEnabled:
+                        description: 'WireguardEnabled enables WireGuard encryption
+                          for all on-the-wire pod-to-pod traffic (default: false)'
+                        type: boolean
                     type: object
                   canal:
                     description: CanalNetworkingSpec declares that we want Canal networking

--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -51,6 +51,9 @@ func (b *PackagesBuilder) Build(c *fi.ModelBuilderContext) error {
 		c.AddTask(&nodetasks.Package{Name: "pigz"})
 		c.AddTask(&nodetasks.Package{Name: "socat"})
 		c.AddTask(&nodetasks.Package{Name: "util-linux"})
+		if b.Distribution.IsUbuntu() && b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.Calico != nil {
+			c.AddTask(&nodetasks.Package{Name: "wireguard"})
+		}
 	} else if b.Distribution.IsRHELFamily() {
 		// From containerd: https://github.com/containerd/cri/blob/master/contrib/ansible/tasks/bootstrap_centos.yaml
 		c.AddTask(&nodetasks.Package{Name: "conntrack-tools"})

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -134,6 +134,9 @@ type CalicoNetworkingSpec struct {
 	TyphaPrometheusMetricsPort int32 `json:"typhaPrometheusMetricsPort,omitempty"`
 	// TyphaReplicas is the number of replicas of Typha to deploy
 	TyphaReplicas int32 `json:"typhaReplicas,omitempty"`
+	// WireguardEnabled enables WireGuard encryption for all on-the-wire pod-to-pod traffic
+	// (default: false)
+	WireguardEnabled bool `json:"wireguardEnabled,omitempty"`
 }
 
 // CanalNetworkingSpec declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -134,6 +134,9 @@ type CalicoNetworkingSpec struct {
 	TyphaPrometheusMetricsPort int32 `json:"typhaPrometheusMetricsPort,omitempty"`
 	// TyphaReplicas is the number of replicas of Typha to deploy
 	TyphaReplicas int32 `json:"typhaReplicas,omitempty"`
+	// WireguardEnabled enables WireGuard encryption for all on-the-wire pod-to-pod traffic
+	// (default: false)
+	WireguardEnabled bool `json:"wireguardEnabled,omitempty"`
 }
 
 // CanalNetworkingSpec declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1295,6 +1295,7 @@ func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.TyphaPrometheusMetricsEnabled = in.TyphaPrometheusMetricsEnabled
 	out.TyphaPrometheusMetricsPort = in.TyphaPrometheusMetricsPort
 	out.TyphaReplicas = in.TyphaReplicas
+	out.WireguardEnabled = in.WireguardEnabled
 	return nil
 }
 
@@ -1318,6 +1319,7 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *
 	out.TyphaPrometheusMetricsEnabled = in.TyphaPrometheusMetricsEnabled
 	out.TyphaPrometheusMetricsPort = in.TyphaPrometheusMetricsPort
 	out.TyphaReplicas = in.TyphaReplicas
+	out.WireguardEnabled = in.WireguardEnabled
 	return nil
 }
 

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -11718,6 +11718,9 @@ spec:
             # Enable Prometheus process metrics collection
             - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
               value: "{{- or .Networking.Calico.PrometheusProcessMetricsEnabled "true" }}"
+            # Enable WireGuard encryption for all on-the-wire pod-to-pod traffic
+            - name: FELIX_WIREGUARDENABLED
+              value: "{{ .Networking.Calico.WireguardEnabled }}"
           securityContext:
             privileged: true
           resources:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3796,6 +3796,9 @@ spec:
             # Enable Prometheus process metrics collection
             - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
               value: "{{- or .Networking.Calico.PrometheusProcessMetricsEnabled "true" }}"
+            # Enable WireGuard encryption for all on-the-wire pod-to-pod traffic
+            - name: FELIX_WIREGUARDENABLED
+              value: "{{ .Networking.Calico.WireguardEnabled }}"
           securityContext:
             privileged: true
           resources:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -726,7 +726,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.7":    "2.6.12-kops.1",
 			"k8s-1.7-v3": "3.8.0-kops.2",
 			"k8s-1.12":   "3.9.6-kops.1",
-			"k8s-1.16":   "3.15.3-kops.1",
+			"k8s-1.16":   "3.15.3-kops.2",
 		}
 
 		{


### PR DESCRIPTION
Cherry pick of #10037 on release-1.18.

#10037: Add wireguardEnabled option in networking Calico

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.