### PR TITLE
Automated cherry pick of #10273: Add support for default version override

### DIFF
--- a/docs/networking/weave.md
+++ b/docs/networking/weave.md
@@ -74,3 +74,13 @@ kops update cluster
 
 Since unencrypted nodes will not be able to connect to nodes configured with encryption enabled, this configuration cannot be changed easily without downtime.
 
+### Override Weave image tag
+
+Weave networking comes with default specs and version which are the recommended ones, already configured by kOps .
+In case users want to override Weave image tag, thus default version, specs should be customized as follows:
+```yaml
+spec:
+  networking:
+    weave:
+      version: "2.7.0"
+```

--- a/docs/networking/weave.md
+++ b/docs/networking/weave.md
@@ -75,6 +75,7 @@ kops update cluster
 Since unencrypted nodes will not be able to connect to nodes configured with encryption enabled, this configuration cannot be changed easily without downtime.
 
 ### Override Weave image tag
+{{ kops_feature_table(kops_added_default='1.19', k8s_min='1.12') }}
 
 Weave networking comes with default specs and version which are the recommended ones, already configured by kOps .
 In case users want to override Weave image tag, thus default version, specs should be customized as follows:

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -3340,6 +3340,10 @@ spec:
                           container. Default 200Mi
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
+                      version:
+                        description: Version specifies the Weave container image tag.
+                          The default depends on the kOps version.
+                        type: string
                     type: object
                 type: object
               nodeAuthorization:

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -86,6 +86,9 @@ type WeaveNetworkingSpec struct {
 	NPCCPULimit *resource.Quantity `json:"npcCPULimit,omitempty"`
 	// NPCExtraArgs are extra arguments that are passed to weave-npc.
 	NPCExtraArgs string `json:"npcExtraArgs,omitempty"`
+
+	// Version specifies the Weave container image tag. The default depends on the kOps version.
+	Version string `json:"version,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -86,6 +86,9 @@ type WeaveNetworkingSpec struct {
 	NPCCPULimit *resource.Quantity `json:"npcCPULimit,omitempty"`
 	// NPCExtraArgs are extra arguments that are passed to weave-npc.
 	NPCExtraArgs string `json:"npcExtraArgs,omitempty"`
+
+	// Version specifies the Weave container image tag. The default depends on the kOps version.
+	Version string `json:"version,omitempty"`
 }
 
 // FlannelNetworkingSpec declares that we want Flannel networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5500,6 +5500,7 @@ func autoConvert_v1alpha2_WeaveNetworkingSpec_To_kops_WeaveNetworkingSpec(in *We
 	out.NPCMemoryLimit = in.NPCMemoryLimit
 	out.NPCCPULimit = in.NPCCPULimit
 	out.NPCExtraArgs = in.NPCExtraArgs
+	out.Version = in.Version
 	return nil
 }
 
@@ -5522,6 +5523,7 @@ func autoConvert_kops_WeaveNetworkingSpec_To_v1alpha2_WeaveNetworkingSpec(in *ko
 	out.NPCMemoryLimit = in.NPCMemoryLimit
 	out.NPCCPULimit = in.NPCCPULimit
 	out.NPCExtraArgs = in.NPCExtraArgs
+	out.Version = in.Version
 	return nil
 }
 

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -17303,7 +17303,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.5'
+          image: 'weaveworks/weave-kube:{{ or .Networking.Weave.Version "2.6.5" }}'
           ports:
             - name: metrics
               containerPort: 6782
@@ -17350,7 +17350,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.5'
+          image: 'weaveworks/weave-npc:{{ or .Networking.Weave.Version "2.6.5" }}'
           ports:
             - name: metrics
               containerPort: 6781

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -175,7 +175,7 @@ spec:
                   name: weave-net
                   key: network-password
             {{- end }}
-          image: 'weaveworks/weave-kube:2.6.5'
+          image: 'weaveworks/weave-kube:{{ or .Networking.Weave.Version "2.6.5" }}'
           ports:
             - name: metrics
               containerPort: 6782
@@ -222,7 +222,7 @@ spec:
             - name: EXTRA_ARGS
               value: "{{ .Networking.Weave.NPCExtraArgs }}"
             {{- end }}
-          image: 'weaveworks/weave-npc:2.6.5'
+          image: 'weaveworks/weave-npc:{{ or .Networking.Weave.Version "2.6.5" }}'
           ports:
             - name: metrics
               containerPort: 6781


### PR DESCRIPTION
Cherry pick of #10273 on release-1.18.

#10273: Add support for default version override

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.