### PR TITLE
Fix bug in MergeAddons and test

### DIFF
--- a/channels/pkg/channels/addon.go
+++ b/channels/pkg/channels/addon.go
@@ -59,7 +59,7 @@ func (m *AddonMenu) MergeAddons(o *AddonMenu) {
 		if existing == nil {
 			m.Addons[k] = v
 		} else {
-			if existing.ChannelVersion().replaces(v.ChannelVersion()) {
+			if v.ChannelVersion().replaces(existing.ChannelVersion()) {
 				m.Addons[k] = v
 			}
 		}

--- a/channels/pkg/channels/addons_test.go
+++ b/channels/pkg/channels/addons_test.go
@@ -258,9 +258,9 @@ func addonString(addon *Addon) string {
 }
 
 func addonMenuString(addonMenu *AddonMenu) string {
-	addonMenuString := fmt.Sprintf("AddonMenu{\n")
+	addonMenuString := "AddonMenu{\n"
 	for _, addon := range addonMenu.Addons {
 		addonMenuString += addonString(addon)
 	}
-	return addonMenuString + fmt.Sprintf("}\n")
+	return addonMenuString + "}\n"
 }


### PR DESCRIPTION
I was a little bit confused by the desired behavior of the AddonMenu merge in channels so I decided to write a test to better understand it.  Can someone help me understand the expected behavior after a merge of two AddonMenus, like what happens in `apply_channel.go`?  Unless my understanding is incorrect, (or I've got a bug in the test) it seems like the merge behavior is incorrect, or maybe just confusing.  

```
--- FAIL: Test_MergeAddons (0.00s)
    addons_test.go:223: Unexpected AddonMenu merge result,
        Merged:
        AddonMenu{
          Addon{Name: a, Version: 1.0.0, KubernetesVersion: >=1.18.0, Id: k8s-1.18},
        }
        
        Expected:
        AddonMenu{
          Addon{Name: a, Version: 1.0.1, KubernetesVersion: >=1.18.0, Id: k8s-1.18},
        }
        
    addons_test.go:223: Unexpected AddonMenu merge result,
        Merged:
        AddonMenu{
          Addon{Name: a, Version: 1.0.0, KubernetesVersion: >=1.18.0, Id: k8s-1.18},
        }
        
        Expected:
        AddonMenu{
          Addon{Name: a, Version: 1.0.1, KubernetesVersion: >=1.18.0, Id: k8s-1.18},
        }
        
FAIL
FAIL	k8s.io/kops/channels/pkg/channels	0.016s
FAIL
```

This test passes with a change in addon.go from:
```
if existing.ChannelVersion().replaces(v.ChannelVersion()) {
```
to:
```
if v.ChannelVersion().replaces(existing.ChannelVersion()) {
```
So either my intuitive understanding of the MergeAddons function is off or this is a bug?  