### PR TITLE
Allow Calico to run on systems with loose reverse path forwarding

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -33035,6 +33035,9 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
+            # Allow Felix to run on systems with loose reverse path forwarding (RPF)
+            - name: FELIX_IGNORELOOSERPF
+              value: "true"
             # Disable IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -813,6 +813,9 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
+            # Allow Felix to run on systems with loose reverse path forwarding (RPF)
+            - name: FELIX_IGNORELOOSERPF
+              value: "true"
             # Disable IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -742,7 +742,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 	if b.Cluster.Spec.Networking.Calico != nil {
 		key := "networking.projectcalico.org"
 		versions := map[string]string{
-			"k8s-1.12": "3.9.6-kops.1",
+			"k8s-1.12": "3.9.6-kops.2",
 			"k8s-1.16": "3.17.1-kops.1",
 		}
 


### PR DESCRIPTION
This should allow Calico to run on instances with newer linux versions, like Ubuntu 20.04.
xRef: https://github.com/rancher/rancher/issues/23316
xRef: https://github.com/projectcalico/felix/issues/2082

Fixes: #10441