### PR TITLE
Set --service-account-issuer for k8s 1.20+

### DIFF
--- a/pkg/model/awsmodel/oidc_provider.go
+++ b/pkg/model/awsmodel/oidc_provider.go
@@ -46,10 +46,7 @@ func (b *OIDCProviderBuilder) Build(c *fi.ModelBuilderContext) error {
 	var issuerURL string
 
 	if featureflag.PublicJWKS.Enabled() {
-		serviceAccountIssuer, err := iam.ServiceAccountIssuer(b.ClusterName(), &b.Cluster.Spec)
-		if err != nil {
-			return err
-		}
+		serviceAccountIssuer := iam.ServiceAccountIssuer(b.ClusterName(), &b.Cluster.Spec)
 		issuerURL = serviceAccountIssuer
 
 		caTaskObject, found := c.Tasks["Keypair/ca"]

--- a/pkg/model/components/discovery.go
+++ b/pkg/model/components/discovery.go
@@ -51,10 +51,7 @@ func (b *DiscoveryOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if kubeAPIServer.ServiceAccountIssuer == nil {
-		serviceAccountIssuer, err := iam.ServiceAccountIssuer(b.ClusterName, clusterSpec)
-		if err != nil {
-			return err
-		}
+		serviceAccountIssuer := iam.ServiceAccountIssuer(b.ClusterName, clusterSpec)
 		kubeAPIServer.ServiceAccountIssuer = &serviceAccountIssuer
 	}
 

--- a/pkg/model/components/discovery.go
+++ b/pkg/model/components/discovery.go
@@ -36,7 +36,7 @@ func (b *DiscoveryOptionsBuilder) BuildOptions(o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 
 	useJWKS := featureflag.PublicJWKS.Enabled()
-	if !useJWKS {
+	if !useJWKS && b.IsKubernetesLT("1.20") {
 		return nil
 	}
 
@@ -45,11 +45,6 @@ func (b *DiscoveryOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	kubeAPIServer := clusterSpec.KubeAPIServer
-
-	if kubeAPIServer.FeatureGates == nil {
-		kubeAPIServer.FeatureGates = make(map[string]string)
-	}
-	kubeAPIServer.FeatureGates["ServiceAccountIssuerDiscovery"] = "true"
 
 	if len(kubeAPIServer.APIAudiences) == 0 {
 		kubeAPIServer.APIAudiences = []string{"kubernetes.svc.default"}
@@ -63,14 +58,21 @@ func (b *DiscoveryOptionsBuilder) BuildOptions(o interface{}) error {
 		kubeAPIServer.ServiceAccountIssuer = &serviceAccountIssuer
 	}
 
-	if kubeAPIServer.ServiceAccountJWKSURI == nil {
-		jwksURL := *kubeAPIServer.ServiceAccountIssuer
-		jwksURL = strings.TrimSuffix(jwksURL, "/") + "/openid/v1/jwks"
-
-		kubeAPIServer.ServiceAccountJWKSURI = &jwksURL
-	}
-
 	// We set apiserver ServiceAccountKey and ServiceAccountSigningKeyFile in nodeup
+
+	if useJWKS {
+		if kubeAPIServer.FeatureGates == nil {
+			kubeAPIServer.FeatureGates = make(map[string]string)
+		}
+		kubeAPIServer.FeatureGates["ServiceAccountIssuerDiscovery"] = "true"
+
+		if kubeAPIServer.ServiceAccountJWKSURI == nil {
+			jwksURL := *kubeAPIServer.ServiceAccountIssuer
+			jwksURL = strings.TrimSuffix(jwksURL, "/") + "/openid/v1/jwks"
+
+			kubeAPIServer.ServiceAccountJWKSURI = &jwksURL
+		}
+	}
 
 	return nil
 }

--- a/pkg/model/iam.go
+++ b/pkg/model/iam.go
@@ -330,10 +330,7 @@ func (b *IAMModelBuilder) buildAWSIAMRolePolicy(role iam.Subject) (fi.Resource, 
 	var policy string
 	serviceAccount, ok := role.ServiceAccount()
 	if ok {
-		serviceAccountIssuer, err := iam.ServiceAccountIssuer(b.ClusterName(), &b.Cluster.Spec)
-		if err != nil {
-			return nil, err
-		}
+		serviceAccountIssuer := iam.ServiceAccountIssuer(b.ClusterName(), &b.Cluster.Spec)
 		oidcProvider := strings.TrimPrefix(serviceAccountIssuer, "https://")
 
 		iamPolicy := &iam.Policy{

--- a/pkg/model/iam/BUILD.bazel
+++ b/pkg/model/iam/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//pkg/apis/kops/model:go_default_library",
-        "//pkg/featureflag:go_default_library",
         "//pkg/util/stringorslice:go_default_library",
         "//pkg/wellknownusers:go_default_library",
         "//upup/pkg/fi:go_default_library",

--- a/pkg/model/iam/subject.go
+++ b/pkg/model/iam/subject.go
@@ -81,8 +81,8 @@ func BuildNodeRoleSubject(igRole kops.InstanceGroupRole) (Subject, error) {
 }
 
 // ServiceAccountIssuer determines the issuer in the ServiceAccount JWTs
-func ServiceAccountIssuer(clusterName string, clusterSpec *kops.ClusterSpec) (string, error) {
-	return "https://api." + clusterName, nil
+func ServiceAccountIssuer(clusterName string, clusterSpec *kops.ClusterSpec) string {
+	return "https://api." + clusterName
 }
 
 // AddServiceAccountRole adds the appropriate mounts / env vars to enable a pod to use a service-account role

--- a/pkg/model/iam/subject.go
+++ b/pkg/model/iam/subject.go
@@ -22,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kops/pkg/apis/kops"
-	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/wellknownusers"
 )
 
@@ -83,11 +82,7 @@ func BuildNodeRoleSubject(igRole kops.InstanceGroupRole) (Subject, error) {
 
 // ServiceAccountIssuer determines the issuer in the ServiceAccount JWTs
 func ServiceAccountIssuer(clusterName string, clusterSpec *kops.ClusterSpec) (string, error) {
-	if featureflag.PublicJWKS.Enabled() {
-		return "https://api." + clusterName, nil
-	}
-
-	return "", fmt.Errorf("ServiceAcccountIssuer not (currently) supported without PublicJWKS")
+	return "https://api." + clusterName, nil
 }
 
 // AddServiceAccountRole adds the appropriate mounts / env vars to enable a pod to use a service-account role


### PR DESCRIPTION
Kubernetes 1.20+ requires the `--service-account-issuer` flag be passed to kube-apiserver

Fixes #10279 

/cc @justinsb 
