### PR TITLE
Automated cherry pick of #10277: Use etcd v3.4.13 for k8s v1.19+

### DIFF
--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -44,6 +44,8 @@ const (
 	DefaultEtcd3Version_1_14 = "3.3.10"
 
 	DefaultEtcd3Version_1_17 = "3.4.3"
+
+	DefaultEtcd3Version_1_19 = "3.4.13"
 )
 
 // BuildOptions is responsible for filling in the defaults for the etcd cluster model
@@ -65,7 +67,9 @@ func (b *EtcdOptionsBuilder) BuildOptions(o interface{}) error {
 		// Ensure the version is set
 		if c.Version == "" && c.Provider == kops.EtcdProviderTypeLegacy {
 			// Even if in legacy mode, etcd version 2 is unsupported as of k8s 1.13
-			if b.IsKubernetesGTE("1.17") {
+			if b.IsKubernetesGTE("1.19") {
+				c.Version = DefaultEtcd3Version_1_19
+			} else if b.IsKubernetesGTE("1.17") {
 				c.Version = DefaultEtcd3Version_1_17
 			} else if b.IsKubernetesGTE("1.14") {
 				c.Version = DefaultEtcd3Version_1_14
@@ -78,7 +82,9 @@ func (b *EtcdOptionsBuilder) BuildOptions(o interface{}) error {
 
 		if c.Version == "" && c.Provider == kops.EtcdProviderTypeManager {
 			// From 1.11, we run the k8s-recommended versions of etcd when using the manager
-			if b.IsKubernetesGTE("1.17") {
+			if b.IsKubernetesGTE("1.19") {
+				c.Version = DefaultEtcd3Version_1_19
+			} else if b.IsKubernetesGTE("1.17") {
 				c.Version = DefaultEtcd3Version_1_17
 			} else if b.IsKubernetesGTE("1.14") {
 				c.Version = DefaultEtcd3Version_1_14

--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -75,7 +75,7 @@ func (b *EtcdManagerOptionsBuilder) BuildOptions(o interface{}) error {
 	return nil
 }
 
-var supportedEtcdVersions = []string{"2.2.1", "3.1.12", "3.2.18", "3.2.24", "3.3.10", "3.3.13", "3.3.17", "3.4.3"}
+var supportedEtcdVersions = []string{"2.2.1", "3.1.12", "3.2.18", "3.2.24", "3.3.10", "3.3.13", "3.3.17", "3.4.3", "3.4.13"}
 
 func etcdVersionIsSupported(version string) bool {
 	version = strings.TrimPrefix(version, "v")


### PR DESCRIPTION
Cherry pick of #10277 on release-1.19.

#10277: Use etcd v3.4.13 for k8s v1.19+

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.