### PR TITLE
Delete security group rules that kops do not know about

### DIFF
--- a/docs/advanced/experimental.md
+++ b/docs/advanced/experimental.md
@@ -22,3 +22,4 @@ The following experimental features are currently available:
 * `+TerraformJSON` - Produce kubernetes.tf.json file instead of writing HCLv2 syntax. Can be consumed by terraform 0.12+
 * `+VFSVaultSupport` - Enables setting Vault as secret/keystore
 * `+APIServerNodes` - Enables support for dedicated API server nodes
+* `+DeleteUnknownSGRules` - Makes kOps delete unknown AWS security group rules 

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -96,6 +96,8 @@ var (
 	AlphaAllowGCE = new("AlphaAllowGCE", Bool(false))
 	// AlphaAllowALI is a feature flag that gates aliyun support while it is alpha.
 	AlphaAllowALI = new("AlphaAllowALI", Bool(false))
+	// DeleteUnknownSGRules will remove AWS SecurityGroup rules that are unknown to kOps.
+	DeleteUnknownSGRules = new("DeleteUnknownSGRules", Bool(false))
 )
 
 // FeatureFlag defines a feature flag

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -942,6 +942,15 @@ resource "aws_security_group" "nodes-bastionuserdata-example-com" {
   vpc_id = aws_vpc.bastionuserdata-example-com.id
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-api-elb-bastionuserdata-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.api-elb-bastionuserdata-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-bastionuserdata-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -976,6 +985,15 @@ resource "aws_security_group_rule" "from-api-elb-bastionuserdata-example-com-egr
   security_group_id = aws_security_group.api-elb-bastionuserdata-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-bastionuserdata-example-com-ingress-tcp-443to443-masters-bastionuserdata-example-com" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-bastionuserdata-example-com.id
+  source_security_group_id = aws_security_group.api-elb-bastionuserdata-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-bastionuserdata-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1138,24 +1156,6 @@ resource "aws_security_group_rule" "from-nodes-bastionuserdata-example-com-ingre
   source_security_group_id = aws_security_group.nodes-bastionuserdata-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.masters-bastionuserdata-example-com.id
-  source_security_group_id = aws_security_group.api-elb-bastionuserdata-example-com.id
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.api-elb-bastionuserdata-example-com.id
-  to_port           = 4
-  type              = "ingress"
 }
 
 resource "aws_subnet" "us-test-1a-bastionuserdata-example-com" {

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -721,6 +721,42 @@
         "CidrIp": "0.0.0.0/0"
       }
     },
+    "AWSEC2SecurityGroupIngressfrom1010016ingresstcp443to443masterscomplexexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
+        },
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp",
+        "CidrIp": "10.1.0.0/16"
+      }
+    },
+    "AWSEC2SecurityGroupIngressfrom1020016ingresstcp443to443masterscomplexexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
+        },
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp",
+        "CidrIp": "10.2.0.0/16"
+      }
+    },
+    "AWSEC2SecurityGroupIngressfrom111024ingressicmp3to4masterscomplexexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
+        },
+        "FromPort": 3,
+        "ToPort": 4,
+        "IpProtocol": "icmp",
+        "CidrIp": "1.1.1.0/24"
+      }
+    },
     "AWSEC2SecurityGroupIngressfrom111024ingresstcp443to443masterscomplexexamplecom": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
@@ -729,6 +765,18 @@
         },
         "FromPort": 443,
         "ToPort": 443,
+        "IpProtocol": "tcp",
+        "CidrIp": "1.1.1.0/24"
+      }
+    },
+    "AWSEC2SecurityGroupIngressfrom111024ingresstcp8443to8443masterscomplexexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
+        },
+        "FromPort": 8443,
+        "ToPort": 8443,
         "IpProtocol": "tcp",
         "CidrIp": "1.1.1.0/24"
       }
@@ -755,6 +803,18 @@
         "ToPort": 22,
         "IpProtocol": "tcp",
         "CidrIp": "1.1.1.1/32"
+      }
+    },
+    "AWSEC2SecurityGroupIngressfrom172200016ingresstcp443to443masterscomplexexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
+        },
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp",
+        "CidrIp": "172.20.0.0/16"
       }
     },
     "AWSEC2SecurityGroupIngressfrommasterscomplexexamplecomingressall0to0masterscomplexexamplecom": {
@@ -855,54 +915,6 @@
         "IpProtocol": "udp"
       }
     },
-    "AWSEC2SecurityGroupIngresshttpselbtomaster": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
-        },
-        "FromPort": 443,
-        "ToPort": 443,
-        "IpProtocol": "tcp",
-        "CidrIp": "172.20.0.0/16"
-      }
-    },
-    "AWSEC2SecurityGroupIngresshttpslbtomaster1010016": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
-        },
-        "FromPort": 443,
-        "ToPort": 443,
-        "IpProtocol": "tcp",
-        "CidrIp": "10.1.0.0/16"
-      }
-    },
-    "AWSEC2SecurityGroupIngresshttpslbtomaster1020016": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
-        },
-        "FromPort": 443,
-        "ToPort": 443,
-        "IpProtocol": "tcp",
-        "CidrIp": "10.2.0.0/16"
-      }
-    },
-    "AWSEC2SecurityGroupIngressicmppmtuapielb111024": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
-        },
-        "FromPort": 3,
-        "ToPort": 4,
-        "IpProtocol": "icmp",
-        "CidrIp": "1.1.1.0/24"
-      }
-    },
     "AWSEC2SecurityGroupIngressnodeporttcpexternaltonode102030024": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
