### PR TITLE
Update kOps version after 1.19.0-beta.1 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,13 @@ PROTOKUBE_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_PROTOKUBE_TAG 
 # We lock the versions of our controllers also
 # We need to keep in sync with:
 #   upup/models/cloudup/resources/addons/dns-controller/
-DNS_CONTROLLER_TAG=1.19.0-alpha.5
+DNS_CONTROLLER_TAG=1.19.0-beta.1
 DNS_CONTROLLER_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_DNS_CONTROLLER_TAG | awk '{print $$2}')
 #   upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/
-KOPS_CONTROLLER_TAG=1.19.0-alpha.5
+KOPS_CONTROLLER_TAG=1.19.0-beta.1
 KOPS_CONTROLLER_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_KOPS_CONTROLLER_TAG | awk '{print $$2}')
 #   pkg/model/components/kubeapiserver/model.go
-KUBE_APISERVER_HEALTHCHECK_TAG=1.19.0-alpha.5
+KUBE_APISERVER_HEALTHCHECK_TAG=1.19.0-beta.1
 KUBE_APISERVER_HEALTHCHECK_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_KUBE_APISERVER_HEALTHCHECK_TAG | awk '{print $$2}')
 
 

--- a/pkg/model/components/kubeapiserver/model.go
+++ b/pkg/model/components/kubeapiserver/model.go
@@ -95,7 +95,7 @@ kind: Pod
 spec:
   containers:
   - name: healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.19.0-alpha.5
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.19.0-beta.1
     livenessProbe:
       httpGet:
         # The sidecar serves a healthcheck on the same port,

--- a/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
+++ b/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
@@ -14,7 +14,7 @@ Contents:
         - --client-key=/secrets/client.key
         command:
         - /kube-apiserver-healthcheck
-        image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.19.0-alpha.5
+        image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.19.0-beta.1
         livenessProbe:
           httpGet:
             host: 127.0.0.1

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -1522,7 +1522,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.19.0-alpha.5
+    version: v1.19.0-beta.1
 spec:
   replicas: 1
   strategy:
@@ -1535,7 +1535,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.19.0-alpha.5
+        version: v1.19.0-beta.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -1549,7 +1549,7 @@ spec:
       serviceAccount: dns-controller
       containers:
       - name: dns-controller
-        image: k8s.gcr.io/kops/dns-controller:1.19.0-alpha.5
+        image: k8s.gcr.io/kops/dns-controller:1.19.0-beta.1
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"
@@ -1821,7 +1821,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.19.0-alpha.5
+    version: v1.19.0-beta.1
 spec:
   selector:
     matchLabels:
@@ -1835,7 +1835,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.19.0-alpha.5
+        version: v1.19.0-beta.1
     spec:
       priorityClassName: system-node-critical
       tolerations:
@@ -1849,7 +1849,7 @@ spec:
       serviceAccount: kops-controller
       containers:
       - name: kops-controller
-        image: k8s.gcr.io/kops/kops-controller:1.19.0-alpha.5
+        image: k8s.gcr.io/kops/kops-controller:1.19.0-beta.1
         volumeMounts:
 {{ if .UseHostCertificates }}
         - mountPath: /etc/ssl/certs

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.19.0-alpha.5
+    version: v1.19.0-beta.1
 spec:
   replicas: 1
   strategy:
@@ -19,7 +19,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.19.0-alpha.5
+        version: v1.19.0-beta.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -33,7 +33,7 @@ spec:
       serviceAccount: dns-controller
       containers:
       - name: dns-controller
-        image: k8s.gcr.io/kops/dns-controller:1.19.0-alpha.5
+        image: k8s.gcr.io/kops/dns-controller:1.19.0-beta.1
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.19.0-alpha.5
+    version: v1.19.0-beta.1
 spec:
   selector:
     matchLabels:
@@ -33,7 +33,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.19.0-alpha.5
+        version: v1.19.0-beta.1
     spec:
       priorityClassName: system-node-critical
       tolerations:
@@ -47,7 +47,7 @@ spec:
       serviceAccount: kops-controller
       containers:
       - name: kops-controller
