### PR TITLE
Automated cherry pick of #10375: Remove resource limits from cluster autoscaler

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -1026,9 +1026,6 @@ spec:
         - image: {{ .Image }}
           name: cluster-autoscaler
           resources:
-            limits:
-              cpu: 100m
-              memory: 300Mi
             requests:
               cpu: 100m
               memory: 300Mi

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -145,9 +145,6 @@ spec:
         - image: {{ .Image }}
           name: cluster-autoscaler
           resources:
-            limits:
-              cpu: 100m
-              memory: 300Mi
             requests:
               cpu: 100m
               memory: 300Mi


### PR DESCRIPTION
Cherry pick of #10375 on release-1.19.

#10375: Remove resource limits from cluster autoscaler

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.