### PR TITLE
Upgrade mkdocs dependencies to latest

### DIFF
--- a/images/mkdocs/requirements.txt
+++ b/images/mkdocs/requirements.txt
@@ -1,5 +1,5 @@
-mkdocs-material~=5.5.14
+mkdocs-material==6.1.7
 mkdocs~=1.1.2
-pymdown-extensions==8.0
-pygments~=2.7.1
+pymdown-extensions==8.0.1
+pygments~=2.7.3
 mkdocs-macros-plugin==0.4.9

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,7 @@ theme:
   name: material
   custom_dir: docs/overrides
   features:
-    - tabs
+    - navigation.tabs
   icon:
     logo: 'material/cloud-outline'
   favicon: 'img/logo-notext.svg'


### PR DESCRIPTION
Except for mkdocs-macros, for some reason it would no longer recognize our hack/mkdocs_macros python module