### PR TITLE
Bump k8s versions on alpha and bump Ubuntu AMI version on stable

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -59,10 +59,10 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.18.0"
-    recommendedVersion: 1.18.13
+    recommendedVersion: 1.18.14
     requiredVersion: 1.18.0
   - range: ">=1.17.0"
-    recommendedVersion: 1.17.15
+    recommendedVersion: 1.17.16
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
     recommendedVersion: 1.16.15
@@ -89,15 +89,15 @@ spec:
   - range: ">=1.19.0-alpha.1"
     #recommendedVersion: "1.19.0-alpha.1"
     #requiredVersion: 1.19.0
-    kubernetesVersion: 1.19.5
+    kubernetesVersion: 1.19.6
   - range: ">=1.18.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.18.0
-    kubernetesVersion: 1.18.13
+    kubernetesVersion: 1.18.14
   - range: ">=1.17.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.17.0
-    kubernetesVersion: 1.17.15
+    kubernetesVersion: 1.17.16
   - range: ">=1.16.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.16.0

--- a/channels/stable
+++ b/channels/stable
@@ -44,7 +44,7 @@ spec:
     - name: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-11-19
       providerID: aws
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201026
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201112.1
       providerID: aws
       kubernetesVersion: ">=1.18.0"
     - providerID: gce


### PR DESCRIPTION
Following an issue that was raised with version tagging on the previous k8s releases from 9 days ago (more info [here](https://groups.google.com/g/kubernetes-dev/c/dNH2yknlCBA/m/7jq8KMcgAgAJ)), there were new patch releases this morning with fixes:
- https://github.com/kubernetes/kubernetes/releases/tag/v1.17.16
- https://github.com/kubernetes/kubernetes/releases/tag/v1.18.14
- https://github.com/kubernetes/kubernetes/releases/tag/v1.19.6

Also, it's been 9 days since the latest Ubuntu AMI version was updated on alpha, so pushing that to stable.