### PR TITLE
Allow setting CPU limit and Mem request / limit for kube API server

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1420,6 +1420,7 @@ k8s.io/cloud-provider v0.20.0-beta.2/go.mod h1:xu40/8K5o/wqZyuChUVqD5CoqVOVzKXE/
 k8s.io/cloud-provider-openstack v1.18.0 h1:v/ebjNEdx0hBaygsRohSS643f41lj2CwvapCbn+aLOs=
 k8s.io/cloud-provider-openstack v1.18.0/go.mod h1:03202t5Sp+4Vmk6pxJ/hVH0fEkm9gMc/pku/QpkJQMQ=
 k8s.io/cluster-bootstrap v0.20.0-beta.2/go.mod h1:kYKZIdQhCt0sh13R7Bjm1JXDg9QVjez8TLlyhtDC8Ck=
+k8s.io/code-generator v0.20.0-beta.2 h1:9b5RwuTexjs/UH3BUMCMI4lTECshBUc/DenKnKc3eCs=
 k8s.io/code-generator v0.20.0-beta.2/go.mod h1:UsqdF+VX4PU2g46NC2JRs4gc+IfrctnwHb76RNbWHJg=
 k8s.io/component-base v0.20.0-beta.2 h1:jg3eglA+HSDgimMoHoFvAiwHAGYxEy2D5HKhLPR4AjM=
 k8s.io/component-base v0.20.0-beta.2/go.mod h1:PS+w/i0JTsaQbtzk8EVPlj2WrY9E23MfWK/K4MNy7uc=

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -916,6 +916,9 @@ spec:
                     items:
                       type: string
                     type: array
+                  cpuLimit:
+                    description: CPULimit, cpu limit compute resource for api server e.g. "500m"
+                    type: string
                   cpuRequest:
                     description: CPURequest, cpu request compute resource for api server. Defaults to "150m"
                     type: string
@@ -1017,6 +1020,12 @@ spec:
                     description: MaxRequestsInflight The maximum number of non-mutating requests in flight at a given time.
                     format: int32
                     type: integer
