### PR TITLE
Automated cherry pick of #10169: Mount the whole /etc/ssl/certs directory for k8s-ec2-srcdst

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -11975,7 +11975,6 @@ spec:
           hostPath:
             path: "/etc/ssl/certs"
             type: Directory
-
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{ end -}}

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -7893,13 +7893,14 @@ spec:
               value: {{ Region }}
           volumeMounts:
             - name: ssl-certs
-              mountPath: "/etc/ssl/certs/ca-certificates.crt"
+              mountPath: "/etc/ssl/certs"
               readOnly: true
           imagePullPolicy: "Always"
       volumes:
         - name: ssl-certs
           hostPath:
-            path: "/etc/ssl/certs/ca-certificates.crt"
+            path: "/etc/ssl/certs"
+            type: Directory
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{- end -}}
@@ -11966,13 +11967,15 @@ spec:
               value: {{ Region }}
           volumeMounts:
             - name: ssl-certs
-              mountPath: "/etc/ssl/certs/ca-certificates.crt"
+              mountPath: "/etc/ssl/certs"
               readOnly: true
           imagePullPolicy: "Always"
       volumes:
         - name: ssl-certs
           hostPath:
-            path: "/etc/ssl/certs/ca-certificates.crt"
+            path: "/etc/ssl/certs"
+            type: Directory
+
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{ end -}}

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -1075,13 +1075,14 @@ spec:
               value: {{ Region }}
           volumeMounts:
             - name: ssl-certs
-              mountPath: "/etc/ssl/certs/ca-certificates.crt"
+              mountPath: "/etc/ssl/certs"
               readOnly: true
           imagePullPolicy: "Always"
       volumes:
         - name: ssl-certs
           hostPath:
-            path: "/etc/ssl/certs/ca-certificates.crt"
+            path: "/etc/ssl/certs"
+            type: Directory
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{- end -}}

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -4044,13 +4044,15 @@ spec:
               value: {{ Region }}
           volumeMounts:
             - name: ssl-certs
-              mountPath: "/etc/ssl/certs/ca-certificates.crt"
+              mountPath: "/etc/ssl/certs"
               readOnly: true
           imagePullPolicy: "Always"
       volumes:
         - name: ssl-certs
           hostPath:
-            path: "/etc/ssl/certs/ca-certificates.crt"
+            path: "/etc/ssl/certs"
+            type: Directory
+
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{ end -}}

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -4052,7 +4052,6 @@ spec:
           hostPath:
             path: "/etc/ssl/certs"
             type: Directory
-
       nodeSelector:
         node-role.kubernetes.io/master: ""
 {{ end -}}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -726,7 +726,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 			"k8s-1.7":    "2.6.12-kops.1",
 			"k8s-1.7-v3": "3.8.0-kops.2",
 			"k8s-1.12":   "3.9.6-kops.1",
-			"k8s-1.16":   "3.15.3-kops.2",
+			"k8s-1.16":   "3.15.3-kops.3",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 47097154eb2bbf222f6015384afd7c891e699738
+    manifestHash: 3b5a8acaf7bd081bc1985bf035466a925c3c0042
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
@@ -57,7 +57,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: dns-controller.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 142c127c3e290b1368068f9a025d7c49d8d109fa
+    manifestHash: b6a15df7088a00228863e7103292bed9af391142
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -65,7 +65,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 18f5b90de244ddbeac6493be898ae7676824d570
+    manifestHash: f93912d1ae4f7ad33479c1ae5e815e3385fa1870
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.18.1
+    version: v1.18.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -21,7 +21,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.18.1
+        version: v1.18.2
     spec:
       containers:
       - command:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -17,7 +17,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.18.1
+    version: v1.18.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -29,7 +29,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.18.1
+        version: v1.18.2
     spec:
       containers:
       - command:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 47097154eb2bbf222f6015384afd7c891e699738
+    manifestHash: 3b5a8acaf7bd081bc1985bf035466a925c3c0042
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
@@ -57,7 +57,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: dns-controller.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 142c127c3e290b1368068f9a025d7c49d8d109fa
+    manifestHash: b6a15df7088a00228863e7103292bed9af391142
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -65,7 +65,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 18f5b90de244ddbeac6493be898ae7676824d570
+    manifestHash: f93912d1ae4f7ad33479c1ae5e815e3385fa1870
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.18.1
+    version: v1.18.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -21,7 +21,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.18.1
+        version: v1.18.2
     spec:
       containers:
       - command:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -17,7 +17,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.18.1
+    version: v1.18.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -29,7 +29,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.18.1
+        version: v1.18.2
     spec:
       containers:
       - command:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 47097154eb2bbf222f6015384afd7c891e699738
+    manifestHash: 3b5a8acaf7bd081bc1985bf035466a925c3c0042
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
@@ -57,7 +57,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: dns-controller.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 142c127c3e290b1368068f9a025d7c49d8d109fa
+    manifestHash: b6a15df7088a00228863e7103292bed9af391142
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -65,7 +65,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 18f5b90de244ddbeac6493be898ae7676824d570
+    manifestHash: f93912d1ae4f7ad33479c1ae5e815e3385fa1870
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 47097154eb2bbf222f6015384afd7c891e699738
+    manifestHash: 3b5a8acaf7bd081bc1985bf035466a925c3c0042
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
@@ -57,7 +57,7 @@ spec:
   - id: k8s-1.6
     kubernetesVersion: <1.12.0
     manifest: dns-controller.addons.k8s.io/k8s-1.6.yaml
-    manifestHash: 142c127c3e290b1368068f9a025d7c49d8d109fa
+    manifestHash: b6a15df7088a00228863e7103292bed9af391142
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -65,7 +65,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 18f5b90de244ddbeac6493be898ae7676824d570
+    manifestHash: f93912d1ae4f7ad33479c1ae5e815e3385fa1870
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #10169 on release-1.18.

#10169: Fix: Mount the whole `/etc/ssl/certs` directory for

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.