### PR TITLE
Automated cherry pick of #9575: Rename NodeReconciler to LegacyNodeReconciler

### DIFF
--- a/cmd/kops-controller/controllers/BUILD.bazel
+++ b/cmd/kops-controller/controllers/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["node_controller.go"],
+    srcs = ["legacy_node_controller.go"],
     importpath = "k8s.io/kops/cmd/kops-controller/controllers",
     visibility = ["//visibility:public"],
     deps = [

--- a/cmd/kops-controller/controllers/BUILD.bazel
+++ b/cmd/kops-controller/controllers/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["legacy_node_controller.go"],
+    srcs = [
+        "legacy_node_controller.go",
+        "node_controller.go",
+    ],
     importpath = "k8s.io/kops/cmd/kops-controller/controllers",
     visibility = ["//visibility:public"],
     deps = [

--- a/cmd/kops-controller/controllers/node_controller.go
+++ b/cmd/kops-controller/controllers/node_controller.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/nodeidentity"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// NewNodeReconciler is the constructor for a NodeReconciler
+func NewNodeReconciler(mgr manager.Manager, identifier nodeidentity.Identifier) (*NodeReconciler, error) {
+	r := &NodeReconciler{
+		client:     mgr.GetClient(),
+		log:        ctrl.Log.WithName("controllers").WithName("Node"),
+		identifier: identifier,
+	}
+
+	coreClient, err := corev1client.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return nil, fmt.Errorf("error building corev1 client: %v", err)
+	}
+	r.coreV1Client = coreClient
+
+	return r, nil
+}
+
+// NodeReconciler observes Node objects, and labels them with the correct labels for the instancegroup
+// This used to be done by the kubelet, but is moving to a central controller for greater security in 1.16
+type NodeReconciler struct {
+	// client is the controller-runtime client
+	client client.Client
+
+	// log is a logr
+	log logr.Logger
+
+	// coreV1Client is a client-go client for patching nodes
+	coreV1Client *corev1client.CoreV1Client
+
+	// identifier is a provider that can securely map node ProviderIDs to labels
+	identifier nodeidentity.Identifier
+}
+
+// +kubebuilder:rbac:groups=,resources=nodes,verbs=get;list;watch;patch
+// Reconcile is the main reconciler function that observes node changes.
+func (r *NodeReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	ctx := context.Background()
+	_ = r.log.WithValues("nodecontroller", req.NamespacedName)
+
+	node := &corev1.Node{}
+	if err := r.client.Get(ctx, req.NamespacedName, node); err != nil {
+		klog.Warningf("unable to fetch node %s: %v", node.Name, err)
+		if apierrors.IsNotFound(err) {
+			// we'll ignore not-found errors, since they can't be fixed by an immediate
+			// requeue (we'll need to wait for a new notification), and we can get them
+			// on deleted requests.
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	info, err := r.identifier.IdentifyNode(ctx, node)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("error identifying node %q: %v", node.Name, err)
+	}
+
+	labels := info.Labels
+
+	updateLabels := make(map[string]string)
+	for k, v := range labels {
+		actual, found := node.Labels[k]
+		if !found || actual != v {
+			updateLabels[k] = v
+		}
+	}
+
+	if len(updateLabels) == 0 {
+		klog.V(4).Infof("no label changes needed for %s", node.Name)
+		return ctrl.Result{}, nil
+	}
+
+	if err := patchNodeLabels(r.coreV1Client, ctx, node, updateLabels); err != nil {
+		klog.Warningf("failed to patch node labels on %s: %v", node.Name, err)
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Node{}).
+		Complete(r)
+}
+
+type nodePatch struct {
+	Metadata *nodePatchMetadata `json:"metadata,omitempty"`
+}
+
+type nodePatchMetadata struct {
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// patchNodeLabels patches the node labels to set the specified labels
+func patchNodeLabels(client *corev1client.CoreV1Client, ctx context.Context, node *corev1.Node, setLabels map[string]string) error {
+	nodePatchMetadata := &nodePatchMetadata{
+		Labels: setLabels,
+	}
+	nodePatch := &nodePatch{
+		Metadata: nodePatchMetadata,
+	}
+	nodePatchJson, err := json.Marshal(nodePatch)
+	if err != nil {
+		return fmt.Errorf("error building node patch: %v", err)
+	}
+
+	klog.V(2).Infof("sending patch for node %q: %q", node.Name, string(nodePatchJson))
+
+	_, err = client.Nodes().Patch(ctx, node.Name, types.StrategicMergePatchType, nodePatchJson, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("error applying patch to node: %v", err)
+	}
+
+	return nil
+}

--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -146,7 +146,8 @@ func buildScheme() error {
 }
 
 func addNodeController(mgr manager.Manager, opt *config.Options) error {
-	var identifier nodeidentity.LegacyIdentifier
+	var legacyIdentifier nodeidentity.LegacyIdentifier
+	var identifier nodeidentity.Identifier
 	var err error
 	switch opt.Cloud {
 	case "aws":
@@ -154,20 +155,21 @@ func addNodeController(mgr manager.Manager, opt *config.Options) error {
 		if err != nil {
 			return fmt.Errorf("error building identifier: %v", err)
 		}
+
 	case "gce":
-		identifier, err = nodeidentitygce.New()
+		legacyIdentifier, err = nodeidentitygce.New()
 		if err != nil {
 			return fmt.Errorf("error building identifier: %v", err)
 		}
 
 	case "openstack":
-		identifier, err = nodeidentityos.New()
+		legacyIdentifier, err = nodeidentityos.New()
 		if err != nil {
 			return fmt.Errorf("error building identifier: %v", err)
 		}
 
 	case "digitalocean":
-		identifier, err = nodeidentitydo.New()
+		legacyIdentifier, err = nodeidentitydo.New()
 		if err != nil {
 			return fmt.Errorf("error building identifier: %v", err)
 		}
@@ -179,16 +181,26 @@ func addNodeController(mgr manager.Manager, opt *config.Options) error {
 		return fmt.Errorf("identifier for cloud %q not implemented", opt.Cloud)
 	}
 
-	if opt.ConfigBase == "" {
-		return fmt.Errorf("must specify configBase")
-	}
+	if identifier != nil {
+		nodeController, err := controllers.NewNodeReconciler(mgr, identifier)
+		if err != nil {
+			return err
+		}
+		if err := nodeController.SetupWithManager(mgr); err != nil {
+			return err
+		}
+	} else {
+		if opt.ConfigBase == "" {
+			return fmt.Errorf("must specify configBase")
+		}
 
-	nodeController, err := controllers.NewLegacyNodeReconciler(mgr, opt.ConfigBase, identifier)
-	if err != nil {
-		return err
-	}
-	if err := nodeController.SetupWithManager(mgr); err != nil {
-		return err
+		nodeController, err := controllers.NewLegacyNodeReconciler(mgr, opt.ConfigBase, legacyIdentifier)
+		if err != nil {
+			return err
+		}
+		if err := nodeController.SetupWithManager(mgr); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -146,7 +146,7 @@ func buildScheme() error {
 }
 
 func addNodeController(mgr manager.Manager, opt *config.Options) error {
-	var identifier nodeidentity.Identifier
+	var identifier nodeidentity.LegacyIdentifier
 	var err error
 	switch opt.Cloud {
 	case "aws":
@@ -183,7 +183,7 @@ func addNodeController(mgr manager.Manager, opt *config.Options) error {
 		return fmt.Errorf("must specify configBase")
 	}
 
-	nodeController, err := controllers.NewNodeReconciler(mgr, opt.ConfigBase, identifier)
+	nodeController, err := controllers.NewLegacyNodeReconciler(mgr, opt.ConfigBase, identifier)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/lifecycle_integration_test.go
+++ b/cmd/kops/lifecycle_integration_test.go
@@ -247,6 +247,7 @@ func runLifecycleTest(h *testutils.IntegrationTestHarness, o *LifecycleTestOptio
 				switch resource {
 				case "ami":
 				case "sshkey":
+				case "lt":
 					// ignore
 
 				default:

--- a/pkg/model/BUILD.bazel
+++ b/pkg/model/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/model/iam:go_default_library",
         "//pkg/model/resources:go_default_library",
         "//pkg/nodeidentity/aws:go_default_library",
+        "//pkg/nodelabels:go_default_library",
         "//pkg/pki:go_default_library",
         "//pkg/rbac:go_default_library",
         "//pkg/tokens:go_default_library",

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kops/pkg/model/components"
 	"k8s.io/kops/pkg/model/iam"
 	nodeidentityaws "k8s.io/kops/pkg/nodeidentity/aws"
+	"k8s.io/kops/pkg/nodelabels"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
@@ -40,7 +41,6 @@ import (
 )
 
 const (
-	clusterAutoscalerNodeTemplateLabel = "k8s.io/cluster-autoscaler/node-template/label/"
 	clusterAutoscalerNodeTemplateTaint = "k8s.io/cluster-autoscaler/node-template/taint/"
 )
 
@@ -192,8 +192,8 @@ func (m *KopsModelContext) CloudTagsForInstanceGroup(ig *kops.InstanceGroup) (ma
 	}
 
 	// Apply labels for cluster autoscaler node labels
-	for k, v := range ig.Spec.NodeLabels {
-		labels[clusterAutoscalerNodeTemplateLabel+k] = v
+	for k, v := range nodelabels.BuildNodeLabels(m.Cluster, ig) {
+		labels[nodeidentityaws.ClusterAutoscalerNodeTemplateLabel+k] = v
 	}
 
 	// Apply labels for cluster autoscaler node taints

--- a/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
@@ -15,6 +15,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
@@ -15,6 +15,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
   some___:x: label

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
@@ -15,6 +15,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
   some___:x: label

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
@@ -65,6 +65,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-1-cluster
@@ -141,6 +143,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-2-cluster
@@ -217,6 +221,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-3-cluster
@@ -293,6 +299,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
@@ -363,6 +371,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-2-cluster
@@ -433,6 +443,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-3-cluster

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
@@ -66,6 +66,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-a
 Name: master-a-1-cluster
@@ -130,6 +132,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-b
 Name: master-b-1-cluster
@@ -194,6 +198,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-c
 Name: master-c-1-cluster
@@ -264,6 +270,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-a
 Name: node-a-1-cluster
@@ -334,6 +342,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-b
 Name: node-b-1-cluster
@@ -404,6 +414,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-c
 Name: node-c-1-cluster

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
@@ -73,6 +73,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-a
 Name: master-a-1-cluster
@@ -149,6 +151,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-b
 Name: master-b-1-cluster
@@ -225,6 +229,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-c
 Name: master-c-1-cluster
@@ -301,6 +307,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-a
 Name: node-a-1-cluster
@@ -371,6 +379,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-b
 Name: node-b-1-cluster
@@ -441,6 +451,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-c
 Name: node-c-1-cluster

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
@@ -25,6 +25,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-a
 Name: master-a-1-cluster
@@ -95,6 +97,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-b
 Name: master-b-1-cluster
@@ -165,6 +169,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-c
 Name: master-c-1-cluster
@@ -235,6 +241,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-a
 Name: node-a-1-cluster
@@ -299,6 +307,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-b
 Name: node-b-1-cluster
@@ -363,6 +373,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-c
 Name: node-c-1-cluster

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
@@ -18,6 +18,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_bastion: "1"
   kops.k8s.io_instancegroup: bastion
 Name: bastion-1-cluster
@@ -82,6 +84,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-1-cluster
@@ -152,6 +156,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
@@ -38,6 +38,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_bastion: "1"
   kops.k8s.io_instancegroup: bastion
 Name: bastion-1-cluster
@@ -108,6 +110,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-1-cluster
@@ -178,6 +182,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
@@ -17,6 +17,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-1-cluster
@@ -87,6 +89,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
@@ -37,6 +37,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-1-cluster
@@ -113,6 +115,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
@@ -15,6 +15,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
@@ -15,6 +15,8 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster

--- a/pkg/nodeidentity/aws/identify.go
+++ b/pkg/nodeidentity/aws/identify.go
@@ -55,7 +55,7 @@ type nodeIdentifier struct {
 }
 
 // New creates and returns a nodeidentity.Identifier for Nodes running on AWS
-func New(CacheNodeidentityInfo bool) (nodeidentity.Identifier, error) {
+func New(CacheNodeidentityInfo bool) (nodeidentity.LegacyIdentifier, error) {
 	config := aws.NewConfig()
 	config = config.WithCredentialsChainVerboseErrors(true)
 
@@ -91,7 +91,7 @@ func stringKeyFunc(obj interface{}) (string, error) {
 }
 
 // IdentifyNode queries AWS for the node identity information
-func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*nodeidentity.Info, error) {
+func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*nodeidentity.LegacyInfo, error) {
 	providerID := node.Spec.ProviderID
 	if providerID == "" {
 		return nil, fmt.Errorf("providerID was not set for node %s", node.Name)
@@ -145,7 +145,7 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 		return nil, fmt.Errorf("%s tag not set on instance %s", CloudTagInstanceGroupName, aws.StringValue(instance.InstanceId))
 	}
 
-	info := &nodeidentity.Info{}
+	info := &nodeidentity.LegacyInfo{}
 	info.InstanceID = instanceID
 	info.InstanceGroup = igName
 	info.InstanceLifecycle = lifecycle

--- a/pkg/nodeidentity/aws/identify.go
+++ b/pkg/nodeidentity/aws/identify.go
@@ -38,7 +38,8 @@ const (
 	// CloudTagInstanceGroupName is a cloud tag that defines the instance group name
 	// This is used by the aws nodeidentifier to securely identify the node instancegroup
 	CloudTagInstanceGroupName = "kops.k8s.io/instancegroup"
-
+	// ClusterAutoscalerNodeTemplateLabel is the prefix used on node labels when copying to cloud tags.
+	ClusterAutoscalerNodeTemplateLabel = "k8s.io/cluster-autoscaler/node-template/label/"
 	// The expiration time of nodeidentity.Info cache.
 	cacheTTL = 60 * time.Minute
 )
@@ -55,7 +56,7 @@ type nodeIdentifier struct {
 }
 
 // New creates and returns a nodeidentity.Identifier for Nodes running on AWS
-func New(CacheNodeidentityInfo bool) (nodeidentity.LegacyIdentifier, error) {
+func New(CacheNodeidentityInfo bool) (nodeidentity.Identifier, error) {
 	config := aws.NewConfig()
 	config = config.WithCredentialsChainVerboseErrors(true)
 
@@ -91,7 +92,7 @@ func stringKeyFunc(obj interface{}) (string, error) {
 }
 
 // IdentifyNode queries AWS for the node identity information
-func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*nodeidentity.LegacyInfo, error) {
+func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*nodeidentity.Info, error) {
 	providerID := node.Spec.ProviderID
 	if providerID == "" {
 		return nil, fmt.Errorf("providerID was not set for node %s", node.Name)
@@ -134,21 +135,21 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 		return nil, fmt.Errorf("found instance %q, but state is %q", instanceID, instanceState)
 	}
 
-	lifecycle := ""
+	labels := map[string]string{}
 	if instance.InstanceLifecycle != nil {
-		lifecycle = *instance.InstanceLifecycle
+		labels[fmt.Sprintf("node-role.kubernetes.io/%s-worker", *instance.InstanceLifecycle)] = "true"
 	}
 
-	// TODO: Should we traverse to the ASG to confirm the tags there?
-	igName := getTag(instance.Tags, CloudTagInstanceGroupName)
-	if igName == "" {
-		return nil, fmt.Errorf("%s tag not set on instance %s", CloudTagInstanceGroupName, aws.StringValue(instance.InstanceId))
+	info := &nodeidentity.Info{
+		InstanceID: instanceID,
+		Labels:     labels,
 	}
 
-	info := &nodeidentity.LegacyInfo{}
-	info.InstanceID = instanceID
-	info.InstanceGroup = igName
-	info.InstanceLifecycle = lifecycle
+	for _, tag := range instance.Tags {
+		if strings.HasPrefix(aws.StringValue(tag.Key), ClusterAutoscalerNodeTemplateLabel) {
+			info.Labels[strings.TrimPrefix(aws.StringValue(tag.Key), ClusterAutoscalerNodeTemplateLabel)] = aws.StringValue(tag.Value)
+		}
+	}
 
 	// If caching is enabled add the nodeidentity.Info to cache.
 	if i.cacheEnabled {
@@ -181,13 +182,4 @@ func (i *nodeIdentifier) getInstance(instanceID string) (*ec2.Instance, error) {
 
 	instance := resp.Reservations[0].Instances[0]
 	return instance, nil
-}
-
-func getTag(tags []*ec2.Tag, key string) string {
-	for _, tag := range tags {
-		if key == aws.StringValue(tag.Key) {
-			return aws.StringValue(tag.Value)
-		}
-	}
-	return ""
 }

--- a/pkg/nodeidentity/do/identify.go
+++ b/pkg/nodeidentity/do/identify.go
@@ -56,8 +56,8 @@ func (t *TokenSource) Token() (*oauth2.Token, error) {
 	return token, nil
 }
 
-// New creates and returns a nodeidentity.Identifier for Nodes running on DO
-func New() (nodeidentity.Identifier, error) {
+// New creates and returns a nodeidentity.LegacyIdentifier for Nodes running on DO
+func New() (nodeidentity.LegacyIdentifier, error) {
 	region, err := getMetadataRegion()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get droplet region: %s", err)
@@ -116,7 +116,7 @@ func getMetadata(url string) (string, error) {
 }
 
 // IdentifyNode queries DO for the node identity information
-func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*nodeidentity.Info, error) {
+func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*nodeidentity.LegacyInfo, error) {
 	providerID := node.Spec.ProviderID
 
 	if providerID == "" {
@@ -144,7 +144,7 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 		return nil, err
 	}
 
-	info := &nodeidentity.Info{}
+	info := &nodeidentity.LegacyInfo{}
 	info.InstanceGroup = kopsGroup
 
 	return info, nil

--- a/pkg/nodeidentity/gce/identify.go
+++ b/pkg/nodeidentity/gce/identify.go
@@ -43,8 +43,8 @@ type nodeIdentifier struct {
 	project string
 }
 
-// New creates and returns a nodeidentity.Identifier for Nodes running on GCE
-func New() (nodeidentity.Identifier, error) {
+// New creates and returns a nodeidentity.LegacyIdentifier for Nodes running on GCE
+func New() (nodeidentity.LegacyIdentifier, error) {
 	ctx := context.Background()
 
 	computeService, err := compute.NewService(ctx)
@@ -75,7 +75,7 @@ func New() (nodeidentity.Identifier, error) {
 }
 
 // IdentifyNode queries GCE for the node identity information
-func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*nodeidentity.Info, error) {
+func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*nodeidentity.LegacyInfo, error) {
 	providerID := node.Spec.ProviderID
 	if providerID == "" {
 		return nil, fmt.Errorf("providerID was not set for node %s", node.Name)
@@ -143,7 +143,7 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 		return nil, fmt.Errorf("ig name not set on instance template %s", instanceTemplate.Name)
 	}
 
-	info := &nodeidentity.Info{}
+	info := &nodeidentity.LegacyInfo{}
 	info.InstanceGroup = igName
 	return info, nil
 }

--- a/pkg/nodeidentity/interfaces.go
+++ b/pkg/nodeidentity/interfaces.go
@@ -22,11 +22,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-type Identifier interface {
-	IdentifyNode(ctx context.Context, node *corev1.Node) (*Info, error)
+type LegacyIdentifier interface {
+	IdentifyNode(ctx context.Context, node *corev1.Node) (*LegacyInfo, error)
 }
 
-type Info struct {
+type LegacyInfo struct {
 	InstanceID        string
 	InstanceGroup     string
 	InstanceLifecycle string

--- a/pkg/nodeidentity/interfaces.go
+++ b/pkg/nodeidentity/interfaces.go
@@ -22,6 +22,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+type Identifier interface {
+	IdentifyNode(ctx context.Context, node *corev1.Node) (*Info, error)
+}
+
+type Info struct {
+	InstanceID string
+	Labels     map[string]string
+}
+
 type LegacyIdentifier interface {
 	IdentifyNode(ctx context.Context, node *corev1.Node) (*LegacyInfo, error)
 }

--- a/pkg/nodeidentity/openstack/identify.go
+++ b/pkg/nodeidentity/openstack/identify.go
@@ -34,8 +34,8 @@ type nodeIdentifier struct {
 	novaClient *gophercloud.ServiceClient
 }
 
-// New creates and returns a nodeidentity.Identifier for Nodes running on OpenStack
-func New() (nodeidentity.Identifier, error) {
+// New creates and returns a nodeidentity.LegacyIdentifier for Nodes running on OpenStack
+func New() (nodeidentity.LegacyIdentifier, error) {
 	env, err := openstack.AuthOptionsFromEnv()
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func New() (nodeidentity.Identifier, error) {
 }
 
 // IdentifyNode queries OpenStack for the node identity information
-func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*nodeidentity.Info, error) {
+func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*nodeidentity.LegacyInfo, error) {
 	providerID := node.Spec.ProviderID
 	if providerID == "" {
 		return nil, fmt.Errorf("providerID was not set for node %s", node.Name)
@@ -94,7 +94,7 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 		return nil, err
 	}
 
-	info := &nodeidentity.Info{}
+	info := &nodeidentity.LegacyInfo{}
 	info.InstanceGroup = kopsGroup
 
 	return info, nil

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -141,6 +141,16 @@ resource "aws_autoscaling_group" "bastion-bastionuserdata-example-com" {
     value               = "bastion.bastionuserdata.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/bastion"
     propagate_at_launch = true
     value               = "1"
@@ -179,6 +189,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-bastionuserdata-exam
     value               = "master-us-test-1a.masters.bastionuserdata.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -215,6 +235,16 @@ resource "aws_autoscaling_group" "nodes-bastionuserdata-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.bastionuserdata.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -416,29 +446,35 @@ resource "aws_launch_template" "bastion-bastionuserdata-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                 = "bastionuserdata.example.com"
-      "Name"                                              = "bastion.bastionuserdata.example.com"
-      "k8s.io/role/bastion"                               = "1"
-      "kops.k8s.io/instancegroup"                         = "bastion"
-      "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+      "KubernetesCluster"                                                          = "bastionuserdata.example.com"
+      "Name"                                                                       = "bastion.bastionuserdata.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/bastionuserdata.example.com"                          = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                 = "bastionuserdata.example.com"
-      "Name"                                              = "bastion.bastionuserdata.example.com"
-      "k8s.io/role/bastion"                               = "1"
-      "kops.k8s.io/instancegroup"                         = "bastion"
-      "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+      "KubernetesCluster"                                                          = "bastionuserdata.example.com"
+      "Name"                                                                       = "bastion.bastionuserdata.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/bastionuserdata.example.com"                          = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                 = "bastionuserdata.example.com"
-    "Name"                                              = "bastion.bastionuserdata.example.com"
-    "k8s.io/role/bastion"                               = "1"
-    "kops.k8s.io/instancegroup"                         = "bastion"
-    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+    "KubernetesCluster"                                                          = "bastionuserdata.example.com"
+    "Name"                                                                       = "bastion.bastionuserdata.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/bastion"                                                        = "1"
+    "kops.k8s.io/instancegroup"                                                  = "bastion"
+    "kubernetes.io/cluster/bastionuserdata.example.com"                          = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_bastion.bastionuserdata.example.com_user_data")
 }
@@ -474,29 +510,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-bastionuserdata-exampl
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                 = "bastionuserdata.example.com"
-      "Name"                                              = "master-us-test-1a.masters.bastionuserdata.example.com"
-      "k8s.io/role/master"                                = "1"
-      "kops.k8s.io/instancegroup"                         = "master-us-test-1a"
-      "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+      "KubernetesCluster"                                                            = "bastionuserdata.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.bastionuserdata.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/bastionuserdata.example.com"                            = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                 = "bastionuserdata.example.com"
-      "Name"                                              = "master-us-test-1a.masters.bastionuserdata.example.com"
-      "k8s.io/role/master"                                = "1"
-      "kops.k8s.io/instancegroup"                         = "master-us-test-1a"
-      "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+      "KubernetesCluster"                                                            = "bastionuserdata.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.bastionuserdata.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/bastionuserdata.example.com"                            = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                 = "bastionuserdata.example.com"
-    "Name"                                              = "master-us-test-1a.masters.bastionuserdata.example.com"
-    "k8s.io/role/master"                                = "1"
-    "kops.k8s.io/instancegroup"                         = "master-us-test-1a"
-    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+    "KubernetesCluster"                                                            = "bastionuserdata.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.bastionuserdata.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/bastionuserdata.example.com"                            = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data")
 }
@@ -528,29 +570,35 @@ resource "aws_launch_template" "nodes-bastionuserdata-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                 = "bastionuserdata.example.com"
-      "Name"                                              = "nodes.bastionuserdata.example.com"
-      "k8s.io/role/node"                                  = "1"
-      "kops.k8s.io/instancegroup"                         = "nodes"
-      "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+      "KubernetesCluster"                                                          = "bastionuserdata.example.com"
+      "Name"                                                                       = "nodes.bastionuserdata.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/bastionuserdata.example.com"                          = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                 = "bastionuserdata.example.com"
-      "Name"                                              = "nodes.bastionuserdata.example.com"
-      "k8s.io/role/node"                                  = "1"
-      "kops.k8s.io/instancegroup"                         = "nodes"
-      "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+      "KubernetesCluster"                                                          = "bastionuserdata.example.com"
+      "Name"                                                                       = "nodes.bastionuserdata.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/bastionuserdata.example.com"                          = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                 = "bastionuserdata.example.com"
-    "Name"                                              = "nodes.bastionuserdata.example.com"
-    "k8s.io/role/node"                                  = "1"
-    "kops.k8s.io/instancegroup"                         = "nodes"
-    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+    "KubernetesCluster"                                                          = "bastionuserdata.example.com"
+    "Name"                                                                       = "nodes.bastionuserdata.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/bastionuserdata.example.com"                          = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.bastionuserdata.example.com_user_data")
 }

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -44,6 +44,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/master",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -122,6 +132,16 @@
           {
             "Key": "foo/bar",
             "Value": "fib+baz",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "node",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "Value": "",
             "PropagateAtLaunch": true
           },
           {
@@ -275,6 +295,14 @@
                   "Value": "fib+baz"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/master",
                   "Value": "1"
                 },
@@ -306,6 +334,14 @@
                 {
                   "Key": "foo/bar",
                   "Value": "fib+baz"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/master",
@@ -392,6 +428,14 @@
                   "Value": "fib+baz"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/node",
                   "Value": "1"
                 },
@@ -423,6 +467,14 @@
                 {
                   "Key": "foo/bar",
                   "Value": "fib+baz"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/node",

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -116,6 +116,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-complex-example-com"
     value               = "fib+baz"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -163,6 +173,16 @@ resource "aws_autoscaling_group" "nodes-complex-example-com" {
     key                 = "foo/bar"
     propagate_at_launch = true
     value               = "fib+baz"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -318,35 +338,41 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                         = "complex.example.com"
-      "Name"                                      = "master-us-test-1a.masters.complex.example.com"
-      "Owner"                                     = "John Doe"
-      "foo/bar"                                   = "fib+baz"
-      "k8s.io/role/master"                        = "1"
-      "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
-      "kubernetes.io/cluster/complex.example.com" = "owned"
+      "KubernetesCluster"                                                            = "complex.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.complex.example.com"
+      "Owner"                                                                        = "John Doe"
+      "foo/bar"                                                                      = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/complex.example.com"                                    = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                         = "complex.example.com"
-      "Name"                                      = "master-us-test-1a.masters.complex.example.com"
-      "Owner"                                     = "John Doe"
-      "foo/bar"                                   = "fib+baz"
-      "k8s.io/role/master"                        = "1"
-      "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
-      "kubernetes.io/cluster/complex.example.com" = "owned"
+      "KubernetesCluster"                                                            = "complex.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.complex.example.com"
+      "Owner"                                                                        = "John Doe"
+      "foo/bar"                                                                      = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/complex.example.com"                                    = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                         = "complex.example.com"
-    "Name"                                      = "master-us-test-1a.masters.complex.example.com"
-    "Owner"                                     = "John Doe"
-    "foo/bar"                                   = "fib+baz"
-    "k8s.io/role/master"                        = "1"
-    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
-    "kubernetes.io/cluster/complex.example.com" = "owned"
+    "KubernetesCluster"                                                            = "complex.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.complex.example.com"
+    "Owner"                                                                        = "John Doe"
+    "foo/bar"                                                                      = "fib+baz"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/complex.example.com"                                    = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data")
 }
@@ -386,35 +412,41 @@ resource "aws_launch_template" "nodes-complex-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                         = "complex.example.com"
-      "Name"                                      = "nodes.complex.example.com"
-      "Owner"                                     = "John Doe"
-      "foo/bar"                                   = "fib+baz"
-      "k8s.io/role/node"                          = "1"
-      "kops.k8s.io/instancegroup"                 = "nodes"
-      "kubernetes.io/cluster/complex.example.com" = "owned"
+      "KubernetesCluster"                                                          = "complex.example.com"
+      "Name"                                                                       = "nodes.complex.example.com"
+      "Owner"                                                                      = "John Doe"
+      "foo/bar"                                                                    = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/complex.example.com"                                  = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                         = "complex.example.com"
-      "Name"                                      = "nodes.complex.example.com"
-      "Owner"                                     = "John Doe"
-      "foo/bar"                                   = "fib+baz"
-      "k8s.io/role/node"                          = "1"
-      "kops.k8s.io/instancegroup"                 = "nodes"
-      "kubernetes.io/cluster/complex.example.com" = "owned"
+      "KubernetesCluster"                                                          = "complex.example.com"
+      "Name"                                                                       = "nodes.complex.example.com"
+      "Owner"                                                                      = "John Doe"
+      "foo/bar"                                                                    = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/complex.example.com"                                  = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                         = "complex.example.com"
-    "Name"                                      = "nodes.complex.example.com"
-    "Owner"                                     = "John Doe"
-    "foo/bar"                                   = "fib+baz"
-    "k8s.io/role/node"                          = "1"
-    "kops.k8s.io/instancegroup"                 = "nodes"
-    "kubernetes.io/cluster/complex.example.com" = "owned"
+    "KubernetesCluster"                                                          = "complex.example.com"
+    "Name"                                                                       = "nodes.complex.example.com"
+    "Owner"                                                                      = "John Doe"
+    "foo/bar"                                                                    = "fib+baz"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/complex.example.com"                                  = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.complex.example.com_user_data")
 }

--- a/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json
@@ -34,6 +34,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/master",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -97,6 +107,16 @@
           {
             "Key": "Name",
             "Value": "nodes.containerd.example.com",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "node",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "Value": "",
             "PropagateAtLaunch": true
           },
           {
@@ -226,6 +246,14 @@
                   "Value": "master-us-test-1a.masters.containerd.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/master",
                   "Value": "1"
                 },
@@ -249,6 +277,14 @@
                 {
                   "Key": "Name",
                   "Value": "master-us-test-1a.masters.containerd.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/master",
@@ -317,6 +353,14 @@
                   "Value": "nodes.containerd.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/node",
                   "Value": "1"
                 },
@@ -340,6 +384,14 @@
                 {
                   "Key": "Name",
                   "Value": "nodes.containerd.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/node",

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -91,6 +91,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-existing-iam-example
     value               = "master-us-test-1a.masters.existing-iam.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -127,6 +137,16 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-existing-iam-example
     key                 = "Name"
     propagate_at_launch = true
     value               = "master-us-test-1b.masters.existing-iam.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/master"
@@ -167,6 +187,16 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-existing-iam-example
     value               = "master-us-test-1c.masters.existing-iam.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -203,6 +233,16 @@ resource "aws_autoscaling_group" "nodes-existing-iam-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.existing-iam.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -356,29 +396,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-existing-iam-example-c
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                              = "existing-iam.example.com"
-      "Name"                                           = "master-us-test-1a.masters.existing-iam.example.com"
-      "k8s.io/role/master"                             = "1"
-      "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
-      "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+      "KubernetesCluster"                                                            = "existing-iam.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.existing-iam.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/existing-iam.example.com"                               = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                              = "existing-iam.example.com"
-      "Name"                                           = "master-us-test-1a.masters.existing-iam.example.com"
-      "k8s.io/role/master"                             = "1"
-      "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
-      "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+      "KubernetesCluster"                                                            = "existing-iam.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.existing-iam.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/existing-iam.example.com"                               = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                              = "existing-iam.example.com"
-    "Name"                                           = "master-us-test-1a.masters.existing-iam.example.com"
-    "k8s.io/role/master"                             = "1"
-    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
-    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+    "KubernetesCluster"                                                            = "existing-iam.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.existing-iam.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/existing-iam.example.com"                               = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data")
 }
@@ -414,29 +460,35 @@ resource "aws_launch_template" "master-us-test-1b-masters-existing-iam-example-c
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                              = "existing-iam.example.com"
-      "Name"                                           = "master-us-test-1b.masters.existing-iam.example.com"
-      "k8s.io/role/master"                             = "1"
-      "kops.k8s.io/instancegroup"                      = "master-us-test-1b"
-      "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+      "KubernetesCluster"                                                            = "existing-iam.example.com"
+      "Name"                                                                         = "master-us-test-1b.masters.existing-iam.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1b"
+      "kubernetes.io/cluster/existing-iam.example.com"                               = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                              = "existing-iam.example.com"
-      "Name"                                           = "master-us-test-1b.masters.existing-iam.example.com"
-      "k8s.io/role/master"                             = "1"
-      "kops.k8s.io/instancegroup"                      = "master-us-test-1b"
-      "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+      "KubernetesCluster"                                                            = "existing-iam.example.com"
+      "Name"                                                                         = "master-us-test-1b.masters.existing-iam.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1b"
+      "kubernetes.io/cluster/existing-iam.example.com"                               = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                              = "existing-iam.example.com"
-    "Name"                                           = "master-us-test-1b.masters.existing-iam.example.com"
-    "k8s.io/role/master"                             = "1"
-    "kops.k8s.io/instancegroup"                      = "master-us-test-1b"
-    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+    "KubernetesCluster"                                                            = "existing-iam.example.com"
+    "Name"                                                                         = "master-us-test-1b.masters.existing-iam.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1b"
+    "kubernetes.io/cluster/existing-iam.example.com"                               = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1b.masters.existing-iam.example.com_user_data")
 }
@@ -472,29 +524,35 @@ resource "aws_launch_template" "master-us-test-1c-masters-existing-iam-example-c
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                              = "existing-iam.example.com"
-      "Name"                                           = "master-us-test-1c.masters.existing-iam.example.com"
-      "k8s.io/role/master"                             = "1"
-      "kops.k8s.io/instancegroup"                      = "master-us-test-1c"
-      "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+      "KubernetesCluster"                                                            = "existing-iam.example.com"
+      "Name"                                                                         = "master-us-test-1c.masters.existing-iam.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1c"
+      "kubernetes.io/cluster/existing-iam.example.com"                               = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                              = "existing-iam.example.com"
-      "Name"                                           = "master-us-test-1c.masters.existing-iam.example.com"
-      "k8s.io/role/master"                             = "1"
-      "kops.k8s.io/instancegroup"                      = "master-us-test-1c"
-      "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+      "KubernetesCluster"                                                            = "existing-iam.example.com"
+      "Name"                                                                         = "master-us-test-1c.masters.existing-iam.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1c"
+      "kubernetes.io/cluster/existing-iam.example.com"                               = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                              = "existing-iam.example.com"
-    "Name"                                           = "master-us-test-1c.masters.existing-iam.example.com"
-    "k8s.io/role/master"                             = "1"
-    "kops.k8s.io/instancegroup"                      = "master-us-test-1c"
-    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+    "KubernetesCluster"                                                            = "existing-iam.example.com"
+    "Name"                                                                         = "master-us-test-1c.masters.existing-iam.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1c"
+    "kubernetes.io/cluster/existing-iam.example.com"                               = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1c.masters.existing-iam.example.com_user_data")
 }
@@ -526,29 +584,35 @@ resource "aws_launch_template" "nodes-existing-iam-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                              = "existing-iam.example.com"
-      "Name"                                           = "nodes.existing-iam.example.com"
-      "k8s.io/role/node"                               = "1"
-      "kops.k8s.io/instancegroup"                      = "nodes"
-      "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+      "KubernetesCluster"                                                          = "existing-iam.example.com"
+      "Name"                                                                       = "nodes.existing-iam.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/existing-iam.example.com"                             = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                              = "existing-iam.example.com"
-      "Name"                                           = "nodes.existing-iam.example.com"
-      "k8s.io/role/node"                               = "1"
-      "kops.k8s.io/instancegroup"                      = "nodes"
-      "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+      "KubernetesCluster"                                                          = "existing-iam.example.com"
+      "Name"                                                                       = "nodes.existing-iam.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/existing-iam.example.com"                             = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                              = "existing-iam.example.com"
-    "Name"                                           = "nodes.existing-iam.example.com"
-    "k8s.io/role/node"                               = "1"
-    "kops.k8s.io/instancegroup"                      = "nodes"
-    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+    "KubernetesCluster"                                                          = "existing-iam.example.com"
+    "Name"                                                                       = "nodes.existing-iam.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/existing-iam.example.com"                             = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.existing-iam.example.com_user_data")
 }

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json
@@ -34,6 +34,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/master",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -97,6 +107,16 @@
           {
             "Key": "Name",
             "Value": "nodes.minimal.example.com",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "node",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "Value": "",
             "PropagateAtLaunch": true
           },
           {
@@ -224,6 +244,14 @@
                   "Value": "master-us-test-1a.masters.minimal.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/master",
                   "Value": "1"
                 },
@@ -247,6 +275,14 @@
                 {
                   "Key": "Name",
                   "Value": "master-us-test-1a.masters.minimal.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/master",
@@ -313,6 +349,14 @@
                   "Value": "nodes.minimal.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/node",
                   "Value": "1"
                 },
@@ -336,6 +380,14 @@
                 {
                   "Key": "Name",
                   "Value": "nodes.minimal.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/node",

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -126,6 +126,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-existingsg-example-c
     value               = "master-us-test-1a.masters.existingsg.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -162,6 +172,16 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-existingsg-example-c
     key                 = "Name"
     propagate_at_launch = true
     value               = "master-us-test-1b.masters.existingsg.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/master"
@@ -202,6 +222,16 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-existingsg-example-c
     value               = "master-us-test-1c.masters.existingsg.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -238,6 +268,16 @@ resource "aws_autoscaling_group" "nodes-existingsg-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.existingsg.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -449,29 +489,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-existingsg-example-com
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                            = "existingsg.example.com"
-      "Name"                                         = "master-us-test-1a.masters.existingsg.example.com"
-      "k8s.io/role/master"                           = "1"
-      "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
-      "kubernetes.io/cluster/existingsg.example.com" = "owned"
+      "KubernetesCluster"                                                            = "existingsg.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.existingsg.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/existingsg.example.com"                                 = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                            = "existingsg.example.com"
-      "Name"                                         = "master-us-test-1a.masters.existingsg.example.com"
-      "k8s.io/role/master"                           = "1"
-      "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
-      "kubernetes.io/cluster/existingsg.example.com" = "owned"
+      "KubernetesCluster"                                                            = "existingsg.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.existingsg.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/existingsg.example.com"                                 = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                            = "existingsg.example.com"
-    "Name"                                         = "master-us-test-1a.masters.existingsg.example.com"
-    "k8s.io/role/master"                           = "1"
-    "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
-    "kubernetes.io/cluster/existingsg.example.com" = "owned"
+    "KubernetesCluster"                                                            = "existingsg.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.existingsg.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/existingsg.example.com"                                 = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data")
 }
@@ -507,29 +553,35 @@ resource "aws_launch_template" "master-us-test-1b-masters-existingsg-example-com
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                            = "existingsg.example.com"
-      "Name"                                         = "master-us-test-1b.masters.existingsg.example.com"
-      "k8s.io/role/master"                           = "1"
-      "kops.k8s.io/instancegroup"                    = "master-us-test-1b"
-      "kubernetes.io/cluster/existingsg.example.com" = "owned"
+      "KubernetesCluster"                                                            = "existingsg.example.com"
+      "Name"                                                                         = "master-us-test-1b.masters.existingsg.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1b"
+      "kubernetes.io/cluster/existingsg.example.com"                                 = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                            = "existingsg.example.com"
-      "Name"                                         = "master-us-test-1b.masters.existingsg.example.com"
-      "k8s.io/role/master"                           = "1"
-      "kops.k8s.io/instancegroup"                    = "master-us-test-1b"
-      "kubernetes.io/cluster/existingsg.example.com" = "owned"
+      "KubernetesCluster"                                                            = "existingsg.example.com"
+      "Name"                                                                         = "master-us-test-1b.masters.existingsg.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1b"
+      "kubernetes.io/cluster/existingsg.example.com"                                 = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                            = "existingsg.example.com"
-    "Name"                                         = "master-us-test-1b.masters.existingsg.example.com"
-    "k8s.io/role/master"                           = "1"
-    "kops.k8s.io/instancegroup"                    = "master-us-test-1b"
-    "kubernetes.io/cluster/existingsg.example.com" = "owned"
+    "KubernetesCluster"                                                            = "existingsg.example.com"
+    "Name"                                                                         = "master-us-test-1b.masters.existingsg.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1b"
+    "kubernetes.io/cluster/existingsg.example.com"                                 = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data")
 }
@@ -565,29 +617,35 @@ resource "aws_launch_template" "master-us-test-1c-masters-existingsg-example-com
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                            = "existingsg.example.com"
-      "Name"                                         = "master-us-test-1c.masters.existingsg.example.com"
-      "k8s.io/role/master"                           = "1"
-      "kops.k8s.io/instancegroup"                    = "master-us-test-1c"
-      "kubernetes.io/cluster/existingsg.example.com" = "owned"
+      "KubernetesCluster"                                                            = "existingsg.example.com"
+      "Name"                                                                         = "master-us-test-1c.masters.existingsg.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1c"
+      "kubernetes.io/cluster/existingsg.example.com"                                 = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                            = "existingsg.example.com"
-      "Name"                                         = "master-us-test-1c.masters.existingsg.example.com"
-      "k8s.io/role/master"                           = "1"
-      "kops.k8s.io/instancegroup"                    = "master-us-test-1c"
-      "kubernetes.io/cluster/existingsg.example.com" = "owned"
+      "KubernetesCluster"                                                            = "existingsg.example.com"
+      "Name"                                                                         = "master-us-test-1c.masters.existingsg.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1c"
+      "kubernetes.io/cluster/existingsg.example.com"                                 = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                            = "existingsg.example.com"
-    "Name"                                         = "master-us-test-1c.masters.existingsg.example.com"
-    "k8s.io/role/master"                           = "1"
-    "kops.k8s.io/instancegroup"                    = "master-us-test-1c"
-    "kubernetes.io/cluster/existingsg.example.com" = "owned"
+    "KubernetesCluster"                                                            = "existingsg.example.com"
+    "Name"                                                                         = "master-us-test-1c.masters.existingsg.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1c"
+    "kubernetes.io/cluster/existingsg.example.com"                                 = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data")
 }
@@ -619,29 +677,35 @@ resource "aws_launch_template" "nodes-existingsg-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                            = "existingsg.example.com"
-      "Name"                                         = "nodes.existingsg.example.com"
-      "k8s.io/role/node"                             = "1"
-      "kops.k8s.io/instancegroup"                    = "nodes"
-      "kubernetes.io/cluster/existingsg.example.com" = "owned"
+      "KubernetesCluster"                                                          = "existingsg.example.com"
+      "Name"                                                                       = "nodes.existingsg.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/existingsg.example.com"                               = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                            = "existingsg.example.com"
-      "Name"                                         = "nodes.existingsg.example.com"
-      "k8s.io/role/node"                             = "1"
-      "kops.k8s.io/instancegroup"                    = "nodes"
-      "kubernetes.io/cluster/existingsg.example.com" = "owned"
+      "KubernetesCluster"                                                          = "existingsg.example.com"
+      "Name"                                                                       = "nodes.existingsg.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/existingsg.example.com"                               = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                            = "existingsg.example.com"
-    "Name"                                         = "nodes.existingsg.example.com"
-    "k8s.io/role/node"                             = "1"
-    "kops.k8s.io/instancegroup"                    = "nodes"
-    "kubernetes.io/cluster/existingsg.example.com" = "owned"
+    "KubernetesCluster"                                                          = "existingsg.example.com"
+    "Name"                                                                       = "nodes.existingsg.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/existingsg.example.com"                               = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.existingsg.example.com_user_data")
 }

--- a/tests/integration/update_cluster/externallb/cloudformation.json
+++ b/tests/integration/update_cluster/externallb/cloudformation.json
@@ -34,6 +34,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/master",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -103,6 +113,16 @@
           {
             "Key": "Name",
             "Value": "nodes.externallb.example.com",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "node",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "Value": "",
             "PropagateAtLaunch": true
           },
           {
@@ -235,6 +255,14 @@
                   "Value": "master-us-test-1a.masters.externallb.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/master",
                   "Value": "1"
                 },
@@ -258,6 +286,14 @@
                 {
                   "Key": "Name",
                   "Value": "master-us-test-1a.masters.externallb.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/master",
@@ -326,6 +362,14 @@
                   "Value": "nodes.externallb.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/node",
                   "Value": "1"
                 },
@@ -349,6 +393,14 @@
                 {
                   "Key": "Name",
                   "Value": "nodes.externallb.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/node",

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -116,6 +116,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-externallb-example-c
     value               = "master-us-test-1a.masters.externallb.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -152,6 +162,16 @@ resource "aws_autoscaling_group" "nodes-externallb-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.externallb.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -281,29 +301,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-externallb-example-com
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                            = "externallb.example.com"
-      "Name"                                         = "master-us-test-1a.masters.externallb.example.com"
-      "k8s.io/role/master"                           = "1"
-      "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
-      "kubernetes.io/cluster/externallb.example.com" = "owned"
+      "KubernetesCluster"                                                            = "externallb.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.externallb.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/externallb.example.com"                                 = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                            = "externallb.example.com"
-      "Name"                                         = "master-us-test-1a.masters.externallb.example.com"
-      "k8s.io/role/master"                           = "1"
-      "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
-      "kubernetes.io/cluster/externallb.example.com" = "owned"
+      "KubernetesCluster"                                                            = "externallb.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.externallb.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/externallb.example.com"                                 = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                            = "externallb.example.com"
-    "Name"                                         = "master-us-test-1a.masters.externallb.example.com"
-    "k8s.io/role/master"                           = "1"
-    "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
-    "kubernetes.io/cluster/externallb.example.com" = "owned"
+    "KubernetesCluster"                                                            = "externallb.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.externallb.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/externallb.example.com"                                 = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data")
 }
@@ -335,29 +361,35 @@ resource "aws_launch_template" "nodes-externallb-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                            = "externallb.example.com"
-      "Name"                                         = "nodes.externallb.example.com"
-      "k8s.io/role/node"                             = "1"
-      "kops.k8s.io/instancegroup"                    = "nodes"
-      "kubernetes.io/cluster/externallb.example.com" = "owned"
+      "KubernetesCluster"                                                          = "externallb.example.com"
+      "Name"                                                                       = "nodes.externallb.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/externallb.example.com"                               = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                            = "externallb.example.com"
-      "Name"                                         = "nodes.externallb.example.com"
-      "k8s.io/role/node"                             = "1"
-      "kops.k8s.io/instancegroup"                    = "nodes"
-      "kubernetes.io/cluster/externallb.example.com" = "owned"
+      "KubernetesCluster"                                                          = "externallb.example.com"
+      "Name"                                                                       = "nodes.externallb.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/externallb.example.com"                               = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                            = "externallb.example.com"
-    "Name"                                         = "nodes.externallb.example.com"
-    "k8s.io/role/node"                             = "1"
-    "kops.k8s.io/instancegroup"                    = "nodes"
-    "kubernetes.io/cluster/externallb.example.com" = "owned"
+    "KubernetesCluster"                                                          = "externallb.example.com"
+    "Name"                                                                       = "nodes.externallb.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/externallb.example.com"                               = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.externallb.example.com_user_data")
 }

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -116,6 +116,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-externalpolicies-exa
     value               = "fib+baz"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -163,6 +173,16 @@ resource "aws_autoscaling_group" "nodes-externalpolicies-example-com" {
     key                 = "foo/bar"
     propagate_at_launch = true
     value               = "fib+baz"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -338,35 +358,41 @@ resource "aws_launch_template" "master-us-test-1a-masters-externalpolicies-examp
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                  = "externalpolicies.example.com"
-      "Name"                                               = "master-us-test-1a.masters.externalpolicies.example.com"
-      "Owner"                                              = "John Doe"
-      "foo/bar"                                            = "fib+baz"
-      "k8s.io/role/master"                                 = "1"
-      "kops.k8s.io/instancegroup"                          = "master-us-test-1a"
-      "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
+      "KubernetesCluster"                                                            = "externalpolicies.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.externalpolicies.example.com"
+      "Owner"                                                                        = "John Doe"
+      "foo/bar"                                                                      = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/externalpolicies.example.com"                           = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                  = "externalpolicies.example.com"
-      "Name"                                               = "master-us-test-1a.masters.externalpolicies.example.com"
-      "Owner"                                              = "John Doe"
-      "foo/bar"                                            = "fib+baz"
-      "k8s.io/role/master"                                 = "1"
-      "kops.k8s.io/instancegroup"                          = "master-us-test-1a"
-      "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
+      "KubernetesCluster"                                                            = "externalpolicies.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.externalpolicies.example.com"
+      "Owner"                                                                        = "John Doe"
+      "foo/bar"                                                                      = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/externalpolicies.example.com"                           = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                  = "externalpolicies.example.com"
-    "Name"                                               = "master-us-test-1a.masters.externalpolicies.example.com"
-    "Owner"                                              = "John Doe"
-    "foo/bar"                                            = "fib+baz"
-    "k8s.io/role/master"                                 = "1"
-    "kops.k8s.io/instancegroup"                          = "master-us-test-1a"
-    "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
+    "KubernetesCluster"                                                            = "externalpolicies.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.externalpolicies.example.com"
+    "Owner"                                                                        = "John Doe"
+    "foo/bar"                                                                      = "fib+baz"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/externalpolicies.example.com"                           = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data")
 }
@@ -398,35 +424,41 @@ resource "aws_launch_template" "nodes-externalpolicies-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                  = "externalpolicies.example.com"
-      "Name"                                               = "nodes.externalpolicies.example.com"
-      "Owner"                                              = "John Doe"
-      "foo/bar"                                            = "fib+baz"
-      "k8s.io/role/node"                                   = "1"
-      "kops.k8s.io/instancegroup"                          = "nodes"
-      "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
+      "KubernetesCluster"                                                          = "externalpolicies.example.com"
+      "Name"                                                                       = "nodes.externalpolicies.example.com"
+      "Owner"                                                                      = "John Doe"
+      "foo/bar"                                                                    = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/externalpolicies.example.com"                         = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                  = "externalpolicies.example.com"
-      "Name"                                               = "nodes.externalpolicies.example.com"
-      "Owner"                                              = "John Doe"
-      "foo/bar"                                            = "fib+baz"
-      "k8s.io/role/node"                                   = "1"
-      "kops.k8s.io/instancegroup"                          = "nodes"
-      "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
+      "KubernetesCluster"                                                          = "externalpolicies.example.com"
+      "Name"                                                                       = "nodes.externalpolicies.example.com"
+      "Owner"                                                                      = "John Doe"
+      "foo/bar"                                                                    = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/externalpolicies.example.com"                         = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                  = "externalpolicies.example.com"
-    "Name"                                               = "nodes.externalpolicies.example.com"
-    "Owner"                                              = "John Doe"
-    "foo/bar"                                            = "fib+baz"
-    "k8s.io/role/node"                                   = "1"
-    "kops.k8s.io/instancegroup"                          = "nodes"
-    "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
+    "KubernetesCluster"                                                          = "externalpolicies.example.com"
+    "Name"                                                                       = "nodes.externalpolicies.example.com"
+    "Owner"                                                                      = "John Doe"
+    "foo/bar"                                                                    = "fib+baz"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/externalpolicies.example.com"                         = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.externalpolicies.example.com_user_data")
 }

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -111,6 +111,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-ha-example-com" {
     value               = "master-us-test-1a.masters.ha.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -147,6 +157,16 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-ha-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "master-us-test-1b.masters.ha.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/master"
@@ -187,6 +207,16 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-ha-example-com" {
     value               = "master-us-test-1c.masters.ha.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -223,6 +253,16 @@ resource "aws_autoscaling_group" "nodes-ha-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.ha.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -408,29 +448,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-ha-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                    = "ha.example.com"
-      "Name"                                 = "master-us-test-1a.masters.ha.example.com"
-      "k8s.io/role/master"                   = "1"
-      "kops.k8s.io/instancegroup"            = "master-us-test-1a"
-      "kubernetes.io/cluster/ha.example.com" = "owned"
+      "KubernetesCluster"                                                            = "ha.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.ha.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/ha.example.com"                                         = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                    = "ha.example.com"
-      "Name"                                 = "master-us-test-1a.masters.ha.example.com"
-      "k8s.io/role/master"                   = "1"
-      "kops.k8s.io/instancegroup"            = "master-us-test-1a"
-      "kubernetes.io/cluster/ha.example.com" = "owned"
+      "KubernetesCluster"                                                            = "ha.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.ha.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/ha.example.com"                                         = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                    = "ha.example.com"
-    "Name"                                 = "master-us-test-1a.masters.ha.example.com"
-    "k8s.io/role/master"                   = "1"
-    "kops.k8s.io/instancegroup"            = "master-us-test-1a"
-    "kubernetes.io/cluster/ha.example.com" = "owned"
+    "KubernetesCluster"                                                            = "ha.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.ha.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/ha.example.com"                                         = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data")
 }
@@ -466,29 +512,35 @@ resource "aws_launch_template" "master-us-test-1b-masters-ha-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                    = "ha.example.com"
-      "Name"                                 = "master-us-test-1b.masters.ha.example.com"
-      "k8s.io/role/master"                   = "1"
-      "kops.k8s.io/instancegroup"            = "master-us-test-1b"
-      "kubernetes.io/cluster/ha.example.com" = "owned"
+      "KubernetesCluster"                                                            = "ha.example.com"
+      "Name"                                                                         = "master-us-test-1b.masters.ha.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1b"
+      "kubernetes.io/cluster/ha.example.com"                                         = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                    = "ha.example.com"
-      "Name"                                 = "master-us-test-1b.masters.ha.example.com"
-      "k8s.io/role/master"                   = "1"
-      "kops.k8s.io/instancegroup"            = "master-us-test-1b"
-      "kubernetes.io/cluster/ha.example.com" = "owned"
+      "KubernetesCluster"                                                            = "ha.example.com"
+      "Name"                                                                         = "master-us-test-1b.masters.ha.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1b"
+      "kubernetes.io/cluster/ha.example.com"                                         = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                    = "ha.example.com"
-    "Name"                                 = "master-us-test-1b.masters.ha.example.com"
-    "k8s.io/role/master"                   = "1"
-    "kops.k8s.io/instancegroup"            = "master-us-test-1b"
-    "kubernetes.io/cluster/ha.example.com" = "owned"
+    "KubernetesCluster"                                                            = "ha.example.com"
+    "Name"                                                                         = "master-us-test-1b.masters.ha.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1b"
+    "kubernetes.io/cluster/ha.example.com"                                         = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data")
 }
@@ -524,29 +576,35 @@ resource "aws_launch_template" "master-us-test-1c-masters-ha-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                    = "ha.example.com"
-      "Name"                                 = "master-us-test-1c.masters.ha.example.com"
-      "k8s.io/role/master"                   = "1"
-      "kops.k8s.io/instancegroup"            = "master-us-test-1c"
-      "kubernetes.io/cluster/ha.example.com" = "owned"
+      "KubernetesCluster"                                                            = "ha.example.com"
+      "Name"                                                                         = "master-us-test-1c.masters.ha.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1c"
+      "kubernetes.io/cluster/ha.example.com"                                         = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                    = "ha.example.com"
-      "Name"                                 = "master-us-test-1c.masters.ha.example.com"
-      "k8s.io/role/master"                   = "1"
-      "kops.k8s.io/instancegroup"            = "master-us-test-1c"
-      "kubernetes.io/cluster/ha.example.com" = "owned"
+      "KubernetesCluster"                                                            = "ha.example.com"
+      "Name"                                                                         = "master-us-test-1c.masters.ha.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1c"
+      "kubernetes.io/cluster/ha.example.com"                                         = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                    = "ha.example.com"
-    "Name"                                 = "master-us-test-1c.masters.ha.example.com"
-    "k8s.io/role/master"                   = "1"
-    "kops.k8s.io/instancegroup"            = "master-us-test-1c"
-    "kubernetes.io/cluster/ha.example.com" = "owned"
+    "KubernetesCluster"                                                            = "ha.example.com"
+    "Name"                                                                         = "master-us-test-1c.masters.ha.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1c"
+    "kubernetes.io/cluster/ha.example.com"                                         = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data")
 }
@@ -578,29 +636,35 @@ resource "aws_launch_template" "nodes-ha-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                    = "ha.example.com"
-      "Name"                                 = "nodes.ha.example.com"
-      "k8s.io/role/node"                     = "1"
-      "kops.k8s.io/instancegroup"            = "nodes"
-      "kubernetes.io/cluster/ha.example.com" = "owned"
+      "KubernetesCluster"                                                          = "ha.example.com"
+      "Name"                                                                       = "nodes.ha.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/ha.example.com"                                       = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                    = "ha.example.com"
-      "Name"                                 = "nodes.ha.example.com"
-      "k8s.io/role/node"                     = "1"
-      "kops.k8s.io/instancegroup"            = "nodes"
-      "kubernetes.io/cluster/ha.example.com" = "owned"
+      "KubernetesCluster"                                                          = "ha.example.com"
+      "Name"                                                                       = "nodes.ha.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/ha.example.com"                                       = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                    = "ha.example.com"
-    "Name"                                 = "nodes.ha.example.com"
-    "k8s.io/role/node"                     = "1"
-    "kops.k8s.io/instancegroup"            = "nodes"
-    "kubernetes.io/cluster/ha.example.com" = "owned"
+    "KubernetesCluster"                                                          = "ha.example.com"
+    "Name"                                                                       = "nodes.ha.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/ha.example.com"                                       = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.ha.example.com_user_data")
 }

--- a/tests/integration/update_cluster/launch_templates/cloudformation.json
+++ b/tests/integration/update_cluster/launch_templates/cloudformation.json
@@ -26,6 +26,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/master",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -81,6 +91,16 @@
           {
             "Key": "Name",
             "Value": "master-us-test-1b.masters.launchtemplates.example.com",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
             "PropagateAtLaunch": true
           },
           {
@@ -142,6 +162,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/master",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -197,6 +227,16 @@
           {
             "Key": "Name",
             "Value": "nodes.launchtemplates.example.com",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "node",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "Value": "",
             "PropagateAtLaunch": true
           },
           {

--- a/tests/integration/update_cluster/launch_templates/kubernetes.tf
+++ b/tests/integration/update_cluster/launch_templates/kubernetes.tf
@@ -108,6 +108,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-launchtemplates-exam
     value               = "master-us-test-1a.masters.launchtemplates.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -141,6 +151,16 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-launchtemplates-exam
     key                 = "Name"
     propagate_at_launch = true
     value               = "master-us-test-1b.masters.launchtemplates.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/master"
@@ -178,6 +198,16 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-launchtemplates-exam
     value               = "master-us-test-1c.masters.launchtemplates.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -212,6 +242,16 @@ resource "aws_autoscaling_group" "nodes-launchtemplates-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.launchtemplates.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
@@ -34,6 +34,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/master",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -97,6 +107,16 @@
           {
             "Key": "Name",
             "Value": "nodes.minimal.example.com",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "node",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "Value": "",
             "PropagateAtLaunch": true
           },
           {
@@ -226,6 +246,14 @@
                   "Value": "master-us-test-1a.masters.minimal.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/master",
                   "Value": "1"
                 },
@@ -249,6 +277,14 @@
                 {
                   "Key": "Name",
                   "Value": "master-us-test-1a.masters.minimal.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/master",
@@ -317,6 +353,14 @@
                   "Value": "nodes.minimal.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/node",
                   "Value": "1"
                 },
@@ -340,6 +384,14 @@
                 {
                   "Key": "Name",
                   "Value": "nodes.minimal.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/node",

--- a/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
+++ b/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
@@ -113,6 +113,16 @@
             "propagate_at_launch": true
           },
           {
+            "key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "value": "master",
+            "propagate_at_launch": true
+          },
+          {
+            "key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "value": "",
+            "propagate_at_launch": true
+          },
+          {
             "key": "k8s.io/role/master",
             "value": "1",
             "propagate_at_launch": true
@@ -160,6 +170,16 @@
           {
             "key": "Name",
             "value": "nodes.minimal-json.example.com",
+            "propagate_at_launch": true
+          },
+          {
+            "key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "value": "node",
+            "propagate_at_launch": true
+          },
+          {
+            "key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "value": "",
             "propagate_at_launch": true
           },
           {
@@ -314,6 +334,8 @@
         "tags": {
           "KubernetesCluster": "minimal-json.example.com",
           "Name": "master-us-test-1a.masters.minimal-json.example.com",
+          "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role": "master",
+          "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master": "",
           "k8s.io/role/master": "1",
           "kops.k8s.io/instancegroup": "master-us-test-1a",
           "kubernetes.io/cluster/minimal-json.example.com": "owned"
@@ -324,6 +346,8 @@
             "tags": {
               "KubernetesCluster": "minimal-json.example.com",
               "Name": "master-us-test-1a.masters.minimal-json.example.com",
+              "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role": "master",
+              "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master": "",
               "k8s.io/role/master": "1",
               "kops.k8s.io/instancegroup": "master-us-test-1a",
               "kubernetes.io/cluster/minimal-json.example.com": "owned"
@@ -334,6 +358,8 @@
             "tags": {
               "KubernetesCluster": "minimal-json.example.com",
               "Name": "master-us-test-1a.masters.minimal-json.example.com",
+              "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role": "master",
+              "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master": "",
               "k8s.io/role/master": "1",
               "kops.k8s.io/instancegroup": "master-us-test-1a",
               "kubernetes.io/cluster/minimal-json.example.com": "owned"
@@ -379,6 +405,8 @@
         "tags": {
           "KubernetesCluster": "minimal-json.example.com",
           "Name": "nodes.minimal-json.example.com",
+          "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role": "node",
+          "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node": "",
           "k8s.io/role/node": "1",
           "kops.k8s.io/instancegroup": "nodes",
           "kubernetes.io/cluster/minimal-json.example.com": "owned"
@@ -389,6 +417,8 @@
             "tags": {
               "KubernetesCluster": "minimal-json.example.com",
               "Name": "nodes.minimal-json.example.com",
+              "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role": "node",
+              "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node": "",
               "k8s.io/role/node": "1",
               "kops.k8s.io/instancegroup": "nodes",
               "kubernetes.io/cluster/minimal-json.example.com": "owned"
@@ -399,6 +429,8 @@
             "tags": {
               "KubernetesCluster": "minimal-json.example.com",
               "Name": "nodes.minimal-json.example.com",
+              "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role": "node",
+              "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node": "",
               "k8s.io/role/node": "1",
               "kops.k8s.io/instancegroup": "nodes",
               "kubernetes.io/cluster/minimal-json.example.com": "owned"

--- a/tests/integration/update_cluster/minimal-tf11/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-tf11/kubernetes.tf
@@ -105,6 +105,18 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-tf11-example
   }
 
   tag = {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    value               = "master"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    value               = ""
+    propagate_at_launch = true
+  }
+
+  tag = {
     key                 = "k8s.io/role/master"
     value               = "1"
     propagate_at_launch = true
@@ -147,6 +159,18 @@ resource "aws_autoscaling_group" "nodes-minimal-tf11-example-com" {
   tag = {
     key                 = "Name"
     value               = "nodes.minimal-tf11.example.com"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    value               = "node"
+    propagate_at_launch = true
+  }
+
+  tag = {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    value               = ""
     propagate_at_launch = true
   }
 
@@ -292,22 +316,26 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-tf11-example-c
   }
 
   tags = {
-    KubernetesCluster                                = "minimal-tf11.example.com"
-    Name                                             = "master-us-test-1a.masters.minimal-tf11.example.com"
-    "k8s.io/role/master"                             = "1"
-    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
-    "kubernetes.io/cluster/minimal-tf11.example.com" = "owned"
+    KubernetesCluster                                                              = "minimal-tf11.example.com"
+    Name                                                                           = "master-us-test-1a.masters.minimal-tf11.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/minimal-tf11.example.com"                               = "owned"
   }
 
   tag_specifications = {
     resource_type = "instance"
 
     tags = {
-      KubernetesCluster                                = "minimal-tf11.example.com"
-      Name                                             = "master-us-test-1a.masters.minimal-tf11.example.com"
-      "k8s.io/role/master"                             = "1"
-      "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
-      "kubernetes.io/cluster/minimal-tf11.example.com" = "owned"
+      KubernetesCluster                                                              = "minimal-tf11.example.com"
+      Name                                                                           = "master-us-test-1a.masters.minimal-tf11.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal-tf11.example.com"                               = "owned"
     }
   }
 
@@ -315,11 +343,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-tf11-example-c
     resource_type = "volume"
 
     tags = {
-      KubernetesCluster                                = "minimal-tf11.example.com"
-      Name                                             = "master-us-test-1a.masters.minimal-tf11.example.com"
-      "k8s.io/role/master"                             = "1"
-      "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
-      "kubernetes.io/cluster/minimal-tf11.example.com" = "owned"
+      KubernetesCluster                                                              = "minimal-tf11.example.com"
+      Name                                                                           = "master-us-test-1a.masters.minimal-tf11.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal-tf11.example.com"                               = "owned"
     }
   }
 
@@ -358,22 +388,26 @@ resource "aws_launch_template" "nodes-minimal-tf11-example-com" {
   }
 
   tags = {
-    KubernetesCluster                                = "minimal-tf11.example.com"
-    Name                                             = "nodes.minimal-tf11.example.com"
-    "k8s.io/role/node"                               = "1"
-    "kops.k8s.io/instancegroup"                      = "nodes"
-    "kubernetes.io/cluster/minimal-tf11.example.com" = "owned"
+    KubernetesCluster                                                            = "minimal-tf11.example.com"
+    Name                                                                         = "nodes.minimal-tf11.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/minimal-tf11.example.com"                             = "owned"
   }
 
   tag_specifications = {
     resource_type = "instance"
 
     tags = {
-      KubernetesCluster                                = "minimal-tf11.example.com"
-      Name                                             = "nodes.minimal-tf11.example.com"
-      "k8s.io/role/node"                               = "1"
-      "kops.k8s.io/instancegroup"                      = "nodes"
-      "kubernetes.io/cluster/minimal-tf11.example.com" = "owned"
+      KubernetesCluster                                                            = "minimal-tf11.example.com"
+      Name                                                                         = "nodes.minimal-tf11.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal-tf11.example.com"                             = "owned"
     }
   }
 
@@ -381,11 +415,13 @@ resource "aws_launch_template" "nodes-minimal-tf11-example-com" {
     resource_type = "volume"
 
     tags = {
-      KubernetesCluster                                = "minimal-tf11.example.com"
-      Name                                             = "nodes.minimal-tf11.example.com"
-      "k8s.io/role/node"                               = "1"
-      "kops.k8s.io/instancegroup"                      = "nodes"
-      "kubernetes.io/cluster/minimal-tf11.example.com" = "owned"
+      KubernetesCluster                                                            = "minimal-tf11.example.com"
+      Name                                                                         = "nodes.minimal-tf11.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal-tf11.example.com"                             = "owned"
     }
   }
 

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -101,6 +101,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com"
     value               = "master-us-test-1a.masters.minimal.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -137,6 +147,16 @@ resource "aws_autoscaling_group" "nodes-minimal-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.minimal.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -266,29 +286,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                         = "minimal.example.com"
-      "Name"                                      = "master-us-test-1a.masters.minimal.example.com"
-      "k8s.io/role/master"                        = "1"
-      "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
-      "kubernetes.io/cluster/minimal.example.com" = "owned"
+      "KubernetesCluster"                                                            = "minimal.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.minimal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                    = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                         = "minimal.example.com"
-      "Name"                                      = "master-us-test-1a.masters.minimal.example.com"
-      "k8s.io/role/master"                        = "1"
-      "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
-      "kubernetes.io/cluster/minimal.example.com" = "owned"
+      "KubernetesCluster"                                                            = "minimal.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.minimal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                    = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "master-us-test-1a.masters.minimal.example.com"
-    "k8s.io/role/master"                        = "1"
-    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
+    "KubernetesCluster"                                                            = "minimal.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.minimal.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/minimal.example.com"                                    = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data")
 }
@@ -320,29 +346,35 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                         = "minimal.example.com"
-      "Name"                                      = "nodes.minimal.example.com"
-      "k8s.io/role/node"                          = "1"
-      "kops.k8s.io/instancegroup"                 = "nodes"
-      "kubernetes.io/cluster/minimal.example.com" = "owned"
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                         = "minimal.example.com"
-      "Name"                                      = "nodes.minimal.example.com"
-      "k8s.io/role/node"                          = "1"
-      "kops.k8s.io/instancegroup"                 = "nodes"
-      "kubernetes.io/cluster/minimal.example.com" = "owned"
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "nodes.minimal.example.com"
-    "k8s.io/role/node"                          = "1"
-    "kops.k8s.io/instancegroup"                 = "nodes"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
+    "KubernetesCluster"                                                          = "minimal.example.com"
+    "Name"                                                                       = "nodes.minimal.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.minimal.example.com_user_data")
 }

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json
@@ -34,6 +34,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/master",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -97,6 +107,16 @@
           {
             "Key": "Name",
             "Value": "master-us-test-1b.masters.mixedinstances.example.com",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
             "PropagateAtLaunch": true
           },
           {
@@ -166,6 +186,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/master",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -218,6 +248,16 @@
           {
             "Key": "Name",
             "Value": "nodes.mixedinstances.example.com",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "node",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "Value": "",
             "PropagateAtLaunch": true
           },
           {
@@ -377,6 +417,14 @@
                   "Value": "master-us-test-1a.masters.mixedinstances.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/master",
                   "Value": "1"
                 },
@@ -400,6 +448,14 @@
                 {
                   "Key": "Name",
                   "Value": "master-us-test-1a.masters.mixedinstances.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/master",
@@ -472,6 +528,14 @@
                   "Value": "master-us-test-1b.masters.mixedinstances.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/master",
                   "Value": "1"
                 },
@@ -495,6 +559,14 @@
                 {
                   "Key": "Name",
                   "Value": "master-us-test-1b.masters.mixedinstances.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/master",
@@ -567,6 +639,14 @@
                   "Value": "master-us-test-1c.masters.mixedinstances.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/master",
                   "Value": "1"
                 },
@@ -590,6 +670,14 @@
                 {
                   "Key": "Name",
                   "Value": "master-us-test-1c.masters.mixedinstances.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/master",
@@ -658,6 +746,14 @@
                   "Value": "nodes.mixedinstances.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/node",
                   "Value": "1"
                 },
@@ -681,6 +777,14 @@
                 {
                   "Key": "Name",
                   "Value": "nodes.mixedinstances.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/node",

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -111,6 +111,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-mixedinstances-examp
     value               = "master-us-test-1a.masters.mixedinstances.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -149,6 +159,16 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-mixedinstances-examp
     value               = "master-us-test-1b.masters.mixedinstances.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -185,6 +205,16 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-mixedinstances-examp
     key                 = "Name"
     propagate_at_launch = true
     value               = "master-us-test-1c.masters.mixedinstances.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/master"
@@ -241,6 +271,16 @@ resource "aws_autoscaling_group" "nodes-mixedinstances-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.mixedinstances.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -426,29 +466,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                = "mixedinstances.example.com"
-      "Name"                                             = "master-us-test-1a.masters.mixedinstances.example.com"
-      "k8s.io/role/master"                               = "1"
-      "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
-      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+      "KubernetesCluster"                                                            = "mixedinstances.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.mixedinstances.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                = "mixedinstances.example.com"
-      "Name"                                             = "master-us-test-1a.masters.mixedinstances.example.com"
-      "k8s.io/role/master"                               = "1"
-      "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
-      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+      "KubernetesCluster"                                                            = "mixedinstances.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.mixedinstances.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                = "mixedinstances.example.com"
-    "Name"                                             = "master-us-test-1a.masters.mixedinstances.example.com"
-    "k8s.io/role/master"                               = "1"
-    "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
-    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+    "KubernetesCluster"                                                            = "mixedinstances.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.mixedinstances.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data")
 }
@@ -484,29 +530,35 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                = "mixedinstances.example.com"
-      "Name"                                             = "master-us-test-1b.masters.mixedinstances.example.com"
-      "k8s.io/role/master"                               = "1"
-      "kops.k8s.io/instancegroup"                        = "master-us-test-1b"
-      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+      "KubernetesCluster"                                                            = "mixedinstances.example.com"
+      "Name"                                                                         = "master-us-test-1b.masters.mixedinstances.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1b"
+      "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                = "mixedinstances.example.com"
-      "Name"                                             = "master-us-test-1b.masters.mixedinstances.example.com"
-      "k8s.io/role/master"                               = "1"
-      "kops.k8s.io/instancegroup"                        = "master-us-test-1b"
-      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+      "KubernetesCluster"                                                            = "mixedinstances.example.com"
+      "Name"                                                                         = "master-us-test-1b.masters.mixedinstances.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1b"
+      "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                = "mixedinstances.example.com"
-    "Name"                                             = "master-us-test-1b.masters.mixedinstances.example.com"
-    "k8s.io/role/master"                               = "1"
-    "kops.k8s.io/instancegroup"                        = "master-us-test-1b"
-    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+    "KubernetesCluster"                                                            = "mixedinstances.example.com"
+    "Name"                                                                         = "master-us-test-1b.masters.mixedinstances.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1b"
+    "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data")
 }
@@ -542,29 +594,35 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                = "mixedinstances.example.com"
-      "Name"                                             = "master-us-test-1c.masters.mixedinstances.example.com"
-      "k8s.io/role/master"                               = "1"
-      "kops.k8s.io/instancegroup"                        = "master-us-test-1c"
-      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+      "KubernetesCluster"                                                            = "mixedinstances.example.com"
+      "Name"                                                                         = "master-us-test-1c.masters.mixedinstances.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1c"
+      "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                = "mixedinstances.example.com"
-      "Name"                                             = "master-us-test-1c.masters.mixedinstances.example.com"
-      "k8s.io/role/master"                               = "1"
-      "kops.k8s.io/instancegroup"                        = "master-us-test-1c"
-      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+      "KubernetesCluster"                                                            = "mixedinstances.example.com"
+      "Name"                                                                         = "master-us-test-1c.masters.mixedinstances.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1c"
+      "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                = "mixedinstances.example.com"
-    "Name"                                             = "master-us-test-1c.masters.mixedinstances.example.com"
-    "k8s.io/role/master"                               = "1"
-    "kops.k8s.io/instancegroup"                        = "master-us-test-1c"
-    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+    "KubernetesCluster"                                                            = "mixedinstances.example.com"
+    "Name"                                                                         = "master-us-test-1c.masters.mixedinstances.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1c"
+    "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data")
 }
@@ -596,29 +654,35 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                = "mixedinstances.example.com"
-      "Name"                                             = "nodes.mixedinstances.example.com"
-      "k8s.io/role/node"                                 = "1"
-      "kops.k8s.io/instancegroup"                        = "nodes"
-      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+      "KubernetesCluster"                                                          = "mixedinstances.example.com"
+      "Name"                                                                       = "nodes.mixedinstances.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/mixedinstances.example.com"                           = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                = "mixedinstances.example.com"
-      "Name"                                             = "nodes.mixedinstances.example.com"
-      "k8s.io/role/node"                                 = "1"
-      "kops.k8s.io/instancegroup"                        = "nodes"
-      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+      "KubernetesCluster"                                                          = "mixedinstances.example.com"
+      "Name"                                                                       = "nodes.mixedinstances.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/mixedinstances.example.com"                           = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                = "mixedinstances.example.com"
-    "Name"                                             = "nodes.mixedinstances.example.com"
-    "k8s.io/role/node"                                 = "1"
-    "kops.k8s.io/instancegroup"                        = "nodes"
-    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+    "KubernetesCluster"                                                          = "mixedinstances.example.com"
+    "Name"                                                                       = "nodes.mixedinstances.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/mixedinstances.example.com"                           = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.mixedinstances.example.com_user_data")
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
@@ -34,6 +34,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/master",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -97,6 +107,16 @@
           {
             "Key": "Name",
             "Value": "master-us-test-1b.masters.mixedinstances.example.com",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
             "PropagateAtLaunch": true
           },
           {
@@ -166,6 +186,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/master",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -218,6 +248,16 @@
           {
             "Key": "Name",
             "Value": "nodes.mixedinstances.example.com",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "node",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "Value": "",
             "PropagateAtLaunch": true
           },
           {
@@ -378,6 +418,14 @@
                   "Value": "master-us-test-1a.masters.mixedinstances.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/master",
                   "Value": "1"
                 },
@@ -401,6 +449,14 @@
                 {
                   "Key": "Name",
                   "Value": "master-us-test-1a.masters.mixedinstances.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/master",
@@ -473,6 +529,14 @@
                   "Value": "master-us-test-1b.masters.mixedinstances.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/master",
                   "Value": "1"
                 },
@@ -496,6 +560,14 @@
                 {
                   "Key": "Name",
                   "Value": "master-us-test-1b.masters.mixedinstances.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/master",
@@ -568,6 +640,14 @@
                   "Value": "master-us-test-1c.masters.mixedinstances.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/master",
                   "Value": "1"
                 },
@@ -591,6 +671,14 @@
                 {
                   "Key": "Name",
                   "Value": "master-us-test-1c.masters.mixedinstances.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/master",
@@ -659,6 +747,14 @@
                   "Value": "nodes.mixedinstances.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/node",
                   "Value": "1"
                 },
@@ -682,6 +778,14 @@
                 {
                   "Key": "Name",
                   "Value": "nodes.mixedinstances.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/node",

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -111,6 +111,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-mixedinstances-examp
     value               = "master-us-test-1a.masters.mixedinstances.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -149,6 +159,16 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-mixedinstances-examp
     value               = "master-us-test-1b.masters.mixedinstances.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -185,6 +205,16 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-mixedinstances-examp
     key                 = "Name"
     propagate_at_launch = true
     value               = "master-us-test-1c.masters.mixedinstances.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/master"
@@ -241,6 +271,16 @@ resource "aws_autoscaling_group" "nodes-mixedinstances-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.mixedinstances.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -426,29 +466,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                = "mixedinstances.example.com"
-      "Name"                                             = "master-us-test-1a.masters.mixedinstances.example.com"
-      "k8s.io/role/master"                               = "1"
-      "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
-      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+      "KubernetesCluster"                                                            = "mixedinstances.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.mixedinstances.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                = "mixedinstances.example.com"
-      "Name"                                             = "master-us-test-1a.masters.mixedinstances.example.com"
-      "k8s.io/role/master"                               = "1"
-      "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
-      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+      "KubernetesCluster"                                                            = "mixedinstances.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.mixedinstances.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                = "mixedinstances.example.com"
-    "Name"                                             = "master-us-test-1a.masters.mixedinstances.example.com"
-    "k8s.io/role/master"                               = "1"
-    "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
-    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+    "KubernetesCluster"                                                            = "mixedinstances.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.mixedinstances.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data")
 }
@@ -484,29 +530,35 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                = "mixedinstances.example.com"
-      "Name"                                             = "master-us-test-1b.masters.mixedinstances.example.com"
-      "k8s.io/role/master"                               = "1"
-      "kops.k8s.io/instancegroup"                        = "master-us-test-1b"
-      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+      "KubernetesCluster"                                                            = "mixedinstances.example.com"
+      "Name"                                                                         = "master-us-test-1b.masters.mixedinstances.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1b"
+      "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                = "mixedinstances.example.com"
-      "Name"                                             = "master-us-test-1b.masters.mixedinstances.example.com"
-      "k8s.io/role/master"                               = "1"
-      "kops.k8s.io/instancegroup"                        = "master-us-test-1b"
-      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+      "KubernetesCluster"                                                            = "mixedinstances.example.com"
+      "Name"                                                                         = "master-us-test-1b.masters.mixedinstances.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1b"
+      "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                = "mixedinstances.example.com"
-    "Name"                                             = "master-us-test-1b.masters.mixedinstances.example.com"
-    "k8s.io/role/master"                               = "1"
-    "kops.k8s.io/instancegroup"                        = "master-us-test-1b"
-    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+    "KubernetesCluster"                                                            = "mixedinstances.example.com"
+    "Name"                                                                         = "master-us-test-1b.masters.mixedinstances.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1b"
+    "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data")
 }
@@ -542,29 +594,35 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                = "mixedinstances.example.com"
-      "Name"                                             = "master-us-test-1c.masters.mixedinstances.example.com"
-      "k8s.io/role/master"                               = "1"
-      "kops.k8s.io/instancegroup"                        = "master-us-test-1c"
-      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+      "KubernetesCluster"                                                            = "mixedinstances.example.com"
+      "Name"                                                                         = "master-us-test-1c.masters.mixedinstances.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1c"
+      "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                = "mixedinstances.example.com"
-      "Name"                                             = "master-us-test-1c.masters.mixedinstances.example.com"
-      "k8s.io/role/master"                               = "1"
-      "kops.k8s.io/instancegroup"                        = "master-us-test-1c"
-      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+      "KubernetesCluster"                                                            = "mixedinstances.example.com"
+      "Name"                                                                         = "master-us-test-1c.masters.mixedinstances.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1c"
+      "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                = "mixedinstances.example.com"
-    "Name"                                             = "master-us-test-1c.masters.mixedinstances.example.com"
-    "k8s.io/role/master"                               = "1"
-    "kops.k8s.io/instancegroup"                        = "master-us-test-1c"
-    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+    "KubernetesCluster"                                                            = "mixedinstances.example.com"
+    "Name"                                                                         = "master-us-test-1c.masters.mixedinstances.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1c"
+    "kubernetes.io/cluster/mixedinstances.example.com"                             = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data")
 }
@@ -596,29 +654,35 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                = "mixedinstances.example.com"
-      "Name"                                             = "nodes.mixedinstances.example.com"
-      "k8s.io/role/node"                                 = "1"
-      "kops.k8s.io/instancegroup"                        = "nodes"
-      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+      "KubernetesCluster"                                                          = "mixedinstances.example.com"
+      "Name"                                                                       = "nodes.mixedinstances.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/mixedinstances.example.com"                           = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                = "mixedinstances.example.com"
-      "Name"                                             = "nodes.mixedinstances.example.com"
-      "k8s.io/role/node"                                 = "1"
-      "kops.k8s.io/instancegroup"                        = "nodes"
-      "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+      "KubernetesCluster"                                                          = "mixedinstances.example.com"
+      "Name"                                                                       = "nodes.mixedinstances.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/mixedinstances.example.com"                           = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                = "mixedinstances.example.com"
-    "Name"                                             = "nodes.mixedinstances.example.com"
-    "k8s.io/role/node"                                 = "1"
-    "kops.k8s.io/instancegroup"                        = "nodes"
-    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+    "KubernetesCluster"                                                          = "mixedinstances.example.com"
+    "Name"                                                                       = "nodes.mixedinstances.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/mixedinstances.example.com"                           = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.mixedinstances.example.com_user_data")
 }

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -131,6 +131,16 @@ resource "aws_autoscaling_group" "bastion-private-shared-subnet-example-com" {
     value               = "bastion.private-shared-subnet.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/bastion"
     propagate_at_launch = true
     value               = "1"
@@ -169,6 +179,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-private-shared-subne
     value               = "master-us-test-1a.masters.private-shared-subnet.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -205,6 +225,16 @@ resource "aws_autoscaling_group" "nodes-private-shared-subnet-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.private-shared-subnet.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -388,29 +418,35 @@ resource "aws_launch_template" "bastion-private-shared-subnet-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                       = "private-shared-subnet.example.com"
-      "Name"                                                    = "bastion.private-shared-subnet.example.com"
-      "k8s.io/role/bastion"                                     = "1"
-      "kops.k8s.io/instancegroup"                               = "bastion"
-      "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+      "KubernetesCluster"                                                          = "private-shared-subnet.example.com"
+      "Name"                                                                       = "bastion.private-shared-subnet.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/private-shared-subnet.example.com"                    = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                       = "private-shared-subnet.example.com"
-      "Name"                                                    = "bastion.private-shared-subnet.example.com"
-      "k8s.io/role/bastion"                                     = "1"
-      "kops.k8s.io/instancegroup"                               = "bastion"
-      "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+      "KubernetesCluster"                                                          = "private-shared-subnet.example.com"
+      "Name"                                                                       = "bastion.private-shared-subnet.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/private-shared-subnet.example.com"                    = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
-    "Name"                                                    = "bastion.private-shared-subnet.example.com"
-    "k8s.io/role/bastion"                                     = "1"
-    "kops.k8s.io/instancegroup"                               = "bastion"
-    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+    "KubernetesCluster"                                                          = "private-shared-subnet.example.com"
+    "Name"                                                                       = "bastion.private-shared-subnet.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/bastion"                                                        = "1"
+    "kops.k8s.io/instancegroup"                                                  = "bastion"
+    "kubernetes.io/cluster/private-shared-subnet.example.com"                    = "owned"
   }
 }
 
@@ -445,29 +481,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-private-shared-subnet-
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                       = "private-shared-subnet.example.com"
-      "Name"                                                    = "master-us-test-1a.masters.private-shared-subnet.example.com"
-      "k8s.io/role/master"                                      = "1"
-      "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
-      "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+      "KubernetesCluster"                                                            = "private-shared-subnet.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.private-shared-subnet.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/private-shared-subnet.example.com"                      = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                       = "private-shared-subnet.example.com"
-      "Name"                                                    = "master-us-test-1a.masters.private-shared-subnet.example.com"
-      "k8s.io/role/master"                                      = "1"
-      "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
-      "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+      "KubernetesCluster"                                                            = "private-shared-subnet.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.private-shared-subnet.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/private-shared-subnet.example.com"                      = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
-    "Name"                                                    = "master-us-test-1a.masters.private-shared-subnet.example.com"
-    "k8s.io/role/master"                                      = "1"
-    "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
-    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+    "KubernetesCluster"                                                            = "private-shared-subnet.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.private-shared-subnet.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/private-shared-subnet.example.com"                      = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data")
 }
@@ -499,29 +541,35 @@ resource "aws_launch_template" "nodes-private-shared-subnet-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                       = "private-shared-subnet.example.com"
-      "Name"                                                    = "nodes.private-shared-subnet.example.com"
-      "k8s.io/role/node"                                        = "1"
-      "kops.k8s.io/instancegroup"                               = "nodes"
-      "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+      "KubernetesCluster"                                                          = "private-shared-subnet.example.com"
+      "Name"                                                                       = "nodes.private-shared-subnet.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/private-shared-subnet.example.com"                    = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                       = "private-shared-subnet.example.com"
-      "Name"                                                    = "nodes.private-shared-subnet.example.com"
-      "k8s.io/role/node"                                        = "1"
-      "kops.k8s.io/instancegroup"                               = "nodes"
-      "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+      "KubernetesCluster"                                                          = "private-shared-subnet.example.com"
+      "Name"                                                                       = "nodes.private-shared-subnet.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/private-shared-subnet.example.com"                    = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
-    "Name"                                                    = "nodes.private-shared-subnet.example.com"
-    "k8s.io/role/node"                                        = "1"
-    "kops.k8s.io/instancegroup"                               = "nodes"
-    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+    "KubernetesCluster"                                                          = "private-shared-subnet.example.com"
+    "Name"                                                                       = "nodes.private-shared-subnet.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/private-shared-subnet.example.com"                    = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.private-shared-subnet.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -34,6 +34,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "node",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/bastion",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -105,6 +115,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/master",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -173,6 +193,16 @@
           {
             "Key": "Name",
             "Value": "nodes.privatecalico.example.com",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "node",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "Value": "",
             "PropagateAtLaunch": true
           },
           {
@@ -318,6 +348,14 @@
                   "Value": "bastion.privatecalico.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/bastion",
                   "Value": "1"
                 },
@@ -341,6 +379,14 @@
                 {
                   "Key": "Name",
                   "Value": "bastion.privatecalico.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/bastion",
@@ -413,6 +459,14 @@
                   "Value": "master-us-test-1a.masters.privatecalico.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/master",
                   "Value": "1"
                 },
@@ -436,6 +490,14 @@
                 {
                   "Key": "Name",
                   "Value": "master-us-test-1a.masters.privatecalico.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/master",
@@ -504,6 +566,14 @@
                   "Value": "nodes.privatecalico.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/node",
                   "Value": "1"
                 },
@@ -527,6 +597,14 @@
                 {
                   "Key": "Name",
                   "Value": "nodes.privatecalico.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/node",

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -141,6 +141,16 @@ resource "aws_autoscaling_group" "bastion-privatecalico-example-com" {
     value               = "bastion.privatecalico.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/bastion"
     propagate_at_launch = true
     value               = "1"
@@ -179,6 +189,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatecalico-exampl
     value               = "master-us-test-1a.masters.privatecalico.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -215,6 +235,16 @@ resource "aws_autoscaling_group" "nodes-privatecalico-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.privatecalico.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -416,29 +446,35 @@ resource "aws_launch_template" "bastion-privatecalico-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                               = "privatecalico.example.com"
-      "Name"                                            = "bastion.privatecalico.example.com"
-      "k8s.io/role/bastion"                             = "1"
-      "kops.k8s.io/instancegroup"                       = "bastion"
-      "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatecalico.example.com"
+      "Name"                                                                       = "bastion.privatecalico.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privatecalico.example.com"                            = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                               = "privatecalico.example.com"
-      "Name"                                            = "bastion.privatecalico.example.com"
-      "k8s.io/role/bastion"                             = "1"
-      "kops.k8s.io/instancegroup"                       = "bastion"
-      "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatecalico.example.com"
+      "Name"                                                                       = "bastion.privatecalico.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privatecalico.example.com"                            = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                               = "privatecalico.example.com"
-    "Name"                                            = "bastion.privatecalico.example.com"
-    "k8s.io/role/bastion"                             = "1"
-    "kops.k8s.io/instancegroup"                       = "bastion"
-    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privatecalico.example.com"
+    "Name"                                                                       = "bastion.privatecalico.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/bastion"                                                        = "1"
+    "kops.k8s.io/instancegroup"                                                  = "bastion"
+    "kubernetes.io/cluster/privatecalico.example.com"                            = "owned"
   }
 }
 
@@ -473,29 +509,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecalico-example-
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                               = "privatecalico.example.com"
-      "Name"                                            = "master-us-test-1a.masters.privatecalico.example.com"
-      "k8s.io/role/master"                              = "1"
-      "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
-      "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privatecalico.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privatecalico.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privatecalico.example.com"                              = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                               = "privatecalico.example.com"
-      "Name"                                            = "master-us-test-1a.masters.privatecalico.example.com"
-      "k8s.io/role/master"                              = "1"
-      "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
-      "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privatecalico.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privatecalico.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privatecalico.example.com"                              = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                               = "privatecalico.example.com"
-    "Name"                                            = "master-us-test-1a.masters.privatecalico.example.com"
-    "k8s.io/role/master"                              = "1"
-    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
-    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+    "KubernetesCluster"                                                            = "privatecalico.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.privatecalico.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/privatecalico.example.com"                              = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data")
 }
@@ -527,29 +569,35 @@ resource "aws_launch_template" "nodes-privatecalico-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                               = "privatecalico.example.com"
-      "Name"                                            = "nodes.privatecalico.example.com"
-      "k8s.io/role/node"                                = "1"
-      "kops.k8s.io/instancegroup"                       = "nodes"
-      "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatecalico.example.com"
+      "Name"                                                                       = "nodes.privatecalico.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatecalico.example.com"                            = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                               = "privatecalico.example.com"
-      "Name"                                            = "nodes.privatecalico.example.com"
-      "k8s.io/role/node"                                = "1"
-      "kops.k8s.io/instancegroup"                       = "nodes"
-      "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatecalico.example.com"
+      "Name"                                                                       = "nodes.privatecalico.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatecalico.example.com"                            = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                               = "privatecalico.example.com"
-    "Name"                                            = "nodes.privatecalico.example.com"
-    "k8s.io/role/node"                                = "1"
-    "kops.k8s.io/instancegroup"                       = "nodes"
-    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privatecalico.example.com"
+    "Name"                                                                       = "nodes.privatecalico.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/privatecalico.example.com"                            = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privatecalico.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -141,6 +141,16 @@ resource "aws_autoscaling_group" "bastion-privatecanal-example-com" {
     value               = "bastion.privatecanal.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/bastion"
     propagate_at_launch = true
     value               = "1"
@@ -179,6 +189,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatecanal-example
     value               = "master-us-test-1a.masters.privatecanal.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -215,6 +235,16 @@ resource "aws_autoscaling_group" "nodes-privatecanal-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.privatecanal.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -416,29 +446,35 @@ resource "aws_launch_template" "bastion-privatecanal-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                              = "privatecanal.example.com"
-      "Name"                                           = "bastion.privatecanal.example.com"
-      "k8s.io/role/bastion"                            = "1"
-      "kops.k8s.io/instancegroup"                      = "bastion"
-      "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatecanal.example.com"
+      "Name"                                                                       = "bastion.privatecanal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privatecanal.example.com"                             = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                              = "privatecanal.example.com"
-      "Name"                                           = "bastion.privatecanal.example.com"
-      "k8s.io/role/bastion"                            = "1"
-      "kops.k8s.io/instancegroup"                      = "bastion"
-      "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatecanal.example.com"
+      "Name"                                                                       = "bastion.privatecanal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privatecanal.example.com"                             = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                              = "privatecanal.example.com"
-    "Name"                                           = "bastion.privatecanal.example.com"
-    "k8s.io/role/bastion"                            = "1"
-    "kops.k8s.io/instancegroup"                      = "bastion"
-    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privatecanal.example.com"
+    "Name"                                                                       = "bastion.privatecanal.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/bastion"                                                        = "1"
+    "kops.k8s.io/instancegroup"                                                  = "bastion"
+    "kubernetes.io/cluster/privatecanal.example.com"                             = "owned"
   }
 }
 
@@ -473,29 +509,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecanal-example-c
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                              = "privatecanal.example.com"
-      "Name"                                           = "master-us-test-1a.masters.privatecanal.example.com"
-      "k8s.io/role/master"                             = "1"
-      "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
-      "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privatecanal.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privatecanal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privatecanal.example.com"                               = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                              = "privatecanal.example.com"
-      "Name"                                           = "master-us-test-1a.masters.privatecanal.example.com"
-      "k8s.io/role/master"                             = "1"
-      "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
-      "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privatecanal.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privatecanal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privatecanal.example.com"                               = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                              = "privatecanal.example.com"
-    "Name"                                           = "master-us-test-1a.masters.privatecanal.example.com"
-    "k8s.io/role/master"                             = "1"
-    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
-    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+    "KubernetesCluster"                                                            = "privatecanal.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.privatecanal.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/privatecanal.example.com"                               = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data")
 }
@@ -527,29 +569,35 @@ resource "aws_launch_template" "nodes-privatecanal-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                              = "privatecanal.example.com"
-      "Name"                                           = "nodes.privatecanal.example.com"
-      "k8s.io/role/node"                               = "1"
-      "kops.k8s.io/instancegroup"                      = "nodes"
-      "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatecanal.example.com"
+      "Name"                                                                       = "nodes.privatecanal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatecanal.example.com"                             = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                              = "privatecanal.example.com"
-      "Name"                                           = "nodes.privatecanal.example.com"
-      "k8s.io/role/node"                               = "1"
-      "kops.k8s.io/instancegroup"                      = "nodes"
-      "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatecanal.example.com"
+      "Name"                                                                       = "nodes.privatecanal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatecanal.example.com"                             = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                              = "privatecanal.example.com"
-    "Name"                                           = "nodes.privatecanal.example.com"
-    "k8s.io/role/node"                               = "1"
-    "kops.k8s.io/instancegroup"                      = "nodes"
-    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privatecanal.example.com"
+    "Name"                                                                       = "nodes.privatecanal.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/privatecanal.example.com"                             = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privatecanal.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json
@@ -34,6 +34,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "node",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/bastion",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -105,6 +115,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/master",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -173,6 +193,16 @@
           {
             "Key": "Name",
             "Value": "nodes.privatecilium.example.com",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "node",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "Value": "",
             "PropagateAtLaunch": true
           },
           {
@@ -318,6 +348,14 @@
                   "Value": "bastion.privatecilium.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/bastion",
                   "Value": "1"
                 },
@@ -341,6 +379,14 @@
                 {
                   "Key": "Name",
                   "Value": "bastion.privatecilium.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/bastion",
@@ -413,6 +459,14 @@
                   "Value": "master-us-test-1a.masters.privatecilium.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/master",
                   "Value": "1"
                 },
@@ -436,6 +490,14 @@
                 {
                   "Key": "Name",
                   "Value": "master-us-test-1a.masters.privatecilium.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/master",
@@ -504,6 +566,14 @@
                   "Value": "nodes.privatecilium.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/node",
                   "Value": "1"
                 },
@@ -527,6 +597,14 @@
                 {
                   "Key": "Name",
                   "Value": "nodes.privatecilium.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/node",

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -141,6 +141,16 @@ resource "aws_autoscaling_group" "bastion-privatecilium-example-com" {
     value               = "bastion.privatecilium.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/bastion"
     propagate_at_launch = true
     value               = "1"
@@ -179,6 +189,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatecilium-exampl
     value               = "master-us-test-1a.masters.privatecilium.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -215,6 +235,16 @@ resource "aws_autoscaling_group" "nodes-privatecilium-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.privatecilium.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -416,29 +446,35 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                               = "privatecilium.example.com"
-      "Name"                                            = "bastion.privatecilium.example.com"
-      "k8s.io/role/bastion"                             = "1"
-      "kops.k8s.io/instancegroup"                       = "bastion"
-      "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatecilium.example.com"
+      "Name"                                                                       = "bastion.privatecilium.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privatecilium.example.com"                            = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                               = "privatecilium.example.com"
-      "Name"                                            = "bastion.privatecilium.example.com"
-      "k8s.io/role/bastion"                             = "1"
-      "kops.k8s.io/instancegroup"                       = "bastion"
-      "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatecilium.example.com"
+      "Name"                                                                       = "bastion.privatecilium.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privatecilium.example.com"                            = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                               = "privatecilium.example.com"
-    "Name"                                            = "bastion.privatecilium.example.com"
-    "k8s.io/role/bastion"                             = "1"
-    "kops.k8s.io/instancegroup"                       = "bastion"
-    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privatecilium.example.com"
+    "Name"                                                                       = "bastion.privatecilium.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/bastion"                                                        = "1"
+    "kops.k8s.io/instancegroup"                                                  = "bastion"
+    "kubernetes.io/cluster/privatecilium.example.com"                            = "owned"
   }
 }
 
@@ -473,29 +509,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                               = "privatecilium.example.com"
-      "Name"                                            = "master-us-test-1a.masters.privatecilium.example.com"
-      "k8s.io/role/master"                              = "1"
-      "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
-      "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privatecilium.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privatecilium.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privatecilium.example.com"                              = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                               = "privatecilium.example.com"
-      "Name"                                            = "master-us-test-1a.masters.privatecilium.example.com"
-      "k8s.io/role/master"                              = "1"
-      "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
-      "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privatecilium.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privatecilium.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privatecilium.example.com"                              = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                               = "privatecilium.example.com"
-    "Name"                                            = "master-us-test-1a.masters.privatecilium.example.com"
-    "k8s.io/role/master"                              = "1"
-    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
-    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+    "KubernetesCluster"                                                            = "privatecilium.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.privatecilium.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/privatecilium.example.com"                              = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data")
 }
@@ -527,29 +569,35 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                               = "privatecilium.example.com"
-      "Name"                                            = "nodes.privatecilium.example.com"
-      "k8s.io/role/node"                                = "1"
-      "kops.k8s.io/instancegroup"                       = "nodes"
-      "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatecilium.example.com"
+      "Name"                                                                       = "nodes.privatecilium.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatecilium.example.com"                            = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                               = "privatecilium.example.com"
-      "Name"                                            = "nodes.privatecilium.example.com"
-      "k8s.io/role/node"                                = "1"
-      "kops.k8s.io/instancegroup"                       = "nodes"
-      "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatecilium.example.com"
+      "Name"                                                                       = "nodes.privatecilium.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatecilium.example.com"                            = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                               = "privatecilium.example.com"
-    "Name"                                            = "nodes.privatecilium.example.com"
-    "k8s.io/role/node"                                = "1"
-    "kops.k8s.io/instancegroup"                       = "nodes"
-    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privatecilium.example.com"
+    "Name"                                                                       = "nodes.privatecilium.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/privatecilium.example.com"                            = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privatecilium.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json
@@ -34,6 +34,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "node",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/bastion",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -105,6 +115,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/master",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -173,6 +193,16 @@
           {
             "Key": "Name",
             "Value": "nodes.privatecilium.example.com",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "node",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "Value": "",
             "PropagateAtLaunch": true
           },
           {
@@ -318,6 +348,14 @@
                   "Value": "bastion.privatecilium.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/bastion",
                   "Value": "1"
                 },
@@ -341,6 +379,14 @@
                 {
                   "Key": "Name",
                   "Value": "bastion.privatecilium.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/bastion",
@@ -413,6 +459,14 @@
                   "Value": "master-us-test-1a.masters.privatecilium.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/master",
                   "Value": "1"
                 },
@@ -436,6 +490,14 @@
                 {
                   "Key": "Name",
                   "Value": "master-us-test-1a.masters.privatecilium.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/master",
@@ -504,6 +566,14 @@
                   "Value": "nodes.privatecilium.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/node",
                   "Value": "1"
                 },
@@ -527,6 +597,14 @@
                 {
                   "Key": "Name",
                   "Value": "nodes.privatecilium.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/node",

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -141,6 +141,16 @@ resource "aws_autoscaling_group" "bastion-privatecilium-example-com" {
     value               = "bastion.privatecilium.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/bastion"
     propagate_at_launch = true
     value               = "1"
@@ -179,6 +189,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatecilium-exampl
     value               = "master-us-test-1a.masters.privatecilium.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -215,6 +235,16 @@ resource "aws_autoscaling_group" "nodes-privatecilium-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.privatecilium.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -416,29 +446,35 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                               = "privatecilium.example.com"
-      "Name"                                            = "bastion.privatecilium.example.com"
-      "k8s.io/role/bastion"                             = "1"
-      "kops.k8s.io/instancegroup"                       = "bastion"
-      "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatecilium.example.com"
+      "Name"                                                                       = "bastion.privatecilium.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privatecilium.example.com"                            = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                               = "privatecilium.example.com"
-      "Name"                                            = "bastion.privatecilium.example.com"
-      "k8s.io/role/bastion"                             = "1"
-      "kops.k8s.io/instancegroup"                       = "bastion"
-      "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatecilium.example.com"
+      "Name"                                                                       = "bastion.privatecilium.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privatecilium.example.com"                            = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                               = "privatecilium.example.com"
-    "Name"                                            = "bastion.privatecilium.example.com"
-    "k8s.io/role/bastion"                             = "1"
-    "kops.k8s.io/instancegroup"                       = "bastion"
-    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privatecilium.example.com"
+    "Name"                                                                       = "bastion.privatecilium.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/bastion"                                                        = "1"
+    "kops.k8s.io/instancegroup"                                                  = "bastion"
+    "kubernetes.io/cluster/privatecilium.example.com"                            = "owned"
   }
 }
 
@@ -473,29 +509,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                               = "privatecilium.example.com"
-      "Name"                                            = "master-us-test-1a.masters.privatecilium.example.com"
-      "k8s.io/role/master"                              = "1"
-      "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
-      "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privatecilium.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privatecilium.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privatecilium.example.com"                              = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                               = "privatecilium.example.com"
-      "Name"                                            = "master-us-test-1a.masters.privatecilium.example.com"
-      "k8s.io/role/master"                              = "1"
-      "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
-      "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privatecilium.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privatecilium.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privatecilium.example.com"                              = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                               = "privatecilium.example.com"
-    "Name"                                            = "master-us-test-1a.masters.privatecilium.example.com"
-    "k8s.io/role/master"                              = "1"
-    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
-    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+    "KubernetesCluster"                                                            = "privatecilium.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.privatecilium.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/privatecilium.example.com"                              = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data")
 }
