### PR TITLE
Automated cherry pick of #10092: Fix circular dependency in tasks related to kubelet

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -566,17 +566,19 @@ func (b *KubeletBuilder) buildKubeletServingCertificate(c *fi.ModelBuilderContex
 			cert, key := b.GetBootstrapCert(name)
 
 			c.AddTask(&nodetasks.File{
-				Path:     filepath.Join(dir, name+".crt"),
-				Contents: cert,
-				Type:     nodetasks.FileType_File,
-				Mode:     fi.String("0644"),
+				Path:           filepath.Join(dir, name+".crt"),
+				Contents:       cert,
+				Type:           nodetasks.FileType_File,
+				Mode:           fi.String("0644"),
+				BeforeServices: []string{"kubelet.service"},
 			})
 
 			c.AddTask(&nodetasks.File{
-				Path:     filepath.Join(dir, name+".key"),
-				Contents: key,
-				Type:     nodetasks.FileType_File,
-				Mode:     fi.String("0400"),
+				Path:           filepath.Join(dir, name+".key"),
+				Contents:       key,
+				Type:           nodetasks.FileType_File,
+				Mode:           fi.String("0400"),
+				BeforeServices: []string{"kubelet.service"},
 			})
 
 		} else {

--- a/nodeup/pkg/model/networking/cilium.go
+++ b/nodeup/pkg/model/networking/cilium.go
@@ -131,17 +131,19 @@ func (b *CiliumBuilder) buildCiliumEtcdSecrets(c *fi.ModelBuilderContext) error 
 		cert, key := b.GetBootstrapCert(name)
 
 		c.AddTask(&nodetasks.File{
-			Path:     filepath.Join(dir, name+".crt"),
-			Contents: cert,
-			Type:     nodetasks.FileType_File,
-			Mode:     fi.String("0644"),
+			Path:           filepath.Join(dir, name+".crt"),
+			Contents:       cert,
+			Type:           nodetasks.FileType_File,
+			Mode:           fi.String("0644"),
+			BeforeServices: []string{"kubelet.service"},
 		})
 
 		c.AddTask(&nodetasks.File{
-			Path:     filepath.Join(dir, name+".key"),
-			Contents: key,
-			Type:     nodetasks.FileType_File,
-			Mode:     fi.String("0400"),
+			Path:           filepath.Join(dir, name+".key"),
+			Contents:       key,
+			Type:           nodetasks.FileType_File,
+			Mode:           fi.String("0400"),
+			BeforeServices: []string{"kubelet.service"},
 		})
 
 		return b.BuildCertificateTask(c, signer, filepath.Join(dir, "etcd-ca.crt"), nil)


### PR DESCRIPTION
Cherry pick of #10092 on release-1.19.

#10092: Fix circular dependency in tasks related to kubelet

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.