### PR TITLE
Update Calico config for eBPF mode

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2144,6 +2144,9 @@ spec:
                       bpfExternalServiceMode:
                         description: 'BPFExternalServiceMode controls how traffic from outside the cluster to NodePorts and ClusterIPs is handled. In Tunnel mode, packet is tunneled from the ingress host to the host with the backing pod and back again. In DSR mode, traffic is tunneled to the host with the backing pod and then returned directly; this requires a network that allows direct return. Default: Tunnel (other options: DSR)'
                         type: string
+                      bpfKubeProxyIptablesCleanupEnabled:
+                        description: BPFKubeProxyIptablesCleanupEnabled controls whether Felix will clean up the iptables rules created by the Kubernetes kube-proxy; should only be enabled if kube-proxy is not running.
+                        type: boolean
                       bpfLogLevel:
                         description: 'BPFLogLevel controls the log level used by the BPF programs. The logs are emitted to the BPF trace pipe, accessible with the command tc exec BPF debug. Default: Off (other options: Info, Debug)'
                         type: string

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -108,6 +108,9 @@ type CalicoNetworkingSpec struct {
 	// this requires a network that allows direct return.
 	// Default: Tunnel (other options: DSR)
 	BPFExternalServiceMode string `json:"bpfExternalServiceMode,omitempty"`
+	// BPFKubeProxyIptablesCleanupEnabled controls whether Felix will clean up the iptables rules
+	// created by the Kubernetes kube-proxy; should only be enabled if kube-proxy is not running.
+	BPFKubeProxyIptablesCleanupEnabled bool `json:"bpfKubeProxyIptablesCleanupEnabled,omitempty"`
 	// BPFLogLevel controls the log level used by the BPF programs. The logs are emitted
 	// to the BPF trace pipe, accessible with the command tc exec BPF debug.
 	// Default: Off (other options: Info, Debug)

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -108,6 +108,9 @@ type CalicoNetworkingSpec struct {
 	// this requires a network that allows direct return.
 	// Default: Tunnel (other options: DSR)
 	BPFExternalServiceMode string `json:"bpfExternalServiceMode,omitempty"`
+	// BPFKubeProxyIptablesCleanupEnabled controls whether Felix will clean up the iptables rules
+	// created by the Kubernetes kube-proxy; should only be enabled if kube-proxy is not running.
+	BPFKubeProxyIptablesCleanupEnabled bool `json:"bpfKubeProxyIptablesCleanupEnabled,omitempty"`
 	// BPFLogLevel controls the log level used by the BPF programs. The logs are emitted
 	// to the BPF trace pipe, accessible with the command tc exec BPF debug.
 	// Default: Off (other options: Info, Debug)

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1327,6 +1327,7 @@ func Convert_kops_CNINetworkingSpec_To_v1alpha2_CNINetworkingSpec(in *kops.CNINe
 func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *CalicoNetworkingSpec, out *kops.CalicoNetworkingSpec, s conversion.Scope) error {
 	out.BPFEnabled = in.BPFEnabled
 	out.BPFExternalServiceMode = in.BPFExternalServiceMode
+	out.BPFKubeProxyIptablesCleanupEnabled = in.BPFKubeProxyIptablesCleanupEnabled
 	out.BPFLogLevel = in.BPFLogLevel
 	out.ChainInsertMode = in.ChainInsertMode
 	out.CPURequest = in.CPURequest
@@ -1358,6 +1359,7 @@ func Convert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *Cali
 func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *kops.CalicoNetworkingSpec, out *CalicoNetworkingSpec, s conversion.Scope) error {
 	out.BPFEnabled = in.BPFEnabled
 	out.BPFExternalServiceMode = in.BPFExternalServiceMode
+	out.BPFKubeProxyIptablesCleanupEnabled = in.BPFKubeProxyIptablesCleanupEnabled
 	out.BPFLogLevel = in.BPFLogLevel
 	out.ChainInsertMode = in.ChainInsertMode
 	out.CPURequest = in.CPURequest

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3939,6 +3939,9 @@ spec:
             # Controls how traffic from outside the cluster to NodePorts and ClusterIPs is handled
             - name: FELIX_BPFEXTERNALSERVICEMODE
               value: "{{- or .Networking.Calico.BPFExternalServiceMode "Tunnel" }}"
+            # Controls whether Felix will clean up the iptables rules created by the Kubernetes kube-proxy
+            - name: FELIX_BPFKUBEPROXYIPTABLESCLEANUPENABLED
+              value: "{{- .Networking.Calico.BPFKubeProxyIptablesCleanupEnabled }}"
             # Controls the log level used by the BPF programs
             - name: FELIX_BPFLOGLEVEL
               value: "{{- or .Networking.Calico.BPFLogLevel "Off" }}"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3425,14 +3425,6 @@ rules:
       - get
   - apiGroups: [""]
     resources:
-      - secrets
-    verbs:
-      # Needed when configuring bgp password in bgppeer
-      - watch
-      - list
-      - get
-  - apiGroups: [""]
-    resources:
       - endpoints
       - services
     verbs:
@@ -3647,7 +3639,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.16.3
+      - image: calico/typha:v3.16.4
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -3764,7 +3756,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.16.3
+          image: calico/cni:v3.16.4
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -3791,7 +3783,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.16.3
+          image: calico/cni:v3.16.4
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -3832,7 +3824,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.16.3
+          image: calico/pod2daemon-flexvol:v3.16.4
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -3843,7 +3835,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.16.3
+          image: calico/node:v3.16.4
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4100,7 +4092,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.16.3
+          image: calico/kube-controllers:v3.16.4
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -1,6 +1,18 @@
-# Pulled and modified from:
-#   https://docs.projectcalico.org/v3.16/manifests/calico-bpf.yaml
-#   https://docs.projectcalico.org/v3.16/manifests/calico-typha.yaml
+# Pulled and modified from: https://docs.projectcalico.org/v3.16/manifests/calico-typha.yaml
+
+{{- if .Networking.Calico.BPFEnabled }}
+---
+# Set these to the IP and port of your API server; In BPF mode, we need to connect directly to the
+# API server because we take over kube-proxy's role.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kubernetes-services-endpoint
+  namespace: kube-system
+data:
+  KUBERNETES_SERVICE_HOST: "{{ .MasterInternalName }}"
+  KUBERNETES_SERVICE_PORT: "443"
+{{- end }}
 
 ---
 # Source: calico/templates/calico-config.yaml
@@ -13,12 +25,6 @@ metadata:
   labels:
     role.kubernetes.io/networking: "1"
 data:
-  {{- if .Networking.Calico.BPFEnabled }}
-  # Set these to the IP and port of your API server; In BPF mode, we need to connect directly to the
-  # API server because we take over kube-proxy's role.
-  kubernetes_service_host: "{{ .MasterInternalName }}"
-  kubernetes_service_port: "443"
-  {{- end }}
   # You must set a non-zero value for Typha replicas below.
   typha_service_name: "{{- if .Networking.Calico.TyphaReplicas -}}calico-typha{{- else -}}none{{- end -}}"
   # Configure the backend to use.
@@ -3766,19 +3772,6 @@ spec:
               name: kubernetes-services-endpoint
               optional: true
           env:
-            {{- if .Networking.Calico.BPFEnabled }}
-            # Overrides for kubernetes API server host/port. Needed in BPF mode.
-            - name: KUBERNETES_SERVICE_HOST
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: kubernetes_service_host
-            - name: KUBERNETES_SERVICE_PORT
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: kubernetes_service_port
-            {{- end }}
             - name: KUBERNETES_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -3806,19 +3799,6 @@ spec:
               name: kubernetes-services-endpoint
               optional: true
           env:
-            {{- if .Networking.Calico.BPFEnabled }}
-            # Overrides for kubernetes API server host/port. Needed in BPF mode.
-            - name: KUBERNETES_SERVICE_HOST
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: kubernetes_service_host
-            - name: KUBERNETES_SERVICE_PORT
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: kubernetes_service_port
-            {{- end }}
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
               value: "10-calico.conflist"
@@ -3870,19 +3850,6 @@ spec:
               name: kubernetes-services-endpoint
               optional: true
           env:
-            {{- if .Networking.Calico.BPFEnabled }}
-            # Overrides for kubernetes API server host/port. Needed in BPF mode.
-            - name: KUBERNETES_SERVICE_HOST
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: kubernetes_service_host
-            - name: KUBERNETES_SERVICE_PORT
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: kubernetes_service_port
-            {{- end }}
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
               value: "kubernetes"


### PR DESCRIPTION
Based on discussion with @fasaxc in Slack I changed the Calico manifest to use an optional ConfigMap to set the k8s endpoints.
Additionally I added an option for the cleanup of iptables rules (in case it's need for migration) and updated the version to 3.16.4.

/cc @seh @olemarkus 