@@ -527,29 +569,35 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                               = "privatecilium.example.com"
-      "Name"                                            = "nodes.privatecilium.example.com"
-      "k8s.io/role/node"                                = "1"
-      "kops.k8s.io/instancegroup"                       = "nodes"
-      "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatecilium.example.com"
+      "Name"                                                                       = "nodes.privatecilium.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatecilium.example.com"                            = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                               = "privatecilium.example.com"
-      "Name"                                            = "nodes.privatecilium.example.com"
-      "k8s.io/role/node"                                = "1"
-      "kops.k8s.io/instancegroup"                       = "nodes"
-      "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatecilium.example.com"
+      "Name"                                                                       = "nodes.privatecilium.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatecilium.example.com"                            = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                               = "privatecilium.example.com"
-    "Name"                                            = "nodes.privatecilium.example.com"
-    "k8s.io/role/node"                                = "1"
-    "kops.k8s.io/instancegroup"                       = "nodes"
-    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privatecilium.example.com"
+    "Name"                                                                       = "nodes.privatecilium.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/privatecilium.example.com"                            = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privatecilium.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
@@ -34,6 +34,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "node",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/bastion",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -105,6 +115,16 @@
             "PropagateAtLaunch": true
           },
           {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "master",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+            "Value": "",
+            "PropagateAtLaunch": true
+          },
+          {
             "Key": "k8s.io/role/master",
             "Value": "1",
             "PropagateAtLaunch": true
@@ -173,6 +193,16 @@
           {
             "Key": "Name",
             "Value": "nodes.privateciliumadvanced.example.com",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+            "Value": "node",
+            "PropagateAtLaunch": true
+          },
+          {
+            "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+            "Value": "",
             "PropagateAtLaunch": true
           },
           {
@@ -318,6 +348,14 @@
                   "Value": "bastion.privateciliumadvanced.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/bastion",
                   "Value": "1"
                 },
@@ -341,6 +379,14 @@
                 {
                   "Key": "Name",
                   "Value": "bastion.privateciliumadvanced.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/bastion",
@@ -413,6 +459,14 @@
                   "Value": "master-us-test-1a.masters.privateciliumadvanced.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/master",
                   "Value": "1"
                 },
@@ -436,6 +490,14 @@
                 {
                   "Key": "Name",
                   "Value": "master-us-test-1a.masters.privateciliumadvanced.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "master"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/master",
@@ -504,6 +566,14 @@
                   "Value": "nodes.privateciliumadvanced.example.com"
                 },
                 {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
+                },
+                {
                   "Key": "k8s.io/role/node",
                   "Value": "1"
                 },
@@ -527,6 +597,14 @@
                 {
                   "Key": "Name",
                   "Value": "nodes.privateciliumadvanced.example.com"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role",
+                  "Value": "node"
+                },
+                {
+                  "Key": "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node",
+                  "Value": ""
                 },
                 {
                   "Key": "k8s.io/role/node",

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -141,6 +141,16 @@ resource "aws_autoscaling_group" "bastion-privateciliumadvanced-example-com" {
     value               = "bastion.privateciliumadvanced.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/bastion"
     propagate_at_launch = true
     value               = "1"
@@ -179,6 +189,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privateciliumadvance
     value               = "master-us-test-1a.masters.privateciliumadvanced.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -215,6 +235,16 @@ resource "aws_autoscaling_group" "nodes-privateciliumadvanced-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.privateciliumadvanced.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -430,29 +460,35 @@ resource "aws_launch_template" "bastion-privateciliumadvanced-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
-      "Name"                                                    = "bastion.privateciliumadvanced.example.com"
-      "k8s.io/role/bastion"                                     = "1"
-      "kops.k8s.io/instancegroup"                               = "bastion"
-      "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privateciliumadvanced.example.com"
+      "Name"                                                                       = "bastion.privateciliumadvanced.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privateciliumadvanced.example.com"                    = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
-      "Name"                                                    = "bastion.privateciliumadvanced.example.com"
-      "k8s.io/role/bastion"                                     = "1"
-      "kops.k8s.io/instancegroup"                               = "bastion"
-      "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privateciliumadvanced.example.com"
+      "Name"                                                                       = "bastion.privateciliumadvanced.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privateciliumadvanced.example.com"                    = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
-    "Name"                                                    = "bastion.privateciliumadvanced.example.com"
-    "k8s.io/role/bastion"                                     = "1"
-    "kops.k8s.io/instancegroup"                               = "bastion"
-    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privateciliumadvanced.example.com"
+    "Name"                                                                       = "bastion.privateciliumadvanced.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/bastion"                                                        = "1"
+    "kops.k8s.io/instancegroup"                                                  = "bastion"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com"                    = "owned"
   }
 }
 
@@ -487,29 +523,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateciliumadvanced-
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
-      "Name"                                                    = "master-us-test-1a.masters.privateciliumadvanced.example.com"
-      "k8s.io/role/master"                                      = "1"
-      "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
-      "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privateciliumadvanced.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privateciliumadvanced.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privateciliumadvanced.example.com"                      = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
-      "Name"                                                    = "master-us-test-1a.masters.privateciliumadvanced.example.com"
-      "k8s.io/role/master"                                      = "1"
-      "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
-      "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privateciliumadvanced.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privateciliumadvanced.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privateciliumadvanced.example.com"                      = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
-    "Name"                                                    = "master-us-test-1a.masters.privateciliumadvanced.example.com"
-    "k8s.io/role/master"                                      = "1"
-    "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
-    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+    "KubernetesCluster"                                                            = "privateciliumadvanced.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.privateciliumadvanced.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com"                      = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data")
 }
