### PR TITLE
Upgrade aws-iam-authenticator to 0.5.2

### DIFF
--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
@@ -61,6 +61,21 @@ rules:
   - create
   - update
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - aws-auth
+  verbs:
+  - get
 
 ---
 apiVersion: v1
@@ -91,6 +106,8 @@ metadata:
   name: aws-iam-authenticator
   labels:
     k8s-app: aws-iam-authenticator
+  annotations:
+    seccomp.security.alpha.kubernetes.io/pod: runtime/default
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -104,6 +121,7 @@ spec:
       labels:
         k8s-app: aws-iam-authenticator
     spec:
+      # use service account with access to
       serviceAccountName: aws-iam-authenticator
 
       # run on the host network (don't depend on CNI)
@@ -125,7 +143,7 @@ spec:
       # - output (output kubeconfig to plug into your apiserver configuration, mounted from the host)
       containers:
       - name: aws-iam-authenticator
-        image: {{ or .Authentication.Aws.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.1-debian-stretch" }}
+        image: {{ or .Authentication.Aws.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.2-debian-stretch" }}
         args:
         - server
         {{- if or (not .Authentication.Aws.BackendMode) (contains "MountedFile" .Authentication.Aws.BackendMode) }}
@@ -139,6 +157,11 @@ spec:
         {{- if .Authentication.Aws.BackendMode }}
         - --backend-mode={{ .Authentication.Aws.BackendMode }}
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
 
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/authentication.aws-k8s-1.12.yaml
@@ -61,6 +61,21 @@ rules:
   - create
   - update
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - aws-auth
+  resources:
+  - configmaps
+  verbs:
+  - get
 
 ---
 
@@ -90,6 +105,8 @@ subjects:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/pod: runtime/default
   labels:
     k8s-app: aws-iam-authenticator
   name: aws-iam-authenticator
@@ -113,7 +130,7 @@ spec:
         - --state-dir=/var/aws-iam-authenticator
         - --kubeconfig-pregenerated=true
         - --backend-mode=CRD,MountedFile
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.1-debian-stretch
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.2-debian-stretch
         livenessProbe:
           httpGet:
             host: 127.0.0.1
@@ -128,6 +145,11 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /etc/aws-iam-authenticator/
           name: config

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -90,7 +90,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: dbfc79bb5908416ca06803461ab076b4896d0f7c
+    manifestHash: 7a5100a7a4938565f3bd64decc8c7767f57ae2cc
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"


### PR DESCRIPTION
I used these manifests as a reference: https://github.com/kubernetes-sigs/aws-iam-authenticator/tree/v0.5.2/deploy

This addresses some security issues disclosed [here](https://bugs.chromium.org/p/project-zero/issues/detail?id=2066).