### PR TITLE
Spotinst: Configure Resource Limits in Ocean Auto Scaler

### DIFF
--- a/docs/advanced/experimental.md
+++ b/docs/advanced/experimental.md
@@ -18,7 +18,7 @@ The following experimental features are currently available:
 * `+KeepLaunchConfigurations` - Prevents garbage collection of old launch configurations
 * `+Spotinst` - Enables the use of the Spot integration
 * `+SpotinstOcean` - Enables the use of the Spot Ocean integration
-* `+SpotinstHybrid` - Toogles between hybrid and full instance group implementations
+* `+SpotinstHybrid` - Toggles between hybrid and full instance group implementations
 * `-SpotinstController` - Toggles the installation of the Spot controller addon off
 * `+SkipEtcdVersionCheck` - Bypasses the check that etcd-manager is using a supported etcd version
 * `+TerraformJSON` - Produce kubernetes.tf.json file instead of writing HCLv2 syntax. Can be consumed by terraform 0.12+

--- a/docs/getting_started/spot-ocean.md
+++ b/docs/getting_started/spot-ocean.md
@@ -167,10 +167,12 @@ metadata:
 | `spotinst.io/autoscaler-cooldown` | Specify a period of time, in seconds, that Ocean should wait between scaling actions. | `300` |
 | `spotinst.io/autoscaler-scale-down-max-percentage` | Specify the maximum scale down percentage. | none |
 | `spotinst.io/autoscaler-scale-down-evaluation-periods` | Specify the number of evaluation periods that should accumulate before a scale down action takes place. | `5` |
+| `spotinst.io/autoscaler-resource-limits-max-vcpu` | Specify the maximum number of virtual CPUs that can be allocated to the cluster. | none |
+| `spotinst.io/autoscaler-resource-limits-max-memory` | Specify the maximum amount of total physical memory (in GiB units) that can be allocated to the cluster. | none |
 
 ## Documentation
 
-If you're new to [Spot](https://spot.io/) and want to get started, please checkout our [Getting Started](https://help.spot.io/getting-started-with-spotinst/) guide, available on the [Spot Help Center](https://help.spot.io/) website.
+If you're new to [Spot](https://spot.io/) and want to get started, please checkout our [Getting Started](https://docs.spot.io/connect-your-cloud-provider/) guide, available on the [Spot Documentation](https://docs.spot.io/) website.
 
 ## Getting Help
 

--- a/pkg/model/spotinstmodel/instance_group.go
+++ b/pkg/model/spotinstmodel/instance_group.go
@@ -107,6 +107,11 @@ const (
 	// instance group to specify the scale down configuration used by the auto scaler.
 	InstanceGroupLabelAutoScalerScaleDownMaxPercentage     = "spotinst.io/autoscaler-scale-down-max-percentage"
 	InstanceGroupLabelAutoScalerScaleDownEvaluationPeriods = "spotinst.io/autoscaler-scale-down-evaluation-periods"
+
+	// InstanceGroupLabelAutoScalerResourceLimits* are the metadata labels used on the
+	// instance group to specify the resource limits configuration used by the auto scaler.
+	InstanceGroupLabelAutoScalerResourceLimitsMaxVCPU   = "spotinst.io/autoscaler-resource-limits-max-vcpu"
+	InstanceGroupLabelAutoScalerResourceLimitsMaxMemory = "spotinst.io/autoscaler-resource-limits-max-memory"
 )
 
 // InstanceGroupModelBuilder configures InstanceGroup objects
@@ -850,6 +855,30 @@ func (b *InstanceGroupModelBuilder) buildAutoScalerOpts(clusterID string, ig *ko
 					opts.Down = new(spotinsttasks.AutoScalerDownOpts)
 				}
 				opts.Down.EvaluationPeriods = fi.Int(int(fi.Int64Value(v)))
+			}
+
+		case InstanceGroupLabelAutoScalerResourceLimitsMaxVCPU:
+			{
+				v, err := parseInt(v)
+				if err != nil {
+					return nil, err
+				}
+				if opts.ResourceLimits == nil {
+					opts.ResourceLimits = new(spotinsttasks.AutoScalerResourceLimitsOpts)
+				}
+				opts.ResourceLimits.MaxVCPU = fi.Int(int(fi.Int64Value(v)))
+			}
+
+		case InstanceGroupLabelAutoScalerResourceLimitsMaxMemory:
+			{
+				v, err := parseInt(v)
+				if err != nil {
+					return nil, err
+				}
+				if opts.ResourceLimits == nil {
+					opts.ResourceLimits = new(spotinsttasks.AutoScalerResourceLimitsOpts)
+				}
+				opts.ResourceLimits.MaxMemory = fi.Int(int(fi.Int64Value(v)))
 			}
 		}
 	}