@@ -541,29 +583,35 @@ resource "aws_launch_template" "nodes-privateciliumadvanced-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
-      "Name"                                                    = "nodes.privateciliumadvanced.example.com"
-      "k8s.io/role/node"                                        = "1"
-      "kops.k8s.io/instancegroup"                               = "nodes"
-      "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privateciliumadvanced.example.com"
+      "Name"                                                                       = "nodes.privateciliumadvanced.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privateciliumadvanced.example.com"                    = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
-      "Name"                                                    = "nodes.privateciliumadvanced.example.com"
-      "k8s.io/role/node"                                        = "1"
-      "kops.k8s.io/instancegroup"                               = "nodes"
-      "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privateciliumadvanced.example.com"
+      "Name"                                                                       = "nodes.privateciliumadvanced.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privateciliumadvanced.example.com"                    = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
-    "Name"                                                    = "nodes.privateciliumadvanced.example.com"
-    "k8s.io/role/node"                                        = "1"
-    "kops.k8s.io/instancegroup"                               = "nodes"
-    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privateciliumadvanced.example.com"
+    "Name"                                                                       = "nodes.privateciliumadvanced.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com"                    = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -151,6 +151,16 @@ resource "aws_autoscaling_group" "bastion-privatedns1-example-com" {
     value               = "fib+baz"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/bastion"
     propagate_at_launch = true
     value               = "1"
@@ -199,6 +209,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatedns1-example-
     value               = "fib+baz"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -245,6 +265,16 @@ resource "aws_autoscaling_group" "nodes-privatedns1-example-com" {
     key                 = "foo/bar"
     propagate_at_launch = true
     value               = "fib+baz"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -460,35 +490,41 @@ resource "aws_launch_template" "bastion-privatedns1-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                             = "privatedns1.example.com"
-      "Name"                                          = "bastion.privatedns1.example.com"
-      "Owner"                                         = "John Doe"
-      "foo/bar"                                       = "fib+baz"
-      "k8s.io/role/bastion"                           = "1"
-      "kops.k8s.io/instancegroup"                     = "bastion"
-      "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatedns1.example.com"
+      "Name"                                                                       = "bastion.privatedns1.example.com"
+      "Owner"                                                                      = "John Doe"
+      "foo/bar"                                                                    = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privatedns1.example.com"                              = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                             = "privatedns1.example.com"
-      "Name"                                          = "bastion.privatedns1.example.com"
-      "Owner"                                         = "John Doe"
-      "foo/bar"                                       = "fib+baz"
-      "k8s.io/role/bastion"                           = "1"
-      "kops.k8s.io/instancegroup"                     = "bastion"
-      "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatedns1.example.com"
+      "Name"                                                                       = "bastion.privatedns1.example.com"
+      "Owner"                                                                      = "John Doe"
+      "foo/bar"                                                                    = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privatedns1.example.com"                              = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                             = "privatedns1.example.com"
-    "Name"                                          = "bastion.privatedns1.example.com"
-    "Owner"                                         = "John Doe"
-    "foo/bar"                                       = "fib+baz"
-    "k8s.io/role/bastion"                           = "1"
-    "kops.k8s.io/instancegroup"                     = "bastion"
-    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privatedns1.example.com"
+    "Name"                                                                       = "bastion.privatedns1.example.com"
+    "Owner"                                                                      = "John Doe"
+    "foo/bar"                                                                    = "fib+baz"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/bastion"                                                        = "1"
+    "kops.k8s.io/instancegroup"                                                  = "bastion"
+    "kubernetes.io/cluster/privatedns1.example.com"                              = "owned"
   }
 }
 
