### PR TITLE
Automated cherry pick of #10265: Push multi-arch images #10270: Fix multi-arch image pushing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,9 +362,14 @@ bazel-crossbuild-dns-controller:
 
 .PHONY: dns-controller-push
 dns-controller-push:
-	DOCKER_REGISTRY=${DOCKER_REGISTRY} DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX} DNS_CONTROLLER_TAG=${DNS_CONTROLLER_PUSH_TAG} bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //dns-controller/cmd/dns-controller:push-image-plain
 	DOCKER_REGISTRY=${DOCKER_REGISTRY} DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX} DNS_CONTROLLER_TAG=${DNS_CONTROLLER_PUSH_TAG} bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //dns-controller/cmd/dns-controller:push-image-amd64
 	DOCKER_REGISTRY=${DOCKER_REGISTRY} DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX} DNS_CONTROLLER_TAG=${DNS_CONTROLLER_PUSH_TAG} bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 //dns-controller/cmd/dns-controller:push-image-arm64
+
+.PHONY: dns-controller-manifest
+dns-controller-manifest:
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller-amd64:${DNS_CONTROLLER_PUSH_TAG}
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller-arm64:${DNS_CONTROLLER_PUSH_TAG}
+	docker manifest push --purge ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG}
 
 # --------------------------------------------------
 # development targets
@@ -813,15 +818,25 @@ crds:
 
 .PHONY: kops-controller-push
 kops-controller-push:
-	DOCKER_REGISTRY=${DOCKER_REGISTRY} DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX} KOPS_CONTROLLER_TAG=${KOPS_CONTROLLER_PUSH_TAG} bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //cmd/kops-controller:push-image-plain
 	DOCKER_REGISTRY=${DOCKER_REGISTRY} DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX} KOPS_CONTROLLER_TAG=${KOPS_CONTROLLER_PUSH_TAG} bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //cmd/kops-controller:push-image-amd64
 	DOCKER_REGISTRY=${DOCKER_REGISTRY} DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX} KOPS_CONTROLLER_TAG=${KOPS_CONTROLLER_PUSH_TAG} bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 //cmd/kops-controller:push-image-arm64
+
+.PHONY: kops-controller-manifest
+kops-controller-manifest:
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller-amd64:${KOPS_CONTROLLER_PUSH_TAG}
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller-arm64:${KOPS_CONTROLLER_PUSH_TAG}
+	docker manifest push --purge ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG}
 
 #------------------------------------------------------
 # kube-apiserver-healthcheck
 
 .PHONY: kube-apiserver-healthcheck-push
 kube-apiserver-healthcheck-push:
-	DOCKER_REGISTRY=${DOCKER_REGISTRY} DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX} KUBE_APISERVER_HEALTHCHECK_TAG=${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG} bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //cmd/kube-apiserver-healthcheck:push-image-plain
 	DOCKER_REGISTRY=${DOCKER_REGISTRY} DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX} KUBE_APISERVER_HEALTHCHECK_TAG=${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG} bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //cmd/kube-apiserver-healthcheck:push-image-amd64
 	DOCKER_REGISTRY=${DOCKER_REGISTRY} DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX} KUBE_APISERVER_HEALTHCHECK_TAG=${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG} bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 //cmd/kube-apiserver-healthcheck:push-image-arm64
+
+.PHONY: kube-apiserver-healthcheck-manifest
+kube-apiserver-healthcheck-manifest:
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck-amd64:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG}
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck-arm64:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG}
+	docker manifest push --purge ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG}

--- a/Makefile
+++ b/Makefile
@@ -367,8 +367,8 @@ dns-controller-push:
 
 .PHONY: dns-controller-manifest
 dns-controller-manifest:
-	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller-amd64:${DNS_CONTROLLER_PUSH_TAG}
-	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller-arm64:${DNS_CONTROLLER_PUSH_TAG}
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG}-amd64
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG}-arm64
 	docker manifest push --purge ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}dns-controller:${DNS_CONTROLLER_PUSH_TAG}
 
 # --------------------------------------------------
@@ -823,8 +823,8 @@ kops-controller-push:
 
 .PHONY: kops-controller-manifest
 kops-controller-manifest:
-	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller-amd64:${KOPS_CONTROLLER_PUSH_TAG}
-	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller-arm64:${KOPS_CONTROLLER_PUSH_TAG}
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG}-amd64
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG}-arm64
 	docker manifest push --purge ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kops-controller:${KOPS_CONTROLLER_PUSH_TAG}
 
 #------------------------------------------------------
@@ -837,6 +837,6 @@ kube-apiserver-healthcheck-push:
 
 .PHONY: kube-apiserver-healthcheck-manifest
 kube-apiserver-healthcheck-manifest:
-	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck-amd64:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG}
-	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck-arm64:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG}
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG}-amd64
+	docker manifest create --amend ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG} ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG}-arm64
 	docker manifest push --purge ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck:${KUBE_APISERVER_HEALTHCHECK_PUSH_TAG}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,8 +4,9 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-# Start by just pushing the image
-- name: 'gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.2.0'
+# Push the images
+- name: 'gcr.io/k8s-testimages/bazelbuild:v20200824-5d057db-2.2.0'
+  id: images
   entrypoint: make
   env:
   # _GIT_TAG is not a valid semver, we use CI=1 instead
@@ -18,7 +19,9 @@ steps:
   - kops-controller-push
   - dns-controller-push
   - kube-apiserver-healthcheck-push
