### PR TITLE
Spotinst: Bump the Ocean Controller to 1.0.69

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -41595,7 +41595,7 @@ spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
         imagePullPolicy: Always
-        image: spotinst/kubernetes-cluster-controller:1.0.68
+        image: spotinst/kubernetes-cluster-controller:1.0.69
         livenessProbe:
           httpGet:
             path: /healthcheck

--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
@@ -199,7 +199,7 @@ spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
         imagePullPolicy: Always
-        image: spotinst/kubernetes-cluster-controller:1.0.68
+        image: spotinst/kubernetes-cluster-controller:1.0.69
         livenessProbe:
           httpGet:
             path: /healthcheck

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder.go
@@ -629,7 +629,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 		{
 			id := "v1.14.0"
 			location := key + "/" + id + ".yaml"
-			version := "1.0.68"
+			version := "1.0.69"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),


### PR DESCRIPTION
This PR upgrades the Ocean Controller to 1.0.69.