### PR TITLE
Calico: Allow operators to choose which encapsulation mode to use

### DIFF
--- a/docs/networking/calico.md
+++ b/docs/networking/calico.md
@@ -30,21 +30,41 @@ kops create cluster \
 
 ## Configuring
 
-### Enable Cross-Subnet mode in Calico (AWS only)
+### Select an Encapsulation Mode
 
-Calico supports a new option for IP-in-IP mode where traffic is only encapsulated
-when it’s destined to subnets with intermediate infrastructure lacking Calico route awareness
-– for example, across heterogeneous public clouds or on AWS where traffic is crossing availability zones/ regions.
+In order to send network traffic to and from Kubernetes pods, Calico can use either of two networking encapsulation modes: [IP-in-IP](https://tools.ietf.org/html/rfc2003)  or [VXLAN](https://tools.ietf.org/html/rfc7348). Though IP-in-IP encapsulation uses fewer bytes of overhead per packet than VXLAN encapsulation, [VXLAN can be a better
+choice when used in concert with Calico's eBPF dataplane|https://docs.projectcalico.org/maintenance/troubleshoot/troubleshoot-ebpf#poor-performance]. In particular, eBPF programs can redirect packets between Layer 2 devices, but not between devices at Layer 2 and Layer 3, as is required to use IP-in-IP tunneling.
 
-With this mode, IP-in-IP encapsulation is only [performed selectively](https://docs.projectcalico.org/v3.10/networking/vxlan-ipip#configure-ip-in-ip-encapsulation-for-only-cross-subnet-traffic).
-This provides better performance in AWS multi-AZ deployments, and in general when deploying on networks where
-pools of nodes with L2 connectivity are connected via a router.
+kOps chooses the IP-in-IP encapsulation mode by default, it still being the Calico project's default choice, which is equivalent to writing the following in the cluster spec:
+```yaml
+  networking:
+    calico:
+      encapsulationMode: ipip
+```
+To use the VXLAN encapsulation mode instead, add the following to the cluster spec:
+```yaml
+  networking:
+    calico:
+      encapsulationMode: vxlan
+```
 
-Note that Calico by default, routes between nodes within a subnet are distributed using a full node-to-node BGP mesh.
+As of Calico version 3.17, in order to use IP-in-IP encapsulation, Calico must use its BIRD networking backend, in which it runs the BIRD BGP daemon in each "calico-node" container to distribute routes to each machine. With the BIRD backend Calico can use either IP-in-IP or VXLAN encapsulation between machines. For now, IP-in-IP encapsulation requires maintaining the routes with BGP, whereas VXLAN encapsulation does not. Conversely, with the VXLAN backend, Calico does not run the BIRD daemon and does not use BGP to maintain routes. This rules out use of IP-in-IP encapsulation, and allows only VXLAN encapsulation. Calico may remove this need for BGP with IP-in-IP encapsulation in the future.
+
+### Enable Cross-Subnet mode in Calico
+
+Calico supports a new option for both of its IP-in-IP and VXLAN encapsulation modes where traffic is only encapsulated
+when it’s destined to subnets with intermediate infrastructure lacking Calico route awareness—for example, across
+heterogeneous public clouds or on AWS where traffic is crossing availability zones.
+
+With this mode, encapsulation is only [performed selectively](https://docs.projectcalico.org/v3.10/networking/vxlan-ipip#configure-ip-in-ip-encapsulation-for-only-cross-subnet-traffic).
+This provides better performance in AWS multi-AZ deployments, or those spanning multiple VPC subnets within a single AZ, and in general when deploying on networks where pools of nodes with L2 connectivity are connected via a router.
+
+Note that by default with Calico—when using its BIRD networking backend—routes between nodes within a subnet are
+distributed using a full node-to-node BGP mesh.
 Each node automatically sets up a BGP peering with every other node within the same L2 network.
 This full node-to-node mesh per L2 network has its scaling challenges for larger scale deployments.
 BGP route reflectors can be used as a replacement to a full mesh, and is useful for scaling up a cluster. [BGP route reflectors are recommended once the number of nodes goes above ~50-100.](https://docs.projectcalico.org/networking/bgp#topologies-for-public-cloud)
-The setup of BGP route reflectors is currently out of the scope of kops.
+The setup of BGP route reflectors is currently out of the scope of kOps.
 
 Read more here: [BGP route reflectors](https://docs.projectcalico.org/reference/architecture/overview#bgp-route-reflector-bird)
 
@@ -55,37 +75,43 @@ To enable this mode in a cluster, add the following to the cluster spec:
     calico:
       crossSubnet: true
 ```
-In the case of AWS, EC2 instances have source/destination checks enabled by default.
-When you enable cross-subnet mode in kOps 1.19+, it is equivalent to:
+In the case of AWS, EC2 instances' ENIs have source/destination checks enabled by default.
+When you enable cross-subnet mode in kOps 1.19+, it is equivalent to either:
 ```yaml
   networking:
     calico:
       awsSrcDstCheck: Disable
       IPIPMode: CrossSubnet
 ```
-An IAM policy will be added to all nodes to allow Calico to execute `ec2:DescribeInstances` and `ec2:ModifyNetworkInterfaceAttribute`, as required when [awsSrcDstCheck](https://docs.projectcalico.org/reference/resources/felixconfig#spec) is set.
+or
+```yaml
+  networking:
+    calico:
+      awsSrcDstCheck: Disable
+      encapsulationMode: vxlan
+```
+depending on which encapsulation mode you have selected.
+
+In AWS an IAM policy will be added to all nodes to allow Calico to execute `ec2:DescribeInstances` and `ec2:ModifyNetworkInterfaceAttribute`, as required when [awsSrcDstCheck](https://docs.projectcalico.org/reference/resources/felixconfig#spec) is set.
 For older versions of kOps, an addon controller ([k8s-ec2-srcdst](https://github.com/ottoyiu/k8s-ec2-srcdst))
 will be deployed as a Pod (which will be scheduled on one of the masters) to facilitate the disabling of said source/destination address checks.
 Only the control plane nodes have an IAM policy to allow k8s-ec2-srcdst to execute `ec2:ModifyInstanceAttribute`.
 
 ### Configuring Calico MTU
 
-The Calico MTU is configurable by editing the cluster and setting `mtu` option in the calico configuration.
-AWS VPCs support jumbo frames, so on cluster creation kOps sets the calico MTU to 8912 bytes (9001 minus overhead).
-
-For more details on Calico MTU please see the [Calico Docs](https://docs.projectcalico.org/networking/mtu#determine-mtu-size).
+The Calico MTU is configurable by editing the cluster and setting `mtu` field in the Calico configuration. If left to its default empty value, Calico will inspect the network devices and [choose a suitable MTU value automatically](https://docs.projectcalico.org/networking/mtu#mtu-and-calico-defaults). If you decide to override this automatic tuning, specify a positive value for the `mtu` field. In AWS, VPCs support jumbo frames of size 9,001, so [the recommended choice for Calico's MTU](https://docs.projectcalico.org/networking/mtu#determine-mtu-size) is either 8,981 for IP-in-IP encapsulation, 8,951 for VXLAN encapsulation, or 8,941 for WireGuard, in each case deducting the appropriate overhead for the encapsulation format.
 
 ```yaml
 spec:
   networking:
     calico:
-      mtu: 8912
+      mtu: 8981
 ```
 
 ### Configuring Calico to use Typha
 
-As of kOps 1.12 Calico uses the kube-apiserver as its datastore. The default setup does not make use of [Typha](https://github.com/projectcalico/typha) - a component intended to lower the impact of Calico on the k8s APIServer which is recommended in [clusters over 50 nodes](https://docs.projectcalico.org/latest/getting-started/kubernetes/installation/calico#installing-with-the-kubernetes-api-datastoremore-than-50-nodes) and is strongly recommended in clusters of 100+ nodes.
-It is possible to configure Calico to use Typha by editing a cluster and adding a `typhaReplicas` option to the Calico spec:
+As of kOps 1.12 Calico uses the kube-apiserver as its datastore. The default setup does not make use of [Typha](https://github.com/projectcalico/typha)—a component intended to lower the impact of Calico on the Kubernetes API Server which is recommended in [clusters over 50 nodes](https://docs.projectcalico.org/latest/getting-started/kubernetes/installation/calico#installing-with-the-kubernetes-api-datastoremore-than-50-nodes) and is strongly recommended in clusters of 100+ nodes.
+It is possible to configure Calico to use Typha by editing a cluster and adding the `typhaReplicas` field with a positive value to the Calico spec:
 
 ```yaml
   networking:
@@ -96,9 +122,11 @@ It is possible to configure Calico to use Typha by editing a cluster and adding 
 ### Configuring the eBPF dataplane
 {{ kops_feature_table(kops_added_default='1.19', k8s_min='1.16') }}
 
-Calico supports using an [eBPF dataplane](https://docs.projectcalico.org/about/about-ebpf) as an alternative to the standard Linux dataplane (which is iptables based). While the standard dataplane focuses on compatibility by inter-working with kube-proxy, and your own iptables rules, the eBPF dataplane focuses on performance, latency and improving user experience with features that aren’t possible in the standard dataplane. As part of that, the eBPF dataplane replaces kube-proxy with an eBPF implementation. The main “user experience” feature is to preserve the source IP of traffic from outside the cluster when traffic hits a NodePort; this makes the server-side logs and network policy much more useful on that path.
+Calico supports using an [eBPF dataplane](https://docs.projectcalico.org/about/about-ebpf) as an alternative to the standard Linux dataplane (which is based on iptables). While the standard dataplane focuses on compatibility by relying on kube-proxy and your own iptables rules, the eBPF dataplane focuses on performance, latency, and improving user experience with features that aren’t possible in the standard dataplane. As part of that, the eBPF dataplane replaces kube-proxy with an eBPF implementation. The main “user experience” feature is to preserve the source IP address of traffic from outside the cluster when traffic hits a node port; this makes the server-side logs and network policy much more useful on that path.
 
 For more details on enabling the eBPF dataplane please refer the [Calico Docs](https://docs.projectcalico.org/maintenance/ebpf/enabling-bpf).
+
+Enable the eBPF dataplane in kOps—while also disabling use of kube-proxy—as follows:
 
 ```yaml
   kubeProxy:
@@ -106,9 +134,21 @@ For more details on enabling the eBPF dataplane please refer the [Calico Docs](h
   networking:
     calico:
       bpfEnabled: true
-      bpfExternalServiceMode: Tunnel
-      bpfLogLevel: Info
 ```
+
+You can further tune Calico's eBPF dataplane with additional options, such as enabling [DSR mode](https://docs.projectcalico.org/maintenance/enabling-bpf#try-out-dsr-mode) to eliminate network hops in node port traffic (feasible only when your cluster conforms to [certain restrictions](https://docs.projectcalico.org/maintenance/troubleshoot/troubleshoot-ebpf#troubleshoot-access-to-services)) or [increasing the log verbosity for Calico's eBPF programs](https://docs.projectcalico.org/maintenance/troubleshoot/troubleshoot-ebpf#ebpf-program-debug-logs):
+
+```yaml
+  kubeProxy:
+    enabled: false
+  networking:
+    calico:
+      bpfEnabled: true
+      bpfExternalServiceMode: DSR
+      bpfLogLevel: Debug
+```
+
+**Note:** Transitioning to or from Calico's eBPF dataplane in an existing cluster is disruptive. kOps cannot orchestrate this transition automatically today.
 
 ### Configuring WireGuard
 {{ kops_feature_table(kops_added_default='1.19', k8s_min='1.16') }}
@@ -139,10 +179,11 @@ For more general information on options available with Calico see the official [
 
 ## Troubleshooting
 
-### New nodes are taking minutes for syncing ip routes and new pods on them can't reach kubedns
+### New nodes are taking minutes for syncing IP routes and new pods on them can't reach kubedns
 
-This is caused by nodes in the Calico etcd nodestore no longer existing. Due to the ephemeral nature of AWS EC2 instances, new nodes are brought up with different hostnames, and nodes that are taken offline remain in the Calico nodestore. This is unlike most datacentre deployments where the hostnames are mostly static in a cluster. Read more about this issue at https://github.com/kubernetes/kops/issues/3224
-This has been solved in kOps 1.9.0, when creating a new cluster no action is needed, but if the cluster was created with a prior kops version the following actions should be taken:
+This is caused by nodes in the Calico etcd nodestore no longer existing. Due to the ephemeral nature of AWS EC2 instances, new nodes are brought up with different hostnames, and nodes that are taken offline remain in the Calico nodestore. This is unlike most datacentre deployments where the hostnames are mostly static in a cluster. Read this issue](https://github.com/kubernetes/kops/issues/3224) for more detail.
+
+This has been solved in kOps 1.9.0, when creating a new cluster no action is needed, but if the cluster was created with a prior kOps version the following actions should be taken:
 
   * Use kOps to update the cluster ```kops update cluster <name> --yes``` and wait for calico-kube-controllers deployment and calico-node daemonset pods to be updated
   * Decommission all invalid nodes, [see here](https://docs.projectcalico.org/v2.6/usage/decommissioning-a-node)

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2906,12 +2906,21 @@ spec:
                         description: CrossSubnet enables Calico's cross-subnet mode
                           when set to true
                         type: boolean
+                      encapsulationMode:
+                        description: 'EncapsulationMode specifies the network packet
+                          encapsulation protocol for Calico to use, employing such
+                          encapsulation at the necessary scope per the related CrossSubnet
+                          field. In "ipip" mode, Calico will use IP-in-IP encapsulation
+                          as needed. In "vxlan" mode, Calico will encapsulate packets
+                          as needed using the VXLAN scheme. Options: ipip (default)
+                          or vxlan'
+                        type: string
                       ipipMode:
                         description: IPIPMode is the encapsulation mode to use for
                           the default Calico IPv4 pool created at start up, determining
                           when to use IP-in-IP encapsulation, conveyed to the "calico-node"
                           daemon container via the CALICO_IPV4POOL_IPIP environment
-                          variable
+                          variable.
                         type: string
                       iptablesBackend:
                         description: 'IptablesBackend controls which variant of iptables

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -134,9 +134,15 @@ type CalicoNetworkingSpec struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// CrossSubnet enables Calico's cross-subnet mode when set to true
 	CrossSubnet bool `json:"crossSubnet,omitempty"`
+	// EncapsulationMode specifies the network packet encapsulation protocol for Calico to use,
+	// employing such encapsulation at the necessary scope per the related CrossSubnet field. In
+	// "ipip" mode, Calico will use IP-in-IP encapsulation as needed. In "vxlan" mode, Calico will
+	// encapsulate packets as needed using the VXLAN scheme.
+	// Options: ipip (default) or vxlan
+	EncapsulationMode string `json:"encapsulationMode,omitempty"`
 	// IPIPMode is the encapsulation mode to use for the default Calico IPv4 pool created at start
 	// up, determining when to use IP-in-IP encapsulation, conveyed to the "calico-node" daemon
-	// container via the CALICO_IPV4POOL_IPIP environment variable
+	// container via the CALICO_IPV4POOL_IPIP environment variable.
 	IPIPMode string `json:"ipipMode,omitempty"`
 	// IPv4AutoDetectionMethod configures how Calico chooses the IP address used to route
 	// between nodes.  This should be set when the host has multiple interfaces

--- a/pkg/apis/kops/v1alpha2/defaults.go
+++ b/pkg/apis/kops/v1alpha2/defaults.go
@@ -26,17 +26,21 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 }
 
 func SetDefaults_ClusterSpec(obj *ClusterSpec) {
+	rebindIfEmpty := func(s *string, replacement string) bool {
+		if *s != "" {
+			return false
+		}
+		*s = replacement
+		return true
+	}
+
 	if obj.Topology == nil {
 		obj.Topology = &TopologySpec{}
 	}
 
-	if obj.Topology.Masters == "" {
-		obj.Topology.Masters = TopologyPublic
-	}
+	rebindIfEmpty(&obj.Topology.Masters, TopologyPublic)
 
-	if obj.Topology.Nodes == "" {
-		obj.Topology.Nodes = TopologyPublic
-	}
+	rebindIfEmpty(&obj.Topology.Nodes, TopologyPublic)
 
 	if obj.Topology.DNS == nil {
 		obj.Topology.DNS = &DNSSpec{}
@@ -90,10 +94,9 @@ func SetDefaults_ClusterSpec(obj *ClusterSpec) {
 
 	if obj.Networking != nil {
 		if obj.Networking.Flannel != nil {
-			if obj.Networking.Flannel.Backend == "" {
-				// Populate with legacy default value; new clusters will be created with vxlan by create cluster
-				obj.Networking.Flannel.Backend = "udp"
-			}
+			// Populate with legacy default value; new clusters will be created with "vxlan" by
+			// "create cluster."
+			rebindIfEmpty(&obj.Networking.Flannel.Backend, "udp")
 		}
 	}
 }

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -134,9 +134,15 @@ type CalicoNetworkingSpec struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// CrossSubnet enables Calico's cross-subnet mode when set to true
 	CrossSubnet bool `json:"crossSubnet,omitempty"`
+	// EncapsulationMode specifies the network packet encapsulation protocol for Calico to use,
+	// employing such encapsulation at the necessary scope per the related CrossSubnet field. In
+	// "ipip" mode, Calico will use IP-in-IP encapsulation as needed. In "vxlan" mode, Calico will
+	// encapsulate packets as needed using the VXLAN scheme.
+	// Options: ipip (default) or vxlan
+	EncapsulationMode string `json:"encapsulationMode,omitempty"`
 	// IPIPMode is the encapsulation mode to use for the default Calico IPv4 pool created at start
 	// up, determining when to use IP-in-IP encapsulation, conveyed to the "calico-node" daemon
-	// container via the CALICO_IPV4POOL_IPIP environment variable
+	// container via the CALICO_IPV4POOL_IPIP environment variable.
 	IPIPMode string `json:"ipipMode,omitempty"`
 	// IPv4AutoDetectionMethod configures how Calico chooses the IP address used to route
 	// between nodes.  This should be set when the host has multiple interfaces

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1355,6 +1355,7 @@ func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.ChainInsertMode = in.ChainInsertMode
 	out.CPURequest = in.CPURequest
 	out.CrossSubnet = in.CrossSubnet
+	out.EncapsulationMode = in.EncapsulationMode
 	out.IPIPMode = in.IPIPMode
 	out.IPv4AutoDetectionMethod = in.IPv4AutoDetectionMethod
 	out.IPv6AutoDetectionMethod = in.IPv6AutoDetectionMethod
@@ -1389,6 +1390,7 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *
 	out.ChainInsertMode = in.ChainInsertMode
 	out.CPURequest = in.CPURequest
 	out.CrossSubnet = in.CrossSubnet
+	out.EncapsulationMode = in.EncapsulationMode
 	out.IPIPMode = in.IPIPMode
 	out.IPv4AutoDetectionMethod = in.IPv4AutoDetectionMethod
 	out.IPv6AutoDetectionMethod = in.IPv6AutoDetectionMethod

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -989,6 +989,24 @@ func validateNetworkingCalico(v *kops.CalicoNetworkingSpec, e kops.EtcdClusterSp
 		allErrs = append(allErrs, IsValidValue(fldPath.Child("chainInsertMode"), &v.ChainInsertMode, valid)...)
 	}
 
+	if v.EncapsulationMode != "" {
+		// Don't tolerate "None" for now, which would disable encapsulation in the default IPPool
+		// object. Note that with no encapsulation, we'd need to select the "bird" networking
+		// backend in order to allow use of BGP to distribute routes for pod traffic.
+		valid := []string{"ipip", "vxlan"}
+		allErrs = append(allErrs, IsValidValue(fldPath.Child("encapsulationMode"), &v.EncapsulationMode, valid)...)
+	}
+
+	if v.IPIPMode != "" {
+		child := fldPath.Child("ipipMode")
+		allErrs = append(allErrs, validateCalicoIPPoolEncapsulationMode(v.IPIPMode, child)...)
+		if v.IPIPMode != "Never" {
+			if v.EncapsulationMode != "" && v.EncapsulationMode != "ipip" {
+				allErrs = append(allErrs, field.Forbidden(child, `IP-in-IP encapsulation requires use of Calico's "ipip" encapsulation mode`))
+			}
+		}
+	}
+
 	if v.IPv4AutoDetectionMethod != "" {
 		allErrs = append(allErrs, validateCalicoAutoDetectionMethod(fldPath.Child("ipv4AutoDetectionMethod"), v.IPv4AutoDetectionMethod, ipv4.Version)...)
 	}
@@ -1068,6 +1086,15 @@ func validateCalicoAutoDetectionMethod(fldPath *field.Path, runtime string, vers
 	default:
 		return field.ErrorList{field.Invalid(fldPath, runtime, "unsupported autodetection method")}
 	}
+}
+
+func validateCalicoIPPoolEncapsulationMode(mode string, fldPath *field.Path) field.ErrorList {
+	valid := []string{"Always", "CrossSubnet", "Never"}
+
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, IsValidValue(fldPath, &mode, valid)...)
+
+	return allErrs
 }
 
 func validateContainerRuntime(runtime *string, fldPath *field.Path) field.ErrorList {
@@ -1153,7 +1180,6 @@ func validateRollingUpdate(rollingUpdate *kops.RollingUpdate, fldpath *field.Pat
 			allErrs = append(allErrs, field.Forbidden(fldpath.Child("maxSurge"), "Cannot be zero if maxUnavailable is zero"))
 		}
 	}
-
 	return allErrs
 }
 

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -89,6 +89,7 @@ func TestValidateCIDR(t *testing.T) {
 }
 
 func testErrors(t *testing.T, context interface{}, actual field.ErrorList, expectedErrors []string) {
+	t.Helper()
 	if len(expectedErrors) == 0 {
 		if len(actual) != 0 {
 			t.Errorf("unexpected errors from %q: %v", context, actual)
@@ -101,7 +102,7 @@ func testErrors(t *testing.T, context interface{}, actual field.ErrorList, expec
 
 		for _, expected := range expectedErrors {
 			if !errStrings.Has(expected) {
-				t.Errorf("expected error %v from %v, was not found in %q", expected, context, errStrings.List())
+				t.Errorf("expected error %q from %v, was not found in %q", expected, context, errStrings.List())
 			}
 		}
 	}
@@ -367,16 +368,19 @@ type caliInput struct {
 
 func Test_Validate_Calico(t *testing.T) {
 	grid := []struct {
+		Description    string
 		Input          caliInput
 		ExpectedErrors []string
 	}{
 		{
+			Description: "empty specs",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{},
 				Etcd:   kops.EtcdClusterSpec{},
 			},
 		},
 		{
+			Description: "positive Typha replica count",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					TyphaReplicas: 3,
@@ -385,6 +389,7 @@ func Test_Validate_Calico(t *testing.T) {
 			},
 		},
 		{
+			Description: "negative Typha replica count",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					TyphaReplicas: -1,
@@ -394,6 +399,7 @@ func Test_Validate_Calico(t *testing.T) {
 			ExpectedErrors: []string{"Invalid value::calico.typhaReplicas"},
 		},
 		{
+			Description: "with etcd version",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{},
 				Etcd: kops.EtcdClusterSpec{
@@ -402,6 +408,7 @@ func Test_Validate_Calico(t *testing.T) {
 			},
 		},
 		{
+			Description: "IPv4 autodetection method",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "first-found",
@@ -410,6 +417,7 @@ func Test_Validate_Calico(t *testing.T) {
 			},
 		},
 		{
+			Description: "IPv6 autodetection method",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv6AutoDetectionMethod: "first-found",
@@ -418,6 +426,7 @@ func Test_Validate_Calico(t *testing.T) {
 			},
 		},
 		{
+			Description: "IPv4 autodetection method with parameter",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "can-reach=8.8.8.8",
@@ -426,6 +435,7 @@ func Test_Validate_Calico(t *testing.T) {
 			},
 		},
 		{
+			Description: "IPv6 autodetection method with parameter",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv6AutoDetectionMethod: "can-reach=2001:4860:4860::8888",
@@ -434,6 +444,7 @@ func Test_Validate_Calico(t *testing.T) {
 			},
 		},
 		{
+			Description: "invalid IPv4 autodetection method",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "bogus",
@@ -443,6 +454,7 @@ func Test_Validate_Calico(t *testing.T) {
 			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
 		},
 		{
+			Description: "invalid IPv6 autodetection method",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv6AutoDetectionMethod: "bogus",
@@ -452,6 +464,7 @@ func Test_Validate_Calico(t *testing.T) {
 			ExpectedErrors: []string{"Invalid value::calico.ipv6AutoDetectionMethod"},
 		},
 		{
+			Description: "invalid IPv6 autodetection method missing parameter",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv6AutoDetectionMethod: "interface=",
@@ -461,6 +474,7 @@ func Test_Validate_Calico(t *testing.T) {
 			ExpectedErrors: []string{"Invalid value::calico.ipv6AutoDetectionMethod"},
 		},
 		{
+			Description: "IPv4 autodetection method with parameter list",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "interface=en.*,eth0",
@@ -469,6 +483,7 @@ func Test_Validate_Calico(t *testing.T) {
 			},
 		},
 		{
+			Description: "IPv6 autodetection method with parameter list",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv6AutoDetectionMethod: "skip-interface=en.*,eth0",
@@ -477,6 +492,7 @@ func Test_Validate_Calico(t *testing.T) {
 			},
 		},
 		{
+			Description: "invalid IPv4 autodetection method parameter (parenthesis)",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "interface=(,en1",
@@ -486,6 +502,7 @@ func Test_Validate_Calico(t *testing.T) {
 			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
 		},
 		{
+			Description: "invalid IPv4 autodetection method parameter (equals)",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "interface=foo=bar",
@@ -495,6 +512,7 @@ func Test_Validate_Calico(t *testing.T) {
 			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
 		},
 		{
+			Description: "invalid IPv4 autodetection method parameter with no name",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "=en0,eth.*",
@@ -504,6 +522,7 @@ func Test_Validate_Calico(t *testing.T) {
 			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
 		},
 		{
+			Description: "AWS source/destination checks off",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					AWSSrcDstCheck: "off",
@@ -513,6 +532,7 @@ func Test_Validate_Calico(t *testing.T) {
 			ExpectedErrors: []string{"Unsupported value::calico.awsSrcDstCheck"},
 		},
 		{
+			Description: "AWS source/destination checks enabled",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					AWSSrcDstCheck: "Enable",
@@ -521,6 +541,7 @@ func Test_Validate_Calico(t *testing.T) {
 			},
 		},
 		{
+			Description: "AWS source/destination checks disabled",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					AWSSrcDstCheck: "Disable",
@@ -529,6 +550,7 @@ func Test_Validate_Calico(t *testing.T) {
 			},
 		},
 		{
+			Description: "AWS source/destination checks left as is",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
 					AWSSrcDstCheck: "DoNothing",
@@ -536,10 +558,135 @@ func Test_Validate_Calico(t *testing.T) {
 				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
+		{
+			Description: "unknown Calico encapsulation mode",
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					EncapsulationMode: "None",
+				},
+				Etcd: kops.EtcdClusterSpec{},
+			},
+			ExpectedErrors: []string{"Unsupported value::calico.encapsulationMode"},
+		},
+		{
+			Description: "unknown Calico IPIP mode",
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					IPIPMode: "unknown",
+				},
+				Etcd: kops.EtcdClusterSpec{},
+			},
+			ExpectedErrors: []string{"Unsupported value::calico.ipipMode"},
+		},
+		// You can't use per-IPPool IP-in-IP encapsulation unless you're using the "ipip"
+		// encapsulation mode.
+		{
+			Description: "Calico IPIP encapsulation mode (implicit) with IPIP IPPool mode (always)",
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					IPIPMode: "Always",
+				},
+				Etcd: kops.EtcdClusterSpec{},
+			},
+		},
+		{
+			Description: "Calico IPIP encapsulation mode (implicit) with IPIP IPPool mode (cross-subnet)",
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					IPIPMode: "CrossSubnet",
+				},
+				Etcd: kops.EtcdClusterSpec{},
+			},
+		},
+		{
+			Description: "Calico IPIP encapsulation mode (implicit) with IPIP IPPool mode (never)",
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					IPIPMode: "Never",
+				},
+				Etcd: kops.EtcdClusterSpec{},
+			},
+		},
+		{
+			Description: "Calico IPIP encapsulation mode (explicit) with IPIP IPPool mode (always)",
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					EncapsulationMode: "ipip",
+					IPIPMode:          "Always",
+				},
+				Etcd: kops.EtcdClusterSpec{},
+			},
+		},
+		{
+			Description: "Calico IPIP encapsulation mode (explicit) with IPIP IPPool mode (cross-subnet)",
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					EncapsulationMode: "ipip",
+					IPIPMode:          "CrossSubnet",
+				},
+				Etcd: kops.EtcdClusterSpec{},
+			},
+		},
+		{
+			Description: "Calico IPIP encapsulation mode (explicit) with IPIP IPPool mode (never)",
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					EncapsulationMode: "ipip",
+					IPIPMode:          "Never",
+				},
+				Etcd: kops.EtcdClusterSpec{},
+			},
+		},
+		{
+			Description: "Calico VXLAN encapsulation mode with IPIP IPPool mode",
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					EncapsulationMode: "vxlan",
+					IPIPMode:          "Always",
+				},
+				Etcd: kops.EtcdClusterSpec{},
+			},
+			ExpectedErrors: []string{`Forbidden::calico.ipipMode`},
+		},
+		{
+			Description: "Calico VXLAN encapsulation mode with IPIP IPPool mode (always)",
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					EncapsulationMode: "vxlan",
+					IPIPMode:          "Always",
+				},
+				Etcd: kops.EtcdClusterSpec{},
+			},
+			ExpectedErrors: []string{`Forbidden::calico.ipipMode`},
+		},
+		{
+			Description: "Calico VXLAN encapsulation mode with IPIP IPPool mode (cross-subnet)",
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					EncapsulationMode: "vxlan",
+					IPIPMode:          "CrossSubnet",
+				},
+				Etcd: kops.EtcdClusterSpec{},
+			},
+			ExpectedErrors: []string{`Forbidden::calico.ipipMode`},
+		},
+		{
+			Description: "Calico VXLAN encapsulation mode with IPIP IPPool mode (never)",
+			Input: caliInput{
+				Calico: &kops.CalicoNetworkingSpec{
+					EncapsulationMode: "vxlan",
+					IPIPMode:          "Never",
+				},
+				Etcd: kops.EtcdClusterSpec{},
+			},
+		},
 	}
+	rootFieldPath := field.NewPath("calico")
 	for _, g := range grid {
-		errs := validateNetworkingCalico(g.Input.Calico, g.Input.Etcd, field.NewPath("calico"))
-		testErrors(t, g.Input, errs, g.ExpectedErrors)
+		t.Run(g.Description, func(t *testing.T) {
+			errs := validateNetworkingCalico(g.Input.Calico, g.Input.Etcd, rootFieldPath)
+			testErrors(t, g.Input, errs, g.ExpectedErrors)
+		})
 	}
 }
 

