### PR TITLE
Automated cherry pick of #10345: Alloq using gp3 for root volumes

### DIFF
--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -196,7 +196,7 @@ func CrossValidateInstanceGroup(g *kops.InstanceGroup, cluster *kops.Cluster, cl
 	}
 
 	if g.Spec.RootVolumeType != nil && kops.CloudProviderID(cluster.Spec.CloudProvider) == kops.CloudProviderAWS {
-		allErrs = append(allErrs, IsValidValue(field.NewPath("spec", "rootVolumeType"), g.Spec.RootVolumeType, []string{"standard", "gp2", "io1", "io2"})...)
+		allErrs = append(allErrs, IsValidValue(field.NewPath("spec", "rootVolumeType"), g.Spec.RootVolumeType, []string{"standard", "gp3", "gp2", "io1", "io2"})...)
 	}
 
 	return allErrs

--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -197,6 +197,9 @@ func TestValidBootDevice(t *testing.T) {
 			volumeType: "standard",
 		},
 		{
+			volumeType: "gp3",
+		},
+		{
 			volumeType: "gp2",
 		},
 		{


### PR DESCRIPTION
Cherry pick of #10345 on release-1.19.

#10345: Alloq using gp3 for root volumes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.