### PR TITLE
Don't try to detach masters

### DIFF
--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -624,13 +624,14 @@ func (c *RollingUpdateCluster) UpdateSingleInstance(cloudMember *cloudinstances.
 		if cloudMember.CloudInstanceGroup.InstanceGroup.IsMaster() {
 			klog.Warning("cannot detach master instances. Assuming --surge=false")
 
-		}
-		err := c.detachInstance(cloudMember)
-		if err != nil {
-			return fmt.Errorf("failed to detach instance: %v", err)
-		}
-		if err := c.maybeValidate(" after detaching instance", c.ValidateCount, cloudMember.CloudInstanceGroup); err != nil {
-			return err
+		} else {
+			err := c.detachInstance(cloudMember)
+			if err != nil {
+				return fmt.Errorf("failed to detach instance: %v", err)
+			}
+			if err := c.maybeValidate(" after detaching instance", c.ValidateCount, cloudMember.CloudInstanceGroup); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
detatchInstance used to return if executed against master IG. This is no longer the case, so kops tries to detach master nodes when deleting instance.

/kind bug