### PR TITLE
Update Calico to v3.17.1

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2858,12 +2858,12 @@ spec:
                       networking
                     properties:
                       awsSrcDstCheck:
-                        description: 'AwsSrcDstCheck enables/disables source/destination
-                          checks (AWS only) Options: "DoNothing" (default) , "Enable"
-                          or "Disable"'
+                        description: 'AWSSrcDstCheck enables/disables ENI source/destination
+                          checks (AWS only) Options: DoNothing (default), Enable,
+                          or Disable'
                         type: string
                       bpfEnabled:
-                        description: BpfEnabled enables the eBPF dataplane mode.
+                        description: BPFEnabled enables the eBPF dataplane mode.
                         type: boolean
                       bpfExternalServiceMode:
                         description: 'BPFExternalServiceMode controls how traffic
@@ -2907,7 +2907,11 @@ spec:
                           when set to true
                         type: boolean
                       ipipMode:
-                        description: IPIPMode is mode for CALICO_IPV4POOL_IPIP
+                        description: IPIPMode is the encapsulation mode to use for
+                          the default Calico IPv4 pool created at start up, determining
+                          when to use IP-in-IP encapsulation, conveyed to the "calico-node"
+                          daemon container via the CALICO_IPV4POOL_IPIP environment
+                          variable
                         type: string
                       iptablesBackend:
                         description: 'IptablesBackend controls which variant of iptables

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -108,7 +108,10 @@ type CalicoNetworkingSpec struct {
 	// Version overrides the Calico container image tag.
 	Version string `json:"version,omitempty"`
 
-	// BpfEnabled enables the eBPF dataplane mode.
+	// AWSSrcDstCheck enables/disables ENI source/destination checks (AWS only)
+	// Options: DoNothing (default), Enable, or Disable
+	AWSSrcDstCheck string `json:"awsSrcDstCheck,omitempty"`
+	// BPFEnabled enables the eBPF dataplane mode.
 	BPFEnabled bool `json:"bpfEnabled,omitempty"`
 	// BPFExternalServiceMode controls how traffic from outside the cluster to NodePorts and ClusterIPs is handled.
 	// In Tunnel mode, packet is tunneled from the ingress host to the host with the backing pod and back again.
@@ -131,9 +134,25 @@ type CalicoNetworkingSpec struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// CrossSubnet enables Calico's cross-subnet mode when set to true
 	CrossSubnet bool `json:"crossSubnet,omitempty"`
-	// AwsSrcDstCheck enables/disables source/destination checks (AWS only)
-	// Options: "DoNothing" (default) , "Enable" or "Disable"
-	AwsSrcDstCheck string `json:"awsSrcDstCheck,omitempty"`
+	// IPIPMode is the encapsulation mode to use for the default Calico IPv4 pool created at start
+	// up, determining when to use IP-in-IP encapsulation, conveyed to the "calico-node" daemon
+	// container via the CALICO_IPV4POOL_IPIP environment variable
+	IPIPMode string `json:"ipipMode,omitempty"`
+	// IPv4AutoDetectionMethod configures how Calico chooses the IP address used to route
+	// between nodes.  This should be set when the host has multiple interfaces
+	// and it is important to select the interface used.
+	// Options: "first-found" (default), "can-reach=DESTINATION",
+	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
+	IPv4AutoDetectionMethod string `json:"ipv4AutoDetectionMethod,omitempty"`
+	// IPv6AutoDetectionMethod configures how Calico chooses the IP address used to route
+	// between nodes.  This should be set when the host has multiple interfaces
+	// and it is important to select the interface used.
+	// Options: "first-found" (default), "can-reach=DESTINATION",
+	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
+	IPv6AutoDetectionMethod string `json:"ipv6AutoDetectionMethod,omitempty"`
+	// IptablesBackend controls which variant of iptables binary Felix uses
+	// Default: Auto (other options: Legacy, NFT)
+	IptablesBackend string `json:"iptablesBackend,omitempty"`
 	// LogSeverityScreen lets us set the desired log level. (Default: info)
 	LogSeverityScreen string `json:"logSeverityScreen,omitempty"`
 	// MTU to be set in the cni-network-config for calico.
@@ -150,23 +169,6 @@ type CalicoNetworkingSpec struct {
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 	// MajorVersion is deprecated as of kOps 1.20 and has no effect
 	MajorVersion string `json:"majorVersion,omitempty"`
-	// IPv4AutoDetectionMethod configures how Calico chooses the IP address used to route
-	// between nodes.  This should be set when the host has multiple interfaces
-	// and it is important to select the interface used.
-	// Options: "first-found" (default), "can-reach=DESTINATION",
-	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
-	IPv4AutoDetectionMethod string `json:"ipv4AutoDetectionMethod,omitempty"`
-	// IPv6AutoDetectionMethod configures how Calico chooses the IP address used to route
-	// between nodes.  This should be set when the host has multiple interfaces
-	// and it is important to select the interface used.
-	// Options: "first-found" (default), "can-reach=DESTINATION",
-	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
-	IPv6AutoDetectionMethod string `json:"ipv6AutoDetectionMethod,omitempty"`
-	// IptablesBackend controls which variant of iptables binary Felix uses
-	// Default: Auto (other options: Legacy, NFT)
-	IptablesBackend string `json:"iptablesBackend,omitempty"`
-	// IPIPMode is mode for CALICO_IPV4POOL_IPIP
-	IPIPMode string `json:"ipipMode,omitempty"`
 	// TyphaPrometheusMetricsEnabled enables Prometheus metrics collection from Typha
 	// (default: false)
 	TyphaPrometheusMetricsEnabled bool `json:"typhaPrometheusMetricsEnabled,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -108,7 +108,10 @@ type CalicoNetworkingSpec struct {
 	// Version overrides the Calico container image tag.
 	Version string `json:"version,omitempty"`
 
-	// BpfEnabled enables the eBPF dataplane mode.
+	// AWSSrcDstCheck enables/disables ENI source/destination checks (AWS only)
+	// Options: DoNothing (default), Enable, or Disable
+	AWSSrcDstCheck string `json:"awsSrcDstCheck,omitempty"`
+	// BPFEnabled enables the eBPF dataplane mode.
 	BPFEnabled bool `json:"bpfEnabled,omitempty"`
 	// BPFExternalServiceMode controls how traffic from outside the cluster to NodePorts and ClusterIPs is handled.
 	// In Tunnel mode, packet is tunneled from the ingress host to the host with the backing pod and back again.
@@ -131,9 +134,25 @@ type CalicoNetworkingSpec struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// CrossSubnet enables Calico's cross-subnet mode when set to true
 	CrossSubnet bool `json:"crossSubnet,omitempty"`
-	// AwsSrcDstCheck enables/disables source/destination checks (AWS only)
-	// Options: "DoNothing" (default) , "Enable" or "Disable"
-	AwsSrcDstCheck string `json:"awsSrcDstCheck,omitempty"`
+	// IPIPMode is the encapsulation mode to use for the default Calico IPv4 pool created at start
+	// up, determining when to use IP-in-IP encapsulation, conveyed to the "calico-node" daemon
+	// container via the CALICO_IPV4POOL_IPIP environment variable
+	IPIPMode string `json:"ipipMode,omitempty"`
+	// IPv4AutoDetectionMethod configures how Calico chooses the IP address used to route
+	// between nodes.  This should be set when the host has multiple interfaces
+	// and it is important to select the interface used.
+	// Options: "first-found" (default), "can-reach=DESTINATION",
+	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
+	IPv4AutoDetectionMethod string `json:"ipv4AutoDetectionMethod,omitempty"`
+	// IPv6AutoDetectionMethod configures how Calico chooses the IP address used to route
+	// between nodes.  This should be set when the host has multiple interfaces
+	// and it is important to select the interface used.
+	// Options: "first-found" (default), "can-reach=DESTINATION",
+	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
+	IPv6AutoDetectionMethod string `json:"ipv6AutoDetectionMethod,omitempty"`
+	// IptablesBackend controls which variant of iptables binary Felix uses
+	// Default: Auto (other options: Legacy, NFT)
+	IptablesBackend string `json:"iptablesBackend,omitempty"`
 	// LogSeverityScreen lets us set the desired log level. (Default: info)
 	LogSeverityScreen string `json:"logSeverityScreen,omitempty"`
 	// MTU to be set in the cni-network-config for calico.
@@ -150,23 +169,6 @@ type CalicoNetworkingSpec struct {
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 	// MajorVersion is deprecated as of kOps 1.20 and has no effect
 	MajorVersion string `json:"majorVersion,omitempty"`
-	// IptablesBackend controls which variant of iptables binary Felix uses
-	// Default: Auto (other options: Legacy, NFT)
-	IptablesBackend string `json:"iptablesBackend,omitempty"`
-	// IPIPMode is mode for CALICO_IPV4POOL_IPIP
-	IPIPMode string `json:"ipipMode,omitempty"`
-	// IPv4AutoDetectionMethod configures how Calico chooses the IP address used to route
-	// between nodes.  This should be set when the host has multiple interfaces
-	// and it is important to select the interface used.
-	// Options: "first-found" (default), "can-reach=DESTINATION",
-	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
-	IPv4AutoDetectionMethod string `json:"ipv4AutoDetectionMethod,omitempty"`
-	// IPv6AutoDetectionMethod configures how Calico chooses the IP address used to route
-	// between nodes.  This should be set when the host has multiple interfaces
-	// and it is important to select the interface used.
-	// Options: "first-found" (default), "can-reach=DESTINATION",
-	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
-	IPv6AutoDetectionMethod string `json:"ipv6AutoDetectionMethod,omitempty"`
 	// TyphaPrometheusMetricsEnabled enables Prometheus metrics collection from Typha
 	// (default: false)
 	TyphaPrometheusMetricsEnabled bool `json:"typhaPrometheusMetricsEnabled,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1347,6 +1347,7 @@ func Convert_kops_CNINetworkingSpec_To_v1alpha2_CNINetworkingSpec(in *kops.CNINe
 func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *CalicoNetworkingSpec, out *kops.CalicoNetworkingSpec, s conversion.Scope) error {
 	out.Registry = in.Registry
 	out.Version = in.Version
+	out.AWSSrcDstCheck = in.AWSSrcDstCheck
 	out.BPFEnabled = in.BPFEnabled
 	out.BPFExternalServiceMode = in.BPFExternalServiceMode
 	out.BPFKubeProxyIptablesCleanupEnabled = in.BPFKubeProxyIptablesCleanupEnabled
@@ -1354,7 +1355,10 @@ func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.ChainInsertMode = in.ChainInsertMode
 	out.CPURequest = in.CPURequest
 	out.CrossSubnet = in.CrossSubnet
-	out.AwsSrcDstCheck = in.AwsSrcDstCheck
+	out.IPIPMode = in.IPIPMode
+	out.IPv4AutoDetectionMethod = in.IPv4AutoDetectionMethod
+	out.IPv6AutoDetectionMethod = in.IPv6AutoDetectionMethod
+	out.IptablesBackend = in.IptablesBackend
 	out.LogSeverityScreen = in.LogSeverityScreen
 	out.MTU = in.MTU
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
@@ -1362,10 +1366,6 @@ func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	out.MajorVersion = in.MajorVersion
-	out.IptablesBackend = in.IptablesBackend
-	out.IPIPMode = in.IPIPMode
-	out.IPv4AutoDetectionMethod = in.IPv4AutoDetectionMethod
-	out.IPv6AutoDetectionMethod = in.IPv6AutoDetectionMethod
 	out.TyphaPrometheusMetricsEnabled = in.TyphaPrometheusMetricsEnabled
 	out.TyphaPrometheusMetricsPort = in.TyphaPrometheusMetricsPort
 	out.TyphaReplicas = in.TyphaReplicas
@@ -1381,6 +1381,7 @@ func Convert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *Cali
 func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *kops.CalicoNetworkingSpec, out *CalicoNetworkingSpec, s conversion.Scope) error {
 	out.Registry = in.Registry
 	out.Version = in.Version
+	out.AWSSrcDstCheck = in.AWSSrcDstCheck
 	out.BPFEnabled = in.BPFEnabled
 	out.BPFExternalServiceMode = in.BPFExternalServiceMode
 	out.BPFKubeProxyIptablesCleanupEnabled = in.BPFKubeProxyIptablesCleanupEnabled
@@ -1388,7 +1389,10 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *
 	out.ChainInsertMode = in.ChainInsertMode
 	out.CPURequest = in.CPURequest
 	out.CrossSubnet = in.CrossSubnet
-	out.AwsSrcDstCheck = in.AwsSrcDstCheck
+	out.IPIPMode = in.IPIPMode
+	out.IPv4AutoDetectionMethod = in.IPv4AutoDetectionMethod
+	out.IPv6AutoDetectionMethod = in.IPv6AutoDetectionMethod
+	out.IptablesBackend = in.IptablesBackend
 	out.LogSeverityScreen = in.LogSeverityScreen
 	out.MTU = in.MTU
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
@@ -1396,10 +1400,6 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	out.MajorVersion = in.MajorVersion
-	out.IPv4AutoDetectionMethod = in.IPv4AutoDetectionMethod
-	out.IPv6AutoDetectionMethod = in.IPv6AutoDetectionMethod
-	out.IptablesBackend = in.IptablesBackend
-	out.IPIPMode = in.IPIPMode
 	out.TyphaPrometheusMetricsEnabled = in.TyphaPrometheusMetricsEnabled
 	out.TyphaPrometheusMetricsPort = in.TyphaPrometheusMetricsPort
 	out.TyphaReplicas = in.TyphaReplicas

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -969,15 +969,9 @@ func validateEtcdMemberSpec(spec kops.EtcdMemberSpec, fieldPath *field.Path) fie
 func validateNetworkingCalico(v *kops.CalicoNetworkingSpec, e kops.EtcdClusterSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if v.TyphaReplicas < 0 {
-		allErrs = append(allErrs,
-			field.Invalid(fldPath.Child("typhaReplicas"), v.TyphaReplicas,
-				fmt.Sprintf("Unable to set number of Typha replicas to less than 0, you've specified %d", v.TyphaReplicas)))
-	}
-
-	if v.AwsSrcDstCheck != "" {
+	if v.AWSSrcDstCheck != "" {
 		valid := []string{"Enable", "Disable", "DoNothing"}
-		allErrs = append(allErrs, IsValidValue(fldPath.Child("awsSrcDstCheck"), &v.AwsSrcDstCheck, valid)...)
+		allErrs = append(allErrs, IsValidValue(fldPath.Child("awsSrcDstCheck"), &v.AWSSrcDstCheck, valid)...)
 	}
 
 	if v.BPFExternalServiceMode != "" {
@@ -995,17 +989,23 @@ func validateNetworkingCalico(v *kops.CalicoNetworkingSpec, e kops.EtcdClusterSp
 		allErrs = append(allErrs, IsValidValue(fldPath.Child("chainInsertMode"), &v.ChainInsertMode, valid)...)
 	}
 
-	if v.IptablesBackend != "" {
-		valid := []string{"Auto", "Legacy", "NFT"}
-		allErrs = append(allErrs, IsValidValue(fldPath.Child("iptablesBackend"), &v.IptablesBackend, valid)...)
-	}
-
 	if v.IPv4AutoDetectionMethod != "" {
 		allErrs = append(allErrs, validateCalicoAutoDetectionMethod(fldPath.Child("ipv4AutoDetectionMethod"), v.IPv4AutoDetectionMethod, ipv4.Version)...)
 	}
 
 	if v.IPv6AutoDetectionMethod != "" {
 		allErrs = append(allErrs, validateCalicoAutoDetectionMethod(fldPath.Child("ipv6AutoDetectionMethod"), v.IPv6AutoDetectionMethod, ipv6.Version)...)
+	}
+
+	if v.IptablesBackend != "" {
+		valid := []string{"Auto", "Legacy", "NFT"}
+		allErrs = append(allErrs, IsValidValue(fldPath.Child("iptablesBackend"), &v.IptablesBackend, valid)...)
+	}
+
+	if v.TyphaReplicas < 0 {
+		allErrs = append(allErrs,
+			field.Invalid(fldPath.Child("typhaReplicas"), v.TyphaReplicas,
+				fmt.Sprintf("Unable to set number of Typha replicas to less than 0, you've specified %d", v.TyphaReplicas)))
 	}
 
 	return allErrs

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -506,7 +506,7 @@ func Test_Validate_Calico(t *testing.T) {
 		{
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
-					AwsSrcDstCheck: "off",
+					AWSSrcDstCheck: "off",
 				},
 				Etcd: kops.EtcdClusterSpec{},
 			},
@@ -515,7 +515,7 @@ func Test_Validate_Calico(t *testing.T) {
 		{
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
-					AwsSrcDstCheck: "Enable",
+					AWSSrcDstCheck: "Enable",
 				},
 				Etcd: kops.EtcdClusterSpec{},
 			},
@@ -523,7 +523,7 @@ func Test_Validate_Calico(t *testing.T) {
 		{
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
-					AwsSrcDstCheck: "Disable",
+					AWSSrcDstCheck: "Disable",
 				},
 				Etcd: kops.EtcdClusterSpec{},
 			},
@@ -531,7 +531,7 @@ func Test_Validate_Calico(t *testing.T) {
 		{
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
-					AwsSrcDstCheck: "DoNothing",
+					AWSSrcDstCheck: "DoNothing",
 				},
 				Etcd: kops.EtcdClusterSpec{},
 			},

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -280,7 +280,7 @@ func (r *NodeRoleMaster) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 		addCiliumEniPermissions(p, resource, b.Cluster.Spec.IAM.Legacy)
 	}
 
-	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.Calico != nil && (b.Cluster.Spec.Networking.Calico.CrossSubnet || b.Cluster.Spec.Networking.Calico.AwsSrcDstCheck != "") {
+	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.Calico != nil && (b.Cluster.Spec.Networking.Calico.CrossSubnet || b.Cluster.Spec.Networking.Calico.AWSSrcDstCheck != "") {
 		addCalicoSrcDstCheckPermissions(p)
 	}
 
@@ -319,7 +319,7 @@ func (r *NodeRoleNode) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 		addLyftVPCPermissions(p, resource, b.Cluster.Spec.IAM.Legacy, b.Cluster.GetName())
 	}
 
-	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.Calico != nil && (b.Cluster.Spec.Networking.Calico.CrossSubnet || b.Cluster.Spec.Networking.Calico.AwsSrcDstCheck != "") {
+	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.Calico != nil && (b.Cluster.Spec.Networking.Calico.CrossSubnet || b.Cluster.Spec.Networking.Calico.AWSSrcDstCheck != "") {
 		addCalicoSrcDstCheckPermissions(p)
 	}
 

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -37240,7 +37240,7 @@ spec:
             # kops additions
             # Enable source/destination checks for AWS
             - name: FELIX_AWSSRCDSTCHECK
-              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}Disable{{- else -}} {{- or .Networking.Calico.AwsSrcDstCheck "DoNothing" -}} {{- end -}}"
+              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}Disable{{- else -}} {{- or .Networking.Calico.AWSSrcDstCheck "DoNothing" -}} {{- end -}}"
             # Enable eBPF dataplane mode
             - name: FELIX_BPFENABLED
               value: "{{ .Networking.Calico.BPFEnabled }}"

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -36955,7 +36955,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.17.0" }}
+      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.17.1" }}
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -37072,7 +37072,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.1" }}
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -37099,7 +37099,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.1" }}
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -37140,7 +37140,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/pod2daemon-flexvol:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/pod2daemon-flexvol:{{ or .Networking.Calico.Version "v3.17.1" }}
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -37151,7 +37151,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.17.1" }}
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -37415,7 +37415,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.17.1" }}
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3910,7 +3910,7 @@ spec:
             # kops additions
             # Enable source/destination checks for AWS
             - name: FELIX_AWSSRCDSTCHECK
-              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}Disable{{- else -}} {{- or .Networking.Calico.AwsSrcDstCheck "DoNothing" -}} {{- end -}}"
+              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}Disable{{- else -}} {{- or .Networking.Calico.AWSSrcDstCheck "DoNothing" -}} {{- end -}}"
             # Enable eBPF dataplane mode
             - name: FELIX_BPFENABLED
               value: "{{ .Networking.Calico.BPFEnabled }}"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3625,7 +3625,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.17.0" }}
+      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.17.1" }}
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -3742,7 +3742,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.1" }}
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -3769,7 +3769,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.1" }}
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -3810,7 +3810,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/pod2daemon-flexvol:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/pod2daemon-flexvol:{{ or .Networking.Calico.Version "v3.17.1" }}
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -3821,7 +3821,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.17.1" }}
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4085,7 +4085,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.17.1" }}
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -732,7 +732,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 		key := "networking.projectcalico.org"
 		versions := map[string]string{
 			"k8s-1.12": "3.9.6-kops.1",
-			"k8s-1.16": "3.17.0-kops.1",
+			"k8s-1.16": "3.17.1-kops.1",
 		}
 
 		{


### PR DESCRIPTION
https://docs.projectcalico.org/release-notes/#v3171
This also orders the fields in CalicoNetworkingSpec and updates the comments to make changes in https://github.com/kubernetes/kops/pull/10404 smaller.

Fixes: https://github.com/kubernetes/kops/issues/10363