@@ -949,18 +961,6 @@
         "ToPort": 32767,
         "IpProtocol": "udp",
         "CidrIp": "1.2.3.4/32"
-      }
-    },
-    "AWSEC2SecurityGroupIngresstcpapi111024": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
-        },
-        "FromPort": 8443,
-        "ToPort": 8443,
-        "IpProtocol": "tcp",
-        "CidrIp": "1.1.1.0/24"
       }
     },
     "AWSEC2SecurityGroupapielbcomplexexamplecom": {

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -831,12 +831,30 @@ resource "aws_security_group" "nodes-complex-example-com" {
   vpc_id = aws_vpc.complex-example-com.id
 }
 
+resource "aws_security_group_rule" "from-1-1-1-0--24-ingress-icmp-3to4-masters-complex-example-com" {
+  cidr_blocks       = ["1.1.1.0/24"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.masters-complex-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-1-1-1-0--24-ingress-tcp-443to443-masters-complex-example-com" {
   cidr_blocks       = ["1.1.1.0/24"]
   from_port         = 443
   protocol          = "tcp"
   security_group_id = aws_security_group.masters-complex-example-com.id
   to_port           = 443
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "from-1-1-1-0--24-ingress-tcp-8443to8443-masters-complex-example-com" {
+  cidr_blocks       = ["1.1.1.0/24"]
+  from_port         = 8443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.masters-complex-example-com.id
+  to_port           = 8443
   type              = "ingress"
 }
 
@@ -855,6 +873,33 @@ resource "aws_security_group_rule" "from-1-1-1-1--32-ingress-tcp-22to22-nodes-co
   protocol          = "tcp"
   security_group_id = aws_security_group.nodes-complex-example-com.id
   to_port           = 22
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "from-10-1-0-0--16-ingress-tcp-443to443-masters-complex-example-com" {
+  cidr_blocks       = ["10.1.0.0/16"]
+  from_port         = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.masters-complex-example-com.id
+  to_port           = 443
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "from-10-2-0-0--16-ingress-tcp-443to443-masters-complex-example-com" {
+  cidr_blocks       = ["10.2.0.0/16"]
+  from_port         = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.masters-complex-example-com.id
+  to_port           = 443
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "from-172-20-0-0--16-ingress-tcp-443to443-masters-complex-example-com" {
+  cidr_blocks       = ["172.20.0.0/16"]
+  from_port         = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.masters-complex-example-com.id
+  to_port           = 443
   type              = "ingress"
 }
 
@@ -957,42 +1002,6 @@ resource "aws_security_group_rule" "from-nodes-complex-example-com-ingress-udp-1
   type                     = "ingress"
 }
 
-resource "aws_security_group_rule" "https-elb-to-master" {
-  cidr_blocks       = ["172.20.0.0/16"]
-  from_port         = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.masters-complex-example-com.id
-  to_port           = 443
-  type              = "ingress"
-}
-
-resource "aws_security_group_rule" "https-lb-to-master-10-1-0-0--16" {
-  cidr_blocks       = ["10.1.0.0/16"]
-  from_port         = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.masters-complex-example-com.id
-  to_port           = 443
-  type              = "ingress"
-}
-
-resource "aws_security_group_rule" "https-lb-to-master-10-2-0-0--16" {
-  cidr_blocks       = ["10.2.0.0/16"]
-  from_port         = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.masters-complex-example-com.id
-  to_port           = 443
-  type              = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-1-1-1-0--24" {
-  cidr_blocks       = ["1.1.1.0/24"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.masters-complex-example-com.id
-  to_port           = 4
-  type              = "ingress"
-}
-
 resource "aws_security_group_rule" "nodeport-tcp-external-to-node-1-2-3-4--32" {
   cidr_blocks       = ["1.2.3.4/32"]
   from_port         = 28000
@@ -1026,15 +1035,6 @@ resource "aws_security_group_rule" "nodeport-udp-external-to-node-10-20-30-0--24
   protocol          = "udp"
   security_group_id = aws_security_group.nodes-complex-example-com.id
   to_port           = 32767
-  type              = "ingress"
-}
-
-resource "aws_security_group_rule" "tcp-api-1-1-1-0--24" {
-  cidr_blocks       = ["1.1.1.0/24"]
-  from_port         = 8443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.masters-complex-example-com.id
-  to_port           = 8443
   type              = "ingress"
 }
 

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -1046,6 +1046,15 @@ resource "aws_security_group" "masters-existingsg-example-com" {
   vpc_id = aws_vpc.existingsg-example-com.id
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-api-elb-existingsg-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = "sg-elb"
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-masters-existingsg-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -1107,6 +1116,33 @@ resource "aws_security_group_rule" "from-api-elb-existingsg-example-com-egress-a
   security_group_id = "sg-elb"
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-existingsg-example-com-ingress-tcp-443to443-masters-existingsg-example-com" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-existingsg-example-com.id
+  source_security_group_id = "sg-elb"
+  to_port                  = 443
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-existingsg-example-com-ingress-tcp-443to443-sg-master-1a-Master" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = "sg-master-1a"
+  source_security_group_id = "sg-elb"
+  to_port                  = 443
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-existingsg-example-com-ingress-tcp-443to443-sg-master-1b-Master" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = "sg-master-1b"
+  source_security_group_id = "sg-elb"
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-masters-existingsg-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1404,42 +1440,6 @@ resource "aws_security_group_rule" "from-sg-nodes-Node-ingress-udp-1to65535-sg-m
   source_security_group_id = "sg-nodes"
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.masters-existingsg-example-com.id
-  source_security_group_id = "sg-elb"
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master-sg-master-1a" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = "sg-master-1a"
-  source_security_group_id = "sg-elb"
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master-sg-master-1b" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = "sg-master-1b"
-  source_security_group_id = "sg-elb"
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = "sg-elb"
-  to_port           = 4
-  type              = "ingress"
 }
 
 resource "aws_subnet" "us-test-1a-existingsg-example-com" {

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -739,6 +739,15 @@ resource "aws_security_group" "nodes-externalpolicies-example-com" {
   vpc_id = aws_vpc.externalpolicies-example-com.id
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-api-elb-externalpolicies-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.api-elb-externalpolicies-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-masters-externalpolicies-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -782,6 +791,15 @@ resource "aws_security_group_rule" "from-api-elb-externalpolicies-example-com-eg
   security_group_id = aws_security_group.api-elb-externalpolicies-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-externalpolicies-example-com-ingress-tcp-443to443-masters-externalpolicies-example-com" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-externalpolicies-example-com.id
+  source_security_group_id = aws_security_group.api-elb-externalpolicies-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-masters-externalpolicies-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -881,24 +899,6 @@ resource "aws_security_group_rule" "from-nodes-externalpolicies-example-com-ingr
   source_security_group_id = aws_security_group.nodes-externalpolicies-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.masters-externalpolicies-example-com.id
-  source_security_group_id = aws_security_group.api-elb-externalpolicies-example-com.id
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.api-elb-externalpolicies-example-com.id
-  to_port           = 4
-  type              = "ingress"
 }
 
 resource "aws_security_group_rule" "nodeport-tcp-external-to-node-1-2-3-4--32" {

--- a/tests/integration/update_cluster/minimal-ipv6/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-ipv6/cloudformation.json
@@ -576,6 +576,18 @@
         "CidrIp": "0.0.0.0/0"
       }
     },
+    "AWSEC2SecurityGroupIngressfrom00000ingressicmp3to4mastersminimalipv6examplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmastersminimalipv6examplecom"
+        },
+        "FromPort": 3,
+        "ToPort": 4,
+        "IpProtocol": "icmp",
+        "CidrIp": "0.0.0.0/0"
+      }
+    },
     "AWSEC2SecurityGroupIngressfrom00000ingresstcp22to22mastersminimalipv6examplecom": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
@@ -612,6 +624,18 @@
         "CidrIp": "0.0.0.0/0"
       }
     },
