### PR TITLE
Fix cilium template by specifying boolean as a string for enable-metrics

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -4646,8 +4646,8 @@ data:
   # NOTE that this will open the port on ALL nodes where Cilium pods are
   # scheduled.
   prometheus-serve-addr: ":{{ .AgentPrometheusPort }}"
-  operator-prometheus-serve-addr: ":6942" 
-  enable-metrics: true
+  operator-prometheus-serve-addr: ":6942"
+  enable-metrics: "true"
   {{ end }}
   {{ if .EnableEncryption }}
   enable-ipsec: "true"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
@@ -53,8 +53,8 @@ data:
   # NOTE that this will open the port on ALL nodes where Cilium pods are
   # scheduled.
   prometheus-serve-addr: ":{{ .AgentPrometheusPort }}"
-  operator-prometheus-serve-addr: ":6942" 
-  enable-metrics: true
+  operator-prometheus-serve-addr: ":6942"
+  enable-metrics: "true"
   {{ end }}
   {{ if .EnableEncryption }}
   enable-ipsec: "true"


### PR DESCRIPTION
Fixes: #10081 

Cilium ConfigMap template was wrong, so I fixed it.
I confirmed that kops can successfully create clusters using this change when `enablePrometheusMetrics` is specified  for Cilium.