### PR TITLE
Update k8s and AMI versions from alpha

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -44,7 +44,7 @@ spec:
     - name: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-11-19
       providerID: aws
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201026
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201112.1
       providerID: aws
       kubernetesVersion: ">=1.18.0"
     - providerID: gce
@@ -59,10 +59,10 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.18.0"
-    recommendedVersion: 1.18.12
+    recommendedVersion: 1.18.13
     requiredVersion: 1.18.0
   - range: ">=1.17.0"
-    recommendedVersion: 1.17.14
+    recommendedVersion: 1.17.15
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
     recommendedVersion: 1.16.15
@@ -89,15 +89,15 @@ spec:
   - range: ">=1.19.0-alpha.1"
     #recommendedVersion: "1.19.0-alpha.1"
     #requiredVersion: 1.19.0
-    kubernetesVersion: 1.19.4
+    kubernetesVersion: 1.19.5
   - range: ">=1.18.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.18.0
-    kubernetesVersion: 1.18.12
+    kubernetesVersion: 1.18.13
   - range: ">=1.17.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.17.0
-    kubernetesVersion: 1.17.14
+    kubernetesVersion: 1.17.15
   - range: ">=1.16.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.16.0


### PR DESCRIPTION
It's been 9 days since we updated these versions on `alpha` channel, seems like we're good to move to `stable`.