### PR TITLE
Update shell style for CLI docs for better compatibility

### DIFF
--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -62,9 +62,9 @@ var (
 	cat instancegroup.yaml | kops create -f -
 
 	# Create a cluster in AWS
-	kops create cluster --name=kubernetes-cluster.example.com \
-		--state=s3://kops-state-1234 --zones=eu-west-1a \
-		--node-count=2 --node-size=t2.micro --master-size=t2.micro \
+	kops create cluster --name=k8s-cluster.example.com \
+		--state=s3://my-state-store --zones=us-east-1a \
+		--node-count=2 --node-size=t3.small --master-size=t3.small \
 		--dns-zone=example.com
 
 	# Create an instancegroup for the k8s-cluster.example.com cluster.
@@ -73,7 +73,7 @@ var (
 
 	# Create a new ssh public key called admin.
 	kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	`))
 	createShort = i18n.T("Create a resource by command line, filename or stdin.")
 )

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -114,19 +114,19 @@ var (
 
 	createClusterExample = templates.Examples(i18n.T(`
 	# Create a cluster in AWS in a single zone.
-	kops create cluster --name=kubernetes-cluster.example.com \
-		--state=s3://kops-state-1234 \
-		--zones=eu-west-1a \
+	kops create cluster --name=k8s-cluster.example.com \
+		--state=s3://my-state-store \
+		--zones=us-east-1a \
 		--node-count=2
 
 	# Create a cluster in AWS with HA masters. This cluster
 	# has also been configured for private networking in a kops-managed VPC.
 	# The bastion flag is set to create an entrypoint for admins to SSH.
-	export NODE_SIZE=${NODE_SIZE:-m4.large}
-	export MASTER_SIZE=${MASTER_SIZE:-m4.large}
-	export ZONES=${ZONES:-"us-east-1d,us-east-1b,us-east-1c"}
 	export KOPS_STATE_STORE="s3://my-state-store"
-	kops create cluster k8s-clusters.example.com \
+	export MASTER_SIZE="c5.large"
+	export NODE_SIZE="m5.large"
+	export ZONES="us-east-1a,us-east-1b,us-east-1c"
+	kops create cluster k8s-cluster.example.com \
 	    --node-count 3 \
 		--zones $ZONES \
 		--node-size $NODE_SIZE \
@@ -138,10 +138,11 @@ var (
 		--yes
 
 	# Create a cluster in GCE.
-	export KOPS_STATE_STORE="gs://mybucket-kops"
-	export ZONES=${MASTER_ZONES:-"us-east1-b,us-east1-c,us-east1-d"}
-	export KOPS_FEATURE_FLAGS=AlphaAllowGCE # Note: GCE support is not GA.
-	kops create cluster kubernetes-k8s-gce.example.com \
+	# Note: GCE support is not GA.
+	export KOPS_FEATURE_FLAGS=AlphaAllowGCE
+	export KOPS_STATE_STORE="gs://my-state-store"
+	export ZONES="us-east1-a,us-east1-b,us-east1-c"
+	kops create cluster k8s-cluster.example.com \
 		--zones $ZONES \
 		--master-zones $ZONES \
 		--node-count 3 \
@@ -149,9 +150,9 @@ var (
 
 	# Generate a cluster spec to apply later.
 	# Run the following, then: kops create -f filename.yaml
-	kops create cluster --name=kubernetes-cluster.example.com \
-		--state=s3://kops-state-1234 \
-		--zones=eu-west-1a \
+	kops create cluster --name=k8s-cluster.example.com \
+		--state=s3://my-state-store \
+		--zones=us-east-1a \
 		--node-count=2 \
 		--dry-run \
 		-oyaml > filename.yaml

--- a/cmd/kops/create_secret.go
+++ b/cmd/kops/create_secret.go
@@ -32,13 +32,13 @@ var (
 	createSecretExample = templates.Examples(i18n.T(`
 	# Create a new ssh public key called admin.
 	kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 
 	kops create secret dockerconfig -f ~/.docker/config.json \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 
 	kops create secret encryptionconfig -f ~/.encryptionconfig.yaml \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	`))
 
 	createSecretShort = i18n.T(`Create a secret.`)

--- a/cmd/kops/create_secret_cilium_encryptionconfig.go
+++ b/cmd/kops/create_secret_cilium_encryptionconfig.go
@@ -39,14 +39,14 @@ var (
 	createSecretCiliumEncryptionconfigExample = templates.Examples(i18n.T(`
 	# Create a new cilium encryption key.
 	kops create secret ciliumpassword -f /path/to/ciliumpassword \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	# Create a new cilium encryption key via stdin.
-	cat <<EOF | kops create secret ciliumpassword --name k8s-cluster.example.com --state s3://example.com -f -
+	cat <<EOF | kops create secret ciliumpassword --name k8s-cluster.example.com --state s3://my-state-store -f -
       keys: $(echo "3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64)) 128")
     EOF	
 	# Replace an existing ciliumpassword secret
 	kops create secret ciliumpassword -f /path/to/ciliumpassword --force \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	`))
 
 	createSecretCiliumEncryptionconfigShort = i18n.T(`Create a cilium encryption key.`)

--- a/cmd/kops/create_secret_dockerconfig.go
+++ b/cmd/kops/create_secret_dockerconfig.go
@@ -40,13 +40,13 @@ var (
 	createSecretDockerconfigExample = templates.Examples(i18n.T(`
 	# Create a new docker config.
 	kops create secret dockerconfig -f /path/to/docker/config.json \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	# Create a docker config via stdin.
 	generate-docker-config.sh | kops create secret dockerconfig -f - \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	# Replace an existing docker config secret.
 	kops create secret dockerconfig -f /path/to/docker/config.json --force \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	`))
 
 	createSecretDockerconfigShort = i18n.T(`Create a docker config.`)

--- a/cmd/kops/create_secret_encryptionconfig.go
+++ b/cmd/kops/create_secret_encryptionconfig.go
@@ -40,13 +40,13 @@ var (
 	createSecretEncryptionconfigExample = templates.Examples(i18n.T(`
 	# Create a new encryption config.
 	kops create secret encryptionconfig -f config.yaml \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	# Create a new encryption config via stdin.
 	generate-encryption-config.sh | kops create secret encryptionconfig -f - \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	# Replace an existing encryption config secret.
 	kops create secret encryptionconfig -f config.yaml --force \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	`))
 
 	createSecretEncryptionconfigShort = i18n.T(`Create an encryption config.`)

--- a/cmd/kops/create_secret_keypair.go
+++ b/cmd/kops/create_secret_keypair.go
@@ -33,7 +33,7 @@ var (
 	Add a ca certificate and private key.
 	kops create secret keypair ca \
 		--cert ~/ca.pem --key ~/ca-key.pem \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	`))
 
 	createSecretKeypairShort = i18n.T(`Create a secret keypair.`)

--- a/cmd/kops/create_secret_keypair_ca.go
+++ b/cmd/kops/create_secret_keypair_ca.go
@@ -43,7 +43,7 @@ var (
 	Add a ca certificate and private key.
 	kops create secret keypair ca \
 		--cert ~/ca.pem --key ~/ca-key.pem \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	`))
 
 	createSecretCacertShort = i18n.T(`Add a ca cert and key`)

--- a/cmd/kops/create_secret_sshpublickey.go
+++ b/cmd/kops/create_secret_sshpublickey.go
@@ -37,7 +37,7 @@ var (
 	createSecretSSHPublicKeyExample = templates.Examples(i18n.T(`
 	# Create a new ssh public key called admin.
 	kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	`))
 
 	createSecretSSHPublicKeyShort = i18n.T(`Create an ssh public key.`)

--- a/cmd/kops/create_secret_weave_encryptionconfig.go
+++ b/cmd/kops/create_secret_weave_encryptionconfig.go
@@ -42,16 +42,16 @@ var (
 	createSecretWeaveEncryptionconfigExample = templates.Examples(i18n.T(`
 	# Create a new random weave password.
 	kops create secret weavepassword \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	# Install a specific weave password.
 	kops create secret weavepassword -f /path/to/weavepassword \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	# Install a specific weave password via stdin.
 	kops create secret weavepassword -f - \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	# Replace an existing weavepassword secret.
 	kops create secret weavepassword -f /path/to/weavepassword --force \
-		--name k8s-cluster.example.com --state s3://example.com
+		--name k8s-cluster.example.com --state s3://my-state-store
 	`))
 
 	createSecretWeaveEncryptionconfigShort = i18n.T(`Create a weave encryption config.`)

--- a/cmd/kops/delete.go
+++ b/cmd/kops/delete.go
@@ -56,7 +56,7 @@ var (
 		pbpaste | kops delete -f -
 
 		# Delete a cluster in AWS.
-		kops delete cluster --name=k8s.example.com --state=s3://kops-state-1234
+		kops delete cluster --name=k8s.example.com --state=s3://my-state-store
 
 		# Delete an instancegroup for the k8s-cluster.example.com cluster.
 		# The --yes option runs the command immediately.

--- a/cmd/kops/edit.go
+++ b/cmd/kops/edit.go
@@ -37,11 +37,11 @@ var (
 
 	editExample = templates.Examples(i18n.T(`
 	# Edit a cluster configuration.
-	kops edit cluster k8s-cluster.example.com --state=s3://kops-state-1234
+	kops edit cluster k8s-cluster.example.com --state=s3://my-state-store
 
 	# Edit a instance group configuration.
 	kops edit ig --name k8s-cluster.example.com \
-	  --state=s3://kops-state-1234 nodes
+	  --state=s3://my-state-store nodes
 	`))
 )
 

--- a/cmd/kops/edit_cluster.go
+++ b/cmd/kops/edit_cluster.go
@@ -57,7 +57,7 @@ var (
 
 	editClusterExample = templates.Examples(i18n.T(`
 		# Edit a cluster configuration in AWS.
-		kops edit cluster k8s.cluster.site --state=s3://kops-state-1234
+		kops edit cluster k8s.cluster.site --state=s3://my-state-store
 	`))
 )
 

--- a/cmd/kops/edit_instancegroup.go
+++ b/cmd/kops/edit_instancegroup.go
@@ -51,7 +51,7 @@ var (
 
 	editInstancegroupExample = templates.Examples(i18n.T(`
 	# Edit an instancegroup desired configuration.
-	kops edit ig --name k8s-cluster.example.com nodes --state=s3://kops-state-1234
+	kops edit ig --name k8s-cluster.example.com nodes --state=s3://my-state-store
 	`))
 
 	editInstancegroupShort = i18n.T(`Edit instancegroup.`)

--- a/cmd/kops/export.go
+++ b/cmd/kops/export.go
@@ -31,7 +31,7 @@ var (
 
 	exportExample = templates.Examples(i18n.T(`
 	# export a kubecfg file
-	kops export kubecfg kubernetes-cluster.example.com
+	kops export kubecfg k8s-cluster.example.com
 		`))
 
 	exportShort = i18n.T(`Export configuration.`)

--- a/cmd/kops/export_kubecfg.go
+++ b/cmd/kops/export_kubecfg.go
@@ -42,13 +42,13 @@ var (
 
 	exportKubecfgExample = templates.Examples(i18n.T(`
 	# export a kubeconfig file with the cluster admin user (make sure you keep this user safe!)
-	kops export kubecfg kubernetes-cluster.example.com --admin
+	kops export kubecfg k8s-cluster.example.com --admin
 
 	# export using a user already existing in the kubeconfig file
-	kops export kubecfg kubernetes-cluster.example.com --user my-oidc-user
+	kops export kubecfg k8s-cluster.example.com --user my-oidc-user
 
 	# export using the internal DNS name, bypassing the cloud load balancer
-	kops export kubecfg kubernetes-cluster.example.com --internal
+	kops export kubecfg k8s-cluster.example.com --internal
 		`))
 
 	exportKubecfgShort = i18n.T(`Export kubecfg.`)

--- a/cmd/kops/update.go
+++ b/cmd/kops/update.go
@@ -32,7 +32,7 @@ var (
 
 	updateExample = templates.Examples(i18n.T(`
 		# After cluster has been created, configure it with:
-		kops update cluster k8s.cluster.site --yes --state=s3://kops-state-1234
+		kops update cluster k8s-cluster.example.com --yes --state=s3://my-state-store
 	`))
 
 	updateShort = i18n.T("Update a cluster.")

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -53,7 +53,7 @@ var (
 
 	updateClusterExample = templates.Examples(i18n.T(`
 	# After cluster has been edited or upgraded, configure it with:
-	kops update cluster k8s-cluster.example.com --yes --state=s3://kops-state-1234 --yes --admin
+	kops update cluster k8s-cluster.example.com --yes --state=s3://my-state-store --yes --admin
 	`))
 
 	updateClusterShort = i18n.T("Update a cluster.")

--- a/cmd/kops/upgrade.go
+++ b/cmd/kops/upgrade.go
@@ -31,7 +31,7 @@ var (
 
 	upgradeExample = templates.Examples(i18n.T(`
 	# Upgrade a cluster's Kubernetes version.
-	kops upgrade cluster kubernetes-cluster.example.com --yes --state=s3://kops-state-1234
+	kops upgrade cluster k8s-cluster.example.com --yes --state=s3://my-state-store
 	`))
 
 	upgradeShort = i18n.T("Upgrade a kubernetes cluster.")

--- a/docs/cli/kops_create.md
+++ b/docs/cli/kops_create.md
@@ -32,9 +32,9 @@ kops create -f FILENAME [flags]
   cat instancegroup.yaml | kops create -f -
   
   # Create a cluster in AWS
-  kops create cluster --name=kubernetes-cluster.example.com \
-  --state=s3://kops-state-1234 --zones=eu-west-1a \
-  --node-count=2 --node-size=t2.micro --master-size=t2.micro \
+  kops create cluster --name=k8s-cluster.example.com \
+  --state=s3://my-state-store --zones=us-east-1a \
+  --node-count=2 --node-size=t3.small --master-size=t3.small \
   --dns-zone=example.com
   
   # Create an instancegroup for the k8s-cluster.example.com cluster.
@@ -43,7 +43,7 @@ kops create -f FILENAME [flags]
   
   # Create a new ssh public key called admin.
   kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
 ```
 
 ### Options

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -27,10 +27,10 @@ kops create cluster [flags]
   # Create a cluster in AWS with HA masters. This cluster
   # has also been configured for private networking in a kops-managed VPC.
   # The bastion flag is set to create an entrypoint for admins to SSH.
-  export NODE_SIZE=${NODE_SIZE:-m5.large}
-  export MASTER_SIZE=${MASTER_SIZE:-c5.large}
-  export ZONES=${ZONES:-"us-east-1a,us-east-1b,us-east-1c"}
   export KOPS_STATE_STORE="s3://my-state-store"
+  export MASTER_SIZE="c5.large"
+  export NODE_SIZE="m5.large"
+  export ZONES="us-east-1a,us-east-1b,us-east-1c"
   kops create cluster k8s-cluster.example.com \
   --node-count 3 \
   --zones $ZONES \
@@ -43,9 +43,10 @@ kops create cluster [flags]
   --yes
   
   # Create a cluster in GCE.
+  # Note: GCE support is not GA.
+  export KOPS_FEATURE_FLAGS=AlphaAllowGCE
   export KOPS_STATE_STORE="gs://my-state-store"
-  export ZONES=${MASTER_ZONES:-"us-east1-a,us-east1-b,us-east1-c"}
-  export KOPS_FEATURE_FLAGS=AlphaAllowGCE # Note: GCE support is not GA.
+  export ZONES="us-east1-a,us-east1-b,us-east1-c"
   kops create cluster k8s-cluster.example.com \
   --zones $ZONES \
   --master-zones $ZONES \

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -19,19 +19,19 @@ kops create cluster [flags]
 
 ```
   # Create a cluster in AWS in a single zone.
-  kops create cluster --name=kubernetes-cluster.example.com \
-  --state=s3://kops-state-1234 \
-  --zones=eu-west-1a \
+  kops create cluster --name=k8s-cluster.example.com \
+  --state=s3://my-state-store \
+  --zones=us-east-1a \
   --node-count=2
   
   # Create a cluster in AWS with HA masters. This cluster
   # has also been configured for private networking in a kops-managed VPC.
   # The bastion flag is set to create an entrypoint for admins to SSH.
-  export NODE_SIZE=${NODE_SIZE:-m4.large}
-  export MASTER_SIZE=${MASTER_SIZE:-m4.large}
-  export ZONES=${ZONES:-"us-east-1d,us-east-1b,us-east-1c"}
+  export NODE_SIZE=${NODE_SIZE:-m5.large}
+  export MASTER_SIZE=${MASTER_SIZE:-c5.large}
+  export ZONES=${ZONES:-"us-east-1a,us-east-1b,us-east-1c"}
   export KOPS_STATE_STORE="s3://my-state-store"
-  kops create cluster k8s-clusters.example.com \
+  kops create cluster k8s-cluster.example.com \
   --node-count 3 \
   --zones $ZONES \
   --node-size $NODE_SIZE \
@@ -43,10 +43,10 @@ kops create cluster [flags]
   --yes
   
   # Create a cluster in GCE.
-  export KOPS_STATE_STORE="gs://mybucket-kops"
-  export ZONES=${MASTER_ZONES:-"us-east1-b,us-east1-c,us-east1-d"}
+  export KOPS_STATE_STORE="gs://my-state-store"
+  export ZONES=${MASTER_ZONES:-"us-east1-a,us-east1-b,us-east1-c"}
   export KOPS_FEATURE_FLAGS=AlphaAllowGCE # Note: GCE support is not GA.
-  kops create cluster kubernetes-k8s-gce.example.com \
+  kops create cluster k8s-cluster.example.com \
   --zones $ZONES \
   --master-zones $ZONES \
   --node-count 3 \
@@ -54,9 +54,9 @@ kops create cluster [flags]
   
   # Generate a cluster spec to apply later.
   # Run the following, then: kops create -f filename.yaml
-  kops create cluster --name=kubernetes-cluster.example.com \
-  --state=s3://kops-state-1234 \
-  --zones=eu-west-1a \
+  kops create cluster --name=k8s-cluster.example.com \
+  --state=s3://my-state-store \
+  --zones=us-east-1a \
   --node-count=2 \
   --dry-run \
   -oyaml > filename.yaml

--- a/docs/cli/kops_create_secret.md
+++ b/docs/cli/kops_create_secret.md
@@ -14,13 +14,13 @@ Create a secret
 ```
   # Create a new ssh public key called admin.
   kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
   
   kops create secret dockerconfig -f ~/.docker/config.json \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
   
   kops create secret encryptionconfig -f ~/.encryptionconfig.yaml \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
 ```
 
 ### Options

--- a/docs/cli/kops_create_secret_ciliumpassword.md
+++ b/docs/cli/kops_create_secret_ciliumpassword.md
@@ -18,14 +18,14 @@ kops create secret ciliumpassword [flags]
 ```
   # Create a new cilium encryption key.
   kops create secret ciliumpassword -f /path/to/ciliumpassword \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
   # Create a new cilium encryption key via stdin.
-  cat <<EOF | kops create secret ciliumpassword --name k8s-cluster.example.com --state s3://example.com -f -
+  cat <<EOF | kops create secret ciliumpassword --name k8s-cluster.example.com --state s3://my-state-store -f -
   keys: $(echo "3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64)) 128")
   EOF
   # Replace an existing ciliumpassword secret
   kops create secret ciliumpassword -f /path/to/ciliumpassword --force \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
 ```
 
 ### Options

--- a/docs/cli/kops_create_secret_dockerconfig.md
+++ b/docs/cli/kops_create_secret_dockerconfig.md
@@ -18,13 +18,13 @@ kops create secret dockerconfig [flags]
 ```
   # Create a new docker config.
   kops create secret dockerconfig -f /path/to/docker/config.json \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
   # Create a docker config via stdin.
   generate-docker-config.sh | kops create secret dockerconfig -f - \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
   # Replace an existing docker config secret.
   kops create secret dockerconfig -f /path/to/docker/config.json --force \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
 ```
 
 ### Options

--- a/docs/cli/kops_create_secret_encryptionconfig.md
+++ b/docs/cli/kops_create_secret_encryptionconfig.md
@@ -18,13 +18,13 @@ kops create secret encryptionconfig [flags]
 ```
   # Create a new encryption config.
   kops create secret encryptionconfig -f config.yaml \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
   # Create a new encryption config via stdin.
   generate-encryption-config.sh | kops create secret encryptionconfig -f - \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
   # Replace an existing encryption config secret.
   kops create secret encryptionconfig -f config.yaml --force \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
 ```
 
 ### Options

--- a/docs/cli/kops_create_secret_keypair.md
+++ b/docs/cli/kops_create_secret_keypair.md
@@ -15,7 +15,7 @@ Create a secret keypair
   Add a ca certificate and private key.
   kops create secret keypair ca \
   --cert ~/ca.pem --key ~/ca-key.pem \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
 ```
 
 ### Options

--- a/docs/cli/kops_create_secret_keypair_ca.md
+++ b/docs/cli/kops_create_secret_keypair_ca.md
@@ -19,7 +19,7 @@ kops create secret keypair ca [flags]
   Add a ca certificate and private key.
   kops create secret keypair ca \
   --cert ~/ca.pem --key ~/ca-key.pem \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
 ```
 
 ### Options

--- a/docs/cli/kops_create_secret_sshpublickey.md
+++ b/docs/cli/kops_create_secret_sshpublickey.md
@@ -18,7 +18,7 @@ kops create secret sshpublickey [flags]
 ```
   # Create a new ssh public key called admin.
   kops create secret sshpublickey admin -i ~/.ssh/id_rsa.pub \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
 ```
 
 ### Options

--- a/docs/cli/kops_create_secret_weavepassword.md
+++ b/docs/cli/kops_create_secret_weavepassword.md
@@ -22,16 +22,16 @@ kops create secret weavepassword [flags]
 ```
   # Create a new random weave password.
   kops create secret weavepassword \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
   # Install a specific weave password.
   kops create secret weavepassword -f /path/to/weavepassword \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
   # Install a specific weave password via stdin.
   kops create secret weavepassword -f - \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
   # Replace an existing weavepassword secret.
   kops create secret weavepassword -f /path/to/weavepassword --force \
-  --name k8s-cluster.example.com --state s3://example.com
+  --name k8s-cluster.example.com --state s3://my-state-store
 ```
 
 ### Options

--- a/docs/cli/kops_delete.md
+++ b/docs/cli/kops_delete.md
@@ -26,7 +26,7 @@ kops delete -f FILENAME [--yes] [flags]
   pbpaste | kops delete -f -
   
   # Delete a cluster in AWS.
-  kops delete cluster --name=k8s.example.com --state=s3://kops-state-1234
+  kops delete cluster --name=k8s.example.com --state=s3://my-state-store
   
   # Delete an instancegroup for the k8s-cluster.example.com cluster.
   # The --yes option runs the command immediately.

--- a/docs/cli/kops_edit.md
+++ b/docs/cli/kops_edit.md
@@ -18,11 +18,11 @@ Edit a resource configuration. This command changes the desired configuration in
 
 ```
   # Edit a cluster configuration.
-  kops edit cluster k8s-cluster.example.com --state=s3://kops-state-1234
+  kops edit cluster k8s-cluster.example.com --state=s3://my-state-store
   
   # Edit a instance group configuration.
   kops edit ig --name k8s-cluster.example.com \
-  --state=s3://kops-state-1234 nodes
+  --state=s3://my-state-store nodes
 ```
 
 ### Options

--- a/docs/cli/kops_edit_cluster.md
+++ b/docs/cli/kops_edit_cluster.md
@@ -24,7 +24,7 @@ kops edit cluster [flags]
 
 ```
   # Edit a cluster configuration in AWS.
-  kops edit cluster k8s.cluster.site --state=s3://kops-state-1234
+  kops edit cluster k8s.cluster.site --state=s3://my-state-store
 ```
 
 ### Options

--- a/docs/cli/kops_edit_instancegroup.md
+++ b/docs/cli/kops_edit_instancegroup.md
@@ -24,7 +24,7 @@ kops edit instancegroup [flags]
 
 ```
   # Edit an instancegroup desired configuration.
-  kops edit ig --name k8s-cluster.example.com nodes --state=s3://kops-state-1234
+  kops edit ig --name k8s-cluster.example.com nodes --state=s3://my-state-store
 ```
 
 ### Options

--- a/docs/cli/kops_export.md
+++ b/docs/cli/kops_export.md
@@ -13,7 +13,7 @@ Export configurations from a cluster.
 
 ```
   # export a kubecfg file
-  kops export kubecfg kubernetes-cluster.example.com
+  kops export kubecfg k8s-cluster.example.com
 ```
 
 ### Options

--- a/docs/cli/kops_export_kubecfg.md
+++ b/docs/cli/kops_export_kubecfg.md
@@ -17,13 +17,13 @@ kops export kubecfg CLUSTERNAME [flags]
 
 ```
   # export a kubeconfig file with the cluster admin user (make sure you keep this user safe!)
-  kops export kubecfg kubernetes-cluster.example.com --admin
+  kops export kubecfg k8s-cluster.example.com --admin
   
   # export using a user already existing in the kubeconfig file
-  kops export kubecfg kubernetes-cluster.example.com --user my-oidc-user
+  kops export kubecfg k8s-cluster.example.com --user my-oidc-user
   
   # export using the internal DNS name, bypassing the cloud load balancer
-  kops export kubecfg kubernetes-cluster.example.com --internal
+  kops export kubecfg k8s-cluster.example.com --internal
 ```
 
 ### Options

--- a/docs/cli/kops_update.md
+++ b/docs/cli/kops_update.md
@@ -13,7 +13,7 @@ Creates or updates cloud resources to match cluster desired configuration.
 
 ```
   # After cluster has been created, configure it with:
-  kops update cluster k8s.cluster.site --yes --state=s3://kops-state-1234
+  kops update cluster k8s-cluster.example.com --yes --state=s3://my-state-store
 ```
 
 ### Options

--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -19,7 +19,7 @@ kops update cluster [flags]
 
 ```
   # After cluster has been edited or upgraded, configure it with:
-  kops update cluster k8s-cluster.example.com --yes --state=s3://kops-state-1234 --yes --admin
+  kops update cluster k8s-cluster.example.com --yes --state=s3://my-state-store --yes --admin
 ```
 
 ### Options

--- a/docs/cli/kops_upgrade.md
+++ b/docs/cli/kops_upgrade.md
@@ -13,7 +13,7 @@ Automates checking for and applying Kubernetes updates. This upgrades a cluster 
 
 ```
   # Upgrade a cluster's Kubernetes version.
-  kops upgrade cluster kubernetes-cluster.example.com --yes --state=s3://kops-state-1234
+  kops upgrade cluster k8s-cluster.example.com --yes --state=s3://my-state-store
 ```
 
 ### Options

--- a/docs/cli/kops_upgrade_cluster.md
+++ b/docs/cli/kops_upgrade_cluster.md
@@ -17,7 +17,7 @@ kops upgrade cluster [flags]
 
 ```
   # Upgrade a cluster's Kubernetes version.
-  kops upgrade cluster kubernetes-cluster.example.com --yes --state=s3://kops-state-1234
+  kops upgrade cluster k8s-cluster.example.com --yes --state=s3://my-state-store
 ```
 
 ### Options


### PR DESCRIPTION
Relevant changes are in the `Update shell style for CLI docs for better compatibility` commit.
Also makes cluster and state store names more uniform.

Fixes: #10119