### PR TITLE
Remove dependency of TerraformJSON feature flag

### DIFF
--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -194,9 +194,9 @@ func TestBastionAdditionalUserData(t *testing.T) {
 
 // TestMinimalJSON runs the test on a minimal data set and outputs JSON
 func TestMinimalJSON(t *testing.T) {
-	featureflag.ParseFlags("+TerraformJSON,-Terraform-0.12")
+	featureflag.ParseFlags("+TerraformJSON")
 	unsetFeaureFlag := func() {
-		featureflag.ParseFlags("-TerraformJSON,+Terraform-0.12")
+		featureflag.ParseFlags("-TerraformJSON")
 	}
 	defer unsetFeaureFlag()
 	newIntegrationTest("minimal-json.example.com", "minimal-json").withJSONOutput().runTestTerraformAWS(t)

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -724,7 +724,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 		checkExisting = false
 		outDir := c.OutDir
 		tfVersion := terraform.Version011
-		if featureflag.Terraform012.Enabled() {
+		if featureflag.Terraform012.Enabled() && !featureflag.TerraformJSON.Enabled() {
 			tfVersion = terraform.Version012
 		}
 		tf := terraform.NewTerraformTarget(cloud, region, project, outDir, tfVersion, cluster.Spec.Target)

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -216,7 +216,7 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 			return err
 		}
 		if d != nil {
-			if featureflag.Terraform012.Enabled() {
+			if featureflag.Terraform012.Enabled() && !featureflag.TerraformJSON.Enabled() {
 				userDataResource := fi.WrapResource(fi.NewBytesResource(d))
 
 				tf.UserData, err = target.AddFile("aws_launch_template", fi.StringValue(e.Name), "user_data", userDataResource, true)


### PR DESCRIPTION
Makes the `TerraformJSON` flag not depend on disabling the `Terraform-0.12` flag.

Suitable for backport to 1.19 branch.