### PR TITLE
Added event-qps and event-burst flags to kubelet

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -591,6 +591,28 @@ spec:
     housekeepingInterval: 30s
 ```
 
+### Event QPS
+{{ kops_feature_table(kops_added_default='1.19') }}
+
+The limit event creations per second in kubelet. Default value is `0` which means unlimited event creations.
+
+```yaml
+spec:
+  kubelet:
+    eventQPS: 0
+```
+
+### Event Burst
+{{ kops_feature_table(kops_added_default='1.19') }}
+
+Maximum size of a bursty event records, temporarily allows event records to burst to this number, while still not exceeding EventQPS. Only used if EventQPS > 0.
+
+```yaml
+spec:
+  kubelet:
+    eventBurst: 10
+```
+
 ## kubeScheduler
 
 This block contains configurations for `kube-scheduler`.  See https://kubernetes.io/docs/admin/kube-scheduler/

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2160,6 +2160,17 @@ spec:
                     description: Enforce Allocatable across pods whenever the overall
                       usage across all pods exceeds Allocatable.
                     type: string
+                  eventBurst:
+                    description: EventBurst temporarily allows event records to burst
+                      to this number, while still not exceeding EventQPS. Only used
+                      if EventQPS > 0.
+                    format: int32
+                    type: integer
+                  eventQPS:
+                    description: EventQPS if > 0, limit event creations per second
+                      to this value.  If 0, unlimited.
+                    format: int32
+                    type: integer
                   evictionHard:
                     description: Comma-delimited list of hard eviction expressions.  For
                       example, 'memory.available<300Mi'.
@@ -2541,6 +2552,17 @@ spec:
                     description: Enforce Allocatable across pods whenever the overall
                       usage across all pods exceeds Allocatable.
                     type: string
+                  eventBurst:
+                    description: EventBurst temporarily allows event records to burst
+                      to this number, while still not exceeding EventQPS. Only used
+                      if EventQPS > 0.
+                    format: int32
+                    type: integer
+                  eventQPS:
+                    description: EventQPS if > 0, limit event creations per second
+                      to this value.  If 0, unlimited.
+                    format: int32
+                    type: integer
                   evictionHard:
                     description: Comma-delimited list of hard eviction expressions.  For
                       example, 'memory.available<300Mi'.

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -339,6 +339,17 @@ spec:
                     description: Enforce Allocatable across pods whenever the overall
                       usage across all pods exceeds Allocatable.
                     type: string
+                  eventBurst:
+                    description: EventBurst temporarily allows event records to burst
+                      to this number, while still not exceeding EventQPS. Only used
+                      if EventQPS > 0.
+                    format: int32
+                    type: integer
+                  eventQPS:
+                    description: EventQPS if > 0, limit event creations per second
+                      to this value.  If 0, unlimited.
+                    format: int32
+                    type: integer
                   evictionHard:
                     description: Comma-delimited list of hard eviction expressions.  For
                       example, 'memory.available<300Mi'.

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -207,6 +207,10 @@ type KubeletConfigSpec struct {
 	CgroupDriver string `json:"cgroupDriver,omitempty" flag:"cgroup-driver"`
 	// HousekeepingInterval allows to specify interval between container housekeepings.
 	HousekeepingInterval *metav1.Duration `json:"housekeepingInterval,omitempty" flag:"housekeeping-interval"`
+	// EventQPS if > 0, limit event creations per second to this value.  If 0, unlimited.
+	EventQPS *int32 `json:"eventQPS,omitempty" flag:"event-qps" flag-empty:"0"`
+	// EventBurst temporarily allows event records to burst to this number, while still not exceeding EventQPS. Only used if EventQPS > 0.
+	EventBurst *int32 `json:"eventBurst,omitempty" flag:"event-burst"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -207,6 +207,10 @@ type KubeletConfigSpec struct {
 	CgroupDriver string `json:"cgroupDriver,omitempty" flag:"cgroup-driver"`
 	// HousekeepingInterval allows to specify interval between container housekeepings.
 	HousekeepingInterval *metav1.Duration `json:"housekeepingInterval,omitempty" flag:"housekeeping-interval"`
+	// EventQPS if > 0, limit event creations per second to this value.  If 0, unlimited.
+	EventQPS *int32 `json:"eventQPS,omitempty" flag:"event-qps" flag-empty:"0"`
+	// EventBurst temporarily allows event records to burst to this number, while still not exceeding EventQPS. Only used if EventQPS > 0.
+	EventBurst *int32 `json:"eventBurst,omitempty" flag:"event-burst"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4689,6 +4689,8 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.ProtectKernelDefaults = in.ProtectKernelDefaults
 	out.CgroupDriver = in.CgroupDriver
 	out.HousekeepingInterval = in.HousekeepingInterval
+	out.EventQPS = in.EventQPS
+	out.EventBurst = in.EventBurst
 	return nil
 }
 
@@ -4778,6 +4780,8 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.ProtectKernelDefaults = in.ProtectKernelDefaults
 	out.CgroupDriver = in.CgroupDriver
 	out.HousekeepingInterval = in.HousekeepingInterval
+	out.EventQPS = in.EventQPS
+	out.EventBurst = in.EventBurst
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3172,6 +3172,16 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.EventQPS != nil {
+		in, out := &in.EventQPS, &out.EventQPS
+		*out = new(int32)
+		**out = **in
+	}
+	if in.EventBurst != nil {
+		in, out := &in.EventBurst, &out.EventBurst
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3354,6 +3354,16 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.EventQPS != nil {
+		in, out := &in.EventQPS, &out.EventQPS
+		*out = new(int32)
+		**out = **in
+	}
+	if in.EventBurst != nil {
+		in, out := &in.EventBurst, &out.EventBurst
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
#6356 Enable kubelet --event-qps flag.
#6150 Will provide the functionality to fix `[WARN] 4.2.9 Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Not Scored)` in kube-bench report (CIS benchmarks)