### PR TITLE
Hotfix/10015 cloud formation lint error

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -314,21 +314,21 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 		},
 	}
 
-	minSize := int32(1)
-	maxSize := int32(1)
+	minSize := fi.Int64(1)
+	maxSize := fi.Int64(1)
 	if ig.Spec.MinSize != nil {
-		minSize = fi.Int32Value(ig.Spec.MinSize)
+		minSize = fi.Int64(int64(*ig.Spec.MinSize))
 	} else if ig.Spec.Role == kops.InstanceGroupRoleNode {
-		minSize = 2
+		minSize = fi.Int64(2)
 	}
 	if ig.Spec.MaxSize != nil {
-		maxSize = *ig.Spec.MaxSize
+		maxSize = fi.Int64(int64(*ig.Spec.MaxSize))
 	} else if ig.Spec.Role == kops.InstanceGroupRoleNode {
-		maxSize = 2
+		maxSize = fi.Int64(2)
 	}
 
-	t.MinSize = fi.Int64(int64(minSize))
-	t.MaxSize = fi.Int64(int64(maxSize))
+	t.MinSize = minSize
+	t.MaxSize = maxSize
 
 	subnets, err := b.GatherSubnets(ig)
 	if err != nil {

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -15,8 +15,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1acomplexexamplecom"
@@ -96,8 +96,8 @@
             ]
           }
         },
-        "MaxSize": 2,
-        "MinSize": 2,
+        "MaxSize": "2",
+        "MinSize": "2",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1acomplexexamplecom"
@@ -1079,9 +1079,9 @@
         "LoadBalancerName": "api-complex-example-com-vd3t5n",
         "Listeners": [
           {
-            "InstancePort": 443,
+            "InstancePort": "443",
             "InstanceProtocol": "TCP",
-            "LoadBalancerPort": 443,
+            "LoadBalancerPort": "443",
             "Protocol": "TCP"
           }
         ],
@@ -1099,10 +1099,10 @@
         ],
         "HealthCheck": {
           "Target": "SSL:443",
-          "HealthyThreshold": 2,
-          "UnhealthyThreshold": 2,
-          "Interval": 10,
-          "Timeout": 5
+          "HealthyThreshold": "2",
+          "UnhealthyThreshold": "2",
+          "Interval": "10",
+          "Timeout": "5"
         },
         "ConnectionSettings": {
           "IdleTimeout": 300

--- a/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json
@@ -15,8 +15,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1acontainerdexamplecom"
@@ -81,8 +81,8 @@
             ]
           }
         },
-        "MaxSize": 2,
-        "MinSize": 2,
+        "MaxSize": "2",
+        "MinSize": "2",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1acontainerdexamplecom"

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json
@@ -15,8 +15,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1aminimalexamplecom"
@@ -81,8 +81,8 @@
             ]
           }
         },
-        "MaxSize": 2,
-        "MinSize": 2,
+        "MaxSize": "2",
+        "MinSize": "2",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1aminimalexamplecom"

--- a/tests/integration/update_cluster/externallb/cloudformation.json
+++ b/tests/integration/update_cluster/externallb/cloudformation.json
@@ -15,8 +15,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1aexternallbexamplecom"
@@ -87,8 +87,8 @@
             ]
           }
         },
-        "MaxSize": 2,
-        "MinSize": 2,
+        "MaxSize": "2",
+        "MinSize": "2",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1aexternallbexamplecom"

--- a/tests/integration/update_cluster/launch_templates/cloudformation.json
+++ b/tests/integration/update_cluster/launch_templates/cloudformation.json
@@ -7,8 +7,8 @@
         "LaunchConfigurationName": {
           "Ref": "AWSAutoScalingLaunchConfigurationmasterustest1amasterslaunchtemplatesexamplecom"
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1alaunchtemplatesexamplecom"
@@ -65,8 +65,8 @@
         "LaunchConfigurationName": {
           "Ref": "AWSAutoScalingLaunchConfigurationmasterustest1bmasterslaunchtemplatesexamplecom"
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1blaunchtemplatesexamplecom"
@@ -123,8 +123,8 @@
         "LaunchConfigurationName": {
           "Ref": "AWSAutoScalingLaunchConfigurationmasterustest1cmasterslaunchtemplatesexamplecom"
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1claunchtemplatesexamplecom"
@@ -181,8 +181,8 @@
         "LaunchConfigurationName": {
           "Ref": "AWSAutoScalingLaunchConfigurationnodeslaunchtemplatesexamplecom"
         },
-        "MaxSize": 2,
-        "MinSize": 2,
+        "MaxSize": "2",
+        "MinSize": "2",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1blaunchtemplatesexamplecom"

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
@@ -15,8 +15,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1aminimalexamplecom"
@@ -81,8 +81,8 @@
             ]
           }
         },
