### PR TITLE
Automated cherry pick of #10316: Allow override of registry and tag for Calico images #10408: Update Calico to v3.17.1

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2177,10 +2177,10 @@ spec:
                     description: CalicoNetworkingSpec declares that we want Calico networking
                     properties:
                       awsSrcDstCheck:
-                        description: 'AwsSrcDstCheck enables/disables source/destination checks (AWS only) Options: "DoNothing" (default) , "Enable" or "Disable"'
+                        description: 'AWSSrcDstCheck enables/disables ENI source/destination checks (AWS only) Options: DoNothing (default), Enable, or Disable'
                         type: string
                       bpfEnabled:
-                        description: BpfEnabled enables the eBPF dataplane mode.
+                        description: BPFEnabled enables the eBPF dataplane mode.
                         type: boolean
                       bpfExternalServiceMode:
                         description: 'BPFExternalServiceMode controls how traffic from outside the cluster to NodePorts and ClusterIPs is handled. In Tunnel mode, packet is tunneled from the ingress host to the host with the backing pod and back again. In DSR mode, traffic is tunneled to the host with the backing pod and then returned directly; this requires a network that allows direct return. Default: Tunnel (other options: DSR)'
@@ -2205,7 +2205,7 @@ spec:
                         description: CrossSubnet enables Calico's cross-subnet mode when set to true
                         type: boolean
                       ipipMode:
-                        description: IPIPMode is mode for CALICO_IPV4POOL_IPIP
+                        description: IPIPMode is the encapsulation mode to use for the default Calico IPv4 pool created at start up, determining when to use IP-in-IP encapsulation, conveyed to the "calico-node" daemon container via the CALICO_IPV4POOL_IPIP environment variable
                         type: string
                       iptablesBackend:
                         description: 'IptablesBackend controls which variant of iptables binary Felix uses Default: Auto (other options: Legacy, NFT)'
@@ -2240,8 +2240,7 @@ spec:
                         description: PrometheusProcessMetricsEnabled enables Prometheus process metrics collection
                         type: boolean
                       registry:
-                        description: Version overrides the Calico container image
-                          registry.
+                        description: Version overrides the Calico container image registry.
                         type: string
                       typhaPrometheusMetricsEnabled:
                         description: 'TyphaPrometheusMetricsEnabled enables Prometheus metrics collection from Typha (default: false)'
@@ -2255,8 +2254,7 @@ spec:
                         format: int32
                         type: integer
                       version:
-                        description: Version overrides the Calico container image
-                          tag.
+                        description: Version overrides the Calico container image tag.
                         type: string
                       wireguardEnabled:
                         description: 'WireguardEnabled enables WireGuard encryption for all on-the-wire pod-to-pod traffic (default: false)'

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2239,6 +2239,10 @@ spec:
                       prometheusProcessMetricsEnabled:
                         description: PrometheusProcessMetricsEnabled enables Prometheus process metrics collection
                         type: boolean
+                      registry:
+                        description: Version overrides the Calico container image
+                          registry.
+                        type: string
                       typhaPrometheusMetricsEnabled:
                         description: 'TyphaPrometheusMetricsEnabled enables Prometheus metrics collection from Typha (default: false)'
                         type: boolean
@@ -2250,6 +2254,10 @@ spec:
                         description: TyphaReplicas is the number of replicas of Typha to deploy
                         format: int32
                         type: integer
