### PR TITLE
Use AWS SDK lists of enum values for API validation

### DIFF
--- a/pkg/apis/kops/validation/BUILD.bazel
+++ b/pkg/apis/kops/validation/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/arn:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
         "//vendor/github.com/blang/semver/v4:go_default_library",
         "//vendor/golang.org/x/net/ipv4:go_default_library",
         "//vendor/golang.org/x/net/ipv6:go_default_library",

--- a/pkg/apis/kops/validation/aws.go
+++ b/pkg/apis/kops/validation/aws.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kops/pkg/apis/kops"
@@ -104,9 +105,8 @@ func awsValidateSpotDurationInMinute(fieldPath *field.Path, ig *kops.InstanceGro
 func awsValidateInstanceInterruptionBehavior(fieldPath *field.Path, ig *kops.InstanceGroup) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if ig.Spec.InstanceInterruptionBehavior != nil {
-		validInterruptionBehaviors := []string{"terminate", "hibernate", "stop"}
 		instanceInterruptionBehavior := *ig.Spec.InstanceInterruptionBehavior
-		allErrs = append(allErrs, IsValidValue(fieldPath, &instanceInterruptionBehavior, validInterruptionBehaviors)...)
+		allErrs = append(allErrs, IsValidValue(fieldPath, &instanceInterruptionBehavior, ec2.InstanceInterruptionBehavior_Values())...)
 	}
 	return allErrs
 }

--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kops/pkg/nodeidentity/aws"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
@@ -55,7 +56,7 @@ func ValidateInstanceGroup(g *kops.InstanceGroup, cloud fi.Cloud) field.ErrorLis
 	}
 
 	if g.Spec.Tenancy != "" {
-		allErrs = append(allErrs, IsValidValue(field.NewPath("spec", "tenancy"), &g.Spec.Tenancy, []string{"default", "dedicated", "host"})...)
+		allErrs = append(allErrs, IsValidValue(field.NewPath("spec", "tenancy"), &g.Spec.Tenancy, ec2.Tenancy_Values())...)
 	}
 
 	if g.Spec.MaxSize != nil && g.Spec.MinSize != nil {


### PR DESCRIPTION
A recent sdk update added `_Values()` functions that return a list of all enums for given values. This updates the API validation's hardcoded lists of strings to instead use these functions.

```go

const (
	// InstanceInterruptionBehaviorHibernate is a InstanceInterruptionBehavior enum value
	InstanceInterruptionBehaviorHibernate = "hibernate"

	// InstanceInterruptionBehaviorStop is a InstanceInterruptionBehavior enum value
	InstanceInterruptionBehaviorStop = "stop"

	// InstanceInterruptionBehaviorTerminate is a InstanceInterruptionBehavior enum value
	InstanceInterruptionBehaviorTerminate = "terminate"
)

// InstanceInterruptionBehavior_Values returns all elements of the InstanceInterruptionBehavior enum
func InstanceInterruptionBehavior_Values() []string {
	return []string{
		InstanceInterruptionBehaviorHibernate,
		InstanceInterruptionBehaviorStop,
		InstanceInterruptionBehaviorTerminate,
	}
}

...

const (
	// TenancyDefault is a Tenancy enum value
	TenancyDefault = "default"

	// TenancyDedicated is a Tenancy enum value
	TenancyDedicated = "dedicated"

	// TenancyHost is a Tenancy enum value
	TenancyHost = "host"
)

// Tenancy_Values returns all elements of the Tenancy enum
func Tenancy_Values() []string {
	return []string{
		TenancyDefault,
		TenancyDedicated,
		TenancyHost,
	}
}

```