### PR TITLE
Spotinst: Support for multiple subnets per zone

### DIFF
--- a/pkg/model/spotinstmodel/instance_group.go
+++ b/pkg/model/spotinstmodel/instance_group.go
@@ -178,6 +178,7 @@ func (b *InstanceGroupModelBuilder) buildElastigroup(c *fi.ModelBuilderContext, 
 	group := &spotinsttasks.Elastigroup{
 		Lifecycle:            b.Lifecycle,
 		Name:                 fi.String(b.AutoscalingGroupName(ig)),
+		Region:               fi.String(b.Region),
 		ImageID:              fi.String(ig.Spec.Image),
 		OnDemandInstanceType: fi.String(strings.Split(ig.Spec.MachineType, ",")[0]),
 		SpotInstanceTypes:    strings.Split(ig.Spec.MachineType, ","),

--- a/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
@@ -47,6 +47,7 @@ type Elastigroup struct {
 	Lifecycle *fi.Lifecycle
 
 	ID                       *string
+	Region                   *string
 	MinSize                  *int64
 	MaxSize                  *int64
 	SpotPercentage           *float64
@@ -186,6 +187,7 @@ func (e *Elastigroup) Find(c *fi.Context) (*Elastigroup, error) {
 	actual := &Elastigroup{}
 	actual.ID = group.ID
 	actual.Name = group.Name
+	actual.Region = group.Region
 
 	// Capacity.
 	{
@@ -218,11 +220,9 @@ func (e *Elastigroup) Find(c *fi.Context) (*Elastigroup, error) {
 
 		// Subnets.
 		{
-			for _, zone := range compute.AvailabilityZones {
-				if zone.SubnetID != nil {
-					actual.Subnets = append(actual.Subnets,
-						&awstasks.Subnet{ID: zone.SubnetID})
-				}
+			for _, subnetID := range compute.SubnetIDs {
+				actual.Subnets = append(actual.Subnets,
+					&awstasks.Subnet{ID: fi.String(subnetID)})
 			}
 			if subnetSlicesEqualIgnoreOrder(actual.Subnets, e.Subnets) {
 				actual.Subnets = e.Subnets
@@ -494,6 +494,7 @@ func (_ *Elastigroup) create(cloud awsup.AWSCloud, a, e, changes *Elastigroup) e
 	{
 		group.SetName(e.Name)
 		group.SetDescription(e.Name)
+		group.SetRegion(e.Region)
 	}
 
 	// Capacity.
@@ -525,16 +526,13 @@ func (_ *Elastigroup) create(cloud awsup.AWSCloud, a, e, changes *Elastigroup) e
 			group.Compute.InstanceTypes.SetSpot(e.SpotInstanceTypes)
 		}
 
-		// Availability zones.
+		// Subnets.
 		{
-			zones := make([]*aws.AvailabilityZone, len(e.Subnets))
+			subnets := make([]string, len(e.Subnets))
 			for i, subnet := range e.Subnets {
-				zone := new(aws.AvailabilityZone)
-				zone.SetName(subnet.AvailabilityZone)
-				zone.SetSubnetId(subnet.ID)
-				zones[i] = zone
+				subnets[i] = fi.StringValue(subnet.ID)
 			}
-			group.Compute.SetAvailabilityZones(zones)
+			group.Compute.SetSubnetIDs(subnets)
 		}
 
 		// Launch Specification.
@@ -796,6 +794,13 @@ func (_ *Elastigroup) update(cloud awsup.AWSCloud, a, e, changes *Elastigroup) e
 	group := new(aws.Group)
 	group.SetId(actual.ID)
 
+	// Region.
+	if changes.Region != nil {
+		group.SetRegion(e.Region)
+		changes.Region = nil
+		changed = true
+	}
+
 	// Strategy.
 	{
 		// Spot percentage.
@@ -902,22 +907,19 @@ func (_ *Elastigroup) update(cloud awsup.AWSCloud, a, e, changes *Elastigroup) e
 			}
 		}
 
-		// Availability zones.
+		// Subnets.
 		{
 			if changes.Subnets != nil {
 				if group.Compute == nil {
 					group.Compute = new(aws.Compute)
 				}
 
-				zones := make([]*aws.AvailabilityZone, len(e.Subnets))
+				subnets := make([]string, len(e.Subnets))
 				for i, subnet := range e.Subnets {
-					zone := new(aws.AvailabilityZone)
-					zone.SetName(subnet.AvailabilityZone)
-					zone.SetSubnetId(subnet.ID)
-					zones[i] = zone
+					subnets[i] = fi.StringValue(subnet.ID)
 				}
 
-				group.Compute.SetAvailabilityZones(zones)
+				group.Compute.SetSubnetIDs(subnets)
 				changes.Subnets = nil
 				changed = true
 			}
@@ -1442,7 +1444,7 @@ func (_ *Elastigroup) RenderTerraform(t *terraform.TerraformTarget, a, e, change
 		Name:        e.Name,
 		Description: e.Name,
 		Product:     e.Product,
-		Region:      fi.String(cloud.Region()),
+		Region:      e.Region,
 
 		DesiredCapacity: e.MinSize,
 		MinSize:         e.MinSize,


### PR DESCRIPTION
This PR adds support for multiple subnets per zone by configuring subnets without specifying zone names (according to the Spot API specification).