### PR TITLE
Deprecate field calico.majorVersion

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2182,7 +2182,7 @@ spec:
                         description: 'LogSeverityScreen lets us set the desired log level. (Default: info)'
                         type: string
                       majorVersion:
-                        description: MajorVersion is the version of Calico to use
+                        description: MajorVersion is deprecated as of kOps 1.20 and has no effect
                         type: string
                       mtu:
                         description: MTU to be set in the cni-network-config for calico.

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -140,7 +140,7 @@ type CalicoNetworkingSpec struct {
 	PrometheusGoMetricsEnabled bool `json:"prometheusGoMetricsEnabled,omitempty"`
 	// PrometheusProcessMetricsEnabled enables Prometheus process metrics collection
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
-	// MajorVersion is the version of Calico to use
+	// MajorVersion is deprecated as of kOps 1.20 and has no effect
 	MajorVersion string `json:"majorVersion,omitempty"`
 	// IPv4AutoDetectionMethod configures how Calico chooses the IP address used to route
 	// between nodes.  This should be set when the host has multiple interfaces

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -140,7 +140,7 @@ type CalicoNetworkingSpec struct {
 	PrometheusGoMetricsEnabled bool `json:"prometheusGoMetricsEnabled,omitempty"`
 	// PrometheusProcessMetricsEnabled enables Prometheus process metrics collection
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
-	// MajorVersion is the version of Calico to use
+	// MajorVersion is deprecated as of kOps 1.20 and has no effect
 	MajorVersion string `json:"majorVersion,omitempty"`
 	// IptablesBackend controls which variant of iptables binary Felix uses
 	// Default: Auto (other options: Legacy, NFT)

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -395,24 +395,11 @@ func Test_Validate_Calico(t *testing.T) {
 		},
 		{
 			Input: caliInput{
-				Calico: &kops.CalicoNetworkingSpec{
-					MajorVersion: "v3",
-				},
+				Calico: &kops.CalicoNetworkingSpec{},
 				Etcd: kops.EtcdClusterSpec{
 					Version: "3.2.18",
 				},
 			},
-		},
-		{
-			Input: caliInput{
-				Calico: &kops.CalicoNetworkingSpec{
-					MajorVersion: "v3",
-				},
-				Etcd: kops.EtcdClusterSpec{
-					Version: "2.2.18",
-				},
-			},
-			ExpectedErrors: []string{"Forbidden::calico.majorVersion"},
 		},
 		{
 			Input: caliInput{

--- a/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
@@ -42,8 +42,7 @@ spec:
   kubernetesVersion: v1.19.6
   masterPublicName: api.private.example.com
   networking:
-    calico:
-      majorVersion: v3
+    calico: {}
   nonMasqueradeCIDR: 100.64.0.0/10
   project: testproject
   sshAccess:

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -766,9 +766,7 @@ func setupNetworking(opt *NewClusterOptions, cluster *api.Cluster) error {
 			Backend: "udp",
 		}
 	case "calico":
-		cluster.Spec.Networking.Calico = &api.CalicoNetworkingSpec{
-			MajorVersion: "v3",
-		}
+		cluster.Spec.Networking.Calico = &api.CalicoNetworkingSpec{}
 	case "canal":
 		cluster.Spec.Networking.Canal = &api.CanalNetworkingSpec{}
 	case "kube-router":

--- a/upup/pkg/fi/cloudup/new_cluster_test.go
+++ b/upup/pkg/fi/cloudup/new_cluster_test.go
@@ -206,9 +206,7 @@ func TestSetupNetworking(t *testing.T) {
 			expected: api.Cluster{
 				Spec: api.ClusterSpec{
 					Networking: &api.NetworkingSpec{
-						Calico: &api.CalicoNetworkingSpec{
-							MajorVersion: "v3",
-						},
+						Calico: &api.CalicoNetworkingSpec{},
 					},
 				},
 			},


### PR DESCRIPTION
Calico v2 is no longer supported starting kOps 1.20, so `calico.majorVersion` is no longer needed.