### PR TITLE
Fix docs feature table not being rendered

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -7,7 +7,3 @@
 .hidden {
 	display: none;
 }
-
-.kops_feature_table .md-typeset__table table{
-	max-width: fit-content;
-}

--- a/hack/mkdocs_macros/feature_stability_table.py
+++ b/hack/mkdocs_macros/feature_stability_table.py
@@ -37,7 +37,7 @@ def define_env(env):
         }
 
         # Create the initial strings to which we'll concatenate the relevant columns
-        title = '** FEATURE STATE **\n\n|'
+        title = '|'
         separators = '|'
         values = '|'
 
@@ -51,9 +51,9 @@ def define_env(env):
                 title += f' {header} |'
             separators += ' :-: |'
             if arg == 'k8s_min':
-                values += f' K8s {kwargs[arg]}  |'
+                values += f' K8s {kwargs[arg]} |'
             else:
-                values += f' Kops {kwargs[arg]}  |'
+                values += f' Kops {kwargs[arg]} |'
 
         # Create a list object containing all the table rows,
         # Then return a string object which contains every list item in a new line.
@@ -62,9 +62,7 @@ def define_env(env):
             separators,
             values
         ]
-        table = '\n'.join(table)
-        table = f'<div class="kops_feature_table">{table}</div>'
-        return table
+        return '\n'.join(table)
 
 
 def main():


### PR DESCRIPTION
Feature tables are no longer generated correctly. Simplifying things seems to fix it.

Before fix:
https://kops.sigs.k8s.io/networking/calico/#configuring-wireguard

After fix:
https://5f83dda2c9e9d40008ce7f05--kubernetes-kops.netlify.app/networking/calico/#configuring-wireguard

/cc @MoShitrit @rifelpet @olemarkus 