### PR TITLE
Automated cherry pick of #10359: Add option for setting the volume encryption key in AWS

### DIFF
--- a/docs/tutorial/working-with-instancegroups.md
+++ b/docs/tutorial/working-with-instancegroups.md
@@ -234,9 +234,29 @@ spec:
   rootVolumeIops: 200
 ```
 
-## Adding additional storage to the instance groups
+## Encrypting the root volume
+{{ kops_feature_table(kops_added_default='1.19') }}
 
-As of Kops 1.12.0 you can add additional storage _(note, presently confined to AWS)_ via the instancegroup specification.
+You can encrypt the root volume  _(note, presently confined to AWS)_ via the instancegroup specification.
+
+```YAML
+metadata:
+  name: nodes
+spec:
+  ...
+  role: Node
+  rootVolumeSize: 200
+  rootVolumeEncryption: true
+  rootVolumeEncryptionKey: arn:aws:kms:us-east-1:012345678910:key/1234abcd-12ab-34cd-56ef-1234567890ab
+```
+
+In the above example the encryption key is optional. The default key for EBS encryption is used when not specified.
+The encryption key can specified as the key ID, alias or ARN, as described in the [AWS docs](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id).
+
+## Adding additional storage to the instance groups
+{{ kops_feature_table(kops_added_default='1.12') }}
+
+You can add additional storage _(note, presently confined to AWS)_ via the instancegroup specification.
 
 ```YAML
 ---
@@ -254,12 +274,13 @@ spec:
   ...
   volumes:
   - device: /dev/xvdd
-    encrypted: true
     size: 20
     type: gp2
+    encrypted: true
+    key: arn:aws:kms:us-east-1:012345678910:key/1234abcd-12ab-34cd-56ef-1234567890ab
 ```
 
-In AWS the above example shows how to add an additional 20gb EBS volume, which applies to each node within the instancegroup.
+In AWS the above example shows how to add an additional encrypted 20gb EBS volume, which applies to each node within the instancegroup.
 
 ## Automatically formatting and mounting the additional storage
 
@@ -347,12 +368,10 @@ So the procedure is:
 * Apply: `kops update cluster <clustername> --yes`
 * (no instances need to be relaunched, so no rolling-update is needed)
 
-## Creating a instance group of mixed instances types (AWS Only)
+## Creating an instance group of mixed instances types (AWS Only)
+{{ kops_feature_table(kops_added_default='1.12') }}
 
 AWS permits the creation of mixed instance EC2 Autoscaling Groups using a [mixed instance policy](https://aws.amazon.com/blogs/aws/new-ec2-auto-scaling-groups-with-multiple-instance-types-purchase-options/), allowing the users to build a target capacity and make up of on-demand and spot instances while offloading the allocation strategy to AWS.
-
-Support for mixed instance groups was added in Kops 1.12.0
-
 
 ```YAML
 ---

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -540,6 +540,9 @@ spec:
               rootVolumeEncryption:
                 description: RootVolumeEncryption enables EBS root volume encryption for an instance
                 type: boolean
+              rootVolumeEncryptionKey:
+                description: RootVolumeEncryptionKey provides the key identifier for root volume encryption
+                type: string
               rootVolumeIops:
                 description: If volume type is io1, then we need to specify the number of Iops.
                 format: int32
@@ -628,6 +631,9 @@ spec:
                       description: Iops is the provision iops for this iops (think io1 in aws)
                       format: int64
                       type: integer
+                    key:
+                      description: Key is the encryption key identifier for the volume
+                      type: string
                     size:
                       description: Size is the size of the volume in GB
                       format: int64

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,5 @@
 [build]
 publish = "site"
 command = "make build-docs-netlify"
