### PR TITLE
Updating alpha with October releases and latest Ubuntu AMI version

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -44,7 +44,7 @@ spec:
     - name: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
       providerID: aws
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201014
       providerID: aws
       kubernetesVersion: ">=1.18.0"
     - providerID: gce
@@ -59,10 +59,10 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.18.0"
-    recommendedVersion: 1.18.9
+    recommendedVersion: 1.18.10
     requiredVersion: 1.18.0
   - range: ">=1.17.0"
-    recommendedVersion: 1.17.12
+    recommendedVersion: 1.17.13
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
     recommendedVersion: 1.16.15
@@ -89,15 +89,15 @@ spec:
   - range: ">=1.19.0-alpha.1"
     #recommendedVersion: "1.19.0-alpha.1"
     #requiredVersion: 1.19.0
-    kubernetesVersion: 1.19.2
+    kubernetesVersion: 1.19.3
   - range: ">=1.18.0-alpha.1"
     recommendedVersion: "1.18.1"
     #requiredVersion: 1.18.0
-    kubernetesVersion: 1.18.9
+    kubernetesVersion: 1.18.10
   - range: ">=1.17.0-alpha.1"
     recommendedVersion: "1.18.1"
     #requiredVersion: 1.17.0
-    kubernetesVersion: 1.17.12
+    kubernetesVersion: 1.17.13
   - range: ">=1.16.0-alpha.1"
     recommendedVersion: "1.18.1"
     #requiredVersion: 1.16.0


### PR DESCRIPTION
Updating alpha channel with yesterday's releases to k8s versions:

- https://github.com/kubernetes/kubernetes/releases/tag/v1.17.13
- https://github.com/kubernetes/kubernetes/releases/tag/v1.18.10
- https://github.com/kubernetes/kubernetes/releases/tag/v1.19.3

Also, updated Ubuntu AMI to latest release:
```
$ aws ec2 describe-images --region us-east-1 --output table \
>     --owners 099720109477 \
>     --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
>     --filters "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-*"
-------------------------------------------------------------------------------------------------------------------------
|                                                    DescribeImages                                                     |
+--------------------------+------------------------------------------------------------------+-------------------------+
|  2020-04-23T11:35:02.000Z|  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200423  |  ami-068663a3c619dd892  |
|  2020-05-29T01:38:58.000Z|  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528  |  ami-0e2512bd9da751ea8  |
|  2020-06-10T01:14:00.000Z|  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200609  |  ami-02ae530dacc099fc9  |
|  2020-06-26T16:09:27.000Z|  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200625  |  ami-0c40fbd26b9ac0da9  |
|  2020-07-02T03:19:54.000Z|  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200701  |  ami-04e7b4117bb0488e4  |
|  2020-07-16T19:18:04.000Z|  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200716  |  ami-0d57c0143330e1fa7  |
|  2020-07-21T00:35:15.000Z|  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200720  |  ami-06c8ff16263f3db59  |
|  2020-07-30T15:39:28.000Z|  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200729  |  ami-0758470213bdd23b1  |
|  2020-08-18T17:26:37.000Z|  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200817  |  ami-05cf2c352da0bfb2e  |
|  2020-09-04T22:45:42.000Z|  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200903  |  ami-03f6f0014076ab3c5  |
|  2020-09-08T00:55:25.000Z|  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907  |  ami-0dba2cb6798deb6d8  |
|  2020-09-17T16:23:49.000Z|  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200916  |  ami-030bb5fda5f7e1896  |
|  2020-09-25T01:16:05.000Z|  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200924  |  ami-0c43b23f011ba5061  |
|  2020-10-14T16:38:23.000Z|  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201014  |  ami-07bfe0a3ec9dfcffa  |
+--------------------------+------------------------------------------------------------------+-------------------------+
```