### PR TITLE
fix cluster-autoscaler README url from cluster_spec -> addons

### DIFF
--- a/addons/cluster-autoscaler/README.md
+++ b/addons/cluster-autoscaler/README.md
@@ -1,6 +1,6 @@
 # Cluster Autoscaler Addon
 
-**This addon is deprecated. See https://kops.sigs.k8s.io/cluster_spec/#cluster-autoscaler**
+**This addon is deprecated. See https://kops.sigs.k8s.io/addons/#cluster-autoscaler**
 
 We strongly recommend using Cluster Autoscaler with the kubernetes version for which it was meant. Refer to the [Cluster Autoscaler documentation compatibility matrix]( https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/README.md#releases)
 


### PR DESCRIPTION
I was looking into adding the cluster-autoscaler for kops, but couldn't find the proper documentation.

Currently the README points to this: https://kops.sigs.k8s.io/cluster_spec/#cluster-autoscaler which doesnt exist anymore due to this commit: https://github.com/kubernetes/kops/commit/c1b4dd6752937d096665537b3074c81ff36eab0b changing the website documentation.

This should remedy that. I didn't open an issue because this seemed like a super simple fix. Hope that's okay!