### PR TITLE
Fix output for CF and TF

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -48,8 +48,8 @@ const PolicyDefaultVersion = "2012-10-17"
 
 // Policy Struct is a collection of fields that form a valid AWS policy document
 type Policy struct {
-	Version   string
 	Statement []*Statement
+	Version   string
 }
 
 // AsJSON converts the policy document to JSON format (parsable by AWS)
@@ -146,6 +146,19 @@ func (s *Statement) MarshalJSON() ([]byte, error) {
 
 	jw := &jsonWriter{w: &b}
 	jw.StartObject()
+
+	if !s.Action.IsEmpty() {
+		jw.Field("Action")
+		jw.Marshal(s.Action)
+		jw.Comma()
+	}
+
+	if len(s.Condition) != 0 {
+		jw.Field("Condition")
+		jw.Marshal(s.Condition)
+		jw.Comma()
+	}
+
 	jw.Field("Effect")
 	jw.Marshal(s.Effect)
 
@@ -154,21 +167,13 @@ func (s *Statement) MarshalJSON() ([]byte, error) {
 		jw.Field("Principal")
 		jw.Marshal(s.Principal)
 	}
-	if !s.Action.IsEmpty() {
-		jw.Comma()
-		jw.Field("Action")
-		jw.Marshal(s.Action)
-	}
+
 	if !s.Resource.IsEmpty() {
 		jw.Comma()
 		jw.Field("Resource")
 		jw.Marshal(s.Resource)
 	}
-	if len(s.Condition) != 0 {
-		jw.Comma()
-		jw.Field("Condition")
-		jw.Marshal(s.Condition)
-	}
+
 	jw.EndObject()
 
 	return b.Bytes(), jw.Error()

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -38,7 +38,7 @@ func TestRoundTrip(t *testing.T) {
 				Action:   stringorslice.Of("ec2:DescribeRegions"),
 				Resource: stringorslice.Of("*"),
 			},
-			JSON: "{\"Effect\":\"Allow\",\"Action\":\"ec2:DescribeRegions\",\"Resource\":\"*\"}",
+			JSON: "{\"Action\":\"ec2:DescribeRegions\",\"Effect\":\"Allow\",\"Resource\":\"*\"}",
 		},
 		{
 			IAM: &Statement{
@@ -46,7 +46,7 @@ func TestRoundTrip(t *testing.T) {
 				Action:   stringorslice.Of("ec2:DescribeRegions", "ec2:DescribeInstances"),
 				Resource: stringorslice.Of("a", "b"),
 			},
-			JSON: "{\"Effect\":\"Deny\",\"Action\":[\"ec2:DescribeRegions\",\"ec2:DescribeInstances\"],\"Resource\":[\"a\",\"b\"]}",
+			JSON: "{\"Action\":[\"ec2:DescribeRegions\",\"ec2:DescribeInstances\"],\"Effect\":\"Deny\",\"Resource\":[\"a\",\"b\"]}",
 		},
 		{
 			IAM: &Statement{
@@ -56,7 +56,7 @@ func TestRoundTrip(t *testing.T) {
 					"foo": 1,
 				},
 			},
-			JSON: "{\"Effect\":\"Deny\",\"Principal\":{\"Federated\":\"federated\"},\"Condition\":{\"foo\":1}}",
+			JSON: "{\"Condition\":{\"foo\":1},\"Effect\":\"Deny\",\"Principal\":{\"Federated\":\"federated\"}}",
 		},
 		{
 			IAM: &Statement{
@@ -66,7 +66,7 @@ func TestRoundTrip(t *testing.T) {
 					"bar": "baz",
 				},
 			},
-			JSON: "{\"Effect\":\"Deny\",\"Principal\":{\"Service\":\"service\"},\"Condition\":{\"bar\":\"baz\"}}",
+			JSON: "{\"Condition\":{\"bar\":\"baz\"},\"Effect\":\"Deny\",\"Principal\":{\"Service\":\"service\"}}",
 		},
 	}
 	for _, g := range grid {

--- a/pkg/model/iam/tests/iam_builder_bastion.json
+++ b/pkg/model/iam/tests/iam_builder_bastion.json
@@ -1,14 +1,14 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/pkg/model/iam/tests/iam_builder_master_legacy.json
+++ b/pkg/model/iam/tests/iam_builder_master_legacy.json
@@ -1,17 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:*"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
@@ -22,54 +20,55 @@
         "autoscaling:UpdateAutoScalingGroup",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:*"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "s3:*"
       ],
