### PR TITLE
upgrade-cluster: test that new image in stable or alpha channel will …

### DIFF
--- a/cmd/kops/upgrade_cluster.go
+++ b/cmd/kops/upgrade_cluster.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/blang/semver/v4"
 	"github.com/spf13/cobra"
@@ -181,7 +180,7 @@ func (c *UpgradeClusterCmd) Run(ctx context.Context, args []string) error {
 			klog.Warningf("No matching images specified in channel; cannot prompt for upgrade")
 		} else {
 			for _, ig := range instanceGroups {
-				if strings.Contains(ig.Spec.Image, "kope.io") {
+				if channel.HasUpstreamImagePrefix(ig.Spec.Image) {
 					if ig.Spec.Image != image.Name {
 						target := ig
 						actions = append(actions, &upgradeAction{

--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -19,6 +19,7 @@ package kops
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/blang/semver/v4"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -320,4 +321,11 @@ func RecommendedKubernetesVersion(c *Channel, kopsVersionString string) *semver.
 	}
 
 	return nil
+}
+
+// Returns true if the given image name has the stable or alpha channel images prefix. Otherwise false.
+func (c *Channel) HasUpstreamImagePrefix(image string) bool {
+	return strings.HasPrefix(image, "kope.io/k8s-") ||
+		strings.HasPrefix(image, "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-") ||
+		strings.HasPrefix(image, "cos-cloud/cos-stable-")
 }

--- a/tests/integration/channel/integration_test.go
+++ b/tests/integration/channel/integration_test.go
@@ -391,3 +391,43 @@ func semverString(sv *semver.Version) string {
 	}
 	return sv.String()
 }
+
+// All Image in stable hannel should have a specified upstream image prefix
+func TestStableChannel(t *testing.T) {
+	sourcePath := "../../../channels/stable"
+	sourceBytes, err := ioutil.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
+	}
+
+	channel, err := kops.ParseChannel(sourceBytes)
+	if err != nil {
+		t.Fatalf("failed to parse channel: %v", err)
+	}
+
+	for _, image := range channel.Spec.Images {
+		if !channel.HasUpstreamImagePrefix(image.Name) {
+			t.Errorf("Stable image '%s' has not a recognized prefix. Add the correct prefix to HasUpstreamImagePrefix function", image.Name)
+		}
+	}
+}
+
+// All Image in stable hannel should have a specified upstream image prefix
+func TestAlphaChannel(t *testing.T) {
+	sourcePath := "../../../channels/alpha"
+	sourceBytes, err := ioutil.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
+	}
+
+	channel, err := kops.ParseChannel(sourceBytes)
+	if err != nil {
+		t.Fatalf("failed to parse channel: %v", err)
+	}
+
+	for _, image := range channel.Spec.Images {
+		if !channel.HasUpstreamImagePrefix(image.Name) {
+			t.Errorf("Alpha image channel '%s' has not a recognized prefix. Add the correct prefix to HasUpstreamImagePrefix function", image.Name)
+		}
+	}
+}

--- a/tests/integration/channel/integration_test.go
+++ b/tests/integration/channel/integration_test.go
@@ -392,42 +392,26 @@ func semverString(sv *semver.Version) string {
 	return sv.String()
 }
 
-// All Image in stable hannel should have a specified upstream image prefix
-func TestStableChannel(t *testing.T) {
-	sourcePath := "../../../channels/stable"
-	sourceBytes, err := ioutil.ReadFile(sourcePath)
-	if err != nil {
-		t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
-	}
+// All Images in channel should have a specified upstream image prefix
+func TestChannelImages(t *testing.T) {
+	for _, channel := range []string{"stable", "alpha"} {
+		t.Run(channel+"-channel", func(t *testing.T) {
+			sourcePath := "../../../channels/" + channel
+			sourceBytes, err := ioutil.ReadFile(sourcePath)
+			if err != nil {
+				t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
+			}
 
-	channel, err := kops.ParseChannel(sourceBytes)
-	if err != nil {
-		t.Fatalf("failed to parse channel: %v", err)
-	}
+			channel, err := kops.ParseChannel(sourceBytes)
+			if err != nil {
+				t.Fatalf("failed to parse channel: %v", err)
+			}
 
-	for _, image := range channel.Spec.Images {
-		if !channel.HasUpstreamImagePrefix(image.Name) {
-			t.Errorf("Stable image '%s' has not a recognized prefix. Add the correct prefix to HasUpstreamImagePrefix function", image.Name)
-		}
-	}
-}
-
-// All Image in stable hannel should have a specified upstream image prefix
-func TestAlphaChannel(t *testing.T) {
-	sourcePath := "../../../channels/alpha"
-	sourceBytes, err := ioutil.ReadFile(sourcePath)
-	if err != nil {
-		t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
-	}
-
-	channel, err := kops.ParseChannel(sourceBytes)
-	if err != nil {
-		t.Fatalf("failed to parse channel: %v", err)
-	}
-
-	for _, image := range channel.Spec.Images {
-		if !channel.HasUpstreamImagePrefix(image.Name) {
-			t.Errorf("Alpha image channel '%s' has not a recognized prefix. Add the correct prefix to HasUpstreamImagePrefix function", image.Name)
-		}
+			for _, image := range channel.Spec.Images {
+				if !channel.HasUpstreamImagePrefix(image.Name) {
+					t.Errorf("unknown image prefix: %q", image.Name)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR adds a test to make sure that stable and alpha channel image will receive proper updates when running kops upgrade cluster. This test will fail if image channel changes without adding the proper prefix in HasUpstreamImagePrefix function.

Example of failed test :
```
=== RUN   TestStableChannel
--- FAIL: TestStableChannel (0.00s)
    integration_test.go:410: Stable image '099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907' has not a recognized prefix. Add the correct prefix to HasUpstreamImagePrefix function
=== RUN   TestAlphaChannel
--- FAIL: TestAlphaChannel (0.00s)
    integration_test.go:430: Alpha image channel '099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907' has not a recognized prefix. Add the correct prefix to HasUpstreamImagePrefix function
FAIL
FAIL	k8s.io/kops/tests/integration/channel	0.023s
FAIL
```

Fixes: #10021