### PR TITLE
Automated cherry pick of #10219: Update validate cluster cli docs

### DIFF
--- a/cmd/kops/validate_cluster.go
+++ b/cmd/kops/validate_cluster.go
@@ -60,10 +60,10 @@ func NewCmdValidateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	validateClusterLong := templates.LongDesc(i18n.T(`
 	This commands validates the following components:
 
-	1. All k8s masters are running and have "Ready" status.
-	2. All k8s nodes are running and have "Ready" status.
-	3. Component status returns healthy for all components.
-	4. All pods with a critical priority are running and healthy.
+	1. All control plane nodes are running and have "Ready" status.
+	2. All worker nodes are running and have "Ready" status.
+	3. All control plane nodes have the expected pods.
+	4. All pods with a critical priority are running and have "Ready" status.
 	`))
 
 	cmd := &cobra.Command{

--- a/docs/cli/kops_validate_cluster.md
+++ b/docs/cli/kops_validate_cluster.md
@@ -9,10 +9,10 @@ Validate a kops cluster.
 
 This commands validates the following components:
 
-  1.  All k8s masters are running and have "Ready" status.
-  2.  All k8s nodes are running and have "Ready" status.
-  3.  Component status returns healthy for all components.
-  4.  All pods with a critical priority are running and healthy.
+  1.  All control plane nodes are running and have "Ready" status.
+  2.  All worker nodes are running and have "Ready" status.
+  3.  All control plane nodes have the expected pods.
+  4.  All pods with a critical priority are running and have "Ready" status.
 
 ```
 kops validate cluster [flags]


### PR DESCRIPTION
Cherry pick of #10219 on release-1.19.

#10219: Update validate cluster cli docs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.