### PR TITLE
Automated cherry pick of #10262: Revert "Switch ARM64 CI to Graviton2 CPU"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-arch: arm64-graviton2
+arch: arm64
 os: linux
 dist: focal
 go: 1.15.4


### PR DESCRIPTION
Cherry pick of #10262 on release-1.19.

#10262: Revert "Switch ARM64 CI to Graviton2 CPU"

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.