+                      version:
+                        description: Version overrides the Calico container image
+                          tag.
+                        type: string
                       wireguardEnabled:
                         description: 'WireguardEnabled enables WireGuard encryption for all on-the-wire pod-to-pod traffic (default: false)'
                         type: boolean

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -108,7 +108,10 @@ type CalicoNetworkingSpec struct {
 	// Version overrides the Calico container image tag.
 	Version string `json:"version,omitempty"`
 
-	// BpfEnabled enables the eBPF dataplane mode.
+	// AWSSrcDstCheck enables/disables ENI source/destination checks (AWS only)
+	// Options: DoNothing (default), Enable, or Disable
+	AWSSrcDstCheck string `json:"awsSrcDstCheck,omitempty"`
+	// BPFEnabled enables the eBPF dataplane mode.
 	BPFEnabled bool `json:"bpfEnabled,omitempty"`
 	// BPFExternalServiceMode controls how traffic from outside the cluster to NodePorts and ClusterIPs is handled.
 	// In Tunnel mode, packet is tunneled from the ingress host to the host with the backing pod and back again.
@@ -131,9 +134,25 @@ type CalicoNetworkingSpec struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// CrossSubnet enables Calico's cross-subnet mode when set to true
 	CrossSubnet bool `json:"crossSubnet,omitempty"`
-	// AwsSrcDstCheck enables/disables source/destination checks (AWS only)
-	// Options: "DoNothing" (default) , "Enable" or "Disable"
-	AwsSrcDstCheck string `json:"awsSrcDstCheck,omitempty"`
+	// IPIPMode is the encapsulation mode to use for the default Calico IPv4 pool created at start
+	// up, determining when to use IP-in-IP encapsulation, conveyed to the "calico-node" daemon
+	// container via the CALICO_IPV4POOL_IPIP environment variable
+	IPIPMode string `json:"ipipMode,omitempty"`
+	// IPv4AutoDetectionMethod configures how Calico chooses the IP address used to route
+	// between nodes.  This should be set when the host has multiple interfaces
+	// and it is important to select the interface used.
+	// Options: "first-found" (default), "can-reach=DESTINATION",
+	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
+	IPv4AutoDetectionMethod string `json:"ipv4AutoDetectionMethod,omitempty"`
+	// IPv6AutoDetectionMethod configures how Calico chooses the IP address used to route
+	// between nodes.  This should be set when the host has multiple interfaces
+	// and it is important to select the interface used.
+	// Options: "first-found" (default), "can-reach=DESTINATION",
+	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
+	IPv6AutoDetectionMethod string `json:"ipv6AutoDetectionMethod,omitempty"`
+	// IptablesBackend controls which variant of iptables binary Felix uses
+	// Default: Auto (other options: Legacy, NFT)
+	IptablesBackend string `json:"iptablesBackend,omitempty"`
 	// LogSeverityScreen lets us set the desired log level. (Default: info)
 	LogSeverityScreen string `json:"logSeverityScreen,omitempty"`
 	// MTU to be set in the cni-network-config for calico.
@@ -150,23 +169,6 @@ type CalicoNetworkingSpec struct {
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 	// MajorVersion is the version of Calico to use
 	MajorVersion string `json:"majorVersion,omitempty"`
-	// IPv4AutoDetectionMethod configures how Calico chooses the IP address used to route
-	// between nodes.  This should be set when the host has multiple interfaces
-	// and it is important to select the interface used.
-	// Options: "first-found" (default), "can-reach=DESTINATION",
-	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
-	IPv4AutoDetectionMethod string `json:"ipv4AutoDetectionMethod,omitempty"`
-	// IPv6AutoDetectionMethod configures how Calico chooses the IP address used to route
-	// between nodes.  This should be set when the host has multiple interfaces
-	// and it is important to select the interface used.
-	// Options: "first-found" (default), "can-reach=DESTINATION",
-	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
-	IPv6AutoDetectionMethod string `json:"ipv6AutoDetectionMethod,omitempty"`
-	// IptablesBackend controls which variant of iptables binary Felix uses
-	// Default: Auto (other options: Legacy, NFT)
-	IptablesBackend string `json:"iptablesBackend,omitempty"`
-	// IPIPMode is mode for CALICO_IPV4POOL_IPIP
-	IPIPMode string `json:"ipipMode,omitempty"`
 	// TyphaPrometheusMetricsEnabled enables Prometheus metrics collection from Typha
 	// (default: false)
 	TyphaPrometheusMetricsEnabled bool `json:"typhaPrometheusMetricsEnabled,omitempty"`

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -103,6 +103,11 @@ type FlannelNetworkingSpec struct {
 
 // CalicoNetworkingSpec declares that we want Calico networking
 type CalicoNetworkingSpec struct {
+	// Version overrides the Calico container image registry.
+	Registry string `json:"registry,omitempty"`
+	// Version overrides the Calico container image tag.
+	Version string `json:"version,omitempty"`
+
 	// BpfEnabled enables the eBPF dataplane mode.
 	BPFEnabled bool `json:"bpfEnabled,omitempty"`
 	// BPFExternalServiceMode controls how traffic from outside the cluster to NodePorts and ClusterIPs is handled.

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -108,7 +108,10 @@ type CalicoNetworkingSpec struct {
 	// Version overrides the Calico container image tag.
 	Version string `json:"version,omitempty"`
 
-	// BpfEnabled enables the eBPF dataplane mode.
+	// AWSSrcDstCheck enables/disables ENI source/destination checks (AWS only)
+	// Options: DoNothing (default), Enable, or Disable
+	AWSSrcDstCheck string `json:"awsSrcDstCheck,omitempty"`
+	// BPFEnabled enables the eBPF dataplane mode.
 	BPFEnabled bool `json:"bpfEnabled,omitempty"`
 	// BPFExternalServiceMode controls how traffic from outside the cluster to NodePorts and ClusterIPs is handled.
 	// In Tunnel mode, packet is tunneled from the ingress host to the host with the backing pod and back again.
@@ -131,9 +134,25 @@ type CalicoNetworkingSpec struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// CrossSubnet enables Calico's cross-subnet mode when set to true
 	CrossSubnet bool `json:"crossSubnet,omitempty"`
-	// AwsSrcDstCheck enables/disables source/destination checks (AWS only)
-	// Options: "DoNothing" (default) , "Enable" or "Disable"
-	AwsSrcDstCheck string `json:"awsSrcDstCheck,omitempty"`
+	// IPIPMode is the encapsulation mode to use for the default Calico IPv4 pool created at start
+	// up, determining when to use IP-in-IP encapsulation, conveyed to the "calico-node" daemon
+	// container via the CALICO_IPV4POOL_IPIP environment variable
+	IPIPMode string `json:"ipipMode,omitempty"`
+	// IPv4AutoDetectionMethod configures how Calico chooses the IP address used to route
+	// between nodes.  This should be set when the host has multiple interfaces
+	// and it is important to select the interface used.
+	// Options: "first-found" (default), "can-reach=DESTINATION",
+	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
+	IPv4AutoDetectionMethod string `json:"ipv4AutoDetectionMethod,omitempty"`
+	// IPv6AutoDetectionMethod configures how Calico chooses the IP address used to route
+	// between nodes.  This should be set when the host has multiple interfaces
+	// and it is important to select the interface used.
+	// Options: "first-found" (default), "can-reach=DESTINATION",
+	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
+	IPv6AutoDetectionMethod string `json:"ipv6AutoDetectionMethod,omitempty"`
+	// IptablesBackend controls which variant of iptables binary Felix uses
+	// Default: Auto (other options: Legacy, NFT)
+	IptablesBackend string `json:"iptablesBackend,omitempty"`
 	// LogSeverityScreen lets us set the desired log level. (Default: info)
 	LogSeverityScreen string `json:"logSeverityScreen,omitempty"`
 	// MTU to be set in the cni-network-config for calico.
@@ -150,23 +169,6 @@ type CalicoNetworkingSpec struct {
 	PrometheusProcessMetricsEnabled bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 	// MajorVersion is the version of Calico to use
 	MajorVersion string `json:"majorVersion,omitempty"`
-	// IptablesBackend controls which variant of iptables binary Felix uses
-	// Default: Auto (other options: Legacy, NFT)
-	IptablesBackend string `json:"iptablesBackend,omitempty"`
-	// IPIPMode is mode for CALICO_IPV4POOL_IPIP
-	IPIPMode string `json:"ipipMode,omitempty"`
-	// IPv4AutoDetectionMethod configures how Calico chooses the IP address used to route
-	// between nodes.  This should be set when the host has multiple interfaces
-	// and it is important to select the interface used.
-	// Options: "first-found" (default), "can-reach=DESTINATION",
-	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
-	IPv4AutoDetectionMethod string `json:"ipv4AutoDetectionMethod,omitempty"`
-	// IPv6AutoDetectionMethod configures how Calico chooses the IP address used to route
-	// between nodes.  This should be set when the host has multiple interfaces
-	// and it is important to select the interface used.
-	// Options: "first-found" (default), "can-reach=DESTINATION",
-	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
-	IPv6AutoDetectionMethod string `json:"ipv6AutoDetectionMethod,omitempty"`
 	// TyphaPrometheusMetricsEnabled enables Prometheus metrics collection from Typha
 	// (default: false)
 	TyphaPrometheusMetricsEnabled bool `json:"typhaPrometheusMetricsEnabled,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -103,6 +103,11 @@ type FlannelNetworkingSpec struct {
 
 // CalicoNetworkingSpec declares that we want Calico networking
 type CalicoNetworkingSpec struct {
+	// Version overrides the Calico container image registry.
+	Registry string `json:"registry,omitempty"`
+	// Version overrides the Calico container image tag.
+	Version string `json:"version,omitempty"`
+
 	// BpfEnabled enables the eBPF dataplane mode.
 	BPFEnabled bool `json:"bpfEnabled,omitempty"`
 	// BPFExternalServiceMode controls how traffic from outside the cluster to NodePorts and ClusterIPs is handled.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1337,6 +1337,7 @@ func Convert_kops_CNINetworkingSpec_To_v1alpha2_CNINetworkingSpec(in *kops.CNINe
 func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *CalicoNetworkingSpec, out *kops.CalicoNetworkingSpec, s conversion.Scope) error {
 	out.Registry = in.Registry
 	out.Version = in.Version
+	out.AWSSrcDstCheck = in.AWSSrcDstCheck
 	out.BPFEnabled = in.BPFEnabled
 	out.BPFExternalServiceMode = in.BPFExternalServiceMode
 	out.BPFKubeProxyIptablesCleanupEnabled = in.BPFKubeProxyIptablesCleanupEnabled
@@ -1344,7 +1345,10 @@ func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.ChainInsertMode = in.ChainInsertMode
 	out.CPURequest = in.CPURequest
 	out.CrossSubnet = in.CrossSubnet
-	out.AwsSrcDstCheck = in.AwsSrcDstCheck
+	out.IPIPMode = in.IPIPMode
+	out.IPv4AutoDetectionMethod = in.IPv4AutoDetectionMethod
+	out.IPv6AutoDetectionMethod = in.IPv6AutoDetectionMethod
+	out.IptablesBackend = in.IptablesBackend
 	out.LogSeverityScreen = in.LogSeverityScreen
 	out.MTU = in.MTU
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
@@ -1352,10 +1356,6 @@ func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	out.MajorVersion = in.MajorVersion
-	out.IptablesBackend = in.IptablesBackend
-	out.IPIPMode = in.IPIPMode
-	out.IPv4AutoDetectionMethod = in.IPv4AutoDetectionMethod
-	out.IPv6AutoDetectionMethod = in.IPv6AutoDetectionMethod
 	out.TyphaPrometheusMetricsEnabled = in.TyphaPrometheusMetricsEnabled
 	out.TyphaPrometheusMetricsPort = in.TyphaPrometheusMetricsPort
 	out.TyphaReplicas = in.TyphaReplicas
@@ -1371,6 +1371,7 @@ func Convert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *Cali
 func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *kops.CalicoNetworkingSpec, out *CalicoNetworkingSpec, s conversion.Scope) error {
 	out.Registry = in.Registry
 	out.Version = in.Version
+	out.AWSSrcDstCheck = in.AWSSrcDstCheck
 	out.BPFEnabled = in.BPFEnabled
 	out.BPFExternalServiceMode = in.BPFExternalServiceMode
 	out.BPFKubeProxyIptablesCleanupEnabled = in.BPFKubeProxyIptablesCleanupEnabled
@@ -1378,7 +1379,10 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *
 	out.ChainInsertMode = in.ChainInsertMode
 	out.CPURequest = in.CPURequest
 	out.CrossSubnet = in.CrossSubnet
-	out.AwsSrcDstCheck = in.AwsSrcDstCheck
+	out.IPIPMode = in.IPIPMode
+	out.IPv4AutoDetectionMethod = in.IPv4AutoDetectionMethod
+	out.IPv6AutoDetectionMethod = in.IPv6AutoDetectionMethod
+	out.IptablesBackend = in.IptablesBackend
 	out.LogSeverityScreen = in.LogSeverityScreen
 	out.MTU = in.MTU
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
@@ -1386,10 +1390,6 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
 	out.PrometheusProcessMetricsEnabled = in.PrometheusProcessMetricsEnabled
 	out.MajorVersion = in.MajorVersion
-	out.IPv4AutoDetectionMethod = in.IPv4AutoDetectionMethod
-	out.IPv6AutoDetectionMethod = in.IPv6AutoDetectionMethod
-	out.IptablesBackend = in.IptablesBackend
-	out.IPIPMode = in.IPIPMode
 	out.TyphaPrometheusMetricsEnabled = in.TyphaPrometheusMetricsEnabled
 	out.TyphaPrometheusMetricsPort = in.TyphaPrometheusMetricsPort
 	out.TyphaReplicas = in.TyphaReplicas

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1335,6 +1335,8 @@ func Convert_kops_CNINetworkingSpec_To_v1alpha2_CNINetworkingSpec(in *kops.CNINe
 }
 
 func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *CalicoNetworkingSpec, out *kops.CalicoNetworkingSpec, s conversion.Scope) error {
+	out.Registry = in.Registry
+	out.Version = in.Version
 	out.BPFEnabled = in.BPFEnabled
 	out.BPFExternalServiceMode = in.BPFExternalServiceMode
 	out.BPFKubeProxyIptablesCleanupEnabled = in.BPFKubeProxyIptablesCleanupEnabled
@@ -1367,6 +1369,8 @@ func Convert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *Cali
 }
 
 func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *kops.CalicoNetworkingSpec, out *CalicoNetworkingSpec, s conversion.Scope) error {
+	out.Registry = in.Registry
+	out.Version = in.Version
 	out.BPFEnabled = in.BPFEnabled
 	out.BPFExternalServiceMode = in.BPFExternalServiceMode
 	out.BPFKubeProxyIptablesCleanupEnabled = in.BPFKubeProxyIptablesCleanupEnabled

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -993,23 +993,9 @@ func ValidateEtcdVersionForCalicoV3(e kops.EtcdClusterSpec, majorVersion string,
 func validateNetworkingCalico(v *kops.CalicoNetworkingSpec, e kops.EtcdClusterSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if v.TyphaReplicas < 0 {
-		allErrs = append(allErrs,
-			field.Invalid(fldPath.Child("typhaReplicas"), v.TyphaReplicas,
-				fmt.Sprintf("Unable to set number of Typha replicas to less than 0, you've specified %d", v.TyphaReplicas)))
-	}
-
-	if v.MajorVersion != "" {
-		valid := []string{"v3"}
-		allErrs = append(allErrs, IsValidValue(fldPath.Child("majorVersion"), &v.MajorVersion, valid)...)
-		if v.MajorVersion == "v3" {
-			allErrs = append(allErrs, ValidateEtcdVersionForCalicoV3(e, v.MajorVersion, fldPath)...)
-		}
-	}
-
-	if v.AwsSrcDstCheck != "" {
+	if v.AWSSrcDstCheck != "" {
 		valid := []string{"Enable", "Disable", "DoNothing"}
-		allErrs = append(allErrs, IsValidValue(fldPath.Child("awsSrcDstCheck"), &v.AwsSrcDstCheck, valid)...)
+		allErrs = append(allErrs, IsValidValue(fldPath.Child("awsSrcDstCheck"), &v.AWSSrcDstCheck, valid)...)
 	}
 
 	if v.BPFExternalServiceMode != "" {
@@ -1027,17 +1013,31 @@ func validateNetworkingCalico(v *kops.CalicoNetworkingSpec, e kops.EtcdClusterSp
 		allErrs = append(allErrs, IsValidValue(fldPath.Child("chainInsertMode"), &v.ChainInsertMode, valid)...)
 	}
 
-	if v.IptablesBackend != "" {
-		valid := []string{"Auto", "Legacy", "NFT"}
-		allErrs = append(allErrs, IsValidValue(fldPath.Child("iptablesBackend"), &v.IptablesBackend, valid)...)
-	}
-
 	if v.IPv4AutoDetectionMethod != "" {
 		allErrs = append(allErrs, validateCalicoAutoDetectionMethod(fldPath.Child("ipv4AutoDetectionMethod"), v.IPv4AutoDetectionMethod, ipv4.Version)...)
 	}
 
 	if v.IPv6AutoDetectionMethod != "" {
 		allErrs = append(allErrs, validateCalicoAutoDetectionMethod(fldPath.Child("ipv6AutoDetectionMethod"), v.IPv6AutoDetectionMethod, ipv6.Version)...)
+	}
+
+	if v.IptablesBackend != "" {
+		valid := []string{"Auto", "Legacy", "NFT"}
+		allErrs = append(allErrs, IsValidValue(fldPath.Child("iptablesBackend"), &v.IptablesBackend, valid)...)
+	}
+
+	if v.MajorVersion != "" {
+		valid := []string{"v3"}
+		allErrs = append(allErrs, IsValidValue(fldPath.Child("majorVersion"), &v.MajorVersion, valid)...)
+		if v.MajorVersion == "v3" {
+			allErrs = append(allErrs, ValidateEtcdVersionForCalicoV3(e, v.MajorVersion, fldPath)...)
+		}
+	}
+
+	if v.TyphaReplicas < 0 {
+		allErrs = append(allErrs,
+			field.Invalid(fldPath.Child("typhaReplicas"), v.TyphaReplicas,
+				fmt.Sprintf("Unable to set number of Typha replicas to less than 0, you've specified %d", v.TyphaReplicas)))
 	}
 
 	return allErrs

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -519,7 +519,7 @@ func Test_Validate_Calico(t *testing.T) {
 		{
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
-					AwsSrcDstCheck: "off",
+					AWSSrcDstCheck: "off",
 				},
 				Etcd: kops.EtcdClusterSpec{},
 			},
@@ -528,7 +528,7 @@ func Test_Validate_Calico(t *testing.T) {
 		{
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
-					AwsSrcDstCheck: "Enable",
+					AWSSrcDstCheck: "Enable",
 				},
 				Etcd: kops.EtcdClusterSpec{},
 			},
@@ -536,7 +536,7 @@ func Test_Validate_Calico(t *testing.T) {
 		{
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
-					AwsSrcDstCheck: "Disable",
+					AWSSrcDstCheck: "Disable",
 				},
 				Etcd: kops.EtcdClusterSpec{},
 			},
@@ -544,7 +544,7 @@ func Test_Validate_Calico(t *testing.T) {
 		{
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{
-					AwsSrcDstCheck: "DoNothing",
+					AWSSrcDstCheck: "DoNothing",
 				},
 				Etcd: kops.EtcdClusterSpec{},
 			},

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -280,7 +280,7 @@ func (r *NodeRoleMaster) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 		addCiliumEniPermissions(p, resource, b.Cluster.Spec.IAM.Legacy)
 	}
 
-	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.Calico != nil && (b.Cluster.Spec.Networking.Calico.CrossSubnet || b.Cluster.Spec.Networking.Calico.AwsSrcDstCheck != "") {
+	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.Calico != nil && (b.Cluster.Spec.Networking.Calico.CrossSubnet || b.Cluster.Spec.Networking.Calico.AWSSrcDstCheck != "") {
 		addCalicoSrcDstCheckPermissions(p)
 	}
 
@@ -319,7 +319,7 @@ func (r *NodeRoleNode) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 		addLyftVPCPermissions(p, resource, b.Cluster.Spec.IAM.Legacy, b.Cluster.GetName())
 	}
 
-	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.Calico != nil && (b.Cluster.Spec.Networking.Calico.CrossSubnet || b.Cluster.Spec.Networking.Calico.AwsSrcDstCheck != "") {
+	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.Calico != nil && (b.Cluster.Spec.Networking.Calico.CrossSubnet || b.Cluster.Spec.Networking.Calico.AWSSrcDstCheck != "") {
 		addCalicoSrcDstCheckPermissions(p)
 	}
 

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -13191,7 +13191,7 @@ spec:
             # kops additions
             # Enable source/destination checks for AWS
             - name: FELIX_AWSSRCDSTCHECK
-              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}Disable{{- else -}} {{- or .Networking.Calico.AwsSrcDstCheck "DoNothing" -}} {{- end -}}"
+              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}Disable{{- else -}} {{- or .Networking.Calico.AWSSrcDstCheck "DoNothing" -}} {{- end -}}"
             # Enable eBPF dataplane mode
             - name: FELIX_BPFENABLED
               value: "{{ .Networking.Calico.BPFEnabled }}"

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -12906,7 +12906,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.17.0" }}
+      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.17.1" }}
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -13023,7 +13023,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.1" }}
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -13050,7 +13050,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.1" }}
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -13091,7 +13091,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/pod2daemon-flexvol:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/pod2daemon-flexvol:{{ or .Networking.Calico.Version "v3.17.1" }}
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -13102,7 +13102,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.17.1" }}
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -13366,7 +13366,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.17.1" }}
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -12906,7 +12906,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: docker.io/calico/typha:v3.17.0
+      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.17.0" }}
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -13023,7 +13023,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.17.0
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.0" }}
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -13050,7 +13050,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.17.0
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.0" }}
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -13091,7 +13091,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: docker.io/calico/pod2daemon-flexvol:v3.17.0
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/pod2daemon-flexvol:{{ or .Networking.Calico.Version "v3.17.0" }}
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -13102,7 +13102,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.17.0
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.17.0" }}
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -13366,7 +13366,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.17.0
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.17.0" }}
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3625,7 +3625,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: docker.io/calico/typha:v3.17.0
+      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.17.0" }}
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -3742,7 +3742,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.17.0
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.0" }}
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -3769,7 +3769,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.17.0
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.0" }}
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -3810,7 +3810,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: docker.io/calico/pod2daemon-flexvol:v3.17.0
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/pod2daemon-flexvol:{{ or .Networking.Calico.Version "v3.17.0" }}
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -3821,7 +3821,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.17.0
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.17.0" }}
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4085,7 +4085,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.17.0
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.17.0" }}
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3910,7 +3910,7 @@ spec:
             # kops additions
             # Enable source/destination checks for AWS
             - name: FELIX_AWSSRCDSTCHECK
-              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}Disable{{- else -}} {{- or .Networking.Calico.AwsSrcDstCheck "DoNothing" -}} {{- end -}}"
+              value: "{{- if and (eq .CloudProvider "aws") (.Networking.Calico.CrossSubnet) -}}Disable{{- else -}} {{- or .Networking.Calico.AWSSrcDstCheck "DoNothing" -}} {{- end -}}"
             # Enable eBPF dataplane mode
             - name: FELIX_BPFENABLED
               value: "{{ .Networking.Calico.BPFEnabled }}"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3625,7 +3625,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.17.0" }}
+      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.17.1" }}
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -3742,7 +3742,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.1" }}
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -3769,7 +3769,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.17.1" }}
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -3810,7 +3810,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/pod2daemon-flexvol:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/pod2daemon-flexvol:{{ or .Networking.Calico.Version "v3.17.1" }}
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -3821,7 +3821,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.17.1" }}
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4085,7 +4085,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.17.0" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.17.1" }}
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -858,7 +858,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 			"k8s-1.7":    "2.6.12-kops.1",
 			"k8s-1.7-v3": "3.8.0-kops.2",
 			"k8s-1.12":   "3.9.6-kops.1",
-			"k8s-1.16":   "3.17.0-kops.1",
+			"k8s-1.16":   "3.17.1-kops.1",
 		}
 
 		{


### PR DESCRIPTION
Cherry pick of #10316 #10408 on release-1.19.

#10316: Allow override of registry and tag for Calico images
#10408: Update Calico to v3.17.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.