@@ -523,35 +559,41 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns1-example-co
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                             = "privatedns1.example.com"
-      "Name"                                          = "master-us-test-1a.masters.privatedns1.example.com"
-      "Owner"                                         = "John Doe"
-      "foo/bar"                                       = "fib+baz"
-      "k8s.io/role/master"                            = "1"
-      "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
-      "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privatedns1.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privatedns1.example.com"
+      "Owner"                                                                        = "John Doe"
+      "foo/bar"                                                                      = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privatedns1.example.com"                                = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                             = "privatedns1.example.com"
-      "Name"                                          = "master-us-test-1a.masters.privatedns1.example.com"
-      "Owner"                                         = "John Doe"
-      "foo/bar"                                       = "fib+baz"
-      "k8s.io/role/master"                            = "1"
-      "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
-      "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privatedns1.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privatedns1.example.com"
+      "Owner"                                                                        = "John Doe"
+      "foo/bar"                                                                      = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privatedns1.example.com"                                = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                             = "privatedns1.example.com"
-    "Name"                                          = "master-us-test-1a.masters.privatedns1.example.com"
-    "Owner"                                         = "John Doe"
-    "foo/bar"                                       = "fib+baz"
-    "k8s.io/role/master"                            = "1"
-    "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
-    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+    "KubernetesCluster"                                                            = "privatedns1.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.privatedns1.example.com"
+    "Owner"                                                                        = "John Doe"
+    "foo/bar"                                                                      = "fib+baz"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/privatedns1.example.com"                                = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data")
 }
