### PR TITLE
Fix to handle exit code of gazelle command in hack/verify-bazel.sh

### DIFF
--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -24,7 +24,7 @@ gazelle_diff=$("${TOOLS_BIN}/gazelle" fix \
   -exclude=tests/e2e \
   -mode=diff \
   -proto=disable \
-  -repo_root="${KOPS_ROOT}")
+  -repo_root="${KOPS_ROOT}") || _=$?
 
 if [[ -n "${gazelle_diff}" ]]; then
   echo "${gazelle_diff}" >&2


### PR DESCRIPTION
I fix a script for development.

When some diff are detected in `gazelle`, the command exit(1), so `verify-bazel.sh` exit without any messages.

For example, I run `gazelle` command directly:
```
$ _output/bin/gazelle fix -external=vendored -exclude=tests/e2e -mode=diff -proto=disable -repo_root=./
--- cmd/kops-controller/pkg/server/BUILD.bazel  1970-01-01 00:00:00.000000000 +0000
+++ cmd/kops-controller/pkg/server/BUILD.bazel  1970-01-01 00:00:00.000000000 +0000
@@ -13,9 +13,9 @@
         "//pkg/apis/nodeup:go_default_library",
         "//pkg/pki:go_default_library",
         "//pkg/rbac:go_default_library",
+        "//upup/pkg/fi:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
-        "//upup/pkg/fi:go_default_library",
     ],
 )
$ echo $?
1
```

And I run `hack/verify-bazel.sh` in the same condition:

```
$ hack/verify-bazel.sh
$ echo $? 
1
```

Because `gazelle` command exits with exit code 1 when it detects some diff, but `hack/verify-bazel.sh` didn't handle the exit code of `gazelle` command.