### PR TITLE
Fix multi-arch image pushing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,8 +367,8 @@ dns-controller-push:
 
 .PHONY: dns-controller-manifest
 dns-controller-manifest:
-	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller-amd64:${DNS_CONTROLLER_PUSH_TAG}
-	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller-arm64:${DNS_CONTROLLER_PUSH_TAG}
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG}-amd64
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG}-arm64
 	docker manifest push --purge ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG}
 
 # --------------------------------------------------
@@ -823,8 +823,8 @@ kops-controller-push:
 
 .PHONY: kops-controller-manifest
 kops-controller-manifest:
-	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller-amd64:${KOPS_CONTROLLER_PUSH_TAG}
-	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller-arm64:${KOPS_CONTROLLER_PUSH_TAG}
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG}-amd64
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG}-arm64
 	docker manifest push --purge ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG}
 
 #------------------------------------------------------
@@ -837,6 +837,6 @@ kube-apiserver-healthcheck-push:
 
 .PHONY: kube-apiserver-healthcheck-manifest
 kube-apiserver-healthcheck-manifest:
-	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck-amd64:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG}
-	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck-arm64:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG}
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG}-amd64
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG}-arm64
 	docker manifest push --purge ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG}

--- a/cmd/kops-controller/BUILD.bazel
+++ b/cmd/kops-controller/BUILD.bazel
@@ -67,8 +67,8 @@ ARCH = [
     format = "Docker",
     image = ":image-%s" % arch,
     registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = "{STABLE_DOCKER_IMAGE_PREFIX}kops-controller-%s" % arch,
-    tag = "{STABLE_KOPS_CONTROLLER_TAG}",
+    repository = "{STABLE_DOCKER_IMAGE_PREFIX}kops-controller",
+    tag = "{STABLE_KOPS_CONTROLLER_TAG}-%s" % arch,
 ) for arch in ARCH]
 
 [container_bundle(

--- a/cmd/kube-apiserver-healthcheck/BUILD.bazel
+++ b/cmd/kube-apiserver-healthcheck/BUILD.bazel
@@ -57,8 +57,8 @@ ARCH = [
     format = "Docker",
     image = ":image-%s" % arch,
     registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = "{STABLE_DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck-%s" % arch,
-    tag = "{STABLE_KUBE_APISERVER_HEALTHCHECK_TAG}",
+    repository = "{STABLE_DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck",
+    tag = "{STABLE_KUBE_APISERVER_HEALTHCHECK_TAG}-%s" % arch,
 ) for arch in ARCH]
 
 [container_bundle(

--- a/dns-controller/cmd/dns-controller/BUILD.bazel
+++ b/dns-controller/cmd/dns-controller/BUILD.bazel
@@ -70,8 +70,8 @@ ARCH = [
     format = "Docker",
     image = ":image-%s" % arch,
     registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = "{STABLE_DOCKER_IMAGE_PREFIX}dns-controller-%s" % arch,
-    tag = "{STABLE_DNS_CONTROLLER_TAG}",
+    repository = "{STABLE_DOCKER_IMAGE_PREFIX}dns-controller",
+    tag = "{STABLE_DNS_CONTROLLER_TAG}-%s" % arch,
 ) for arch in ARCH]
 
 [container_bundle(


### PR DESCRIPTION
Manifest pushing seems broken because of cross-repo image pushing. Switching to pushing to same repo tags with arch suffix should get it fixed, same as we do with etcd-manager.

https://storage.googleapis.com/kubernetes-jenkins/logs/kops-postsubmit-push-to-staging/1329154456519970816/build-log.txt