### PR TITLE
Add paramaeters related to Taint based Evictions in kube-apiserver

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -446,6 +446,17 @@ spec:
     eventTTL: 03h0m0s
 ```
 
+### Taint based Evictions
+
+There are two parameters related to taint based evictions. These parameters indicate default value of the `tolerationSeconds` for `notReady:NoExecute` and `unreachable:NoExecute`.
+
+```yaml
+spec:
+  kubeAPIServer:
+    defaultNotReadyTolerationSeconds: 600
+    defaultUnreachableTolerationSeconds: 600
+```
+
 ## externalDns
 
 This block contains configuration options for your `external-DNS` provider.

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -922,6 +922,14 @@ spec:
                   cpuRequest:
                     description: CPURequest, cpu request compute resource for api server. Defaults to "150m"
                     type: string
+                  defaultNotReadyTolerationSeconds:
+                    description: DefaultNotReadyTolerationSeconds
+                    format: int64
+                    type: integer
+                  defaultUnreachableTolerationSeconds:
+                    description: DefaultUnreachableTolerationSeconds
+                    format: int64
+                    type: integer
                   disableAdmissionPlugins:
                     description: DisableAdmissionPlugins is a list of disabled admission plugins
                     items:

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -490,6 +490,11 @@ type KubeAPIServerConfig struct {
 	// CorsAllowedOrigins is a list of origins for CORS. An allowed origin can be a regular
 	// expression to support subdomain matching. If this list is empty CORS will not be enabled.
 	CorsAllowedOrigins []string `json:"corsAllowedOrigins,omitempty" flag:"cors-allowed-origins"`
+
+	// DefaultNotReadyTolerationSeconds indicates the tolerationSeconds of the toleration for notReady:NoExecute that is added by default to every pod that does not already have such a toleration.
+	DefaultNotReadyTolerationSeconds *int64 `json:"defaultNotReadyTolerationSeconds,omitempty" flag:"default-not-ready-toleration-seconds"`
+	// DefaultUnreachableTolerationSeconds indicates the tolerationSeconds of the toleration for unreachable:NoExecute that is added by default to every pod that does not already have such a toleration.
+	DefaultUnreachableTolerationSeconds *int64 `json:"defaultUnreachableTolerationSeconds,omitempty" flag:"default-unreachable-toleration-seconds"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -490,6 +490,11 @@ type KubeAPIServerConfig struct {
 	// CorsAllowedOrigins is a list of origins for CORS. An allowed origin can be a regular
 	// expression to support subdomain matching. If this list is empty CORS will not be enabled.
 	CorsAllowedOrigins []string `json:"corsAllowedOrigins,omitempty" flag:"cors-allowed-origins"`
+
+	// DefaultNotReadyTolerationSeconds
+	DefaultNotReadyTolerationSeconds *int64 `json:"defaultNotReadyTolerationSeconds,omitempty" flag:"default-not-ready-toleration-seconds"`
+	// DefaultUnreachableTolerationSeconds
+	DefaultUnreachableTolerationSeconds *int64 `json:"defaultUnreachableTolerationSeconds,omitempty" flag:"default-unreachable-toleration-seconds"`
 }
 
 // KubeControllerManagerConfig is the configuration for the controller

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3994,6 +3994,8 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.AuditDynamicConfiguration = in.AuditDynamicConfiguration
 	out.EnableProfiling = in.EnableProfiling
 	out.CorsAllowedOrigins = in.CorsAllowedOrigins
+	out.DefaultNotReadyTolerationSeconds = in.DefaultNotReadyTolerationSeconds
+	out.DefaultUnreachableTolerationSeconds = in.DefaultUnreachableTolerationSeconds
 	return nil
 }
 
@@ -4102,6 +4104,8 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.AuditDynamicConfiguration = in.AuditDynamicConfiguration
 	out.EnableProfiling = in.EnableProfiling
 	out.CorsAllowedOrigins = in.CorsAllowedOrigins
+	out.DefaultNotReadyTolerationSeconds = in.DefaultNotReadyTolerationSeconds
+	out.DefaultUnreachableTolerationSeconds = in.DefaultUnreachableTolerationSeconds
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2404,6 +2404,16 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.DefaultNotReadyTolerationSeconds != nil {
+		in, out := &in.DefaultNotReadyTolerationSeconds, &out.DefaultNotReadyTolerationSeconds
+		*out = new(int64)
+		**out = **in
+	}
+	if in.DefaultUnreachableTolerationSeconds != nil {
+		in, out := &in.DefaultUnreachableTolerationSeconds, &out.DefaultUnreachableTolerationSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2586,6 +2586,16 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.DefaultNotReadyTolerationSeconds != nil {
+		in, out := &in.DefaultNotReadyTolerationSeconds, &out.DefaultNotReadyTolerationSeconds
+		*out = new(int64)
+		**out = **in
+	}
+	if in.DefaultUnreachableTolerationSeconds != nil {
+		in, out := &in.DefaultUnreachableTolerationSeconds, &out.DefaultUnreachableTolerationSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
closes: #6612 

I added two parameters in kube-apiserver: 

- defaultNotReadyTolerationSeconds
- defaultUnreachableTolerationSeconds

these parameters control the pod toleration time.
You can specify it in cluster spec:

```yaml
spec:
  # ...
  kubeAPIServer:
    defaultNotReadyTolerationSeconds: 600
    defaultUnreachableTolerationSeconds: 600
```
