### PR TITLE
Explicitly set the target environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 arch: arm64-graviton2
 os: linux
 dist: focal
+virt: vm
 go: 1.15.4
 
 go_import_path: k8s.io/kops


### PR DESCRIPTION
TravisCI uses AMD64 silently instead of ARM64 at the moment.

/cc @olemarkus 