+    "AWSEC2SecurityGroupIngressfrom0ingressicmpv61to1mastersminimalipv6examplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmastersminimalipv6examplecom"
+        },
+        "FromPort": -1,
+        "ToPort": -1,
+        "IpProtocol": "icmpv6",
+        "CidrIpv6": "::/0"
+      }
+    },
     "AWSEC2SecurityGroupIngressfrom0ingresstcp22to22mastersminimalipv6examplecom": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
@@ -646,6 +670,18 @@
         "ToPort": 443,
         "IpProtocol": "tcp",
         "CidrIpv6": "::/0"
+      }
+    },
+    "AWSEC2SecurityGroupIngressfrom172200016ingresstcp443to443mastersminimalipv6examplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmastersminimalipv6examplecom"
+        },
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp",
+        "CidrIp": "172.20.0.0/16"
       }
     },
     "AWSEC2SecurityGroupIngressfrommastersminimalipv6examplecomingressall0to0mastersminimalipv6examplecom": {
@@ -744,42 +780,6 @@
         "FromPort": 1,
         "ToPort": 65535,
         "IpProtocol": "udp"
-      }
-    },
-    "AWSEC2SecurityGroupIngresshttpselbtomaster": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupmastersminimalipv6examplecom"
-        },
-        "FromPort": 443,
-        "ToPort": 443,
-        "IpProtocol": "tcp",
-        "CidrIp": "172.20.0.0/16"
-      }
-    },
-    "AWSEC2SecurityGroupIngressicmppmtuapielb00000": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupmastersminimalipv6examplecom"
-        },
-        "FromPort": 3,
-        "ToPort": 4,
-        "IpProtocol": "icmp",
-        "CidrIp": "0.0.0.0/0"
-      }
-    },
-    "AWSEC2SecurityGroupIngressicmpv6pmtuapielb0": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupmastersminimalipv6examplecom"
-        },
-        "FromPort": -1,
-        "ToPort": -1,
-        "IpProtocol": "icmpv6",
-        "CidrIpv6": "::/0"
       }
     },
     "AWSEC2SecurityGroupapielbminimalipv6examplecom": {

--- a/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
@@ -697,6 +697,15 @@ resource "aws_security_group" "nodes-minimal-ipv6-example-com" {
   vpc_id = aws_vpc.minimal-ipv6-example-com.id
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-masters-minimal-ipv6-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-masters-minimal-ipv6-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -721,6 +730,24 @@ resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-masters
   protocol          = "tcp"
   security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
   to_port           = 443
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "from-172-20-0-0--16-ingress-tcp-443to443-masters-minimal-ipv6-example-com" {
+  cidr_blocks       = ["172.20.0.0/16"]
+  from_port         = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  to_port           = 443
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "from-__--0-ingress-icmpv6--1to-1-masters-minimal-ipv6-example-com" {
+  from_port         = -1
+  ipv6_cidr_blocks  = ["::/0"]
+  protocol          = "icmpv6"
+  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  to_port           = -1
   type              = "ingress"
 }
 
@@ -848,33 +875,6 @@ resource "aws_security_group_rule" "from-nodes-minimal-ipv6-example-com-ingress-
   source_security_group_id = aws_security_group.nodes-minimal-ipv6-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  cidr_blocks       = ["172.20.0.0/16"]
-  from_port         = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
-  to_port           = 443
-  type              = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
-  to_port           = 4
-  type              = "ingress"
-}
-
-resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
-  from_port         = -1
-  ipv6_cidr_blocks  = ["::/0"]
-  protocol          = "icmpv6"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
-  to_port           = -1
-  type              = "ingress"
 }
 
 resource "aws_subnet" "us-test-1a-minimal-ipv6-example-com" {

--- a/tests/integration/update_cluster/private-shared-ip/cloudformation.json
+++ b/tests/integration/update_cluster/private-shared-ip/cloudformation.json
@@ -858,6 +858,18 @@
         "CidrIp": "0.0.0.0/0"
       }
     },