-        "MaxSize": 2,
-        "MinSize": 2,
+        "MaxSize": "2",
+        "MinSize": "2",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1aminimalexamplecom"

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json
@@ -15,8 +15,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1amixedinstancesexamplecom"
@@ -81,8 +81,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1bmixedinstancesexamplecom"
@@ -147,8 +147,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1cmixedinstancesexamplecom"
@@ -202,8 +202,8 @@
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
         "AutoScalingGroupName": "nodes.mixedinstances.example.com",
-        "MaxSize": 2,
-        "MinSize": 2,
+        "MaxSize": "2",
+        "MinSize": "2",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1bmixedinstancesexamplecom"

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
@@ -15,8 +15,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1amixedinstancesexamplecom"
@@ -81,8 +81,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1bmixedinstancesexamplecom"
@@ -147,8 +147,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1cmixedinstancesexamplecom"
@@ -202,8 +202,8 @@
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
         "AutoScalingGroupName": "nodes.mixedinstances.example.com",
-        "MaxSize": 2,
-        "MinSize": 2,
+        "MaxSize": "2",
+        "MinSize": "2",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1bmixedinstancesexamplecom"

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -15,8 +15,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetutilityustest1aprivatecalicoexamplecom"
@@ -86,8 +86,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1aprivatecalicoexamplecom"
@@ -157,8 +157,8 @@
             ]
           }
         },
-        "MaxSize": 2,
-        "MinSize": 2,
+        "MaxSize": "2",
+        "MinSize": "2",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1aprivatecalicoexamplecom"
@@ -1228,9 +1228,9 @@
         "LoadBalancerName": "api-privatecalico-example-0uch4k",
         "Listeners": [
           {
-            "InstancePort": 443,
+            "InstancePort": "443",
             "InstanceProtocol": "TCP",
-            "LoadBalancerPort": 443,
+            "LoadBalancerPort": "443",
             "Protocol": "TCP"
           }
         ],
@@ -1246,10 +1246,10 @@
         ],
         "HealthCheck": {
           "Target": "SSL:443",
-          "HealthyThreshold": 2,
-          "UnhealthyThreshold": 2,
-          "Interval": 10,
-          "Timeout": 5
+          "HealthyThreshold": "2",
+          "UnhealthyThreshold": "2",
+          "Interval": "10",
+          "Timeout": "5"
         },
         "ConnectionSettings": {
           "IdleTimeout": 300
@@ -1277,9 +1277,9 @@
         "LoadBalancerName": "bastion-privatecalico-exa-hocohm",
         "Listeners": [
           {
-            "InstancePort": 22,
+            "InstancePort": "22",
             "InstanceProtocol": "TCP",
-            "LoadBalancerPort": 22,
+            "LoadBalancerPort": "22",
             "Protocol": "TCP"
           }
         ],
@@ -1295,10 +1295,10 @@
         ],
         "HealthCheck": {
           "Target": "TCP:22",
-          "HealthyThreshold": 2,
-          "UnhealthyThreshold": 2,
-          "Interval": 10,
-          "Timeout": 5
+          "HealthyThreshold": "2",
+          "UnhealthyThreshold": "2",
+          "Interval": "10",
+          "Timeout": "5"
         },
         "ConnectionSettings": {
           "IdleTimeout": 300

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json
@@ -15,8 +15,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetutilityustest1aprivateciliumexamplecom"
@@ -86,8 +86,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1aprivateciliumexamplecom"
@@ -157,8 +157,8 @@
             ]
           }
         },
