### PR TITLE
Spotinst: Ignore volume type case sensitivity to prevent unnecessary updates

### DIFF
--- a/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
@@ -286,7 +286,7 @@ func (e *Elastigroup) Find(c *fi.Context) (*Elastigroup, error) {
 							actual.RootVolumeOpts.IOPS = fi.Int32(int32(fi.IntValue(b.EBS.IOPS)))
 						}
 
-						actual.RootVolumeOpts.Type = b.EBS.VolumeType
+						actual.RootVolumeOpts.Type = fi.String(strings.ToLower(fi.StringValue(b.EBS.VolumeType)))
 						actual.RootVolumeOpts.Size = fi.Int32(int32(fi.IntValue(b.EBS.VolumeSize)))
 					}
 				}


### PR DESCRIPTION
This PR ensures the volume type is always in a lowercase format to prevent unnecessary updates:
```
...
Will modify resources:
  Elastigroup/master-us-west-2a.masters.[...]
    RootVolumeOpts           {"Type":"GP2","Size":64} -> {"Type":"gp2","Size":64}
...
```