### PR TITLE
Update DigitalOcean cloud-controller-manager to v0.1.30

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -1376,7 +1376,7 @@ spec:
           operator: Exists
           tolerationSeconds: 300
       containers:
-      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.24
+      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.30
         name: digitalocean-cloud-controller-manager
         command:
           - "/bin/digitalocean-cloud-controller-manager"

--- a/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
@@ -48,7 +48,7 @@ spec:
           operator: Exists
           tolerationSeconds: 300
       containers:
-      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.24
+      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.30
         name: digitalocean-cloud-controller-manager
         command:
           - "/bin/digitalocean-cloud-controller-manager"


### PR DESCRIPTION
This changes bumps DigitalOcean's cloud-controller-manager to version 0.1.30 which brings a number of new features.