-        "MaxSize": 2,
-        "MinSize": 2,
+        "MaxSize": "2",
+        "MinSize": "2",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1aprivateciliumexamplecom"
@@ -1214,9 +1214,9 @@
         "LoadBalancerName": "api-privatecilium-example-fnt793",
         "Listeners": [
           {
-            "InstancePort": 443,
+            "InstancePort": "443",
             "InstanceProtocol": "TCP",
-            "LoadBalancerPort": 443,
+            "LoadBalancerPort": "443",
             "Protocol": "TCP"
           }
         ],
@@ -1232,10 +1232,10 @@
         ],
         "HealthCheck": {
           "Target": "SSL:443",
-          "HealthyThreshold": 2,
-          "UnhealthyThreshold": 2,
-          "Interval": 10,
-          "Timeout": 5
+          "HealthyThreshold": "2",
+          "UnhealthyThreshold": "2",
+          "Interval": "10",
+          "Timeout": "5"
         },
         "ConnectionSettings": {
           "IdleTimeout": 300
@@ -1263,9 +1263,9 @@
         "LoadBalancerName": "bastion-privatecilium-exa-l2ms01",
         "Listeners": [
           {
-            "InstancePort": 22,
+            "InstancePort": "22",
             "InstanceProtocol": "TCP",
-            "LoadBalancerPort": 22,
+            "LoadBalancerPort": "22",
             "Protocol": "TCP"
           }
         ],
@@ -1281,10 +1281,10 @@
         ],
         "HealthCheck": {
           "Target": "TCP:22",
-          "HealthyThreshold": 2,
-          "UnhealthyThreshold": 2,
-          "Interval": 10,
-          "Timeout": 5
+          "HealthyThreshold": "2",
+          "UnhealthyThreshold": "2",
+          "Interval": "10",
+          "Timeout": "5"
         },
         "ConnectionSettings": {
           "IdleTimeout": 300

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json
@@ -15,8 +15,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetutilityustest1aprivateciliumexamplecom"
@@ -86,8 +86,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1aprivateciliumexamplecom"
@@ -157,8 +157,8 @@
             ]
           }
         },
-        "MaxSize": 2,
-        "MinSize": 2,
+        "MaxSize": "2",
+        "MinSize": "2",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1aprivateciliumexamplecom"
@@ -1214,9 +1214,9 @@
         "LoadBalancerName": "api-privatecilium-example-fnt793",
         "Listeners": [
           {
-            "InstancePort": 443,
+            "InstancePort": "443",
             "InstanceProtocol": "TCP",
-            "LoadBalancerPort": 443,
+            "LoadBalancerPort": "443",
             "Protocol": "TCP"
           }
         ],
@@ -1232,10 +1232,10 @@
         ],
         "HealthCheck": {
           "Target": "SSL:443",
-          "HealthyThreshold": 2,
-          "UnhealthyThreshold": 2,
-          "Interval": 10,
-          "Timeout": 5
+          "HealthyThreshold": "2",
+          "UnhealthyThreshold": "2",
+          "Interval": "10",
+          "Timeout": "5"
         },
         "ConnectionSettings": {
           "IdleTimeout": 300
@@ -1263,9 +1263,9 @@
         "LoadBalancerName": "bastion-privatecilium-exa-l2ms01",
         "Listeners": [
           {
-            "InstancePort": 22,
+            "InstancePort": "22",
             "InstanceProtocol": "TCP",
-            "LoadBalancerPort": 22,
+            "LoadBalancerPort": "22",
             "Protocol": "TCP"
           }
         ],
@@ -1281,10 +1281,10 @@
         ],
         "HealthCheck": {
           "Target": "TCP:22",
-          "HealthyThreshold": 2,
-          "UnhealthyThreshold": 2,
-          "Interval": 10,
-          "Timeout": 5
+          "HealthyThreshold": "2",
+          "UnhealthyThreshold": "2",
+          "Interval": "10",
+          "Timeout": "5"
         },
         "ConnectionSettings": {
           "IdleTimeout": 300

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
@@ -15,8 +15,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetutilityustest1aprivateciliumadvancedexamplecom"
@@ -86,8 +86,8 @@
             ]
           }
         },
-        "MaxSize": 1,
-        "MinSize": 1,
+        "MaxSize": "1",
+        "MinSize": "1",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1aprivateciliumadvancedexamplecom"
@@ -157,8 +157,8 @@
             ]
           }
         },