@@ -583,35 +625,41 @@ resource "aws_launch_template" "nodes-privatedns1-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                             = "privatedns1.example.com"
-      "Name"                                          = "nodes.privatedns1.example.com"
-      "Owner"                                         = "John Doe"
-      "foo/bar"                                       = "fib+baz"
-      "k8s.io/role/node"                              = "1"
-      "kops.k8s.io/instancegroup"                     = "nodes"
-      "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatedns1.example.com"
+      "Name"                                                                       = "nodes.privatedns1.example.com"
+      "Owner"                                                                      = "John Doe"
+      "foo/bar"                                                                    = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatedns1.example.com"                              = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                             = "privatedns1.example.com"
-      "Name"                                          = "nodes.privatedns1.example.com"
-      "Owner"                                         = "John Doe"
-      "foo/bar"                                       = "fib+baz"
-      "k8s.io/role/node"                              = "1"
-      "kops.k8s.io/instancegroup"                     = "nodes"
-      "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatedns1.example.com"
+      "Name"                                                                       = "nodes.privatedns1.example.com"
+      "Owner"                                                                      = "John Doe"
+      "foo/bar"                                                                    = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatedns1.example.com"                              = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                             = "privatedns1.example.com"
-    "Name"                                          = "nodes.privatedns1.example.com"
-    "Owner"                                         = "John Doe"
-    "foo/bar"                                       = "fib+baz"
-    "k8s.io/role/node"                              = "1"
-    "kops.k8s.io/instancegroup"                     = "nodes"
-    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privatedns1.example.com"
+    "Name"                                                                       = "nodes.privatedns1.example.com"
+    "Owner"                                                                      = "John Doe"
+    "foo/bar"                                                                    = "fib+baz"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/privatedns1.example.com"                              = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privatedns1.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -136,6 +136,16 @@ resource "aws_autoscaling_group" "bastion-privatedns2-example-com" {
     value               = "bastion.privatedns2.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/bastion"
     propagate_at_launch = true
     value               = "1"
