### PR TITLE
[Digital Ocean] Promote to Beta

### DIFF
--- a/docs/getting_started/digitalocean.md
+++ b/docs/getting_started/digitalocean.md
@@ -23,9 +23,6 @@ export DIGITALOCEAN_ACCESS_TOKEN=<access-token>  # where <access-token> is the a
 export S3_ENDPOINT=nyc3.digitaloceanspaces.com # this can also be ams3.digitaloceanspaces.com or sgp1.digitaloceanspaces.com depending on where you created your Spaces bucket
 export S3_ACCESS_KEY_ID=<access-key-id>  # where <access-key-id> is the Spaces API Access Key for your bucket
 export S3_SECRET_ACCESS_KEY=<secret-key>  # where <secret-key> is the Spaces API Secret Key for your bucket
-
-# this is required since DigitalOcean support is currently in alpha so it is feature gated
-export KOPS_FEATURE_FLAGS="AlphaAllowDO"
 ```
 
 ## Creating a Single Master Cluster
@@ -46,8 +43,21 @@ kops update cluster my-cluster.example.com --yes
 kops create cluster --cloud=digitalocean --name=my-cluster.example.com --image=debian-9-x64 --networking=flannel --zones=ams3 --ssh-public-key=~/.ssh/id_rsa.pub --node-size=c-4
 kops update cluster my-cluster.example.com --yes
 
+# to validate a cluster
+kops validate cluster my-cluster.example.com
+
 # to delete a cluster
 kops delete cluster my-cluster.example.com --yes
+
+# to export kubecfg
+* follow steps as mentioned [here](https://kops.sigs.k8s.io/cli/kops_export_kubecfg/#examples). 
+
+# to update a cluster
+* follow steps as mentioned [here](https://kops.sigs.k8s.io/operations/updates_and_upgrades/#manual-update)
+
+# to install csi driver for DO block storage
+* follow steps as mentiond [here](https://github.com/digitalocean/csi-digitalocean#installing-to-kubernetes)
+
 ```
 
 ## Creating a Multi-Master HA Cluster
@@ -67,7 +77,7 @@ kops delete cluster dev5.k8s.local --yes
 
 kOps for DigitalOcean currently does not support these features:
 
-* rolling update for instance groups
+* kops terraform support for DO
 
 # Next steps
 

--- a/docs/getting_started/digitalocean.md
+++ b/docs/getting_started/digitalocean.md
@@ -1,6 +1,6 @@
 # Getting Started with kOps on DigitalOcean
 
