### PR TITLE
Expose metrics port when PrometheusMetricsEnabled set to true in Calico

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -36961,6 +36961,11 @@ spec:
         - containerPort: 5473
           name: calico-typha
           protocol: TCP
+        {{- if .Networking.Calico.TyphaPrometheusMetricsEnabled }}
+        - containerPort: {{- or .Networking.Calico.TyphaPrometheusMetricsPort "9093" }}
+          name: metrics
+          protocol: TCP
+        {{- end }}
         envFrom:
         - configMapRef:
             # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -37295,6 +37300,12 @@ spec:
               - -felix-ready
               - -bird-ready
             periodSeconds: 10
+          {{- if .Networking.Calico.PrometheusMetricsEnabled }}
+          ports:
+          - containerPort: {{- or .Networking.Calico.PrometheusMetricsPort "9091" }}
+            name: metrics
+            protocol: TCP
+          {{- end }}
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3632,7 +3632,7 @@ spec:
           name: calico-typha
           protocol: TCP
         {{- if .Networking.Calico.TyphaPrometheusMetricsEnabled }}
-        - containerPort: {{- or .Networking.Calico.TyphaPrometheusMetricsPort "9091" }}
+        - containerPort: {{- or .Networking.Calico.TyphaPrometheusMetricsPort "9093" }}
           name: metrics
           protocol: TCP
         {{- end }}

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3631,6 +3631,11 @@ spec:
         - containerPort: 5473
           name: calico-typha
           protocol: TCP
+        {{- if .Networking.Calico.TyphaPrometheusMetricsEnabled }}
+        - containerPort: {{- or .Networking.Calico.TyphaPrometheusMetricsPort "9091" }}
+          name: metrics
+          protocol: TCP
+        {{- end }}
         envFrom:
         - configMapRef:
             # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -3965,6 +3970,12 @@ spec:
               - -felix-ready
               - -bird-ready
             periodSeconds: 10
+          {{- if .Networking.Calico.PrometheusMetricsEnabled }}
+          ports:
+          - containerPort: {{- or .Networking.Calico.PrometheusMetricsPort "9091" }}
+            name: metrics
+            protocol: TCP
+          {{- end }}
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules


### PR DESCRIPTION
Problem:
Currently `PrometheusMetricsEnabled` only start servings metrics on `PrometheusMetricsPort` . But Prometheus can not scrape it. This PR will expose that service so Prometheus can scrape it. 
Sample config for Prometheus-operator
```apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  labels:
    k8s-app: calico-node
    monitoredBy: prometheus-infra
  name: calico-node
  namespace: kube-system
spec:
  podMetricsEndpoints:
  - interval: 30s
    path: /metrics
    port: metrics
  namespaceSelector:
    matchNames:
    - kube-system
  selector:
    matchLabels:
      k8s-app: calico-node