-ignore = "git diff --quiet HEAD^ HEAD netlify.toml Makefile mkdocs.yml docs/ images/ hack/"
 # available here https://github.com/netlify/build-image/blob/xenial/included_software.md#languages
 environment = { PYTHON_VERSION = "3.7" }

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -108,6 +108,8 @@ type InstanceGroupSpec struct {
 	RootVolumeDeleteOnTermination *bool `json:"rootVolumeDeleteOnTermination,omitempty"`
 	// RootVolumeEncryption enables EBS root volume encryption for an instance
 	RootVolumeEncryption *bool `json:"rootVolumeEncryption,omitempty"`
+	// RootVolumeEncryptionKey provides the key identifier for root volume encryption
+	RootVolumeEncryptionKey *string `json:"rootVolumeEncryptionKey,omitempty"`
 	// Volumes is a collection of additional volumes to create for instances within this InstanceGroup
 	Volumes []VolumeSpec `json:"volumes,omitempty"`
 	// VolumeMounts a collection of volume mounts
@@ -225,6 +227,8 @@ type VolumeSpec struct {
 	Encrypted *bool `json:"encrypted,omitempty"`
 	// Iops is the provision iops for this iops (think io1 in aws)
 	Iops *int64 `json:"iops,omitempty"`
+	// Key is the encryption key identifier for the volume
+	Key *string `json:"key,omitempty"`
 	// Size is the size of the volume in GB
 	Size int64 `json:"size,omitempty"`
 	// Type is the type of volume to create and is cloud specific

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -105,6 +105,8 @@ type InstanceGroupSpec struct {
 	RootVolumeDeleteOnTermination *bool `json:"rootVolumeDeleteOnTermination,omitempty"`
 	// RootVolumeEncryption enables EBS root volume encryption for an instance
 	RootVolumeEncryption *bool `json:"rootVolumeEncryption,omitempty"`
+	// RootVolumeEncryptionKey provides the key identifier for root volume encryption
+	RootVolumeEncryptionKey *string `json:"rootVolumeEncryptionKey,omitempty"`
 	// Volumes is a collection of additional volumes to create for instances within this InstanceGroup
 	Volumes []VolumeSpec `json:"volumes,omitempty"`
 	// VolumeMounts a collection of volume mounts
@@ -223,6 +225,8 @@ type VolumeSpec struct {
 	Encrypted *bool `json:"encrypted,omitempty"`
 	// Iops is the provision iops for this iops (think io1 in aws)
 	Iops *int64 `json:"iops,omitempty"`
+	// Key is the encryption key identifier for the volume
+	Key *string `json:"key,omitempty"`
 	// Size is the size of the volume in GB
 	Size int64 `json:"size,omitempty"`
 	// Type is the type of volume to create and is cloud specific

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3452,6 +3452,7 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	out.RootVolumeOptimization = in.RootVolumeOptimization
 	out.RootVolumeDeleteOnTermination = in.RootVolumeDeleteOnTermination
 	out.RootVolumeEncryption = in.RootVolumeEncryption
+	out.RootVolumeEncryptionKey = in.RootVolumeEncryptionKey
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]kops.VolumeSpec, len(*in))
@@ -3591,6 +3592,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	out.RootVolumeOptimization = in.RootVolumeOptimization
 	out.RootVolumeDeleteOnTermination = in.RootVolumeDeleteOnTermination
 	out.RootVolumeEncryption = in.RootVolumeEncryption
+	out.RootVolumeEncryptionKey = in.RootVolumeEncryptionKey
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]VolumeSpec, len(*in))
@@ -5737,6 +5739,7 @@ func autoConvert_v1alpha2_VolumeSpec_To_kops_VolumeSpec(in *VolumeSpec, out *kop
 	out.Device = in.Device
 	out.Encrypted = in.Encrypted
 	out.Iops = in.Iops
+	out.Key = in.Key
 	out.Size = in.Size
 	out.Type = in.Type
 	return nil
@@ -5752,6 +5755,7 @@ func autoConvert_kops_VolumeSpec_To_v1alpha2_VolumeSpec(in *kops.VolumeSpec, out
 	out.Device = in.Device
 	out.Encrypted = in.Encrypted
 	out.Iops = in.Iops
+	out.Key = in.Key
 	out.Size = in.Size
 	out.Type = in.Type
 	return nil

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1779,6 +1779,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RootVolumeEncryptionKey != nil {
+		in, out := &in.RootVolumeEncryptionKey, &out.RootVolumeEncryptionKey
+		*out = new(string)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]VolumeSpec, len(*in))
@@ -3977,6 +3982,11 @@ func (in *VolumeSpec) DeepCopyInto(out *VolumeSpec) {
 	if in.Iops != nil {
 		in, out := &in.Iops, &out.Iops
 		*out = new(int64)
+		**out = **in
+	}
+	if in.Key != nil {
+		in, out := &in.Key, &out.Key
+		*out = new(string)
 		**out = **in
 	}
 	return

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -1945,6 +1945,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RootVolumeEncryptionKey != nil {
+		in, out := &in.RootVolumeEncryptionKey, &out.RootVolumeEncryptionKey
+		*out = new(string)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]VolumeSpec, len(*in))
@@ -4191,6 +4196,11 @@ func (in *VolumeSpec) DeepCopyInto(out *VolumeSpec) {
 	if in.Iops != nil {
 		in, out := &in.Iops, &out.Iops
 		*out = new(int64)
+		**out = **in
+	}
+	if in.Key != nil {
+		in, out := &in.Key, &out.Key
+		*out = new(string)
 		**out = **in
 	}
 	return

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -416,6 +416,7 @@ resource "aws_launch_template" "bastion-bastionuserdata-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 32
       volume_type           = "gp2"
     }
@@ -476,6 +477,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-bastionuserdata-exampl
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -540,6 +542,7 @@ resource "aws_launch_template" "nodes-bastionuserdata-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -250,7 +250,8 @@
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
                 "DeleteOnTermination": true,
-                "Encrypted": true
+                "Encrypted": true,
+                "KmsKeyId": "arn:aws:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab"
               }
             },
             {
@@ -387,7 +388,9 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 20,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": true,
+                "KmsKeyId": "arn:aws:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab"
               }
             }
           ],

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -100,6 +100,8 @@ spec:
     deleteOnTermination: false
     size: 20
     type: gp2
