### PR TITLE
Automated cherry pick of #10151: Use LT versions instead of timestamped LTs

### DIFF
--- a/cloudmock/aws/mockautoscaling/group.go
+++ b/cloudmock/aws/mockautoscaling/group.go
@@ -18,7 +18,6 @@ package mockautoscaling
 
 import (
 	"fmt"
-	"hash/crc64"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -78,8 +77,10 @@ func (m *MockAutoscaling) CreateAutoScalingGroup(input *autoscaling.CreateAutoSc
 	}
 
 	if input.LaunchTemplate != nil {
-		launchTemplateCrc := crc64.Checksum([]byte(aws.StringValue(input.LaunchTemplate.LaunchTemplateName)), crc64.MakeTable(crc64.ECMA))
-		g.LaunchTemplate.LaunchTemplateId = aws.String(fmt.Sprintf("lt-%x", launchTemplateCrc))
+		g.LaunchTemplate.LaunchTemplateName = input.AutoScalingGroupName
+		if g.LaunchTemplate.LaunchTemplateId == nil {
+			return nil, fmt.Errorf("AutoScalingGroup has LaunchTemplate without ID")
+		}
 	}
 
 	for _, tag := range input.Tags {

--- a/cloudmock/aws/mockec2/api.go
+++ b/cloudmock/aws/mockec2/api.go
@@ -55,8 +55,7 @@ type MockEC2 struct {
 
 	InternetGateways map[string]*ec2.InternetGateway
 
-	launchTemplateNumber int
-	LaunchTemplates      map[string]*launchTemplateInfo
+	LaunchTemplates map[string]*launchTemplateInfo
 
 	NatGateways map[string]*ec2.NatGateway
 

--- a/cloudmock/aws/mockec2/api.go
+++ b/cloudmock/aws/mockec2/api.go
@@ -55,7 +55,8 @@ type MockEC2 struct {
 
 	InternetGateways map[string]*ec2.InternetGateway
 
-	LaunchTemplates map[string]*launchTemplateInfo
+	launchTemplateNumber int
+	LaunchTemplates      map[string]*launchTemplateInfo
 
 	NatGateways map[string]*ec2.NatGateway
 

--- a/cloudmock/aws/mockec2/launch_templates.go
+++ b/cloudmock/aws/mockec2/launch_templates.go
@@ -87,8 +87,9 @@ func (m *MockEC2) CreateLaunchTemplate(request *ec2.CreateLaunchTemplateInput) (
 
 	klog.V(2).Infof("Mock CreateLaunchTemplate: %v", request)
 
-	crc := crc64.Checksum([]byte(aws.StringValue(request.LaunchTemplateName)), crc64.MakeTable(crc64.ECMA))
-	id := fmt.Sprintf("lt-%x", crc)
+	m.launchTemplateNumber++
+	n := m.launchTemplateNumber
+	id := fmt.Sprintf("lt-%d", n)
 
 	if m.LaunchTemplates == nil {
 		m.LaunchTemplates = make(map[string]*launchTemplateInfo)

--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -145,7 +145,7 @@ func ListResourcesAWS(cloud awsup.AWSCloud, clusterName string) (map[string]*res
 		if err != nil {
 			return nil, err
 		}
-		lts, err := FindAutoScalingLaunchTemplates(cloud, clusterName, securityGroups)
+		lts, err := FindAutoScalingLaunchTemplates(cloud, clusterName)
 		if err != nil {
 			return nil, err
 		}
@@ -1179,8 +1179,8 @@ func ListAutoScalingGroups(cloud fi.Cloud, clusterName string) ([]*resources.Res
 	return resourceTrackers, nil
 }
 
-// FindAutoScalingLaunchTemplates finds any launch configurations which reference the security groups
-func FindAutoScalingLaunchTemplates(cloud fi.Cloud, clusterName string, securityGroups sets.String) ([]*resources.Resource, error) {
+// FindAutoScalingLaunchTemplates finds any launch templates owned by the cluster (by tag).
+func FindAutoScalingLaunchTemplates(cloud fi.Cloud, clusterName string) ([]*resources.Resource, error) {
 	c := cloud.(awsup.AWSCloud)
 
 	klog.V(2).Infof("Finding all AutoScaling LaunchTemplates owned by the cluster")
@@ -1188,8 +1188,8 @@ func FindAutoScalingLaunchTemplates(cloud fi.Cloud, clusterName string, security
 	input := &ec2.DescribeLaunchTemplatesInput{
 		Filters: []*ec2.Filter{
 			{
-				Name:   aws.String("tag:KubernetesCluster"),
-				Values: []*string{aws.String(clusterName)},
+				Name:   aws.String("tag:kubernetes.io/cluster/" + clusterName),
+				Values: []*string{aws.String("owned")},
 			},
 		},
 	}

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -429,7 +429,7 @@ resource "aws_launch_template" "bastion-bastionuserdata-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "bastion.bastionuserdata.example.com-"
+  name = "bastion.bastionuserdata.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -493,7 +493,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-bastionuserdata-exampl
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.bastionuserdata.example.com-"
+  name = "master-us-test-1a.masters.bastionuserdata.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true
@@ -553,7 +553,7 @@ resource "aws_launch_template" "nodes-bastionuserdata-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.bastionuserdata.example.com-"
+  name = "nodes.bastionuserdata.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -297,7 +297,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.complex.example.com-"
+  name = "master-us-test-1a.masters.complex.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -374,7 +374,7 @@ resource "aws_launch_template" "nodes-complex-example-com" {
   monitoring {
     enabled = true
   }
-  name_prefix = "nodes.complex.example.com-"
+  name = "nodes.complex.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -387,7 +387,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-existing-iam-example-c
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.existing-iam.example.com-"
+  name = "master-us-test-1a.masters.existing-iam.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -451,7 +451,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-existing-iam-example-c
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1b.masters.existing-iam.example.com-"
+  name = "master-us-test-1b.masters.existing-iam.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -515,7 +515,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-existing-iam-example-c
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1c.masters.existing-iam.example.com-"
+  name = "master-us-test-1c.masters.existing-iam.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -575,7 +575,7 @@ resource "aws_launch_template" "nodes-existing-iam-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.existing-iam.example.com-"
+  name = "nodes.existing-iam.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -468,7 +468,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-existingsg-example-com
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.existingsg.example.com-"
+  name = "master-us-test-1a.masters.existingsg.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -532,7 +532,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-existingsg-example-com
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1b.masters.existingsg.example.com-"
+  name = "master-us-test-1b.masters.existingsg.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -596,7 +596,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-existingsg-example-com
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1c.masters.existingsg.example.com-"
+  name = "master-us-test-1c.masters.existingsg.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -656,7 +656,7 @@ resource "aws_launch_template" "nodes-existingsg-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.existingsg.example.com-"
+  name = "nodes.existingsg.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -280,7 +280,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-externallb-example-com
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.externallb.example.com-"
+  name = "master-us-test-1a.masters.externallb.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -340,7 +340,7 @@ resource "aws_launch_template" "nodes-externallb-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.externallb.example.com-"
+  name = "nodes.externallb.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -345,7 +345,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-externalpolicies-examp
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.externalpolicies.example.com-"
+  name = "master-us-test-1a.masters.externalpolicies.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -414,7 +414,7 @@ resource "aws_launch_template" "nodes-externalpolicies-example-com" {
   monitoring {
     enabled = true
   }
-  name_prefix = "nodes.externalpolicies.example.com-"
+  name = "nodes.externalpolicies.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -439,7 +439,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-ha-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.ha.example.com-"
+  name = "master-us-test-1a.masters.ha.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -503,7 +503,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-ha-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1b.masters.ha.example.com-"
+  name = "master-us-test-1b.masters.ha.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -567,7 +567,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-ha-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1c.masters.ha.example.com-"
+  name = "master-us-test-1c.masters.ha.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -627,7 +627,7 @@ resource "aws_launch_template" "nodes-ha-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.ha.example.com-"
+  name = "nodes.ha.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true

--- a/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
+++ b/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
@@ -294,7 +294,7 @@
     },
     "aws_launch_template": {
       "master-us-test-1a-masters-minimal-json-example-com": {
-        "name_prefix": "master-us-test-1a.masters.minimal-json.example.com-",
+        "name": "master-us-test-1a.masters.minimal-json.example.com",
         "lifecycle": {
           "create_before_destroy": true
         },
@@ -369,7 +369,7 @@
         "user_data": "${file(\"${path.module}/data/aws_launch_template_master-us-test-1a.masters.minimal-json.example.com_user_data\")}"
       },
       "nodes-minimal-json-example-com": {
-        "name_prefix": "nodes.minimal-json.example.com-",
+        "name": "nodes.minimal-json.example.com",
         "lifecycle": {
           "create_before_destroy": true
         },

--- a/tests/integration/update_cluster/minimal-tf11/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-tf11/kubernetes.tf
@@ -280,7 +280,7 @@ resource "aws_key_pair" "kubernetes-minimal-tf11-example-com-c4a6ed9aa889b9e2c39
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-minimal-tf11-example-com" {
-  name_prefix = "master-us-test-1a.masters.minimal-tf11.example.com-"
+  name = "master-us-test-1a.masters.minimal-tf11.example.com"
 
   lifecycle = {
     create_before_destroy = true
@@ -357,7 +357,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-tf11-example-c
 }
 
 resource "aws_launch_template" "nodes-minimal-tf11-example-com" {
-  name_prefix = "nodes.minimal-tf11.example.com-"
+  name = "nodes.minimal-tf11.example.com"
 
   lifecycle = {
     create_before_destroy = true

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -277,7 +277,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.minimal.example.com-"
+  name = "master-us-test-1a.masters.minimal.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -337,7 +337,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.minimal.example.com-"
+  name = "nodes.minimal.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -457,7 +457,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.mixedinstances.example.com-"
+  name = "master-us-test-1a.masters.mixedinstances.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -521,7 +521,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1b.masters.mixedinstances.example.com-"
+  name = "master-us-test-1b.masters.mixedinstances.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -585,7 +585,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1c.masters.mixedinstances.example.com-"
+  name = "master-us-test-1c.masters.mixedinstances.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -645,7 +645,7 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.mixedinstances.example.com-"
+  name = "nodes.mixedinstances.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -457,7 +457,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.mixedinstances.example.com-"
+  name = "master-us-test-1a.masters.mixedinstances.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -521,7 +521,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1b.masters.mixedinstances.example.com-"
+  name = "master-us-test-1b.masters.mixedinstances.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -585,7 +585,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1c.masters.mixedinstances.example.com-"
+  name = "master-us-test-1c.masters.mixedinstances.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -645,7 +645,7 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.mixedinstances.example.com-"
+  name = "nodes.mixedinstances.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -401,7 +401,7 @@ resource "aws_launch_template" "bastion-private-shared-subnet-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "bastion.private-shared-subnet.example.com-"
+  name = "bastion.private-shared-subnet.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -464,7 +464,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-private-shared-subnet-
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.private-shared-subnet.example.com-"
+  name = "master-us-test-1a.masters.private-shared-subnet.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true
@@ -524,7 +524,7 @@ resource "aws_launch_template" "nodes-private-shared-subnet-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.private-shared-subnet.example.com-"
+  name = "nodes.private-shared-subnet.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -429,7 +429,7 @@ resource "aws_launch_template" "bastion-privatecalico-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "bastion.privatecalico.example.com-"
+  name = "bastion.privatecalico.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -492,7 +492,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecalico-example-
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.privatecalico.example.com-"
+  name = "master-us-test-1a.masters.privatecalico.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true
@@ -552,7 +552,7 @@ resource "aws_launch_template" "nodes-privatecalico-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.privatecalico.example.com-"
+  name = "nodes.privatecalico.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -429,7 +429,7 @@ resource "aws_launch_template" "bastion-privatecanal-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "bastion.privatecanal.example.com-"
+  name = "bastion.privatecanal.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -492,7 +492,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecanal-example-c
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.privatecanal.example.com-"
+  name = "master-us-test-1a.masters.privatecanal.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true
@@ -552,7 +552,7 @@ resource "aws_launch_template" "nodes-privatecanal-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.privatecanal.example.com-"
+  name = "nodes.privatecanal.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -429,7 +429,7 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "bastion.privatecilium.example.com-"
+  name = "bastion.privatecilium.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -492,7 +492,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.privatecilium.example.com-"
+  name = "master-us-test-1a.masters.privatecilium.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true
@@ -552,7 +552,7 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.privatecilium.example.com-"
+  name = "nodes.privatecilium.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -429,7 +429,7 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "bastion.privatecilium.example.com-"
+  name = "bastion.privatecilium.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -492,7 +492,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.privatecilium.example.com-"
+  name = "master-us-test-1a.masters.privatecilium.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true
@@ -552,7 +552,7 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.privatecilium.example.com-"
+  name = "nodes.privatecilium.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -443,7 +443,7 @@ resource "aws_launch_template" "bastion-privateciliumadvanced-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "bastion.privateciliumadvanced.example.com-"
+  name = "bastion.privateciliumadvanced.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -506,7 +506,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateciliumadvanced-
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.privateciliumadvanced.example.com-"
+  name = "master-us-test-1a.masters.privateciliumadvanced.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true
@@ -566,7 +566,7 @@ resource "aws_launch_template" "nodes-privateciliumadvanced-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.privateciliumadvanced.example.com-"
+  name = "nodes.privateciliumadvanced.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -473,7 +473,7 @@ resource "aws_launch_template" "bastion-privatedns1-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "bastion.privatedns1.example.com-"
+  name = "bastion.privatedns1.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -542,7 +542,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns1-example-co
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.privatedns1.example.com-"
+  name = "master-us-test-1a.masters.privatedns1.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true
@@ -608,7 +608,7 @@ resource "aws_launch_template" "nodes-privatedns1-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.privatedns1.example.com-"
+  name = "nodes.privatedns1.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -415,7 +415,7 @@ resource "aws_launch_template" "bastion-privatedns2-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "bastion.privatedns2.example.com-"
+  name = "bastion.privatedns2.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -478,7 +478,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns2-example-co
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.privatedns2.example.com-"
+  name = "master-us-test-1a.masters.privatedns2.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true
@@ -538,7 +538,7 @@ resource "aws_launch_template" "nodes-privatedns2-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.privatedns2.example.com-"
+  name = "nodes.privatedns2.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -429,7 +429,7 @@ resource "aws_launch_template" "bastion-privateflannel-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "bastion.privateflannel.example.com-"
+  name = "bastion.privateflannel.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -492,7 +492,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateflannel-example
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.privateflannel.example.com-"
+  name = "master-us-test-1a.masters.privateflannel.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true
@@ -552,7 +552,7 @@ resource "aws_launch_template" "nodes-privateflannel-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.privateflannel.example.com-"
+  name = "nodes.privateflannel.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -435,7 +435,7 @@ resource "aws_launch_template" "bastion-privatekopeio-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "bastion.privatekopeio.example.com-"
+  name = "bastion.privatekopeio.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -498,7 +498,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatekopeio-example-
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.privatekopeio.example.com-"
+  name = "master-us-test-1a.masters.privatekopeio.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true
@@ -558,7 +558,7 @@ resource "aws_launch_template" "nodes-privatekopeio-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.privatekopeio.example.com-"
+  name = "nodes.privatekopeio.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -429,7 +429,7 @@ resource "aws_launch_template" "bastion-privateweave-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "bastion.privateweave.example.com-"
+  name = "bastion.privateweave.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -492,7 +492,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateweave-example-c
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.privateweave.example.com-"
+  name = "master-us-test-1a.masters.privateweave.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true
@@ -552,7 +552,7 @@ resource "aws_launch_template" "nodes-privateweave-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.privateweave.example.com-"
+  name = "nodes.privateweave.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true

--- a/tests/integration/update_cluster/public-jwks/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks/kubernetes.tf
@@ -304,7 +304,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.minimal.example.com-"
+  name = "master-us-test-1a.masters.minimal.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -364,7 +364,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.minimal.example.com-"
+  name = "nodes.minimal.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -263,7 +263,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedsubnet-example-c
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.sharedsubnet.example.com-"
+  name = "master-us-test-1a.masters.sharedsubnet.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -323,7 +323,7 @@ resource "aws_launch_template" "nodes-sharedsubnet-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.sharedsubnet.example.com-"
+  name = "nodes.sharedsubnet.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -263,7 +263,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedvpc-example-com"
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.sharedvpc.example.com-"
+  name = "master-us-test-1a.masters.sharedvpc.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -323,7 +323,7 @@ resource "aws_launch_template" "nodes-sharedvpc-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.sharedvpc.example.com-"
+  name = "nodes.sharedvpc.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -406,7 +406,7 @@ resource "aws_launch_template" "bastion-unmanaged-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "bastion.unmanaged.example.com-"
+  name = "bastion.unmanaged.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -469,7 +469,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-unmanaged-example-com"
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "master-us-test-1a.masters.unmanaged.example.com-"
+  name = "master-us-test-1a.masters.unmanaged.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true
@@ -529,7 +529,7 @@ resource "aws_launch_template" "nodes-unmanaged-example-com" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix = "nodes.unmanaged.example.com-"
+  name = "nodes.unmanaged.example.com"
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -366,8 +366,8 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 				},
 				LaunchTemplate: &autoscaling.LaunchTemplate{
 					LaunchTemplateSpecification: &autoscaling.LaunchTemplateSpecification{
-						LaunchTemplateName: e.LaunchTemplate.Name,
-						Version:            aws.String("$Latest"),
+						LaunchTemplateId: e.LaunchTemplate.ID,
+						Version:          aws.String("$Latest"),
 					},
 				},
 			}
@@ -379,8 +379,8 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 			}
 		} else if e.LaunchTemplate != nil {
 			request.LaunchTemplate = &autoscaling.LaunchTemplateSpecification{
-				LaunchTemplateName: e.LaunchTemplate.Name,
-				Version:            aws.String("$Latest"),
+				LaunchTemplateId: e.LaunchTemplate.ID,
+				Version:          aws.String("$Latest"),
 			}
 		} else {
 			return fmt.Errorf("could not find one of launch template, mixed instances policy, or launch configuration")
@@ -446,8 +446,8 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 
 		if changes.LaunchTemplate != nil {
 			spec := &autoscaling.LaunchTemplateSpecification{
-				LaunchTemplateName: changes.LaunchTemplate.Name,
-				Version:            aws.String("$Latest"),
+				LaunchTemplateId: changes.LaunchTemplate.ID,
+				Version:          aws.String("$Latest"),
 			}
 			if e.UseMixedInstancesPolicy() {
 				setup(request).LaunchTemplate = &autoscaling.LaunchTemplate{LaunchTemplateSpecification: spec}
@@ -481,8 +481,8 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 			if setup(request).LaunchTemplate == nil {
 				setup(request).LaunchTemplate = &autoscaling.LaunchTemplate{
 					LaunchTemplateSpecification: &autoscaling.LaunchTemplateSpecification{
-						LaunchTemplateName: changes.LaunchTemplate.Name,
-						Version:            aws.String("$Latest"),
+						LaunchTemplateId: changes.LaunchTemplate.ID,
+						Version:          aws.String("$Latest"),
 					},
 				}
 			}

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
@@ -19,7 +19,6 @@ package awstasks
 import (
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"k8s.io/kops/upup/pkg/fi"

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
@@ -147,15 +147,14 @@ func (t *LaunchTemplate) CheckChanges(a, e, changes *LaunchTemplate) error {
 func (t *LaunchTemplate) FindDeletions(c *fi.Context) ([]fi.Deletion, error) {
 	var removals []fi.Deletion
 
-	configurations, err := t.findAllLaunchTemplates(c)
+	list, err := t.findAllLaunchTemplates(c)
 	if err != nil {
 		return nil, err
 	}
 
-	prefix := fmt.Sprintf("%s-", fi.StringValue(t.Name))
-	for _, configuration := range configurations {
-		if strings.HasPrefix(aws.StringValue(configuration.LaunchTemplateName), prefix) {
-			removals = append(removals, &deleteLaunchTemplate{lc: configuration})
+	for _, lt := range list {
+		if aws.StringValue(lt.LaunchTemplateName) != aws.StringValue(t.Name) {
+			removals = append(removals, &deleteLaunchTemplate{lc: lt})
 		}
 	}
 

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -149,13 +149,18 @@ func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, e, changes *LaunchT
 		}
 		e.ID = output.LaunchTemplate.LaunchTemplateId
 	} else {
-		// TODO: Update the LaunchTemplate tags
 		input := &ec2.CreateLaunchTemplateVersionInput{
 			LaunchTemplateName: t.Name,
 			LaunchTemplateData: data,
 		}
 		if _, err = c.Cloud.EC2().CreateLaunchTemplateVersion(input); err != nil {
 			return fmt.Errorf("error creating LaunchTemplateVersion: %v", err)
+		}
+		if changes.Tags != nil {
+			err = c.UpdateTags(fi.StringValue(a.ID), e.Tags)
+			if err != nil {
+				return fmt.Errorf("error updating LaunchTemplate tags: %v", err)
+			}
 		}
 		e.ID = a.ID
 	}

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -20,44 +20,36 @@ import (
 	"encoding/base64"
 	"fmt"
 	"sort"
-	"strings"
-
-	"k8s.io/kops/upup/pkg/fi"
-	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 )
 
 // RenderAWS is responsible for performing creating / updating the launch template
-func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, ep, changes *LaunchTemplate) error {
-	name := t.LaunchTemplateName()
-
+func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, e, changes *LaunchTemplate) error {
 	// @step: resolve the image id to an AMI for us
 	image, err := c.Cloud.ResolveImage(fi.StringValue(t.ImageID))
 	if err != nil {
 		return err
 	}
 
-	// @step: lets build the launch template input
-	input := &ec2.CreateLaunchTemplateInput{
-		LaunchTemplateData: &ec2.RequestLaunchTemplateData{
-			DisableApiTermination: fi.Bool(false),
-			EbsOptimized:          t.RootVolumeOptimization,
-			ImageId:               image.ImageId,
-			InstanceType:          t.InstanceType,
-			NetworkInterfaces: []*ec2.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{
-				{
-					AssociatePublicIpAddress: t.AssociatePublicIP,
-					DeleteOnTermination:      aws.Bool(true),
-					DeviceIndex:              fi.Int64(0),
-				},
+	// @step: lets build the launch template data
+	data := &ec2.RequestLaunchTemplateData{
+		DisableApiTermination: fi.Bool(false),
+		EbsOptimized:          t.RootVolumeOptimization,
+		ImageId:               image.ImageId,
+		InstanceType:          t.InstanceType,
+		NetworkInterfaces: []*ec2.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{
+			{
+				AssociatePublicIpAddress: t.AssociatePublicIP,
+				DeleteOnTermination:      aws.Bool(true),
+				DeviceIndex:              fi.Int64(0),
 			},
 		},
-		LaunchTemplateName: aws.String(name),
 	}
-	lc := input.LaunchTemplateData
 
 	// @step: add the actual block device mappings
 	rootDevices, err := t.buildRootDevice(c.Cloud)
@@ -74,52 +66,48 @@ func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, ep, changes *Launch
 	}
 	for _, x := range []map[string]*BlockDeviceMapping{rootDevices, ephemeralDevices, additionalDevices} {
 		for name, device := range x {
-			input.LaunchTemplateData.BlockDeviceMappings = append(input.LaunchTemplateData.BlockDeviceMappings, device.ToLaunchTemplateBootDeviceRequest(name))
+			data.BlockDeviceMappings = append(data.BlockDeviceMappings, device.ToLaunchTemplateBootDeviceRequest(name))
 		}
 	}
 
 	// @step: add the ssh key
 	if t.SSHKey != nil {
-		lc.KeyName = t.SSHKey.Name
+		data.KeyName = t.SSHKey.Name
 	}
 	// @step: add the security groups
 	for _, sg := range t.SecurityGroups {
-		lc.NetworkInterfaces[0].Groups = append(lc.NetworkInterfaces[0].Groups, sg.ID)
+		data.NetworkInterfaces[0].Groups = append(data.NetworkInterfaces[0].Groups, sg.ID)
 	}
 	// @step: add any tenancy details
 	if t.Tenancy != nil {
-		lc.Placement = &ec2.LaunchTemplatePlacementRequest{Tenancy: t.Tenancy}
+		data.Placement = &ec2.LaunchTemplatePlacementRequest{Tenancy: t.Tenancy}
 	}
 	// @step: set the instance monitoring
-	lc.Monitoring = &ec2.LaunchTemplatesMonitoringRequest{Enabled: fi.Bool(false)}
+	data.Monitoring = &ec2.LaunchTemplatesMonitoringRequest{Enabled: fi.Bool(false)}
 	if t.InstanceMonitoring != nil {
-		lc.Monitoring = &ec2.LaunchTemplatesMonitoringRequest{Enabled: t.InstanceMonitoring}
+		data.Monitoring = &ec2.LaunchTemplatesMonitoringRequest{Enabled: t.InstanceMonitoring}
 	}
 	// @step: add the iam instance profile
 	if t.IAMInstanceProfile != nil {
-		lc.IamInstanceProfile = &ec2.LaunchTemplateIamInstanceProfileSpecificationRequest{
+		data.IamInstanceProfile = &ec2.LaunchTemplateIamInstanceProfileSpecificationRequest{
 			Name: t.IAMInstanceProfile.Name,
 		}
 	}
 	// @step: add the tags
+	var tags []*ec2.Tag
 	if len(t.Tags) > 0 {
-		var tags []*ec2.Tag
 		for k, v := range t.Tags {
 			tags = append(tags, &ec2.Tag{
 				Key:   aws.String(k),
 				Value: aws.String(v),
 			})
 		}
-		lc.TagSpecifications = append(lc.TagSpecifications, &ec2.LaunchTemplateTagSpecificationRequest{
+		data.TagSpecifications = append(data.TagSpecifications, &ec2.LaunchTemplateTagSpecificationRequest{
 			ResourceType: aws.String(ec2.ResourceTypeInstance),
 			Tags:         tags,
 		})
-		lc.TagSpecifications = append(lc.TagSpecifications, &ec2.LaunchTemplateTagSpecificationRequest{
+		data.TagSpecifications = append(data.TagSpecifications, &ec2.LaunchTemplateTagSpecificationRequest{
 			ResourceType: aws.String(ec2.ResourceTypeVolume),
-			Tags:         tags,
-		})
-		input.TagSpecifications = append(input.TagSpecifications, &ec2.TagSpecification{
-			ResourceType: aws.String(ec2.ResourceTypeLaunchTemplate),
 			Tags:         tags,
 		})
 	}
@@ -129,7 +117,7 @@ func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, ep, changes *Launch
 		if err != nil {
 			return fmt.Errorf("error rendering LaunchTemplate UserData: %v", err)
 		}
-		lc.UserData = aws.String(base64.StdEncoding.EncodeToString(d))
+		data.UserData = aws.String(base64.StdEncoding.EncodeToString(d))
 	}
 	// @step: add market options
 	if fi.StringValue(t.SpotPrice) != "" {
@@ -138,17 +126,39 @@ func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, ep, changes *Launch
 			InstanceInterruptionBehavior: t.InstanceInterruptionBehavior,
 			MaxPrice:                     t.SpotPrice,
 		}
-		lc.InstanceMarketOptions = &ec2.LaunchTemplateInstanceMarketOptionsRequest{
+		data.InstanceMarketOptions = &ec2.LaunchTemplateInstanceMarketOptionsRequest{
 			MarketType:  fi.String("spot"),
 			SpotOptions: s,
 		}
 	}
 	// @step: attempt to create the launch template
-	if _, err = c.Cloud.EC2().CreateLaunchTemplate(input); err != nil {
-		return fmt.Errorf("error creating LaunchTemplate: %v", err)
+	if a == nil {
+		input := &ec2.CreateLaunchTemplateInput{
+			LaunchTemplateName: t.Name,
+			LaunchTemplateData: data,
+			TagSpecifications: []*ec2.TagSpecification{
+				{
+					ResourceType: aws.String(ec2.ResourceTypeLaunchTemplate),
+					Tags:         tags,
+				},
+			},
+		}
+		output, err := c.Cloud.EC2().CreateLaunchTemplate(input)
+		if err != nil || output.LaunchTemplate == nil {
+			return fmt.Errorf("error creating LaunchTemplate %q: %v", fi.StringValue(t.Name), err)
+		}
+		e.ID = output.LaunchTemplate.LaunchTemplateId
+	} else {
+		// TODO: Update the LaunchTemplate tags
+		input := &ec2.CreateLaunchTemplateVersionInput{
+			LaunchTemplateName: t.Name,
+			LaunchTemplateData: data,
+		}
+		if _, err = c.Cloud.EC2().CreateLaunchTemplateVersion(input); err != nil {
+			return fmt.Errorf("error creating LaunchTemplateVersion: %v", err)
+		}
+		e.ID = a.ID
 	}
-
-	ep.ID = fi.String(name)
 
 	return nil
 }
@@ -161,7 +171,7 @@ func (t *LaunchTemplate) Find(c *fi.Context) (*LaunchTemplate, error) {
 	}
 
 	// @step: get the latest launch template version
-	lt, err := t.findLatestLaunchTemplate(c)
+	lt, err := t.findLatestLaunchTemplateVersion(c)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +183,7 @@ func (t *LaunchTemplate) Find(c *fi.Context) (*LaunchTemplate, error) {
 
 	actual := &LaunchTemplate{
 		AssociatePublicIP:      fi.Bool(false),
-		ID:                     lt.LaunchTemplateName,
+		ID:                     lt.LaunchTemplateId,
 		ImageID:                lt.LaunchTemplateData.ImageId,
 		InstanceMonitoring:     fi.Bool(false),
 		InstanceType:           lt.LaunchTemplateData.InstanceType,
@@ -306,83 +316,39 @@ func (t *LaunchTemplate) findAllLaunchTemplates(c *fi.Context) ([]*ec2.LaunchTem
 	}
 }
 
-// findLaunchTemplates returns a list of launch templates
-func (t *LaunchTemplate) findLaunchTemplates(c *fi.Context) ([]*ec2.LaunchTemplateVersion, error) {
+// findLatestLaunchTemplateVersion returns the latest template
+func (t *LaunchTemplate) findLatestLaunchTemplateVersion(c *fi.Context) (*ec2.LaunchTemplateVersion, error) {
 	cloud, ok := c.Cloud.(awsup.AWSCloud)
 	if !ok {
-		return []*ec2.LaunchTemplateVersion{}, fmt.Errorf("invalid cloud provider: %v, expected: awsup.AWSCloud", c.Cloud)
+		return nil, fmt.Errorf("invalid cloud provider: %v, expected: awsup.AWSCloud", c.Cloud)
 	}
 
-	// @step: get a list of the launch templates
-	templates, err := t.findAllLaunchTemplates(c)
+	input := &ec2.DescribeLaunchTemplateVersionsInput{
+		LaunchTemplateName: t.Name,
+		Versions:           []*string{aws.String("$Latest")},
+	}
+
+	output, err := cloud.EC2().DescribeLaunchTemplateVersions(input)
 	if err != nil {
-		return nil, err
-	}
-
-	prefix := fmt.Sprintf("%s-", fi.StringValue(t.Name))
-
-	// @step: get the launch template versions for the templates we are interested in
-	var list []*ec2.LaunchTemplateVersion
-	var next *string
-	for _, x := range templates {
-		if strings.HasPrefix(aws.StringValue(x.LaunchTemplateName), prefix) {
-			err := func() error {
-				for {
-					resp, err := cloud.EC2().DescribeLaunchTemplateVersions(&ec2.DescribeLaunchTemplateVersionsInput{
-						LaunchTemplateName: x.LaunchTemplateName,
-						NextToken:          next,
-					})
-					if err != nil {
-						return err
-					}
-					list = append(list, resp.LaunchTemplateVersions...)
-					if resp.NextToken == nil {
-						return nil
-					}
-
-					next = resp.NextToken
-				}
-			}()
-			if err != nil {
-				return nil, err
-			}
+		if awsup.AWSErrorCode(err) == "InvalidLaunchTemplateName.NotFoundException" {
+			klog.V(4).Infof("Got InvalidLaunchTemplateName.NotFoundException error describing latest launch template version: %q", aws.StringValue(t.Name))
+			return nil, nil
+		} else {
+			return nil, err
 		}
 	}
 
-	// @step: sort the configurations in chronological order
-	sort.Slice(list, func(i, j int) bool {
-		ti := list[i].CreateTime
-		tj := list[j].CreateTime
-		if tj == nil {
-			return true
-		}
-		if ti == nil {
-			return false
-		}
-		return ti.UnixNano() < tj.UnixNano()
-	})
-
-	return list, nil
-}
-
-// findLatestLaunchTemplate returns the latest template
-func (t *LaunchTemplate) findLatestLaunchTemplate(c *fi.Context) (*ec2.LaunchTemplateVersion, error) {
-	// @step: get a list of configuration
-	configurations, err := t.findLaunchTemplates(c)
-	if err != nil {
-		return nil, err
-	}
-	if len(configurations) == 0 {
+	if len(output.LaunchTemplateVersions) == 0 {
 		return nil, nil
 	}
 
-	return configurations[len(configurations)-1], nil
+	return output.LaunchTemplateVersions[0], nil
 }
 
 // deleteLaunchTemplate tracks a LaunchConfiguration that we're going to delete
 // It implements fi.Deletion
 type deleteLaunchTemplate struct {
-	lc *ec2.LaunchTemplateVersion
+	lc *ec2.LaunchTemplate
 }
 
 var _ fi.Deletion = &deleteLaunchTemplate{}

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -326,7 +326,7 @@ func (t *LaunchTemplate) findAllLaunchTemplates(c *fi.Context) ([]*ec2.LaunchTem
 	return list, nil
 }
 
-// findLatestLaunchTemplateVersion returns the latest template
+// findLatestLaunchTemplateVersion returns the latest template version
 func (t *LaunchTemplate) findLatestLaunchTemplateVersion(c *fi.Context) (*ec2.LaunchTemplateVersion, error) {
 	cloud, ok := c.Cloud.(awsup.AWSCloud)
 	if !ok {

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -109,8 +109,8 @@ type terraformLaunchTemplateTagSpecification struct {
 }
 
 type terraformLaunchTemplate struct {
-	// NamePrefix is the name of the launch template
-	NamePrefix *string `json:"name_prefix,omitempty" cty:"name_prefix"`
+	// Name is the name of the launch template
+	Name *string `json:"name,omitempty" cty:"name"`
 	// Lifecycle is the terraform lifecycle
 	Lifecycle *terraform.Lifecycle `json:"lifecycle,omitempty" cty:"lifecycle"`
 
@@ -168,7 +168,7 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 	}
 
 	tf := terraformLaunchTemplate{
-		NamePrefix:   fi.String(fi.StringValue(e.Name) + "-"),
+		Name:         e.Name,
 		EBSOptimized: e.RootVolumeOptimization,
 		ImageID:      image,
 		InstanceType: e.InstanceType,

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
@@ -75,7 +75,7 @@ resource "aws_launch_template" "test" {
   monitoring {
     enabled = true
   }
-  name_prefix = "test-"
+  name = "test"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -148,7 +148,7 @@ resource "aws_launch_template" "test" {
   monitoring {
     enabled = true
   }
-  name_prefix = "test-"
+  name = "test"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true

--- a/upup/pkg/fi/cloudup/awsup/aws_apitarget.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_apitarget.go
@@ -50,9 +50,19 @@ func (t *AWSAPITarget) AddAWSTags(id string, expected map[string]string) error {
 	return t.Cloud.AddAWSTags(id, expected)
 }
 
+func (t *AWSAPITarget) GetTags(id string) (map[string]string, error) {
+	return t.Cloud.GetTags(id)
+}
+func (t *AWSAPITarget) CreateTags(id string, tags map[string]string) error {
+	return t.Cloud.CreateTags(id, tags)
+}
 func (t *AWSAPITarget) DeleteTags(id string, tags map[string]string) error {
 	return t.Cloud.DeleteTags(id, tags)
 }
+func (t *AWSAPITarget) UpdateTags(id string, tags map[string]string) error {
+	return t.Cloud.UpdateTags(id, tags)
+}
+
 func (t *AWSAPITarget) AddELBV2Tags(ResourceArn string, expected map[string]string) error {
 	actual, err := t.Cloud.GetELBV2Tags(ResourceArn)
 	if err != nil {

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -723,10 +723,10 @@ func findAutoscalingGroupLaunchConfiguration(c AWSCloud, g *autoscaling.Group) (
 			return "", fmt.Errorf("error finding launch template by ID: %q", id)
 		}
 		launchTemplate := output.LaunchTemplates[0]
-		if version == "" || version == "$Default" {
-			version = strconv.FormatInt(*launchTemplate.DefaultVersionNumber, 10)
-		} else {
+		if version == "$Latest" {
 			version = strconv.FormatInt(*launchTemplate.LatestVersionNumber, 10)
+		} else {
+			version = strconv.FormatInt(*launchTemplate.DefaultVersionNumber, 10)
 		}
 	}
 	klog.V(4).Infof("Launch Template Version used for compare: %q", version)

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -158,6 +158,10 @@ func (c *MockAWSCloud) GetTags(resourceID string) (map[string]string, error) {
 	return getTags(c, resourceID)
 }
 
+func (c *MockAWSCloud) UpdateTags(id string, tags map[string]string) error {
+	return updateTags(c, id, tags)
+}
+
 func (c *MockAWSCloud) GetELBTags(loadBalancerName string) (map[string]string, error) {
 	return getELBTags(c, loadBalancerName)
 }


### PR DESCRIPTION
Cherry pick of #10151 on release-1.19.

#10151: Use LaunchTemplate versions instead of timestamped

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.