### PR TITLE
[addons/CA] Add support for specifying resources and metrics

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -710,6 +710,23 @@ spec:
 
 For more details on `horizontalPodAutoscaler` flags see the [official HPA docs](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) and the [kOps guides on how to set it up](horizontal_pod_autoscaling.md).
 
+## Cluster autoscaler
+{{ kops_feature_table(kops_added_default='1.19', k8s_min='1.15') }}
+
+Cluster autoscaler can be enabled to automatically adjust the size of the kubernetes cluster.
+
+```yaml
+spec:
+  clusterAutoscaler:
+    enabled: true
+    skipNodesWithLocalStorage: true
+    skipNodesWithSystemPods: true
+    cpuRequest: "100m"
+    memoryRequest: "300Mi"
+```
+
+Read more about cluster autoscaler in the [official documentation](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler).
+
 ###  Feature Gates
 
 Feature gates can be configured on the kubelet.

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -459,6 +459,14 @@ spec:
                     description: 'BalanceSimilarNodeGroups makes cluster autoscaler
                       treat similar node groups as one. Default: false'
                     type: boolean
+                  cpuRequest:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'CPURequest of cluster autoscaler container. Default:
+                      100m'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   enabled:
                     description: 'Enabled enables the cluster autoscaler. Default:
                       false'
@@ -472,6 +480,14 @@ spec:
                     description: 'Image is the docker container used. Default: the
                       latest supported image for the specified kubernetes version.'
                     type: string
+                  memoryRequest:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'MemoryRequest of cluster autoscaler container. Default:
+                      300Mi'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   newPodScaleUpDelay:
                     description: 'NewPodScaleUpDelay causes cluster autoscaler to
                       ignore unschedulable pods until they are a certain "age", regardless

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -856,6 +856,12 @@ type ClusterAutoscalerConfig struct {
 	// Image is the docker container used.
 	// Default: the latest supported image for the specified kubernetes version.
 	Image *string `json:"image,omitempty"`
+	// MemoryRequest of cluster autoscaler container.
+	// Default: 300Mi
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest of cluster autoscaler container.
+	// Default: 100m
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 }
 
 // MetricsServerConfig determines the metrics server configuration.

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -855,6 +855,12 @@ type ClusterAutoscalerConfig struct {
 	// Image is the docker container used.
 	// Default: the latest supported image for the specified kubernetes version.
 	Image *string `json:"image,omitempty"`
+	// MemoryRequest of cluster autoscaler container.
+	// Default: 300Mi
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest of cluster autoscaler container.
+	// Default: 100m
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 }
 
 // MetricsServerConfig determines the metrics server configuration.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1927,6 +1927,8 @@ func autoConvert_v1alpha2_ClusterAutoscalerConfig_To_kops_ClusterAutoscalerConfi
 	out.SkipNodesWithLocalStorage = in.SkipNodesWithLocalStorage
 	out.NewPodScaleUpDelay = in.NewPodScaleUpDelay
 	out.Image = in.Image
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
 	return nil
 }
 
@@ -1944,6 +1946,8 @@ func autoConvert_kops_ClusterAutoscalerConfig_To_v1alpha2_ClusterAutoscalerConfi
 	out.SkipNodesWithLocalStorage = in.SkipNodesWithLocalStorage
 	out.NewPodScaleUpDelay = in.NewPodScaleUpDelay
 	out.Image = in.Image
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -664,6 +664,16 @@ func (in *ClusterAutoscalerConfig) DeepCopyInto(out *ClusterAutoscalerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -764,6 +764,16 @@ func (in *ClusterAutoscalerConfig) DeepCopyInto(out *ClusterAutoscalerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -44,13 +44,13 @@ func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o interface{}) error {
 		if err == nil {
 			switch v.Minor {
 			case 19:
-				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.19.0"
+				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.19.1"
 			case 18:
-				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.18.2"
+				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.18.3"
 			case 17:
-				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.17.3"
+				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.17.4"
 			case 16:
-				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.16.6"
+				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.16.7"
 			case 15:
 				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.15.7"
 			case 14:

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -27356,6 +27356,10 @@ spec:
     metadata:
       labels:
         app: cluster-autoscaler
+      annotations:
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
     spec:
       serviceAccountName: cluster-autoscaler
       tolerations:
@@ -27368,8 +27372,8 @@ spec:
           name: cluster-autoscaler
           resources:
             requests:
-              cpu: 100m
-              memory: 300Mi
+              cpu: {{ or .CPURequest "100m"}}
+              memory: {{ or .MemoryRequest "300Mi"}}
           command:
             - ./cluster-autoscaler
             - --balance-similar-node-groups={{ .BalanceSimilarNodeGroups }}
@@ -27396,7 +27400,8 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
-{{ end }}`)
+{{ end }}
+`)
 
 func cloudupResourcesAddonsClusterAutoscalerAddonsK8sIoK8s115YamlTemplateBytes() ([]byte, error) {
 	return _cloudupResourcesAddonsClusterAutoscalerAddonsK8sIoK8s115YamlTemplate, nil

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -134,6 +134,10 @@ spec:
     metadata:
       labels:
         app: cluster-autoscaler
+      annotations:
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
     spec:
       serviceAccountName: cluster-autoscaler
       tolerations:
@@ -146,8 +150,8 @@ spec:
           name: cluster-autoscaler
           resources:
             requests:
-              cpu: 100m
-              memory: 300Mi
+              cpu: {{ or .CPURequest "100m"}}
+              memory: {{ or .MemoryRequest "300Mi"}}
           command:
             - ./cluster-autoscaler
             - --balance-similar-node-groups={{ .BalanceSimilarNodeGroups }}


### PR DESCRIPTION
In this PR, we make some additions on Cluster Autoscaler Addon Specs

#### Resources
We enable users to set their desired capacity for cluster-autoscaler addon.

There are edge cases, especially in big clusters, where autoscaler needs
to reconcile a large number of objects thus may need increased memory to
avoid OOMkills or increased cpu to avoid saturation.

#### Metrics
Cluster autoscaler provides valuable insights for monitoring capacity
allocation and scheduling aspects of a cluster. In this commit, we
enable users to add proper annotation on deployment to scrape metrics
via Prometheus.

Signed-off-by: dntosas <ntosas@gmail.com>