### PR TITLE
hack/goimports - Replace mapfile with read

### DIFF
--- a/hack/update-goimports.sh
+++ b/hack/update-goimports.sh
@@ -26,6 +26,6 @@ go build -o "${TOOLS_BIN}/goimports" golang.org/x/tools/cmd/goimports
 
 cd "${KOPS_ROOT}" || exit 1
 
-mapfile -t files < <(find . -type f -name '*.go' -not -path "./vendor/*")
+IFS=$'\n' read -r -d '' -a files < <( find . -type f -name '*.go' -not -path "./vendor/*" && printf '\0' )
 
 "${TOOLS_BIN}/goimports" -w "${files[@]}"

--- a/hack/verify-goimports.sh
+++ b/hack/verify-goimports.sh
@@ -26,7 +26,7 @@ go build -o "${TOOLS_BIN}/goimports" golang.org/x/tools/cmd/goimports
 
 cd "${KOPS_ROOT}" || exit 1
 
-mapfile -t files < <(find . -type f -name '*.go' -not -path "./vendor/*")
+IFS=$'\n' read -r -d '' -a files < <( find . -type f -name '*.go' -not -path "./vendor/*" && printf '\0' )
 
 output=$("${TOOLS_BIN}/goimports" -l "${files[@]}")
 


### PR DESCRIPTION
`mapfile` was introduced in bash 4.

We can use `read` instead to achieve the same thing - listing all .go files in the repo into an array


followup to https://github.com/kubernetes/kops/pull/10407

/cc @seh 