@@ -174,6 +184,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatedns2-example-
     value               = "master-us-test-1a.masters.privatedns2.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -210,6 +230,16 @@ resource "aws_autoscaling_group" "nodes-privatedns2-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.privatedns2.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -402,29 +432,35 @@ resource "aws_launch_template" "bastion-privatedns2-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                             = "privatedns2.example.com"
-      "Name"                                          = "bastion.privatedns2.example.com"
-      "k8s.io/role/bastion"                           = "1"
-      "kops.k8s.io/instancegroup"                     = "bastion"
-      "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatedns2.example.com"
+      "Name"                                                                       = "bastion.privatedns2.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privatedns2.example.com"                              = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                             = "privatedns2.example.com"
-      "Name"                                          = "bastion.privatedns2.example.com"
-      "k8s.io/role/bastion"                           = "1"
-      "kops.k8s.io/instancegroup"                     = "bastion"
-      "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatedns2.example.com"
+      "Name"                                                                       = "bastion.privatedns2.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privatedns2.example.com"                              = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                             = "privatedns2.example.com"
-    "Name"                                          = "bastion.privatedns2.example.com"
-    "k8s.io/role/bastion"                           = "1"
-    "kops.k8s.io/instancegroup"                     = "bastion"
-    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privatedns2.example.com"
+    "Name"                                                                       = "bastion.privatedns2.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/bastion"                                                        = "1"
+    "kops.k8s.io/instancegroup"                                                  = "bastion"
+    "kubernetes.io/cluster/privatedns2.example.com"                              = "owned"
   }
 }
 