-        "MaxSize": 2,
-        "MinSize": 2,
+        "MaxSize": "2",
+        "MinSize": "2",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnetustest1aprivateciliumadvancedexamplecom"
@@ -1245,9 +1245,9 @@
         "LoadBalancerName": "api-privateciliumadvanced-0cffmm",
         "Listeners": [
           {
-            "InstancePort": 443,
+            "InstancePort": "443",
             "InstanceProtocol": "TCP",
-            "LoadBalancerPort": 443,
+            "LoadBalancerPort": "443",
             "Protocol": "TCP"
           }
         ],
@@ -1263,10 +1263,10 @@
         ],
         "HealthCheck": {
           "Target": "SSL:443",
-          "HealthyThreshold": 2,
-          "UnhealthyThreshold": 2,
-          "Interval": 10,
-          "Timeout": 5
+          "HealthyThreshold": "2",
+          "UnhealthyThreshold": "2",
+          "Interval": "10",
+          "Timeout": "5"
         },
         "ConnectionSettings": {
           "IdleTimeout": 300
@@ -1294,9 +1294,9 @@
         "LoadBalancerName": "bastion-privateciliumadva-0jni40",
         "Listeners": [
           {
-            "InstancePort": 22,
+            "InstancePort": "22",
             "InstanceProtocol": "TCP",
-            "LoadBalancerPort": 22,
+            "LoadBalancerPort": "22",
             "Protocol": "TCP"
           }
         ],
@@ -1312,10 +1312,10 @@
         ],
         "HealthCheck": {
           "Target": "TCP:22",
-          "HealthyThreshold": 2,
-          "UnhealthyThreshold": 2,
-          "Interval": 10,
-          "Timeout": 5
+          "HealthyThreshold": "2",
+          "UnhealthyThreshold": "2",
+          "Interval": "10",
+          "Timeout": "5"
         },
         "ConnectionSettings": {
           "IdleTimeout": 300

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -862,8 +862,8 @@ type cloudformationAutoscalingGroup struct {
 	Name                    *string                                               `json:"AutoScalingGroupName,omitempty"`
 	LaunchConfigurationName *cloudformation.Literal                               `json:"LaunchConfigurationName,omitempty"`
 	LaunchTemplate          *cloudformationAutoscalingLaunchTemplateSpecification `json:"LaunchTemplate,omitempty"`
-	MaxSize                 *int64                                                `json:"MaxSize,omitempty"`
-	MinSize                 *int64                                                `json:"MinSize,omitempty"`
+	MaxSize                 *string                                               `json:"MaxSize,omitempty"`
+	MinSize                 *string                                               `json:"MinSize,omitempty"`
 	VPCZoneIdentifier       []*cloudformation.Literal                             `json:"VPCZoneIdentifier,omitempty"`
 	Tags                    []*cloudformationASGTag                               `json:"Tags,omitempty"`
 	MetricsCollection       []*cloudformationASGMetricsCollection                 `json:"MetricsCollection,omitempty"`
@@ -876,8 +876,8 @@ type cloudformationAutoscalingGroup struct {
 func (_ *AutoscalingGroup) RenderCloudformation(t *cloudformation.CloudformationTarget, a, e, changes *AutoscalingGroup) error {
 	cf := &cloudformationAutoscalingGroup{
 		Name:    e.Name,
-		MinSize: e.MinSize,
-		MaxSize: e.MaxSize,
+		MinSize: fi.ToString(e.MinSize),
+		MaxSize: fi.ToString(e.MaxSize),
 		MetricsCollection: []*cloudformationASGMetricsCollection{
 			{
 				Granularity: e.Granularity,

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
@@ -349,8 +349,8 @@ func TestAutoscalingGroupCloudformationRender(t *testing.T) {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
         "AutoScalingGroupName": "test1",
-        "MaxSize": 10,
-        "MinSize": 5,
+        "MaxSize": "10",
+        "MinSize": "5",
         "VPCZoneIdentifier": [
           {
             "Ref": "AWSEC2Subnettestsg"

--- a/upup/pkg/fi/cloudup/awstasks/load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/load_balancer.go
@@ -805,18 +805,18 @@ type cloudformationLoadBalancer struct {
 }
 
 type cloudformationLoadBalancerListener struct {
-	InstancePort         int    `json:"InstancePort"`
+	InstancePort         string `json:"InstancePort"`
 	InstanceProtocol     string `json:"InstanceProtocol"`
-	LoadBalancerPort     int64  `json:"LoadBalancerPort"`
+	LoadBalancerPort     string `json:"LoadBalancerPort"`
 	LoadBalancerProtocol string `json:"Protocol"`
 }
 
 type cloudformationLoadBalancerHealthCheck struct {
 	Target             *string `json:"Target"`
-	HealthyThreshold   *int64  `json:"HealthyThreshold"`
-	UnhealthyThreshold *int64  `json:"UnhealthyThreshold"`
-	Interval           *int64  `json:"Interval"`
-	Timeout            *int64  `json:"Timeout"`
+	HealthyThreshold   *string `json:"HealthyThreshold"`
+	UnhealthyThreshold *string `json:"UnhealthyThreshold"`
+	Interval           *string `json:"Interval"`
+	Timeout            *string `json:"Timeout"`
 }
 
 type cloudformationConnectionDrainingPolicy struct {
@@ -853,15 +853,11 @@ func (_ *LoadBalancer) RenderCloudformation(t *cloudformation.CloudformationTarg
 	}
 
 	for loadBalancerPort, listener := range e.Listeners {
-		loadBalancerPortInt, err := strconv.ParseInt(loadBalancerPort, 10, 64)
-		if err != nil {
-			return fmt.Errorf("error parsing load balancer listener port: %q", loadBalancerPort)
-		}
 
 		tf.Listener = append(tf.Listener, &cloudformationLoadBalancerListener{
 			InstanceProtocol:     "TCP",
-			InstancePort:         listener.InstancePort,
-			LoadBalancerPort:     loadBalancerPortInt,
+			InstancePort:         strconv.Itoa(listener.InstancePort),
+			LoadBalancerPort:     loadBalancerPort,
 			LoadBalancerProtocol: "TCP",
 		})
 	}
@@ -869,10 +865,10 @@ func (_ *LoadBalancer) RenderCloudformation(t *cloudformation.CloudformationTarg
 	if e.HealthCheck != nil {
 		tf.HealthCheck = &cloudformationLoadBalancerHealthCheck{
 			Target:             e.HealthCheck.Target,
-			HealthyThreshold:   e.HealthCheck.HealthyThreshold,
-			UnhealthyThreshold: e.HealthCheck.UnhealthyThreshold,
-			Interval:           e.HealthCheck.Interval,
-			Timeout:            e.HealthCheck.Timeout,
+			HealthyThreshold:   fi.ToString(e.HealthCheck.HealthyThreshold),
+			UnhealthyThreshold: fi.ToString(e.HealthCheck.UnhealthyThreshold),
+			Interval:           fi.ToString(e.HealthCheck.Interval),
+			Timeout:            fi.ToString(e.HealthCheck.Timeout),
 		}
 	}
 

--- a/upup/pkg/fi/values.go
+++ b/upup/pkg/fi/values.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 )
 
 func StringValue(s *string) string {
@@ -201,4 +202,23 @@ func DebugAsJsonStringIndent(v interface{}) string {
 		return fmt.Sprintf("error marshaling: %v", err)
 	}
 	return string(data)
+}
+
+func ToInt64(s *string) *int64 {
+	if s == nil {
+		return nil
+	}
+	v, err := strconv.ParseInt(*s, 10, 64)
+	if err != nil {
+		return nil
+	}
+	return &v
+}
+
+func ToString(v *int64) *string {
+	if v == nil {
+		return nil
+	}
+	s := strconv.FormatInt(*v, 10)
+	return &s
 }


### PR DESCRIPTION
connects https://github.com/kubernetes/kops/issues/10015
The ./hack/update-expected.sh script generates some fields which are
required to be string fields and hence results in linting errors.

This PR changes those fields to string/*string and removes lint
warnings.


- [x] Sort help for error 
E3031 CidrIp contains invalid characters (Pattern: x.x.x.x/y) at Resources/AWSEC2SecurityGroupIngressicmppmtuapielb20010850040/Properties/CidrIp
tests/integration/update_cluster/complex/cloudformation.json:629:9