--- a/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
@@ -81,13 +81,14 @@ type RootVolumeOpts struct {
 }
 
 type AutoScalerOpts struct {
-	Enabled   *bool
-	ClusterID *string
-	Cooldown  *int
-	Labels    map[string]string
-	Taints    []*corev1.Taint
-	Headroom  *AutoScalerHeadroomOpts
-	Down      *AutoScalerDownOpts
+	Enabled        *bool
+	ClusterID      *string
+	Cooldown       *int
+	Labels         map[string]string
+	Taints         []*corev1.Taint
+	Headroom       *AutoScalerHeadroomOpts
+	Down           *AutoScalerDownOpts
+	ResourceLimits *AutoScalerResourceLimitsOpts
 }
 
 type AutoScalerHeadroomOpts struct {
@@ -100,6 +101,11 @@ type AutoScalerHeadroomOpts struct {
 type AutoScalerDownOpts struct {
 	MaxPercentage     *float64
 	EvaluationPeriods *int
+}
+
+type AutoScalerResourceLimitsOpts struct {
+	MaxVCPU   *int
+	MaxMemory *int
 }
 
 var _ fi.Task = &Elastigroup{}
@@ -1393,12 +1399,13 @@ type terraformElastigroupIntegration struct {
 }
 
 type terraformAutoScaler struct {
-	Enabled    *bool                        `json:"autoscale_is_enabled,omitempty" cty:"autoscale_is_enabled"`
-	AutoConfig *bool                        `json:"autoscale_is_auto_config,omitempty" cty:"autoscale_is_auto_config"`
-	Cooldown   *int                         `json:"autoscale_cooldown,omitempty" cty:"autoscale_cooldown"`
-	Headroom   *terraformAutoScalerHeadroom `json:"autoscale_headroom,omitempty" cty:"autoscale_headroom"`
-	Down       *terraformAutoScalerDown     `json:"autoscale_down,omitempty" cty:"autoscale_down"`
-	Labels     []*terraformKV               `json:"autoscale_labels,omitempty" cty:"autoscale_labels"`
+	Enabled        *bool                              `json:"autoscale_is_enabled,omitempty" cty:"autoscale_is_enabled"`
+	AutoConfig     *bool                              `json:"autoscale_is_auto_config,omitempty" cty:"autoscale_is_auto_config"`
+	Cooldown       *int                               `json:"autoscale_cooldown,omitempty" cty:"autoscale_cooldown"`
+	Headroom       *terraformAutoScalerHeadroom       `json:"autoscale_headroom,omitempty" cty:"autoscale_headroom"`
+	Down           *terraformAutoScalerDown           `json:"autoscale_down,omitempty" cty:"autoscale_down"`
+	ResourceLimits *terraformAutoScalerResourceLimits `json:"resource_limits,omitempty" cty:"resource_limits"`
+	Labels         []*terraformKV                     `json:"autoscale_labels,omitempty" cty:"autoscale_labels"`
 }
 
 type terraformAutoScalerHeadroom struct {
@@ -1411,6 +1418,11 @@ type terraformAutoScalerHeadroom struct {
 type terraformAutoScalerDown struct {
 	MaxPercentage     *float64 `json:"max_scale_down_percentage,omitempty" cty:"max_scale_down_percentage"`
 	EvaluationPeriods *int     `json:"evaluation_periods,omitempty" cty:"evaluation_periods"`
+}
+
+type terraformAutoScalerResourceLimits struct {
+	MaxVCPU   *int `json:"max_vcpu,omitempty" cty:"max_vcpu"`
+	MaxMemory *int `json:"max_memory_gib,omitempty" cty:"max_memory_gib"`
 }
 
 type terraformKV struct {

--- a/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
@@ -312,6 +312,14 @@ func (o *Ocean) Find(c *fi.Context) (*Ocean, error) {
 					EvaluationPeriods: down.EvaluationPeriods,
 				}
 			}
+
+			// Resource limits.
+			if limits := ocean.AutoScaler.ResourceLimits; limits != nil {
+				actual.AutoScalerOpts.ResourceLimits = &AutoScalerResourceLimitsOpts{
+					MaxVCPU:   limits.MaxVCPU,
+					MaxMemory: limits.MaxMemoryGiB,
+				}
+			}
 		}
 	}
 
@@ -532,6 +540,14 @@ func (_ *Ocean) create(cloud awsup.AWSCloud, a, e, changes *Ocean) error {
 					autoScaler.Down = &aws.AutoScalerDown{
 						MaxScaleDownPercentage: down.MaxPercentage,
 						EvaluationPeriods:      down.EvaluationPeriods,
+					}
+				}
+
+				// Resource limits.
+				if limits := opts.ResourceLimits; limits != nil {
+					autoScaler.ResourceLimits = &aws.AutoScalerResourceLimits{
+						MaxVCPU:      limits.MaxVCPU,
+						MaxMemoryGiB: limits.MaxMemory,
 					}
 				}
 
@@ -961,6 +977,16 @@ func (_ *Ocean) update(cloud awsup.AWSCloud, a, e, changes *Ocean) error {
 					autoScaler.SetDown(nil)
 				}
 
+				// Resource limits.
+				if limits := opts.ResourceLimits; limits != nil {
+					autoScaler.ResourceLimits = &aws.AutoScalerResourceLimits{
+						MaxVCPU:      limits.MaxVCPU,
+						MaxMemoryGiB: limits.MaxMemory,
+					}
+				} else if a.AutoScalerOpts.ResourceLimits != nil {
+					autoScaler.SetResourceLimits(nil)
+				}
+
 				ocean.SetAutoScaler(autoScaler)
 				changed = true
 			}
@@ -1177,6 +1203,14 @@ func (_ *Ocean) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Oce
 					tf.AutoScaler.Down = &terraformAutoScalerDown{
 						MaxPercentage:     down.MaxPercentage,
 						EvaluationPeriods: down.EvaluationPeriods,
+					}
+				}
+
+				// Resource limits.
+				if limits := opts.ResourceLimits; limits != nil {
+					tf.AutoScaler.ResourceLimits = &terraformAutoScalerResourceLimits{
+						MaxVCPU:   limits.MaxVCPU,
+						MaxMemory: limits.MaxVCPU,
 					}
 				}
 


### PR DESCRIPTION
This PR adds support for configuring [Resource Limits](https://docs.spot.io/ocean/features/scaling-kubernetes?id=resource-limits) in Ocean Auto Scaler.