### PR TITLE
Automated cherry pick of #10144: allow reauth for openstack client

### DIFF
--- a/util/pkg/vfs/swiftfs.go
+++ b/util/pkg/vfs/swiftfs.go
@@ -51,8 +51,6 @@ func NewSwiftClient() (*gophercloud.ServiceClient, error) {
 		return nil, err
 	}
 
-	authOption.AllowReauth = true
-
 	pc, err := openstack.NewClient(authOption.IdentityEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("error building openstack provider client: %v", err)
@@ -145,6 +143,7 @@ func (oc OpenstackConfig) GetCredential() (gophercloud.AuthOptions, error) {
 	if env.ApplicationCredentialID != "" && env.Username == "" {
 		env.Scope = &gophercloud.AuthScope{}
 	}
+	env.AllowReauth = true
 	return env, nil
 
 }


### PR DESCRIPTION
Cherry pick of #10144 on release-1.19.

#10144: allow reauth for openstack client

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.