+    "AWSEC2SecurityGroupIngressfrom00000ingressicmp3to4apielbprivatesharedipexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupapielbprivatesharedipexamplecom"
+        },
+        "FromPort": 3,
+        "ToPort": 4,
+        "IpProtocol": "icmp",
+        "CidrIp": "0.0.0.0/0"
+      }
+    },
     "AWSEC2SecurityGroupIngressfrom00000ingresstcp22to22bastionelbprivatesharedipexamplecom": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
@@ -880,6 +892,20 @@
         "ToPort": 443,
         "IpProtocol": "tcp",
         "CidrIp": "0.0.0.0/0"
+      }
+    },
+    "AWSEC2SecurityGroupIngressfromapielbprivatesharedipexamplecomingresstcp443to443mastersprivatesharedipexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmastersprivatesharedipexamplecom"
+        },
+        "SourceSecurityGroupId": {
+          "Ref": "AWSEC2SecurityGroupapielbprivatesharedipexamplecom"
+        },
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp"
       }
     },
     "AWSEC2SecurityGroupIngressfrombastionelbprivatesharedipexamplecomingresstcp22to22bastionprivatesharedipexamplecom": {
@@ -1020,32 +1046,6 @@
         "FromPort": 1,
         "ToPort": 65535,
         "IpProtocol": "udp"
-      }
-    },
-    "AWSEC2SecurityGroupIngresshttpselbtomaster": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupmastersprivatesharedipexamplecom"
-        },
-        "SourceSecurityGroupId": {
-          "Ref": "AWSEC2SecurityGroupapielbprivatesharedipexamplecom"
-        },
-        "FromPort": 443,
-        "ToPort": 443,
-        "IpProtocol": "tcp"
-      }
-    },
-    "AWSEC2SecurityGroupIngressicmppmtuapielb00000": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupapielbprivatesharedipexamplecom"
-        },
-        "FromPort": 3,
-        "ToPort": 4,
-        "IpProtocol": "icmp",
-        "CidrIp": "0.0.0.0/0"
       }
     },
     "AWSEC2SecurityGroupapielbprivatesharedipexamplecom": {

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -911,6 +911,15 @@ resource "aws_security_group" "nodes-private-shared-ip-example-com" {
   vpc_id = "vpc-12345678"
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-api-elb-private-shared-ip-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.api-elb-private-shared-ip-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-private-shared-ip-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -945,6 +954,15 @@ resource "aws_security_group_rule" "from-api-elb-private-shared-ip-example-com-e
   security_group_id = aws_security_group.api-elb-private-shared-ip-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-private-shared-ip-example-com-ingress-tcp-443to443-masters-private-shared-ip-example-com" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-private-shared-ip-example-com.id
+  source_security_group_id = aws_security_group.api-elb-private-shared-ip-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-elb-private-shared-ip-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1107,24 +1125,6 @@ resource "aws_security_group_rule" "from-nodes-private-shared-ip-example-com-ing
   source_security_group_id = aws_security_group.nodes-private-shared-ip-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.masters-private-shared-ip-example-com.id
-  source_security_group_id = aws_security_group.api-elb-private-shared-ip-example-com.id
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.api-elb-private-shared-ip-example-com.id
-  to_port           = 4
-  type              = "ingress"
 }
 
 resource "aws_subnet" "us-test-1a-private-shared-ip-example-com" {

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -848,6 +848,15 @@ resource "aws_security_group" "nodes-private-shared-subnet-example-com" {
   vpc_id = "vpc-12345678"
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-api-elb-private-shared-subnet-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.api-elb-private-shared-subnet-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-private-shared-subnet-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -882,6 +891,15 @@ resource "aws_security_group_rule" "from-api-elb-private-shared-subnet-example-c
   security_group_id = aws_security_group.api-elb-private-shared-subnet-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-private-shared-subnet-example-com-ingress-tcp-443to443-masters-private-shared-subnet-example-com" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-private-shared-subnet-example-com.id
+  source_security_group_id = aws_security_group.api-elb-private-shared-subnet-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-elb-private-shared-subnet-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1044,24 +1062,6 @@ resource "aws_security_group_rule" "from-nodes-private-shared-subnet-example-com
   source_security_group_id = aws_security_group.nodes-private-shared-subnet-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.masters-private-shared-subnet-example-com.id
-  source_security_group_id = aws_security_group.api-elb-private-shared-subnet-example-com.id
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.api-elb-private-shared-subnet-example-com.id
-  to_port           = 4
-  type              = "ingress"
 }
 
 terraform {

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -933,6 +933,18 @@
         "CidrIp": "0.0.0.0/0"
       }
     },
+    "AWSEC2SecurityGroupIngressfrom00000ingressicmp3to4apielbprivatecalicoexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupapielbprivatecalicoexamplecom"
+        },
+        "FromPort": 3,
+        "ToPort": 4,
+        "IpProtocol": "icmp",
+        "CidrIp": "0.0.0.0/0"
+      }
+    },
     "AWSEC2SecurityGroupIngressfrom00000ingresstcp22to22bastionelbprivatecalicoexamplecom": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
