### PR TITLE
Use Region method of fi.Cloud

### DIFF
--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -438,9 +438,6 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 				return fmt.Errorf("azure support is currently alpha, and is feature-gated. Please export KOPS_FEATURE_FLAGS=Azure")
 			}
 
-			azureCloud := cloud.(azure.AzureCloud)
-			region = azureCloud.Region()
-
 			if len(sshPublicKeys) == 0 {
 				return fmt.Errorf("SSH public key must be specified when running with AzureCloud (create with `kops create secret --name %s sshpublickey admin -i ~/.ssh/id_rsa.pub`)", cluster.ObjectMeta.Name)
 			}

--- a/upup/pkg/fi/cloudup/awstasks/render_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/render_test.go
@@ -56,10 +56,10 @@ func doRenderTests(t *testing.T, method string, cases []*renderTest) {
 
 		switch method {
 		case "RenderTerraform":
-			target = terraform.NewTerraformTarget(cloud, "eu-west-2", "test", outdir, nil)
+			target = terraform.NewTerraformTarget(cloud, "test", outdir, nil)
 			filename = "kubernetes.tf"
 		case "RenderCloudformation":
-			target = cloudformation.NewCloudformationTarget(cloud, "eu-west-2", "test", outdir)
+			target = cloudformation.NewCloudformationTarget(cloud, "test", outdir)
 			filename = "kubernetes.json"
 		default:
 			t.Errorf("unknown render method: %s", method)

--- a/upup/pkg/fi/cloudup/cloudformation/target.go
+++ b/upup/pkg/fi/cloudup/cloudformation/target.go
@@ -31,7 +31,6 @@ import (
 
 type CloudformationTarget struct {
 	Cloud   fi.Cloud
-	Region  string
 	Project string
 
 	outDir string
@@ -41,10 +40,9 @@ type CloudformationTarget struct {
 	resources map[string]*cloudformationResource
 }
 
-func NewCloudformationTarget(cloud fi.Cloud, region, project string, outDir string) *CloudformationTarget {
+func NewCloudformationTarget(cloud fi.Cloud, project string, outDir string) *CloudformationTarget {
 	return &CloudformationTarget{
 		Cloud:     cloud,
-		Region:    region,
 		Project:   project,
 		outDir:    outDir,
 		resources: make(map[string]*cloudformationResource),

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -538,7 +538,7 @@ func addServiceAccounts(serviceAccounts []*compute.ServiceAccount) *terraformSer
 func (_ *InstanceTemplate) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *InstanceTemplate) error {
 	project := t.Project
 
-	i, err := e.mapToGCE(project, t.Region)
+	i, err := e.mapToGCE(project, t.Cloud.Region())
 	if err != nil {
 		return err
 	}

--- a/upup/pkg/fi/cloudup/terraform/target.go
+++ b/upup/pkg/fi/cloudup/terraform/target.go
@@ -33,7 +33,6 @@ import (
 
 type TerraformTarget struct {
 	Cloud   fi.Cloud
-	Region  string
 	Project string
 
 	ClusterName string
@@ -52,10 +51,9 @@ type TerraformTarget struct {
 	clusterSpecTarget *kops.TargetSpec
 }
 
-func NewTerraformTarget(cloud fi.Cloud, region, project string, outDir string, clusterSpecTarget *kops.TargetSpec) *TerraformTarget {
+func NewTerraformTarget(cloud fi.Cloud, project string, outDir string, clusterSpecTarget *kops.TargetSpec) *TerraformTarget {
 	return &TerraformTarget{
 		Cloud:   cloud,
-		Region:  region,
 		Project: project,
 
 		outDir:            outDir,

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -41,7 +41,7 @@ func (t *TerraformTarget) finishHCL2(taskMap map[string]fi.Task) error {
 	}
 	providerBlock := rootBody.AppendNewBlock("provider", []string{providerName})
 	providerBody := providerBlock.Body()
-	providerBody.SetAttributeValue("region", cty.StringVal(t.Region))
+	providerBody.SetAttributeValue("region", cty.StringVal(t.Cloud.Region()))
 	for k, v := range tfGetProviderExtraConfig(t.clusterSpecTarget) {
 		providerBody.SetAttributeValue(k, cty.StringVal(v))
 	}

--- a/upup/pkg/fi/cloudup/terraform/target_json.go
+++ b/upup/pkg/fi/cloudup/terraform/target_json.go
@@ -47,14 +47,14 @@ func (t *TerraformTarget) finishJSON(taskMap map[string]fi.Task) error {
 	if t.Cloud.ProviderID() == kops.CloudProviderGCE {
 		providerGoogle := make(map[string]interface{})
 		providerGoogle["project"] = t.Project
-		providerGoogle["region"] = t.Region
+		providerGoogle["region"] = t.Cloud.Region()
 		for k, v := range tfGetProviderExtraConfig(t.clusterSpecTarget) {
 			providerGoogle[k] = v
 		}
 		providersByName["google"] = providerGoogle
 	} else if t.Cloud.ProviderID() == kops.CloudProviderAWS {
 		providerAWS := make(map[string]interface{})
-		providerAWS["region"] = t.Region
+		providerAWS["region"] = t.Cloud.Region()
 		for k, v := range tfGetProviderExtraConfig(t.clusterSpecTarget) {
 			providerAWS[k] = v
 		}


### PR DESCRIPTION
There's no need to track it separately, now that we have the Region
method on the Cloud interface.