### PR TITLE
AWS IAM Role Tagging

### DIFF
--- a/cloudmock/aws/mockiam/iamrole.go
+++ b/cloudmock/aws/mockiam/iamrole.go
@@ -64,6 +64,7 @@ func (m *MockIAM) CreateRole(request *iam.CreateRoleInput) (*iam.CreateRoleOutpu
 		},
 		RoleName: request.RoleName,
 		RoleId:   &roleID,
+		Tags:     request.Tags,
 	}
 
 	if m.Roles == nil {

--- a/pkg/model/iam.go
+++ b/pkg/model/iam.go
@@ -136,6 +136,7 @@ func (b *IAMModelBuilder) buildIAMRole(role iam.Subject, iamName string, c *fi.M
 		Lifecycle: b.Lifecycle,
 
 		RolePolicyDocument: rolePolicy,
+		Tags:               b.CloudTags(iamName, false),
 	}
 
 	if isServiceAccount {

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -380,16 +380,31 @@ resource "aws_iam_role_policy" "nodes-bastionuserdata-example-com" {
 resource "aws_iam_role" "bastions-bastionuserdata-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.bastionuserdata.example.com_policy")
   name               = "bastions.bastionuserdata.example.com"
+  tags = {
+    "KubernetesCluster"                                 = "bastionuserdata.example.com"
+    "Name"                                              = "bastions.bastionuserdata.example.com"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "masters-bastionuserdata-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.bastionuserdata.example.com_policy")
   name               = "masters.bastionuserdata.example.com"
+  tags = {
+    "KubernetesCluster"                                 = "bastionuserdata.example.com"
+    "Name"                                              = "masters.bastionuserdata.example.com"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-bastionuserdata-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.bastionuserdata.example.com_policy")
   name               = "nodes.bastionuserdata.example.com"
+  tags = {
+    "KubernetesCluster"                                 = "bastionuserdata.example.com"
+    "Name"                                              = "nodes.bastionuserdata.example.com"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "bastionuserdata-example-com" {

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -1577,7 +1577,29 @@
           ],
           "Version": "2012-10-17"
         },
-        "PermissionsBoundary": "arn:aws:iam:00000000000:policy/boundaries"
+        "PermissionsBoundary": "arn:aws:iam:00000000000:policy/boundaries",
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "complex.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "masters.complex.example.com"
+          },
+          {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
+          },
+          {
+            "Key": "kubernetes.io/cluster/complex.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolenodescomplexexamplecom": {
@@ -1596,7 +1618,29 @@
           ],
           "Version": "2012-10-17"
         },
-        "PermissionsBoundary": "arn:aws:iam:00000000000:policy/boundaries"
+        "PermissionsBoundary": "arn:aws:iam:00000000000:policy/boundaries",
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "complex.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "nodes.complex.example.com"
+          },
+          {
+            "Key": "Owner",
+            "Value": "John Doe"
+          },
+          {
+            "Key": "foo/bar",
+            "Value": "fib+baz"
+          },
+          {
+            "Key": "kubernetes.io/cluster/complex.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSRoute53RecordSetapicomplexexamplecom": {

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -256,12 +256,26 @@ resource "aws_iam_role" "masters-complex-example-com" {
   assume_role_policy   = file("${path.module}/data/aws_iam_role_masters.complex.example.com_policy")
   name                 = "masters.complex.example.com"
   permissions_boundary = "arn:aws:iam:00000000000:policy/boundaries"
+  tags = {
+    "KubernetesCluster"                         = "complex.example.com"
+    "Name"                                      = "masters.complex.example.com"
+    "Owner"                                     = "John Doe"
+    "foo/bar"                                   = "fib+baz"
+    "kubernetes.io/cluster/complex.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-complex-example-com" {
   assume_role_policy   = file("${path.module}/data/aws_iam_role_nodes.complex.example.com_policy")
   name                 = "nodes.complex.example.com"
   permissions_boundary = "arn:aws:iam:00000000000:policy/boundaries"
+  tags = {
+    "KubernetesCluster"                         = "complex.example.com"
+    "Name"                                      = "nodes.complex.example.com"
+    "Owner"                                     = "John Doe"
+    "foo/bar"                                   = "fib+baz"
+    "kubernetes.io/cluster/complex.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "complex-example-com" {

--- a/tests/integration/update_cluster/compress/kubernetes.tf
+++ b/tests/integration/update_cluster/compress/kubernetes.tf
@@ -229,11 +229,21 @@ resource "aws_iam_role_policy" "nodes-compress-example-com" {
 resource "aws_iam_role" "masters-compress-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.compress.example.com_policy")
   name               = "masters.compress.example.com"
+  tags = {
+    "KubernetesCluster"                          = "compress.example.com"
+    "Name"                                       = "masters.compress.example.com"
+    "kubernetes.io/cluster/compress.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-compress-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.compress.example.com_policy")
   name               = "nodes.compress.example.com"
+  tags = {
+    "KubernetesCluster"                          = "compress.example.com"
+    "Name"                                       = "nodes.compress.example.com"
+    "kubernetes.io/cluster/compress.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "compress-example-com" {

--- a/tests/integration/update_cluster/containerd-custom/cloudformation.json
+++ b/tests/integration/update_cluster/containerd-custom/cloudformation.json
@@ -1059,7 +1059,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "containerd.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "masters.containerd.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/containerd.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolenodescontainerdexamplecom": {
@@ -1077,7 +1091,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "containerd.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "nodes.containerd.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/containerd.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     }
   }

--- a/tests/integration/update_cluster/containerd/cloudformation.json
+++ b/tests/integration/update_cluster/containerd/cloudformation.json
@@ -1059,7 +1059,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "containerd.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "masters.containerd.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/containerd.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolenodescontainerdexamplecom": {
@@ -1077,7 +1091,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "containerd.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "nodes.containerd.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/containerd.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     }
   }

--- a/tests/integration/update_cluster/docker-custom/cloudformation.json
+++ b/tests/integration/update_cluster/docker-custom/cloudformation.json
@@ -1059,7 +1059,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "docker.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "masters.docker.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/docker.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolenodesdockerexamplecom": {
@@ -1077,7 +1091,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "docker.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "nodes.docker.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/docker.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     }
   }

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -420,11 +420,21 @@ resource "aws_iam_role_policy" "nodes-existingsg-example-com" {
 resource "aws_iam_role" "masters-existingsg-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.existingsg.example.com_policy")
   name               = "masters.existingsg.example.com"
+  tags = {
+    "KubernetesCluster"                            = "existingsg.example.com"
+    "Name"                                         = "masters.existingsg.example.com"
+    "kubernetes.io/cluster/existingsg.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-existingsg-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.existingsg.example.com_policy")
   name               = "nodes.existingsg.example.com"
+  tags = {
+    "KubernetesCluster"                            = "existingsg.example.com"
+    "Name"                                         = "nodes.existingsg.example.com"
+    "kubernetes.io/cluster/existingsg.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "existingsg-example-com" {

--- a/tests/integration/update_cluster/externallb/cloudformation.json
+++ b/tests/integration/update_cluster/externallb/cloudformation.json
@@ -1074,7 +1074,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "externallb.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "masters.externallb.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/externallb.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolenodesexternallbexamplecom": {
@@ -1092,7 +1106,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "externallb.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "nodes.externallb.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/externallb.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     }
   }

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -233,11 +233,21 @@ resource "aws_iam_role_policy" "nodes-externallb-example-com" {
 resource "aws_iam_role" "masters-externallb-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.externallb.example.com_policy")
   name               = "masters.externallb.example.com"
+  tags = {
+    "KubernetesCluster"                            = "externallb.example.com"
+    "Name"                                         = "masters.externallb.example.com"
+    "kubernetes.io/cluster/externallb.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-externallb-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.externallb.example.com_policy")
   name               = "nodes.externallb.example.com"
+  tags = {
+    "KubernetesCluster"                            = "externallb.example.com"
+    "Name"                                         = "nodes.externallb.example.com"
+    "kubernetes.io/cluster/externallb.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "externallb-example-com" {

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -293,11 +293,25 @@ resource "aws_iam_role_policy" "nodes-externalpolicies-example-com" {
 resource "aws_iam_role" "masters-externalpolicies-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.externalpolicies.example.com_policy")
   name               = "masters.externalpolicies.example.com"
+  tags = {
+    "KubernetesCluster"                                  = "externalpolicies.example.com"
+    "Name"                                               = "masters.externalpolicies.example.com"
+    "Owner"                                              = "John Doe"
+    "foo/bar"                                            = "fib+baz"
+    "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-externalpolicies-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.externalpolicies.example.com_policy")
   name               = "nodes.externalpolicies.example.com"
+  tags = {
+    "KubernetesCluster"                                  = "externalpolicies.example.com"
+    "Name"                                               = "nodes.externalpolicies.example.com"
+    "Owner"                                              = "John Doe"
+    "foo/bar"                                            = "fib+baz"
+    "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "externalpolicies-example-com" {

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -391,11 +391,21 @@ resource "aws_iam_role_policy" "nodes-ha-example-com" {
 resource "aws_iam_role" "masters-ha-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.ha.example.com_policy")
   name               = "masters.ha.example.com"
+  tags = {
+    "KubernetesCluster"                    = "ha.example.com"
+    "Name"                                 = "masters.ha.example.com"
+    "kubernetes.io/cluster/ha.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-ha-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.ha.example.com_policy")
   name               = "nodes.ha.example.com"
+  tags = {
+    "KubernetesCluster"                    = "ha.example.com"
+    "Name"                                 = "nodes.ha.example.com"
+    "kubernetes.io/cluster/ha.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "ha-example-com" {

--- a/tests/integration/update_cluster/launch_templates/cloudformation.json
+++ b/tests/integration/update_cluster/launch_templates/cloudformation.json
@@ -1282,7 +1282,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "launchtemplates.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "masters.launchtemplates.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/launchtemplates.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolenodeslaunchtemplatesexamplecom": {
@@ -1300,7 +1314,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "launchtemplates.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "nodes.launchtemplates.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/launchtemplates.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     }
   }

--- a/tests/integration/update_cluster/launch_templates/kubernetes.tf
+++ b/tests/integration/update_cluster/launch_templates/kubernetes.tf
@@ -380,11 +380,21 @@ resource "aws_iam_role_policy" "nodes-launchtemplates-example-com" {
 resource "aws_iam_role" "masters-launchtemplates-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.launchtemplates.example.com_policy")
   name               = "masters.launchtemplates.example.com"
+  tags = {
+    "KubernetesCluster"                                 = "launchtemplates.example.com"
+    "Name"                                              = "masters.launchtemplates.example.com"
+    "kubernetes.io/cluster/launchtemplates.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-launchtemplates-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.launchtemplates.example.com_policy")
   name               = "nodes.launchtemplates.example.com"
+  tags = {
+    "KubernetesCluster"                                 = "launchtemplates.example.com"
+    "Name"                                              = "nodes.launchtemplates.example.com"
+    "kubernetes.io/cluster/launchtemplates.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "launchtemplates-example-com" {

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
@@ -1059,7 +1059,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "minimal.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "masters.minimal.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/minimal.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolenodesminimalexamplecom": {
@@ -1077,7 +1091,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "minimal.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "nodes.minimal.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/minimal.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     }
   }

--- a/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
+++ b/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
@@ -252,11 +252,21 @@
     "aws_iam_role": {
       "masters-minimal-json-example-com": {
         "name": "masters.minimal-json.example.com",
-        "assume_role_policy": "${file(\"${path.module}/data/aws_iam_role_masters.minimal-json.example.com_policy\")}"
+        "assume_role_policy": "${file(\"${path.module}/data/aws_iam_role_masters.minimal-json.example.com_policy\")}",
+        "tags": {
+          "KubernetesCluster": "minimal-json.example.com",
+          "Name": "masters.minimal-json.example.com",
+          "kubernetes.io/cluster/minimal-json.example.com": "owned"
+        }
       },
       "nodes-minimal-json-example-com": {
         "name": "nodes.minimal-json.example.com",
-        "assume_role_policy": "${file(\"${path.module}/data/aws_iam_role_nodes.minimal-json.example.com_policy\")}"
+        "assume_role_policy": "${file(\"${path.module}/data/aws_iam_role_nodes.minimal-json.example.com_policy\")}",
+        "tags": {
+          "KubernetesCluster": "minimal-json.example.com",
+          "Name": "nodes.minimal-json.example.com",
+          "kubernetes.io/cluster/minimal-json.example.com": "owned"
+        }
       }
     },
     "aws_iam_role_policy": {

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -229,11 +229,21 @@ resource "aws_iam_role_policy" "nodes-minimal-example-com" {
 resource "aws_iam_role" "masters-minimal-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.minimal.example.com_policy")
   name               = "masters.minimal.example.com"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "masters.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-minimal-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.minimal.example.com_policy")
   name               = "nodes.minimal.example.com"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "nodes.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "minimal-example-com" {

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json
@@ -1672,7 +1672,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "mixedinstances.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "masters.mixedinstances.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/mixedinstances.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolenodesmixedinstancesexamplecom": {
@@ -1690,7 +1704,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "mixedinstances.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "nodes.mixedinstances.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/mixedinstances.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     }
   }

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -409,11 +409,21 @@ resource "aws_iam_role_policy" "nodes-mixedinstances-example-com" {
 resource "aws_iam_role" "masters-mixedinstances-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.mixedinstances.example.com_policy")
   name               = "masters.mixedinstances.example.com"
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "masters.mixedinstances.example.com"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-mixedinstances-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.mixedinstances.example.com_policy")
   name               = "nodes.mixedinstances.example.com"
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "nodes.mixedinstances.example.com"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "mixedinstances-example-com" {

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
@@ -1673,7 +1673,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "mixedinstances.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "masters.mixedinstances.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/mixedinstances.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolenodesmixedinstancesexamplecom": {
@@ -1691,7 +1705,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "mixedinstances.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "nodes.mixedinstances.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/mixedinstances.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     }
   }

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -409,11 +409,21 @@ resource "aws_iam_role_policy" "nodes-mixedinstances-example-com" {
 resource "aws_iam_role" "masters-mixedinstances-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.mixedinstances.example.com_policy")
   name               = "masters.mixedinstances.example.com"
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "masters.mixedinstances.example.com"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-mixedinstances-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.mixedinstances.example.com_policy")
   name               = "nodes.mixedinstances.example.com"
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "nodes.mixedinstances.example.com"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "mixedinstances-example-com" {

--- a/tests/integration/update_cluster/private-shared-ip/cloudformation.json
+++ b/tests/integration/update_cluster/private-shared-ip/cloudformation.json
@@ -1552,7 +1552,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "private-shared-ip.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "bastions.private-shared-ip.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/private-shared-ip.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolemastersprivatesharedipexamplecom": {
@@ -1570,7 +1584,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "private-shared-ip.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "masters.private-shared-ip.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/private-shared-ip.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolenodesprivatesharedipexamplecom": {
@@ -1588,7 +1616,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "private-shared-ip.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "nodes.private-shared-ip.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/private-shared-ip.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSRoute53RecordSetapiprivatesharedipexamplecom": {

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -366,16 +366,31 @@ resource "aws_iam_role_policy" "nodes-private-shared-ip-example-com" {
 resource "aws_iam_role" "bastions-private-shared-ip-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.private-shared-ip.example.com_policy")
   name               = "bastions.private-shared-ip.example.com"
+  tags = {
+    "KubernetesCluster"                                   = "private-shared-ip.example.com"
+    "Name"                                                = "bastions.private-shared-ip.example.com"
+    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "masters-private-shared-ip-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.private-shared-ip.example.com_policy")
   name               = "masters.private-shared-ip.example.com"
+  tags = {
+    "KubernetesCluster"                                   = "private-shared-ip.example.com"
+    "Name"                                                = "masters.private-shared-ip.example.com"
+    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-private-shared-ip-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.private-shared-ip.example.com_policy")
   name               = "nodes.private-shared-ip.example.com"
+  tags = {
+    "KubernetesCluster"                                   = "private-shared-ip.example.com"
+    "Name"                                                = "nodes.private-shared-ip.example.com"
+    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
+  }
 }
 
 resource "aws_key_pair" "kubernetes-private-shared-ip-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -361,16 +361,31 @@ resource "aws_iam_role_policy" "nodes-private-shared-subnet-example-com" {
 resource "aws_iam_role" "bastions-private-shared-subnet-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.private-shared-subnet.example.com_policy")
   name               = "bastions.private-shared-subnet.example.com"