@@ -955,6 +967,20 @@
         "ToPort": 443,
         "IpProtocol": "tcp",
         "CidrIp": "0.0.0.0/0"
+      }
+    },
+    "AWSEC2SecurityGroupIngressfromapielbprivatecalicoexamplecomingresstcp443to443mastersprivatecalicoexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmastersprivatecalicoexamplecom"
+        },
+        "SourceSecurityGroupId": {
+          "Ref": "AWSEC2SecurityGroupapielbprivatecalicoexamplecom"
+        },
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp"
       }
     },
     "AWSEC2SecurityGroupIngressfrombastionelbprivatecalicoexamplecomingresstcp22to22bastionprivatecalicoexamplecom": {
@@ -1109,32 +1135,6 @@
         "FromPort": 1,
         "ToPort": 65535,
         "IpProtocol": "udp"
-      }
-    },
-    "AWSEC2SecurityGroupIngresshttpselbtomaster": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupmastersprivatecalicoexamplecom"
-        },
-        "SourceSecurityGroupId": {
-          "Ref": "AWSEC2SecurityGroupapielbprivatecalicoexamplecom"
-        },
-        "FromPort": 443,
-        "ToPort": 443,
-        "IpProtocol": "tcp"
-      }
-    },
-    "AWSEC2SecurityGroupIngressicmppmtuapielb00000": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupapielbprivatecalicoexamplecom"
-        },
-        "FromPort": 3,
-        "ToPort": 4,
-        "IpProtocol": "icmp",
-        "CidrIp": "0.0.0.0/0"
       }
     },
     "AWSEC2SecurityGroupapielbprivatecalicoexamplecom": {

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -941,6 +941,15 @@ resource "aws_security_group" "nodes-privatecalico-example-com" {
   vpc_id = aws_vpc.privatecalico-example-com.id
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-api-elb-privatecalico-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.api-elb-privatecalico-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-privatecalico-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -975,6 +984,15 @@ resource "aws_security_group_rule" "from-api-elb-privatecalico-example-com-egres
   security_group_id = aws_security_group.api-elb-privatecalico-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-privatecalico-example-com-ingress-tcp-443to443-masters-privatecalico-example-com" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-privatecalico-example-com.id
+  source_security_group_id = aws_security_group.api-elb-privatecalico-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-elb-privatecalico-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1146,24 +1164,6 @@ resource "aws_security_group_rule" "from-nodes-privatecalico-example-com-ingress
   source_security_group_id = aws_security_group.nodes-privatecalico-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.masters-privatecalico-example-com.id
-  source_security_group_id = aws_security_group.api-elb-privatecalico-example-com.id
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.api-elb-privatecalico-example-com.id
-  to_port           = 4
-  type              = "ingress"
 }
 
 resource "aws_subnet" "us-test-1a-privatecalico-example-com" {

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -941,6 +941,15 @@ resource "aws_security_group" "nodes-privatecanal-example-com" {
   vpc_id = aws_vpc.privatecanal-example-com.id
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-api-elb-privatecanal-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.api-elb-privatecanal-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-privatecanal-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -975,6 +984,15 @@ resource "aws_security_group_rule" "from-api-elb-privatecanal-example-com-egress
   security_group_id = aws_security_group.api-elb-privatecanal-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-privatecanal-example-com-ingress-tcp-443to443-masters-privatecanal-example-com" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-privatecanal-example-com.id
+  source_security_group_id = aws_security_group.api-elb-privatecanal-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-elb-privatecanal-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1137,24 +1155,6 @@ resource "aws_security_group_rule" "from-nodes-privatecanal-example-com-ingress-
   source_security_group_id = aws_security_group.nodes-privatecanal-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.masters-privatecanal-example-com.id
-  source_security_group_id = aws_security_group.api-elb-privatecanal-example-com.id
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.api-elb-privatecanal-example-com.id
-  to_port           = 4
-  type              = "ingress"
 }
 
 resource "aws_subnet" "us-test-1a-privatecanal-example-com" {

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json
@@ -933,6 +933,18 @@
         "CidrIp": "0.0.0.0/0"
       }
     },
+    "AWSEC2SecurityGroupIngressfrom00000ingressicmp3to4apielbprivateciliumexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupapielbprivateciliumexamplecom"
+        },
+        "FromPort": 3,
+        "ToPort": 4,
+        "IpProtocol": "icmp",
+        "CidrIp": "0.0.0.0/0"
+      }
+    },
     "AWSEC2SecurityGroupIngressfrom00000ingresstcp22to22bastionelbprivateciliumexamplecom": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
@@ -955,6 +967,20 @@
         "ToPort": 443,
         "IpProtocol": "tcp",
         "CidrIp": "0.0.0.0/0"