+    encrypted: true
+    key: arn:aws:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab
   additionalUserData:
   - name: myscript.sh
     type: text/x-shellscript
@@ -124,6 +126,7 @@ spec:
   minSize: 1
   role: Master
   rootVolumeEncryption: true
+  rootVolumeEncryptionKey: arn:aws:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab
   subnets:
   - us-test-1a
   additionalUserData:

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -100,6 +100,8 @@ spec:
     deleteOnTermination: false
     size: 20
     type: gp2
+    encrypted: true
+    key: arn:aws:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab
   additionalUserData:
   - name: myscript.sh
     type: text/x-shellscript
@@ -124,6 +126,7 @@ spec:
   minSize: 1
   role: Master
   rootVolumeEncryption: true
+  rootVolumeEncryptionKey: arn:aws:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab
   subnets:
   - us-test-1a
   additionalUserData:

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -281,6 +281,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
     ebs {
       delete_on_termination = true
       encrypted             = true
+      kms_key_id            = "arn:aws:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab"
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -359,6 +360,8 @@ resource "aws_launch_template" "nodes-complex-example-com" {
     device_name = "/dev/xvdd"
     ebs {
       delete_on_termination = true
+      encrypted             = true
+      kms_key_id            = "arn:aws:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab"
       volume_size           = 20
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/compress/kubernetes.tf
+++ b/tests/integration/update_cluster/compress/kubernetes.tf
@@ -250,6 +250,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-compress-example-com" 
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -313,6 +314,7 @@ resource "aws_launch_template" "nodes-compress-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json
@@ -205,7 +205,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             },
             {
@@ -316,7 +317,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 128,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             }
           ],

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -370,6 +370,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-existing-iam-example-c
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -434,6 +435,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-existing-iam-example-c
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -498,6 +500,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-existing-iam-example-c
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -562,6 +565,7 @@ resource "aws_launch_template" "nodes-existing-iam-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json
@@ -205,7 +205,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             },
             {
@@ -314,7 +315,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 128,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             }
           ],

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -451,6 +451,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-existingsg-example-com
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -515,6 +516,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-existingsg-example-com
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -579,6 +581,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-existingsg-example-com
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -643,6 +646,7 @@ resource "aws_launch_template" "nodes-existingsg-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/externallb/cloudformation.json
+++ b/tests/integration/update_cluster/externallb/cloudformation.json
@@ -220,7 +220,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             },
             {
@@ -331,7 +332,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 128,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             }
           ],

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -264,6 +264,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-externallb-example-com
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -328,6 +329,7 @@ resource "aws_launch_template" "nodes-externallb-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -328,6 +328,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-externalpolicies-examp
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -398,6 +399,7 @@ resource "aws_launch_template" "nodes-externalpolicies-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -422,6 +422,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-ha-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -486,6 +487,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-ha-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -550,6 +552,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-ha-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -614,6 +617,7 @@ resource "aws_launch_template" "nodes-ha-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/launch_templates/cloudformation.json
+++ b/tests/integration/update_cluster/launch_templates/cloudformation.json
@@ -282,7 +282,8 @@
             "Ebs": {
               "VolumeType": "gp2",
               "VolumeSize": 64,
-              "DeleteOnTermination": true
+              "DeleteOnTermination": true,
+              "Encrypted": false
             }
           }
         ],