+  tags = {
+    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
+    "Name"                                                    = "bastions.private-shared-subnet.example.com"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "masters-private-shared-subnet-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.private-shared-subnet.example.com_policy")
   name               = "masters.private-shared-subnet.example.com"
+  tags = {
+    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
+    "Name"                                                    = "masters.private-shared-subnet.example.com"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-private-shared-subnet-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.private-shared-subnet.example.com_policy")
   name               = "nodes.private-shared-subnet.example.com"
+  tags = {
+    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
+    "Name"                                                    = "nodes.private-shared-subnet.example.com"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+  }
 }
 
 resource "aws_key_pair" "kubernetes-private-shared-subnet-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -1697,7 +1697,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "privatecalico.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "bastions.privatecalico.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/privatecalico.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolemastersprivatecalicoexamplecom": {
@@ -1715,7 +1729,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "privatecalico.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "masters.privatecalico.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/privatecalico.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolenodesprivatecalicoexamplecom": {
@@ -1733,7 +1761,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "privatecalico.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "nodes.privatecalico.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/privatecalico.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSRoute53RecordSetapiprivatecalicoexamplecom": {

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -380,16 +380,31 @@ resource "aws_iam_role_policy" "nodes-privatecalico-example-com" {
 resource "aws_iam_role" "bastions-privatecalico-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.privatecalico.example.com_policy")
   name               = "bastions.privatecalico.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatecalico.example.com"
+    "Name"                                            = "bastions.privatecalico.example.com"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "masters-privatecalico-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.privatecalico.example.com_policy")
   name               = "masters.privatecalico.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatecalico.example.com"
