### PR TITLE
Automated cherry pick of #10414: This will expose metrics port when

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -12912,6 +12912,11 @@ spec:
         - containerPort: 5473
           name: calico-typha
           protocol: TCP
+        {{- if .Networking.Calico.TyphaPrometheusMetricsEnabled }}
+        - containerPort: {{- or .Networking.Calico.TyphaPrometheusMetricsPort "9093" }}
+          name: metrics
+          protocol: TCP
+        {{- end }}
         envFrom:
         - configMapRef:
             # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -13246,6 +13251,12 @@ spec:
               - -felix-ready
               - -bird-ready
             periodSeconds: 10
+          {{- if .Networking.Calico.PrometheusMetricsEnabled }}
+          ports:
+          - containerPort: {{- or .Networking.Calico.PrometheusMetricsPort "9091" }}
+            name: metrics
+            protocol: TCP
+          {{- end }}
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3632,7 +3632,7 @@ spec:
           name: calico-typha
           protocol: TCP
         {{- if .Networking.Calico.TyphaPrometheusMetricsEnabled }}
-        - containerPort: {{- or .Networking.Calico.TyphaPrometheusMetricsPort "9091" }}
+        - containerPort: {{- or .Networking.Calico.TyphaPrometheusMetricsPort "9093" }}
           name: metrics
           protocol: TCP
         {{- end }}

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3631,6 +3631,11 @@ spec:
         - containerPort: 5473
           name: calico-typha
           protocol: TCP
+        {{- if .Networking.Calico.TyphaPrometheusMetricsEnabled }}
+        - containerPort: {{- or .Networking.Calico.TyphaPrometheusMetricsPort "9091" }}
+          name: metrics
+          protocol: TCP
+        {{- end }}
         envFrom:
         - configMapRef:
             # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -3965,6 +3970,12 @@ spec:
               - -felix-ready
               - -bird-ready
             periodSeconds: 10
+          {{- if .Networking.Calico.PrometheusMetricsEnabled }}
+          ports:
+          - containerPort: {{- or .Networking.Calico.PrometheusMetricsPort "9091" }}
+            name: metrics
+            protocol: TCP
+          {{- end }}
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules


### PR DESCRIPTION
Cherry pick of #10414 on release-1.19.

#10414: This will expose metrics port when

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.