--- a/pkg/model/components/BUILD.bazel
+++ b/pkg/model/components/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "apiserver.go",
+        "calico.go",
         "cilium.go",
         "clusterautoscaler.go",
         "containerd.go",

--- a/pkg/model/components/calico.go
+++ b/pkg/model/components/calico.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+import (
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/upup/pkg/fi/loader"
+)
+
+// CalicoOptionsBuilder prepares settings related to the Calico CNI implementation.
+type CalicoOptionsBuilder struct {
+	Context *OptionsContext
+}
+
+var _ loader.OptionsBuilder = &CalicoOptionsBuilder{}
+
+func (b *CalicoOptionsBuilder) BuildOptions(o interface{}) error {
+	clusterSpec := o.(*kops.ClusterSpec)
+	c := clusterSpec.Networking.Calico
+	if c == nil {
+		return nil
+	}
+
+	rebindIfEmpty := func(s *string, replacement string) bool {
+		if *s != "" {
+			return false
+		}
+		*s = replacement
+		return true
+	}
+
+	activeMode := "Always"
+	if c.CrossSubnet {
+		activeMode = "CrossSubnet"
+	}
+	switch c.EncapsulationMode {
+	case "":
+		c.EncapsulationMode = "ipip"
+		fallthrough
+	case "ipip":
+		rebindIfEmpty(&c.IPIPMode, activeMode)
+	case "vxlan":
+		rebindIfEmpty(&c.IPIPMode, "Never")
+	}
+
+	return nil
+}

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -33359,7 +33359,7 @@ data:
   # You must set a non-zero value for Typha replicas below.
   typha_service_name: "{{- if .Networking.Calico.TyphaReplicas -}}calico-typha{{- else -}}none{{- end -}}"
   # Configure the backend to use.
