### PR TITLE
Update Kops Go build supported versions 1.15

### DIFF
--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -47,5 +47,5 @@ and then configure your IDE to connect its debugger to port 2345 on localhost.
 
  - Make sure `$GOPATH` is set, and your [workspace](https://golang.org/doc/code.html#Workspaces) is configured.
  - kops will not compile with symlinks in `$GOPATH`. See issue go issue [17451](https://github.com/golang/go/issues/17451) for more information
- - building kops requires go 1.12 or 1.13
+ - building kops requires go 1.15
  - Kops will only compile if the source is checked out in `$GOPATH/src/k8s.io/kops`. If you try to use `$GOPATH/src/github.com/kubernetes/kops` you will run into issues with package imports not working as expected.


### PR DESCRIPTION
Update Kops documentation to reflect support for Go versions `go1.14+` and `go1.15+`.

Kops `make verify` and `make all examples test` successfully tested against Go versions `go1.14`, `go1.15` and `go1.15.3`.

Latest Go version `go1.13.15` is no longer supported due to the following error...

```
$ go version
go version go1.13.15 linux/amd64

$ make clean && make apimachinery
if test -e /c/GitHub/kops/.build; then rm -rfv /c/GitHub/kops/.build; fi
bazel clean
INFO: Starting clean (this may take a while). Consider using --async if the clean takes more than several minutes.
rm -rf tests/integration/update_cluster/*/.terraform
sh -c hack/make-apimachinery.sh
-mod=mod not supported (can be '', 'readonly', or 'vendor')
make: *** [Makefile:526: apimachinery-codegen] Error 1
```
