### PR TITLE
Drop support for containerd 1.2

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1115,7 +1115,7 @@ func validateContainerdConfig(config *kops.ContainerdConfig, fldPath *field.Path
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("version"), config.Version,
 				fmt.Sprintf("unable to parse version string: %s", err.Error())))
 		}
-		if sv.LT(semver.MustParse("1.2.4")) {
+		if sv.LT(semver.MustParse("1.3.4")) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("version"), config.Version, "unsupported legacy version"))
 		}
 	}

--- a/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd-cloudformation/cloudformation.json.extracted.yaml
@@ -144,15 +144,15 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
           [plugins."io.containerd.grpc.v1.cri".cni]
             conf_template = "/etc/containerd/cni-config.template"
     logLevel: info
-    version: 1.2.10
+    version: 1.4.3
   docker:
     skipInstall: true
   encryptionConfig: null
   etcdClusters:
     events:
-      version: 3.3.10
+      version: 3.4.13
     main:
-      version: 3.3.10
+      version: 3.4.13
   kubeAPIServer:
     allowPrivileged: true
     anonymousAuth: false
@@ -175,9 +175,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     - http://127.0.0.1:4001
     etcdServersOverrides:
     - /events#http://127.0.0.1:4002
-    image: k8s.gcr.io/kube-apiserver:v1.14.0
-    insecureBindAddress: 127.0.0.1
-    insecurePort: 8080
+    image: k8s.gcr.io/kube-apiserver:v1.19.0
     kubeletPreferredAddressTypes:
     - InternalIP
     - Hostname
@@ -201,7 +199,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     clusterCIDR: 100.96.0.0/11
     clusterName: containerd.example.com
     configureCloudRoutes: true
-    image: k8s.gcr.io/kube-controller-manager:v1.14.0
+    image: k8s.gcr.io/kube-controller-manager:v1.19.0
     leaderElection:
       leaderElect: true
     logLevel: 2
@@ -210,10 +208,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
     hostnameOverride: '@aws'
-    image: k8s.gcr.io/kube-proxy:v1.14.0
+    image: k8s.gcr.io/kube-proxy:v1.19.0
     logLevel: 2
   kubeScheduler:
-    image: k8s.gcr.io/kube-scheduler:v1.14.0
+    image: k8s.gcr.io/kube-scheduler:v1.19.0
     leaderElection:
       leaderElect: true
     logLevel: 2
@@ -225,8 +223,6 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
@@ -240,8 +236,6 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
@@ -259,15 +253,15 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
   cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
     amd64:
-    - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
-    - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
-    - 3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-    - 50cdf38749642ec43d6ac50f4a3f1f7f6ac688e8d8b4e1c5b7be06e1a82f06e9@https://download.docker.com/linux/static/stable/x86_64/docker-19.03.5.tgz
+    - 3f03e5c160a8b658d30b34824a1c00abadbac96e62c4d01bf5c9271a2debc3ab@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubelet
+    - 79bb0d2f05487ff533999a639c075043c70a0a1ba25c1629eb1eef6ebe3ba70f@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubectl
+    - 994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz
+    - 2697a342e3477c211ab48313e259fd7e32ad1f5ded19320e6a559f50a82bff3d@https://github.com/containerd/containerd/releases/download/v1.4.3/cri-containerd-cni-1.4.3-linux-amd64.tar.gz
     arm64:
-    - df38e04576026393055ccc77c0dce73612996561@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/arm64/kubelet
-    - 01c2b6b43d36b6bfafc80a3737391c19ebfb8ad5@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/arm64/kubectl
-    - 7fec91af78e9548df306f0ec43bea527c8c10cc3a9682c33e971c8522a7fcded@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-arm64-v0.7.5.tgz
-    - 0deddac5ae6f18ff0e6ce6a143c2cfd99c56dfb58be507770d840240fc9c51a9@https://download.docker.com/linux/static/stable/aarch64/docker-19.03.5.tgz
+    - d8fa5a9739ecc387dfcc55afa91ac6f4b0ccd01f1423c423dbd312d787bbb6bf@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/arm64/kubelet
+    - d4adf1b6b97252025cb2f7febf55daa3f42dc305822e3da133f77fd33071ec2f@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/arm64/kubectl
+    - 43fbf750c5eccb10accffeeb092693c32b236fb25d919cf058c91a677822c999@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.6/cni-plugins-linux-arm64-v0.8.6.tgz
+    - 6e3f80e8451ecbe7b3559247721c3e226be6b228acaadee7e13683f80c20e81c@https://download.docker.com/linux/static/stable/aarch64/docker-20.10.0.tgz
   ClusterName: containerd.example.com
   ConfigBase: memfs://clusters.example.com/containerd.example.com
   InstanceGroupName: master-us-test-1a
@@ -280,8 +274,6 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
@@ -311,6 +303,9 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
       - https://artifacts.k8s.io/binaries/kops/1.19.0-alpha.3/images/protokube-arm64.tar.gz
       - https://github.com/kubernetes/kops/releases/download/v1.19.0-alpha.3/images-protokube-arm64.tar.gz
       - https://kubeupv2.s3.amazonaws.com/kops/1.19.0-alpha.3/images/protokube-arm64.tar.gz
