### PR TITLE
Automated cherry pick of #10187: Fix auto scaling group changes when using spot instances

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -455,13 +455,14 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 		}
 
 		if changes.LaunchTemplate != nil {
-			// @note: at the moment we are only using launch templates when using mixed instance policies,
-			// but this might change
-			setup(request).LaunchTemplate = &autoscaling.LaunchTemplate{
-				LaunchTemplateSpecification: &autoscaling.LaunchTemplateSpecification{
-					LaunchTemplateName: changes.LaunchTemplate.ID,
-					Version:            &launchTemplateVersion,
-				},
+			spec := &autoscaling.LaunchTemplateSpecification{
+				LaunchTemplateId: changes.LaunchTemplate.ID,
+				Version:          &launchTemplateVersion,
+			}
+			if e.UseMixedInstancesPolicy() {
+				setup(request).LaunchTemplate = &autoscaling.LaunchTemplate{LaunchTemplateSpecification: spec}
+			} else {
+				request.LaunchTemplate = spec
 			}
 			changes.LaunchTemplate = nil
 		}


### PR DESCRIPTION
Cherry pick of #10187 on release-1.19.

#10187: Fix auto scaling group changes when using spot instances

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.