### PR TITLE
Automated cherry pick of #10239: Use separate domain for kops-controller bootstrap

### DIFF
--- a/nodeup/pkg/model/kops_controller.go
+++ b/nodeup/pkg/model/kops_controller.go
@@ -62,7 +62,7 @@ func (b *KopsControllerBuilder) Build(c *fi.ModelBuilderContext) error {
 		Signer:         fi.CertificateIDCA,
 		Type:           "server",
 		Subject:        nodetasks.PKIXName{CommonName: "kops-controller"},
-		AlternateNames: []string{b.Cluster.Spec.MasterInternalName},
+		AlternateNames: []string{"kops-controller.internal." + b.Cluster.ObjectMeta.Name},
 	}
 	c.AddTask(issueCert)
 

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -2768,6 +2768,10 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         version: v1.19.0-beta.1
+{{ if UseKopsControllerForNodeBootstrap }}
+      annotations:
+        dns.alpha.kubernetes.io/internal: kops-controller.internal.{{ ClusterName }}
+{{ end }}
     spec:
       priorityClassName: system-node-critical
       tolerations:

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -34,6 +34,10 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         version: v1.19.0-beta.1
+{{ if UseKopsControllerForNodeBootstrap }}
+      annotations:
+        dns.alpha.kubernetes.io/internal: kops-controller.internal.{{ ClusterName }}
+{{ end }}
     spec:
       priorityClassName: system-node-critical
       tolerations:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a7d47f4a668812e334b505231855a82cef2f670c
+    manifestHash: 5a0a74b65c83649d0a494311a55e7c39a98475a6
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -26,6 +26,8 @@ spec:
       k8s-app: kops-controller
   template:
     metadata:
+      annotations:
+        dns.alpha.kubernetes.io/internal: kops-controller.internal.minimal.example.com
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a7d47f4a668812e334b505231855a82cef2f670c
+    manifestHash: 5a0a74b65c83649d0a494311a55e7c39a98475a6
     name: kops-controller.addons.k8s.io
     selector:
       k8s-addon: kops-controller.addons.k8s.io

--- a/upup/pkg/fi/nodeup/nodetasks/bootstrap_client.go
+++ b/upup/pkg/fi/nodeup/nodetasks/bootstrap_client.go
@@ -151,7 +151,7 @@ func (b *BootstrapClient) queryBootstrap(c *fi.Context, req *nodeup.BootstrapReq
 
 	bootstrapUrl := url.URL{
 		Scheme: "https",
-		Host:   net.JoinHostPort(c.Cluster.Spec.MasterInternalName, strconv.Itoa(wellknownports.KopsControllerPort)),
+		Host:   net.JoinHostPort("kops-controller.internal."+c.Cluster.ObjectMeta.Name, strconv.Itoa(wellknownports.KopsControllerPort)),
 		Path:   "/bootstrap",
 	}
 	httpReq, err := http.NewRequest("POST", bootstrapUrl.String(), bytes.NewReader(reqBytes))


### PR DESCRIPTION
Cherry pick of #10239 on release-1.19.

#10239: Use separate domain for kops-controller bootstrap

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.