### PR TITLE
Remove support for disabling manifest normalization

### DIFF
--- a/pkg/assets/BUILD.bazel
+++ b/pkg/assets/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//pkg/apis/kops/util:go_default_library",
-        "//pkg/featureflag:go_default_library",
         "//pkg/kubemanifest:go_default_library",
         "//pkg/values:go_default_library",
         "//util/pkg/hashing:go_default_library",

--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -30,17 +30,12 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/util"
-	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/kubemanifest"
 	"k8s.io/kops/pkg/values"
 	"k8s.io/kops/util/pkg/hashing"
 	"k8s.io/kops/util/pkg/mirrors"
 	"k8s.io/kops/util/pkg/vfs"
 )
-
-// RewriteManifests controls whether we rewrite manifests
-// Because manifest rewriting converts everything to and from YAML, we normalize everything by doing so
-var RewriteManifests = featureflag.New("RewriteManifests", featureflag.Bool(true))
 
 // AssetBuilder discovers and remaps assets.
 type AssetBuilder struct {
@@ -109,10 +104,6 @@ func NewAssetBuilder(cluster *kops.Cluster, phase string) *AssetBuilder {
 // This will:
 // * rewrite the images if they are being redirected to a mirror, and ensure the image is uploaded
 func (a *AssetBuilder) RemapManifest(data []byte) ([]byte, error) {
-	if !RewriteManifests.Enabled() {
-		return data, nil
-	}
-
 	objects, err := kubemanifest.LoadObjectsFrom(data)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This appears to have been to support migration to kOps 1.7.
