### PR TITLE
Fix cloudformation lint job

### DIFF
--- a/hack/cfn-lint.Dockerfile
+++ b/hack/cfn-lint.Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.8-alpine
+ARG CFNLINT_VERSION
+RUN pip install "cfn-lint==${CFNLINT_VERSION}" pydot
+ENTRYPOINT ["cfn-lint"]

--- a/hack/verify-cloudformation.sh
+++ b/hack/verify-cloudformation.sh
@@ -27,12 +27,7 @@ IMAGE="cfn-python-lint:${TAG}"
 # https://github.com/aws-cloudformation/cfn-python-lint/issues/1025
 function docker_build() {
   echo "Building cfn-python-lint image"
-  TMP=$(mktemp -d)
-  git clone -q -b "${TAG}" https://github.com/aws-cloudformation/cfn-python-lint "${TMP}"
-  pushd "${TMP}"
-  docker build --tag "${IMAGE}" .
-  popd
-  rm -rf "${TMP}"
+  docker build --build-arg "CFNLINT_VERSION=${TAG}" --tag "${IMAGE}" - < "${KOPS_ROOT}/hack/cfn-lint.Dockerfile"
 }
 
 docker image inspect "${IMAGE}" >/dev/null 2>&1 || docker_build


### PR DESCRIPTION
The [Dockerfile we were using in the cfn-python-lint repo](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/Dockerfile) wasn't actually pinned to the version associated with the git tag, it always installs the latest version.
A [recent release](https://github.com/aws-cloudformation/cfn-python-lint/releases/tag/v0.41.0) consolidated error rules regarding invalid values (https://github.com/aws-cloudformation/cfn-python-lint/pull/1750)

We use an intentionally invalid "us-test-1" region and zones in much of our testing. We used to be able to ignore this "invalid AZ" error ([E2510](https://github.com/kubernetes/kops/blob/master/hack/.cfnlintrc.yaml#L3)), but now we would need to ignore all invalid values for all resource properties.

This pins cfn-python-lint to an older version by providing our own Dockerfile, but we'll have to figure out how we want to handle this longer term.

Fixes https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/9666/pull-kops-verify-cloudformation/1328738395379208192