### PR TITLE
Automated cherry pick of #10098: Use Debian10 image for DO

### DIFF
--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -43,7 +43,7 @@ const (
 	defaultMasterMachineTypeDO  = "s-2vcpu-4gb"
 	defaultMasterMachineTypeALI = "ecs.n2.medium"
 
-	defaultDONodeImage  = "debian-9-x64"
+	defaultDONodeImage  = "debian-10-x64"
 	defaultALINodeImage = "centos_7_04_64_20G_alibase_201701015.vhd"
 )
 

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -43,7 +43,7 @@ const (
 	defaultMasterMachineTypeDO  = "s-2vcpu-4gb"
 	defaultMasterMachineTypeALI = "ecs.n2.medium"
 
-	defaultDONodeImage  = "debian-10-x64"
+	defaultDONodeImage  = "ubuntu-20-04-x64"
 	defaultALINodeImage = "centos_7_04_64_20G_alibase_201701015.vhd"
 )
 


### PR DESCRIPTION
Cherry pick of #10098 on release-1.19.

#10098: Use Debian10 image for DO

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.