### PR TITLE
Fix NLB naming for terraform and cloudformation targets

### DIFF
--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -1135,7 +1135,7 @@
     "AWSElasticLoadBalancingV2LoadBalancerapicomplexexamplecom": {
       "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "Properties": {
-        "Name": "api-complex-example-com",
+        "Name": "api-complex-example-com-vd3t5n",
         "Scheme": "internet-facing",
         "Subnets": [
           {

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -452,7 +452,7 @@ resource "aws_lb" "api-complex-example-com" {
   enable_cross_zone_load_balancing = true
   internal                         = false
   load_balancer_type               = "network"
-  name                             = "api-complex-example-com"
+  name                             = "api-complex-example-com-vd3t5n"
   subnets                          = [aws_subnet.us-test-1a-complex-example-com.id]
   tags = {
     "KubernetesCluster"                         = "complex.example.com"

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -654,7 +654,7 @@ type terraformNetworkLoadBalancerListenerAction struct {
 
 func (_ *NetworkLoadBalancer) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *NetworkLoadBalancer) error {
 	nlbTF := &terraformNetworkLoadBalancer{
-		Name:                   *e.Name,
+		Name:                   *e.LoadBalancerName,
 		Internal:               fi.StringValue(e.Scheme) == elbv2.LoadBalancerSchemeEnumInternal,
 		Type:                   elbv2.LoadBalancerTypeEnumNetwork,
 		Tags:                   e.Tags,
@@ -732,7 +732,7 @@ type cloudformationNetworkLoadBalancerListenerAction struct {
 
 func (_ *NetworkLoadBalancer) RenderCloudformation(t *cloudformation.CloudformationTarget, a, e, changes *NetworkLoadBalancer) error {
 	nlbCF := &cloudformationNetworkLoadBalancer{
-		Name:    *e.Name,
+		Name:    *e.LoadBalancerName,
 		Subnets: make([]*cloudformation.Literal, 0),
 		Type:    elbv2.LoadBalancerTypeEnumNetwork,
 		Tags:    buildCloudformationTags(e.Tags),


### PR DESCRIPTION
This ensures we use the LoadBalancerName field rather than the name of the NLB task itself. The `direct` target is already using LoadBalancerName:

https://github.com/kubernetes/kops/blob/e91ed114499294f3e4242c6b23e7150a5c7262ec/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go#L503-L504

This will need to be cherry-picked to release-1.19.


ref: https://github.com/kubernetes/kops/pull/10154#issuecomment-720820551