-- name: 'gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.2.0'
+# Push the artifacts
+- name: 'gcr.io/k8s-testimages/bazelbuild:v20200824-5d057db-2.2.0'
+  id: artifacts
   entrypoint: make
   env:
   # _GIT_TAG is not a valid semver, we use CI=1 instead
@@ -31,6 +34,21 @@ steps:
   - LATEST_FILE=markers/${_PULL_BASE_REF}/latest-ci.txt
   args:
   - gcs-upload-and-tag
+# Push the manifests
+- name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db'
+  id: manifests
+  waitFor: [images]
+  entrypoint: make
+  env:
+  - DOCKER_CLI_EXPERIMENTAL=enabled
+  - CI=$_CI
+  - PULL_BASE_REF=$_PULL_BASE_REF
+  - DOCKER_REGISTRY=$_DOCKER_REGISTRY
+  - DOCKER_IMAGE_PREFIX=$_DOCKER_IMAGE_PREFIX
+  args:
+  - kops-controller-manifest
+  - dns-controller-manifest
+  - kube-apiserver-healthcheck-manifest
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution

--- a/cmd/kops-controller/BUILD.bazel
+++ b/cmd/kops-controller/BUILD.bazel
@@ -57,16 +57,6 @@ ARCH = [
     stamp = True,
 ) for arch in ARCH]
 
-# TODO: Remove / replace when multi-arch images are available
-container_push(
-    name = "push-image-plain",
-    format = "Docker",
-    image = ":image-amd64",
-    registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = "{STABLE_DOCKER_IMAGE_PREFIX}kops-controller",
-    tag = "{STABLE_KOPS_CONTROLLER_TAG}",
-)
-
 [container_push(
     name = "push-image-%s" % arch,
     format = "Docker",

--- a/cmd/kops-controller/BUILD.bazel
+++ b/cmd/kops-controller/BUILD.bazel
@@ -62,8 +62,8 @@ ARCH = [
     format = "Docker",
     image = ":image-%s" % arch,
     registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = "{STABLE_DOCKER_IMAGE_PREFIX}kops-controller-%s" % arch,
-    tag = "{STABLE_KOPS_CONTROLLER_TAG}",
+    repository = "{STABLE_DOCKER_IMAGE_PREFIX}kops-controller",
+    tag = "{STABLE_KOPS_CONTROLLER_TAG}-%s" % arch,
 ) for arch in ARCH]
 
 [container_bundle(

--- a/cmd/kube-apiserver-healthcheck/BUILD.bazel
+++ b/cmd/kube-apiserver-healthcheck/BUILD.bazel
@@ -52,8 +52,8 @@ ARCH = [
     format = "Docker",
     image = ":image-%s" % arch,
     registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = "{STABLE_DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck-%s" % arch,
-    tag = "{STABLE_KUBE_APISERVER_HEALTHCHECK_TAG}",
+    repository = "{STABLE_DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck",
+    tag = "{STABLE_KUBE_APISERVER_HEALTHCHECK_TAG}-%s" % arch,
 ) for arch in ARCH]
 
 [container_bundle(

--- a/cmd/kube-apiserver-healthcheck/BUILD.bazel
+++ b/cmd/kube-apiserver-healthcheck/BUILD.bazel
@@ -47,16 +47,6 @@ ARCH = [
     stamp = True,
 ) for arch in ARCH]
 
-# TODO: Remove / replace when multi-arch images are available
-container_push(
-    name = "push-image-plain",
-    format = "Docker",
-    image = ":image-amd64",
-    registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = "{STABLE_DOCKER_IMAGE_PREFIX}kube-apiserver-healthcheck",
-    tag = "{STABLE_KUBE_APISERVER_HEALTHCHECK_TAG}",
-)
-
 [container_push(
     name = "push-image-%s" % arch,
     format = "Docker",

--- a/dns-controller/cmd/dns-controller/BUILD.bazel
+++ b/dns-controller/cmd/dns-controller/BUILD.bazel
@@ -65,8 +65,8 @@ ARCH = [
     format = "Docker",
     image = ":image-%s" % arch,
     registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = "{STABLE_DOCKER_IMAGE_PREFIX}dns-controller-%s" % arch,
-    tag = "{STABLE_DNS_CONTROLLER_TAG}",
+    repository = "{STABLE_DOCKER_IMAGE_PREFIX}dns-controller",
+    tag = "{STABLE_DNS_CONTROLLER_TAG}-%s" % arch,
 ) for arch in ARCH]
 
 [container_bundle(

--- a/dns-controller/cmd/dns-controller/BUILD.bazel
+++ b/dns-controller/cmd/dns-controller/BUILD.bazel
@@ -60,16 +60,6 @@ ARCH = [
     stamp = True,
 ) for arch in ARCH]
 
-# TODO: Remove / replace when multi-arch images are available
-container_push(
-    name = "push-image-plain",
-    format = "Docker",
-    image = ":image-amd64",
-    registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = "{STABLE_DOCKER_IMAGE_PREFIX}dns-controller",
-    tag = "{STABLE_DNS_CONTROLLER_TAG}",
-)
-
 [container_push(
     name = "push-image-%s" % arch,
     format = "Docker",


### PR DESCRIPTION
Cherry pick of #10265 #10270 on release-1.19.

#10265: Push multi-arch images
#10270: Fix multi-arch image pushing

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.