@@ -459,29 +495,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns2-example-co
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                             = "privatedns2.example.com"
-      "Name"                                          = "master-us-test-1a.masters.privatedns2.example.com"
-      "k8s.io/role/master"                            = "1"
-      "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
-      "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privatedns2.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privatedns2.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privatedns2.example.com"                                = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                             = "privatedns2.example.com"
-      "Name"                                          = "master-us-test-1a.masters.privatedns2.example.com"
-      "k8s.io/role/master"                            = "1"
-      "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
-      "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privatedns2.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privatedns2.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privatedns2.example.com"                                = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                             = "privatedns2.example.com"
-    "Name"                                          = "master-us-test-1a.masters.privatedns2.example.com"
-    "k8s.io/role/master"                            = "1"
-    "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
-    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+    "KubernetesCluster"                                                            = "privatedns2.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.privatedns2.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/privatedns2.example.com"                                = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data")
 }
@@ -513,29 +555,35 @@ resource "aws_launch_template" "nodes-privatedns2-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                             = "privatedns2.example.com"
-      "Name"                                          = "nodes.privatedns2.example.com"
-      "k8s.io/role/node"                              = "1"
-      "kops.k8s.io/instancegroup"                     = "nodes"
-      "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatedns2.example.com"
+      "Name"                                                                       = "nodes.privatedns2.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatedns2.example.com"                              = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                             = "privatedns2.example.com"
-      "Name"                                          = "nodes.privatedns2.example.com"
-      "k8s.io/role/node"                              = "1"
-      "kops.k8s.io/instancegroup"                     = "nodes"
-      "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatedns2.example.com"
+      "Name"                                                                       = "nodes.privatedns2.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatedns2.example.com"                              = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                             = "privatedns2.example.com"
-    "Name"                                          = "nodes.privatedns2.example.com"
-    "k8s.io/role/node"                              = "1"
-    "kops.k8s.io/instancegroup"                     = "nodes"
-    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privatedns2.example.com"
+    "Name"                                                                       = "nodes.privatedns2.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/privatedns2.example.com"                              = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privatedns2.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -141,6 +141,16 @@ resource "aws_autoscaling_group" "bastion-privateflannel-example-com" {
     value               = "bastion.privateflannel.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/bastion"
     propagate_at_launch = true
     value               = "1"
@@ -179,6 +189,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privateflannel-examp
     value               = "master-us-test-1a.masters.privateflannel.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -215,6 +235,16 @@ resource "aws_autoscaling_group" "nodes-privateflannel-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.privateflannel.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -416,29 +446,35 @@ resource "aws_launch_template" "bastion-privateflannel-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                = "privateflannel.example.com"
-      "Name"                                             = "bastion.privateflannel.example.com"
-      "k8s.io/role/bastion"                              = "1"
-      "kops.k8s.io/instancegroup"                        = "bastion"
-      "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privateflannel.example.com"
+      "Name"                                                                       = "bastion.privateflannel.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privateflannel.example.com"                           = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                = "privateflannel.example.com"
-      "Name"                                             = "bastion.privateflannel.example.com"
-      "k8s.io/role/bastion"                              = "1"
-      "kops.k8s.io/instancegroup"                        = "bastion"
-      "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privateflannel.example.com"
+      "Name"                                                                       = "bastion.privateflannel.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privateflannel.example.com"                           = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                = "privateflannel.example.com"
-    "Name"                                             = "bastion.privateflannel.example.com"
-    "k8s.io/role/bastion"                              = "1"
-    "kops.k8s.io/instancegroup"                        = "bastion"
-    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privateflannel.example.com"
+    "Name"                                                                       = "bastion.privateflannel.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/bastion"                                                        = "1"
+    "kops.k8s.io/instancegroup"                                                  = "bastion"
+    "kubernetes.io/cluster/privateflannel.example.com"                           = "owned"
   }
 }
 
@@ -473,29 +509,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateflannel-example
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                = "privateflannel.example.com"
-      "Name"                                             = "master-us-test-1a.masters.privateflannel.example.com"
-      "k8s.io/role/master"                               = "1"
-      "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
-      "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privateflannel.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privateflannel.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privateflannel.example.com"                             = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                = "privateflannel.example.com"
-      "Name"                                             = "master-us-test-1a.masters.privateflannel.example.com"
-      "k8s.io/role/master"                               = "1"
-      "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
-      "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privateflannel.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privateflannel.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privateflannel.example.com"                             = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                = "privateflannel.example.com"
-    "Name"                                             = "master-us-test-1a.masters.privateflannel.example.com"
-    "k8s.io/role/master"                               = "1"
-    "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
-    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+    "KubernetesCluster"                                                            = "privateflannel.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.privateflannel.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/privateflannel.example.com"                             = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data")
 }
@@ -527,29 +569,35 @@ resource "aws_launch_template" "nodes-privateflannel-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                                = "privateflannel.example.com"
-      "Name"                                             = "nodes.privateflannel.example.com"
-      "k8s.io/role/node"                                 = "1"
-      "kops.k8s.io/instancegroup"                        = "nodes"
-      "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privateflannel.example.com"
+      "Name"                                                                       = "nodes.privateflannel.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privateflannel.example.com"                           = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                                = "privateflannel.example.com"
-      "Name"                                             = "nodes.privateflannel.example.com"
-      "k8s.io/role/node"                                 = "1"
-      "kops.k8s.io/instancegroup"                        = "nodes"
-      "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privateflannel.example.com"
+      "Name"                                                                       = "nodes.privateflannel.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privateflannel.example.com"                           = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                                = "privateflannel.example.com"
-    "Name"                                             = "nodes.privateflannel.example.com"
-    "k8s.io/role/node"                                 = "1"
-    "kops.k8s.io/instancegroup"                        = "nodes"
-    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privateflannel.example.com"
+    "Name"                                                                       = "nodes.privateflannel.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/privateflannel.example.com"                           = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privateflannel.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -156,6 +156,16 @@ resource "aws_autoscaling_group" "bastion-privatekopeio-example-com" {
     value               = "bastion.privatekopeio.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/bastion"
     propagate_at_launch = true
     value               = "1"
@@ -194,6 +204,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatekopeio-exampl
     value               = "master-us-test-1a.masters.privatekopeio.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -230,6 +250,16 @@ resource "aws_autoscaling_group" "nodes-privatekopeio-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.privatekopeio.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -422,29 +452,35 @@ resource "aws_launch_template" "bastion-privatekopeio-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                               = "privatekopeio.example.com"
-      "Name"                                            = "bastion.privatekopeio.example.com"
-      "k8s.io/role/bastion"                             = "1"
-      "kops.k8s.io/instancegroup"                       = "bastion"
-      "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatekopeio.example.com"
+      "Name"                                                                       = "bastion.privatekopeio.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privatekopeio.example.com"                            = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                               = "privatekopeio.example.com"
-      "Name"                                            = "bastion.privatekopeio.example.com"
-      "k8s.io/role/bastion"                             = "1"
-      "kops.k8s.io/instancegroup"                       = "bastion"
-      "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatekopeio.example.com"
+      "Name"                                                                       = "bastion.privatekopeio.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privatekopeio.example.com"                            = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                               = "privatekopeio.example.com"
-    "Name"                                            = "bastion.privatekopeio.example.com"
-    "k8s.io/role/bastion"                             = "1"
-    "kops.k8s.io/instancegroup"                       = "bastion"
-    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privatekopeio.example.com"
+    "Name"                                                                       = "bastion.privatekopeio.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/bastion"                                                        = "1"
+    "kops.k8s.io/instancegroup"                                                  = "bastion"
+    "kubernetes.io/cluster/privatekopeio.example.com"                            = "owned"
   }
 }
 
@@ -479,29 +515,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatekopeio-example-
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                               = "privatekopeio.example.com"
-      "Name"                                            = "master-us-test-1a.masters.privatekopeio.example.com"
-      "k8s.io/role/master"                              = "1"
-      "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
-      "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privatekopeio.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privatekopeio.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privatekopeio.example.com"                              = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                               = "privatekopeio.example.com"
-      "Name"                                            = "master-us-test-1a.masters.privatekopeio.example.com"
-      "k8s.io/role/master"                              = "1"
-      "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
-      "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privatekopeio.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privatekopeio.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privatekopeio.example.com"                              = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                               = "privatekopeio.example.com"
-    "Name"                                            = "master-us-test-1a.masters.privatekopeio.example.com"
-    "k8s.io/role/master"                              = "1"
-    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
-    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+    "KubernetesCluster"                                                            = "privatekopeio.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.privatekopeio.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/privatekopeio.example.com"                              = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data")
 }
