### PR TITLE
Revert "Switch ARM64 CI to Graviton2 CPU"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-arch: arm64-graviton2
+arch: arm64
 os: linux
 dist: focal
 go: 1.15.4


### PR DESCRIPTION
This reverts commit e7614fda

https://docs.travis-ci.com/user/multi-cpu-architectures/#multi-cpu-availaibility
> The two arm64 tags are used right now to distinguish between OSS-support only (arch: arm64) and available both for OSS & commercial (arch: arm64-graviton2, available only on travis-ci.com).

/cc @olemarkus 