### PR TITLE
Parse TargetGroup names from ARNs

### DIFF
--- a/pkg/model/awsmodel/BUILD.bazel
+++ b/pkg/model/awsmodel/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awstasks:go_default_library",
         "//upup/pkg/fi/fitasks:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/arn:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -418,6 +418,7 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 			c.AddTask(tg)
 		}
 	}
+	sort.Stable(awstasks.OrderTargetGroupsByName(t.TargetGroups))
 
 	// @step: are we using a mixed instance policy
 	if ig.Spec.MixedInstancesPolicy != nil {

--- a/pkg/testutils/integrationtestharness.go
+++ b/pkg/testutils/integrationtestharness.go
@@ -247,8 +247,15 @@ func (h *IntegrationTestHarness) SetupMockAWS() *awsup.MockAWSCloud {
 	}, "nat-b2345678")
 
 	mockELBV2.CreateTargetGroup(&elbv2.CreateTargetGroupInput{
-		Name: aws.String("my-external-tg"),
+		Name: aws.String("my-external-tg-1"),
 	})
+	mockELBV2.CreateTargetGroup(&elbv2.CreateTargetGroupInput{
+		Name: aws.String("my-external-tg-2"),
+	})
+	mockELBV2.CreateTargetGroup(&elbv2.CreateTargetGroupInput{
+		Name: aws.String("my-external-tg-3"),
+	})
+
 	return cloud
 }
 

--- a/tests/integration/update_cluster/externallb/cloudformation.json
+++ b/tests/integration/update_cluster/externallb/cloudformation.json
@@ -75,10 +75,12 @@
           }
         ],
         "LoadBalancerNames": [
-          "my-other-elb"
+          "my-external-elb-2",
+          "my-external-elb-3"
         ],
         "TargetGroupARNs": [
-          "arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg/1"
+          "arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-2/2",
+          "arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-3/3"
         ]
       }
     },
@@ -157,7 +159,10 @@
           }
         ],
         "LoadBalancerNames": [
-          "my-elb"
+          "my-external-elb-1"
+        ],
+        "TargetGroupARNs": [
+          "arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1"
         ]
       }
     },

--- a/tests/integration/update_cluster/externallb/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/externallb/in-v1alpha2.yaml
@@ -58,7 +58,8 @@ spec:
   subnets:
   - us-test-1a
   externalLoadBalancers:
-  - loadBalancerName: my-elb
+  - targetGroupArn: arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1
+  - loadBalancerName: my-external-elb-1
 
 ---
 
@@ -79,7 +80,9 @@ spec:
   subnets:
   - us-test-1a
   externalLoadBalancers:
-  - targetGroupArn: arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg/1
-  - loadBalancerName: my-other-elb
+  - targetGroupArn: arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-2/2
+  - targetGroupArn: arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-3/3
+  - loadBalancerName: my-external-elb-2
+  - loadBalancerName: my-external-elb-3
 
 

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -86,7 +86,7 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-externallb-example-c
     id      = aws_launch_template.master-us-test-1a-masters-externallb-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-externallb-example-com.latest_version
   }
-  load_balancers      = ["my-other-elb"]
+  load_balancers      = ["my-external-elb-2", "my-external-elb-3"]
   max_size            = 1
   metrics_granularity = "1Minute"
   min_size            = 1
@@ -126,7 +126,7 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-externallb-example-c
     propagate_at_launch = true
     value               = "owned"
   }
-  target_group_arns   = ["arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg/1"]
+  target_group_arns   = ["arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-2/2", "arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-3/3"]
   vpc_zone_identifier = [aws_subnet.us-test-1a-externallb-example-com.id]
 }
 
@@ -136,7 +136,7 @@ resource "aws_autoscaling_group" "nodes-externallb-example-com" {
     id      = aws_launch_template.nodes-externallb-example-com.id
     version = aws_launch_template.nodes-externallb-example-com.latest_version
   }
-  load_balancers      = ["my-elb"]
+  load_balancers      = ["my-external-elb-1"]
   max_size            = 2
   metrics_granularity = "1Minute"
   min_size            = 2
@@ -176,6 +176,7 @@ resource "aws_autoscaling_group" "nodes-externallb-example-com" {
     propagate_at_launch = true
     value               = "owned"
   }
+  target_group_arns   = ["arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1"]
   vpc_zone_identifier = [aws_subnet.us-test-1a-externallb-example-com.id]
 }
 

--- a/upup/pkg/fi/cloudup/awstasks/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/awstasks/BUILD.bazel
@@ -90,6 +90,7 @@ go_library(
         "//util/pkg/maps:go_default_library",
         "//util/pkg/slice:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/arn:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/awserr:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/autoscaling:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -179,6 +179,7 @@ func (e *AutoscalingGroup) Find(c *fi.Context) (*AutoscalingGroup, error) {
 			return nil, err
 		}
 		actual.TargetGroups = targetGroups
+		sort.Stable(OrderTargetGroupsByName(actual.TargetGroups))
 	}
 
 	if g.VPCZoneIdentifier != nil {

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -533,9 +533,11 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 		var attachLBRequest *autoscaling.AttachLoadBalancersInput
 		var detachLBRequest *autoscaling.DetachLoadBalancersInput
 		if changes.LoadBalancers != nil {
-			attachLBRequest = &autoscaling.AttachLoadBalancersInput{
-				AutoScalingGroupName: e.Name,
-				LoadBalancerNames:    e.AutoscalingLoadBalancers(),
+			if e != nil && len(e.LoadBalancers) > 0 {
+				attachLBRequest = &autoscaling.AttachLoadBalancersInput{
+					AutoScalingGroupName: e.Name,
+					LoadBalancerNames:    e.AutoscalingLoadBalancers(),
+				}
 			}
 
 			if a != nil && len(a.LoadBalancers) > 0 {
@@ -549,9 +551,11 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 		var attachTGRequest *autoscaling.AttachLoadBalancerTargetGroupsInput
 		var detachTGRequest *autoscaling.DetachLoadBalancerTargetGroupsInput
 		if changes.TargetGroups != nil {
-			attachTGRequest = &autoscaling.AttachLoadBalancerTargetGroupsInput{
-				AutoScalingGroupName: e.Name,
-				TargetGroupARNs:      e.AutoscalingTargetGroups(),
+			if e != nil && len(e.TargetGroups) > 0 {
+				attachTGRequest = &autoscaling.AttachLoadBalancerTargetGroupsInput{
+					AutoScalingGroupName: e.Name,
+					TargetGroupARNs:      e.AutoscalingTargetGroups(),
+				}
 			}
 
 			if a != nil && len(a.TargetGroups) > 0 {


### PR DESCRIPTION
Fixes: #10268 
Summary of fixes:
1. duplicate tasks names because the names for external TGs are the same for each IG
2. model names differ from actual names so always show changes
3. ordering is required to not show false changes