+  staticManifests:
+  - key: kube-apiserver-healthcheck
+    path: manifests/static/kube-apiserver-healthcheck.yaml
 
   __EOF_KUBE_ENV
 
@@ -462,14 +457,14 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
           [plugins."io.containerd.grpc.v1.cri".cni]
             conf_template = "/etc/containerd/cni-config.template"
     logLevel: info
-    version: 1.2.10
+    version: 1.4.3
   docker:
     skipInstall: true
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
     hostnameOverride: '@aws'
-    image: k8s.gcr.io/kube-proxy:v1.14.0
+    image: k8s.gcr.io/kube-proxy:v1.19.0
     logLevel: 2
   kubelet:
     anonymousAuth: false
@@ -479,8 +474,6 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
@@ -497,15 +490,15 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
   cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
   Assets:
     amd64:
-    - c3b736fd0f003765c12d99f2c995a8369e6241f4@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
-    - 7e3a3ea663153f900cbd52900a39c91fa9f334be@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
-    - 3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-    - 50cdf38749642ec43d6ac50f4a3f1f7f6ac688e8d8b4e1c5b7be06e1a82f06e9@https://download.docker.com/linux/static/stable/x86_64/docker-19.03.5.tgz
+    - 3f03e5c160a8b658d30b34824a1c00abadbac96e62c4d01bf5c9271a2debc3ab@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubelet
+    - 79bb0d2f05487ff533999a639c075043c70a0a1ba25c1629eb1eef6ebe3ba70f@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubectl
+    - 994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz
+    - 2697a342e3477c211ab48313e259fd7e32ad1f5ded19320e6a559f50a82bff3d@https://github.com/containerd/containerd/releases/download/v1.4.3/cri-containerd-cni-1.4.3-linux-amd64.tar.gz
     arm64:
-    - df38e04576026393055ccc77c0dce73612996561@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/arm64/kubelet
-    - 01c2b6b43d36b6bfafc80a3737391c19ebfb8ad5@https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/arm64/kubectl
-    - 7fec91af78e9548df306f0ec43bea527c8c10cc3a9682c33e971c8522a7fcded@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-arm64-v0.7.5.tgz
-    - 0deddac5ae6f18ff0e6ce6a143c2cfd99c56dfb58be507770d840240fc9c51a9@https://download.docker.com/linux/static/stable/aarch64/docker-19.03.5.tgz
+    - d8fa5a9739ecc387dfcc55afa91ac6f4b0ccd01f1423c423dbd312d787bbb6bf@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/arm64/kubelet
+    - d4adf1b6b97252025cb2f7febf55daa3f42dc305822e3da133f77fd33071ec2f@https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/arm64/kubectl
+    - 43fbf750c5eccb10accffeeb092693c32b236fb25d919cf058c91a677822c999@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.6/cni-plugins-linux-arm64-v0.8.6.tgz
+    - 6e3f80e8451ecbe7b3559247721c3e226be6b228acaadee7e13683f80c20e81c@https://download.docker.com/linux/static/stable/aarch64/docker-20.10.0.tgz
   ClusterName: containerd.example.com
   ConfigBase: memfs://clusters.example.com/containerd.example.com
   InstanceGroupName: nodes
@@ -518,8 +511,6 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      ExperimentalCriticalPodAnnotation: "true"
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2

--- a/tests/integration/update_cluster/containerd-cloudformation/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/containerd-cloudformation/in-v1alpha2.yaml
@@ -10,8 +10,6 @@ spec:
   cloudProvider: aws
   configBase: memfs://clusters.example.com/containerd.example.com
   containerRuntime: containerd
-  containerd:
-    version: 1.2.10
   etcdClusters:
   - etcdMembers:
     - instanceGroup: master-us-test-1a
@@ -24,7 +22,7 @@ spec:
   iam: {}
   kubelet:
     anonymousAuth: false
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.19.0
   masterInternalName: api.internal.containerd.example.com
   masterPublicName: api.containerd.example.com
   networkCIDR: 172.20.0.0/16

--- a/upup/pkg/fi/cloudup/containerd.go
+++ b/upup/pkg/fi/cloudup/containerd.go
@@ -165,15 +165,9 @@ func findAllContainerdHashesAmd64() map[string]string {
 
 func findAllContainerdDockerMappings() map[string]string {
 	versions := map[string]string{
-		"1.2.4":  "18.09.3",
-		"1.2.5":  "18.09.4",
-		"1.2.6":  "19.03.2",
-		"1.2.10": "19.03.5",
-		"1.2.12": "19.03.6",
-		"1.2.13": "19.03.11",
-		"1.3.7":  "19.03.13",
-		"1.3.9":  "19.03.14",
-		"1.4.3":  "20.10.0",
+		"1.3.7": "19.03.13",
+		"1.3.9": "19.03.14",
+		"1.4.3": "20.10.0",
 	}
 
 	return versions


### PR DESCRIPTION
Containerd 1.2 was only meant to be used for ARM64, when no other alternative version existed.
Containerd 1.2 was never the default in a released version of kOps, or advertised as supported.
At the moment, there is no need for it anymore, it is no longer supported and makes more complicated improvements to the config files.