### PR TITLE
WIP: Don't force APIServer --allow-privileged flag to true for k8s 1.19+

### DIFF
--- a/docs/releases/1.19-NOTES.md
+++ b/docs/releases/1.19-NOTES.md
@@ -35,6 +35,9 @@ If you already have a default `StorageClass`, you should set `cloudConfig.Openst
 The certificates on a node will expire sometime between 455 and 485 days after the node's creation.
 The expiration times vary randomly so that nodes are likely to have their certs expire at different times than other nodes.
 
+* For Kubernetes 1.19 and later, we no longer force the APIServer `--allow-privileged` flag to `true`. As of Kubernetes 1.19 it will default to `false`.
+This may be set using the `spec.kubeApiServer.allowPrivileged` field in the cluster spec.
+
 ### CLI
 
 * The `kops update cluster` command will now refuse to run on a cluster that

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -163,7 +163,9 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 
 	c.BindAddress = "0.0.0.0"
 
-	c.AllowPrivileged = fi.Bool(true)
+	if b.IsKubernetesLT("1.19") {
+		c.AllowPrivileged = fi.Bool(true)
+	}
 	c.ServiceClusterIPRange = clusterSpec.ServiceClusterIPRange
 	c.EtcdServers = []string{"http://127.0.0.1:4001"}
 	c.EtcdServersOverrides = []string{"/events#http://127.0.0.1:4002"}


### PR DESCRIPTION
We should use defaults that are less secure than upstream Kubernetes defaults, much less force settings to such less secure values.