### PR TITLE
Don't install the misc packages for k8s 1.20+

### DIFF
--- a/nodeup/pkg/model/miscutils.go
+++ b/nodeup/pkg/model/miscutils.go
@@ -42,18 +42,18 @@ func (b *MiscUtilsBuilder) Build(c *fi.ModelBuilderContext) error {
 		return nil
 	}
 
-	// TODO: These packages have been auto-installed for a long time, and likely we don't need all of them any longer
-	// We could prune from auto-install at a particular k8s release (e.g. 1.13?)
-
 	var packages []string
 	if b.Distribution.IsDebianFamily() {
-		packages = append(packages, "curl")
-		packages = append(packages, "wget")
 		packages = append(packages, "nfs-common")
-		packages = append(packages, "perl")
-		packages = append(packages, "python-apt")
-		packages = append(packages, "apt-transport-https")
+		if b.IsKubernetesLT("1.20") {
+			packages = append(packages, "curl")
+			packages = append(packages, "wget")
+			packages = append(packages, "perl")
+			packages = append(packages, "python-apt")
+			packages = append(packages, "apt-transport-https")
+		}
 	} else if b.Distribution.IsRHELFamily() {
+		// TODO: These packages have been auto-installed for a long time, and likely we don't need all of them any longer
 		packages = append(packages, "curl")
 		packages = append(packages, "wget")
 		packages = append(packages, "nfs-utils")
@@ -64,7 +64,7 @@ func (b *MiscUtilsBuilder) Build(c *fi.ModelBuilderContext) error {
 		return nil
 	}
 
-	if b.Distribution.IsUbuntu() {
+	if b.Distribution.IsUbuntu() && b.IsKubernetesLT("1.20") {
 		packages = append(packages, "netcat-traditional")
 		packages = append(packages, "git")
 	}

--- a/nodeup/pkg/model/miscutils.go
+++ b/nodeup/pkg/model/miscutils.go
@@ -44,7 +44,6 @@ func (b *MiscUtilsBuilder) Build(c *fi.ModelBuilderContext) error {
 
 	var packages []string
 	if b.Distribution.IsDebianFamily() {
-		packages = append(packages, "nfs-common")
 		if b.IsKubernetesLT("1.20") {
 			packages = append(packages, "curl")
 			packages = append(packages, "wget")
@@ -56,7 +55,6 @@ func (b *MiscUtilsBuilder) Build(c *fi.ModelBuilderContext) error {
 		// TODO: These packages have been auto-installed for a long time, and likely we don't need all of them any longer
 		packages = append(packages, "curl")
 		packages = append(packages, "wget")
-		packages = append(packages, "nfs-utils")
 		packages = append(packages, "python2")
 		packages = append(packages, "git")
 	} else {

--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -38,6 +38,7 @@ func (b *PackagesBuilder) Build(c *fi.ModelBuilderContext) error {
 	//   ebtables - kops #1711
 	//   ethtool - kops #1830
 	if b.Distribution.IsDebianFamily() {
+		c.AddTask(&nodetasks.Package{Name: "nfs-common"})
 		// From containerd: https://github.com/containerd/cri/blob/master/contrib/ansible/tasks/bootstrap_ubuntu.yaml
 		c.AddTask(&nodetasks.Package{Name: "bridge-utils"})
 		c.AddTask(&nodetasks.Package{Name: "cgroupfs-mount"})
@@ -52,6 +53,7 @@ func (b *PackagesBuilder) Build(c *fi.ModelBuilderContext) error {
 		c.AddTask(&nodetasks.Package{Name: "socat"})
 		c.AddTask(&nodetasks.Package{Name: "util-linux"})
 	} else if b.Distribution.IsRHELFamily() {
+		c.AddTask(&nodetasks.Package{Name: "nfs-utils"})
 		// From containerd: https://github.com/containerd/cri/blob/master/contrib/ansible/tasks/bootstrap_centos.yaml
 		c.AddTask(&nodetasks.Package{Name: "conntrack-tools"})
 		c.AddTask(&nodetasks.Package{Name: "ebtables"})


### PR DESCRIPTION
I intend to make the boundary be 1.20, but the e2e tests are currently configured with 1.19.