### PR TITLE
Fix additionalSecurityGroups support for NLB

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -203,7 +203,7 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchConfigurationTask(c *fi.ModelB
 	if b.APILoadBalancerClass() == kops.LoadBalancerClassNetwork {
 		for _, id := range b.Cluster.Spec.API.LoadBalancer.AdditionalSecurityGroups {
 			sgTask := &awstasks.SecurityGroup{
-				ID:        fi.String("nlb-" + id),
+				ID:        fi.String(id),
 				Lifecycle: b.SecurityLifecycle,
 				Name:      fi.String("nlb-" + id),
 				Shared:    fi.Bool(true),

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -271,8 +271,8 @@
                 {
                   "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
                 },
-                "nlb-sg-exampleid3",
-                "nlb-sg-exampleid4"
+                "sg-exampleid3",
+                "sg-exampleid4"
               ]
             }
           ],
@@ -404,9 +404,9 @@
                 {
                   "Ref": "AWSEC2SecurityGroupnodescomplexexamplecom"
                 },
-                "nlb-sg-exampleid3",
-                "nlb-sg-exampleid4",
                 "sg-exampleid3",
+                "sg-exampleid3",
+                "sg-exampleid4",
                 "sg-exampleid4"
               ]
             }

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -1,11 +1,11 @@
 locals {
   cluster_name                 = "complex.example.com"
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-complex-example-com.id]
-  master_security_group_ids    = [aws_security_group.masters-complex-example-com.id, "nlb-sg-exampleid3", "nlb-sg-exampleid4"]
+  master_security_group_ids    = [aws_security_group.masters-complex-example-com.id, "sg-exampleid3", "sg-exampleid4"]
   masters_role_arn             = aws_iam_role.masters-complex-example-com.arn
   masters_role_name            = aws_iam_role.masters-complex-example-com.name
   node_autoscaling_group_ids   = [aws_autoscaling_group.nodes-complex-example-com.id]
-  node_security_group_ids      = [aws_security_group.nodes-complex-example-com.id, "nlb-sg-exampleid3", "nlb-sg-exampleid4", "sg-exampleid3", "sg-exampleid4"]
+  node_security_group_ids      = [aws_security_group.nodes-complex-example-com.id, "sg-exampleid3", "sg-exampleid3", "sg-exampleid4", "sg-exampleid4"]
   node_subnet_ids              = [aws_subnet.us-test-1a-complex-example-com.id]
   nodes_role_arn               = aws_iam_role.nodes-complex-example-com.arn
   nodes_role_name              = aws_iam_role.nodes-complex-example-com.name
@@ -25,7 +25,7 @@ output "master_autoscaling_group_ids" {
 }
 
 output "master_security_group_ids" {
-  value = [aws_security_group.masters-complex-example-com.id, "nlb-sg-exampleid3", "nlb-sg-exampleid4"]
+  value = [aws_security_group.masters-complex-example-com.id, "sg-exampleid3", "sg-exampleid4"]
 }
 
 output "masters_role_arn" {
@@ -41,7 +41,7 @@ output "node_autoscaling_group_ids" {
 }
 
 output "node_security_group_ids" {
-  value = [aws_security_group.nodes-complex-example-com.id, "nlb-sg-exampleid3", "nlb-sg-exampleid4", "sg-exampleid3", "sg-exampleid4"]
+  value = [aws_security_group.nodes-complex-example-com.id, "sg-exampleid3", "sg-exampleid3", "sg-exampleid4", "sg-exampleid4"]
 }
 
 output "node_subnet_ids" {
@@ -301,7 +301,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
-    security_groups             = [aws_security_group.masters-complex-example-com.id, "nlb-sg-exampleid3", "nlb-sg-exampleid4"]
+    security_groups             = [aws_security_group.masters-complex-example-com.id, "sg-exampleid3", "sg-exampleid4"]
   }
   tag_specifications {
     resource_type = "instance"
@@ -375,7 +375,7 @@ resource "aws_launch_template" "nodes-complex-example-com" {
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
-    security_groups             = [aws_security_group.nodes-complex-example-com.id, "nlb-sg-exampleid3", "nlb-sg-exampleid4", "sg-exampleid3", "sg-exampleid4"]
+    security_groups             = [aws_security_group.nodes-complex-example-com.id, "sg-exampleid3", "sg-exampleid3", "sg-exampleid4", "sg-exampleid4"]
   }
   tag_specifications {
     resource_type = "instance"


### PR DESCRIPTION
We were correctly adding the security groups to the master ASGs but identified them incorrectly.

ref: https://github.com/kubernetes/kops/pull/10158#issuecomment-721111686