### PR TITLE
Fix disabling spot instances when using launch templates

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -136,7 +136,9 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateTask(c *fi.ModelBuilde
 	//   You cannot use a launch template that is set to request Spot Instances (InstanceMarketOptions)
 	//   when you configure an Auto Scaling group with a mixed instances policy.
 	if ig.Spec.MixedInstancesPolicy == nil {
-		lt.SpotPrice = lc.SpotPrice
+		lt.SpotPrice = fi.String(lc.SpotPrice)
+	} else {
+		lt.SpotPrice = fi.String("")
 	}
 	if ig.Spec.SpotDurationInMinutes != nil {
 		lt.SpotDurationInMinutes = ig.Spec.SpotDurationInMinutes

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -456,8 +456,8 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 
 		if changes.LaunchTemplate != nil {
 			spec := &autoscaling.LaunchTemplateSpecification{
-				LaunchTemplateId: changes.LaunchTemplate.ID,
-				Version:          &launchTemplateVersion,
+				LaunchTemplateName: changes.LaunchTemplate.ID,
+				Version:            &launchTemplateVersion,
 			}
 			if e.UseMixedInstancesPolicy() {
 				setup(request).LaunchTemplate = &autoscaling.LaunchTemplate{LaunchTemplateSpecification: spec}

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
@@ -64,7 +64,7 @@ type LaunchTemplate struct {
 	// SecurityGroups is a list of security group associated
 	SecurityGroups []*SecurityGroup
 	// SpotPrice is set to the spot-price bid if this is a spot pricing request
-	SpotPrice string
+	SpotPrice *string
 	// SpotDurationInMinutes is set for requesting spot blocks
 	SpotDurationInMinutes *int64
 	// Tags are the keypairs to apply to the instance and volume on launch as well as the launch template itself.

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation.go
@@ -180,8 +180,8 @@ func (t *LaunchTemplate) RenderCloudformation(target *cloudformation.Cloudformat
 		},
 	}
 
-	if e.SpotPrice != "" {
-		marketSpotOptions := cloudformationLaunchTemplateMarketOptionsSpotOptions{MaxPrice: fi.String(e.SpotPrice)}
+	if fi.StringValue(e.SpotPrice) != "" {
+		marketSpotOptions := cloudformationLaunchTemplateMarketOptionsSpotOptions{MaxPrice: e.SpotPrice}
 		if e.SpotDurationInMinutes != nil {
 			marketSpotOptions.BlockDurationMinutes = e.SpotDurationInMinutes
 		}

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation_test.go
@@ -37,7 +37,7 @@ func TestLaunchTemplateCloudformationRender(t *testing.T) {
 				RootVolumeOptimization:       fi.Bool(true),
 				RootVolumeIops:               fi.Int64(100),
 				RootVolumeSize:               fi.Int64(64),
-				SpotPrice:                    "10",
+				SpotPrice:                    fi.String("10"),
 				SpotDurationInMinutes:        fi.Int64(120),
 				InstanceInterruptionBehavior: fi.String("hibernate"),
 				SSHKey: &SSHKey{

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -181,8 +181,8 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 		},
 	}
 
-	if e.SpotPrice != "" {
-		marketSpotOptions := terraformLaunchTemplateMarketOptionsSpotOptions{MaxPrice: fi.String(e.SpotPrice)}
+	if fi.StringValue(e.SpotPrice) != "" {
+		marketSpotOptions := terraformLaunchTemplateMarketOptionsSpotOptions{MaxPrice: e.SpotPrice}
 		if e.SpotDurationInMinutes != nil {
 			marketSpotOptions.BlockDurationMinutes = e.SpotDurationInMinutes
 		}

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
@@ -34,7 +34,7 @@ func TestLaunchTemplateTerraformRender(t *testing.T) {
 				ID:                           fi.String("test-11"),
 				InstanceMonitoring:           fi.Bool(true),
 				InstanceType:                 fi.String("t2.medium"),
-				SpotPrice:                    "0.1",
+				SpotPrice:                    fi.String("0.1"),
 				SpotDurationInMinutes:        fi.Int64(60),
 				InstanceInterruptionBehavior: fi.String("hibernate"),
 				RootVolumeOptimization:       fi.Bool(true),


### PR DESCRIPTION
Some extra fixes after #10187, to be able to remove the SpotPrice when already set.

/cc @rifelpet 