@@ -311,7 +312,8 @@
             "Ebs": {
               "VolumeType": "gp2",
               "VolumeSize": 64,
-              "DeleteOnTermination": true
+              "DeleteOnTermination": true,
+              "Encrypted": false
             }
           }
         ],
@@ -340,7 +342,8 @@
             "Ebs": {
               "VolumeType": "gp2",
               "VolumeSize": 64,
-              "DeleteOnTermination": true
+              "DeleteOnTermination": true,
+              "Encrypted": false
             }
           }
         ],
@@ -369,7 +372,8 @@
             "Ebs": {
               "VolumeType": "gp2",
               "VolumeSize": 128,
-              "DeleteOnTermination": true
+              "DeleteOnTermination": true,
+              "Encrypted": false
             }
           }
         ],

--- a/tests/integration/update_cluster/launch_templates/kubernetes.tf
+++ b/tests/integration/update_cluster/launch_templates/kubernetes.tf
@@ -419,6 +419,7 @@ resource "aws_launch_configuration" "master-us-test-1a-masters-launchtemplates-e
   name_prefix = "master-us-test-1a.masters.launchtemplates.example.com-"
   root_block_device {
     delete_on_termination = true
+    encrypted             = false
     volume_size           = 64
     volume_type           = "gp2"
   }
@@ -439,6 +440,7 @@ resource "aws_launch_configuration" "master-us-test-1b-masters-launchtemplates-e
   name_prefix = "master-us-test-1b.masters.launchtemplates.example.com-"
   root_block_device {
     delete_on_termination = true
+    encrypted             = false
     volume_size           = 64
     volume_type           = "gp2"
   }
@@ -459,6 +461,7 @@ resource "aws_launch_configuration" "master-us-test-1c-masters-launchtemplates-e
   name_prefix = "master-us-test-1c.masters.launchtemplates.example.com-"
   root_block_device {
     delete_on_termination = true
+    encrypted             = false
     volume_size           = 64
     volume_type           = "gp2"
   }
@@ -479,6 +482,7 @@ resource "aws_launch_configuration" "nodes-launchtemplates-example-com" {
   name_prefix = "nodes.launchtemplates.example.com-"
   root_block_device {
     delete_on_termination = true
+    encrypted             = false
     volume_size           = 128
     volume_type           = "gp2"
   }

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
@@ -205,7 +205,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             },
             {
@@ -316,7 +317,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 128,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             }
           ],

--- a/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
+++ b/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
@@ -305,7 +305,8 @@
               {
                 "volume_type": "gp2",
                 "volume_size": 64,
-                "delete_on_termination": true
+                "delete_on_termination": true,
+                "encrypted": false
               }
             ]
           },
@@ -380,7 +381,8 @@
               {
                 "volume_type": "gp2",
                 "volume_size": 128,
-                "delete_on_termination": true
+                "delete_on_termination": true,
+                "encrypted": false
               }
             ]
           }

--- a/tests/integration/update_cluster/minimal-tf11/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-tf11/kubernetes.tf
@@ -293,6 +293,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-tf11-example-c
       volume_type           = "gp2"
       volume_size           = 64
       delete_on_termination = true
+      encrypted             = false
     }
   }
 
@@ -370,6 +371,7 @@ resource "aws_launch_template" "nodes-minimal-tf11-example-com" {
       volume_type           = "gp2"
       volume_size           = 128
       delete_on_termination = true
+      encrypted             = false
     }
   }
 

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -260,6 +260,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -324,6 +325,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json
@@ -376,7 +376,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             },
             {
@@ -487,7 +488,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             },
             {
@@ -598,7 +600,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             },
             {
@@ -709,7 +712,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 128,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             }
           ],

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -440,6 +440,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -504,6 +505,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -568,6 +570,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -632,6 +635,7 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
@@ -377,7 +377,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             },
             {
@@ -488,7 +489,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             },
             {
@@ -599,7 +601,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             },
             {
@@ -710,7 +713,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 128,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             }
           ],

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -440,6 +440,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -504,6 +505,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -568,6 +570,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -632,6 +635,7 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/private-shared-ip/cloudformation.json
+++ b/tests/integration/update_cluster/private-shared-ip/cloudformation.json
@@ -249,7 +249,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 32,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             }
           ],
