### PR TITLE
Make verify-cloudformation job fail when issues are found

### DIFF
--- a/hack/verify-cloudformation.sh
+++ b/hack/verify-cloudformation.sh
@@ -42,7 +42,7 @@ RC=$?
 
 if [ $RC != 0 ]; then
   echo -e "\nCloudformation linting failed\n"
-  exit 0 # TODO: exit $RC once issues have been addressed to make this a blocking check
+  exit $RC
 else
   echo -e "\nCloudformation linting succeeded\n"
 fi


### PR DESCRIPTION
With #10131 merged, we can now make the job fail if an issue is found. The failure wont prevent the PR from being merged since the job is optional, but it will at least be visible to reviewers.