+    "Name"                                            = "masters.privatecalico.example.com"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-privatecalico-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.privatecalico.example.com_policy")
   name               = "nodes.privatecalico.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatecalico.example.com"
+    "Name"                                            = "nodes.privatecalico.example.com"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "privatecalico-example-com" {

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -380,16 +380,31 @@ resource "aws_iam_role_policy" "nodes-privatecanal-example-com" {
 resource "aws_iam_role" "bastions-privatecanal-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.privatecanal.example.com_policy")
   name               = "bastions.privatecanal.example.com"
+  tags = {
+    "KubernetesCluster"                              = "privatecanal.example.com"
+    "Name"                                           = "bastions.privatecanal.example.com"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "masters-privatecanal-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.privatecanal.example.com_policy")
   name               = "masters.privatecanal.example.com"
+  tags = {
+    "KubernetesCluster"                              = "privatecanal.example.com"
+    "Name"                                           = "masters.privatecanal.example.com"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-privatecanal-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.privatecanal.example.com_policy")
   name               = "nodes.privatecanal.example.com"
+  tags = {
+    "KubernetesCluster"                              = "privatecanal.example.com"
+    "Name"                                           = "nodes.privatecanal.example.com"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "privatecanal-example-com" {

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json
@@ -1683,7 +1683,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "privatecilium.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "bastions.privatecilium.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/privatecilium.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolemastersprivateciliumexamplecom": {
@@ -1701,7 +1715,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "privatecilium.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "masters.privatecilium.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/privatecilium.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolenodesprivateciliumexamplecom": {
@@ -1719,7 +1747,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "privatecilium.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "nodes.privatecilium.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/privatecilium.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSRoute53RecordSetapiprivateciliumexamplecom": {

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -380,16 +380,31 @@ resource "aws_iam_role_policy" "nodes-privatecilium-example-com" {
 resource "aws_iam_role" "bastions-privatecilium-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.privatecilium.example.com_policy")
   name               = "bastions.privatecilium.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "bastions.privatecilium.example.com"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "masters-privatecilium-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.privatecilium.example.com_policy")
   name               = "masters.privatecilium.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "masters.privatecilium.example.com"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-privatecilium-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.privatecilium.example.com_policy")
   name               = "nodes.privatecilium.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "nodes.privatecilium.example.com"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "privatecilium-example-com" {

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json
@@ -1683,7 +1683,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "privatecilium.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "bastions.privatecilium.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/privatecilium.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolemastersprivateciliumexamplecom": {
@@ -1701,7 +1715,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "privatecilium.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "masters.privatecilium.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/privatecilium.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolenodesprivateciliumexamplecom": {
@@ -1719,7 +1747,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "privatecilium.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "nodes.privatecilium.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/privatecilium.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSRoute53RecordSetapiprivateciliumexamplecom": {

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -380,16 +380,31 @@ resource "aws_iam_role_policy" "nodes-privatecilium-example-com" {
 resource "aws_iam_role" "bastions-privatecilium-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.privatecilium.example.com_policy")
   name               = "bastions.privatecilium.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "bastions.privatecilium.example.com"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "masters-privatecilium-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.privatecilium.example.com_policy")
   name               = "masters.privatecilium.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "masters.privatecilium.example.com"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-privatecilium-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.privatecilium.example.com_policy")
   name               = "nodes.privatecilium.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "nodes.privatecilium.example.com"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "privatecilium-example-com" {

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
@@ -1734,7 +1734,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "privateciliumadvanced.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "bastions.privateciliumadvanced.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/privateciliumadvanced.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolemastersprivateciliumadvancedexamplecom": {
@@ -1752,7 +1766,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "privateciliumadvanced.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "masters.privateciliumadvanced.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/privateciliumadvanced.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSIAMRolenodesprivateciliumadvancedexamplecom": {
@@ -1770,7 +1798,21 @@
             }
           ],
           "Version": "2012-10-17"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "privateciliumadvanced.example.com"
