### PR TITLE
Add fuzzer and OSS-fuzz build script

### DIFF
--- a/hack/.packages
+++ b/hack/.packages
@@ -167,6 +167,7 @@ k8s.io/kops/protokube/pkg/hostmount
 k8s.io/kops/protokube/pkg/protokube
 k8s.io/kops/protokube/tests/integration/build_etcd_manifest
 k8s.io/kops/tests/codecs
+k8s.io/kops/tests/fuzz
 k8s.io/kops/tests/integration/channel
 k8s.io/kops/tests/integration/conversion
 k8s.io/kops/upup/models

--- a/tests/fuzz/BUILD.bazel
+++ b/tests/fuzz/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["fuzz.go"],
+    importpath = "k8s.io/kops/tests/fuzz",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/jsonutils:go_default_library"],
+)

--- a/tests/fuzz/build.sh
+++ b/tests/fuzz/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cp "$SRC"/AFL/dictionaries/json.dict "$OUT"/fuzz_write_token.dict
+zip "$OUT"/fuzz_write_token_seed_corpus.zip "$SRC"/go-fuzz-corpus/json/corpus/*
+
+compile_go_fuzzer k8s.io/kops/tests/fuzz FuzzWriteToken fuzz_write_token

--- a/tests/fuzz/fuzz.go
+++ b/tests/fuzz/fuzz.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fuzz
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"k8s.io/kops/pkg/jsonutils"
+)
+
+func FuzzWriteToken(data []byte) int {
+	var buf bytes.Buffer
+	out := jsonutils.NewJSONStreamWriter(&buf)
+	in := json.NewDecoder(strings.NewReader(string(data)))
+	token, err := in.Token()
+	if err != nil {
+		return -1
+	}
+	err = out.WriteToken(token)
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds a go-fuzz fuzzer that targets `WriteToken` as well as a build script to integrate Kops into OSS-fuzz. 

I have the integration script available for OSS-fuzz and will be happy to finalize the integration. For this, at least one maintainers email is needed for potential bug reports.

Fuzzing is a way of testing programs whereby pseudo-random data is passed to a target application with the goal of finding bugs and vulnerabilities. Kubernetes is already being fuzzed continuously by way of OSS-fuzz, and this has led to finding bugs and vulnerabilities. 