### PR TITLE
Fix cloudformation lint errors

### DIFF
--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -640,7 +640,7 @@
         "FromPort": 443,
         "ToPort": 443,
         "IpProtocol": "tcp",
-        "CidrIp": "2001:0:8500::/40"
+        "CidrIpv6": "2001:0:8500::/40"
       }
     },
     "AWSEC2SecurityGroupIngresshttpselbtomaster": {
@@ -678,7 +678,7 @@
         "FromPort": 3,
         "ToPort": 4,
         "IpProtocol": "icmp",
-        "CidrIp": "2001:0:8500::/40"
+        "CidrIpv6": "2001:0:8500::/40"
       }
     },
     "AWSEC2SecurityGroupIngressnodeporttcpexternaltonode102030024": {
@@ -806,7 +806,7 @@
         "FromPort": 22,
         "ToPort": 22,
         "IpProtocol": "tcp",
-        "CidrIp": "2001:0:85a3::/48"
+        "CidrIpv6": "2001:0:85a3::/48"
       }
     },
     "AWSEC2SecurityGroupIngresssshexternaltonode111132": {
@@ -830,7 +830,7 @@
         "FromPort": 22,
         "ToPort": 22,
         "IpProtocol": "tcp",
-        "CidrIp": "2001:0:85a3::/48"
+        "CidrIpv6": "2001:0:85a3::/48"
       }
     },
     "AWSEC2SecurityGroupapielbcomplexexamplecom": {

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json
@@ -318,7 +318,7 @@
           },
           "InstancesDistribution": {
             "OnDemandPercentageAboveBaseCapacity": 5,
-            "SpotInstancePool": 3
+            "SpotInstancePools": 3
           }
         }
       }

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
@@ -318,7 +318,7 @@
           },
           "InstancesDistribution": {
             "OnDemandPercentageAboveBaseCapacity": 5,
-            "SpotInstancePool": 3,
+            "SpotInstancePools": 3,
             "SpotMaxPrice": "0.1"
           }
         }

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -846,7 +846,7 @@ type cloudformationAutoscalingInstanceDistribution struct {
 	// SpotAllocationStrategy is the spot allocation stratergy
 	SpotAllocationStrategy *string `json:"SpotAllocationStrategy,omitempty"`
 	// SpotInstancePool is the number of pools
-	SpotInstancePool *int64 `json:"SpotInstancePool,omitempty"`
+	SpotInstancePools *int64 `json:"SpotInstancePools,omitempty"`
 	// SpotMaxPrice is the max bid on spot instance, defaults to demand value
 	SpotMaxPrice *string `json:"SpotMaxPrice,omitempty"`
 }
@@ -901,7 +901,7 @@ func (_ *AutoscalingGroup) RenderCloudformation(t *cloudformation.Cloudformation
 				OnDemandBaseCapacity:                e.MixedOnDemandBase,
 				OnDemandPercentageAboveBaseCapacity: e.MixedOnDemandAboveBase,
 				SpotAllocationStrategy:              e.MixedSpotAllocationStrategy,
-				SpotInstancePool:                    e.MixedSpotInstancePools,
+				SpotInstancePools:                   e.MixedSpotInstancePools,
 				SpotMaxPrice:                        e.MixedSpotMaxPrice,
 			},
 		}

--- a/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
@@ -348,6 +348,7 @@ type cloudformationSecurityGroupIngress struct {
 
 	Protocol *string `json:"IpProtocol,omitempty"`
 	CidrIp   *string `json:"CidrIp,omitempty"`
+	CidrIpv6 *string `json:"CidrIpv6,omitempty"`
 }
 
 func (_ *SecurityGroupRule) RenderCloudformation(t *cloudformation.CloudformationTarget, a, e, changes *SecurityGroupRule) error {
@@ -383,7 +384,11 @@ func (_ *SecurityGroupRule) RenderCloudformation(t *cloudformation.Cloudformatio
 	}
 
 	if e.CIDR != nil {
-		tf.CidrIp = e.CIDR
+		if strings.Contains(fi.StringValue(e.CIDR), ":") {
+			tf.CidrIpv6 = e.CIDR
+		} else {
+			tf.CidrIp = e.CIDR
+		}
 	}
 
 	return t.RenderResource(cfType, *e.Name, tf)


### PR DESCRIPTION
```
E3002 Invalid Property Resources/AWSAutoScalingAutoScalingGroupnodesmixedinstancesexamplecom/Properties/MixedInstancesPolicy/InstancesDistribution/SpotInstancePool
//kops/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json:321:13

E3031 CidrIp contains invalid characters (Pattern: x.x.x.x/y) at Resources/AWSEC2SecurityGroupIngresssshexternaltonode2001085a348/Properties/CidrIp
//kops/tests/integration/update_cluster/complex/cloudformation.json:833:9
```

New output:

```
$ make verify-cloudformation
hack/verify-cloudformation.sh

Cloudformation linting succeeded
```

I'm using the strings.Contains to determine if a CIDR is v6 since it seems simplest given that we know the value wont have a port number [0]

ref: #10015

[0] https://stackoverflow.com/questions/22751035/golang-distinguish-ipv4-ipv6