### PR TITLE
 Setup a second NLB listener when an AWS ACM certificate is used

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -218,7 +218,7 @@ func validateClusterSpec(spec *kops.ClusterSpec, c *kops.Cluster, fieldPath *fie
 			allErrs = append(allErrs, field.Forbidden(fieldPath, "cannot use NLB together with spotinst"))
 		}
 		if spec.API.LoadBalancer.SSLCertificate != "" && spec.API.LoadBalancer.Class != kops.LoadBalancerClassNetwork && c.IsKubernetesGTE("1.19") {
-			allErrs = append(allErrs, field.Forbidden(fieldPath, "sslCertificate requires network loadbalancer for K8s 1.19+ see <TODO: permalink here>"))
+			allErrs = append(allErrs, field.Forbidden(fieldPath, "sslCertificate requires network loadbalancer for K8s 1.19+ see https://github.com/kubernetes/kops/blob/master/permalinks/acm_nlb.md"))
 		}
 		if spec.API.LoadBalancer.Class == kops.LoadBalancerClassNetwork && spec.API.LoadBalancer.UseForInternalApi && spec.API.LoadBalancer.Type == kops.LoadBalancerTypeInternal {
 			allErrs = append(allErrs, field.Forbidden(fieldPath, "useForInternalApi cannot be used with internal NLB due lack of hairpinning support"))

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -217,6 +217,12 @@ func validateClusterSpec(spec *kops.ClusterSpec, c *kops.Cluster, fieldPath *fie
 		if featureflag.Spotinst.Enabled() && spec.API.LoadBalancer.Class == kops.LoadBalancerClassNetwork {
 			allErrs = append(allErrs, field.Forbidden(fieldPath, "cannot use NLB together with spotinst"))
 		}
+		if spec.API.LoadBalancer.SSLCertificate != "" && spec.API.LoadBalancer.Class != kops.LoadBalancerClassNetwork && c.IsKubernetesGTE("1.19") {
+			allErrs = append(allErrs, field.Forbidden(fieldPath, "sslCertificate requires network loadbalancer for K8s 1.19+ see <TODO: permalink here>"))
+		}
+		if spec.API.LoadBalancer.Class == kops.LoadBalancerClassNetwork && spec.API.LoadBalancer.UseForInternalApi && spec.API.LoadBalancer.Type == kops.LoadBalancerTypeInternal {
+			allErrs = append(allErrs, field.Forbidden(fieldPath, "useForInternalApi cannot be used with internal NLB due lack of hairpinning support"))
+		}
 	}
 
 	return allErrs

--- a/pkg/kubeconfig/create_kubecfg.go
+++ b/pkg/kubeconfig/create_kubecfg.go
@@ -99,11 +99,17 @@ func BuildKubecfg(cluster *kops.Cluster, keyStore fi.Keystore, secretStore fi.Se
 
 	b := NewKubeconfigBuilder()
 
+	// Use the secondary load balancer port if a certificate is on the primary listener
+	if admin != 0 && cluster.Spec.API != nil && cluster.Spec.API.LoadBalancer != nil && cluster.Spec.API.LoadBalancer.SSLCertificate != "" && cluster.Spec.API.LoadBalancer.Class == kops.LoadBalancerClassNetwork {
+		server = server + ":8443"
+	}
+
 	b.Context = clusterName
 	b.Server = server
 
-	// add the CA Cert to the kubeconfig only if we didn't specify a SSL cert for the LB or are targeting the internal DNS name
-	if cluster.Spec.API == nil || cluster.Spec.API.LoadBalancer == nil || cluster.Spec.API.LoadBalancer.SSLCertificate == "" || internal {
+	// add the CA Cert to the kubeconfig only if we didn't specify a certificate for the LB
+	//  or if we're using admin credentials and the secondary port
+	if cluster.Spec.API == nil || cluster.Spec.API.LoadBalancer == nil || cluster.Spec.API.LoadBalancer.SSLCertificate == "" || cluster.Spec.API.LoadBalancer.Class == kops.LoadBalancerClassNetwork || internal {
 		cert, _, _, err := keyStore.FindKeypair(fi.CertificateIDCA)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching CA keypair: %v", err)

--- a/pkg/kubeconfig/create_kubecfg_test.go
+++ b/pkg/kubeconfig/create_kubecfg_test.go
@@ -71,10 +71,20 @@ func (f fakeKeyStore) MirrorTo(basedir vfs.Path) error {
 }
 
 // build a generic minimal cluster
-func buildMinimalCluster(clusterName string, masterPublicName string) *kops.Cluster {
+func buildMinimalCluster(clusterName string, masterPublicName string, lbCert bool, nlb bool) *kops.Cluster {
 	cluster := testutils.BuildMinimalCluster(clusterName)
 	cluster.Spec.MasterPublicName = masterPublicName
 	cluster.Spec.MasterInternalName = fmt.Sprintf("internal.%v", masterPublicName)
+	cluster.Spec.KubernetesVersion = "1.19.3"
+	cluster.Spec.API = &kops.AccessSpec{
+		LoadBalancer: &kops.LoadBalancerAccessSpec{},
+	}
+	if lbCert {
+		cluster.Spec.API.LoadBalancer.SSLCertificate = "cert-arn"
+	}
+	if nlb {
+		cluster.Spec.API.LoadBalancer.Class = kops.LoadBalancerClassNetwork
+	}
 	return cluster
 }
 
@@ -107,9 +117,12 @@ func TestBuildKubecfg(t *testing.T) {
 		useKopsAuthenticationPlugin bool
 	}
 
-	publiccluster := buildMinimalCluster("testcluster", "testcluster.test.com")
-	emptyMasterPublicNameCluster := buildMinimalCluster("emptyMasterPublicNameCluster", "")
-	gossipCluster := buildMinimalCluster("testgossipcluster.k8s.local", "")
+	publicCluster := buildMinimalCluster("testcluster", "testcluster.test.com", false, false)
+	emptyMasterPublicNameCluster := buildMinimalCluster("emptyMasterPublicNameCluster", "", false, false)
+	gossipCluster := buildMinimalCluster("testgossipcluster.k8s.local", "", false, false)
+	certCluster := buildMinimalCluster("testcluster", "testcluster.test.com", true, false)
+	certNLBCluster := buildMinimalCluster("testcluster", "testcluster.test.com", true, true)
+	certGossipNLBCluster := buildMinimalCluster("testgossipcluster.k8s.local", "", true, true)
 
 	tests := []struct {
 		name           string
@@ -121,7 +134,7 @@ func TestBuildKubecfg(t *testing.T) {
 		{
 			name: "Test Kube Config Data For Public DNS with admin",
 			args: args{
-				cluster: publiccluster,
+				cluster: publicCluster,
 				status:  fakeStatusStore{},
 				admin:   DefaultKubecfgAdminLifetime,
 				user:    "",
@@ -135,9 +148,54 @@ func TestBuildKubecfg(t *testing.T) {
 			wantClientCert: true,
 		},
 		{
+			name: "Test Kube Config Data For Public DNS with admin and secondary NLB port",
+			args: args{
+				cluster: certNLBCluster,
+				status:  fakeStatusStore{},
+				admin:   DefaultKubecfgAdminLifetime,
+			},
+			want: &KubeconfigBuilder{
+				Context: "testcluster",
+				Server:  "https://testcluster.test.com:8443",
+				CACert:  []byte(certData),
+				User:    "testcluster",
+			},
+			wantClientCert: true,
+		},
+		{
+			name: "Test Kube Config Data For Public DNS with admin and CLB ACM Certificate",
+			args: args{
+				cluster: certCluster,
+				status:  fakeStatusStore{},
+				admin:   DefaultKubecfgAdminLifetime,
+			},
+			want: &KubeconfigBuilder{
+				Context: "testcluster",
+				Server:  "https://testcluster.test.com",
+				CACert:  nil,
+				User:    "testcluster",
+			},
+			wantClientCert: true,
+		},
+		{
+			name: "Test Kube Config Data For Public DNS without admin and with ACM certificate",
+			args: args{
+				cluster: certNLBCluster,
+				status:  fakeStatusStore{},
+				admin:   0,
+			},
+			want: &KubeconfigBuilder{
+				Context: "testcluster",
+				Server:  "https://testcluster.test.com",
+				CACert:  []byte(certData),
+				User:    "testcluster",
+			},
+			wantClientCert: false,
+		},
+		{
 			name: "Test Kube Config Data For Public DNS without admin",
 			args: args{
-				cluster: publiccluster,
+				cluster: publicCluster,
 				status:  fakeStatusStore{},
 				admin:   0,
 				user:    "myuser",
@@ -191,7 +249,7 @@ func TestBuildKubecfg(t *testing.T) {
 		{
 			name: "Public DNS with kops auth plugin",
 			args: args{
-				cluster:                     publiccluster,
+				cluster:                     publicCluster,
 				status:                      fakeStatusStore{},
 				admin:                       0,
 				useKopsAuthenticationPlugin: true,
@@ -214,7 +272,7 @@ func TestBuildKubecfg(t *testing.T) {
 		{
 			name: "Test Kube Config Data For internal DNS name with admin",
 			args: args{
-				cluster:  publiccluster,
+				cluster:  publicCluster,
 				status:   fakeStatusStore{},
 				admin:    DefaultKubecfgAdminLifetime,
 				internal: true,
@@ -224,6 +282,29 @@ func TestBuildKubecfg(t *testing.T) {
 				Server:  "https://internal.testcluster.test.com",
 				CACert:  []byte(certData),
 				User:    "testcluster",
+			},
+			wantClientCert: true,
+		},
+		{
+			name: "Test Kube Config Data For Gossip cluster with admin and secondary NLB port",
+			args: args{
+				cluster: certGossipNLBCluster,
+				status: fakeStatusStore{
+					GetApiIngressStatusFn: func(cluster *kops.Cluster) ([]kops.ApiIngressStatus, error) {
+						return []kops.ApiIngressStatus{
+							{
+								Hostname: "nlbHostName",
+							},
+						}, nil
+					},
+				},
+				admin: DefaultKubecfgAdminLifetime,
+			},
+			want: &KubeconfigBuilder{
+				Context: "testgossipcluster.k8s.local",
+				Server:  "https://nlbHostName:8443",
+				CACert:  []byte(certData),
+				User:    "testgossipcluster.k8s.local",
 			},
 			wantClientCert: true,
 		},

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -371,6 +371,9 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 		if b.UseLoadBalancerForAPI() && ig.Spec.Role == kops.InstanceGroupRoleMaster {
 			if b.UseNetworkLoadBalancer() {
 				t.TargetGroups = append(t.TargetGroups, b.LinkToTargetGroup("api"))
+				if b.Cluster.Spec.API.LoadBalancer.SSLCertificate != "" {
+					t.TargetGroups = append(t.TargetGroups, b.LinkToTargetGroup("tcp"))
+				}
 			} else {
 				t.LoadBalancers = append(t.LoadBalancers, b.LinkToCLB("api"))
 			}

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -364,6 +364,8 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 
 	t.InstanceProtection = ig.Spec.InstanceProtection
 
+	t.TargetGroups = []*awstasks.TargetGroup{}
+
 	// When Spotinst Elastigroups are used, there is no need to create
 	// a separate task for the attachment of the load balancer since this
 	// is already done as part of the Elastigroup's creation, if needed.
@@ -384,7 +386,7 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 		}
 	}
 
-	for _, extLB := range ig.Spec.ExternalLoadBalancers {
+	for i, extLB := range ig.Spec.ExternalLoadBalancers {
 		if extLB.LoadBalancerName != nil {
 			lb := &awstasks.ClassicLoadBalancer{
 				Name:             extLB.LoadBalancerName,
@@ -397,7 +399,7 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 
 		if extLB.TargetGroupARN != nil {
 			tg := &awstasks.TargetGroup{
-				Name:   extLB.TargetGroupARN,
+				Name:   fi.String(fmt.Sprintf("external-tg-%d", i)),
 				ARN:    extLB.TargetGroupARN,
 				Shared: fi.Bool(true),
 			}

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -370,9 +370,9 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 	if !featureflag.Spotinst.Enabled() {
 		if b.UseLoadBalancerForAPI() && ig.Spec.Role == kops.InstanceGroupRoleMaster {
 			if b.UseNetworkLoadBalancer() {
-				t.TargetGroups = append(t.TargetGroups, b.LinkToTargetGroup("api"))
+				t.TargetGroups = append(t.TargetGroups, b.LinkToTargetGroup("tcp"))
 				if b.Cluster.Spec.API.LoadBalancer.SSLCertificate != "" {
-					t.TargetGroups = append(t.TargetGroups, b.LinkToTargetGroup("tcp"))
+					t.TargetGroups = append(t.TargetGroups, b.LinkToTargetGroup("tls"))
 				}
 			} else {
 				t.LoadBalancers = append(t.LoadBalancers, b.LinkToCLB("api"))

--- a/pkg/model/firewall.go
+++ b/pkg/model/firewall.go
@@ -418,6 +418,7 @@ func (b *KopsModelContext) GetSecurityGroups(role kops.InstanceGroupRole) ([]Sec
 				"port=4002", // etcd events
 				"port=4789", // VXLAN
 				"port=179",  // Calico
+				"port=8443", // k8s api secondary listener
 
 				// TODO: UDP vs TCP
 				// TODO: Protocol 4 for calico

--- a/pkg/model/names.go
+++ b/pkg/model/names.go
@@ -105,7 +105,7 @@ func (b *KopsModelContext) LinkToNLB(prefix string) *awstasks.NetworkLoadBalance
 }
 
 func (b *KopsModelContext) LinkToTargetGroup(prefix string) *awstasks.TargetGroup {
-	name := b.NLBTargetGroupName(prefix) // TODO: this will need to change for the ACM cert bugfix since we'll have multiple TGs
+	name := b.NLBTargetGroupName(prefix)
 	return &awstasks.TargetGroup{Name: &name}
 }
 

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -86,10 +86,10 @@
         ],
         "TargetGroupARNs": [
           {
-            "Ref": "AWSElasticLoadBalancingV2TargetGroupapicomplexexamplecomvd3t5n"
+            "Ref": "AWSElasticLoadBalancingV2TargetGrouptcpcomplexexamplecomvpjolq"
           },
           {
-            "Ref": "AWSElasticLoadBalancingV2TargetGrouptcpcomplexexamplecomvpjolq"
+            "Ref": "AWSElasticLoadBalancingV2TargetGrouptlscomplexexamplecom5nursn"
           }
         ]
       }
@@ -1184,7 +1184,7 @@
           {
             "Type": "forward",
             "TargetGroupArn": {
-              "Ref": "AWSElasticLoadBalancingV2TargetGroupapicomplexexamplecomvd3t5n"
+              "Ref": "AWSElasticLoadBalancingV2TargetGrouptcpcomplexexamplecomvpjolq"
             }
           }
         ],
@@ -1202,7 +1202,7 @@
           {
             "Type": "forward",
             "TargetGroupArn": {
-              "Ref": "AWSElasticLoadBalancingV2TargetGrouptcpcomplexexamplecomvpjolq"
+              "Ref": "AWSElasticLoadBalancingV2TargetGrouptlscomplexexamplecom5nursn"
             }
           }
         ],
@@ -1248,42 +1248,6 @@
         ]
       }
     },
-    "AWSElasticLoadBalancingV2TargetGroupapicomplexexamplecomvd3t5n": {
-      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
-      "Properties": {
-        "Name": "api-complex-example-com-vd3t5n",
-        "Port": 443,
-        "Protocol": "TLS",
-        "VpcId": {
-          "Ref": "AWSEC2VPCcomplexexamplecom"
-        },
-        "Tags": [
-          {
-            "Key": "KubernetesCluster",
-            "Value": "complex.example.com"
-          },
-          {
-            "Key": "Name",
-            "Value": "api-complex-example-com-vd3t5n"
-          },
-          {
-            "Key": "Owner",
-            "Value": "John Doe"
-          },
-          {
-            "Key": "foo/bar",
-            "Value": "fib+baz"
-          },
-          {
-            "Key": "kubernetes.io/cluster/complex.example.com",
-            "Value": "owned"
-          }
-        ],
-        "HealthCheckProtocol": "TLS",
-        "HealthyThresholdCount": 2,
-        "UnhealthyThresholdCount": 2
-      }
-    },
     "AWSElasticLoadBalancingV2TargetGrouptcpcomplexexamplecomvpjolq": {
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
       "Properties": {
@@ -1316,6 +1280,42 @@
           }
         ],
         "HealthCheckProtocol": "TCP",
+        "HealthyThresholdCount": 2,
+        "UnhealthyThresholdCount": 2
+      }
+    },
+    "AWSElasticLoadBalancingV2TargetGrouptlscomplexexamplecom5nursn": {
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "Properties": {
+        "Name": "tls-complex-example-com-5nursn",
+        "Port": 443,
+        "Protocol": "TLS",
+        "VpcId": {
+          "Ref": "AWSEC2VPCcomplexexamplecom"
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "complex.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "tls-complex-example-com-5nursn"
+          },
+          {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
+          },
+          {
+            "Key": "kubernetes.io/cluster/complex.example.com",
+            "Value": "owned"
+          }
+        ],
+        "HealthCheckProtocol": "TLS",
         "HealthyThresholdCount": 2,
         "UnhealthyThresholdCount": 2
       }

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -87,6 +87,9 @@
         "TargetGroupARNs": [
           {
             "Ref": "AWSElasticLoadBalancingV2TargetGroupapicomplexexamplecomvd3t5n"
+          },
+          {
+            "Ref": "AWSElasticLoadBalancingV2TargetGrouptcpcomplexexamplecomvpjolq"
           }
         ]
       }
@@ -850,6 +853,30 @@
         "CidrIpv6": "2001:0:85a3::/48"
       }
     },
+    "AWSEC2SecurityGroupIngresstcpapi111024": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
+        },
+        "FromPort": 8443,
+        "ToPort": 8443,
+        "IpProtocol": "tcp",
+        "CidrIp": "1.1.1.0/24"
+      }
+    },
+    "AWSEC2SecurityGroupIngresstcpapi20010850040": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
+        },
+        "FromPort": 8443,
+        "ToPort": 8443,
+        "IpProtocol": "tcp",
+        "CidrIpv6": "2001:0:8500::/40"
+      }
+    },
     "AWSEC2SecurityGroupapielbcomplexexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
@@ -1148,6 +1175,11 @@
     "AWSElasticLoadBalancingV2Listenerapicomplexexamplecom443": {
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
       "Properties": {
+        "Certificates": [
+          {
+            "CertificateArn": "arn:aws:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678"
+          }
+        ],
         "DefaultActions": [
           {
             "Type": "forward",
@@ -1160,6 +1192,24 @@
           "Ref": "AWSElasticLoadBalancingV2LoadBalancerapicomplexexamplecom"
         },
         "Port": 443,
+        "Protocol": "TLS"
+      }
+    },
+    "AWSElasticLoadBalancingV2Listenerapicomplexexamplecom8443": {
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Properties": {
+        "DefaultActions": [
+          {
+            "Type": "forward",
+            "TargetGroupArn": {
+              "Ref": "AWSElasticLoadBalancingV2TargetGrouptcpcomplexexamplecomvpjolq"
+            }
+          }
+        ],
+        "LoadBalancerArn": {
+          "Ref": "AWSElasticLoadBalancingV2LoadBalancerapicomplexexamplecom"
+        },
+        "Port": 8443,
         "Protocol": "TCP"
       }
     },
@@ -1203,7 +1253,7 @@
       "Properties": {
         "Name": "api-complex-example-com-vd3t5n",
         "Port": 443,
-        "Protocol": "TCP",
+        "Protocol": "TLS",
         "VpcId": {
           "Ref": "AWSEC2VPCcomplexexamplecom"
         },
@@ -1215,6 +1265,42 @@
           {
             "Key": "Name",
             "Value": "api-complex-example-com-vd3t5n"
+          },
+          {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
+          },
+          {
+            "Key": "kubernetes.io/cluster/complex.example.com",
+            "Value": "owned"
+          }
+        ],
+        "HealthCheckProtocol": "TLS",
+        "HealthyThresholdCount": 2,
+        "UnhealthyThresholdCount": 2
+      }
+    },
+    "AWSElasticLoadBalancingV2TargetGrouptcpcomplexexamplecomvpjolq": {
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "Properties": {
+        "Name": "tcp-complex-example-com-vpjolq",
+        "Port": 443,
+        "Protocol": "TCP",
+        "VpcId": {
+          "Ref": "AWSEC2VPCcomplexexamplecom"
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "complex.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "tcp-complex-example-com-vpjolq"
           },
           {
             "Key": "Owner",

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -12,6 +12,7 @@ spec:
       - sg-exampleid4
       crossZoneLoadBalancing: true
       class: Network
+      sslCertificate: arn:aws:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678
   kubernetesApiAccess:
   - 1.1.1.0/24
   - 2001:0:8500::/40

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -12,6 +12,7 @@ spec:
       - sg-exampleid4
       crossZoneLoadBalancing: true
       class: Network
+      sslCertificate: arn:aws:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678
   kubernetesApiAccess:
   - 1.1.1.0/24
   - 2001:0:8500::/40

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -135,7 +135,7 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-complex-example-com"
     propagate_at_launch = true
     value               = "owned"
   }
-  target_group_arns   = [aws_lb_target_group.api-complex-example-com-vd3t5n.id]
+  target_group_arns   = [aws_lb_target_group.api-complex-example-com-vd3t5n.id, aws_lb_target_group.tcp-complex-example-com-vpjolq.id]
   vpc_zone_identifier = [aws_subnet.us-test-1a-complex-example-com.id]
 }
 
@@ -423,27 +423,57 @@ resource "aws_launch_template" "nodes-complex-example-com" {
 }
 
 resource "aws_lb_listener" "api-complex-example-com-443" {
+  certificate_arn = "arn:aws:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678"
   default_action {
     target_group_arn = aws_lb_target_group.api-complex-example-com-vd3t5n.id
     type             = "forward"
   }
   load_balancer_arn = aws_lb.api-complex-example-com.id
   port              = 443
+  protocol          = "TLS"
+}
+
+resource "aws_lb_listener" "api-complex-example-com-8443" {
+  default_action {
+    target_group_arn = aws_lb_target_group.tcp-complex-example-com-vpjolq.id
+    type             = "forward"
+  }
+  load_balancer_arn = aws_lb.api-complex-example-com.id
+  port              = 8443
   protocol          = "TCP"
 }
 
 resource "aws_lb_target_group" "api-complex-example-com-vd3t5n" {
   health_check {
     healthy_threshold   = 2
-    protocol            = "TCP"
+    protocol            = "TLS"
     unhealthy_threshold = 2
   }
   name     = "api-complex-example-com-vd3t5n"
   port     = 443
-  protocol = "TCP"
+  protocol = "TLS"
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "api-complex-example-com-vd3t5n"
+    "Owner"                                     = "John Doe"
+    "foo/bar"                                   = "fib+baz"
+    "kubernetes.io/cluster/complex.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.complex-example-com.id
+}
+
+resource "aws_lb_target_group" "tcp-complex-example-com-vpjolq" {
+  health_check {
+    healthy_threshold   = 2
+    protocol            = "TCP"
+    unhealthy_threshold = 2
+  }
+  name     = "tcp-complex-example-com-vpjolq"
+  port     = 443
+  protocol = "TCP"
+  tags = {
+    "KubernetesCluster"                         = "complex.example.com"
+    "Name"                                      = "tcp-complex-example-com-vpjolq"
     "Owner"                                     = "John Doe"
     "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
@@ -713,6 +743,24 @@ resource "aws_security_group_rule" "ssh-external-to-node-2001_0_85a3__--48" {
   protocol          = "tcp"
   security_group_id = aws_security_group.nodes-complex-example-com.id
   to_port           = 22
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "tcp-api-1-1-1-0--24" {
+  cidr_blocks       = ["1.1.1.0/24"]
+  from_port         = 8443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.masters-complex-example-com.id
+  to_port           = 8443
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "tcp-api-2001_0_8500__--40" {
+  cidr_blocks       = ["2001:0:8500::/40"]
+  from_port         = 8443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.masters-complex-example-com.id
+  to_port           = 8443
   type              = "ingress"
 }
 

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -135,7 +135,7 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-complex-example-com"
     propagate_at_launch = true
     value               = "owned"
   }
-  target_group_arns   = [aws_lb_target_group.api-complex-example-com-vd3t5n.id, aws_lb_target_group.tcp-complex-example-com-vpjolq.id]
+  target_group_arns   = [aws_lb_target_group.tcp-complex-example-com-vpjolq.id, aws_lb_target_group.tls-complex-example-com-5nursn.id]
   vpc_zone_identifier = [aws_subnet.us-test-1a-complex-example-com.id]
 }
 
@@ -425,7 +425,7 @@ resource "aws_launch_template" "nodes-complex-example-com" {
 resource "aws_lb_listener" "api-complex-example-com-443" {
   certificate_arn = "arn:aws:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678"
   default_action {
-    target_group_arn = aws_lb_target_group.api-complex-example-com-vd3t5n.id
+    target_group_arn = aws_lb_target_group.tcp-complex-example-com-vpjolq.id
     type             = "forward"
   }
   load_balancer_arn = aws_lb.api-complex-example-com.id
@@ -435,31 +435,12 @@ resource "aws_lb_listener" "api-complex-example-com-443" {
 
 resource "aws_lb_listener" "api-complex-example-com-8443" {
   default_action {
-    target_group_arn = aws_lb_target_group.tcp-complex-example-com-vpjolq.id
+    target_group_arn = aws_lb_target_group.tls-complex-example-com-5nursn.id
     type             = "forward"
   }
   load_balancer_arn = aws_lb.api-complex-example-com.id
   port              = 8443
   protocol          = "TCP"
-}
-
-resource "aws_lb_target_group" "api-complex-example-com-vd3t5n" {
-  health_check {
-    healthy_threshold   = 2
-    protocol            = "TLS"
-    unhealthy_threshold = 2
-  }
-  name     = "api-complex-example-com-vd3t5n"
-  port     = 443
-  protocol = "TLS"
-  tags = {
-    "KubernetesCluster"                         = "complex.example.com"
-    "Name"                                      = "api-complex-example-com-vd3t5n"
-    "Owner"                                     = "John Doe"
-    "foo/bar"                                   = "fib+baz"
-    "kubernetes.io/cluster/complex.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.complex-example-com.id
 }
 
 resource "aws_lb_target_group" "tcp-complex-example-com-vpjolq" {
@@ -474,6 +455,25 @@ resource "aws_lb_target_group" "tcp-complex-example-com-vpjolq" {
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "tcp-complex-example-com-vpjolq"
+    "Owner"                                     = "John Doe"
+    "foo/bar"                                   = "fib+baz"
+    "kubernetes.io/cluster/complex.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.complex-example-com.id
+}
+
+resource "aws_lb_target_group" "tls-complex-example-com-5nursn" {
+  health_check {
+    healthy_threshold   = 2
+    protocol            = "TLS"
+    unhealthy_threshold = 2
+  }
+  name     = "tls-complex-example-com-5nursn"
+  port     = 443
+  protocol = "TLS"
+  tags = {
+    "KubernetesCluster"                         = "complex.example.com"
+    "Name"                                      = "tls-complex-example-com-5nursn"
     "Owner"                                     = "John Doe"
     "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -465,7 +465,7 @@ resource "aws_lb_target_group" "tcp-complex-example-com-vpjolq" {
 resource "aws_lb_target_group" "tls-complex-example-com-5nursn" {
   health_check {
     healthy_threshold   = 2
-    protocol            = "TLS"
+    protocol            = "TCP"
     unhealthy_threshold = 2
   }
   name     = "tls-complex-example-com-5nursn"

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -163,12 +163,11 @@ func (e *AutoscalingGroup) Find(c *fi.Context) (*AutoscalingGroup, error) {
 	}
 
 	if len(g.TargetGroupARNs) > 0 {
-		targetGroups := make([]*TargetGroup, 0)
+		actualTGs := make([]*TargetGroup, 0)
 		for _, tg := range g.TargetGroupARNs {
-			targetGroups = append(actual.TargetGroups, &TargetGroup{ARN: aws.String(*tg)})
+			actualTGs = append(actualTGs, &TargetGroup{ARN: aws.String(*tg)})
 		}
-
-		targetGroups, err := ReconcileTargetGroups(c.Cloud.(awsup.AWSCloud), targetGroups, e.TargetGroups)
+		targetGroups, err := ReconcileTargetGroups(c.Cloud.(awsup.AWSCloud), actualTGs, e.TargetGroups)
 		if err != nil {
 			return nil, err
 		}

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -162,6 +162,7 @@ func (e *AutoscalingGroup) Find(c *fi.Context) (*AutoscalingGroup, error) {
 		}
 	}
 
+	actual.TargetGroups = []*TargetGroup{}
 	if len(g.TargetGroupARNs) > 0 {
 		actualTGs := make([]*TargetGroup, 0)
 		for _, tg := range g.TargetGroupARNs {
@@ -643,7 +644,7 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 		}
 		if detachTGRequest != nil {
 			if _, err := t.Cloud.Autoscaling().DetachLoadBalancerTargetGroups(detachTGRequest); err != nil {
-				return fmt.Errorf("error attaching TargetGroups: %v", err)
+				return fmt.Errorf("error detaching TargetGroups: %v", err)
 			}
 		}
 		if attachTGRequest != nil {

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -123,7 +123,7 @@ func (e *NetworkLoadBalancerListener) GetDependencies(tasks map[string]fi.Task) 
 	return nil
 }
 
-// OrderListenersByPort implements sort.Interface for []OrderTargetGroupsByPort, based on port number
+// OrderListenersByPort implements sort.Interface for []OrderListenersByPort, based on port number
 type OrderListenersByPort []*NetworkLoadBalancerListener
 
 func (a OrderListenersByPort) Len() int      { return len(a) }
@@ -336,7 +336,6 @@ func (e *NetworkLoadBalancer) Find(c *fi.Context) (*NetworkLoadBalancer, error) 
 	actual.Scheme = lb.Scheme
 	actual.VPC = &VPC{ID: lb.VpcId}
 	actual.Type = lb.Type
-	actual.TargetGroups = make([]*TargetGroup, 0)
 
 	tagMap, err := describeNetworkLoadBalancerTags(cloud, []string{*loadBalancerArn})
 	if err != nil {
@@ -362,8 +361,6 @@ func (e *NetworkLoadBalancer) Find(c *fi.Context) (*NetworkLoadBalancer, error) 
 		if err != nil {
 			return nil, fmt.Errorf("error querying for NLB listeners :%v", err)
 		}
-
-		actual.Listeners = make([]*NetworkLoadBalancerListener, 0)
 
 		for _, l := range response.Listeners {
 			actualListener := &NetworkLoadBalancerListener{}
@@ -400,7 +397,7 @@ func (e *NetworkLoadBalancer) Find(c *fi.Context) (*NetworkLoadBalancer, error) 
 			}
 			actual.TargetGroups = targetGroups
 		}
-		sort.Stable(OrderTargetGroupsByPort(actual.TargetGroups))
+		sort.Stable(OrderTargetGroupsByName(actual.TargetGroups))
 
 	}
 
@@ -494,7 +491,7 @@ func (e *NetworkLoadBalancer) Normalize() {
 	// We need to sort our arrays consistently, so we don't get spurious changes
 	sort.Stable(OrderSubnetsById(e.Subnets))
 	sort.Stable(OrderListenersByPort(e.Listeners))
-	sort.Stable(OrderTargetGroupsByPort(e.TargetGroups))
+	sort.Stable(OrderTargetGroupsByName(e.TargetGroups))
 }
 
 func (s *NetworkLoadBalancer) CheckChanges(a, e, changes *NetworkLoadBalancer) error {

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -362,6 +362,8 @@ func (e *NetworkLoadBalancer) Find(c *fi.Context) (*NetworkLoadBalancer, error) 
 			return nil, fmt.Errorf("error querying for NLB listeners :%v", err)
 		}
 
+		actual.Listeners = []*NetworkLoadBalancerListener{}
+		actual.TargetGroups = []*TargetGroup{}
 		for _, l := range response.Listeners {
 			actualListener := &NetworkLoadBalancerListener{}
 			actualListener.Port = int(aws.Int64Value(l.Port))

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -113,7 +113,6 @@ func (e *NetworkLoadBalancerListener) GetDependencies(tasks map[string]fi.Task) 
 	return nil
 }
 
-
 // OrderListenersByPort implements sort.Interface for []OrderTargetGroupsByPort, based on port number
 type OrderListenersByPort []*NetworkLoadBalancerListener
 
@@ -731,11 +730,15 @@ type cloudformationNetworkLoadBalancer struct {
 }
 
 type cloudformationNetworkLoadBalancerListener struct {
-	Certificates    []string                                          `json:"Certificates,omitempty"`
-	DefaultActions  []cloudformationNetworkLoadBalancerListenerAction `json:"DefaultActions"`
-	LoadBalancerARN *cloudformation.Literal                           `json:"LoadBalancerArn"`
-	Port            int64                                             `json:"Port"`
-	Protocol        string                                            `json:"Protocol"`
+	Certificates    []cloudformationNetworkLoadBalancerListenerCertificate `json:"Certificates,omitempty"`
+	DefaultActions  []cloudformationNetworkLoadBalancerListenerAction      `json:"DefaultActions"`
+	LoadBalancerARN *cloudformation.Literal                                `json:"LoadBalancerArn"`
+	Port            int64                                                  `json:"Port"`
+	Protocol        string                                                 `json:"Protocol"`
+}
+
+type cloudformationNetworkLoadBalancerListenerCertificate struct {
+	CertificateArn string `json:"CertificateArn"`
 }
 
 type cloudformationNetworkLoadBalancerListenerAction struct {
@@ -775,7 +778,9 @@ func (_ *NetworkLoadBalancer) RenderCloudformation(t *cloudformation.Cloudformat
 			},
 		}
 		if listener.SSLCertificateID != "" {
-			listenerCF.Certificates = []string{listener.SSLCertificateID}
+			listenerCF.Certificates = []cloudformationNetworkLoadBalancerListenerCertificate{
+				{CertificateArn: listener.SSLCertificateID},
+			}
 			listenerCF.Protocol = elbv2.ProtocolEnumTls
 		} else {
 			listenerCF.Protocol = elbv2.ProtocolEnumTcp

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -400,6 +400,7 @@ func (e *NetworkLoadBalancer) Find(c *fi.Context) (*NetworkLoadBalancer, error) 
 			}
 			actual.TargetGroups = targetGroups
 		}
+		sort.Stable(OrderTargetGroupsByPort(actual.TargetGroups))
 
 	}
 

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup.go
@@ -60,8 +60,7 @@ func (e *TargetGroup) Find(c *fi.Context) (*TargetGroup, error) {
 	request := &elbv2.DescribeTargetGroupsInput{}
 	if e.ARN != nil {
 		request.TargetGroupArns = []*string{e.ARN}
-	}
-	if e.Name != nil {
+	} else if e.Name != nil {
 		request.Names = []*string{e.Name}
 	}
 
@@ -200,9 +199,6 @@ type OrderTargetGroupsByName []*TargetGroup
 func (a OrderTargetGroupsByName) Len() int      { return len(a) }
 func (a OrderTargetGroupsByName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a OrderTargetGroupsByName) Less(i, j int) bool {
-	if a[i].ARN != nil || a[j].ARN != nil {
-		return fi.StringValue(a[i].ARN) < fi.StringValue(a[j].ARN)
-	}
 	return fi.StringValue(a[i].Name) < fi.StringValue(a[j].Name)
 }
 

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup.go
@@ -290,7 +290,7 @@ func (_ *TargetGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, change
 		HealthCheck: terraformTargetGroupHealthCheck{
 			HealthyThreshold:   *e.HealthyThreshold,
 			UnhealthyThreshold: *e.UnhealthyThreshold,
-			Protocol:           *e.Protocol,
+			Protocol:           elbv2.ProtocolEnumTcp,
 		},
 	}
 

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup.go
@@ -200,7 +200,10 @@ type OrderTargetGroupsByPort []*TargetGroup
 func (a OrderTargetGroupsByPort) Len() int      { return len(a) }
 func (a OrderTargetGroupsByPort) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a OrderTargetGroupsByPort) Less(i, j int) bool {
-	return fi.Int64Value(a[i].Port) < fi.Int64Value(a[j].Port)
+	if a[i].ARN != nil || a[j].ARN != nil {
+		return fi.StringValue(a[i].ARN) < fi.StringValue(a[j].ARN)
+	}
+	return fi.StringValue(a[i].Name) < fi.StringValue(a[j].Name)
 }
 
 // pkg/model/awsmodel doesn't know the ARN of the API TargetGroup tasks that it passes to the master ASGs,

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup.go
@@ -194,12 +194,12 @@ func (_ *TargetGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *TargetGrou
 	return nil
 }
 
-// OrderTargetGroupsByPort implements sort.Interface for []OrderTargetGroupsByPort, based on port number
-type OrderTargetGroupsByPort []*TargetGroup
+// OrderTargetGroupsByName implements sort.Interface for []OrderTargetGroupsByName, based on port number
+type OrderTargetGroupsByName []*TargetGroup
 
-func (a OrderTargetGroupsByPort) Len() int      { return len(a) }
-func (a OrderTargetGroupsByPort) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a OrderTargetGroupsByPort) Less(i, j int) bool {
+func (a OrderTargetGroupsByName) Len() int      { return len(a) }
+func (a OrderTargetGroupsByName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a OrderTargetGroupsByName) Less(i, j int) bool {
 	if a[i].ARN != nil || a[j].ARN != nil {
 		return fi.StringValue(a[i].ARN) < fi.StringValue(a[j].ARN)
 	}


### PR DESCRIPTION
This uses commits from https://github.com/kubernetes/kops/pull/9761 combined with the new NLB support to provision a second NLB listener. It requires converting the `Listeners` and `TargetGroups` NLB fields to slices in which each listener should forward traffic to the target group of the same list index. I couldn't use a map of port number to TargetGroup because fi/loader.go uses reflection to set values of fields that are Tasks, and map values aren't addressable which resulted in a panic.

I also temporarily pulled in the commit from https://github.com/kubernetes/kops/pull/10076/files to run the e2e presubmit job with an ACM cert. Before we merge this I'll remove the commit.

ref: https://github.com/kubernetes/kops/issues/9756