### PR TITLE
Add nodeLocalDNSCache.kubeDnsOnly option

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -603,6 +603,8 @@ NodeLocal DNSCache can be enabled if you are using CoreDNS. It is used to improv
 
 `memoryRequest` and `cpuRequest` for the `node-local-dns` pods can also be configured. If not set, they will be configured by default to `5Mi` and `25m` respectively.
 
+If `forwardToKubeDNS` is enabled, kubedns will be used as a default upstream
+
 ```yaml
 spec:
   kubeDNS:

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1358,6 +1358,9 @@ spec:
                       enabled:
                         description: Enabled activates the node-local-dns addon
                         type: boolean
+                      forwardToKubeDNS:
+                        description: If enabled, nodelocal dns will use kubedns as a default upstream
+                        type: boolean
                       localIP:
                         description: Local listen IP address. It can be any IP in the 169.254.20.0/16 space or any other IP address that can be guaranteed to not collide with any existing IP.
                         type: string

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -418,6 +418,8 @@ type NodeLocalDNSConfig struct {
 	Enabled *bool `json:"enabled,omitempty"`
 	// Local listen IP address. It can be any IP in the 169.254.20.0/16 space or any other IP address that can be guaranteed to not collide with any existing IP.
 	LocalIP string `json:"localIP,omitempty"`
+	// If enabled, nodelocal dns will use kubedns as a default upstream
+	ForwardToKubeDNS *bool `json:"forwardToKubeDNS,omitempty"`
 	// MemoryRequest specifies the memory requests of each node-local-dns container in the daemonset. Default 5Mi.
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
 	// CPURequest specifies the cpu requests of each node-local-dns container in the daemonset. Default 25m.

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -420,6 +420,8 @@ type NodeLocalDNSConfig struct {
 	Enabled *bool `json:"enabled,omitempty"`
 	// Local listen IP address. It can be any IP in the 169.254.20.0/16 space or any other IP address that can be guaranteed to not collide with any existing IP.
 	LocalIP string `json:"localIP,omitempty"`
+	// If enabled, nodelocal dns will use kubedns as a default upstream
+	ForwardToKubeDNS *bool `json:"forwardToKubeDNS,omitempty"`
 	// MemoryRequest specifies the memory requests of each node-local-dns container in the daemonset. Default 5Mi.
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
 	// CPURequest specifies the cpu requests of each node-local-dns container in the daemonset. Default 25m.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5137,6 +5137,7 @@ func Convert_kops_NodeAuthorizerSpec_To_v1alpha2_NodeAuthorizerSpec(in *kops.Nod
 func autoConvert_v1alpha2_NodeLocalDNSConfig_To_kops_NodeLocalDNSConfig(in *NodeLocalDNSConfig, out *kops.NodeLocalDNSConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
 	out.LocalIP = in.LocalIP
+	out.ForwardToKubeDNS = in.ForwardToKubeDNS
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	return nil
@@ -5150,6 +5151,7 @@ func Convert_v1alpha2_NodeLocalDNSConfig_To_kops_NodeLocalDNSConfig(in *NodeLoca
 func autoConvert_kops_NodeLocalDNSConfig_To_v1alpha2_NodeLocalDNSConfig(in *kops.NodeLocalDNSConfig, out *NodeLocalDNSConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
 	out.LocalIP = in.LocalIP
+	out.ForwardToKubeDNS = in.ForwardToKubeDNS
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	return nil

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3407,6 +3407,11 @@ func (in *NodeLocalDNSConfig) DeepCopyInto(out *NodeLocalDNSConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ForwardToKubeDNS != nil {
+		in, out := &in.ForwardToKubeDNS, &out.ForwardToKubeDNS
+		*out = new(bool)
+		**out = **in
+	}
 	if in.MemoryRequest != nil {
 		in, out := &in.MemoryRequest, &out.MemoryRequest
 		x := (*in).DeepCopy()

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3605,6 +3605,11 @@ func (in *NodeLocalDNSConfig) DeepCopyInto(out *NodeLocalDNSConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ForwardToKubeDNS != nil {
+		in, out := &in.ForwardToKubeDNS, &out.ForwardToKubeDNS
+		*out = new(bool)
+		**out = **in
+	}
 	if in.MemoryRequest != nil {
 		in, out := &in.MemoryRequest, &out.MemoryRequest
 		x := (*in).DeepCopy()

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -86,6 +86,9 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 	if fi.BoolValue(nodeLocalDNS.Enabled) && nodeLocalDNS.LocalIP == "" {
 		nodeLocalDNS.LocalIP = "169.254.20.10"
 	}
+	if fi.BoolValue(nodeLocalDNS.Enabled) && nodeLocalDNS.ForwardToKubeDNS == nil {
+		nodeLocalDNS.ForwardToKubeDNS = fi.Bool(false)
+	}
 
 	if nodeLocalDNS.MemoryRequest == nil || nodeLocalDNS.MemoryRequest.IsZero() {
 		defaultMemoryRequest := resource.MustParse("5Mi")

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -19165,6 +19165,19 @@ data:
         prometheus :9253
         health {{ KubeDNS.NodeLocalDNS.LocalIP }}:{{ NodeLocalDNSHealthCheck }}
     }
+    {{- if KubeDNS.NodeLocalDNS.ForwardToKubeDNS }}
+    .:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}
+        forward . {{ NodeLocalDNSClusterIP }} {
+          force_tcp
+        }
+        prometheus :9253
+    }
+    {{- else }}
     in-addr.arpa:53 {
         errors
         cache 30
@@ -19196,6 +19209,7 @@ data:
         forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
     }
+    {{- end }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -19285,7 +19299,8 @@ spec:
           name: node-local-dns
           items:
             - key: Corefile
-              path: Corefile.base`)
+              path: Corefile.base
+`)
 
 func cloudupResourcesAddonsNodelocaldnsAddonsK8sIoK8s112YamlTemplateBytes() ([]byte, error) {
 	return _cloudupResourcesAddonsNodelocaldnsAddonsK8sIoK8s112YamlTemplate, nil

--- a/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
@@ -57,6 +57,19 @@ data:
         prometheus :9253
         health {{ KubeDNS.NodeLocalDNS.LocalIP }}:{{ NodeLocalDNSHealthCheck }}
     }
+    {{- if KubeDNS.NodeLocalDNS.ForwardToKubeDNS }}
+    .:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}
+        forward . {{ NodeLocalDNSClusterIP }} {
+          force_tcp
+        }
+        prometheus :9253
+    }
+    {{- else }}
     in-addr.arpa:53 {
         errors
         cache 30
@@ -88,6 +101,7 @@ data:
         forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
     }
+    {{- end }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
## Add a kubeDnsOnly option for nodeLocalDNScache

Add ability to use kube-dns as upstream on node-local-dns, instead of using systems default in resolv.conf

With this flag enabled, even if we use the node-local-dns to cache responses, we use as upstream the main kube-dns server for all types of requests, and not only the ones of *.cluster.local

This way we can customize the main kube-dns for external domains and make this changes also effective to the node-local-dns nodes

### Example use case
In our case, we're using rewrites on coredns to easily route some requests to internal services without exiting the cluster, and without modifying the application. With this flag we can keep this behaviour and still use node-local-dns:

```
rewrite name exact queue.myapp.com queue-system.myapp.svc.cluster.local
```

A dns request of `queue.myapp.com` to coredns will return the internal IP address of the service `queue-system` in `myapp` namespace

So far when enabling node-local-dns in kops this behaviour dissapeared and `queue.myapp.com` was resolving to an external internet IP address.
With this patch we can decide if to route all traffic to internal kube-dns, or keep the actual behaviour