### PR TITLE
Add K8s Docker runtime support deprecation release note

### DIFF
--- a/docs/releases/1.19-NOTES.md
+++ b/docs/releases/1.19-NOTES.md
@@ -113,10 +113,9 @@ has been updated by a newer version of kOps unless it is given the `--allow-kops
 
 # Deprecations
 
-* Support for Kubernetes versions 1.11 and 1.12 are deprecated and will be removed in kOps 1.20.
+* Support for Kubernetes versions 1.11 and 1.12 has been deprecated and will be removed in kOps 1.20.
 
-* As of kOps 1.20, the default container runtime will be `containerd` instead of Docker for new clusters. For existing clusters the default behaviour can be overridden using either the `--container-runtime` flag or add `spec.containerRuntime` to the cluster spec. This change closely tracks the upstream deprecation of Docker in Kubernetes 1.20 and will be removed in a future release.
-  For more information see [this page](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG/CHANGELOG-1.20.md#deprecation).
+* Support for Docker container runtime has been deprecated and will be replaced with containerd for new clusters as of kOps 1.20. For existing clusters the default behaviour can be overridden by setting `spec.containerRuntime: containerd` in the cluster spec. This change closely tracks the upstream [deprecation of Docker](https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker).
 
 * Support for Terraform version 0.11 has been deprecated and will be removed in kOps 1.20.
 

--- a/docs/releases/1.19-NOTES.md
+++ b/docs/releases/1.19-NOTES.md
@@ -115,6 +115,9 @@ has been updated by a newer version of kOps unless it is given the `--allow-kops
 
 * Support for Kubernetes versions 1.11 and 1.12 are deprecated and will be removed in kOps 1.20.
 
+* As of kOps 1.20, the default container runtime will be `containerd` instead of Docker for new clusters. For existing clusters the default behaviour can be overridden using either the `--container-runtime` flag or add `spec.containerRuntime` to the cluster spec. This change closely tracks the upstream deprecation of Docker in Kubernetes 1.20 and will be removed in a future release.
+  For more information see [this page](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG/CHANGELOG-1.20.md#deprecation).
+
 * Support for Terraform version 0.11 has been deprecated and will be removed in kOps 1.20.
 
 * Support for feature flag `Terraform-0.12` has been deprecated and will be removed in kOps 1.20. All generated Terraform HCL2/JSON files will support versions `0.12.26+` and `0.13.0+`.


### PR DESCRIPTION
**What this PR does / why we need it**:
As Kubernetes will deprecate Docker runtime support from version 1.20 and will be removed in a future release (currently planned for the 1.22 release in late 2021), notify users that the default container runtime will be set to `containerd` from kOps 1.20.

https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG/CHANGELOG-1.20.md#deprecation

**Which issue(s) this PR fixes**
#10356 

**Special notes for your reviewer**:
PR #10370 raised to set default container runtime to `containerd` in kOps 1.20. 