### PR TITLE
Automated cherry pick of #10442: Allow Calico to run on systems with loose reverse path

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -7635,6 +7635,9 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
+            # Allow Felix to run on systems with loose reverse path forwarding (RPF)
+            - name: FELIX_IGNORELOOSERPF
+              value: "true"
             # Disable IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -809,6 +809,9 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
+            # Allow Felix to run on systems with loose reverse path forwarding (RPF)
+            - name: FELIX_IGNORELOOSERPF
+              value: "true"
             # Disable IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -725,7 +725,7 @@ func (b *BootstrapChannelBuilder) buildAddons() *channelsapi.Addons {
 		versions := map[string]string{
 			"k8s-1.7":    "2.6.12-kops.1",
 			"k8s-1.7-v3": "3.8.0-kops.2",
-			"k8s-1.12":   "3.9.6-kops.1",
+			"k8s-1.12":   "3.9.6-kops.2",
 			"k8s-1.16":   "3.15.3-kops.3",
 		}
 


### PR DESCRIPTION
Cherry pick of #10442 on release-1.18.

#10442: Allow Calico to run on systems with loose reverse path

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.