### PR TITLE
Compare KubernetesAPIAccess to OpenStack allowedCIDRs deterministically

### DIFF
--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -19,6 +19,7 @@ package openstackmodel
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -281,6 +282,8 @@ func (b *ServerGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Pool:      poolTask,
 		}
 		if useVIPACL {
+			// sort for consistent comparison
+			sort.Strings(b.Cluster.Spec.KubernetesAPIAccess)
 			listenerTask.AllowedCIDRs = b.Cluster.Spec.KubernetesAPIAccess
 		}
 		c.AddTask(listenerTask)

--- a/upup/pkg/fi/cloudup/openstacktasks/lblistener.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lblistener.go
@@ -18,6 +18,7 @@ package openstacktasks
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
 	openstackutil "k8s.io/cloud-provider-openstack/pkg/util/openstack"
@@ -56,6 +57,8 @@ func (s *LBListener) CompareWithID() *string {
 }
 
 func NewLBListenerTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle *fi.Lifecycle, lb *listeners.Listener, find *LBListener) (*LBListener, error) {
+	// sort for consistent comparison
+	sort.Strings(lb.AllowedCIDRs)
 	listenerTask := &LBListener{
 		ID:           fi.String(lb.ID),
 		Name:         fi.String(lb.Name),


### PR DESCRIPTION
This fixes #10173 by sorting the Allowed CIDRs and KubernetesAPIAccess, which will result in tasks comparing deterministic slices.

The issue in question mentions comparing the unordered contents against each other, but the change required for that might be considerable.

https://github.com/kubernetes/kops/blob/3941bd507d62a9ef7bb36f91b45478120f840d9b/upup/pkg/fi/changes.go#L181 compares indexed values directly against each other, so I think the implicit assumption is that all comparison slices should be ordered.