### PR TITLE
Tolerate missing detached EC2 instances

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -485,7 +485,11 @@ func deleteInstance(c AWSCloud, i *cloudinstances.CloudInstance) error {
 	}
 
 	if _, err := c.EC2().TerminateInstances(request); err != nil {
-		return fmt.Errorf("error deleting instance %q: %v", id, err)
+		if AWSErrorCode(err) == "InvalidInstanceID.NotFound" {
+			klog.V(2).Infof("Got InvalidInstanceID.NotFound error deleting instance %q; will treat as already-deleted", id)
+		} else {
+			return fmt.Errorf("error deleting instance %q: %v", id, err)
+		}
 	}
 
 	klog.V(8).Infof("deleted aws ec2 instance %q", id)


### PR DESCRIPTION
Sometimes we see the following error during a rolling update:

> I1125 18:12:46.467059     165 instancegroups.go:340] Draining the node: "ip-X-X-X-X.X.compute.internal".
 I1125 18:12:46.473365     165 instancegroups.go:359] deleting node "ip-X-X-X-X.X.compute.internal" from kubernetes
 I1125 18:12:46.476756     165 instancegroups.go:486] Stopping instance "i-XXXXXXXX", node "ip-X-X-X-X.X.compute.internal",  in group "X" (this may take a while).
 E1125 18:12:46.523269     165 instancegroups.go:367] error deleting instance "i-XXXXXXXX", node "ip-X-X- X-X.X.compute.internal": error deleting instance "i-XXXXXXXX", node "ip-X-X-X-X.X.compute.internal": error deleting instance "i-XXXXXXXX": InvalidInstanceID.NotFound: The instance ID 'i-XXXXXXXXX' does not exist
	status code: 400, request id: 91238c21-1caf-41eb-91d7-534d4ca67ed0

It's possible that the EC2 instance to have disappeared by the time it
was detached (it may have been a spot instance for example)

In any case, we can't do much when we do not find an instance id, and
throwing this error during the update is not very user friendly.

As such, we can simply report and tolerate this problem instead of
exiting with non-zero code. This is similar to how we handle missing
EC2 when updating an IG[1]

[1] https://github.com/kubernetes/kops/pull/594