### PR TITLE
Cleanup channels error output

### DIFF
--- a/channels/pkg/cmd/root.go
+++ b/channels/pkg/cmd/root.go
@@ -44,8 +44,10 @@ func NewCmdRoot(f Factory, out io.Writer) *cobra.Command {
 	options := &CmdRootOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "channels",
-		Short: "channels applies software from a channel",
+		Use:           "channels",
+		Short:         "channels applies software from a channel",
+		SilenceErrors: true,
+		SilenceUsage:  true,
 	}
 
 	cmd.PersistentFlags().AddGoFlagSet(goflag.CommandLine)


### PR DESCRIPTION
This removes a redundant printing of error messages and no longer prints the usage help text when channels fails.

Before:
```
$ ./.build/local/channels apply channel -f ./upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml --yes
NAME				CURRENT	UPDATE
core.addons.k8s.io		-	1.4.0
dns-controller.addons.k8s.io	-	1.19.0-alpha.4
kops-controller.addons.k8s.io	-	1.19.0-alpha.4
kube-dns.addons.k8s.io		-	1.15.13-kops.3
kubelet-api.rbac.addons.k8s.io	-	v0.0.1
limit-range.addons.k8s.io	-	1.5.0
storage-aws.addons.k8s.io	-	1.15.0
I1018 16:49:43.908920   87960 addon.go:140] Applying update from "./upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io/k8s-1.12.yaml"
Error: error updating "dns-controller.addons.k8s.io": error applying update from "./upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io/k8s-1.12.yaml": error reading manifest: open ./upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io/k8s-1.12.yaml: no such file or directory
Usage:
  channels apply channel [flags]

Flags:
  -f, --filename strings   Apply from a local file
  -h, --help               help for channel
      --yes                Apply update

Global Flags:
      --add_dir_header                   If true, adds the file directory to the header of the log messages
      --alsologtostderr                  log to standard error as well as files
      --config string                    config file (default is $HOME/.channels.yaml)
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --log_file string                  If non-empty, use this log file
      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --logtostderr                      log to standard error instead of files (default true)
      --skip_headers                     If true, avoid header prefixes in the log messages
      --skip_log_headers                 If true, avoid headers when opening log files
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          number for the log level verbosity
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging


error updating "dns-controller.addons.k8s.io": error applying update from "./upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io/k8s-1.12.yaml": error reading manifest: open ./upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io/k8s-1.12.yaml: no such file or directory
```

After:
```
$ ./.build/local/channels apply channel -f ./upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml --yes
NAME				CURRENT	UPDATE
core.addons.k8s.io		-	1.4.0
dns-controller.addons.k8s.io	-	1.19.0-alpha.4
kops-controller.addons.k8s.io	-	1.19.0-alpha.4
kube-dns.addons.k8s.io		-	1.15.13-kops.3
kubelet-api.rbac.addons.k8s.io	-	v0.0.1
limit-range.addons.k8s.io	-	1.5.0
storage-aws.addons.k8s.io	-	1.15.0
I1018 16:51:08.918451   88636 addon.go:140] Applying update from "./upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/core.addons.k8s.io/v1.4.0.yaml"

error updating "core.addons.k8s.io": error applying update from "./upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/core.addons.k8s.io/v1.4.0.yaml": error reading manifest: open ./upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/core.addons.k8s.io/v1.4.0.yaml: no such file or directory
```