-**WARNING**: digitalocean support on kOps is currently **alpha** meaning it is in the early stages of development and subject to change, please use with caution.
+**WARNING**: digitalocean support on kOps promoted to **beta** currently meaning it is subject to change, so please use with caution.
 
 ## Requirements
 

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -72,7 +72,7 @@ const (
 )
 
 var (
-	// AlphaAllowDO is a feature flag that gates DigitalOcean support while it is alpha
+	// AlphaAllowDO is a feature flag that gates cloudprovider support while it is alpha
 	AlphaAllowDO = featureflag.New("AlphaAllowDO", featureflag.Bool(false))
 	// AlphaAllowGCE is a feature flag that gates GCE support while it is alpha
 	AlphaAllowGCE = featureflag.New("AlphaAllowGCE", featureflag.Bool(false))
@@ -392,10 +392,6 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 
 	case kops.CloudProviderDO:
 		{
-			if !AlphaAllowDO.Enabled() {
-				return fmt.Errorf("DigitalOcean support is currently (very) alpha and is feature-gated. export KOPS_FEATURE_FLAGS=AlphaAllowDO to enable it")
-			}
-
 			if len(sshPublicKeys) == 0 && (c.Cluster.Spec.SSHKeyName == nil || *c.Cluster.Spec.SSHKeyName == "") {
 				return fmt.Errorf("SSH public key must be specified when running with DigitalOcean (create with `kops create secret --name %s sshpublickey admin -i ~/.ssh/id_rsa.pub`)", cluster.ObjectMeta.Name)
 			}

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -72,8 +72,6 @@ const (
 )
 
 var (
-	// AlphaAllowDO is a feature flag that gates cloudprovider support while it is alpha
-	AlphaAllowDO = featureflag.New("AlphaAllowDO", featureflag.Bool(false))
 	// AlphaAllowGCE is a feature flag that gates GCE support while it is alpha
 	AlphaAllowGCE = featureflag.New("AlphaAllowGCE", featureflag.Bool(false))
 	// AlphaAllowALI is a feature flag that gates aliyun support while it is alpha

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,5 @@
 # cloud.google.com/go v0.54.0
+## explicit
 cloud.google.com/go/compute/metadata
 # github.com/Azure/azure-pipeline-go v0.2.3
 ## explicit
@@ -30,12 +31,14 @@ github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter
 github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta
 github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock
 # github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+## explicit
 github.com/MakeNowJust/heredoc
 # github.com/Masterminds/goutils v1.1.0
 github.com/Masterminds/goutils
 # github.com/Masterminds/semver/v3 v3.1.0
 github.com/Masterminds/semver/v3
 # github.com/Masterminds/sprig/v3 v3.1.0
+## explicit
 github.com/Masterminds/sprig/v3
 # github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
 github.com/Microsoft/go-winio
@@ -47,6 +50,7 @@ github.com/PuerkitoBio/urlesc
 # github.com/agext/levenshtein v1.2.1
 github.com/agext/levenshtein
 # github.com/aliyun/alibaba-cloud-sdk-go v1.61.264
+## explicit
 github.com/aliyun/alibaba-cloud-sdk-go/sdk
 github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth
 github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials
@@ -65,6 +69,7 @@ github.com/apparentlymart/go-textseg/v12/textseg
 # github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
 github.com/armon/go-metrics
 # github.com/aws/amazon-ec2-instance-selector/v2 v2.0.1
+## explicit
 github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity
 github.com/aws/amazon-ec2-instance-selector/v2/pkg/cli
 github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector
@@ -132,6 +137,7 @@ github.com/aws/aws-sdk-go/service/s3
 github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bazelbuild/bazel-gazelle v0.19.1
+## explicit
 github.com/bazelbuild/bazel-gazelle/cmd/gazelle
 github.com/bazelbuild/bazel-gazelle/config
 github.com/bazelbuild/bazel-gazelle/flag
@@ -155,20 +161,24 @@ github.com/beorn7/perks/quantile
 # github.com/blang/semver v3.5.1+incompatible
 github.com/blang/semver
 # github.com/blang/semver/v4 v4.0.0
+## explicit
 github.com/blang/semver/v4
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
 # github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1
+## explicit
 github.com/chai2010/gettext-go/gettext
 github.com/chai2010/gettext-go/gettext/mo
 github.com/chai2010/gettext-go/gettext/plural
 github.com/chai2010/gettext-go/gettext/po
 # github.com/client9/misspell v0.3.4
+## explicit
 github.com/client9/misspell
 github.com/client9/misspell/cmd/misspell
 # github.com/containerd/containerd v1.3.3
 github.com/containerd/containerd/errdefs
 # github.com/coreos/etcd v3.3.17+incompatible
+## explicit
 github.com/coreos/etcd/client
 github.com/coreos/etcd/pkg/pathutil
 github.com/coreos/etcd/pkg/srv
@@ -181,6 +191,7 @@ github.com/cpuguy83/go-md2man/v2/md2man
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/denverdino/aliyungo v0.0.0-20191128015008-acd8035bbb1d
+## explicit
 github.com/denverdino/aliyungo/common
 github.com/denverdino/aliyungo/ecs
 github.com/denverdino/aliyungo/ess
@@ -223,6 +234,7 @@ github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-units v0.4.0
 github.com/docker/go-units
 # github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c
+## explicit
 github.com/docker/spdystream
 github.com/docker/spdystream/spdy
 # github.com/emicklei/go-restful v2.9.6+incompatible
@@ -239,15 +251,20 @@ github.com/form3tech-oss/jwt-go
 # github.com/fsnotify/fsnotify v1.4.9
 github.com/fsnotify/fsnotify
 # github.com/fullsailor/pkcs7 v0.0.0-20180422025557-ae226422660e
+## explicit
 github.com/fullsailor/pkcs7
 # github.com/ghodss/yaml v1.0.0
+## explicit
 github.com/ghodss/yaml
 # github.com/go-bindata/go-bindata v3.1.2+incompatible
+## explicit
 github.com/go-bindata/go-bindata
 github.com/go-bindata/go-bindata/go-bindata
 # github.com/go-ini/ini v1.51.0
+## explicit
 github.com/go-ini/ini
 # github.com/go-logr/logr v0.2.1-0.20200730175230-ee2de8da5be6
+## explicit
 github.com/go-logr/logr
 # github.com/go-openapi/jsonpointer v0.19.3
 github.com/go-openapi/jsonpointer
@@ -260,6 +277,7 @@ github.com/go-openapi/swag
 # github.com/gobuffalo/flect v0.2.0
 github.com/gobuffalo/flect
 # github.com/gogo/protobuf v1.3.1
+## explicit
 github.com/gogo/protobuf/gogoproto
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/protoc-gen-gogo/descriptor
@@ -277,6 +295,7 @@ github.com/golang/snappy
 # github.com/google/btree v1.0.0
 github.com/google/btree
 # github.com/google/go-cmp v0.5.2
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
@@ -287,6 +306,7 @@ github.com/google/go-querystring/query
 # github.com/google/gofuzz v1.1.0
 github.com/google/gofuzz
 # github.com/google/uuid v1.1.2
+## explicit
 github.com/google/uuid
 # github.com/googleapis/gax-go/v2 v2.0.5
 github.com/googleapis/gax-go/v2
@@ -295,6 +315,7 @@ github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 github.com/googleapis/gnostic/openapiv2
 # github.com/gophercloud/gophercloud v0.11.1-0.20200518183226-7aec46f32c19 => github.com/gophercloud/gophercloud v0.11.0
+## explicit
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/internal
 github.com/gophercloud/gophercloud/openstack
@@ -337,6 +358,7 @@ github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects
 github.com/gophercloud/gophercloud/openstack/utils
 github.com/gophercloud/gophercloud/pagination
 # github.com/gorilla/mux v1.7.3
+## explicit
 github.com/gorilla/mux
 # github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
 github.com/gregjones/httpcache
@@ -374,6 +396,7 @@ github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
 # github.com/hashicorp/hcl/v2 v2.7.0
+## explicit
 github.com/hashicorp/hcl/v2
 github.com/hashicorp/hcl/v2/ext/customdecode
 github.com/hashicorp/hcl/v2/hclsyntax
@@ -381,6 +404,7 @@ github.com/hashicorp/hcl/v2/hclwrite
 # github.com/hashicorp/memberlist v0.1.4
 github.com/hashicorp/memberlist
 # github.com/hashicorp/vault/api v1.0.4
+## explicit
 github.com/hashicorp/vault/api
 # github.com/hashicorp/vault/sdk v0.1.13
 github.com/hashicorp/vault/sdk/helper/compressutil
@@ -396,17 +420,20 @@ github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
 # github.com/jacksontj/memberlistmesh v0.0.0-20190905163944-93462b9d2bb7
+## explicit
 github.com/jacksontj/memberlistmesh
 github.com/jacksontj/memberlistmesh/clusterpb
 # github.com/jmespath/go-jmespath v0.4.0
 github.com/jmespath/go-jmespath
 # github.com/jpillora/backoff v0.0.0-20170918002102-8eab2debe79d
+## explicit
 github.com/jpillora/backoff
 # github.com/json-iterator/go v1.1.10
 github.com/json-iterator/go
 # github.com/konsorten/go-windows-terminal-sequences v1.0.3
 github.com/konsorten/go-windows-terminal-sequences
 # github.com/kr/fs v0.1.0
+## explicit
 github.com/kr/fs
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 github.com/liggitt/tabwriter
@@ -425,6 +452,7 @@ github.com/mattn/go-isatty
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/miekg/coredns v0.0.0-20161111164017-20e25559d5ea
+## explicit
 github.com/miekg/coredns/middleware/etcd/msg
 # github.com/miekg/dns v1.1.4
 github.com/miekg/dns
@@ -435,6 +463,7 @@ github.com/mitchellh/go-homedir
 # github.com/mitchellh/go-wordwrap v1.0.0
 github.com/mitchellh/go-wordwrap
 # github.com/mitchellh/mapstructure v1.1.2
+## explicit
 github.com/mitchellh/mapstructure
 # github.com/mitchellh/reflectwalk v1.0.0
 github.com/mitchellh/reflectwalk
@@ -462,10 +491,12 @@ github.com/pierrec/lz4/internal/xxh32
 # github.com/pkg/errors v0.9.1
 github.com/pkg/errors
 # github.com/pkg/sftp v0.0.0-20160930220758-4d0e916071f6
+## explicit
 github.com/pkg/sftp
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.7.1
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
@@ -488,6 +519,7 @@ github.com/ryanuber/go-glob
 # github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529
 github.com/sean-/seed
 # github.com/sergi/go-diff v1.0.0
+## explicit
 github.com/sergi/go-diff/diffmatchpatch
 # github.com/shurcooL/sanitized_anchor_name v1.0.0
 github.com/shurcooL/sanitized_anchor_name
@@ -499,15 +531,19 @@ github.com/spf13/afero/mem
 # github.com/spf13/cast v1.3.1
 github.com/spf13/cast
 # github.com/spf13/cobra v1.1.1
+## explicit
 github.com/spf13/cobra
 github.com/spf13/cobra/doc
 # github.com/spf13/jwalterweatherman v1.1.0
 github.com/spf13/jwalterweatherman
 # github.com/spf13/pflag v1.0.5
+## explicit
 github.com/spf13/pflag
 # github.com/spf13/viper v1.7.0
+## explicit
 github.com/spf13/viper
 # github.com/spotinst/spotinst-sdk-go v1.58.0
+## explicit
 github.com/spotinst/spotinst-sdk-go/service/elastigroup
 github.com/spotinst/spotinst-sdk-go/service/elastigroup/providers/aws
 github.com/spotinst/spotinst-sdk-go/service/elastigroup/providers/azure
@@ -526,6 +562,7 @@ github.com/spotinst/spotinst-sdk-go/spotinst/util/stringutil
 github.com/spotinst/spotinst-sdk-go/spotinst/util/uritemplates
 github.com/spotinst/spotinst-sdk-go/spotinst/util/useragent
 # github.com/stretchr/testify v1.6.1
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/subosito/gotenv v1.2.0
@@ -534,8 +571,10 @@ github.com/subosito/gotenv
 ## explicit
 github.com/urfave/cli
 # github.com/weaveworks/mesh v0.0.0-20170419100114-1f158d31de55
+## explicit
 github.com/weaveworks/mesh
 # github.com/zclconf/go-cty v1.3.1
+## explicit
 github.com/zclconf/go-cty/cty
 github.com/zclconf/go-cty/cty/convert
 github.com/zclconf/go-cty/cty/function
@@ -565,6 +604,7 @@ go.uber.org/atomic
 # go.uber.org/multierr v1.1.0
 go.uber.org/multierr
 # go.uber.org/zap v1.10.0
+## explicit
 go.uber.org/zap
 go.uber.org/zap/buffer
 go.uber.org/zap/internal/bufferpool
@@ -572,6 +612,7 @@ go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
 go.uber.org/zap/zapcore
 # golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
+## explicit
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blake2b
 golang.org/x/crypto/blowfish
@@ -595,6 +636,7 @@ golang.org/x/crypto/ssh/terminal
 golang.org/x/mod/module
 golang.org/x/mod/semver
 # golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+## explicit
 golang.org/x/net/bpf
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
@@ -612,6 +654,7 @@ golang.org/x/net/ipv6
 golang.org/x/net/proxy
 golang.org/x/net/trace
 # golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+## explicit
 golang.org/x/oauth2
 golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
@@ -620,6 +663,7 @@ golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 golang.org/x/sync/errgroup
 # golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+## explicit
 golang.org/x/sys/cpu
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix
@@ -640,6 +684,7 @@ golang.org/x/text/width
 # golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 golang.org/x/time/rate
 # golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f
+## explicit
 golang.org/x/tools/cmd/goimports
 golang.org/x/tools/go/analysis
 golang.org/x/tools/go/analysis/passes/inspect
@@ -673,6 +718,7 @@ golang.org/x/xerrors/internal
 # gomodules.xyz/jsonpatch/v2 v2.0.1
 gomodules.xyz/jsonpatch/v2
 # google.golang.org/api v0.22.0
+## explicit
 google.golang.org/api/compute/v0.alpha
 google.golang.org/api/compute/v0.beta
 google.golang.org/api/compute/v1
@@ -773,11 +819,13 @@ google.golang.org/protobuf/types/known/anypb
 google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/gcfg.v1 v1.2.3
+## explicit
 gopkg.in/gcfg.v1
 gopkg.in/gcfg.v1/scanner
 gopkg.in/gcfg.v1/token
 gopkg.in/gcfg.v1/types
 # gopkg.in/inf.v0 v0.9.1
+## explicit
 gopkg.in/inf.v0
 # gopkg.in/ini.v1 v1.57.0
 gopkg.in/ini.v1
@@ -789,12 +837,15 @@ gopkg.in/square/go-jose.v2/jwt
 # gopkg.in/warnings.v0 v0.1.2
 gopkg.in/warnings.v0
 # gopkg.in/yaml.v2 v2.3.0
+## explicit
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 gopkg.in/yaml.v3
 # helm.sh/helm v2.17.0+incompatible
+## explicit
 helm.sh/helm/pkg/strvals
 # honnef.co/go/tools v0.0.1-2020.1.4
+## explicit
 honnef.co/go/tools/arg
 honnef.co/go/tools/cmd/staticcheck
 honnef.co/go/tools/code
@@ -825,6 +876,7 @@ honnef.co/go/tools/stylecheck
 honnef.co/go/tools/unused
 honnef.co/go/tools/version
 # k8s.io/api v0.20.0-beta.2 => k8s.io/api v0.20.0-beta.2
+## explicit
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
@@ -876,6 +928,7 @@ k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 # k8s.io/apimachinery v0.20.0-beta.2 => k8s.io/apimachinery v0.20.0-beta.2
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -930,6 +983,7 @@ k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/cli-runtime v0.20.0-beta.2 => k8s.io/cli-runtime v0.20.0-beta.2
+## explicit
 k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/kustomize
 k8s.io/cli-runtime/pkg/kustomize/k8sdeps
@@ -943,6 +997,7 @@ k8s.io/cli-runtime/pkg/kustomize/k8sdeps/validator
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
 # k8s.io/client-go v0.20.0-beta.2 => k8s.io/client-go v0.20.0-beta.2
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached/disk
 k8s.io/client-go/discovery/fake
@@ -1195,6 +1250,7 @@ k8s.io/cloud-provider/volume/helpers
 k8s.io/cloud-provider-openstack/pkg/util/errors
 k8s.io/cloud-provider-openstack/pkg/util/openstack
 # k8s.io/component-base v0.20.0-beta.2 => k8s.io/component-base v0.20.0-beta.2
+## explicit
 k8s.io/component-base/metrics
 k8s.io/component-base/metrics/legacyregistry
 k8s.io/component-base/metrics/prometheus/restclient
@@ -1202,6 +1258,7 @@ k8s.io/component-base/version
 # k8s.io/csi-translation-lib v0.20.0-beta.2 => k8s.io/csi-translation-lib v0.20.0-beta.2
 k8s.io/csi-translation-lib/plugins
 # k8s.io/gengo v0.0.0-20201113003025-83324d819ded
+## explicit
 k8s.io/gengo/args
 k8s.io/gengo/generator
 k8s.io/gengo/namer
@@ -1210,6 +1267,7 @@ k8s.io/gengo/types
 # k8s.io/klog v1.0.0
 k8s.io/klog
 # k8s.io/klog/v2 v2.4.0
+## explicit
 k8s.io/klog/v2
 k8s.io/klog/v2/klogr
 # k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd
@@ -1217,6 +1275,7 @@ k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/util/proto/validation
 # k8s.io/kubectl v0.0.0 => k8s.io/kubectl v0.20.0-beta.2
+## explicit
 k8s.io/kubectl/pkg/cmd/util
 k8s.io/kubectl/pkg/cmd/util/editor
 k8s.io/kubectl/pkg/cmd/util/editor/crlf
@@ -1232,9 +1291,11 @@ k8s.io/kubectl/pkg/util/templates
 k8s.io/kubectl/pkg/util/term
 k8s.io/kubectl/pkg/validation
 # k8s.io/legacy-cloud-providers v0.0.0 => k8s.io/legacy-cloud-providers v0.20.0-beta.2
+## explicit
 k8s.io/legacy-cloud-providers/aws
 k8s.io/legacy-cloud-providers/gce
 # k8s.io/utils v0.0.0-20201110183641-67b214c5f920
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/exec
 k8s.io/utils/integer
@@ -1246,6 +1307,7 @@ k8s.io/utils/nsenter
 k8s.io/utils/pointer
 k8s.io/utils/trace
 # sigs.k8s.io/controller-runtime v0.6.1
+## explicit
 sigs.k8s.io/controller-runtime
 sigs.k8s.io/controller-runtime/pkg/builder
 sigs.k8s.io/controller-runtime/pkg/cache
@@ -1282,6 +1344,7 @@ sigs.k8s.io/controller-runtime/pkg/webhook/conversion
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/certwatcher
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 # sigs.k8s.io/controller-tools v0.2.8
+## explicit
 sigs.k8s.io/controller-tools/cmd/controller-gen
 sigs.k8s.io/controller-tools/pkg/crd
 sigs.k8s.io/controller-tools/pkg/crd/markers
@@ -1322,4 +1385,27 @@ sigs.k8s.io/kustomize/pkg/types
 # sigs.k8s.io/structured-merge-diff/v4 v4.0.2
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml
+# k8s.io/api => k8s.io/api v0.20.0-beta.2
+# k8s.io/apimachinery => k8s.io/apimachinery v0.20.0-beta.2
+# k8s.io/client-go => k8s.io/client-go v0.20.0-beta.2
+# k8s.io/cloud-provider => k8s.io/cloud-provider v0.20.0-beta.2
+# k8s.io/kubectl => k8s.io/kubectl v0.20.0-beta.2
+# k8s.io/apiserver => k8s.io/apiserver v0.20.0-beta.2
+# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.20.0-beta.2
+# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.20.0-beta.2
+# k8s.io/kube-proxy => k8s.io/kube-proxy v0.20.0-beta.2
+# k8s.io/cri-api => k8s.io/cri-api v0.20.0-beta.2
+# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.20.0-beta.2
+# k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.20.0-beta.2
+# k8s.io/component-base => k8s.io/component-base v0.20.0-beta.2
+# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.20.0-beta.2
+# k8s.io/metrics => k8s.io/metrics v0.20.0-beta.2
+# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.20.0-beta.2
+# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.20.0-beta.2
+# k8s.io/kubelet => k8s.io/kubelet v0.20.0-beta.2
+# k8s.io/cli-runtime => k8s.io/cli-runtime v0.20.0-beta.2
+# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.20.0-beta.2
+# k8s.io/code-generator => k8s.io/code-generator v0.20.0-beta.2
+# github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.11.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1408,4 +1408,3 @@ sigs.k8s.io/yaml
 # k8s.io/cli-runtime => k8s.io/cli-runtime v0.20.0-beta.2
 # k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.20.0-beta.2
 # k8s.io/code-generator => k8s.io/code-generator v0.20.0-beta.2
-# github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.11.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,4 @@
 # cloud.google.com/go v0.54.0
-## explicit
 cloud.google.com/go/compute/metadata
 # github.com/Azure/azure-pipeline-go v0.2.3
 ## explicit
@@ -31,14 +30,12 @@ github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter
 github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta
 github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock
 # github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
-## explicit
 github.com/MakeNowJust/heredoc
 # github.com/Masterminds/goutils v1.1.0
 github.com/Masterminds/goutils
 # github.com/Masterminds/semver/v3 v3.1.0
 github.com/Masterminds/semver/v3
 # github.com/Masterminds/sprig/v3 v3.1.0
-## explicit
 github.com/Masterminds/sprig/v3
 # github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
 github.com/Microsoft/go-winio
@@ -50,7 +47,6 @@ github.com/PuerkitoBio/urlesc
 # github.com/agext/levenshtein v1.2.1
 github.com/agext/levenshtein
 # github.com/aliyun/alibaba-cloud-sdk-go v1.61.264
-## explicit
 github.com/aliyun/alibaba-cloud-sdk-go/sdk
 github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth
 github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials
@@ -69,7 +65,6 @@ github.com/apparentlymart/go-textseg/v12/textseg
 # github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
 github.com/armon/go-metrics
 # github.com/aws/amazon-ec2-instance-selector/v2 v2.0.1
-## explicit
 github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity
 github.com/aws/amazon-ec2-instance-selector/v2/pkg/cli
 github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector
@@ -137,7 +132,6 @@ github.com/aws/aws-sdk-go/service/s3
 github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bazelbuild/bazel-gazelle v0.19.1
-## explicit
 github.com/bazelbuild/bazel-gazelle/cmd/gazelle
 github.com/bazelbuild/bazel-gazelle/config
 github.com/bazelbuild/bazel-gazelle/flag
@@ -161,24 +155,20 @@ github.com/beorn7/perks/quantile
 # github.com/blang/semver v3.5.1+incompatible
 github.com/blang/semver
 # github.com/blang/semver/v4 v4.0.0
-## explicit
 github.com/blang/semver/v4
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
 # github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1
-## explicit
 github.com/chai2010/gettext-go/gettext
 github.com/chai2010/gettext-go/gettext/mo
 github.com/chai2010/gettext-go/gettext/plural
 github.com/chai2010/gettext-go/gettext/po
 # github.com/client9/misspell v0.3.4
-## explicit
 github.com/client9/misspell
 github.com/client9/misspell/cmd/misspell
 # github.com/containerd/containerd v1.3.3
 github.com/containerd/containerd/errdefs
 # github.com/coreos/etcd v3.3.17+incompatible
-## explicit
 github.com/coreos/etcd/client
 github.com/coreos/etcd/pkg/pathutil
 github.com/coreos/etcd/pkg/srv
@@ -191,7 +181,6 @@ github.com/cpuguy83/go-md2man/v2/md2man
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/denverdino/aliyungo v0.0.0-20191128015008-acd8035bbb1d
-## explicit
 github.com/denverdino/aliyungo/common
 github.com/denverdino/aliyungo/ecs
 github.com/denverdino/aliyungo/ess
@@ -234,7 +223,6 @@ github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-units v0.4.0
 github.com/docker/go-units
 # github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c
-## explicit
 github.com/docker/spdystream
 github.com/docker/spdystream/spdy
 # github.com/emicklei/go-restful v2.9.6+incompatible
@@ -251,20 +239,15 @@ github.com/form3tech-oss/jwt-go
 # github.com/fsnotify/fsnotify v1.4.9
 github.com/fsnotify/fsnotify
 # github.com/fullsailor/pkcs7 v0.0.0-20180422025557-ae226422660e
-## explicit
 github.com/fullsailor/pkcs7
 # github.com/ghodss/yaml v1.0.0
-## explicit
 github.com/ghodss/yaml
 # github.com/go-bindata/go-bindata v3.1.2+incompatible
-## explicit
 github.com/go-bindata/go-bindata
 github.com/go-bindata/go-bindata/go-bindata
 # github.com/go-ini/ini v1.51.0
-## explicit
 github.com/go-ini/ini
 # github.com/go-logr/logr v0.2.1-0.20200730175230-ee2de8da5be6
-## explicit
 github.com/go-logr/logr
 # github.com/go-openapi/jsonpointer v0.19.3
 github.com/go-openapi/jsonpointer
@@ -277,7 +260,6 @@ github.com/go-openapi/swag
 # github.com/gobuffalo/flect v0.2.0
 github.com/gobuffalo/flect
 # github.com/gogo/protobuf v1.3.1
-## explicit
 github.com/gogo/protobuf/gogoproto
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/protoc-gen-gogo/descriptor
@@ -295,7 +277,6 @@ github.com/golang/snappy
 # github.com/google/btree v1.0.0
 github.com/google/btree
 # github.com/google/go-cmp v0.5.2
-## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
@@ -306,7 +287,6 @@ github.com/google/go-querystring/query
 # github.com/google/gofuzz v1.1.0
 github.com/google/gofuzz
 # github.com/google/uuid v1.1.2
-## explicit
 github.com/google/uuid
 # github.com/googleapis/gax-go/v2 v2.0.5
 github.com/googleapis/gax-go/v2
@@ -315,7 +295,6 @@ github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 github.com/googleapis/gnostic/openapiv2
 # github.com/gophercloud/gophercloud v0.11.1-0.20200518183226-7aec46f32c19 => github.com/gophercloud/gophercloud v0.11.0
-## explicit
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/internal
 github.com/gophercloud/gophercloud/openstack
@@ -358,7 +337,6 @@ github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects
 github.com/gophercloud/gophercloud/openstack/utils
 github.com/gophercloud/gophercloud/pagination
 # github.com/gorilla/mux v1.7.3
-## explicit
 github.com/gorilla/mux
 # github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
 github.com/gregjones/httpcache
@@ -396,7 +374,6 @@ github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
 # github.com/hashicorp/hcl/v2 v2.7.0
-## explicit
 github.com/hashicorp/hcl/v2
 github.com/hashicorp/hcl/v2/ext/customdecode
 github.com/hashicorp/hcl/v2/hclsyntax
@@ -404,7 +381,6 @@ github.com/hashicorp/hcl/v2/hclwrite
 # github.com/hashicorp/memberlist v0.1.4
 github.com/hashicorp/memberlist
 # github.com/hashicorp/vault/api v1.0.4
-## explicit
 github.com/hashicorp/vault/api
 # github.com/hashicorp/vault/sdk v0.1.13
 github.com/hashicorp/vault/sdk/helper/compressutil
@@ -420,20 +396,17 @@ github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
 # github.com/jacksontj/memberlistmesh v0.0.0-20190905163944-93462b9d2bb7
-## explicit
 github.com/jacksontj/memberlistmesh
 github.com/jacksontj/memberlistmesh/clusterpb
 # github.com/jmespath/go-jmespath v0.4.0
 github.com/jmespath/go-jmespath
 # github.com/jpillora/backoff v0.0.0-20170918002102-8eab2debe79d
-## explicit
 github.com/jpillora/backoff
 # github.com/json-iterator/go v1.1.10
 github.com/json-iterator/go
 # github.com/konsorten/go-windows-terminal-sequences v1.0.3
 github.com/konsorten/go-windows-terminal-sequences
 # github.com/kr/fs v0.1.0
-## explicit
 github.com/kr/fs
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 github.com/liggitt/tabwriter
@@ -452,7 +425,6 @@ github.com/mattn/go-isatty
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/miekg/coredns v0.0.0-20161111164017-20e25559d5ea
-## explicit
 github.com/miekg/coredns/middleware/etcd/msg
 # github.com/miekg/dns v1.1.4
 github.com/miekg/dns
@@ -463,7 +435,6 @@ github.com/mitchellh/go-homedir
 # github.com/mitchellh/go-wordwrap v1.0.0
 github.com/mitchellh/go-wordwrap
 # github.com/mitchellh/mapstructure v1.1.2
-## explicit
 github.com/mitchellh/mapstructure
 # github.com/mitchellh/reflectwalk v1.0.0
 github.com/mitchellh/reflectwalk
@@ -491,12 +462,10 @@ github.com/pierrec/lz4/internal/xxh32
 # github.com/pkg/errors v0.9.1
 github.com/pkg/errors
 # github.com/pkg/sftp v0.0.0-20160930220758-4d0e916071f6
-## explicit
 github.com/pkg/sftp
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.7.1
-## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
@@ -519,7 +488,6 @@ github.com/ryanuber/go-glob
 # github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529
 github.com/sean-/seed
 # github.com/sergi/go-diff v1.0.0
-## explicit
 github.com/sergi/go-diff/diffmatchpatch
 # github.com/shurcooL/sanitized_anchor_name v1.0.0
 github.com/shurcooL/sanitized_anchor_name
@@ -531,19 +499,15 @@ github.com/spf13/afero/mem
 # github.com/spf13/cast v1.3.1
 github.com/spf13/cast
 # github.com/spf13/cobra v1.1.1
-## explicit
 github.com/spf13/cobra
 github.com/spf13/cobra/doc
 # github.com/spf13/jwalterweatherman v1.1.0
 github.com/spf13/jwalterweatherman
 # github.com/spf13/pflag v1.0.5
-## explicit
 github.com/spf13/pflag
 # github.com/spf13/viper v1.7.0
-## explicit
 github.com/spf13/viper
 # github.com/spotinst/spotinst-sdk-go v1.58.0
-## explicit
 github.com/spotinst/spotinst-sdk-go/service/elastigroup
 github.com/spotinst/spotinst-sdk-go/service/elastigroup/providers/aws
 github.com/spotinst/spotinst-sdk-go/service/elastigroup/providers/azure
@@ -562,7 +526,6 @@ github.com/spotinst/spotinst-sdk-go/spotinst/util/stringutil
 github.com/spotinst/spotinst-sdk-go/spotinst/util/uritemplates
 github.com/spotinst/spotinst-sdk-go/spotinst/util/useragent
 # github.com/stretchr/testify v1.6.1
-## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/subosito/gotenv v1.2.0
@@ -571,10 +534,8 @@ github.com/subosito/gotenv
 ## explicit
 github.com/urfave/cli
 # github.com/weaveworks/mesh v0.0.0-20170419100114-1f158d31de55
-## explicit
 github.com/weaveworks/mesh
 # github.com/zclconf/go-cty v1.3.1
-## explicit
 github.com/zclconf/go-cty/cty
 github.com/zclconf/go-cty/cty/convert
 github.com/zclconf/go-cty/cty/function
@@ -604,7 +565,6 @@ go.uber.org/atomic
 # go.uber.org/multierr v1.1.0
 go.uber.org/multierr
 # go.uber.org/zap v1.10.0
-## explicit
 go.uber.org/zap
 go.uber.org/zap/buffer
 go.uber.org/zap/internal/bufferpool
@@ -612,7 +572,6 @@ go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
 go.uber.org/zap/zapcore
 # golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
-## explicit
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blake2b
 golang.org/x/crypto/blowfish
@@ -636,7 +595,6 @@ golang.org/x/crypto/ssh/terminal
 golang.org/x/mod/module
 golang.org/x/mod/semver
 # golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
-## explicit
 golang.org/x/net/bpf
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
@@ -654,7 +612,6 @@ golang.org/x/net/ipv6
 golang.org/x/net/proxy
 golang.org/x/net/trace
 # golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-## explicit
 golang.org/x/oauth2
 golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
@@ -663,7 +620,6 @@ golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 golang.org/x/sync/errgroup
 # golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
-## explicit
 golang.org/x/sys/cpu
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix
@@ -684,7 +640,6 @@ golang.org/x/text/width
 # golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 golang.org/x/time/rate
 # golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f
-## explicit
 golang.org/x/tools/cmd/goimports
 golang.org/x/tools/go/analysis
 golang.org/x/tools/go/analysis/passes/inspect
@@ -718,7 +673,6 @@ golang.org/x/xerrors/internal
 # gomodules.xyz/jsonpatch/v2 v2.0.1
 gomodules.xyz/jsonpatch/v2
 # google.golang.org/api v0.22.0
-## explicit
 google.golang.org/api/compute/v0.alpha
 google.golang.org/api/compute/v0.beta
 google.golang.org/api/compute/v1
@@ -819,13 +773,11 @@ google.golang.org/protobuf/types/known/anypb
 google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/gcfg.v1 v1.2.3
-## explicit
 gopkg.in/gcfg.v1
 gopkg.in/gcfg.v1/scanner
 gopkg.in/gcfg.v1/token
 gopkg.in/gcfg.v1/types
 # gopkg.in/inf.v0 v0.9.1
-## explicit
 gopkg.in/inf.v0
 # gopkg.in/ini.v1 v1.57.0
 gopkg.in/ini.v1
@@ -837,15 +789,12 @@ gopkg.in/square/go-jose.v2/jwt
 # gopkg.in/warnings.v0 v0.1.2
 gopkg.in/warnings.v0
 # gopkg.in/yaml.v2 v2.3.0
-## explicit
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 gopkg.in/yaml.v3
 # helm.sh/helm v2.17.0+incompatible
-## explicit
 helm.sh/helm/pkg/strvals
 # honnef.co/go/tools v0.0.1-2020.1.4
-## explicit
 honnef.co/go/tools/arg
 honnef.co/go/tools/cmd/staticcheck
 honnef.co/go/tools/code
@@ -876,7 +825,6 @@ honnef.co/go/tools/stylecheck
 honnef.co/go/tools/unused
 honnef.co/go/tools/version
 # k8s.io/api v0.20.0-beta.2 => k8s.io/api v0.20.0-beta.2
-## explicit
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
@@ -928,7 +876,6 @@ k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 # k8s.io/apimachinery v0.20.0-beta.2 => k8s.io/apimachinery v0.20.0-beta.2
-## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -983,7 +930,6 @@ k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/cli-runtime v0.20.0-beta.2 => k8s.io/cli-runtime v0.20.0-beta.2
-## explicit
 k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/kustomize
 k8s.io/cli-runtime/pkg/kustomize/k8sdeps
@@ -997,7 +943,6 @@ k8s.io/cli-runtime/pkg/kustomize/k8sdeps/validator
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
 # k8s.io/client-go v0.20.0-beta.2 => k8s.io/client-go v0.20.0-beta.2
-## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached/disk
 k8s.io/client-go/discovery/fake
@@ -1250,7 +1195,6 @@ k8s.io/cloud-provider/volume/helpers
 k8s.io/cloud-provider-openstack/pkg/util/errors
 k8s.io/cloud-provider-openstack/pkg/util/openstack
 # k8s.io/component-base v0.20.0-beta.2 => k8s.io/component-base v0.20.0-beta.2
-## explicit
 k8s.io/component-base/metrics
 k8s.io/component-base/metrics/legacyregistry
 k8s.io/component-base/metrics/prometheus/restclient
@@ -1258,7 +1202,6 @@ k8s.io/component-base/version
 # k8s.io/csi-translation-lib v0.20.0-beta.2 => k8s.io/csi-translation-lib v0.20.0-beta.2
 k8s.io/csi-translation-lib/plugins
 # k8s.io/gengo v0.0.0-20201113003025-83324d819ded
-## explicit
 k8s.io/gengo/args
 k8s.io/gengo/generator
 k8s.io/gengo/namer
@@ -1267,7 +1210,6 @@ k8s.io/gengo/types
 # k8s.io/klog v1.0.0
 k8s.io/klog
 # k8s.io/klog/v2 v2.4.0
-## explicit
 k8s.io/klog/v2
 k8s.io/klog/v2/klogr
 # k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd
@@ -1275,7 +1217,6 @@ k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/util/proto/validation
 # k8s.io/kubectl v0.0.0 => k8s.io/kubectl v0.20.0-beta.2
-## explicit
 k8s.io/kubectl/pkg/cmd/util
 k8s.io/kubectl/pkg/cmd/util/editor
 k8s.io/kubectl/pkg/cmd/util/editor/crlf
@@ -1291,11 +1232,9 @@ k8s.io/kubectl/pkg/util/templates
 k8s.io/kubectl/pkg/util/term
 k8s.io/kubectl/pkg/validation
 # k8s.io/legacy-cloud-providers v0.0.0 => k8s.io/legacy-cloud-providers v0.20.0-beta.2
-## explicit
 k8s.io/legacy-cloud-providers/aws
 k8s.io/legacy-cloud-providers/gce
 # k8s.io/utils v0.0.0-20201110183641-67b214c5f920
-## explicit
 k8s.io/utils/buffer
 k8s.io/utils/exec
 k8s.io/utils/integer
@@ -1307,7 +1246,6 @@ k8s.io/utils/nsenter
 k8s.io/utils/pointer
 k8s.io/utils/trace
 # sigs.k8s.io/controller-runtime v0.6.1
-## explicit
 sigs.k8s.io/controller-runtime
 sigs.k8s.io/controller-runtime/pkg/builder
 sigs.k8s.io/controller-runtime/pkg/cache
@@ -1344,7 +1282,6 @@ sigs.k8s.io/controller-runtime/pkg/webhook/conversion
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/certwatcher
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 # sigs.k8s.io/controller-tools v0.2.8
-## explicit
 sigs.k8s.io/controller-tools/cmd/controller-gen
 sigs.k8s.io/controller-tools/pkg/crd
 sigs.k8s.io/controller-tools/pkg/crd/markers
@@ -1385,27 +1322,4 @@ sigs.k8s.io/kustomize/pkg/types
 # sigs.k8s.io/structured-merge-diff/v4 v4.0.2
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
-## explicit
 sigs.k8s.io/yaml
-# k8s.io/api => k8s.io/api v0.20.0-beta.2
-# k8s.io/apimachinery => k8s.io/apimachinery v0.20.0-beta.2
-# k8s.io/client-go => k8s.io/client-go v0.20.0-beta.2
-# k8s.io/cloud-provider => k8s.io/cloud-provider v0.20.0-beta.2
-# k8s.io/kubectl => k8s.io/kubectl v0.20.0-beta.2
-# k8s.io/apiserver => k8s.io/apiserver v0.20.0-beta.2
-# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.20.0-beta.2
-# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.20.0-beta.2
-# k8s.io/kube-proxy => k8s.io/kube-proxy v0.20.0-beta.2
-# k8s.io/cri-api => k8s.io/cri-api v0.20.0-beta.2
-# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.20.0-beta.2
-# k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.20.0-beta.2
-# k8s.io/component-base => k8s.io/component-base v0.20.0-beta.2
-# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.20.0-beta.2
-# k8s.io/metrics => k8s.io/metrics v0.20.0-beta.2
-# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.20.0-beta.2
-# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.20.0-beta.2
-# k8s.io/kubelet => k8s.io/kubelet v0.20.0-beta.2
-# k8s.io/cli-runtime => k8s.io/cli-runtime v0.20.0-beta.2
-# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.20.0-beta.2
-# k8s.io/code-generator => k8s.io/code-generator v0.20.0-beta.2
-# github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.11.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1408,3 +1408,4 @@ sigs.k8s.io/yaml
 # k8s.io/cli-runtime => k8s.io/cli-runtime v0.20.0-beta.2
 # k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.20.0-beta.2
 # k8s.io/code-generator => k8s.io/code-generator v0.20.0-beta.2
+# github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.11.0


### PR DESCRIPTION
Hi,
I wanted thoughts on promoting Digital Ocean to Beta. Currently, a good amount of KOPS functionality is in place for DO, and I wanted to check with the KOPS maintainers if you are okay with this promotion.

Tested with both single cluster and multi-master HA setup
Tested kubernetes upgrade with kops update feature (ex: from v1.19.3 to v1.19.4)
Tested kops validate command on cluster creation
Tested creating multiple instance groups and managing & updating & deleting it.
Tested using the cluster with a DO load balancer when a new service with type: LoadBalancer is used.
Tested creating new PV with CSI drivers for managing DO volumes.

FYI - @timoreimann 