+      "Effect": "Allow",
       "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
     },
     {
-      "Effect": "Allow",
       "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
         "s3:ListBucket",
         "s3:ListBucketVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:s3:::kops-tests"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "kms:ListGrants",
         "kms:RevokeGrant"
       ],
+      "Effect": "Allow",
       "Resource": [
         "key-id-1",
         "key-id-2",
@@ -77,7 +76,6 @@
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "kms:CreateGrant",
         "kms:Decrypt",
@@ -86,6 +84,7 @@
         "kms:GenerateDataKey*",
         "kms:ReEncrypt*"
       ],
+      "Effect": "Allow",
       "Resource": [
         "key-id-1",
         "key-id-2",
@@ -93,16 +92,15 @@
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ecr:GetAuthorizationToken",
         "ecr:BatchCheckLayerAvailability",
@@ -112,9 +110,11 @@
         "ecr:ListImages",
         "ecr:BatchGetImage"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "iam-builder-test.k8s.local"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "iam-builder-test.k8s.local"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,41 +121,41 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "s3:Get*"
       ],
+      "Effect": "Allow",
       "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
     },
     {
-      "Effect": "Allow",
       "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
         "s3:ListBucket",
         "s3:ListBucketVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:s3:::kops-tests"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "kms:CreateGrant",
         "kms:Decrypt",
@@ -166,11 +164,13 @@
         "kms:GenerateDataKey*",
         "kms:ReEncrypt*"
       ],
+      "Effect": "Allow",
       "Resource": [
         "key-id-1",
         "key-id-2",
         "key-id-3"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "iam-builder-test.k8s.local"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "iam-builder-test.k8s.local"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,41 +121,41 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "s3:Get*"
       ],
+      "Effect": "Allow",
       "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
     },
     {
-      "Effect": "Allow",
       "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
         "s3:ListBucket",
         "s3:ListBucketVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:s3:::kops-tests"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "kms:CreateGrant",
         "kms:Decrypt",
@@ -166,6 +164,7 @@
         "kms:GenerateDataKey*",
         "kms:ReEncrypt*"
       ],
+      "Effect": "Allow",
       "Resource": [
         "key-id-1",
         "key-id-2",
@@ -173,7 +172,6 @@
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ecr:GetAuthorizationToken",
         "ecr:BatchCheckLayerAvailability",
@@ -183,9 +181,11 @@
         "ecr:ListImages",
         "ecr:BatchGetImage"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/pkg/model/iam/tests/iam_builder_node_legacy.json
+++ b/pkg/model/iam/tests/iam_builder_node_legacy.json
@@ -1,46 +1,44 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "s3:*"
       ],
