### PR TITLE
GCE: ignore (output-only) networkInterface.name

### DIFF
--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -353,6 +353,10 @@ func matches(l, r *compute.InstanceTemplate) bool {
 			c.Metadata.Fingerprint = ""
 			sort.Sort(ByKey(c.Metadata.Items))
 		}
+		// Ignore output fields
+		for _, ni := range c.NetworkInterfaces {
+			ni.Name = ""
+		}
 		return &c
 	}
 	normalize := func(v *compute.InstanceTemplate) *compute.InstanceTemplate {


### PR DESCRIPTION
This field was causing spurious differences to be detected.

We probably should be comparing the values in the kops model, not the
GCE model.