### PR TITLE
Push alpha to stable

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -23,25 +23,25 @@ spec:
       providerID: aws
       kubernetesVersion: ">=1.10.0 <1.11.0"
     # Stretch is the default for 1.11 (for nvme)
-    - name: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2020-07-20
+    - name: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2020-11-19
       providerID: aws
       kubernetesVersion: ">=1.11.0 <1.12.0"
-    - name: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2020-07-20
+    - name: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2020-11-19
       providerID: aws
       kubernetesVersion: ">=1.12.0 <1.13.0"
-    - name: kope.io/k8s-1.13-debian-stretch-amd64-hvm-ebs-2020-07-20
+    - name: kope.io/k8s-1.13-debian-stretch-amd64-hvm-ebs-2020-11-19
       providerID: aws
       kubernetesVersion: ">=1.13.0 <1.14.0"
-    - name: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-07-20
+    - name: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-11-19
       providerID: aws
       kubernetesVersion: ">=1.14.0 <1.15.0"
-    - name: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+    - name: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
       providerID: aws
       kubernetesVersion: ">=1.15.0 <1.16.0"
-    - name: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-07-20
+    - name: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-11-19
       providerID: aws
       kubernetesVersion: ">=1.16.0 <1.17.0"
-    - name: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
+    - name: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-11-19
       providerID: aws
       kubernetesVersion: ">=1.17.0 <1.18.0"
     - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201026
@@ -59,10 +59,10 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.18.0"
-    recommendedVersion: 1.18.10
+    recommendedVersion: 1.18.12
     requiredVersion: 1.18.0
   - range: ">=1.17.0"
-    recommendedVersion: 1.17.13
+    recommendedVersion: 1.17.14
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
     recommendedVersion: 1.16.15
@@ -89,15 +89,15 @@ spec:
   - range: ">=1.19.0-alpha.1"
     #recommendedVersion: "1.19.0-alpha.1"
     #requiredVersion: 1.19.0
-    kubernetesVersion: 1.19.3
+    kubernetesVersion: 1.19.4
   - range: ">=1.18.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.18.0
-    kubernetesVersion: 1.18.10
+    kubernetesVersion: 1.18.12
   - range: ">=1.17.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.17.0
-    kubernetesVersion: 1.17.13
+    kubernetesVersion: 1.17.14
   - range: ">=1.16.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.16.0

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -61,7 +61,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -81,7 +81,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes-us-test-1a
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -77,7 +77,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -97,7 +97,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b
 spec:
-  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -117,7 +117,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1c
 spec:
-  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -137,7 +137,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1a
 spec:
-  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -157,7 +157,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1b
 spec:
-  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -177,7 +177,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1c
 spec:
-  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -83,7 +83,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -103,7 +103,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b
 spec:
-  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -123,7 +123,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1c
 spec:
-  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -143,7 +143,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1a
 spec:
-  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -163,7 +163,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1b
 spec:
-  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -183,7 +183,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1c
 spec:
-  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -81,7 +81,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a-1
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -101,7 +101,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a-2
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -121,7 +121,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a-3
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -141,7 +141,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b-1
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -161,7 +161,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b-2
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -181,7 +181,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1a
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -201,7 +201,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1b
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -70,7 +70,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -90,7 +90,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -110,7 +110,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: nodes-us-test-1a
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal/expected-v1alpha2.yaml
@@ -61,7 +61,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -81,7 +81,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -70,7 +70,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -90,7 +90,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -110,7 +110,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: nodes-us-test-1a
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -64,7 +64,7 @@ metadata:
     kops.k8s.io/cluster: overrides.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -84,7 +84,7 @@ metadata:
     kops.k8s.io/cluster: overrides.example.com
   name: nodes-us-test-1a
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -73,7 +73,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -96,7 +96,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid3
   - sg-exampleid4
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -119,7 +119,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid
   - sg-exampleid2
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -70,7 +70,7 @@ metadata:
     kops.k8s.io/cluster: private-subnets.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -90,7 +90,7 @@ metadata:
     kops.k8s.io/cluster: private-subnets.example.com
   name: nodes-us-test-1a
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
@@ -63,7 +63,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -83,7 +83,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: nodes-us-test-1a
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
@@ -63,7 +63,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -83,7 +83,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: nodes-us-test-1a
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -62,7 +62,7 @@ metadata:
     kops.k8s.io/cluster: vpc.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -82,7 +82,7 @@ metadata:
     kops.k8s.io/cluster: vpc.example.com
   name: nodes-us-test-1a
 spec:
-  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-07-20
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-11-19
   machineType: t2.medium
   maxSize: 1
   minSize: 1


### PR DESCRIPTION
It's been 3 weeks since we pushed [November k8s releases](https://github.com/kubernetes/kops/pull/10227) and 2 weeks since the [AMI updates for legacy versions](https://github.com/kubernetes/kops/pull/10269), looks like they are ready for `stable`.