### PR TITLE
Add default runtime and runtimes fields in the docker config

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -437,6 +437,9 @@ spec:
                   dataRoot:
                     description: DataRoot is the root directory of persistent docker state (default "/var/lib/docker")
                     type: string
+                  defaultRuntime:
+                    description: DefaultRuntime is the default OCI runtime for containers (default "runc")
+                    type: string
                   defaultUlimit:
                     description: DefaultUlimit is the ulimits for containers
                     items:
@@ -498,6 +501,11 @@ spec:
                     type: integer
                   registryMirrors:
                     description: RegistryMirrors is a referred list of docker registry mirror
+                    items:
+                      type: string
+                    type: array
+                  runtimes:
+                    description: Runtimes registers an additional OCI compatible runtime (default [])
                     items:
                       type: string
                     type: array

--- a/pkg/apis/kops/dockerconfig.go
+++ b/pkg/apis/kops/dockerconfig.go
@@ -28,6 +28,8 @@ type DockerConfig struct {
 	DataRoot *string `json:"dataRoot,omitempty" flag:"data-root"`
 	// DefaultUlimit is the ulimits for containers
 	DefaultUlimit []string `json:"defaultUlimit,omitempty" flag:"default-ulimit,repeat"`
+	// DefaultRuntime is the default OCI runtime for containers (default "runc")
+	DefaultRuntime *string `json:"defaultRuntime,omitempty" flag:"default-runtime"`
 	// ExecOpt is a series of options passed to the runtime
 	ExecOpt []string `json:"execOpt,omitempty" flag:"exec-opt,repeat"`
 	// ExecRoot is the root directory for execution state files (default "/var/run/docker")
@@ -60,6 +62,8 @@ type DockerConfig struct {
 	MTU *int32 `json:"mtu,omitempty" flag:"mtu"`
 	// RegistryMirrors is a referred list of docker registry mirror
 	RegistryMirrors []string `json:"registryMirrors,omitempty" flag:"registry-mirror,repeat"`
+	// Runtimes registers an additional OCI compatible runtime (default [])
+	Runtimes []string `json:"runtimes,omitempty" flag:"add-runtime,repeat"`
 	// SelinuxEnabled enables SELinux support
 	SelinuxEnabled *bool `json:"selinuxEnabled,omitempty" flag:"selinux-enabled"`
 	// SkipInstall when set to true will prevent kops from installing and modifying Docker in any way

--- a/pkg/apis/kops/v1alpha2/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha2/dockerconfig.go
@@ -28,6 +28,8 @@ type DockerConfig struct {
 	DataRoot *string `json:"dataRoot,omitempty" flag:"data-root"`
 	// DefaultUlimit is the ulimits for containers
 	DefaultUlimit []string `json:"defaultUlimit,omitempty" flag:"default-ulimit,repeat"`
+	// DefaultRuntime is the default OCI runtime for containers (default "runc")
+	DefaultRuntime *string `json:"defaultRuntime,omitempty" flag:"default-runtime"`
 	// ExecOpt is a series of options passed to the runtime
 	ExecOpt []string `json:"execOpt,omitempty" flag:"exec-opt,repeat"`
 	// ExecRoot is the root directory for execution state files (default "/var/run/docker")
@@ -60,6 +62,8 @@ type DockerConfig struct {
 	MTU *int32 `json:"mtu,omitempty" flag:"mtu"`
 	// RegistryMirrors is a referred list of docker registry mirror
 	RegistryMirrors []string `json:"registryMirrors,omitempty" flag:"registry-mirror,repeat"`
+	// Runtimes registers an additional OCI compatible runtime (default [])
+	Runtimes []string `json:"runtimes,omitempty" flag:"add-runtime,repeat"`
 	// SelinuxEnabled enables SELinux support
 	SelinuxEnabled *bool `json:"selinuxEnabled,omitempty" flag:"selinux-enabled"`
 	// SkipInstall when set to true will prevent kops from installing and modifying Docker in any way

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2712,6 +2712,7 @@ func autoConvert_v1alpha2_DockerConfig_To_kops_DockerConfig(in *DockerConfig, ou
 	out.BridgeIP = in.BridgeIP
 	out.DataRoot = in.DataRoot
 	out.DefaultUlimit = in.DefaultUlimit
+	out.DefaultRuntime = in.DefaultRuntime
 	out.ExecOpt = in.ExecOpt
 	out.ExecRoot = in.ExecRoot
 	out.Experimental = in.Experimental
@@ -2728,6 +2729,7 @@ func autoConvert_v1alpha2_DockerConfig_To_kops_DockerConfig(in *DockerConfig, ou
 	out.MetricsAddress = in.MetricsAddress
 	out.MTU = in.MTU
 	out.RegistryMirrors = in.RegistryMirrors
+	out.Runtimes = in.Runtimes
 	out.SelinuxEnabled = in.SelinuxEnabled
 	out.SkipInstall = in.SkipInstall
 	out.Storage = in.Storage
@@ -2748,6 +2750,7 @@ func autoConvert_kops_DockerConfig_To_v1alpha2_DockerConfig(in *kops.DockerConfi
 	out.BridgeIP = in.BridgeIP
 	out.DataRoot = in.DataRoot
 	out.DefaultUlimit = in.DefaultUlimit
+	out.DefaultRuntime = in.DefaultRuntime
 	out.ExecOpt = in.ExecOpt
 	out.ExecRoot = in.ExecRoot
 	out.Experimental = in.Experimental
@@ -2764,6 +2767,7 @@ func autoConvert_kops_DockerConfig_To_v1alpha2_DockerConfig(in *kops.DockerConfi
 	out.MetricsAddress = in.MetricsAddress
 	out.MTU = in.MTU
 	out.RegistryMirrors = in.RegistryMirrors
+	out.Runtimes = in.Runtimes
 	out.SelinuxEnabled = in.SelinuxEnabled
 	out.SkipInstall = in.SkipInstall
 	out.Storage = in.Storage

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1105,6 +1105,11 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.DefaultRuntime != nil {
+		in, out := &in.DefaultRuntime, &out.DefaultRuntime
+		*out = new(string)
+		**out = **in
+	}
 	if in.ExecOpt != nil {
 		in, out := &in.ExecOpt, &out.ExecOpt
 		*out = make([]string, len(*in))
@@ -1177,6 +1182,11 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 	}
 	if in.RegistryMirrors != nil {
 		in, out := &in.RegistryMirrors, &out.RegistryMirrors
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Runtimes != nil {
+		in, out := &in.Runtimes, &out.Runtimes
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -1228,6 +1228,11 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.DefaultRuntime != nil {
+		in, out := &in.DefaultRuntime, &out.DefaultRuntime
+		*out = new(string)
+		**out = **in
+	}
 	if in.ExecOpt != nil {
 		in, out := &in.ExecOpt, &out.ExecOpt
 		*out = make([]string, len(*in))
@@ -1300,6 +1305,11 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 	}
 	if in.RegistryMirrors != nil {
 		in, out := &in.RegistryMirrors, &out.RegistryMirrors
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Runtimes != nil {
+		in, out := &in.Runtimes, &out.Runtimes
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}


### PR DESCRIPTION
Add the capability of defining the default runtime and runtimes fields for the docker daemon used in kops nodes.

This fixes https://github.com/kubernetes/kops/issues/10127