### PR TITLE
IAM ServiceAccount Roles: truncate name at 64 characters

### DIFF
--- a/pkg/model/iam/BUILD.bazel
+++ b/pkg/model/iam/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/wellknownusers:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awstasks:go_default_library",
+        "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//util/pkg/vfs:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/model/iam/types.go
+++ b/pkg/model/iam/types.go
@@ -21,7 +21,11 @@ import (
 	"fmt"
 
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 )
+
+// MaxLengthIAMRoleName defines the max length of an IAMRole name
+const MaxLengthIAMRoleName = 64
 
 // ParseStatements parses JSON into a list of Statements
 func ParseStatements(policy string) ([]*Statement, error) {
@@ -48,7 +52,10 @@ func (b *IAMModelContext) IAMNameForServiceAccountRole(role Subject) (string, er
 		return "", fmt.Errorf("role %v does not have ServiceAccount", role)
 	}
 
-	return serviceAccount.Name + "." + serviceAccount.Namespace + ".sa." + b.ClusterName(), nil
+	name := serviceAccount.Name + "." + serviceAccount.Namespace + ".sa." + b.ClusterName()
+	name = awsup.TruncateString(name, awsup.TruncateStringOptions{MaxLength: MaxLengthIAMRoleName, AlwaysAddHash: false})
+
+	return name, nil
 }
 
 // ClusterName returns the cluster name

--- a/upup/pkg/fi/cloudup/awsup/aws_utils_test.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awsup
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -138,5 +139,57 @@ func Test_GetResourceName32(t *testing.T) {
 		if actual != g.Expected {
 			t.Errorf("unexpected result from %q+%q.  expected %q, got %q", g.Prefix, g.ClusterName, g.Expected, actual)
 		}
+	}
+}
+
+func TestTruncateString(t *testing.T) {
+	grid := []struct {
+		Input         string
+		Expected      string
+		MaxLength     int
+		AlwaysAddHash bool
+	}{
+		{
+			Input:     "foo",
+			Expected:  "foo",
+			MaxLength: 64,
+		},
+		{
+			Input:     "this_string_is_33_characters_long",
+			Expected:  "this_string_is_33_characters_long",
+			MaxLength: 64,
+		},
+		{
+			Input:         "this_string_is_33_characters_long",
+			Expected:      "this_string_is_33_characters_long-t4mk8d",
+			MaxLength:     64,
+			AlwaysAddHash: true,
+		},
+		{
+			Input:     "this_string_is_longer_it_is_46_characters_long",
+			Expected:  "this_string_is_longer_it_-ha2gug",
+			MaxLength: 32,
+		},
+		{
+			Input:         "this_string_is_longer_it_is_46_characters_long",
+			Expected:      "this_string_is_longer_it_-ha2gug",
+			MaxLength:     32,
+			AlwaysAddHash: true,
+		},
+		{
+			Input:     "this_string_is_even_longer_due_to_extreme_verbosity_it_is_in_fact_84_characters_long",
+			Expected:  "this_string_is_even_longer_due_to_extreme_verbosity_it_is-7mc0g6",
+			MaxLength: 64,
+		},
+	}
+
+	for _, g := range grid {
+		t.Run(fmt.Sprintf("input:%s/maxLength:%d/alwaysAddHash:%v", g.Input, g.MaxLength, g.AlwaysAddHash), func(t *testing.T) {
+			opt := TruncateStringOptions{MaxLength: g.MaxLength, AlwaysAddHash: g.AlwaysAddHash}
+			actual := TruncateString(g.Input, opt)
+			if actual != g.Expected {
+				t.Errorf("TruncateString(%q, %+v) => %q, expected %q", g.Input, opt, actual, g.Expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
The maximum IAM role name length is 64 characters, which we hit much
more often now that we are constructing complex names.  Use our normal
strategy of adding a hash when we truncate.

This is not a breaking change, because these names were not valid
previously.