+      "Effect": "Allow",
       "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
     },
     {
-      "Effect": "Allow",
       "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
         "s3:ListBucket",
         "s3:ListBucketVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:s3:::kops-tests"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ecr:GetAuthorizationToken",
         "ecr:BatchCheckLayerAvailability",
@@ -50,9 +48,11 @@
         "ecr:ListImages",
         "ecr:BatchGetImage"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/pkg/model/iam/tests/iam_builder_node_strict.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict.json
@@ -1,21 +1,20 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "s3:Get*"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/addons/*",
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/cluster.spec",
@@ -29,16 +28,17 @@
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
         "s3:ListBucket",
         "s3:ListBucketVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:s3:::kops-tests"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
@@ -1,21 +1,20 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "s3:Get*"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/addons/*",
         "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/cluster.spec",
@@ -29,19 +28,18 @@
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
         "s3:ListBucket",
         "s3:ListBucketVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:s3:::kops-tests"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ecr:GetAuthorizationToken",
         "ecr:BatchCheckLayerAvailability",
@@ -51,9 +49,11 @@
         "ecr:ListImages",
         "ecr:BatchGetImage"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_bastions.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_bastions.bastionuserdata.example.com_policy
@@ -1,14 +1,14 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "bastionuserdata.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "bastionuserdata.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_nodes.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_nodes.bastionuserdata.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -850,6 +850,7 @@
     "AWSEC2SecurityGroupapielbcomplexexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "api-elb.complex.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCcomplexexamplecom"
         },
@@ -881,6 +882,7 @@
     "AWSEC2SecurityGroupmasterscomplexexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "masters.complex.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCcomplexexamplecom"
         },
@@ -912,6 +914,7 @@
     "AWSEC2SecurityGroupnodescomplexexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "nodes.complex.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCcomplexexamplecom"
         },
@@ -1231,6 +1234,7 @@
     "AWSIAMInstanceProfilemasterscomplexexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "masters.complex.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolemasterscomplexexamplecom"
@@ -1241,6 +1245,7 @@
     "AWSIAMInstanceProfilenodescomplexexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "nodes.complex.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolenodescomplexexamplecom"

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -395,6 +395,9 @@
           },
           "ImageId": "ami-12345678",
           "InstanceType": "t2.medium",
+          "Monitoring": {
+            "Enabled": true
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "complex.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "complex.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_nodes.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_nodes.complex.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -371,6 +371,9 @@ resource "aws_launch_template" "nodes-complex-example-com" {
   lifecycle {
     create_before_destroy = true
   }
+  monitoring {
+    enabled = true
+  }
   name_prefix = "nodes.complex.example.com-"
   network_interfaces {
     associate_public_ip_address = true

--- a/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json
@@ -611,6 +611,7 @@
     "AWSEC2SecurityGroupmasterscontainerdexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "masters.containerd.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCcontainerdexamplecom"
         },
@@ -634,6 +635,7 @@
     "AWSEC2SecurityGroupnodescontainerdexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "nodes.containerd.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCcontainerdexamplecom"
         },
@@ -806,6 +808,7 @@
     "AWSIAMInstanceProfilemasterscontainerdexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "masters.containerd.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolemasterscontainerdexamplecom"
@@ -816,6 +819,7 @@
     "AWSIAMInstanceProfilenodescontainerdexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "nodes.containerd.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolenodescontainerdexamplecom"

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json
@@ -607,6 +607,7 @@
     "AWSEC2SecurityGroupmastersminimalexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "masters.minimal.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCminimalexamplecom"
         },
@@ -630,6 +631,7 @@
     "AWSEC2SecurityGroupnodesminimalexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "nodes.minimal.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCminimalexamplecom"
         },

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "existingsg.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "existingsg.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_nodes.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_nodes.existingsg.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/externallb/cloudformation.json
+++ b/tests/integration/update_cluster/externallb/cloudformation.json
@@ -620,6 +620,7 @@
     "AWSEC2SecurityGroupmastersexternallbexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "masters.externallb.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCexternallbexamplecom"
         },
@@ -643,6 +644,7 @@
     "AWSEC2SecurityGroupnodesexternallbexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "nodes.externallb.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCexternallbexamplecom"
         },
@@ -815,6 +817,7 @@
     "AWSIAMInstanceProfilemastersexternallbexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "masters.externallb.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolemastersexternallbexamplecom"
@@ -825,6 +828,7 @@
     "AWSIAMInstanceProfilenodesexternallbexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "nodes.externallb.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolenodesexternallbexamplecom"

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "externallb.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "externallb.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_nodes.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_nodes.externallb.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "externalpolicies.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "externalpolicies.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_nodes.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_nodes.externalpolicies.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -411,6 +411,9 @@ resource "aws_launch_template" "nodes-externalpolicies-example-com" {
   lifecycle {
     create_before_destroy = true
   }
+  monitoring {
+    enabled = true
+  }
   name_prefix = "nodes.externalpolicies.example.com-"
   network_interfaces {
     associate_public_ip_address = true

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "ha.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "ha.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_nodes.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_nodes.ha.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/launch_templates/cloudformation.json
+++ b/tests/integration/update_cluster/launch_templates/cloudformation.json
@@ -630,6 +630,7 @@
     "AWSEC2SecurityGroupmasterslaunchtemplatesexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "masters.launchtemplates.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPClaunchtemplatesexamplecom"
         },
@@ -653,6 +654,7 @@
     "AWSEC2SecurityGroupnodeslaunchtemplatesexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "nodes.launchtemplates.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPClaunchtemplatesexamplecom"
         },
@@ -1035,6 +1037,7 @@
     "AWSIAMInstanceProfilemasterslaunchtemplatesexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "masters.launchtemplates.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolemasterslaunchtemplatesexamplecom"
@@ -1045,6 +1048,7 @@
     "AWSIAMInstanceProfilenodeslaunchtemplatesexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "nodes.launchtemplates.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolenodeslaunchtemplatesexamplecom"

--- a/tests/integration/update_cluster/launch_templates/data/aws_iam_role_policy_masters.launchtemplates.example.com_policy
+++ b/tests/integration/update_cluster/launch_templates/data/aws_iam_role_policy_masters.launchtemplates.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "launchtemplates.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "launchtemplates.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/launch_templates/data/aws_iam_role_policy_nodes.launchtemplates.example.com_policy
+++ b/tests/integration/update_cluster/launch_templates/data/aws_iam_role_policy_nodes.launchtemplates.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
@@ -611,6 +611,7 @@
     "AWSEC2SecurityGroupmastersminimalexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "masters.minimal.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCminimalexamplecom"
         },
@@ -634,6 +635,7 @@
     "AWSEC2SecurityGroupnodesminimalexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "nodes.minimal.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCminimalexamplecom"
         },
@@ -806,6 +808,7 @@
     "AWSIAMInstanceProfilemastersminimalexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "masters.minimal.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolemastersminimalexamplecom"
@@ -816,6 +819,7 @@
     "AWSIAMInstanceProfilenodesminimalexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "nodes.minimal.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolenodesminimalexamplecom"

--- a/tests/integration/update_cluster/minimal-json/data/aws_iam_role_policy_masters.minimal-json.example.com_policy
+++ b/tests/integration/update_cluster/minimal-json/data/aws_iam_role_policy_masters.minimal-json.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "minimal-json.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "minimal-json.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/minimal-json/data/aws_iam_role_policy_nodes.minimal-json.example.com_policy
+++ b/tests/integration/update_cluster/minimal-json/data/aws_iam_role_policy_nodes.minimal-json.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "minimal.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "minimal.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json
@@ -1004,6 +1004,7 @@
     "AWSEC2SecurityGroupmastersmixedinstancesexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "masters.mixedinstances.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCmixedinstancesexamplecom"
         },
@@ -1027,6 +1028,7 @@
     "AWSEC2SecurityGroupnodesmixedinstancesexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "nodes.mixedinstances.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCmixedinstancesexamplecom"
         },
@@ -1409,6 +1411,7 @@
     "AWSIAMInstanceProfilemastersmixedinstancesexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "masters.mixedinstances.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolemastersmixedinstancesexamplecom"
@@ -1419,6 +1422,7 @@
     "AWSIAMInstanceProfilenodesmixedinstancesexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "nodes.mixedinstances.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolenodesmixedinstancesexamplecom"

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "mixedinstances.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "mixedinstances.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
@@ -1005,6 +1005,7 @@
     "AWSEC2SecurityGroupmastersmixedinstancesexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "masters.mixedinstances.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCmixedinstancesexamplecom"
         },
@@ -1028,6 +1029,7 @@
     "AWSEC2SecurityGroupnodesmixedinstancesexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "nodes.mixedinstances.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCmixedinstancesexamplecom"
         },
@@ -1410,6 +1412,7 @@
     "AWSIAMInstanceProfilemastersmixedinstancesexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "masters.mixedinstances.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolemastersmixedinstancesexamplecom"
@@ -1420,6 +1423,7 @@
     "AWSIAMInstanceProfilenodesmixedinstancesexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "nodes.mixedinstances.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolenodesmixedinstancesexamplecom"

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "mixedinstances.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "mixedinstances.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_bastions.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_bastions.private-shared-subnet.example.com_policy
@@ -1,14 +1,14 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "private-shared-subnet.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "private-shared-subnet.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_nodes.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_nodes.private-shared-subnet.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -996,6 +996,7 @@
     "AWSEC2SecurityGroupapielbprivatecalicoexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "api-elb.privatecalico.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivatecalicoexamplecom"
         },
@@ -1019,6 +1020,7 @@
     "AWSEC2SecurityGroupbastionelbprivatecalicoexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "bastion-elb.privatecalico.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivatecalicoexamplecom"
         },
@@ -1042,6 +1044,7 @@
     "AWSEC2SecurityGroupbastionprivatecalicoexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "bastion.privatecalico.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivatecalicoexamplecom"
         },
@@ -1065,6 +1068,7 @@
     "AWSEC2SecurityGroupmastersprivatecalicoexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "masters.privatecalico.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivatecalicoexamplecom"
         },
@@ -1088,6 +1092,7 @@
     "AWSEC2SecurityGroupnodesprivatecalicoexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "nodes.privatecalico.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivatecalicoexamplecom"
         },
@@ -1400,6 +1405,7 @@
     "AWSIAMInstanceProfilebastionsprivatecalicoexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "bastions.privatecalico.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolebastionsprivatecalicoexamplecom"
@@ -1410,6 +1416,7 @@
     "AWSIAMInstanceProfilemastersprivatecalicoexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "masters.privatecalico.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolemastersprivatecalicoexamplecom"
@@ -1420,6 +1427,7 @@
     "AWSIAMInstanceProfilenodesprivatecalicoexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "nodes.privatecalico.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolenodesprivatecalicoexamplecom"

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_bastions.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_bastions.privatecalico.example.com_policy
@@ -1,14 +1,14 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "privatecalico.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "privatecalico.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_nodes.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_nodes.privatecalico.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_bastions.privatecanal.example.com_policy
+++ b/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_bastions.privatecanal.example.com_policy
@@ -1,14 +1,14 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_masters.privatecanal.example.com_policy
+++ b/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_masters.privatecanal.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "privatecanal.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "privatecanal.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_nodes.privatecanal.example.com_policy
+++ b/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_nodes.privatecanal.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json
@@ -982,6 +982,7 @@
     "AWSEC2SecurityGroupapielbprivateciliumexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "api-elb.privatecilium.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivateciliumexamplecom"
         },
@@ -1005,6 +1006,7 @@
     "AWSEC2SecurityGroupbastionelbprivateciliumexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "bastion-elb.privatecilium.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivateciliumexamplecom"
         },
@@ -1028,6 +1030,7 @@
     "AWSEC2SecurityGroupbastionprivateciliumexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "bastion.privatecilium.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivateciliumexamplecom"
         },
@@ -1051,6 +1054,7 @@
     "AWSEC2SecurityGroupmastersprivateciliumexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "masters.privatecilium.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivateciliumexamplecom"
         },
@@ -1074,6 +1078,7 @@
     "AWSEC2SecurityGroupnodesprivateciliumexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "nodes.privatecilium.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivateciliumexamplecom"
         },
@@ -1386,6 +1391,7 @@
     "AWSIAMInstanceProfilebastionsprivateciliumexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "bastions.privatecilium.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolebastionsprivateciliumexamplecom"
@@ -1396,6 +1402,7 @@
     "AWSIAMInstanceProfilemastersprivateciliumexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "masters.privatecilium.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolemastersprivateciliumexamplecom"
@@ -1406,6 +1413,7 @@
     "AWSIAMInstanceProfilenodesprivateciliumexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "nodes.privatecilium.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolenodesprivateciliumexamplecom"

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_bastions.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_bastions.privatecilium.example.com_policy
@@ -1,14 +1,14 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "privatecilium.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "privatecilium.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json
@@ -982,6 +982,7 @@
     "AWSEC2SecurityGroupapielbprivateciliumexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "api-elb.privatecilium.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivateciliumexamplecom"
         },
@@ -1005,6 +1006,7 @@
     "AWSEC2SecurityGroupbastionelbprivateciliumexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "bastion-elb.privatecilium.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivateciliumexamplecom"
         },
@@ -1028,6 +1030,7 @@
     "AWSEC2SecurityGroupbastionprivateciliumexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "bastion.privatecilium.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivateciliumexamplecom"
         },
@@ -1051,6 +1054,7 @@
     "AWSEC2SecurityGroupmastersprivateciliumexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "masters.privatecilium.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivateciliumexamplecom"
         },
@@ -1074,6 +1078,7 @@
     "AWSEC2SecurityGroupnodesprivateciliumexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "nodes.privatecilium.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivateciliumexamplecom"
         },
@@ -1386,6 +1391,7 @@
     "AWSIAMInstanceProfilebastionsprivateciliumexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "bastions.privatecilium.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolebastionsprivateciliumexamplecom"
@@ -1396,6 +1402,7 @@
     "AWSIAMInstanceProfilemastersprivateciliumexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "masters.privatecilium.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolemastersprivateciliumexamplecom"
@@ -1406,6 +1413,7 @@
     "AWSIAMInstanceProfilenodesprivateciliumexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "nodes.privatecilium.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolenodesprivateciliumexamplecom"

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_bastions.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_bastions.privatecilium.example.com_policy
@@ -1,14 +1,14 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "privatecilium.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "privatecilium.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
@@ -982,6 +982,7 @@
     "AWSEC2SecurityGroupapielbprivateciliumadvancedexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "api-elb.privateciliumadvanced.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivateciliumadvancedexamplecom"
         },
@@ -1005,6 +1006,7 @@
     "AWSEC2SecurityGroupbastionelbprivateciliumadvancedexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "bastion-elb.privateciliumadvanced.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivateciliumadvancedexamplecom"
         },
@@ -1028,6 +1030,7 @@
     "AWSEC2SecurityGroupbastionprivateciliumadvancedexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "bastion.privateciliumadvanced.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivateciliumadvancedexamplecom"
         },
@@ -1051,6 +1054,7 @@
     "AWSEC2SecurityGroupmastersprivateciliumadvancedexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "masters.privateciliumadvanced.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivateciliumadvancedexamplecom"
         },
@@ -1074,6 +1078,7 @@
     "AWSEC2SecurityGroupnodesprivateciliumadvancedexamplecom": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
+        "GroupName": "nodes.privateciliumadvanced.example.com",
         "VpcId": {
           "Ref": "AWSEC2VPCprivateciliumadvancedexamplecom"
         },
@@ -1417,6 +1422,7 @@
     "AWSIAMInstanceProfilebastionsprivateciliumadvancedexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "bastions.privateciliumadvanced.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolebastionsprivateciliumadvancedexamplecom"
@@ -1427,6 +1433,7 @@
     "AWSIAMInstanceProfilemastersprivateciliumadvancedexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "masters.privateciliumadvanced.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolemastersprivateciliumadvancedexamplecom"
@@ -1437,6 +1444,7 @@
     "AWSIAMInstanceProfilenodesprivateciliumadvancedexamplecom": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
+        "InstanceProfileName": "nodes.privateciliumadvanced.example.com",
         "Roles": [
           {
             "Ref": "AWSIAMRolenodesprivateciliumadvancedexamplecom"

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_bastions.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_bastions.privateciliumadvanced.example.com_policy
@@ -1,14 +1,14 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "privateciliumadvanced.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "privateciliumadvanced.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,51 +121,51 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeSubnets",
         "ec2:AttachNetworkInterface",
@@ -182,9 +180,11 @@
         "ec2:ModifyNetworkInterfaceAttribute",
         "ec2:DescribeVpcs"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_nodes.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_nodes.privateciliumadvanced.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_bastions.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_bastions.privatedns1.example.com_policy
@@ -1,14 +1,14 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "privatedns1.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "privatedns1.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z2AFAKE1ZON3NO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_nodes.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_nodes.privatedns1.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_bastions.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_bastions.privatedns2.example.com_policy
@@ -1,14 +1,14 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "privatedns2.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "privatedns2.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z3AFAKE1ZOMORE"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_nodes.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_nodes.privatedns2.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_bastions.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_bastions.privateflannel.example.com_policy
@@ -1,14 +1,14 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "privateflannel.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "privateflannel.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_nodes.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_nodes.privateflannel.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_bastions.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_bastions.privatekopeio.example.com_policy
@@ -1,14 +1,14 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "privatekopeio.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "privatekopeio.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_nodes.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_nodes.privatekopeio.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_bastions.privateweave.example.com_policy
+++ b/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_bastions.privateweave.example.com_policy
@@ -1,14 +1,14 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_masters.privateweave.example.com_policy
+++ b/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_masters.privateweave.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "privateweave.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "privateweave.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_nodes.privateweave.example.com_policy
+++ b/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_nodes.privateweave.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/public-jwks/data/aws_iam_role_dns-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks/data/aws_iam_role_dns-controller.kube-system.sa.minimal.example.com_policy
@@ -1,17 +1,17 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
-      "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/api.minimal.example.com"
-      },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
           "api.minimal.example.com:sub": "system:serviceaccount:kube-system:dns-controller"
         }
+      },
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::123456789012:oidc-provider/api.minimal.example.com"
       }
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/public-jwks/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
@@ -1,34 +1,34 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/public-jwks/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "minimal.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "minimal.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,19 +121,21 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/public-jwks/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "sharedsubnet.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "sharedsubnet.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_nodes.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_nodes.sharedsubnet.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "sharedvpc.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "sharedvpc.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_nodes.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_nodes.sharedvpc.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_bastions.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_bastions.unmanaged.example.com_policy
@@ -1,14 +1,14 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
@@ -1,8 +1,6 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeInstances",
@@ -13,12 +11,12 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVolumes"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:CreateSecurityGroup",
         "ec2:CreateTags",
@@ -27,12 +25,12 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -43,45 +41,45 @@
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "ec2:ResourceTag/KubernetesCluster": "unmanaged.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "ec2:DescribeLaunchTemplateVersions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup"
       ],
-      "Resource": [
-        "*"
-      ],
       "Condition": {
         "StringEquals": {
           "autoscaling:ResourceTag/KubernetesCluster": "unmanaged.example.com"
         }
-      }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -100,12 +98,12 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeVpcs",
         "elasticloadbalancing:AddTags",
@@ -123,48 +121,50 @@
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "iam:ListServerCertificates",
         "iam:GetServerCertificate"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetHostedZone"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:GetChange"
       ],
+      "Effect": "Allow",
       "Resource": [
         "arn:aws:route53:::change/*"
       ]
     },
     {
-      "Effect": "Allow",
       "Action": [
         "route53:ListHostedZones"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_nodes.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_nodes.unmanaged.example.com_policy
@@ -1,15 +1,15 @@
 {
-  "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeRegions"
       ],
+      "Effect": "Allow",
       "Resource": [
         "*"
       ]
     }
-  ]
+  ],
+  "Version": "2012-10-17"
 }

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -191,7 +191,10 @@ func (e *AutoscalingGroup) Find(c *fi.Context) (*AutoscalingGroup, error) {
 	if len(g.Tags) != 0 {
 		actual.Tags = make(map[string]string)
 		for _, tag := range g.Tags {
-			actual.Tags[fi.StringValue(tag.Key)] = fi.StringValue(tag.Value)
+			if strings.HasPrefix(aws.StringValue(tag.Key), "aws:cloudformation:") {
+				continue
+			}
+			actual.Tags[aws.StringValue(tag.Key)] = aws.StringValue(tag.Value)
 		}
 	}
 

--- a/upup/pkg/fi/cloudup/awstasks/classic_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/classic_load_balancer.go
@@ -320,6 +320,9 @@ func (e *ClassicLoadBalancer) Find(c *fi.Context) (*ClassicLoadBalancer, error) 
 	}
 	actual.Tags = make(map[string]string)
 	for _, tag := range tagMap[*e.LoadBalancerName] {
+		if strings.HasPrefix(aws.StringValue(tag.Key), "aws:cloudformation:") {
+			continue
+		}
 		actual.Tags[aws.StringValue(tag.Key)] = aws.StringValue(tag.Value)
 	}
 

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
@@ -126,14 +126,14 @@ func (_ *IAMInstanceProfileRole) RenderTerraform(t *terraform.TerraformTarget, a
 }
 
 type cloudformationIAMInstanceProfile struct {
-	//Path  *string              `json:"name"`
-	Roles []*cloudformation.Literal `json:"Roles"`
+	InstanceProfileName *string                   `json:"InstanceProfileName"`
+	Roles               []*cloudformation.Literal `json:"Roles"`
 }
 
 func (_ *IAMInstanceProfileRole) RenderCloudformation(t *cloudformation.CloudformationTarget, a, e, changes *IAMInstanceProfileRole) error {
 	cf := &cloudformationIAMInstanceProfile{
-		//Path:  e.InstanceProfile.Name,
-		Roles: []*cloudformation.Literal{e.Role.CloudformationLink()},
+		InstanceProfileName: e.InstanceProfile.Name,
+		Roles:               []*cloudformation.Literal{e.Role.CloudformationLink()},
 	}
 
 	return t.RenderResource("AWS::IAM::InstanceProfile", *e.InstanceProfile.Name, cf)

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation.go
@@ -206,6 +206,11 @@ func (t *LaunchTemplate) RenderCloudformation(target *cloudformation.Cloudformat
 	if e.Tenancy != nil {
 		data.Placement = []*cloudformationLaunchTemplatePlacement{{Tenancy: e.Tenancy}}
 	}
+	if e.InstanceMonitoring != nil {
+		data.Monitoring = &cloudformationLaunchTemplateMonitoring{
+			Enabled: e.InstanceMonitoring,
+		}
+	}
 	if e.IAMInstanceProfile != nil {
 		data.IAMInstanceProfile = &cloudformationLaunchTemplateIAMProfile{
 			Name: e.IAMInstanceProfile.CloudformationLink(),

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation_test.go
@@ -72,6 +72,9 @@ func TestLaunchTemplateCloudformationRender(t *testing.T) {
               "MaxPrice": "10"
             }
           },
+          "Monitoring": {
+            "Enabled": true
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -155,6 +158,9 @@ func TestLaunchTemplateCloudformationRender(t *testing.T) {
           },
           "InstanceType": "t2.medium",
           "KeyName": "mykey",
+          "Monitoring": {
+            "Enabled": true
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -205,6 +205,11 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 	if e.Tenancy != nil {
 		tf.Placement = []*terraformLaunchTemplatePlacement{{Tenancy: e.Tenancy}}
 	}
+	if e.InstanceMonitoring != nil {
+		tf.Monitoring = []*terraformLaunchTemplateMonitoring{
+			{Enabled: e.InstanceMonitoring},
+		}
+	}
 	if e.IAMInstanceProfile != nil {
 		tf.IAMInstanceProfile = []*terraformLaunchTemplateIAMProfile{
 			{Name: e.IAMInstanceProfile.TerraformLink()},

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
@@ -72,6 +72,9 @@ resource "aws_launch_template" "test" {
   lifecycle {
     create_before_destroy = true
   }
+  monitoring {
+    enabled = true
+  }
   name_prefix = "test-"
   network_interfaces {
     associate_public_ip_address = true
@@ -147,6 +150,9 @@ resource "aws_launch_template" "test" {
   key_name      = "mykey"
   lifecycle {
     create_before_destroy = true
+  }
+  monitoring {
+    enabled = true
   }
   name_prefix = "test-"
   network_interfaces {

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -324,6 +324,9 @@ func (e *NetworkLoadBalancer) Find(c *fi.Context) (*NetworkLoadBalancer, error) 
 	}
 	actual.Tags = make(map[string]string)
 	for _, tag := range tagMap[*loadBalancerArn] {
+		if strings.HasPrefix(aws.StringValue(tag.Key), "aws:cloudformation:") {
+			continue
+		}
 		actual.Tags[aws.StringValue(tag.Key)] = aws.StringValue(tag.Value)
 	}
 

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -222,7 +222,7 @@ func (e *SecurityGroup) TerraformLink() *terraform.Literal {
 }
 
 type cloudformationSecurityGroup struct {
-	//Name        *string            `json:"name"`
+	GroupName   *string                 `json:"GroupName"`
 	VpcId       *cloudformation.Literal `json:"VpcId"`
 	Description *string                 `json:"GroupDescription"`
 	Tags        []cloudformationTag     `json:"Tags,omitempty"`
@@ -236,7 +236,7 @@ func (_ *SecurityGroup) RenderCloudformation(t *cloudformation.CloudformationTar
 	}
 
 	tf := &cloudformationSecurityGroup{
-		//Name:        e.Name,
+		GroupName:   e.Name,
 		VpcId:       e.VPC.CloudformationLink(),
 		Description: e.Description,
 		Tags:        buildCloudformationTags(e.Tags),

--- a/upup/pkg/fi/cloudup/awstasks/tags.go
+++ b/upup/pkg/fi/cloudup/awstasks/tags.go
@@ -17,6 +17,8 @@ limitations under the License.
 package awstasks
 
 import (
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
@@ -27,6 +29,9 @@ func mapEC2TagsToMap(tags []*ec2.Tag) map[string]string {
 	}
 	m := make(map[string]string)
 	for _, t := range tags {
+		if strings.HasPrefix(aws.StringValue(t.Key), "aws:cloudformation:") {
+			continue
+		}
 		m[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
 	}
 	return m


### PR DESCRIPTION
This addresses a few issues that makes `update cluster` show that there are unapplied changes:
* add missing resource names for CF
* add missing instance monitoring for CF and TF
* Ignore tags added by CF
* order policy document sections alphabetically