-  calico_backend: "bird"
+  calico_backend: "{{- if eq .Networking.Calico.EncapsulationMode "vxlan" -}}vxlan{{- else -}}bird{{- end -}}"
 
   # Configure the MTU to use for workload interfaces and tunnels.
   # By default, MTU is auto-detected, and explicitly setting this field should not be required.
@@ -37201,10 +37201,10 @@ spec:
               value: "{{- or .Networking.Calico.IPv6AutoDetectionMethod "first-found" }}"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
-              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}CrossSubnet{{- else -}} {{- or .Networking.Calico.IPIPMode "Always" -}} {{- end -}}"
+              value: "{{ CalicoIPv4PoolIPIPMode }}"
             # Enable or Disable VXLAN on the default IP pool.
             - name: CALICO_IPV4POOL_VXLAN
-              value: "Never"
+              value: "{{ CalicoIPv4PoolVXLANMode }}"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:
@@ -37290,7 +37290,9 @@ spec:
               command:
               - /bin/calico-node
               - -felix-live
+              {{- if eq .Networking.Calico.EncapsulationMode "ipip" }}
               - -bird-live
+              {{- end }}
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
@@ -37299,7 +37301,9 @@ spec:
               command:
               - /bin/calico-node
               - -felix-ready
+              {{- if eq .Networking.Calico.EncapsulationMode "ipip" }}
               - -bird-ready
