### PR TITLE
Remove hack/workaround from etcd-manager certificate expiration advisory

### DIFF
--- a/docs/advisories/etcd-manager-certificate-expiration.md
+++ b/docs/advisories/etcd-manager-certificate-expiration.md
@@ -39,7 +39,7 @@ We have two suggested workflows to upgrade etcd-manager in your cluster. While b
    Follow the normal steps when upgrading Kops and confirm the etcd-manager image will be updated based on the output of `kops update cluster`.
    ```
    kops update cluster --yes
-   kops rolling-update cluster --instance-group-roles=Master
+   kops rolling-update cluster --instance-group-roles=Master --cloudonly
    ```
 2. Another solution is to override the etcd-manager image in the ClusterSpec.
    The image will be set in two places, one for each etcdCluster (main and events).
@@ -48,23 +48,5 @@ We have two suggested workflows to upgrade etcd-manager in your cluster. While b
    # Set `spec.etcdClusters[*].manager.image` to `kopeio/etcd-manager:3.0.20200428`
    kops update cluster # confirm the image is being updated
    kops update cluster --yes
-   kops rolling-update cluster --instance-group-roles=Master --force
+   kops rolling-update cluster --instance-group-roles=Master --force --cloudonly
    ```
-
-## Hack/Workaround
-
-**This will not prevent the issue from occurring again, only reset the 1 year expiration.**
-
-A rolling-update of the master nodes can be avoided by manually deleting the certificates to force them to be recreated.
-Perform these steps on each master instance at a time.
-
-1. SSH into the instance and delete the pki directory from each volume mount.
-   ```
-   # Mount paths may vary between cloud providers and OS distributions
-   sudo rm -rf /mnt/master-vol-*/pki
-   ```
-2. Restart the two etcd-manager containers. Alternatively you can reboot the instance or terminate the instance in the autoscaling group.
-   ```
-   sudo docker restart $(sudo docker ps -q -f "label=io.kubernetes.container.name=etcd-manager")
-   ```
-   When the container restarts, etcd-manager will reissue the certs and rejoin the etcd cluster. etcd membership can be confirmed with `etcdctl endpoint status` by following the instructions in the [docs](https://kops.sigs.k8s.io/operations/etcd_administration/#direct-data-access).


### PR DESCRIPTION
The hack/workaround works only on some versions so best not to have it at all. Also, I think `--cloudonly` is needed for the rolling-update to work.
We could add some hack/workaround in the issue, if we want to share the link with someone in Slack at some point.

https://deploy-preview-10102--kubernetes-kops.netlify.app/advisories/etcd-manager-certificate-expiration/#solution

/cc @rifelpet @olemarkus 