+                  memoryLimit:
+                    description: MemoryLimit, memory limit compute resource for api server e.g. "30Mi"
+                    type: string
+                  memoryRequest:
+                    description: MemoryRequest, memory request compute resource for api server e.g. "30Mi"
+                    type: string
                   minRequestTimeout:
                     description: MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out. Currently only honored by the watch request handler
                     format: int32

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -471,6 +471,12 @@ type KubeAPIServerConfig struct {
 
 	// CPURequest, cpu request compute resource for api server. Defaults to "150m"
 	CPURequest string `json:"cpuRequest,omitempty"`
+	// CPULimit, cpu limit compute resource for api server e.g. "500m"
+	CPULimit string `json:"cpuLimit,omitempty"`
+	// MemoryRequest, memory request compute resource for api server e.g. "30Mi"
+	MemoryRequest string `json:"memoryRequest,omitempty"`
+	// MemoryLimit, memory limit compute resource for api server e.g. "30Mi"
+	MemoryLimit string `json:"memoryLimit,omitempty"`
 
 	// Amount of time to retain Kubernetes events
 	EventTTL *metav1.Duration `json:"eventTTL,omitempty" flag:"event-ttl"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -471,6 +471,12 @@ type KubeAPIServerConfig struct {
 
 	// CPURequest, cpu request compute resource for api server. Defaults to "150m"
 	CPURequest string `json:"cpuRequest,omitempty"`
+	// CPULimit, cpu limit compute resource for api server e.g. "500m"
+	CPULimit string `json:"cpuLimit,omitempty"`
+	// MemoryRequest, memory request compute resource for api server e.g. "30Mi"
+	MemoryRequest string `json:"memoryRequest,omitempty"`
+	// MemoryLimit, memory limit compute resource for api server e.g. "30Mi"
+	MemoryLimit string `json:"memoryLimit,omitempty"`
 
 	// Amount of time to retain Kubernetes events
 	EventTTL *metav1.Duration `json:"eventTTL,omitempty" flag:"event-ttl"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3987,6 +3987,9 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.ServiceAccountJWKSURI = in.ServiceAccountJWKSURI
 	out.APIAudiences = in.APIAudiences
 	out.CPURequest = in.CPURequest
+	out.CPULimit = in.CPULimit
+	out.MemoryRequest = in.MemoryRequest
+	out.MemoryLimit = in.MemoryLimit
 	out.EventTTL = in.EventTTL
 	out.AuditDynamicConfiguration = in.AuditDynamicConfiguration
 	out.EnableProfiling = in.EnableProfiling
@@ -4092,6 +4095,9 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.ServiceAccountJWKSURI = in.ServiceAccountJWKSURI
 	out.APIAudiences = in.APIAudiences
 	out.CPURequest = in.CPURequest
+	out.CPULimit = in.CPULimit
+	out.MemoryRequest = in.MemoryRequest
+	out.MemoryLimit = in.MemoryLimit
 	out.EventTTL = in.EventTTL
 	out.AuditDynamicConfiguration = in.AuditDynamicConfiguration
 	out.EnableProfiling = in.EnableProfiling

--- a/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
@@ -185,6 +185,8 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscomplexexamplecom.Properties.
     authorizationMode: AlwaysAllow
     bindAddress: 0.0.0.0
     cloudProvider: aws
+    cpuLimit: 500m
+    cpuRequest: 200m
     enableAdmissionPlugins:
     - NamespaceLifecycle
     - LimitRanger
@@ -208,6 +210,8 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscomplexexamplecom.Properties.
     - Hostname
     - ExternalIP
     logLevel: 2
+    memoryLimit: 1000Mi
+    memoryRequest: 800Mi
     requestheaderAllowedNames:
     - aggregator
     requestheaderExtraHeaderPrefixes:

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
@@ -184,6 +184,8 @@ kubeAPIServer:
   authorizationMode: AlwaysAllow
   bindAddress: 0.0.0.0
   cloudProvider: aws
+  cpuLimit: 500m
+  cpuRequest: 200m
   enableAdmissionPlugins:
   - NamespaceLifecycle
   - LimitRanger
@@ -207,6 +209,8 @@ kubeAPIServer:
   - Hostname
   - ExternalIP
   logLevel: 2
+  memoryLimit: 1000Mi
+  memoryRequest: 800Mi
   requestheaderAllowedNames:
   - aggregator
   requestheaderExtraHeaderPrefixes:

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -37,6 +37,10 @@ spec:
   kubeAPIServer:
     serviceNodePortRange: 28000-32767
     auditWebhookBatchThrottleQps: 3.14
+    cpuRequest: 200m
+    cpuLimit: 500m
+    memoryRequest: 800Mi
+    memoryLimit: 1000Mi
   kubelet:
     anonymousAuth: false
   kubernetesVersion: v1.14.0

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -37,6 +37,10 @@ spec:
   kubeAPIServer:
     serviceNodePortRange: 28000-32767
     auditWebhookBatchThrottleQps: 3.14
+    cpuRequest: 200m
+    cpuLimit: 500m
+    memoryRequest: 800Mi
+    memoryLimit: 1000Mi
   kubelet:
     anonymousAuth: false
   kubernetesVersion: v1.14.0


### PR DESCRIPTION
Allow setting CPU limit and Mem request / limit for kube API server.

We had a user overload our API server with a few requests recently, which in turn caused the host to OOM different components causing debugging delays and stability issues. We eventually manually applied CPU & Mem Req/Limit to API server causing the API server pod to OOM instead of host level systems. This caused the cluster to become more stable while we debugged the underlying issue.

This change allows for those setting to be permanently set which would allow for a faster recover if something like this happens again in the future. 