@@ -356,7 +357,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             },
             {
@@ -467,7 +469,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 128,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             }
           ],

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -393,6 +393,7 @@ resource "aws_launch_template" "bastion-private-shared-ip-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 32
       volume_type           = "gp2"
     }
@@ -452,6 +453,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-private-shared-ip-exam
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -516,6 +518,7 @@ resource "aws_launch_template" "nodes-private-shared-ip-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -388,6 +388,7 @@ resource "aws_launch_template" "bastion-private-shared-subnet-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 32
       volume_type           = "gp2"
     }
@@ -447,6 +448,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-private-shared-subnet-
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -511,6 +513,7 @@ resource "aws_launch_template" "nodes-private-shared-subnet-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -311,7 +311,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 32,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             }
           ],
@@ -418,7 +419,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             },
             {
@@ -529,7 +531,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 128,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             }
           ],

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -416,6 +416,7 @@ resource "aws_launch_template" "bastion-privatecalico-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 32
       volume_type           = "gp2"
     }
@@ -475,6 +476,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecalico-example-
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -539,6 +541,7 @@ resource "aws_launch_template" "nodes-privatecalico-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -416,6 +416,7 @@ resource "aws_launch_template" "bastion-privatecanal-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 32
       volume_type           = "gp2"
     }
@@ -475,6 +476,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecanal-example-c
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -539,6 +541,7 @@ resource "aws_launch_template" "nodes-privatecanal-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json
@@ -311,7 +311,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 32,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             }
           ],
@@ -418,7 +419,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             },
             {
@@ -529,7 +531,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 128,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             }
           ],

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -416,6 +416,7 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 32
       volume_type           = "gp2"
     }
@@ -475,6 +476,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -539,6 +541,7 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json
@@ -311,7 +311,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 32,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             }
           ],
@@ -418,7 +419,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             },
             {
@@ -529,7 +531,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 128,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             }
           ],

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -416,6 +416,7 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 32
       volume_type           = "gp2"
     }
@@ -475,6 +476,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -539,6 +541,7 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
@@ -311,7 +311,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 32,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             }
           ],
@@ -418,7 +419,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 64,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             },
             {
@@ -529,7 +531,8 @@
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 128,
-                "DeleteOnTermination": true
+                "DeleteOnTermination": true,
+                "Encrypted": false
               }
             }
           ],

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -430,6 +430,7 @@ resource "aws_launch_template" "bastion-privateciliumadvanced-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 32
       volume_type           = "gp2"
     }
@@ -489,6 +490,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateciliumadvanced-
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -553,6 +555,7 @@ resource "aws_launch_template" "nodes-privateciliumadvanced-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -460,6 +460,7 @@ resource "aws_launch_template" "bastion-privatedns1-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 32
       volume_type           = "gp2"
     }
@@ -525,6 +526,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns1-example-co
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -595,6 +597,7 @@ resource "aws_launch_template" "nodes-privatedns1-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -402,6 +402,7 @@ resource "aws_launch_template" "bastion-privatedns2-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 32
       volume_type           = "gp2"
     }
@@ -461,6 +462,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns2-example-co
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -525,6 +527,7 @@ resource "aws_launch_template" "nodes-privatedns2-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -416,6 +416,7 @@ resource "aws_launch_template" "bastion-privateflannel-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 32
       volume_type           = "gp2"
     }
@@ -475,6 +476,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateflannel-example
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -539,6 +541,7 @@ resource "aws_launch_template" "nodes-privateflannel-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -422,6 +422,7 @@ resource "aws_launch_template" "bastion-privatekopeio-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 32
       volume_type           = "gp2"
     }
@@ -481,6 +482,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatekopeio-example-
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -545,6 +547,7 @@ resource "aws_launch_template" "nodes-privatekopeio-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -416,6 +416,7 @@ resource "aws_launch_template" "bastion-privateweave-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 32
       volume_type           = "gp2"
     }
