### PR TITLE
Allow nodeup to install old versions of docker

### DIFF
--- a/upup/pkg/fi/nodeup/nodetasks/package.go
+++ b/upup/pkg/fi/nodeup/nodetasks/package.go
@@ -324,7 +324,7 @@ func (_ *Package) RenderLocal(t *local.LocalTarget, a, e, changes *Package) erro
 		var args []string
 		env := os.Environ()
 		if d.IsDebianFamily() {
-			args = []string{"apt-get", "install", "--yes", "--no-install-recommends"}
+			args = []string{"apt-get", "install", "--yes", "--no-install-recommends", "--allow-downgrades"}
 			env = append(env, "DEBIAN_FRONTEND=noninteractive")
 		} else if d.IsRHELFamily() {
 			if d == distributions.DistributionCentos8 || d == distributions.DistributionRhel8 {


### PR DESCRIPTION
If the cloud image contains newer version of docker already, and we specify cluster docker version via kops to an older version of docker, then the kubernetes cluster will freak out when we perform the rolling-update on kubernetes master node, because the nodeup boot sequence will fail due to the following error.

```
$ sudo apt-get install --yes --no-install-recommends /var/cache/nodeup/packages/docker-ce.deb
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'docker-ce' instead of '/var/cache/nodeup/packages/docker-ce.deb'
The following package was automatically installed and is no longer required:
  libopts25
Use 'sudo apt autoremove' to remove it.
The following packages will be REMOVED:
  docker-ce-cli
The following packages will be DOWNGRADED:
  docker-ce
0 upgraded, 0 newly installed, 1 downgraded, 1 to remove and 49 not upgraded.
E: Packages were downgraded and -y was used without --allow-downgrades.
```