### PR TITLE
Simplify node local dns

### DIFF
--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -76,8 +76,7 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if clusterSpec.Kubelet.ClusterDNS == "" {
-		if clusterSpec.KubeDNS != nil && clusterSpec.KubeDNS.NodeLocalDNS != nil && fi.BoolValue(clusterSpec.KubeDNS.NodeLocalDNS.Enabled) &&
-			((clusterSpec.KubeProxy != nil && clusterSpec.KubeProxy.ProxyMode == "ipvs") || (clusterSpec.Networking != nil && clusterSpec.Networking.Cilium != nil)) {
+		if clusterSpec.KubeDNS != nil && clusterSpec.KubeDNS.NodeLocalDNS != nil && fi.BoolValue(clusterSpec.KubeDNS.NodeLocalDNS.Enabled) {
 			clusterSpec.Kubelet.ClusterDNS = clusterSpec.KubeDNS.NodeLocalDNS.LocalIP
 		} else {
 			ip, err := WellKnownServiceIP(clusterSpec, 10)

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -19029,7 +19029,7 @@ data:
         }
         reload
         loop
-        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}{{ if NodeLocalDNSServerIP }} {{ NodeLocalDNSServerIP }}{{ end }}
+        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}
         forward . {{ NodeLocalDNSClusterIP }} {
           force_tcp
         }
@@ -19041,7 +19041,7 @@ data:
         cache 30
         reload
         loop
-        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}{{ if NodeLocalDNSServerIP }} {{ NodeLocalDNSServerIP }}{{ end }}
+        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}
         forward . {{ NodeLocalDNSClusterIP }} {
           force_tcp
         }
@@ -19052,7 +19052,7 @@ data:
         cache 30
         reload
         loop
-        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}{{ if NodeLocalDNSServerIP }} {{ NodeLocalDNSServerIP }}{{ end }}
+        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}
         forward . {{ NodeLocalDNSClusterIP }} {
           force_tcp
         }
@@ -19063,7 +19063,7 @@ data:
         cache 30
         reload
         loop
-        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}{{ if NodeLocalDNSServerIP }} {{ NodeLocalDNSServerIP }}{{ end }}
+        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}
         forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
     }
@@ -19105,16 +19105,16 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: k8s.gcr.io/k8s-dns-node-cache:1.15.10
+        image: k8s.gcr.io/dns/k8s-dns-node-cache:1.15.14
         resources:
           requests:
             cpu: {{ KubeDNS.NodeLocalDNS.CPURequest }}
             memory: {{ KubeDNS.NodeLocalDNS.MemoryRequest }}
-        {{ if NodeLocalDNSServerIP }}
-        args: [ "-localip", "{{ .KubeDNS.NodeLocalDNS.LocalIP }},{{ NodeLocalDNSServerIP }}", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream" ]
-        {{ else }}
-        args: [ "-localip", "{{ .KubeDNS.NodeLocalDNS.LocalIP }}", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream" ]
-        {{ end }}
+        args:
+          - -localip={{ .KubeDNS.NodeLocalDNS.LocalIP }}
+          - -conf=/etc/Corefile
+          - -upstreamsvc=kube-dns-upstream
+          - -setupiptables=false
         securityContext:
           privileged: true
         ports:

--- a/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
@@ -50,7 +50,7 @@ data:
         }
         reload
         loop
-        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}{{ if NodeLocalDNSServerIP }} {{ NodeLocalDNSServerIP }}{{ end }}
+        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}
         forward . {{ NodeLocalDNSClusterIP }} {
           force_tcp
         }
@@ -62,7 +62,7 @@ data:
         cache 30
         reload
         loop
-        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}{{ if NodeLocalDNSServerIP }} {{ NodeLocalDNSServerIP }}{{ end }}
+        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}
         forward . {{ NodeLocalDNSClusterIP }} {
           force_tcp
         }
@@ -73,7 +73,7 @@ data:
         cache 30
         reload
         loop
-        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}{{ if NodeLocalDNSServerIP }} {{ NodeLocalDNSServerIP }}{{ end }}
+        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}
         forward . {{ NodeLocalDNSClusterIP }} {
           force_tcp
         }
@@ -84,7 +84,7 @@ data:
         cache 30
         reload
         loop
-        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}{{ if NodeLocalDNSServerIP }} {{ NodeLocalDNSServerIP }}{{ end }}
+        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}
         forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
     }
@@ -126,16 +126,16 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: k8s.gcr.io/k8s-dns-node-cache:1.15.10
+        image: k8s.gcr.io/dns/k8s-dns-node-cache:1.15.14
         resources:
           requests:
             cpu: {{ KubeDNS.NodeLocalDNS.CPURequest }}
             memory: {{ KubeDNS.NodeLocalDNS.MemoryRequest }}
-        {{ if NodeLocalDNSServerIP }}
-        args: [ "-localip", "{{ .KubeDNS.NodeLocalDNS.LocalIP }},{{ NodeLocalDNSServerIP }}", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream" ]
-        {{ else }}
-        args: [ "-localip", "{{ .KubeDNS.NodeLocalDNS.LocalIP }}", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream" ]
-        {{ end }}
+        args:
+          - -localip={{ .KubeDNS.NodeLocalDNS.LocalIP }}
+          - -conf=/etc/Corefile
+          - -upstreamsvc=kube-dns-upstream
+          - -setupiptables=false
         securityContext:
           privileged: true
         ports:

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -105,12 +105,6 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 		}
 		return "__PILLAR__CLUSTER__DNS__"
 	}
-	dest["NodeLocalDNSServerIP"] = func() string {
-		if cluster.Spec.KubeProxy.ProxyMode == "ipvs" {
-			return ""
-		}
-		return cluster.Spec.KubeDNS.ServerIP
-	}
 	dest["NodeLocalDNSHealthCheck"] = func() string {
 		return fmt.Sprintf("%d", wellknownports.NodeLocalDNSHealthCheck)
 	}


### PR DESCRIPTION
Since we actually control the kubelet cluster dns IP we don't need to make things complex with iptables rules and complex port bindings.
That upstream defaults to these is only to make things simpler for those deploying this to vendor managed k8s clusters.

I think other maintainers suggested this when reviewing the PR that introduced this addon.