+              {{- end }}
             periodSeconds: 10
           {{- if .Networking.Calico.PrometheusMetricsEnabled }}
           ports:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -28,7 +28,7 @@ data:
   # You must set a non-zero value for Typha replicas below.
   typha_service_name: "{{- if .Networking.Calico.TyphaReplicas -}}calico-typha{{- else -}}none{{- end -}}"
   # Configure the backend to use.
-  calico_backend: "bird"
+  calico_backend: "{{- if eq .Networking.Calico.EncapsulationMode "vxlan" -}}vxlan{{- else -}}bird{{- end -}}"
 
   # Configure the MTU to use for workload interfaces and tunnels.
   # By default, MTU is auto-detected, and explicitly setting this field should not be required.
@@ -3870,10 +3870,10 @@ spec:
               value: "{{- or .Networking.Calico.IPv6AutoDetectionMethod "first-found" }}"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
-              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}CrossSubnet{{- else -}} {{- or .Networking.Calico.IPIPMode "Always" -}} {{- end -}}"
+              value: "{{ CalicoIPv4PoolIPIPMode }}"
             # Enable or Disable VXLAN on the default IP pool.
             - name: CALICO_IPV4POOL_VXLAN
-              value: "Never"
+              value: "{{ CalicoIPv4PoolVXLANMode }}"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:
@@ -3959,7 +3959,9 @@ spec:
               command:
               - /bin/calico-node
               - -felix-live
