### PR TITLE
Update AWS VPC CNI to 1.7.5

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -4379,7 +4379,7 @@ rules:
   resources:
   - nodes
   verbs: ["list", "watch", "get", "update"]
-- apiGroups: ["extensions"]
+- apiGroups: ["extensions", "apps"]
   resources:
   - daemonsets
   verbs: ["list", "watch"]
@@ -4452,7 +4452,7 @@ spec:
       tolerations:
       - operator: Exists
       containers:
-      - image: "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.1" }}"
+      - image: "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.5" }}"
         imagePullPolicy: Always
         ports:
         - containerPort: 61678
@@ -4527,8 +4527,13 @@ spec:
           name: run-dir
         - mountPath: /var/run/dockershim.sock
           name: dockershim
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
       initContainers:
-      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.1
+      - env:
+        - name: DISABLE_TCP_EARLY_DEMUX
+          value: "false"
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.5
         imagePullPolicy: Always
         name: aws-vpc-cni-init
         resources: {}
@@ -4549,6 +4554,9 @@ spec:
       - hostPath:
           path: /var/run/dockershim.sock
         name: dockershim
+      - hostPath:
+          path: /run/xtables.lock
+        name: xtables-lock
       - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -21,7 +21,7 @@ rules:
   resources:
   - nodes
   verbs: ["list", "watch", "get", "update"]
-- apiGroups: ["extensions"]
+- apiGroups: ["extensions", "apps"]
   resources:
   - daemonsets
   verbs: ["list", "watch"]
@@ -94,7 +94,7 @@ spec:
       tolerations:
       - operator: Exists
       containers:
-      - image: "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.1" }}"
+      - image: "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.5" }}"
         imagePullPolicy: Always
         ports:
         - containerPort: 61678
@@ -169,8 +169,13 @@ spec:
           name: run-dir
         - mountPath: /var/run/dockershim.sock
           name: dockershim
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
       initContainers:
-      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.1
+      - env:
+        - name: DISABLE_TCP_EARLY_DEMUX
+          value: "false"
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.5
         imagePullPolicy: Always
         name: aws-vpc-cni-init
         resources: {}
@@ -191,6 +196,9 @@ spec:
       - hostPath:
           path: /var/run/dockershim.sock
         name: dockershim
+      - hostPath:
+          path: /run/xtables.lock
+        name: xtables-lock
       - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -105,7 +105,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0'
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 4399dbdb75f15e9484e6f1b9b7930ba0c28ea755
+    manifestHash: c5ef06e0be88bdb1292b63b08eeea836ad2837bd
     name: networking.amazon-vpc-routed-eni
     selector:
       role.kubernetes.io/networking: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -29,6 +29,7 @@ rules:
   - update
 - apiGroups:
   - extensions
+  - apps
   resources:
   - daemonsets
   verbs:
@@ -138,7 +139,7 @@ spec:
           value: "10"
         - name: AWS_VPC_K8S_CNI_LOGLEVEL
           value: debug
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.5
         imagePullPolicy: Always
         livenessProbe:
           exec:
@@ -174,9 +175,14 @@ spec:
           name: run-dir
         - mountPath: /var/run/dockershim.sock
           name: dockershim
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
       hostNetwork: true
       initContainers:
-      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.1
+      - env:
+        - name: DISABLE_TCP_EARLY_DEMUX
+          value: "false"
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.5
         imagePullPolicy: Always
         name: aws-vpc-cni-init
         resources: {}
@@ -201,6 +207,9 @@ spec:
       - hostPath:
           path: /var/run/dockershim.sock
         name: dockershim
+      - hostPath:
+          path: /run/xtables.lock
+        name: xtables-lock
       - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate


### PR DESCRIPTION
In this PR:
- Update AWS VPC image on main and init container to v.1.7.5
- Adding `apps` `apiGroup` to handle `list` and `watch` `daemonsets`, since `extensions` is no more (we should remove `extensions` at some point, but I figured I would still leave it here since the [original manifest](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/config/v1.7/aws-k8s-cni-cn.yaml#L47) still contains it).
- Adding `xtables-lock` volume and volumeMount which were introduced in [v1.7.1](https://github.com/aws/amazon-vpc-cni-k8s/pull/1187) as a fix for `iptables`
- Adding `DISABLE_TCP_EARLY_DEMUX` toggle as introduced in [v1.7.3](https://github.com/aws/amazon-vpc-cni-k8s/pull/1222)