### PR TITLE
Move NLB's VPC CIDR security group rule logic into model

### DIFF
--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -357,8 +357,19 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 				Protocol:      fi.String("tcp"),
 				SecurityGroup: masterGroup.Task,
 				ToPort:        fi.Int64(443),
-				VPC:           b.LinkToVPC(),
+				CIDR:          fi.String(b.Cluster.Spec.NetworkCIDR),
 			})
+			for _, cidr := range b.Cluster.Spec.AdditionalNetworkCIDRs {
+				c.AddTask(&awstasks.SecurityGroupRule{
+					Name:          fi.String(fmt.Sprintf("https-lb-to-master%s-%s", suffix, cidr)),
+					Lifecycle:     b.SecurityLifecycle,
+					FromPort:      fi.Int64(443),
+					Protocol:      fi.String("tcp"),
+					SecurityGroup: masterGroup.Task,
+					ToPort:        fi.Int64(443),
+					CIDR:          fi.String(cidr),
+				})
+			}
 		}
 	}
 

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -643,7 +643,32 @@
         },
         "FromPort": 443,
         "ToPort": 443,
-        "IpProtocol": "tcp"
+        "IpProtocol": "tcp",
+        "CidrIp": "172.20.0.0/16"
+      }
+    },
+    "AWSEC2SecurityGroupIngresshttpslbtomaster1010016": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
+        },
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp",
+        "CidrIp": "10.1.0.0/16"
+      }
+    },
+    "AWSEC2SecurityGroupIngresshttpslbtomaster1020016": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
+        },
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp",
+        "CidrIp": "10.2.0.0/16"
       }
     },
     "AWSEC2SecurityGroupIngressicmppmtuapielb111024": {

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -543,6 +543,25 @@ resource "aws_security_group_rule" "https-api-elb-2001_0_8500__--40" {
 }
 
 resource "aws_security_group_rule" "https-elb-to-master" {
+  cidr_blocks       = ["172.20.0.0/16"]
+  from_port         = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.masters-complex-example-com.id
+  to_port           = 443
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "https-lb-to-master-10-1-0-0--16" {
+  cidr_blocks       = ["10.1.0.0/16"]
+  from_port         = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.masters-complex-example-com.id
+  to_port           = 443
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "https-lb-to-master-10-2-0-0--16" {
+  cidr_blocks       = ["10.2.0.0/16"]
   from_port         = 443
   protocol          = "tcp"
   security_group_id = aws_security_group.masters-complex-example-com.id


### PR DESCRIPTION
This way the security group rule task doesn't need to be aware of VPCs, since we should always know the VPC CIDR ahead of time via cluster spec.

This also fixes the terraform and cloudformation rendering of this rule (see the added cidr block in the integration test outputs)

These rules are for NLB's health checks. The AWS docs recommend allowing access from the entire VPC CIDRs
Also add rules for additionalNetworkCIDRs, supporting VPCs with multiple CIDR blocks.

ref: https://github.com/kubernetes/kops/pull/9011#issuecomment-720143425