+              {{- if eq .Networking.Calico.EncapsulationMode "ipip" }}
               - -bird-live
+              {{- end }}
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
@@ -3968,7 +3970,9 @@ spec:
               command:
               - /bin/calico-node
               - -felix-ready
+              {{- if eq .Networking.Calico.EncapsulationMode "ipip" }}
               - -bird-ready
+              {{- end }}
             periodSeconds: 10
           {{- if .Networking.Calico.PrometheusMetricsEnabled }}
           ports:

--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -275,6 +275,7 @@ func (c *populateClusterSpec) run(clientset simple.Clientset) error {
 			codeModels = append(codeModels, &components.KubeControllerManagerOptionsBuilder{OptionsContext: optionsContext})
 			codeModels = append(codeModels, &components.KubeSchedulerOptionsBuilder{OptionsContext: optionsContext})
 			codeModels = append(codeModels, &components.KubeProxyOptionsBuilder{Context: optionsContext})
+			codeModels = append(codeModels, &components.CalicoOptionsBuilder{Context: optionsContext})
 			codeModels = append(codeModels, &components.CiliumOptionsBuilder{Context: optionsContext})
 			codeModels = append(codeModels, &components.OpenStackOptionsBulder{Context: optionsContext})
 			codeModels = append(codeModels, &components.DiscoveryOptionsBuilder{OptionsContext: optionsContext})

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -143,6 +143,45 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 		}
 	}
 
