### PR TITLE
[Digital Ocean] Use Debian10 as default image

### DIFF
--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -43,7 +43,7 @@ const (
 	defaultMasterMachineTypeDO  = "s-2vcpu-4gb"
 	defaultMasterMachineTypeALI = "ecs.n2.medium"
 
-	defaultDONodeImage  = "debian-9-x64"
+	defaultDONodeImage  = "debian-10-x64"
 	defaultALINodeImage = "centos_7_04_64_20G_alibase_201701015.vhd"
 )
 

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -43,7 +43,7 @@ const (
 	defaultMasterMachineTypeDO  = "s-2vcpu-4gb"
 	defaultMasterMachineTypeALI = "ecs.n2.medium"
 
-	defaultDONodeImage  = "debian-10-x64"
+	defaultDONodeImage  = "ubuntu-20-04-x64"
 	defaultALINodeImage = "centos_7_04_64_20G_alibase_201701015.vhd"
 )
 


### PR DESCRIPTION
Cilium leverages and builds on the kernel BPF functionality as well as various subsystems which integrate with BPF. Therefore, host systems are required to run Linux kernel version 4.9.17 or later to run a Cilium agent.

Using Debian10 should ensure we have the latest kernel that Cilium expects.