### PR TITLE
Automated cherry pick of #10038: Add support for KubeAPIServer --request-timeout flag

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1235,6 +1235,10 @@ spec:
                   proxyClientKeyFile:
                     description: The apiserver's client key used for outbound requests.
                     type: string
+                  requestTimeout:
+                    description: RequestTimeout configures the duration a handler
+                      must keep a request open before timing it out. (default 1m0s)
+                    type: string
                   requestheaderAllowedNames:
                     description: List of client certificate common names to allow
                       to provide usernames in headers specified by --requestheader-username-headers.

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -435,6 +435,9 @@ type KubeAPIServerConfig struct {
 	// EtcdQuorumRead configures the etcd-quorum-read flag, which forces consistent reads from etcd
 	EtcdQuorumRead *bool `json:"etcdQuorumRead,omitempty" flag:"etcd-quorum-read"`
 
+	// RequestTimeout configures the duration a handler must keep a request open before timing it out. (default 1m0s)
+	RequestTimeout *metav1.Duration `json:"requestTimeout,omitempty" flag:"request-timeout"`
+
 	// MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out.
 	// Currently only honored by the watch request handler
 	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -435,6 +435,9 @@ type KubeAPIServerConfig struct {
 	// EtcdQuorumRead configures the etcd-quorum-read flag, which forces consistent reads from etcd
 	EtcdQuorumRead *bool `json:"etcdQuorumRead,omitempty" flag:"etcd-quorum-read"`
 
+	// RequestTimeout configures the duration a handler must keep a request open before timing it out. (default 1m0s)
+	RequestTimeout *metav1.Duration `json:"requestTimeout,omitempty" flag:"request-timeout"`
+
 	// MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out.
 	// Currently only honored by the watch request handler
 	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3786,6 +3786,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.MaxMutatingRequestsInflight = in.MaxMutatingRequestsInflight
 	out.HTTP2MaxStreamsPerConnection = in.HTTP2MaxStreamsPerConnection
 	out.EtcdQuorumRead = in.EtcdQuorumRead
+	out.RequestTimeout = in.RequestTimeout
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.TargetRamMb = in.TargetRamMb
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
@@ -3889,6 +3890,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.MaxMutatingRequestsInflight = in.MaxMutatingRequestsInflight
 	out.HTTP2MaxStreamsPerConnection = in.HTTP2MaxStreamsPerConnection
 	out.EtcdQuorumRead = in.EtcdQuorumRead
+	out.RequestTimeout = in.RequestTimeout
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.TargetRamMb = in.TargetRamMb
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2238,6 +2238,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RequestTimeout != nil {
+		in, out := &in.RequestTimeout, &out.RequestTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.MinRequestTimeout != nil {
 		in, out := &in.MinRequestTimeout, &out.MinRequestTimeout
 		*out = new(int32)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2420,6 +2420,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RequestTimeout != nil {
+		in, out := &in.RequestTimeout, &out.RequestTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.MinRequestTimeout != nil {
 		in, out := &in.MinRequestTimeout, &out.MinRequestTimeout
 		*out = new(int32)


### PR DESCRIPTION
Cherry pick of #10038 on release-1.18.

#10038: Add support for KubeAPIServer --request-timeout flag

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.