### PR TITLE
Automated cherry pick of #10418: Add support for containerd v1.4.3 ARM64

### DIFF
--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -54,10 +54,8 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 		if fi.StringValue(containerd.Version) == "" {
 			if b.IsKubernetesGTE("1.19") {
 				containerd.Version = fi.String("1.4.3")
-			} else if b.IsKubernetesGTE("1.18") {
-				containerd.Version = fi.String("1.3.4")
 			} else {
-				return fmt.Errorf("containerd version is required")
+				containerd.Version = fi.String("1.3.9")
 			}
 		}
 

--- a/pkg/model/components/containerd_test.go
+++ b/pkg/model/components/containerd_test.go
@@ -36,61 +36,6 @@ func buildContainerdCluster(version string) *kopsapi.Cluster {
 	}
 }
 
-func Test_Build_Containerd_Unsupported_Version(t *testing.T) {
-	kubernetesVersions := []string{"1.4.8", "1.5.2", "1.9.0", "1.10.11"}
-	for _, v := range kubernetesVersions {
-
-		c := buildContainerdCluster(v)
-		c.Spec.ContainerRuntime = "containerd"
-		b := assets.NewAssetBuilder(c, "")
-
-		version, err := util.ParseKubernetesVersion(v)
-		if err != nil {
-			t.Fatalf("unexpected error from ParseKubernetesVersion %s: %v", v, err)
-		}
-
-		ob := &ContainerdOptionsBuilder{
-			&OptionsContext{
-				AssetBuilder:      b,
-				KubernetesVersion: *version,
-			},
-		}
-
-		err = ob.BuildOptions(&c.Spec)
-		if err == nil {
-			t.Fatalf("expecting error from BuildOptions when Kubernetes version < 1.11: %s", v)
-		}
-	}
-}
-
-func Test_Build_Containerd_Untested_Version(t *testing.T) {
-	kubernetesVersions := []string{"1.11.0", "1.11.2", "1.14.0", "1.16.3"}
-
-	for _, v := range kubernetesVersions {
-
-		c := buildContainerdCluster(v)
-		c.Spec.ContainerRuntime = "containerd"
-		b := assets.NewAssetBuilder(c, "")
-
-		version, err := util.ParseKubernetesVersion(v)
-		if err != nil {
-			t.Fatalf("unexpected error from ParseKubernetesVersion %s: %v", v, err)
-		}
-
-		ob := &ContainerdOptionsBuilder{
-			&OptionsContext{
-				AssetBuilder:      b,
-				KubernetesVersion: *version,
-			},
-		}
-
-		err = ob.BuildOptions(&c.Spec)
-		if err == nil {
-			t.Fatalf("expecting error when Kubernetes version >= 1.11 and < 1.18: %s", v)
-		}
-	}
-}
-
 func Test_Build_Containerd_Supported_Version(t *testing.T) {
 	kubernetesVersions := []string{"1.18.0", "1.18.3"}
 

--- a/upup/pkg/fi/cloudup/containerd.go
+++ b/upup/pkg/fi/cloudup/containerd.go
@@ -100,7 +100,7 @@ func findContainerdVersionUrl(arch architectures.Architecture, version string) (
 	var u string
 	switch arch {
 	case architectures.ArchitectureAmd64:
-		if sv.GTE(semver.MustParse("1.4.0")) {
+		if sv.GTE(semver.MustParse("1.3.8")) {
 			u = fmt.Sprintf(containerdVersionUrlAmd64, version, version)
 		} else {
 			u = fmt.Sprintf(containerdLegacyUrlAmd64, version)
@@ -153,6 +153,7 @@ func findContainerdVersionHash(arch architectures.Architecture, version string) 
 func findAllContainerdHashesAmd64() map[string]string {
 	hashes := map[string]string{
 		"1.3.4": "4616971c3ad21c24f2f2320fa1c085577a91032a068dd56a41c7c4b71a458087",
+		"1.3.9": "96663699e0f888fbf232ae6629a367aa7421f6b95044e7ee5d4d4e02841fac75",
 		"1.4.0": "b379f29417efd583f77e095173d4d0bd6bb001f0081b2a63d152ee7aef653ce1",
 		"1.4.1": "757efb93a4f3161efc447a943317503d8a7ded5cb4cc0cba3f3318d7ce1542ed",
 		"1.4.2": "9d0fd5f4d2bc58b345728432b7daac75fc99c1da91afa4f41e6103f618e74012",

--- a/upup/pkg/fi/cloudup/containerd.go
+++ b/upup/pkg/fi/cloudup/containerd.go
@@ -35,7 +35,7 @@ const (
 	// containerd legacy packages URLs for v1.2.x and v1.3.x
 	containerdLegacyUrlAmd64 = "https://storage.googleapis.com/cri-containerd-release/cri-containerd-%s.linux-amd64.tar.gz"
 	// containerd version that is available for both AMD64 and ARM64, used in case the selected version is not available for ARM64
-	containerdFallbackVersion = "1.2.13"
+	containerdFallbackVersion = "1.4.3"
 )
 
 func findContainerdAsset(c *kops.Cluster, assetBuilder *assets.AssetBuilder, arch architectures.Architecture) (*url.URL, *hashing.Hash, error) {
@@ -106,7 +106,7 @@ func findContainerdVersionUrl(arch architectures.Architecture, version string) (
 			u = fmt.Sprintf(containerdLegacyUrlAmd64, version)
 		}
 	case architectures.ArchitectureArm64:
-		// For now there are only official AMD64 builds, using Default Docker version instead
+		// For now there are only official AMD64 builds, always using fallback Docker version instead
 		if findAllContainerdHashesAmd64()[version] != "" {
 			u = fmt.Sprintf(dockerVersionUrlArm64, findAllContainerdDockerMappings()[containerdFallbackVersion])
 		}
@@ -135,7 +135,7 @@ func findContainerdVersionHash(arch architectures.Architecture, version string) 
 	case architectures.ArchitectureAmd64:
 		h = findAllContainerdHashesAmd64()[version]
 	case architectures.ArchitectureArm64:
-		// For now there are only official AMD64 builds, using Default Docker version instead
+		// For now there are only official AMD64 builds, always using fallback Docker version instead
 		if findAllContainerdHashesAmd64()[version] != "" {
 			h = findAllDockerHashesArm64()[findAllContainerdDockerMappings()[containerdFallbackVersion]]
 		}
@@ -172,6 +172,7 @@ func findAllContainerdDockerMappings() map[string]string {
 		"1.2.13": "19.03.11",
 		"1.3.7":  "19.03.13",
 		"1.3.9":  "19.03.14",
+		"1.4.3":  "20.10.0",
 	}
 
 	return versions

--- a/upup/pkg/fi/cloudup/containerd_test.go
+++ b/upup/pkg/fi/cloudup/containerd_test.go
@@ -43,22 +43,22 @@ func TestContainerdVersionUrlHash(t *testing.T) {
 		{
 			arch:    architectures.ArchitectureArm64,
 			version: "1.3.4",
-			url:     "https://download.docker.com/linux/static/stable/aarch64/docker-19.03.11.tgz",
-			hash:    "9cd49fe82f6b7ec413b04daef35bc0c87b01d6da67611e5beef36291538d3145",
+			url:     "https://download.docker.com/linux/static/stable/aarch64/docker-20.10.0.tgz",
+			hash:    "6e3f80e8451ecbe7b3559247721c3e226be6b228acaadee7e13683f80c20e81c",
 			err:     nil,
 		},
 		{
 			arch:    architectures.ArchitectureAmd64,
-			version: "1.3.7",
-			url:     "https://download.docker.com/linux/static/stable/x86_64/docker-19.03.13.tgz",
-			hash:    "ddb13aff1fcdcceb710bf71a210169b9c1abfd7420eeaf42cf7975f8fae2fcc8",
+			version: "1.3.9",
+			url:     "https://github.com/containerd/containerd/releases/download/v1.3.9/cri-containerd-cni-1.3.9-linux-amd64.tar.gz",
+			hash:    "96663699e0f888fbf232ae6629a367aa7421f6b95044e7ee5d4d4e02841fac75",
 			err:     nil,
 		},
 		{
 			arch:    architectures.ArchitectureArm64,
-			version: "1.3.7",
-			url:     "https://download.docker.com/linux/static/stable/aarch64/docker-19.03.13.tgz",
-			hash:    "bdf080af7d6f383ad80e415e9c1952a63c7038c149dc673b7598bfca4d3311ec",
+			version: "1.3.9",
+			url:     "https://download.docker.com/linux/static/stable/aarch64/docker-20.10.0.tgz",
+			hash:    "6e3f80e8451ecbe7b3559247721c3e226be6b228acaadee7e13683f80c20e81c",
 			err:     nil,
 		},
 		{
@@ -71,8 +71,8 @@ func TestContainerdVersionUrlHash(t *testing.T) {
 		{
 			arch:    architectures.ArchitectureArm64,
 			version: "1.4.1",
-			url:     "https://download.docker.com/linux/static/stable/aarch64/docker-19.03.11.tgz",
-			hash:    "9cd49fe82f6b7ec413b04daef35bc0c87b01d6da67611e5beef36291538d3145",
+			url:     "https://download.docker.com/linux/static/stable/aarch64/docker-20.10.0.tgz",
+			hash:    "6e3f80e8451ecbe7b3559247721c3e226be6b228acaadee7e13683f80c20e81c",
 			err:     nil,
 		},
 	}
@@ -159,7 +159,7 @@ func TestContainerdVersionUrl(t *testing.T) {
 		{
 			arch:    architectures.ArchitectureArm64,
 			version: "1.3.4",
-			url:     "https://download.docker.com/linux/static/stable/aarch64/docker-19.03.11.tgz",
+			url:     "https://download.docker.com/linux/static/stable/aarch64/docker-20.10.0.tgz",
 			err:     nil,
 		},
 		{
@@ -171,7 +171,7 @@ func TestContainerdVersionUrl(t *testing.T) {
 		{
 			arch:    architectures.ArchitectureArm64,
 			version: "1.4.1",
-			url:     "https://download.docker.com/linux/static/stable/aarch64/docker-19.03.11.tgz",
+			url:     "https://download.docker.com/linux/static/stable/aarch64/docker-20.10.0.tgz",
 			err:     nil,
 		},
 	}
@@ -254,7 +254,7 @@ func TestContainerdVersionHash(t *testing.T) {
 		{
 			arch:    architectures.ArchitectureArm64,
 			version: "1.4.1",
-			hash:    "9cd49fe82f6b7ec413b04daef35bc0c87b01d6da67611e5beef36291538d3145",
+			hash:    "6e3f80e8451ecbe7b3559247721c3e226be6b228acaadee7e13683f80c20e81c",
 			err:     nil,
 		},
 	}

--- a/upup/pkg/fi/cloudup/docker.go
+++ b/upup/pkg/fi/cloudup/docker.go
@@ -174,6 +174,7 @@ func findAllDockerHashesAmd64() map[string]string {
 		"19.03.12": "88de1b87b8a2582fe827154899475a72fb707c5793cfb39d2a24813ba1f31197",
 		"19.03.13": "ddb13aff1fcdcceb710bf71a210169b9c1abfd7420eeaf42cf7975f8fae2fcc8",
 		"19.03.14": "9f1ec28e357a8f18e9561129239caf9c0807d74756e21cc63637c7fdeaafe847",
+		"20.10.0":  "02936a3585f12f13b21b95e02ae722d74eaf1870b536997e914659ee307b2ac4",
 	}
 
 	return hashes
@@ -216,6 +217,7 @@ func findAllDockerHashesArm64() map[string]string {
 		"19.03.12": "bc7810d58e32360652abfddc9cb43405feee4ed9592aedc1132fb35eede9fa9e",
 		"19.03.13": "bdf080af7d6f383ad80e415e9c1952a63c7038c149dc673b7598bfca4d3311ec",
 		"19.03.14": "8350eaa0c0965bb8eb9d45a014f4b6728c985715f56466077dfe6feb271d9518",
+		"20.10.0":  "6e3f80e8451ecbe7b3559247721c3e226be6b228acaadee7e13683f80c20e81c",
 	}
 
 	return hashes


### PR DESCRIPTION
Cherry pick of #10418 on release-1.19.

#10418: Add support for containerd v1.4.3 ARM64

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.