### PR TITLE
Update etcd-manager to 3.0.20201117

### DIFF
--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/loader"
 )
 
-const DefaultBackupImage = "kopeio/etcd-backup:3.0.20200531"
+const DefaultBackupImage = "kopeio/etcd-backup:3.0.20201117"
 
 // EtcdOptionsBuilder adds options for etcd to the model
 type EtcdOptionsBuilder struct {

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -170,7 +170,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - image: kopeio/etcd-manager:3.0.20200531
+  - image: kopeio/etcd-manager:3.0.20201117
     name: etcd-manager
     resources:
       requests:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -80,7 +80,7 @@ Contents:
         - /bin/sh
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3997 --insecure=false --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20200531
+        image: kopeio/etcd-manager:3.0.20201117
         name: etcd-manager
         resources:
           requests:
@@ -139,7 +139,7 @@ Contents:
         - /bin/sh
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3996 --insecure=false --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20200531
+        image: kopeio/etcd-manager:3.0.20201117
         name: etcd-manager
         resources:
           requests:

--- a/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
@@ -80,7 +80,7 @@ Contents:
         - /bin/sh
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3997 --insecure=false --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20200531
+        image: kopeio/etcd-manager:3.0.20201117
         name: etcd-manager
         resources:
           requests:
@@ -145,7 +145,7 @@ Contents:
         - /bin/sh
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3996 --insecure=false --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20200531
+        image: kopeio/etcd-manager:3.0.20201117
         name: etcd-manager
         resources:
           requests:

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -83,7 +83,7 @@ Contents:
         env:
         - name: ETCD_QUOTA_BACKEND_BYTES
           value: "10737418240"
-        image: kopeio/etcd-manager:3.0.20200531
+        image: kopeio/etcd-manager:3.0.20201117
         name: etcd-manager
         resources:
           requests:
@@ -145,7 +145,7 @@ Contents:
         env:
         - name: ETCD_QUOTA_BACKEND_BYTES
           value: "10737418240"
-        image: kopeio/etcd-manager:3.0.20200531
+        image: kopeio/etcd-manager:3.0.20201117
         name: etcd-manager
         resources:
           requests:

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -89,7 +89,7 @@ Contents:
           value: http://proxy.example.com
         - name: no_proxy
           value: noproxy.example.com
-        image: kopeio/etcd-manager:3.0.20200531
+        image: kopeio/etcd-manager:3.0.20201117
         name: etcd-manager
         resources:
           requests:
@@ -163,7 +163,7 @@ Contents:
           value: http://proxy.example.com
         - name: no_proxy
           value: noproxy.example.com
-        image: kopeio/etcd-manager:3.0.20200531
+        image: kopeio/etcd-manager:3.0.20201117
         name: etcd-manager
         resources:
           requests:


### PR DESCRIPTION
Release notes for 3.0.20201117:

* Release notes for 3.0.20200531
* Adds support for using OS application credentials
* Fixes usage of OpenStack Swift reauthentication
* Move from debian-hyperkube-base to debian-base
* Add license headers to each file
* Fix some typos picked up by verify-spelling
* Fix some problems with trailing spaces
* Add support for etcd 3.4.13
* Switch to gcr.io/cloud-marketplace-containers/google/debian10 - Fix
 for #340 option 1
* Support for ARM64
* BUG: OpenStack ignore AvailabilityZone in discovery
* Added full cinder ID to candidateDeviceNodes
* feat(etcd-manager-ctl): use backupname to delete backup instead of timestamp
* Update kops to pick up AllowAuth Openstack
* Build base image by raw expansion of deb packages
* Switch the cloudbuild docker image, locking to 2.2.0
* Fix build on case-insensitive file systems (MacOS)
* Set AltNames on server certificates
* govet: Fix a log message