@@ -475,6 +476,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateweave-example-c
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -539,6 +541,7 @@ resource "aws_launch_template" "nodes-privateweave-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/public-jwks/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks/kubernetes.tf
@@ -287,6 +287,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -351,6 +352,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -246,6 +246,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedsubnet-example-c
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -310,6 +311,7 @@ resource "aws_launch_template" "nodes-sharedsubnet-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -246,6 +246,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedvpc-example-com"
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -310,6 +311,7 @@ resource "aws_launch_template" "nodes-sharedvpc-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -393,6 +393,7 @@ resource "aws_launch_template" "bastion-unmanaged-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 32
       volume_type           = "gp2"
     }
@@ -452,6 +453,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-unmanaged-example-com"
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 64
       volume_type           = "gp2"
     }
@@ -516,6 +518,7 @@ resource "aws_launch_template" "nodes-unmanaged-example-com" {
     device_name = "/dev/xvda"
     ebs {
       delete_on_termination = true
+      encrypted             = false
       volume_size           = 128
       volume_type           = "gp2"
     }

--- a/upup/pkg/fi/cloudup/awstasks/block_device_mappings.go
+++ b/upup/pkg/fi/cloudup/awstasks/block_device_mappings.go
@@ -32,6 +32,8 @@ type BlockDeviceMapping struct {
 	EbsDeleteOnTermination *bool
 	// EbsEncrypted indicates the volume should be encrypted
 	EbsEncrypted *bool
+	// EbsKmsKey is the encryption key identifier for the volume
+	EbsKmsKey *string
 	// EbsVolumeIops is provisioned iops
 	EbsVolumeIops *int64
 	// EbsVolumeSize is the size of the volume
@@ -51,6 +53,7 @@ func BlockDeviceMappingFromEC2(i *ec2.BlockDeviceMapping) (string, *BlockDeviceM
 	if i.Ebs != nil {
 		o.EbsDeleteOnTermination = i.Ebs.DeleteOnTermination
 		o.EbsEncrypted = i.Ebs.Encrypted
+		o.EbsKmsKey = i.Ebs.KmsKeyId
 		o.EbsVolumeIops = i.Ebs.Iops
 		o.EbsVolumeSize = i.Ebs.VolumeSize
 		o.EbsVolumeType = i.Ebs.VolumeType
@@ -74,6 +77,9 @@ func (i *BlockDeviceMapping) ToEC2(deviceName string) *ec2.BlockDeviceMapping {
 		}
 		if fi.StringValue(o.Ebs.VolumeType) == ec2.VolumeTypeIo1 {
 			o.Ebs.Iops = i.EbsVolumeIops
+		}
+		if fi.BoolValue(o.Ebs.Encrypted) {
+			o.Ebs.KmsKeyId = i.EbsKmsKey
 		}
 	}
 
@@ -131,26 +137,33 @@ func BlockDeviceMappingFromLaunchTemplateBootDeviceRequest(i *ec2.LaunchTemplate
 		o.EbsDeleteOnTermination = i.Ebs.DeleteOnTermination
 		o.EbsVolumeSize = i.Ebs.VolumeSize
 		o.EbsVolumeType = i.Ebs.VolumeType
+		o.EbsVolumeIops = i.Ebs.Iops
 		o.EbsEncrypted = i.Ebs.Encrypted
+		o.EbsKmsKey = i.Ebs.KmsKeyId
 	}
 
 	return aws.StringValue(i.DeviceName), o
 }
 
-// ToLaunchTemplateBootDeviceRequest coverts in the internal block device mapping to a launcg template request
+// ToLaunchTemplateBootDeviceRequest coverts in the internal block device mapping to a launch template request
 func (i *BlockDeviceMapping) ToLaunchTemplateBootDeviceRequest(deviceName string) *ec2.LaunchTemplateBlockDeviceMappingRequest {
 	o := &ec2.LaunchTemplateBlockDeviceMappingRequest{
 		DeviceName:  aws.String(deviceName),
 		VirtualName: i.VirtualName,
 	}
-	if i.EbsDeleteOnTermination != nil || i.EbsVolumeSize != nil || i.EbsVolumeType != nil || i.EbsVolumeIops != nil || i.EbsEncrypted != nil {
+	if i.EbsDeleteOnTermination != nil || i.EbsVolumeSize != nil || i.EbsVolumeType != nil || i.EbsEncrypted != nil {
 		o.Ebs = &ec2.LaunchTemplateEbsBlockDeviceRequest{
 			DeleteOnTermination: i.EbsDeleteOnTermination,
 			Encrypted:           i.EbsEncrypted,
 			VolumeSize:          i.EbsVolumeSize,
 			VolumeType:          i.EbsVolumeType,
-			Iops:                i.EbsVolumeIops,
 		}
+	}
+	if fi.StringValue(i.EbsVolumeType) == ec2.VolumeTypeIo1 {
+		o.Ebs.Iops = i.EbsVolumeIops
+	}
+	if fi.BoolValue(i.EbsEncrypted) {
+		o.Ebs.KmsKeyId = i.EbsKmsKey
 	}
 
 	return o

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -255,6 +255,11 @@ func (t *LaunchTemplate) Find(c *fi.Context) (*LaunchTemplate, error) {
 			actual.RootVolumeType = b.Ebs.VolumeType
 			actual.RootVolumeIops = b.Ebs.Iops
 			actual.RootVolumeEncryption = b.Ebs.Encrypted
+			if b.Ebs.KmsKeyId != nil {
+				actual.RootVolumeKmsKey = b.Ebs.KmsKeyId
+			} else {
+				actual.RootVolumeKmsKey = fi.String("")
+			}
 		} else {
 			_, d := BlockDeviceMappingFromLaunchTemplateBootDeviceRequest(b)
 			actual.BlockDeviceMappings = append(actual.BlockDeviceMappings, d)

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation.go
@@ -90,6 +90,8 @@ type cloudformationLaunchTemplateBlockDeviceEBS struct {
 	DeleteOnTermination *bool `json:"DeleteOnTermination,omitempty"`
 	// Encrypted indicates the device is encrypted
 	Encrypted *bool `json:"Encrypted,omitempty"`
+	// KmsKeyID is the encryption key identifier for the volume
+	KmsKeyID *string `json:"KmsKeyId,omitempty"`
 }
 
 type cloudformationLaunchTemplateBlockDevice struct {
@@ -240,6 +242,7 @@ func (t *LaunchTemplate) RenderCloudformation(target *cloudformation.Cloudformat
 				VolumeSize:          x.EbsVolumeSize,
 				VolumeType:          x.EbsVolumeType,
 				Encrypted:           x.EbsEncrypted,
+				KmsKeyID:            x.EbsKmsKey,
 			},
 		})
 	}
@@ -252,6 +255,7 @@ func (t *LaunchTemplate) RenderCloudformation(target *cloudformation.Cloudformat
 				VolumeSize:          x.EbsVolumeSize,
 				VolumeType:          x.EbsVolumeType,
 				Encrypted:           x.EbsEncrypted,
+				KmsKeyID:            x.EbsKmsKey,
 			},
 		})
 	}

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -90,6 +90,8 @@ type terraformLaunchTemplateBlockDeviceEBS struct {
 	DeleteOnTermination *bool `json:"delete_on_termination,omitempty" cty:"delete_on_termination"`
 	// Encrypted indicates the device should be encrypted
 	Encrypted *bool `json:"encrypted,omitempty" cty:"encrypted"`
+	// KmsKeyID is the encryption key identifier for the volume
+	KmsKeyID *string `json:"kms_key_id,omitempty" cty:"kms_key_id"`
 }
 
 type terraformLaunchTemplateBlockDevice struct {
@@ -251,6 +253,7 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 				{
 					DeleteOnTermination: fi.Bool(true),
 					Encrypted:           x.EbsEncrypted,
+					KmsKeyID:            x.EbsKmsKey,
 					IOPS:                x.EbsVolumeIops,
 					VolumeSize:          x.EbsVolumeSize,
 					VolumeType:          x.EbsVolumeType,
@@ -270,6 +273,7 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 					DeleteOnTermination: fi.Bool(true),
 					Encrypted:           x.EbsEncrypted,
 					IOPS:                x.EbsVolumeIops,
+					KmsKeyID:            x.EbsKmsKey,
 					VolumeSize:          x.EbsVolumeSize,
 					VolumeType:          x.EbsVolumeType,
 				},


### PR DESCRIPTION
Cherry pick of #10359 on release-1.19.

#10359: Add option for setting the volume encryption key in AWS

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.