### PR TITLE
Make etcd-manager log verbosity configurable

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -622,6 +622,10 @@ spec:
                         image:
                           description: Image is the etcd manager image to use.
                           type: string
+                        logLevel:
+                          description: LogLevel allows the klog library verbose log level to be set for etcd-manager. The default is 6. https://github.com/google/glog#verbose-logging
+                          format: int32
+                          type: integer
                       type: object
                     memoryRequest:
                       anyOf:

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -512,6 +512,9 @@ type EtcdManagerSpec struct {
 	// This allows etcd setting to be overwriten. No config validation is done.
 	// A list of etcd config ENV vars can be found at https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/configuration.md
 	Env []EnvVar `json:"env,omitempty"`
+	// LogLevel allows the klog library verbose log level to be set for etcd-manager. The default is 6.
+	// https://github.com/google/glog#verbose-logging
+	LogLevel *int32 `json:"logLevel,omitempty"`
 }
 
 // EtcdMemberSpec is a specification for a etcd member

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -509,6 +509,9 @@ type EtcdManagerSpec struct {
 	// This allows etcd setting to be configured/overwriten. No config validation is done.
 	// A list of etcd config ENV vars can be found at https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/configuration.md
 	Env []EnvVar `json:"env,omitempty"`
+	// LogLevel allows the klog library verbose log level to be set for etcd-manager. The default is 6.
+	// https://github.com/google/glog#verbose-logging
+	LogLevel *int32 `json:"logLevel,omitempty"`
 }
 
 // EtcdMemberSpec is a specification for a etcd member

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2957,6 +2957,7 @@ func autoConvert_v1alpha2_EtcdManagerSpec_To_kops_EtcdManagerSpec(in *EtcdManage
 	} else {
 		out.Env = nil
 	}
+	out.LogLevel = in.LogLevel
 	return nil
 }
 
@@ -2978,6 +2979,7 @@ func autoConvert_kops_EtcdManagerSpec_To_v1alpha2_EtcdManagerSpec(in *kops.EtcdM
 	} else {
 		out.Env = nil
 	}
+	out.LogLevel = in.LogLevel
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1323,6 +1323,11 @@ func (in *EtcdManagerSpec) DeepCopyInto(out *EtcdManagerSpec) {
 		*out = make([]EnvVar, len(*in))
 		copy(*out, *in)
 	}
+	if in.LogLevel != nil {
+		in, out := &in.LogLevel, &out.LogLevel
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -1473,6 +1473,11 @@ func (in *EtcdManagerSpec) DeepCopyInto(out *EtcdManagerSpec) {
 		*out = make([]EnvVar, len(*in))
 		copy(*out, *in)
 	}
+	if in.LogLevel != nil {
+		in, out := &in.LogLevel, &out.LogLevel
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -330,7 +330,12 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec) (*v1.Pod
 		EtcdInsecure:  etcdInsecure,
 	}
 
-	config.LogVerbosity = 6
+	config.LogLevel = 6
+
+	if etcdCluster.Manager != nil && etcdCluster.Manager.LogLevel != nil {
+		klog.Warningf("overriding log level in manifest %s, new level is %d", bundle, int(*etcdCluster.Manager.LogLevel))
+		config.LogLevel = int(*etcdCluster.Manager.LogLevel)
+	}
 
 	{
 		scheme := "https"
@@ -512,8 +517,8 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec) (*v1.Pod
 
 // config defines the flags for etcd-manager
 type config struct {
-	// LogVerbosity sets the log verbosity level
-	LogVerbosity int `flag:"v"`
+	// LogLevel sets the log verbosity level
+	LogLevel int `flag:"v"`
 
 	// Containerized is set if etcd-manager is running in a container
 	Containerized bool `flag:"containerized"`

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/cluster.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/cluster.yaml
@@ -15,6 +15,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     manager:
+      logLevel: 3
       env:
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
@@ -28,6 +29,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     manager:
+      logLevel: 3
       env:
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -79,7 +79,7 @@ Contents:
       - command:
         - /bin/sh
         - -c
-        - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3997 --insecure=false --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+        - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3997 --insecure=false --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995 --v=3 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
         env:
         - name: ETCD_QUOTA_BACKEND_BYTES
           value: "10737418240"
@@ -141,7 +141,7 @@ Contents:
       - command:
         - /bin/sh
         - -c
-        - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3996 --insecure=false --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+        - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3996 --insecure=false --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994 --v=3 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
         env:
         - name: ETCD_QUOTA_BACKEND_BYTES
           value: "10737418240"


### PR DESCRIPTION
This PR addresses #7946, which I believed was closed in error - the PR referenced as a fix allows the etcd log level to be changed, but etcd-manager has its own klog-based log level which was hardcoded to a quite verbose level in Kops itself, even reducing the log level of etcd you still have to deal with a lot of noise which then has to be filtered out in fluentd or whatever you use to collect/aggregate container logs.

I took https://github.com/kubernetes/kops/pull/8402 as a guide, please let me know what you think.