### PR TITLE
Allow to use custom csi plugin image and enable topology support

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -195,6 +195,10 @@ spec:
                           createStorageClass:
                             description: CreateStorageClass provisions a default class for the Cinder plugin
                             type: boolean
+                          csiPluginImage:
+                            type: string
+                          csiTopologySupport:
+                            type: boolean
                           ignore-volume-az:
                             type: boolean
                           override-volume-az:

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -706,7 +706,9 @@ type OpenstackBlockStorageConfig struct {
 	IgnoreAZ   *bool   `json:"ignore-volume-az,omitempty"`
 	OverrideAZ *string `json:"override-volume-az,omitempty"`
 	// CreateStorageClass provisions a default class for the Cinder plugin
-	CreateStorageClass *bool `json:"createStorageClass,omitempty"`
+	CreateStorageClass *bool  `json:"createStorageClass,omitempty"`
+	CSIPluginImage     string `json:"csiPluginImage,omitempty"`
+	CSITopologySupport *bool  `json:"csiTopologySupport,omitempty"`
 }
 
 // OpenstackMonitor defines the config for a health monitor

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -707,7 +707,9 @@ type OpenstackBlockStorageConfig struct {
 	IgnoreAZ   *bool   `json:"ignore-volume-az,omitempty"`
 	OverrideAZ *string `json:"override-volume-az,omitempty"`
 	// CreateStorageClass provisions a default class for the Cinder plugin
-	CreateStorageClass *bool `json:"createStorageClass,omitempty"`
+	CreateStorageClass *bool  `json:"createStorageClass,omitempty"`
+	CSIPluginImage     string `json:"csiPluginImage,omitempty"`
+	CSITopologySupport *bool  `json:"csiTopologySupport,omitempty"`
 }
 
 // OpenstackMonitor defines the config for a health monitor

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5197,6 +5197,8 @@ func autoConvert_v1alpha2_OpenstackBlockStorageConfig_To_kops_OpenstackBlockStor
 	out.IgnoreAZ = in.IgnoreAZ
 	out.OverrideAZ = in.OverrideAZ
 	out.CreateStorageClass = in.CreateStorageClass
+	out.CSIPluginImage = in.CSIPluginImage
+	out.CSITopologySupport = in.CSITopologySupport
 	return nil
 }
 
@@ -5210,6 +5212,8 @@ func autoConvert_kops_OpenstackBlockStorageConfig_To_v1alpha2_OpenstackBlockStor
 	out.IgnoreAZ = in.IgnoreAZ
 	out.OverrideAZ = in.OverrideAZ
 	out.CreateStorageClass = in.CreateStorageClass
+	out.CSIPluginImage = in.CSIPluginImage
+	out.CSITopologySupport = in.CSITopologySupport
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3494,6 +3494,11 @@ func (in *OpenstackBlockStorageConfig) DeepCopyInto(out *OpenstackBlockStorageCo
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CSITopologySupport != nil {
+		in, out := &in.CSITopologySupport, &out.CSITopologySupport
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3708,6 +3708,11 @@ func (in *OpenstackBlockStorageConfig) DeepCopyInto(out *OpenstackBlockStorageCo
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CSITopologySupport != nil {
+		in, out := &in.CSITopologySupport, &out.CSITopologySupport
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -15641,6 +15641,9 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
+{{ if WithDefaultBool .CloudConfig.Openstack.BlockStorage.CSITopologySupport false }}
+            - --feature-gates=Topology=true
+{{ end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -15671,7 +15674,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: cinder-csi-plugin
-          image: docker.io/k8scloudprovider/cinder-csi-plugin:{{ OpenStackCCMTag }}
+          image: "{{- if .CloudConfig.Openstack.BlockStorage.CSIPluginImage -}} {{ .CloudConfig.Openstack.BlockStorage.CSIPluginImage }} {{- else -}} docker.io/k8scloudprovider/cinder-csi-plugin:{{OpenStackCCMTag}} {{- end -}}"
           args:
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"
@@ -15800,7 +15803,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: docker.io/k8scloudprovider/cinder-csi-plugin:{{ OpenStackCCMTag }}
+          image: "{{- if .CloudConfig.Openstack.BlockStorage.CSIPluginImage -}} {{ .CloudConfig.Openstack.BlockStorage.CSIPluginImage }} {{- else -}} docker.io/k8scloudprovider/cinder-csi-plugin:{{OpenStackCCMTag}} {{- end -}}"
           args :
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"

--- a/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
@@ -288,6 +288,9 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
+{{ if WithDefaultBool .CloudConfig.Openstack.BlockStorage.CSITopologySupport false }}
+            - --feature-gates=Topology=true
+{{ end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -318,7 +321,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: cinder-csi-plugin
-          image: docker.io/k8scloudprovider/cinder-csi-plugin:{{ OpenStackCCMTag }}
+          image: "{{- if .CloudConfig.Openstack.BlockStorage.CSIPluginImage -}} {{ .CloudConfig.Openstack.BlockStorage.CSIPluginImage }} {{- else -}} docker.io/k8scloudprovider/cinder-csi-plugin:{{OpenStackCCMTag}} {{- end -}}"
           args:
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"
@@ -447,7 +450,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: docker.io/k8scloudprovider/cinder-csi-plugin:{{ OpenStackCCMTag }}
+          image: "{{- if .CloudConfig.Openstack.BlockStorage.CSIPluginImage -}} {{ .CloudConfig.Openstack.BlockStorage.CSIPluginImage }} {{- else -}} docker.io/k8scloudprovider/cinder-csi-plugin:{{OpenStackCCMTag}} {{- end -}}"
           args :
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"


### PR DESCRIPTION
Topology support is going to be added 2.0.4 provisioner, but that is not yet published. This is why at least we need featureflag for it.

Also I added feature to add custom csi plugin image to verify things with newer image if needed.