### PR TITLE
Default to exporting a kubecfg, even without credentials

### DIFF
--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -27,7 +27,7 @@ kops update cluster [flags]
 ```
       --admin duration[=18h0m0s]      Also export a cluster admin user credential with the specified lifetime and add it to the cluster context
       --allow-kops-downgrade          Allow an older version of kops to update the cluster than last used
-      --create-kube-config            Will control automatically creating the kube config file on your local filesystem
+      --create-kube-config            Will control automatically creating the kube config file on your local filesystem (default true)
   -h, --help                          help for cluster
       --internal                      Use the cluster's internal DNS name. Implies --create-kube-config
       --lifecycle-overrides strings   comma separated list of phase overrides, example: SecurityGroups=Ignore,InternetGateway=ExistsAndWarnIfChanges


### PR DESCRIPTION
We do log a hint for the user when we have exported an empty kubecfg,
but this now supports the "current cluster" UX.

Issue #9990