### PR TITLE
Automated cherry pick of #10209: Update Go to v1.15.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.2
+          go-version: 1.15.4
 
       - uses: actions/checkout@v2
         with:
@@ -33,7 +33,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.2
+        go-version: 1.15.4
 
     - uses: actions/checkout@v2
       with:
@@ -50,7 +50,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.2
+        go-version: 1.15.4
 
     - uses: actions/checkout@v2
       with:
@@ -67,7 +67,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.2
+          go-version: 1.15.4
 
       - uses: actions/checkout@v2
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: go
-arch:
-  - amd64
-  - arm64
+arch: arm64
 os: linux
 dist: focal
-go: 1.15.2
+go: 1.15.4
 
 go_import_path: k8s.io/kops
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,8 +29,8 @@ go_rules_dependencies()
 go_download_sdk(
     name = "go_sdk",
     sdks = {
-        "darwin_amd64": ("go1.15.2.darwin-amd64.tar.gz", "9bd39600d9fa1fa4a5ccce8761d249f7421cffe671376f791293c4138f3d7c62"),
-        "linux_amd64": ("go1.15.2.linux-amd64.tar.gz", "b49fda1ca29a1946d6bb2a5a6982cf07ccd2aba849289508ee0f9918f6bb4552"),
+        "darwin_amd64": ("go1.15.4.darwin-amd64.tar.gz", "aaf8c5323e0557211680960a8f51bedf98ab9a368775a687d6cf1f0079232b1d"),
+        "linux_amd64": ("go1.15.4.linux-amd64.tar.gz", "eb61005f0b932c93b424a3a4eaa67d72196c79129d9a3ea8578047683e2c80d5"),
     },
 )
 


### PR DESCRIPTION
Cherry pick of #10209 on release-1.19.

#10209: Update Go to v1.15.4

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.