### PR TITLE
Fix nil pointer when deleting instance

### DIFF
--- a/cmd/kops/delete_instance.go
+++ b/cmd/kops/delete_instance.go
@@ -242,6 +242,7 @@ func RunDeleteInstance(ctx context.Context, f *util.Factory, out io.Writer, opti
 	}
 
 	d := &instancegroups.RollingUpdateCluster{
+		Cluster:           cluster,
 		Ctx:               ctx,
 		MasterInterval:    0,
 		NodeInterval:      0,


### PR DESCRIPTION
/kind bug
`kops delete instance` do not pass on cluster resulting in a nil pointer dereference