+	if cluster.Spec.Networking != nil && cluster.Spec.Networking.Calico != nil {
+		c := cluster.Spec.Networking.Calico
+		dest["CalicoIPv4PoolIPIPMode"] = func() string {
+			if c.EncapsulationMode != "ipip" {
+				return "Never"
+			}
+			if c.IPIPMode != "" {
+				return c.IPIPMode
+			}
+			if c.CrossSubnet {
+				return "CrossSubnet"
+			}
+			return "Always"
+		}
+		dest["CalicoIPv4PoolVXLANMode"] = func() string {
+			if c.EncapsulationMode != "vxlan" {
+				return "Never"
+			}
+			if c.CrossSubnet {
+				return "CrossSubnet"
+			}
+			return "Always"
+		}
+	}
+
+	if cluster.Spec.Networking != nil && cluster.Spec.Networking.Cilium != nil {
+		ciliumsecretString := ""
+		ciliumsecret, _ := secretStore.Secret("ciliumpassword")
+		if ciliumsecret != nil {
+			ciliumsecretString, err = ciliumsecret.AsString()
+			if err != nil {
+				return err
+			}
+			klog.V(4).Info("Cilium secret function successfully registered")
+		}
+
+		dest["CiliumSecret"] = func() string { return ciliumsecretString }
+	}
+
 	if cluster.Spec.Networking != nil && cluster.Spec.Networking.Flannel != nil {
 		flannelBackendType := cluster.Spec.Networking.Flannel.Backend
 		if flannelBackendType == "" {
@@ -164,20 +203,6 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 		}
 
 		dest["WeaveSecret"] = func() string { return weavesecretString }
-	}
-
-	if cluster.Spec.Networking != nil && cluster.Spec.Networking.Cilium != nil {
-		ciliumsecretString := ""
-		ciliumsecret, _ := secretStore.Secret("ciliumpassword")
-		if ciliumsecret != nil {
-			ciliumsecretString, err = ciliumsecret.AsString()
-			if err != nil {
-				return err
-			}
-			klog.V(4).Info("Cilium secret function successfully registered")
-		}
-
-		dest["CiliumSecret"] = func() string { return ciliumsecretString }
 	}
 
 	return nil


### PR DESCRIPTION
Introduce a new "encapsulationMode" field in Calico's portion of the _Cluster_ specification to allow switching between the the IP-in-IP and VXLAN encapsulation protocols. For now, we accept the values "ipip" and "vxlan," and forgo a possible "none" value that would disable encapsulation altogether (at least for the default Calico IP pool).

Augment the default-populating procedure for Calico to take this field into account when deciding both which networking backend to use and whether to use IP-in-IP or VXLAN encapsulation for the default IP pool. Note that these values supplied for [the "CALICO_IPV4POOL_IPIP" and "CALICO_IPV4POOL_VXLAN" environment variables](https://docs.projectcalico.org/reference/node/configuration#configuring-the-default-ip-pools) in the "calico-node" _DaemonSet_ pod spec only matter for creating the "default" _IPPool_ pool object when no such objects already exist.

Generalize the documentation for the "crossSubnet" field to cover environments more broad than just AWS, as Calico can employ this selective encapsulation in any environment in which it can detect boundaries between subnets.

Fixes #10168.