### PR TITLE
Spotinst: Schedule Ocean Controller to Linux nodes only

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -41560,6 +41560,13 @@ spec:
       priorityClassName: system-cluster-critical
       affinity:
         nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             preference:

--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
@@ -172,6 +172,13 @@ spec:
       priorityClassName: system-cluster-critical
       affinity:
         nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             preference:


### PR DESCRIPTION
This PR adds a node affinity to the Ocean Controller deployment to schedule it to Linux nodes only.