### PR TITLE
Fix cluster validation dependency on local kubeconfig

### DIFF
--- a/cmd/kops/delete_instance.go
+++ b/cmd/kops/delete_instance.go
@@ -265,7 +265,7 @@ func RunDeleteInstance(ctx context.Context, f *util.Factory, out io.Writer, opti
 
 	var clusterValidator validation.ClusterValidator
 	if !options.CloudOnly {
-		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, k8sClient)
+		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, config, k8sClient)
 		if err != nil {
 			return fmt.Errorf("cannot create cluster validator: %v", err)
 		}

--- a/cmd/kops/delete_instance.go
+++ b/cmd/kops/delete_instance.go
@@ -265,7 +265,7 @@ func RunDeleteInstance(ctx context.Context, f *util.Factory, out io.Writer, opti
 
 	var clusterValidator validation.ClusterValidator
 	if !options.CloudOnly {
-		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, config, k8sClient)
+		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, config.Host, k8sClient)
 		if err != nil {
 			return fmt.Errorf("cannot create cluster validator: %v", err)
 		}

--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -426,7 +426,7 @@ func RunRollingUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer
 
 	var clusterValidator validation.ClusterValidator
 	if !options.CloudOnly {
-		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, k8sClient)
+		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, config, k8sClient)
 		if err != nil {
 			return fmt.Errorf("cannot create cluster validator: %v", err)
 		}

--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -426,7 +426,7 @@ func RunRollingUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer
 
 	var clusterValidator validation.ClusterValidator
 	if !options.CloudOnly {
-		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, config, k8sClient)
+		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, config.Host, k8sClient)
 		if err != nil {
 			return fmt.Errorf("cannot create cluster validator: %v", err)
 		}

--- a/cmd/kops/validate_cluster.go
+++ b/cmd/kops/validate_cluster.go
@@ -155,7 +155,7 @@ func RunValidateCluster(ctx context.Context, f *util.Factory, cmd *cobra.Command
 	timeout := time.Now().Add(options.wait)
 	pollInterval := 10 * time.Second
 
-	validator, err := validation.NewClusterValidator(cluster, cloud, list, config, k8sClient)
+	validator, err := validation.NewClusterValidator(cluster, cloud, list, config.Host, k8sClient)
 	if err != nil {
 		return nil, fmt.Errorf("unexpected error creating validatior: %v", err)
 	}

--- a/cmd/kops/validate_cluster.go
+++ b/cmd/kops/validate_cluster.go
@@ -155,7 +155,7 @@ func RunValidateCluster(ctx context.Context, f *util.Factory, cmd *cobra.Command
 	timeout := time.Now().Add(options.wait)
 	pollInterval := 10 * time.Second
 
-	validator, err := validation.NewClusterValidator(cluster, cloud, list, k8sClient)
+	validator, err := validation.NewClusterValidator(cluster, cloud, list, config, k8sClient)
 	if err != nil {
 		return nil, fmt.Errorf("unexpected error creating validatior: %v", err)
 	}

--- a/pkg/validation/BUILD.bazel
+++ b/pkg/validation/BUILD.bazel
@@ -17,7 +17,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
-        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/pager:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],

--- a/pkg/validation/BUILD.bazel
+++ b/pkg/validation/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
-        "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/pager:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],

--- a/pkg/validation/validate_cluster_test.go
+++ b/pkg/validation/validate_cluster_test.go
@@ -121,7 +121,7 @@ func testValidate(t *testing.T, groups map[string]*cloudinstances.CloudInstanceG
 
 	mockcloud := BuildMockCloud(t, groups, cluster, instanceGroups)
 
-	validator, err := NewClusterValidator(cluster, mockcloud, &kopsapi.InstanceGroupList{Items: instanceGroups}, nil, fake.NewSimpleClientset(objects...))
+	validator, err := NewClusterValidator(cluster, mockcloud, &kopsapi.InstanceGroupList{Items: instanceGroups}, "https://api.testcluster.k8s.local", fake.NewSimpleClientset(objects...))
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func Test_ValidateCloudGroupMissing(t *testing.T) {
 
 	mockcloud := BuildMockCloud(t, nil, cluster, instanceGroups)
 
-	validator, err := NewClusterValidator(cluster, mockcloud, &kopsapi.InstanceGroupList{Items: instanceGroups}, nil, fake.NewSimpleClientset())
+	validator, err := NewClusterValidator(cluster, mockcloud, &kopsapi.InstanceGroupList{Items: instanceGroups}, "https://api.testcluster.k8s.local", fake.NewSimpleClientset())
 	require.NoError(t, err)
 	v, err := validator.Validate()
 	require.NoError(t, err)

--- a/pkg/validation/validate_cluster_test.go
+++ b/pkg/validation/validate_cluster_test.go
@@ -121,7 +121,7 @@ func testValidate(t *testing.T, groups map[string]*cloudinstances.CloudInstanceG
 
 	mockcloud := BuildMockCloud(t, groups, cluster, instanceGroups)
 
-	validator, err := NewClusterValidator(cluster, mockcloud, &kopsapi.InstanceGroupList{Items: instanceGroups}, fake.NewSimpleClientset(objects...))
+	validator, err := NewClusterValidator(cluster, mockcloud, &kopsapi.InstanceGroupList{Items: instanceGroups}, nil, fake.NewSimpleClientset(objects...))
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func Test_ValidateCloudGroupMissing(t *testing.T) {
 
 	mockcloud := BuildMockCloud(t, nil, cluster, instanceGroups)
 
-	validator, err := NewClusterValidator(cluster, mockcloud, &kopsapi.InstanceGroupList{Items: instanceGroups}, fake.NewSimpleClientset())
+	validator, err := NewClusterValidator(cluster, mockcloud, &kopsapi.InstanceGroupList{Items: instanceGroups}, nil, fake.NewSimpleClientset())
 	require.NoError(t, err)
 	v, err := validator.Validate()
 	require.NoError(t, err)


### PR DESCRIPTION
This PR fixes cluster validation dependency on a local kubeconfig file.

Cluster validation requires a local kubeconfig file with a context having the same name as the cluster.
This PR replaces this requirement by providing a `rest.Config`, the same that was used to build the `k8sclient` used to communicate with the target cluster.