### PR TITLE
Add verify-cloudformation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -459,6 +459,10 @@ verify-shellcheck:
 verify-terraform:
 	hack/verify-terraform.sh
 
+.PHONE: verify-cloudformation
+verify-cloudformation:
+	hack/verify-cloudformation.sh
+
 .PHONY: verify-bindata
 verify-bindata:
 	hack/verify-bindata.sh

--- a/hack/.cfnlintrc.yaml
+++ b/hack/.cfnlintrc.yaml
@@ -1,0 +1,3 @@
+ignore_checks:
+- W3010 # Don't hardcode AZs
+- E2510 # us-test-1a is not a valid AZ

--- a/hack/verify-cloudformation.sh
+++ b/hack/verify-cloudformation.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+TAG=v0.39.0
+IMAGE="cfn-python-lint:${TAG}"
+
+# There is no official docker image so build it locally
+# https://github.com/aws-cloudformation/cfn-python-lint/issues/1025
+function docker_build() {
+  echo "Building cfn-python-lint image"
+  TMP=$(mktemp -d)
+  git clone -q -b "${TAG}" https://github.com/aws-cloudformation/cfn-python-lint "${TMP}"
+  pushd "${TMP}"
+  docker build --tag "${IMAGE}" .
+  popd
+  rm -rf "${TMP}"
+}
+
+docker image inspect "${IMAGE}" >/dev/null 2>&1 || docker_build
+
+docker run --rm -v "${KOPS_ROOT}:/${KOPS_ROOT}" -v "${KOPS_ROOT}/hack/.cfnlintrc.yaml:/root/.cfnlintrc" "${IMAGE}" "/${KOPS_ROOT}/tests/integration/update_cluster/**/cloudformation.json"
+RC=$?
+
+if [ $RC != 0 ]; then
+  echo -e "\nCloudformation linting failed\n"
+  exit 0 # TODO: exit $RC once issues have been addressed to make this a blocking check
+else
+  echo -e "\nCloudformation linting succeeded\n"
+fi


### PR DESCRIPTION
This is an official AWS linter for cloudformation: https://github.com/aws-cloudformation/cfn-python-lint

It has already caught a few bugs in our cloudformation json generation logic. Examples:

```
E3002 Invalid Property Resources/AWSAutoScalingAutoScalingGroupnodesmixedinstancesexamplecom/Properties/MixedInstancesPolicy/InstancesDistribution/SpotInstancePool
//kops/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json:321:13

E3031 CidrIp contains invalid characters (Pattern: x.x.x.x/y) at Resources/AWSEC2SecurityGroupIngresssshexternaltonode2001085a348/Properties/CidrIp
//kops/tests/integration/update_cluster/complex/cloudformation.json:833:9

I3011 The default action when replacing/removing a resource is to delete it. Set explicit values for UpdateReplacePolicy / DeletionPolicy on potentially stateful resource: Resources/AWSEC2Volumeustest1aetcdeventsprivateciliumexamplecom
//kops/tests/integration/update_cluster/privatecilium2/cloudformation.json:1227:5
```

It currently exits 0 while we add it to the presubmit jobs. Once we address the issues we'll update it to exit nonzero if there are regressions.

ref: #10015