-        image: k8s.gcr.io/kops/kops-controller:1.19.0-alpha.5
+        image: k8s.gcr.io/kops/kops-controller:1.19.0-beta.1
         volumeMounts:
 {{ if .UseHostCertificates }}
         - mountPath: /etc/ssl/certs

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -172,7 +172,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 
 	{
 		key := "kops-controller.addons.k8s.io"
-		version := "1.19.0-alpha.5"
+		version := "1.19.0-beta.1"
 
 		{
 			location := key + "/k8s-1.16.yaml"
@@ -191,7 +191,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 
 	if featureflag.PublicJWKS.Enabled() {
 		key := "anonymous-issuer-discovery.addons.k8s.io"
-		version := "1.19.0-alpha.5"
+		version := "1.19.0-beta.1"
 
 		{
 			location := key + "/k8s-1.16.yaml"
@@ -374,7 +374,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 	if externalDNS == nil || !externalDNS.Disable {
 		{
 			key := "dns-controller.addons.k8s.io"
-			version := "1.19.0-alpha.5"
+			version := "1.19.0-beta.1"
 
 			{
 				location := key + "/k8s-1.12.yaml"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -7,11 +7,11 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6965b8587712568af06e0751545c87b2949855a7
+    manifestHash: 5ed0e7436ab350bb4e287e27f7e5aa2fb1eaf8f9
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.19.0-alpha.5
+    version: 1.19.0-beta.1
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
     name: core.addons.k8s.io
@@ -47,11 +47,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e8240400cebfa9a338f8ff1f647e203fe43cbbcf
+    manifestHash: ce7de4257bc531869a3bcc20ef50bd183dc9dcf0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.19.0-alpha.5
+    version: 1.19.0-beta.1
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -7,11 +7,11 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 93ce0c2a3093c8cf80abd3c863429e5b9c458fbd
+    manifestHash: a7d47f4a668812e334b505231855a82cef2f670c
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.19.0-alpha.5
+    version: 1.19.0-beta.1
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
     name: core.addons.k8s.io
@@ -40,11 +40,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e8240400cebfa9a338f8ff1f647e203fe43cbbcf
+    manifestHash: ce7de4257bc531869a3bcc20ef50bd183dc9dcf0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.19.0-alpha.5
+    version: 1.19.0-beta.1
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.19.0-alpha.5
+    version: v1.19.0-beta.1
   name: dns-controller
   namespace: kube-system
 spec:
@@ -21,7 +21,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.19.0-alpha.5
+        version: v1.19.0-beta.1
     spec:
       containers:
       - command:
@@ -34,7 +34,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.19.0-alpha.5
+        image: k8s.gcr.io/kops/dns-controller:1.19.0-beta.1
         name: dns-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -17,7 +17,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.19.0-alpha.5
+    version: v1.19.0-beta.1
   name: kops-controller
   namespace: kube-system
 spec:
@@ -29,14 +29,14 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.19.0-alpha.5
+        version: v1.19.0-beta.1
     spec:
       containers:
       - command:
         - /kops-controller
         - --v=2
         - --conf=/etc/kubernetes/kops-controller/config/config.yaml
-        image: k8s.gcr.io/kops/kops-controller:1.19.0-alpha.5
+        image: k8s.gcr.io/kops/kops-controller:1.19.0-beta.1
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -7,11 +7,11 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6965b8587712568af06e0751545c87b2949855a7
+    manifestHash: 5ed0e7436ab350bb4e287e27f7e5aa2fb1eaf8f9
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.19.0-alpha.5
+    version: 1.19.0-beta.1
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
     name: core.addons.k8s.io
@@ -47,11 +47,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e8240400cebfa9a338f8ff1f647e203fe43cbbcf
+    manifestHash: ce7de4257bc531869a3bcc20ef50bd183dc9dcf0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.19.0-alpha.5
+    version: 1.19.0-beta.1
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/jwks/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/jwks/manifest.yaml
@@ -19,7 +19,7 @@ spec:
     name: anonymous-access.addons.k8s.io
     selector:
       k8s-addon: anonymous-access.addons.k8s.io
-    version: 1.19.0-alpha.5
+    version: 1.19.0-beta.1
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
     name: core.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.19.0-alpha.5
+    version: v1.19.0-beta.1
   name: dns-controller
   namespace: kube-system
 spec:
@@ -21,7 +21,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.19.0-alpha.5
+        version: v1.19.0-beta.1
     spec:
       containers:
       - command:
@@ -38,7 +38,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.19.0-alpha.5
+        image: k8s.gcr.io/kops/dns-controller:1.19.0-beta.1
         name: dns-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -17,7 +17,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.19.0-alpha.5
+    version: v1.19.0-beta.1
   name: kops-controller
   namespace: kube-system
 spec:
@@ -29,14 +29,14 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.19.0-alpha.5
+        version: v1.19.0-beta.1
     spec:
       containers:
       - command:
         - /kops-controller
         - --v=2
         - --conf=/etc/kubernetes/kops-controller/config/config.yaml
-        image: k8s.gcr.io/kops/kops-controller:1.19.0-alpha.5
+        image: k8s.gcr.io/kops/kops-controller:1.19.0-beta.1
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/manifest.yaml
@@ -7,11 +7,11 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6965b8587712568af06e0751545c87b2949855a7
+    manifestHash: 5ed0e7436ab350bb4e287e27f7e5aa2fb1eaf8f9
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.19.0-alpha.5
+    version: 1.19.0-beta.1
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: anonymous-issuer-discovery.addons.k8s.io/k8s-1.16.yaml
@@ -19,7 +19,7 @@ spec:
     name: anonymous-issuer-discovery.addons.k8s.io
     selector:
       k8s-addon: anonymous-issuer-discovery.addons.k8s.io
-    version: 1.19.0-alpha.5
+    version: 1.19.0-beta.1
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
     name: core.addons.k8s.io
@@ -55,11 +55,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 5bde4e91a731d201df8463bb87750b051a4a0cfb
+    manifestHash: 85434c74cf83a50ba33843ed7bafce5cb5891fdb
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.19.0-alpha.5
+    version: 1.19.0-beta.1
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.19.0-alpha.5
+    version: v1.19.0-beta.1
   name: dns-controller
   namespace: kube-system
 spec:
@@ -21,7 +21,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.19.0-alpha.5
+        version: v1.19.0-beta.1
     spec:
       containers:
       - command:
@@ -34,7 +34,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.19.0-alpha.5
+        image: k8s.gcr.io/kops/dns-controller:1.19.0-beta.1
         name: dns-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -17,7 +17,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.19.0-alpha.5
+    version: v1.19.0-beta.1
   name: kops-controller
   namespace: kube-system
 spec:
@@ -29,14 +29,14 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.19.0-alpha.5
+        version: v1.19.0-beta.1
     spec:
       containers:
       - command:
         - /kops-controller
         - --v=2
         - --conf=/etc/kubernetes/kops-controller/config/config.yaml
-        image: k8s.gcr.io/kops/kops-controller:1.19.0-alpha.5
+        image: k8s.gcr.io/kops/kops-controller:1.19.0-beta.1
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -7,11 +7,11 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 93ce0c2a3093c8cf80abd3c863429e5b9c458fbd
+    manifestHash: a7d47f4a668812e334b505231855a82cef2f670c
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.19.0-alpha.5
+    version: 1.19.0-beta.1
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
     name: core.addons.k8s.io
@@ -40,11 +40,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e8240400cebfa9a338f8ff1f647e203fe43cbbcf
+    manifestHash: ce7de4257bc531869a3bcc20ef50bd183dc9dcf0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.19.0-alpha.5
+    version: 1.19.0-beta.1
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -7,11 +7,11 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6965b8587712568af06e0751545c87b2949855a7
+    manifestHash: 5ed0e7436ab350bb4e287e27f7e5aa2fb1eaf8f9
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.19.0-alpha.5
+    version: 1.19.0-beta.1
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
     name: core.addons.k8s.io
@@ -47,11 +47,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e8240400cebfa9a338f8ff1f647e203fe43cbbcf
+    manifestHash: ce7de4257bc531869a3bcc20ef50bd183dc9dcf0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.19.0-alpha.5
+    version: 1.19.0-beta.1
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/urls_test.go
+++ b/upup/pkg/fi/cloudup/urls_test.go
@@ -35,33 +35,33 @@ func Test_BuildMirroredAsset(t *testing.T) {
 		{
 			url: "https://kubeupv2.s3.amazonaws.com/kops/%s/images/protokube-linux-amd64",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.19.0-alpha.5/images/protokube-linux-amd64",
-				"https://github.com/kubernetes/kops/releases/download/v1.19.0-alpha.5/images-protokube-linux-amd64",
-				"https://kubeupv2.s3.amazonaws.com/kops/1.19.0-alpha.5/images/protokube-linux-amd64",
+				"https://artifacts.k8s.io/binaries/kops/1.19.0-beta.1/images/protokube-linux-amd64",
+				"https://github.com/kubernetes/kops/releases/download/v1.19.0-beta.1/images-protokube-linux-amd64",
+				"https://kubeupv2.s3.amazonaws.com/kops/1.19.0-beta.1/images/protokube-linux-amd64",
 			},
 		},
 		{
 			url: "https://kubeupv2.s3.amazonaws.com/kops/%s/images/protokube-linux-arm64",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.19.0-alpha.5/images/protokube-linux-arm64",
-				"https://github.com/kubernetes/kops/releases/download/v1.19.0-alpha.5/images-protokube-linux-arm64",
-				"https://kubeupv2.s3.amazonaws.com/kops/1.19.0-alpha.5/images/protokube-linux-arm64",
+				"https://artifacts.k8s.io/binaries/kops/1.19.0-beta.1/images/protokube-linux-arm64",
+				"https://github.com/kubernetes/kops/releases/download/v1.19.0-beta.1/images-protokube-linux-arm64",
+				"https://kubeupv2.s3.amazonaws.com/kops/1.19.0-beta.1/images/protokube-linux-arm64",
 			},
 		},
 		{
 			url: "https://kubeupv2.s3.amazonaws.com/kops/%s/linux/amd64/nodeup",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.19.0-alpha.5/linux/amd64/nodeup",
-				"https://github.com/kubernetes/kops/releases/download/v1.19.0-alpha.5/nodeup-linux-amd64",
-				"https://kubeupv2.s3.amazonaws.com/kops/1.19.0-alpha.5/linux/amd64/nodeup",
+				"https://artifacts.k8s.io/binaries/kops/1.19.0-beta.1/linux/amd64/nodeup",
+				"https://github.com/kubernetes/kops/releases/download/v1.19.0-beta.1/nodeup-linux-amd64",
+				"https://kubeupv2.s3.amazonaws.com/kops/1.19.0-beta.1/linux/amd64/nodeup",
 			},
 		},
 		{
 			url: "https://kubeupv2.s3.amazonaws.com/kops/%s/linux/arm64/nodeup",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.19.0-alpha.5/linux/arm64/nodeup",
-				"https://github.com/kubernetes/kops/releases/download/v1.19.0-alpha.5/nodeup-linux-arm64",
-				"https://kubeupv2.s3.amazonaws.com/kops/1.19.0-alpha.5/linux/arm64/nodeup",
+				"https://artifacts.k8s.io/binaries/kops/1.19.0-beta.1/linux/arm64/nodeup",
+				"https://github.com/kubernetes/kops/releases/download/v1.19.0-beta.1/nodeup-linux-arm64",
+				"https://kubeupv2.s3.amazonaws.com/kops/1.19.0-beta.1/linux/arm64/nodeup",
 			},
 		},
 	}

--- a/version.go
+++ b/version.go
@@ -23,8 +23,8 @@ var Version = KOPS_RELEASE_VERSION
 
 // These constants are parsed by build tooling - be careful about changing the formats
 const (
-	KOPS_RELEASE_VERSION = "1.19.0-alpha.5"
-	KOPS_CI_VERSION      = "1.19.0-alpha.6"
+	KOPS_RELEASE_VERSION = "1.19.0-beta.1"
+	KOPS_CI_VERSION      = "1.20.0-alpha.1"
 )
 
 // GitVersion should be replaced by the makefile


### PR DESCRIPTION
```
*********************************************************************************

The cluster was last updated by kops version 1.19.0-beta.1
To permit updating by the older version 1.19.0-alpha.5, run with the --allow-kops-downgrade flag

*********************************************************************************
```