### PR TITLE
Automated cherry pick of #10398: Explicitly specify http_endpoint in launch_template terraform

### DIFF
--- a/docs/instance_groups.md
+++ b/docs/instance_groups.md
@@ -45,6 +45,17 @@ spec:
   instanceProtection: true
 ```
 
+## instanceMetadata
+
+By default, both IMDSv1 and IMDSv2 are enabled. The instance metadata service can be configured to allow only IMDSv2.
+
+```YAML
+spec:
+  instanceMetadata:
+    httpPutResponseHopLimit: 1
+    httpTokens: required
+```
+
 ## externalLoadBalancers
 
 Instance groups can be linked to up to 10 load balancers. When attached, any instance launched will

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -431,6 +431,7 @@ resource "aws_launch_template" "bastion-bastionuserdata-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -500,6 +501,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-bastionuserdata-exampl
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -565,6 +567,7 @@ resource "aws_launch_template" "nodes-bastionuserdata-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -299,6 +299,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "required"
   }
@@ -379,6 +380,7 @@ resource "aws_launch_template" "nodes-complex-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/compress/kubernetes.tf
+++ b/tests/integration/update_cluster/compress/kubernetes.tf
@@ -268,6 +268,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-compress-example-com" 
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -332,6 +333,7 @@ resource "aws_launch_template" "nodes-compress-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -389,6 +389,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-existing-iam-example-c
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -458,6 +459,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-existing-iam-example-c
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -527,6 +529,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-existing-iam-example-c
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -592,6 +595,7 @@ resource "aws_launch_template" "nodes-existing-iam-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -470,6 +470,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-existingsg-example-com
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -539,6 +540,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-existingsg-example-com
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -608,6 +610,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-existingsg-example-com
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -673,6 +676,7 @@ resource "aws_launch_template" "nodes-existingsg-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -283,6 +283,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-externallb-example-com
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -348,6 +349,7 @@ resource "aws_launch_template" "nodes-externallb-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -347,6 +347,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-externalpolicies-examp
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -418,6 +419,7 @@ resource "aws_launch_template" "nodes-externalpolicies-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -441,6 +441,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-ha-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -510,6 +511,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-ha-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -579,6 +581,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-ha-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -644,6 +647,7 @@ resource "aws_launch_template" "nodes-ha-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
+++ b/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
@@ -324,6 +324,7 @@
         "instance_type": "m3.medium",
         "key_name": "${aws_key_pair.kubernetes-minimal-json-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}",
         "metadata_options": {
+          "http_endpoint": "enabled",
           "http_put_response_hop_limit": 1,
           "http_tokens": "optional"
         },
@@ -400,6 +401,7 @@
         "instance_type": "t2.medium",
         "key_name": "${aws_key_pair.kubernetes-minimal-json-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}",
         "metadata_options": {
+          "http_endpoint": "enabled",
           "http_put_response_hop_limit": 1,
           "http_tokens": "optional"
         },

--- a/tests/integration/update_cluster/minimal-tf11/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-tf11/kubernetes.tf
@@ -311,6 +311,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-tf11-example-c
   key_name      = "${aws_key_pair.kubernetes-minimal-tf11-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
 
   metadata_options = {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -389,6 +390,7 @@ resource "aws_launch_template" "nodes-minimal-tf11-example-com" {
   key_name      = "${aws_key_pair.kubernetes-minimal-tf11-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id}"
 
   metadata_options = {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -279,6 +279,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -344,6 +345,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -459,6 +459,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -528,6 +529,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -597,6 +599,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -662,6 +665,7 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -459,6 +459,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -528,6 +529,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -597,6 +599,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -662,6 +665,7 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -408,6 +408,7 @@ resource "aws_launch_template" "bastion-private-shared-ip-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -476,6 +477,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-private-shared-ip-exam
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -541,6 +543,7 @@ resource "aws_launch_template" "nodes-private-shared-ip-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -403,6 +403,7 @@ resource "aws_launch_template" "bastion-private-shared-subnet-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -471,6 +472,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-private-shared-subnet-
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -536,6 +538,7 @@ resource "aws_launch_template" "nodes-private-shared-subnet-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -431,6 +431,7 @@ resource "aws_launch_template" "bastion-privatecalico-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -499,6 +500,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecalico-example-
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -564,6 +566,7 @@ resource "aws_launch_template" "nodes-privatecalico-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -431,6 +431,7 @@ resource "aws_launch_template" "bastion-privatecanal-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -499,6 +500,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecanal-example-c
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -564,6 +566,7 @@ resource "aws_launch_template" "nodes-privatecanal-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -431,6 +431,7 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -499,6 +500,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -564,6 +566,7 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -431,6 +431,7 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -499,6 +500,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -564,6 +566,7 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -445,6 +445,7 @@ resource "aws_launch_template" "bastion-privateciliumadvanced-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -513,6 +514,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateciliumadvanced-
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -578,6 +580,7 @@ resource "aws_launch_template" "nodes-privateciliumadvanced-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -475,6 +475,7 @@ resource "aws_launch_template" "bastion-privatedns1-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -549,6 +550,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns1-example-co
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -620,6 +622,7 @@ resource "aws_launch_template" "nodes-privatedns1-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -417,6 +417,7 @@ resource "aws_launch_template" "bastion-privatedns2-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -485,6 +486,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns2-example-co
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -550,6 +552,7 @@ resource "aws_launch_template" "nodes-privatedns2-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -431,6 +431,7 @@ resource "aws_launch_template" "bastion-privateflannel-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -499,6 +500,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateflannel-example
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -564,6 +566,7 @@ resource "aws_launch_template" "nodes-privateflannel-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -437,6 +437,7 @@ resource "aws_launch_template" "bastion-privatekopeio-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -505,6 +506,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatekopeio-example-
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -570,6 +572,7 @@ resource "aws_launch_template" "nodes-privatekopeio-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -431,6 +431,7 @@ resource "aws_launch_template" "bastion-privateweave-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -499,6 +500,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateweave-example-c
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -564,6 +566,7 @@ resource "aws_launch_template" "nodes-privateweave-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/public-jwks/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks/kubernetes.tf
@@ -306,6 +306,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -371,6 +372,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -265,6 +265,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedsubnet-example-c
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -330,6 +331,7 @@ resource "aws_launch_template" "nodes-sharedsubnet-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -265,6 +265,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedvpc-example-com"
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -330,6 +331,7 @@ resource "aws_launch_template" "nodes-sharedvpc-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -408,6 +408,7 @@ resource "aws_launch_template" "bastion-unmanaged-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -476,6 +477,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-unmanaged-example-com"
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -541,6 +543,7 @@ resource "aws_launch_template" "nodes-unmanaged-example-com" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -111,6 +111,8 @@ type terraformLaunchTemplateTagSpecification struct {
 }
 
 type terraformLaunchTemplateInstanceMetadata struct {
+	// HTTPEndpoint enables or disables the HTTP metadata endpoint on instances.
+	HTTPEndpoint *string `json:"http_endpoint,omitempty" cty:"http_endpoint"`
 	// HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for instance metadata requests.
 	HTTPPutResponseHopLimit *int64 `json:"http_put_response_hop_limit,omitempty" cty:"http_put_response_hop_limit"`
 	// HTTPTokens is the state of token usage for your instance metadata requests.
@@ -185,6 +187,8 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 		InstanceType: e.InstanceType,
 		Lifecycle:    &terraform.Lifecycle{CreateBeforeDestroy: fi.Bool(true)},
 		MetadataOptions: &terraformLaunchTemplateInstanceMetadata{
+			// See issue https://github.com/hashicorp/terraform-provider-aws/issues/12564.
+			HTTPEndpoint:            fi.String("enabled"),
 			HTTPTokens:              e.HTTPTokens,
 			HTTPPutResponseHopLimit: e.HTTPPutResponseHopLimit,
 		},

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
@@ -75,6 +75,7 @@ resource "aws_launch_template" "test" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -154,6 +155,7 @@ resource "aws_launch_template" "test" {
     create_before_destroy = true
   }
   metadata_options {
+    http_endpoint               = "enabled"
     http_put_response_hop_limit = 5
     http_tokens                 = "required"
   }


### PR DESCRIPTION
Cherry pick of #10398 on release-1.19.

#10398: Explicitly specify http_endpoint in launch_template terraform

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.