### PR TITLE
OpenStack Reset deviceID status if needed

### DIFF
--- a/pkg/instancegroups/rollingupdate_os_test.go
+++ b/pkg/instancegroups/rollingupdate_os_test.go
@@ -172,7 +172,7 @@ func makeGroupOS(t *testing.T, groups map[string]*cloudinstances.CloudInstanceGr
 					Port: port.ID,
 				},
 			},
-		})
+		}, "")
 		if err != nil {
 			t.Fatalf("Failed to make group: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -108,7 +108,7 @@ type OpenstackCloud interface {
 	ListInstances(servers.ListOptsBuilder) ([]servers.Server, error)
 
 	// CreateInstance will create an openstack server provided create opts
-	CreateInstance(servers.CreateOptsBuilder) (*servers.Server, error)
+	CreateInstance(servers.CreateOptsBuilder, string) (*servers.Server, error)
 
 	//DeleteInstanceWithID will delete instance
 	DeleteInstanceWithID(instanceID string) error
@@ -215,6 +215,9 @@ type OpenstackCloud interface {
 
 	//GetPort will return a Neutron port by ID
 	GetPort(id string) (*ports.Port, error)
+
+	//UpdatePort will update a Neutron port by ID and options
+	UpdatePort(id string, opt ports.UpdateOptsBuilder) (*ports.Port, error)
 
 	//ListPorts will return the Neutron ports which match the options
 	ListPorts(opt ports.ListOptsBuilder) ([]ports.Port, error)

--- a/upup/pkg/fi/cloudup/openstack/mock_cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/mock_cloud.go
@@ -169,8 +169,8 @@ func (c *MockCloud) AttachVolume(serverID string, opts volumeattach.CreateOpts) 
 	return attachVolume(c, serverID, opts)
 }
 
-func (c *MockCloud) CreateInstance(opt servers.CreateOptsBuilder) (*servers.Server, error) {
-	return createInstance(c, opt)
+func (c *MockCloud) CreateInstance(opt servers.CreateOptsBuilder, portID string) (*servers.Server, error) {
+	return createInstance(c, opt, portID)
 }
 
 func (c *MockCloud) CreateKeypair(opt keypairs.CreateOptsBuilder) (*keypairs.KeyPair, error) {
@@ -353,6 +353,10 @@ func (c *MockCloud) GetPool(poolID string, memberID string) (member *v2pools.Mem
 
 func (c *MockCloud) GetPort(id string) (*ports.Port, error) {
 	return getPort(c, id)
+}
+
+func (c *MockCloud) UpdatePort(id string, opt ports.UpdateOptsBuilder) (*ports.Port, error) {
+	return updatePort(c, id, opt)
 }
 
 func (c *MockCloud) GetStorageAZFromCompute(computeAZ string) (*az.AvailabilityZone, error) {

--- a/upup/pkg/fi/cloudup/openstacktasks/instance.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance.go
@@ -292,7 +292,7 @@ func (_ *Instance) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, change
 			return err
 		}
 
-		v, err := t.Cloud.CreateInstance(opts)
+		v, err := t.Cloud.CreateInstance(opts, fi.StringValue(e.Port.ID))
 		if err != nil {
 			return fmt.Errorf("Error creating instance: %v", err)
 		}


### PR DESCRIPTION
Because we changed the behaviour how kops rolling update works, we are all the time randomly seeing following error:

```
{"conflictingRequest": {"message": "Port e3a94980-6b13-4ed1-8188-0c3634964915 is still in use.", "code": 409}}
```

The problem here is that we delete the instance that used port x, and then we are creating new instance using port x. Seems that this behaviour is now too fast at least for our OpenStack. Still after one hour the port is attached to deleted instance. This seems OpenStack bug, but because its quite easy to fix in kops side - I will do it.

With this code we are able to run rolling updates also in these cases.

/cc @olemarkus 