+      }
+    },
+    "AWSEC2SecurityGroupIngressfromapielbprivateciliumexamplecomingresstcp443to443mastersprivateciliumexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmastersprivateciliumexamplecom"
+        },
+        "SourceSecurityGroupId": {
+          "Ref": "AWSEC2SecurityGroupapielbprivateciliumexamplecom"
+        },
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp"
       }
     },
     "AWSEC2SecurityGroupIngressfrombastionelbprivateciliumexamplecomingresstcp22to22bastionprivateciliumexamplecom": {
@@ -1095,32 +1121,6 @@
         "FromPort": 1,
         "ToPort": 65535,
         "IpProtocol": "udp"
-      }
-    },
-    "AWSEC2SecurityGroupIngresshttpselbtomaster": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupmastersprivateciliumexamplecom"
-        },
-        "SourceSecurityGroupId": {
-          "Ref": "AWSEC2SecurityGroupapielbprivateciliumexamplecom"
-        },
-        "FromPort": 443,
-        "ToPort": 443,
-        "IpProtocol": "tcp"
-      }
-    },
-    "AWSEC2SecurityGroupIngressicmppmtuapielb00000": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupapielbprivateciliumexamplecom"
-        },
-        "FromPort": 3,
-        "ToPort": 4,
-        "IpProtocol": "icmp",
-        "CidrIp": "0.0.0.0/0"
       }
     },
     "AWSEC2SecurityGroupapielbprivateciliumexamplecom": {

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -941,6 +941,15 @@ resource "aws_security_group" "nodes-privatecilium-example-com" {
   vpc_id = aws_vpc.privatecilium-example-com.id
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-api-elb-privatecilium-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.api-elb-privatecilium-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-privatecilium-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -975,6 +984,15 @@ resource "aws_security_group_rule" "from-api-elb-privatecilium-example-com-egres
   security_group_id = aws_security_group.api-elb-privatecilium-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-privatecilium-example-com-ingress-tcp-443to443-masters-privatecilium-example-com" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-privatecilium-example-com.id
+  source_security_group_id = aws_security_group.api-elb-privatecilium-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-elb-privatecilium-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1137,24 +1155,6 @@ resource "aws_security_group_rule" "from-nodes-privatecilium-example-com-ingress
   source_security_group_id = aws_security_group.nodes-privatecilium-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.masters-privatecilium-example-com.id
-  source_security_group_id = aws_security_group.api-elb-privatecilium-example-com.id
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.api-elb-privatecilium-example-com.id
-  to_port           = 4
-  type              = "ingress"
 }
 
 resource "aws_subnet" "us-test-1a-privatecilium-example-com" {

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json
@@ -933,6 +933,18 @@
         "CidrIp": "0.0.0.0/0"
       }
     },
+    "AWSEC2SecurityGroupIngressfrom00000ingressicmp3to4apielbprivateciliumexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupapielbprivateciliumexamplecom"
+        },
+        "FromPort": 3,
+        "ToPort": 4,
+        "IpProtocol": "icmp",
+        "CidrIp": "0.0.0.0/0"
+      }
+    },
     "AWSEC2SecurityGroupIngressfrom00000ingresstcp22to22bastionelbprivateciliumexamplecom": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
@@ -955,6 +967,20 @@
         "ToPort": 443,
         "IpProtocol": "tcp",
         "CidrIp": "0.0.0.0/0"
+      }
+    },
+    "AWSEC2SecurityGroupIngressfromapielbprivateciliumexamplecomingresstcp443to443mastersprivateciliumexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmastersprivateciliumexamplecom"
+        },
+        "SourceSecurityGroupId": {
+          "Ref": "AWSEC2SecurityGroupapielbprivateciliumexamplecom"
+        },
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp"
       }
     },
     "AWSEC2SecurityGroupIngressfrombastionelbprivateciliumexamplecomingresstcp22to22bastionprivateciliumexamplecom": {
@@ -1095,32 +1121,6 @@
         "FromPort": 1,
         "ToPort": 65535,
         "IpProtocol": "udp"
-      }
-    },
-    "AWSEC2SecurityGroupIngresshttpselbtomaster": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupmastersprivateciliumexamplecom"
-        },
-        "SourceSecurityGroupId": {
-          "Ref": "AWSEC2SecurityGroupapielbprivateciliumexamplecom"
-        },
-        "FromPort": 443,
-        "ToPort": 443,
-        "IpProtocol": "tcp"
-      }
-    },
-    "AWSEC2SecurityGroupIngressicmppmtuapielb00000": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupapielbprivateciliumexamplecom"
-        },
-        "FromPort": 3,
-        "ToPort": 4,
-        "IpProtocol": "icmp",
-        "CidrIp": "0.0.0.0/0"
       }
     },
     "AWSEC2SecurityGroupapielbprivateciliumexamplecom": {

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -948,6 +948,15 @@ resource "aws_security_group" "nodes-privatecilium-example-com" {
   vpc_id = aws_vpc.privatecilium-example-com.id
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-api-elb-privatecilium-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.api-elb-privatecilium-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-privatecilium-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -982,6 +991,15 @@ resource "aws_security_group_rule" "from-api-elb-privatecilium-example-com-egres
   security_group_id = aws_security_group.api-elb-privatecilium-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-privatecilium-example-com-ingress-tcp-443to443-masters-privatecilium-example-com" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-privatecilium-example-com.id
+  source_security_group_id = aws_security_group.api-elb-privatecilium-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-elb-privatecilium-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1144,24 +1162,6 @@ resource "aws_security_group_rule" "from-nodes-privatecilium-example-com-ingress
   source_security_group_id = aws_security_group.nodes-privatecilium-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.masters-privatecilium-example-com.id
-  source_security_group_id = aws_security_group.api-elb-privatecilium-example-com.id
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.api-elb-privatecilium-example-com.id
-  to_port           = 4
-  type              = "ingress"
 }
 
 resource "aws_subnet" "us-test-1a-privatecilium-example-com" {

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
@@ -933,6 +933,18 @@
         "CidrIp": "0.0.0.0/0"
       }
     },
