### PR TITLE
Automated cherry pick of #10447: Bump AWS-CNI to version 1.7.8

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -4507,7 +4507,7 @@ var _cloudupResourcesAddonsNetworkingAmazonVpcRoutedEniK8s116YamlTemplate = []by
         - "name": "{{ .Name }}"
           "value": "{{ .Value }}"
         {{- end }}
-        "image": "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.7" }}"
+        "image": "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.8" }}"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -4550,7 +4550,7 @@ var _cloudupResourcesAddonsNetworkingAmazonVpcRoutedEniK8s116YamlTemplate = []by
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.7"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.8"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -148,7 +148,7 @@
         - "name": "{{ .Name }}"
           "value": "{{ .Value }}"
         {{- end }}
-        "image": "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.7" }}"
+        "image": "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.8" }}"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -191,7 +191,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.7"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.8"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -105,7 +105,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0'
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 3d6e78dd6589bb6a6ef4ede3d99a2c9ec9b9f037
+    manifestHash: 4939462053b97b341540edcb525d6064ce8567de
     name: networking.amazon-vpc-routed-eni
     selector:
       role.kubernetes.io/networking: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -151,7 +151,7 @@ spec:
           value: "10"
         - name: AWS_VPC_K8S_CNI_LOGLEVEL
           value: debug
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.7
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.8
         imagePullPolicy: Always
         livenessProbe:
           exec:
@@ -194,7 +194,7 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.7
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.8
         imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:


### PR DESCRIPTION
Cherry pick of #10447 on release-1.19.

#10447: Bump AWS-CNI to version 1.7.8

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.