+          },
+          {
+            "Key": "Name",
+            "Value": "nodes.privateciliumadvanced.example.com"
+          },
+          {
+            "Key": "kubernetes.io/cluster/privateciliumadvanced.example.com",
+            "Value": "owned"
+          }
+        ]
       }
     },
     "AWSRoute53RecordSetapiprivateciliumadvancedexamplecom": {

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -394,16 +394,31 @@ resource "aws_iam_role_policy" "nodes-privateciliumadvanced-example-com" {
 resource "aws_iam_role" "bastions-privateciliumadvanced-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.privateciliumadvanced.example.com_policy")
   name               = "bastions.privateciliumadvanced.example.com"
+  tags = {
+    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+    "Name"                                                    = "bastions.privateciliumadvanced.example.com"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "masters-privateciliumadvanced-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.privateciliumadvanced.example.com_policy")
   name               = "masters.privateciliumadvanced.example.com"
+  tags = {
+    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+    "Name"                                                    = "masters.privateciliumadvanced.example.com"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-privateciliumadvanced-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.privateciliumadvanced.example.com_policy")
   name               = "nodes.privateciliumadvanced.example.com"
+  tags = {
+    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+    "Name"                                                    = "nodes.privateciliumadvanced.example.com"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "privateciliumadvanced-example-com" {

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -420,16 +420,37 @@ resource "aws_iam_role_policy" "nodes-privatedns1-example-com" {
 resource "aws_iam_role" "bastions-privatedns1-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.privatedns1.example.com_policy")
   name               = "bastions.privatedns1.example.com"
+  tags = {
+    "KubernetesCluster"                             = "privatedns1.example.com"
+    "Name"                                          = "bastions.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "masters-privatedns1-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.privatedns1.example.com_policy")
   name               = "masters.privatedns1.example.com"
+  tags = {
+    "KubernetesCluster"                             = "privatedns1.example.com"
+    "Name"                                          = "masters.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-privatedns1-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.privatedns1.example.com_policy")
   name               = "nodes.privatedns1.example.com"
+  tags = {
+    "KubernetesCluster"                             = "privatedns1.example.com"
+    "Name"                                          = "nodes.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "privatedns1-example-com" {

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -375,16 +375,31 @@ resource "aws_iam_role_policy" "nodes-privatedns2-example-com" {
 resource "aws_iam_role" "bastions-privatedns2-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.privatedns2.example.com_policy")
   name               = "bastions.privatedns2.example.com"
+  tags = {
+    "KubernetesCluster"                             = "privatedns2.example.com"
+    "Name"                                          = "bastions.privatedns2.example.com"
+    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "masters-privatedns2-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.privatedns2.example.com_policy")
   name               = "masters.privatedns2.example.com"
+  tags = {
+    "KubernetesCluster"                             = "privatedns2.example.com"
+    "Name"                                          = "masters.privatedns2.example.com"
+    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-privatedns2-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.privatedns2.example.com_policy")
   name               = "nodes.privatedns2.example.com"
+  tags = {
+    "KubernetesCluster"                             = "privatedns2.example.com"
+    "Name"                                          = "nodes.privatedns2.example.com"
+    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+  }
 }
 
 resource "aws_key_pair" "kubernetes-privatedns2-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -380,16 +380,31 @@ resource "aws_iam_role_policy" "nodes-privateflannel-example-com" {
 resource "aws_iam_role" "bastions-privateflannel-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.privateflannel.example.com_policy")
   name               = "bastions.privateflannel.example.com"
+  tags = {
+    "KubernetesCluster"                                = "privateflannel.example.com"
+    "Name"                                             = "bastions.privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "masters-privateflannel-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.privateflannel.example.com_policy")
   name               = "masters.privateflannel.example.com"
+  tags = {
+    "KubernetesCluster"                                = "privateflannel.example.com"
+    "Name"                                             = "masters.privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-privateflannel-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.privateflannel.example.com_policy")
   name               = "nodes.privateflannel.example.com"
+  tags = {
+    "KubernetesCluster"                                = "privateflannel.example.com"
+    "Name"                                             = "nodes.privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "privateflannel-example-com" {

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -386,16 +386,31 @@ resource "aws_iam_role_policy" "nodes-privatekopeio-example-com" {
 resource "aws_iam_role" "bastions-privatekopeio-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.privatekopeio.example.com_policy")
   name               = "bastions.privatekopeio.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "bastions.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "masters-privatekopeio-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.privatekopeio.example.com_policy")
   name               = "masters.privatekopeio.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "masters.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-privatekopeio-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.privatekopeio.example.com_policy")
   name               = "nodes.privatekopeio.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "nodes.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "privatekopeio-example-com" {

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -380,16 +380,31 @@ resource "aws_iam_role_policy" "nodes-privateweave-example-com" {
 resource "aws_iam_role" "bastions-privateweave-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.privateweave.example.com_policy")
   name               = "bastions.privateweave.example.com"
+  tags = {
+    "KubernetesCluster"                              = "privateweave.example.com"
+    "Name"                                           = "bastions.privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "masters-privateweave-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.privateweave.example.com_policy")
   name               = "masters.privateweave.example.com"
+  tags = {
+    "KubernetesCluster"                              = "privateweave.example.com"
+    "Name"                                           = "masters.privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-privateweave-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.privateweave.example.com_policy")
   name               = "nodes.privateweave.example.com"
+  tags = {
+    "KubernetesCluster"                              = "privateweave.example.com"
+    "Name"                                           = "nodes.privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "privateweave-example-com" {

--- a/tests/integration/update_cluster/public-jwks/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks/kubernetes.tf
@@ -251,16 +251,31 @@ resource "aws_iam_role_policy" "nodes-minimal-example-com" {
 resource "aws_iam_role" "dns-controller-kube-system-sa-minimal-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_dns-controller.kube-system.sa.minimal.example.com_policy")
   name               = "dns-controller.kube-system.sa.minimal.example.com"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "dns-controller.kube-system.sa.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "masters-minimal-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.minimal.example.com_policy")
   name               = "masters.minimal.example.com"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "masters.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-minimal-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.minimal.example.com_policy")
   name               = "nodes.minimal.example.com"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "nodes.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_internet_gateway" "minimal-example-com" {

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -224,11 +224,21 @@ resource "aws_iam_role_policy" "nodes-sharedsubnet-example-com" {
 resource "aws_iam_role" "masters-sharedsubnet-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.sharedsubnet.example.com_policy")
   name               = "masters.sharedsubnet.example.com"
+  tags = {
+    "KubernetesCluster"                              = "sharedsubnet.example.com"
+    "Name"                                           = "masters.sharedsubnet.example.com"
+    "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-sharedsubnet-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.sharedsubnet.example.com_policy")
   name               = "nodes.sharedsubnet.example.com"
+  tags = {
+    "KubernetesCluster"                              = "sharedsubnet.example.com"
+    "Name"                                           = "nodes.sharedsubnet.example.com"
+    "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
+  }
 }
 
 resource "aws_key_pair" "kubernetes-sharedsubnet-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -224,11 +224,21 @@ resource "aws_iam_role_policy" "nodes-sharedvpc-example-com" {
 resource "aws_iam_role" "masters-sharedvpc-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.sharedvpc.example.com_policy")
   name               = "masters.sharedvpc.example.com"
+  tags = {
+    "KubernetesCluster"                           = "sharedvpc.example.com"
+    "Name"                                        = "masters.sharedvpc.example.com"
+    "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-sharedvpc-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.sharedvpc.example.com_policy")
   name               = "nodes.sharedvpc.example.com"
+  tags = {
+    "KubernetesCluster"                           = "sharedvpc.example.com"
+    "Name"                                        = "nodes.sharedvpc.example.com"
+    "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
+  }
 }
 
 resource "aws_key_pair" "kubernetes-sharedvpc-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -366,16 +366,31 @@ resource "aws_iam_role_policy" "nodes-unmanaged-example-com" {
 resource "aws_iam_role" "bastions-unmanaged-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.unmanaged.example.com_policy")
   name               = "bastions.unmanaged.example.com"
+  tags = {
+    "KubernetesCluster"                           = "unmanaged.example.com"
+    "Name"                                        = "bastions.unmanaged.example.com"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "masters-unmanaged-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.unmanaged.example.com_policy")
   name               = "masters.unmanaged.example.com"
+  tags = {
+    "KubernetesCluster"                           = "unmanaged.example.com"
+    "Name"                                        = "masters.unmanaged.example.com"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role" "nodes-unmanaged-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_nodes.unmanaged.example.com_policy")
   name               = "nodes.unmanaged.example.com"
+  tags = {
+    "KubernetesCluster"                           = "unmanaged.example.com"
+    "Name"                                        = "nodes.unmanaged.example.com"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+  }
 }
 
 resource "aws_key_pair" "kubernetes-unmanaged-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {

--- a/upup/pkg/fi/cloudup/awstasks/tags.go
+++ b/upup/pkg/fi/cloudup/awstasks/tags.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/iam"
 )
 
 func mapEC2TagsToMap(tags []*ec2.Tag) map[string]string {
@@ -33,6 +34,34 @@ func mapEC2TagsToMap(tags []*ec2.Tag) map[string]string {
 			continue
 		}
 		m[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+	return m
+}
+
+func mapIAMTagsToMap(tags []*iam.Tag) map[string]string {
+	if tags == nil {
+		return nil
+	}
+	m := make(map[string]string)
+	for _, t := range tags {
+		if strings.HasPrefix(aws.StringValue(t.Key), "aws:cloudformation:") {
+			continue
+		}
+		m[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+	return m
+}
+
+func mapToIAMTags(tags map[string]string) []*iam.Tag {
+	if tags == nil {
+		return nil
+	}
+	m := make([]*iam.Tag, 0)
+	for k, v := range tags {
+		m = append(m, &iam.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		})
 	}
 	return m
 }


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kops/issues/9640

This adds support for tagging IAM roles with the usual cloud tags, as demonstrated by the updated integration test outputs.

An idea I had for this was to add tags for service account roles that specify the service account name and namespace but we need to decide on the tag keys to use. I'm not aware of any official recommendations for this but we could do something similar to what the aws-load-balancer-controller does for ingress tags:

https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/9776d298fddc1bb7fe9245510467d2507580ec96/internal/alb/generator/tag.go#L14

`kubernetes.io/namespace`
`kubernetes.io/service-account-name`

I'd like to ensure that would be acceptable first given the reserved nature of `kubernetes.io`. Any ideas @justinsb?