### PR TITLE
Automated cherry pick of #10169: Mount the whole /etc/ssl/certs directory for k8s-ec2-srcdst

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -13503,7 +13503,6 @@ spec:
           hostPath:
             path: "/etc/ssl/certs"
             type: Directory
-
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{ end -}}

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -9250,13 +9250,14 @@ spec:
               value: {{ Region }}
           volumeMounts:
             - name: ssl-certs
-              mountPath: "/etc/ssl/certs/ca-certificates.crt"
+              mountPath: "/etc/ssl/certs"
               readOnly: true
           imagePullPolicy: "Always"
       volumes:
         - name: ssl-certs
           hostPath:
-            path: "/etc/ssl/certs/ca-certificates.crt"
+            path: "/etc/ssl/certs"
+            type: Directory
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{- end -}}
@@ -13494,13 +13495,15 @@ spec:
               value: {{ Region }}
           volumeMounts:
             - name: ssl-certs
-              mountPath: "/etc/ssl/certs/ca-certificates.crt"
+              mountPath: "/etc/ssl/certs"
               readOnly: true
           imagePullPolicy: "Always"
       volumes:
         - name: ssl-certs
           hostPath:
-            path: "/etc/ssl/certs/ca-certificates.crt"
+            path: "/etc/ssl/certs"
+            type: Directory
+
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{ end -}}

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -1079,13 +1079,14 @@ spec:
               value: {{ Region }}
           volumeMounts:
             - name: ssl-certs
-              mountPath: "/etc/ssl/certs/ca-certificates.crt"
+              mountPath: "/etc/ssl/certs"
               readOnly: true
           imagePullPolicy: "Always"
       volumes:
         - name: ssl-certs
           hostPath:
-            path: "/etc/ssl/certs/ca-certificates.crt"
+            path: "/etc/ssl/certs"
+            type: Directory
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{- end -}}

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -4215,13 +4215,15 @@ spec:
               value: {{ Region }}
           volumeMounts:
             - name: ssl-certs
-              mountPath: "/etc/ssl/certs/ca-certificates.crt"
+              mountPath: "/etc/ssl/certs"
               readOnly: true
           imagePullPolicy: "Always"
       volumes:
         - name: ssl-certs
           hostPath:
-            path: "/etc/ssl/certs/ca-certificates.crt"
+            path: "/etc/ssl/certs"
+            type: Directory
+
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{ end -}}

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -4223,7 +4223,6 @@ spec:
           hostPath:
             path: "/etc/ssl/certs"
             type: Directory
-
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{ end -}}


### PR DESCRIPTION
Cherry pick of #10169 on release-1.19.

#10169: Fix: Mount the whole `/etc/ssl/certs` directory for

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.