+    "AWSEC2SecurityGroupIngressfrom00000ingressicmp3to4apielbprivateciliumadvancedexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupapielbprivateciliumadvancedexamplecom"
+        },
+        "FromPort": 3,
+        "ToPort": 4,
+        "IpProtocol": "icmp",
+        "CidrIp": "0.0.0.0/0"
+      }
+    },
     "AWSEC2SecurityGroupIngressfrom00000ingresstcp22to22bastionelbprivateciliumadvancedexamplecom": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
@@ -955,6 +967,20 @@
         "ToPort": 443,
         "IpProtocol": "tcp",
         "CidrIp": "0.0.0.0/0"
+      }
+    },
+    "AWSEC2SecurityGroupIngressfromapielbprivateciliumadvancedexamplecomingresstcp443to443mastersprivateciliumadvancedexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmastersprivateciliumadvancedexamplecom"
+        },
+        "SourceSecurityGroupId": {
+          "Ref": "AWSEC2SecurityGroupapielbprivateciliumadvancedexamplecom"
+        },
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp"
       }
     },
     "AWSEC2SecurityGroupIngressfrombastionelbprivateciliumadvancedexamplecomingresstcp22to22bastionprivateciliumadvancedexamplecom": {
@@ -1095,32 +1121,6 @@
         "FromPort": 1,
         "ToPort": 65535,
         "IpProtocol": "udp"
-      }
-    },
-    "AWSEC2SecurityGroupIngresshttpselbtomaster": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupmastersprivateciliumadvancedexamplecom"
-        },
-        "SourceSecurityGroupId": {
-          "Ref": "AWSEC2SecurityGroupapielbprivateciliumadvancedexamplecom"
-        },
-        "FromPort": 443,
-        "ToPort": 443,
-        "IpProtocol": "tcp"
-      }
-    },
-    "AWSEC2SecurityGroupIngressicmppmtuapielb00000": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "AWSEC2SecurityGroupapielbprivateciliumadvancedexamplecom"
-        },
-        "FromPort": 3,
-        "ToPort": 4,
-        "IpProtocol": "icmp",
-        "CidrIp": "0.0.0.0/0"
       }
     },
     "AWSEC2SecurityGroupapielbprivateciliumadvancedexamplecom": {

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -971,6 +971,15 @@ resource "aws_security_group" "nodes-privateciliumadvanced-example-com" {
   vpc_id = aws_vpc.privateciliumadvanced-example-com.id
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-api-elb-privateciliumadvanced-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.api-elb-privateciliumadvanced-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-privateciliumadvanced-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -1005,6 +1014,15 @@ resource "aws_security_group_rule" "from-api-elb-privateciliumadvanced-example-c
   security_group_id = aws_security_group.api-elb-privateciliumadvanced-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-privateciliumadvanced-example-com-ingress-tcp-443to443-masters-privateciliumadvanced-example-com" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-privateciliumadvanced-example-com.id
+  source_security_group_id = aws_security_group.api-elb-privateciliumadvanced-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-elb-privateciliumadvanced-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1167,24 +1185,6 @@ resource "aws_security_group_rule" "from-nodes-privateciliumadvanced-example-com
   source_security_group_id = aws_security_group.nodes-privateciliumadvanced-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.masters-privateciliumadvanced-example-com.id
-  source_security_group_id = aws_security_group.api-elb-privateciliumadvanced-example-com.id
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.api-elb-privateciliumadvanced-example-com.id
-  to_port           = 4
-  type              = "ingress"
 }
 
 resource "aws_subnet" "us-test-1a-privateciliumadvanced-example-com" {

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -1036,6 +1036,15 @@ resource "aws_security_group" "nodes-privatedns1-example-com" {
   vpc_id = aws_vpc.privatedns1-example-com.id
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-api-elb-privatedns1-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.api-elb-privatedns1-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-privatedns1-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -1070,6 +1079,15 @@ resource "aws_security_group_rule" "from-api-elb-privatedns1-example-com-egress-
   security_group_id = aws_security_group.api-elb-privatedns1-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-privatedns1-example-com-ingress-tcp-443to443-masters-privatedns1-example-com" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-privatedns1-example-com.id
+  source_security_group_id = aws_security_group.api-elb-privatedns1-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-elb-privatedns1-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1232,24 +1250,6 @@ resource "aws_security_group_rule" "from-nodes-privatedns1-example-com-ingress-u
   source_security_group_id = aws_security_group.nodes-privatedns1-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.masters-privatedns1-example-com.id
-  source_security_group_id = aws_security_group.api-elb-privatedns1-example-com.id
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.api-elb-privatedns1-example-com.id
-  to_port           = 4
-  type              = "ingress"
 }
 
 resource "aws_subnet" "us-test-1a-privatedns1-example-com" {

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -920,6 +920,15 @@ resource "aws_security_group" "nodes-privatedns2-example-com" {
   vpc_id = "vpc-12345678"
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-api-elb-privatedns2-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.api-elb-privatedns2-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-privatedns2-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -954,6 +963,15 @@ resource "aws_security_group_rule" "from-api-elb-privatedns2-example-com-egress-
   security_group_id = aws_security_group.api-elb-privatedns2-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-privatedns2-example-com-ingress-tcp-443to443-masters-privatedns2-example-com" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-privatedns2-example-com.id
+  source_security_group_id = aws_security_group.api-elb-privatedns2-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-elb-privatedns2-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1116,24 +1134,6 @@ resource "aws_security_group_rule" "from-nodes-privatedns2-example-com-ingress-u
   source_security_group_id = aws_security_group.nodes-privatedns2-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.masters-privatedns2-example-com.id
-  source_security_group_id = aws_security_group.api-elb-privatedns2-example-com.id
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.api-elb-privatedns2-example-com.id
-  to_port           = 4
-  type              = "ingress"
 }
 
 resource "aws_subnet" "us-test-1a-privatedns2-example-com" {

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -941,6 +941,15 @@ resource "aws_security_group" "nodes-privateflannel-example-com" {
   vpc_id = aws_vpc.privateflannel-example-com.id
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-api-elb-privateflannel-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.api-elb-privateflannel-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-privateflannel-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -975,6 +984,15 @@ resource "aws_security_group_rule" "from-api-elb-privateflannel-example-com-egre
   security_group_id = aws_security_group.api-elb-privateflannel-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-privateflannel-example-com-ingress-tcp-443to443-masters-privateflannel-example-com" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-privateflannel-example-com.id
+  source_security_group_id = aws_security_group.api-elb-privateflannel-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-elb-privateflannel-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1137,24 +1155,6 @@ resource "aws_security_group_rule" "from-nodes-privateflannel-example-com-ingres
   source_security_group_id = aws_security_group.nodes-privateflannel-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.masters-privateflannel-example-com.id
-  source_security_group_id = aws_security_group.api-elb-privateflannel-example-com.id
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.api-elb-privateflannel-example-com.id
-  to_port           = 4
-  type              = "ingress"
 }
 
 resource "aws_subnet" "us-test-1a-privateflannel-example-com" {

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -963,6 +963,15 @@ resource "aws_security_group" "nodes-privatekopeio-example-com" {
   vpc_id = aws_vpc.privatekopeio-example-com.id
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-api-elb-privatekopeio-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.api-elb-privatekopeio-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-privatekopeio-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -997,6 +1006,15 @@ resource "aws_security_group_rule" "from-api-elb-privatekopeio-example-com-egres
   security_group_id = aws_security_group.api-elb-privatekopeio-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-privatekopeio-example-com-ingress-tcp-443to443-masters-privatekopeio-example-com" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-privatekopeio-example-com.id
+  source_security_group_id = aws_security_group.api-elb-privatekopeio-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-elb-privatekopeio-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1159,24 +1177,6 @@ resource "aws_security_group_rule" "from-nodes-privatekopeio-example-com-ingress
   source_security_group_id = aws_security_group.nodes-privatekopeio-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.masters-privatekopeio-example-com.id
-  source_security_group_id = aws_security_group.api-elb-privatekopeio-example-com.id
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.api-elb-privatekopeio-example-com.id
-  to_port           = 4
-  type              = "ingress"
 }
 
 resource "aws_subnet" "us-test-1a-privatekopeio-example-com" {

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -941,6 +941,15 @@ resource "aws_security_group" "nodes-privateweave-example-com" {
   vpc_id = aws_vpc.privateweave-example-com.id
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-api-elb-privateweave-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.api-elb-privateweave-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-privateweave-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -975,6 +984,15 @@ resource "aws_security_group_rule" "from-api-elb-privateweave-example-com-egress
   security_group_id = aws_security_group.api-elb-privateweave-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-privateweave-example-com-ingress-tcp-443to443-masters-privateweave-example-com" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-privateweave-example-com.id
+  source_security_group_id = aws_security_group.api-elb-privateweave-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-elb-privateweave-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1137,24 +1155,6 @@ resource "aws_security_group_rule" "from-nodes-privateweave-example-com-ingress-
   source_security_group_id = aws_security_group.nodes-privateweave-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.masters-privateweave-example-com.id
-  source_security_group_id = aws_security_group.api-elb-privateweave-example-com.id
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.api-elb-privateweave-example-com.id
-  to_port           = 4
-  type              = "ingress"
 }
 
 resource "aws_subnet" "us-test-1a-privateweave-example-com" {

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -853,6 +853,15 @@ resource "aws_security_group" "nodes-unmanaged-example-com" {
   vpc_id = "vpc-12345678"
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-icmp-3to4-api-elb-unmanaged-example-com" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3
+  protocol          = "icmp"
+  security_group_id = aws_security_group.api-elb-unmanaged-example-com.id
+  to_port           = 4
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-unmanaged-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -887,6 +896,15 @@ resource "aws_security_group_rule" "from-api-elb-unmanaged-example-com-egress-al
   security_group_id = aws_security_group.api-elb-unmanaged-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-unmanaged-example-com-ingress-tcp-443to443-masters-unmanaged-example-com" {
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-unmanaged-example-com.id
+  source_security_group_id = aws_security_group.api-elb-unmanaged-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-elb-unmanaged-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1049,24 +1067,6 @@ resource "aws_security_group_rule" "from-nodes-unmanaged-example-com-ingress-udp
   source_security_group_id = aws_security_group.nodes-unmanaged-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "https-elb-to-master" {
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.masters-unmanaged-example-com.id
-  source_security_group_id = aws_security_group.api-elb-unmanaged-example-com.id
-  to_port                  = 443
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3
-  protocol          = "icmp"
-  security_group_id = aws_security_group.api-elb-unmanaged-example-com.id
-  to_port           = 4
-  type              = "ingress"
 }
 
 resource "aws_subnet" "us-test-1a-unmanaged-example-com" {


### PR DESCRIPTION
This PR will make kops remove all rules that _should_ be safe to remove. It will still ignore rules that belong to CCM or that links to other security groups.

The RemoveRules struct on SG tasks should also be redundant now.