@@ -533,29 +575,35 @@ resource "aws_launch_template" "nodes-privatekopeio-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                               = "privatekopeio.example.com"
-      "Name"                                            = "nodes.privatekopeio.example.com"
-      "k8s.io/role/node"                                = "1"
-      "kops.k8s.io/instancegroup"                       = "nodes"
-      "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatekopeio.example.com"
+      "Name"                                                                       = "nodes.privatekopeio.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatekopeio.example.com"                            = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                               = "privatekopeio.example.com"
-      "Name"                                            = "nodes.privatekopeio.example.com"
-      "k8s.io/role/node"                                = "1"
-      "kops.k8s.io/instancegroup"                       = "nodes"
-      "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privatekopeio.example.com"
+      "Name"                                                                       = "nodes.privatekopeio.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatekopeio.example.com"                            = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                               = "privatekopeio.example.com"
-    "Name"                                            = "nodes.privatekopeio.example.com"
-    "k8s.io/role/node"                                = "1"
-    "kops.k8s.io/instancegroup"                       = "nodes"
-    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privatekopeio.example.com"
+    "Name"                                                                       = "nodes.privatekopeio.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/privatekopeio.example.com"                            = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privatekopeio.example.com_user_data")
 }

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -141,6 +141,16 @@ resource "aws_autoscaling_group" "bastion-privateweave-example-com" {
     value               = "bastion.privateweave.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/bastion"
     propagate_at_launch = true
     value               = "1"
@@ -179,6 +189,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privateweave-example
     value               = "master-us-test-1a.masters.privateweave.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -215,6 +235,16 @@ resource "aws_autoscaling_group" "nodes-privateweave-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.privateweave.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -416,29 +446,35 @@ resource "aws_launch_template" "bastion-privateweave-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                              = "privateweave.example.com"
-      "Name"                                           = "bastion.privateweave.example.com"
-      "k8s.io/role/bastion"                            = "1"
-      "kops.k8s.io/instancegroup"                      = "bastion"
-      "kubernetes.io/cluster/privateweave.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privateweave.example.com"
+      "Name"                                                                       = "bastion.privateweave.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privateweave.example.com"                             = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                              = "privateweave.example.com"
-      "Name"                                           = "bastion.privateweave.example.com"
-      "k8s.io/role/bastion"                            = "1"
-      "kops.k8s.io/instancegroup"                      = "bastion"
-      "kubernetes.io/cluster/privateweave.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privateweave.example.com"
+      "Name"                                                                       = "bastion.privateweave.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/privateweave.example.com"                             = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                              = "privateweave.example.com"
-    "Name"                                           = "bastion.privateweave.example.com"
-    "k8s.io/role/bastion"                            = "1"
-    "kops.k8s.io/instancegroup"                      = "bastion"
-    "kubernetes.io/cluster/privateweave.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privateweave.example.com"
+    "Name"                                                                       = "bastion.privateweave.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/bastion"                                                        = "1"
+    "kops.k8s.io/instancegroup"                                                  = "bastion"
+    "kubernetes.io/cluster/privateweave.example.com"                             = "owned"
   }
 }
 
@@ -473,29 +509,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateweave-example-c
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                              = "privateweave.example.com"
-      "Name"                                           = "master-us-test-1a.masters.privateweave.example.com"
-      "k8s.io/role/master"                             = "1"
-      "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
-      "kubernetes.io/cluster/privateweave.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privateweave.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privateweave.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privateweave.example.com"                               = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                              = "privateweave.example.com"
-      "Name"                                           = "master-us-test-1a.masters.privateweave.example.com"
-      "k8s.io/role/master"                             = "1"
-      "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
-      "kubernetes.io/cluster/privateweave.example.com" = "owned"
+      "KubernetesCluster"                                                            = "privateweave.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.privateweave.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/privateweave.example.com"                               = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                              = "privateweave.example.com"
-    "Name"                                           = "master-us-test-1a.masters.privateweave.example.com"
-    "k8s.io/role/master"                             = "1"
-    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
-    "kubernetes.io/cluster/privateweave.example.com" = "owned"
+    "KubernetesCluster"                                                            = "privateweave.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.privateweave.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/privateweave.example.com"                               = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.privateweave.example.com_user_data")
 }
@@ -527,29 +569,35 @@ resource "aws_launch_template" "nodes-privateweave-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                              = "privateweave.example.com"
-      "Name"                                           = "nodes.privateweave.example.com"
-      "k8s.io/role/node"                               = "1"
-      "kops.k8s.io/instancegroup"                      = "nodes"
-      "kubernetes.io/cluster/privateweave.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privateweave.example.com"
+      "Name"                                                                       = "nodes.privateweave.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privateweave.example.com"                             = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                              = "privateweave.example.com"
-      "Name"                                           = "nodes.privateweave.example.com"
-      "k8s.io/role/node"                               = "1"
-      "kops.k8s.io/instancegroup"                      = "nodes"
-      "kubernetes.io/cluster/privateweave.example.com" = "owned"
+      "KubernetesCluster"                                                          = "privateweave.example.com"
+      "Name"                                                                       = "nodes.privateweave.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privateweave.example.com"                             = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                              = "privateweave.example.com"
-    "Name"                                           = "nodes.privateweave.example.com"
-    "k8s.io/role/node"                               = "1"
-    "kops.k8s.io/instancegroup"                      = "nodes"
-    "kubernetes.io/cluster/privateweave.example.com" = "owned"
+    "KubernetesCluster"                                                          = "privateweave.example.com"
+    "Name"                                                                       = "nodes.privateweave.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/privateweave.example.com"                             = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privateweave.example.com_user_data")
 }

--- a/tests/integration/update_cluster/public-jwks/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks/kubernetes.tf
@@ -111,6 +111,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com"
     value               = "master-us-test-1a.masters.minimal.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -147,6 +157,16 @@ resource "aws_autoscaling_group" "nodes-minimal-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.minimal.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -293,29 +313,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                         = "minimal.example.com"
-      "Name"                                      = "master-us-test-1a.masters.minimal.example.com"
-      "k8s.io/role/master"                        = "1"
-      "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
-      "kubernetes.io/cluster/minimal.example.com" = "owned"
+      "KubernetesCluster"                                                            = "minimal.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.minimal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                    = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                         = "minimal.example.com"
-      "Name"                                      = "master-us-test-1a.masters.minimal.example.com"
-      "k8s.io/role/master"                        = "1"
-      "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
-      "kubernetes.io/cluster/minimal.example.com" = "owned"
+      "KubernetesCluster"                                                            = "minimal.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.minimal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                    = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "master-us-test-1a.masters.minimal.example.com"
-    "k8s.io/role/master"                        = "1"
-    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
+    "KubernetesCluster"                                                            = "minimal.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.minimal.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/minimal.example.com"                                    = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data")
 }
@@ -347,29 +373,35 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                         = "minimal.example.com"
-      "Name"                                      = "nodes.minimal.example.com"
-      "k8s.io/role/node"                          = "1"
-      "kops.k8s.io/instancegroup"                 = "nodes"
-      "kubernetes.io/cluster/minimal.example.com" = "owned"
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                         = "minimal.example.com"
-      "Name"                                      = "nodes.minimal.example.com"
-      "k8s.io/role/node"                          = "1"
-      "kops.k8s.io/instancegroup"                 = "nodes"
-      "kubernetes.io/cluster/minimal.example.com" = "owned"
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "nodes.minimal.example.com"
-    "k8s.io/role/node"                          = "1"
-    "kops.k8s.io/instancegroup"                 = "nodes"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
+    "KubernetesCluster"                                                          = "minimal.example.com"
+    "Name"                                                                       = "nodes.minimal.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.minimal.example.com_user_data")
 }

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -96,6 +96,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-sharedsubnet-example
     value               = "master-us-test-1a.masters.sharedsubnet.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -132,6 +142,16 @@ resource "aws_autoscaling_group" "nodes-sharedsubnet-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.sharedsubnet.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -252,29 +272,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedsubnet-example-c
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                              = "sharedsubnet.example.com"
-      "Name"                                           = "master-us-test-1a.masters.sharedsubnet.example.com"
-      "k8s.io/role/master"                             = "1"
-      "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
-      "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
+      "KubernetesCluster"                                                            = "sharedsubnet.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.sharedsubnet.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/sharedsubnet.example.com"                               = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                              = "sharedsubnet.example.com"
-      "Name"                                           = "master-us-test-1a.masters.sharedsubnet.example.com"
-      "k8s.io/role/master"                             = "1"
-      "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
-      "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
+      "KubernetesCluster"                                                            = "sharedsubnet.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.sharedsubnet.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/sharedsubnet.example.com"                               = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                              = "sharedsubnet.example.com"
-    "Name"                                           = "master-us-test-1a.masters.sharedsubnet.example.com"
-    "k8s.io/role/master"                             = "1"
-    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
-    "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
+    "KubernetesCluster"                                                            = "sharedsubnet.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.sharedsubnet.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/sharedsubnet.example.com"                               = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data")
 }
@@ -306,29 +332,35 @@ resource "aws_launch_template" "nodes-sharedsubnet-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                              = "sharedsubnet.example.com"
-      "Name"                                           = "nodes.sharedsubnet.example.com"
-      "k8s.io/role/node"                               = "1"
-      "kops.k8s.io/instancegroup"                      = "nodes"
-      "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
+      "KubernetesCluster"                                                          = "sharedsubnet.example.com"
+      "Name"                                                                       = "nodes.sharedsubnet.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/sharedsubnet.example.com"                             = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                              = "sharedsubnet.example.com"
-      "Name"                                           = "nodes.sharedsubnet.example.com"
-      "k8s.io/role/node"                               = "1"
-      "kops.k8s.io/instancegroup"                      = "nodes"
-      "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
+      "KubernetesCluster"                                                          = "sharedsubnet.example.com"
+      "Name"                                                                       = "nodes.sharedsubnet.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/sharedsubnet.example.com"                             = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                              = "sharedsubnet.example.com"
-    "Name"                                           = "nodes.sharedsubnet.example.com"
-    "k8s.io/role/node"                               = "1"
-    "kops.k8s.io/instancegroup"                      = "nodes"
-    "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
+    "KubernetesCluster"                                                          = "sharedsubnet.example.com"
+    "Name"                                                                       = "nodes.sharedsubnet.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/sharedsubnet.example.com"                             = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data")
 }

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -96,6 +96,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-sharedvpc-example-co
     value               = "master-us-test-1a.masters.sharedvpc.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -132,6 +142,16 @@ resource "aws_autoscaling_group" "nodes-sharedvpc-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.sharedvpc.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -252,29 +272,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedvpc-example-com"
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                           = "sharedvpc.example.com"
-      "Name"                                        = "master-us-test-1a.masters.sharedvpc.example.com"
-      "k8s.io/role/master"                          = "1"
-      "kops.k8s.io/instancegroup"                   = "master-us-test-1a"
-      "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
+      "KubernetesCluster"                                                            = "sharedvpc.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.sharedvpc.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/sharedvpc.example.com"                                  = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                           = "sharedvpc.example.com"
-      "Name"                                        = "master-us-test-1a.masters.sharedvpc.example.com"
-      "k8s.io/role/master"                          = "1"
-      "kops.k8s.io/instancegroup"                   = "master-us-test-1a"
-      "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
+      "KubernetesCluster"                                                            = "sharedvpc.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.sharedvpc.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/sharedvpc.example.com"                                  = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                           = "sharedvpc.example.com"
-    "Name"                                        = "master-us-test-1a.masters.sharedvpc.example.com"
-    "k8s.io/role/master"                          = "1"
-    "kops.k8s.io/instancegroup"                   = "master-us-test-1a"
-    "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
+    "KubernetesCluster"                                                            = "sharedvpc.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.sharedvpc.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/sharedvpc.example.com"                                  = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data")
 }
@@ -306,29 +332,35 @@ resource "aws_launch_template" "nodes-sharedvpc-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                           = "sharedvpc.example.com"
-      "Name"                                        = "nodes.sharedvpc.example.com"
-      "k8s.io/role/node"                            = "1"
-      "kops.k8s.io/instancegroup"                   = "nodes"
-      "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
+      "KubernetesCluster"                                                          = "sharedvpc.example.com"
+      "Name"                                                                       = "nodes.sharedvpc.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/sharedvpc.example.com"                                = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                           = "sharedvpc.example.com"
-      "Name"                                        = "nodes.sharedvpc.example.com"
-      "k8s.io/role/node"                            = "1"
-      "kops.k8s.io/instancegroup"                   = "nodes"
-      "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
+      "KubernetesCluster"                                                          = "sharedvpc.example.com"
+      "Name"                                                                       = "nodes.sharedvpc.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/sharedvpc.example.com"                                = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                           = "sharedvpc.example.com"
-    "Name"                                        = "nodes.sharedvpc.example.com"
-    "k8s.io/role/node"                            = "1"
-    "kops.k8s.io/instancegroup"                   = "nodes"
-    "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
+    "KubernetesCluster"                                                          = "sharedvpc.example.com"
+    "Name"                                                                       = "nodes.sharedvpc.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/sharedvpc.example.com"                                = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.sharedvpc.example.com_user_data")
 }

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -136,6 +136,16 @@ resource "aws_autoscaling_group" "bastion-unmanaged-example-com" {
     value               = "bastion.unmanaged.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/bastion"
     propagate_at_launch = true
     value               = "1"
@@ -174,6 +184,16 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-unmanaged-example-co
     value               = "master-us-test-1a.masters.unmanaged.example.com"
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "master"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/role/master"
     propagate_at_launch = true
     value               = "1"
@@ -210,6 +230,16 @@ resource "aws_autoscaling_group" "nodes-unmanaged-example-com" {
     key                 = "Name"
     propagate_at_launch = true
     value               = "nodes.unmanaged.example.com"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
+    propagate_at_launch = true
+    value               = "node"
+  }
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
+    propagate_at_launch = true
+    value               = ""
   }
   tag {
     key                 = "k8s.io/role/node"
@@ -393,29 +423,35 @@ resource "aws_launch_template" "bastion-unmanaged-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                           = "unmanaged.example.com"
-      "Name"                                        = "bastion.unmanaged.example.com"
-      "k8s.io/role/bastion"                         = "1"
-      "kops.k8s.io/instancegroup"                   = "bastion"
-      "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+      "KubernetesCluster"                                                          = "unmanaged.example.com"
+      "Name"                                                                       = "bastion.unmanaged.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/unmanaged.example.com"                                = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                           = "unmanaged.example.com"
-      "Name"                                        = "bastion.unmanaged.example.com"
-      "k8s.io/role/bastion"                         = "1"
-      "kops.k8s.io/instancegroup"                   = "bastion"
-      "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+      "KubernetesCluster"                                                          = "unmanaged.example.com"
+      "Name"                                                                       = "bastion.unmanaged.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/bastion"                                                        = "1"
+      "kops.k8s.io/instancegroup"                                                  = "bastion"
+      "kubernetes.io/cluster/unmanaged.example.com"                                = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                           = "unmanaged.example.com"
-    "Name"                                        = "bastion.unmanaged.example.com"
-    "k8s.io/role/bastion"                         = "1"
-    "kops.k8s.io/instancegroup"                   = "bastion"
-    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+    "KubernetesCluster"                                                          = "unmanaged.example.com"
+    "Name"                                                                       = "bastion.unmanaged.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/bastion"                                                        = "1"
+    "kops.k8s.io/instancegroup"                                                  = "bastion"
+    "kubernetes.io/cluster/unmanaged.example.com"                                = "owned"
   }
 }
 
@@ -450,29 +486,35 @@ resource "aws_launch_template" "master-us-test-1a-masters-unmanaged-example-com"
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                           = "unmanaged.example.com"
-      "Name"                                        = "master-us-test-1a.masters.unmanaged.example.com"
-      "k8s.io/role/master"                          = "1"
-      "kops.k8s.io/instancegroup"                   = "master-us-test-1a"
-      "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+      "KubernetesCluster"                                                            = "unmanaged.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.unmanaged.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/unmanaged.example.com"                                  = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                           = "unmanaged.example.com"
-      "Name"                                        = "master-us-test-1a.masters.unmanaged.example.com"
-      "k8s.io/role/master"                          = "1"
-      "kops.k8s.io/instancegroup"                   = "master-us-test-1a"
-      "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+      "KubernetesCluster"                                                            = "unmanaged.example.com"
+      "Name"                                                                         = "master-us-test-1a.masters.unmanaged.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+      "k8s.io/role/master"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+      "kubernetes.io/cluster/unmanaged.example.com"                                  = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                           = "unmanaged.example.com"
-    "Name"                                        = "master-us-test-1a.masters.unmanaged.example.com"
-    "k8s.io/role/master"                          = "1"
-    "kops.k8s.io/instancegroup"                   = "master-us-test-1a"
-    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+    "KubernetesCluster"                                                            = "unmanaged.example.com"
+    "Name"                                                                         = "master-us-test-1a.masters.unmanaged.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"             = "master"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master" = ""
+    "k8s.io/role/master"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                    = "master-us-test-1a"
+    "kubernetes.io/cluster/unmanaged.example.com"                                  = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data")
 }
@@ -504,29 +546,35 @@ resource "aws_launch_template" "nodes-unmanaged-example-com" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "KubernetesCluster"                           = "unmanaged.example.com"
-      "Name"                                        = "nodes.unmanaged.example.com"
-      "k8s.io/role/node"                            = "1"
-      "kops.k8s.io/instancegroup"                   = "nodes"
-      "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+      "KubernetesCluster"                                                          = "unmanaged.example.com"
+      "Name"                                                                       = "nodes.unmanaged.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/unmanaged.example.com"                                = "owned"
     }
   }
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "KubernetesCluster"                           = "unmanaged.example.com"
-      "Name"                                        = "nodes.unmanaged.example.com"
-      "k8s.io/role/node"                            = "1"
-      "kops.k8s.io/instancegroup"                   = "nodes"
-      "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+      "KubernetesCluster"                                                          = "unmanaged.example.com"
+      "Name"                                                                       = "nodes.unmanaged.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/unmanaged.example.com"                                = "owned"
     }
   }
   tags = {
-    "KubernetesCluster"                           = "unmanaged.example.com"
-    "Name"                                        = "nodes.unmanaged.example.com"
-    "k8s.io/role/node"                            = "1"
-    "kops.k8s.io/instancegroup"                   = "nodes"
-    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+    "KubernetesCluster"                                                          = "unmanaged.example.com"
+    "Name"                                                                       = "nodes.unmanaged.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+    "k8s.io/role/node"                                                           = "1"
+    "kops.k8s.io/instancegroup"                                                  = "nodes"
+    "kubernetes.io/cluster/unmanaged.example.com"                                = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.unmanaged.example.com_user_data")
 }


### PR DESCRIPTION
Cherry pick of #9575 on release-1.19.

#9575: Rename NodeReconciler to LegacyNodeReconciler

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.