### PR TITLE
Mount the whole /etc/ssl/certs directory for k8s-ec2-srcdst

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -6655,13 +6655,14 @@ spec:
               value: {{ Region }}
           volumeMounts:
             - name: ssl-certs
-              mountPath: "/etc/ssl/certs/ca-certificates.crt"
+              mountPath: "/etc/ssl/certs"
               readOnly: true
           imagePullPolicy: "Always"
       volumes:
         - name: ssl-certs
           hostPath:
-            path: "/etc/ssl/certs/ca-certificates.crt"
+            path: "/etc/ssl/certs"
+            type: Directory
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{- end -}}
@@ -10899,13 +10900,15 @@ spec:
               value: {{ Region }}
           volumeMounts:
             - name: ssl-certs
-              mountPath: "/etc/ssl/certs/ca-certificates.crt"
+              mountPath: "/etc/ssl/certs"
               readOnly: true
           imagePullPolicy: "Always"
       volumes:
         - name: ssl-certs
           hostPath:
-            path: "/etc/ssl/certs/ca-certificates.crt"
+            path: "/etc/ssl/certs"
+            type: Directory
+
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{ end -}}

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -10908,7 +10908,6 @@ spec:
           hostPath:
             path: "/etc/ssl/certs"
             type: Directory
-
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{ end -}}

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -1079,13 +1079,14 @@ spec:
               value: {{ Region }}
           volumeMounts:
             - name: ssl-certs
-              mountPath: "/etc/ssl/certs/ca-certificates.crt"
+              mountPath: "/etc/ssl/certs"
               readOnly: true
           imagePullPolicy: "Always"
       volumes:
         - name: ssl-certs
           hostPath:
-            path: "/etc/ssl/certs/ca-certificates.crt"
+            path: "/etc/ssl/certs"
+            type: Directory
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{- end -}}

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -4215,13 +4215,15 @@ spec:
               value: {{ Region }}
           volumeMounts:
             - name: ssl-certs
-              mountPath: "/etc/ssl/certs/ca-certificates.crt"
+              mountPath: "/etc/ssl/certs"
               readOnly: true
           imagePullPolicy: "Always"
       volumes:
         - name: ssl-certs
           hostPath:
-            path: "/etc/ssl/certs/ca-certificates.crt"
+            path: "/etc/ssl/certs"
+            type: Directory
+
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{ end -}}

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -4223,7 +4223,6 @@ spec:
           hostPath:
             path: "/etc/ssl/certs"
             type: Directory
-
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{ end -}}


### PR DESCRIPTION
This PR fixes a particular issue when deploying Calico CNI in other AMI not based on Debian where the local SSL CA Cert store doesn't always point to `ca-certificates.crt`

@hakman suggested to mount the whole directory instead of referring to a file as a workaorund. More details on #10150 
Signed-off-by: Marcos Soutullo Rodriguez