### PR TITLE
Automated cherry pick of #9917: Remove force_tcp flag for nodelocalcache dot zone

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -18217,9 +18217,7 @@ data:
         reload
         loop
         bind {{ KubeDNS.NodeLocalDNS.LocalIP }}{{ if NodeLocalDNSServerIP }} {{ NodeLocalDNSServerIP }}{{ end }}
-        forward . __PILLAR__UPSTREAM__SERVERS__ {
-          force_tcp
-        }
+        forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
     }
 ---

--- a/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
@@ -85,9 +85,7 @@ data:
         reload
         loop
         bind {{ KubeDNS.NodeLocalDNS.LocalIP }}{{ if NodeLocalDNSServerIP }} {{ NodeLocalDNSServerIP }}{{ end }}
-        forward . __PILLAR__UPSTREAM__SERVERS__ {
-          force_tcp
-        }
+        forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
     }
 ---


### PR DESCRIPTION
Cherry pick of #9917 on release-1.18.

#9917: Remove force_tcp flag for nodelocalcache dot zone

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.