### PR TITLE
Automated cherry pick of #10486: Added event-qps to kubelet flags Change default value for

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -564,6 +564,28 @@ spec:
     housekeepingInterval: 30s
 ```
 
+### Event QPS
+{{ kops_feature_table(kops_added_default='1.19') }}
+
+The limit event creations per second in kubelet. Default value is `0` which means unlimited event creations.
+
+```yaml
+spec:
+  kubelet:
+    eventQPS: 0
+```
+
+### Event Burst
+{{ kops_feature_table(kops_added_default='1.19') }}
+
+Maximum size of a bursty event records, temporarily allows event records to burst to this number, while still not exceeding EventQPS. Only used if EventQPS > 0.
+
+```yaml
+spec:
+  kubelet:
+    eventBurst: 10
+```
+
 ## kubeScheduler
 
 This block contains configurations for `kube-scheduler`.  See https://kubernetes.io/docs/admin/kube-scheduler/

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1652,6 +1652,14 @@ spec:
                   enforceNodeAllocatable:
                     description: Enforce Allocatable across pods whenever the overall usage across all pods exceeds Allocatable.
                     type: string
+                  eventBurst:
+                    description: EventBurst temporarily allows event records to burst to this number, while still not exceeding EventQPS. Only used if EventQPS > 0.
+                    format: int32
+                    type: integer
+                  eventQPS:
+                    description: EventQPS if > 0, limit event creations per second to this value.  If 0, unlimited.
+                    format: int32
+                    type: integer
                   evictionHard:
                     description: Comma-delimited list of hard eviction expressions.  For example, 'memory.available<300Mi'.
                     type: string
@@ -1933,6 +1941,14 @@ spec:
                   enforceNodeAllocatable:
                     description: Enforce Allocatable across pods whenever the overall usage across all pods exceeds Allocatable.
                     type: string
+                  eventBurst:
+                    description: EventBurst temporarily allows event records to burst to this number, while still not exceeding EventQPS. Only used if EventQPS > 0.
+                    format: int32
+                    type: integer
+                  eventQPS:
+                    description: EventQPS if > 0, limit event creations per second to this value.  If 0, unlimited.
+                    format: int32
+                    type: integer
                   evictionHard:
                     description: Comma-delimited list of hard eviction expressions.  For example, 'memory.available<300Mi'.
                     type: string

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -281,6 +281,14 @@ spec:
                   enforceNodeAllocatable:
                     description: Enforce Allocatable across pods whenever the overall usage across all pods exceeds Allocatable.
                     type: string
+                  eventBurst:
+                    description: EventBurst temporarily allows event records to burst to this number, while still not exceeding EventQPS. Only used if EventQPS > 0.
+                    format: int32
+                    type: integer
+                  eventQPS:
+                    description: EventQPS if > 0, limit event creations per second to this value.  If 0, unlimited.
+                    format: int32
+                    type: integer
                   evictionHard:
                     description: Comma-delimited list of hard eviction expressions.  For example, 'memory.available<300Mi'.
                     type: string

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -207,6 +207,10 @@ type KubeletConfigSpec struct {
 	CgroupDriver string `json:"cgroupDriver,omitempty" flag:"cgroup-driver"`
 	// HousekeepingInterval allows to specify interval between container housekeepings.
 	HousekeepingInterval *metav1.Duration `json:"housekeepingInterval,omitempty" flag:"housekeeping-interval"`
+	// EventQPS if > 0, limit event creations per second to this value.  If 0, unlimited.
+	EventQPS *int32 `json:"eventQPS,omitempty" flag:"event-qps" flag-empty:"0"`
+	// EventBurst temporarily allows event records to burst to this number, while still not exceeding EventQPS. Only used if EventQPS > 0.
+	EventBurst *int32 `json:"eventBurst,omitempty" flag:"event-burst"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -207,6 +207,10 @@ type KubeletConfigSpec struct {
 	CgroupDriver string `json:"cgroupDriver,omitempty" flag:"cgroup-driver"`
 	// HousekeepingInterval allows to specify interval between container housekeepings.
 	HousekeepingInterval *metav1.Duration `json:"housekeepingInterval,omitempty" flag:"housekeeping-interval"`
+	// EventQPS if > 0, limit event creations per second to this value.  If 0, unlimited.
+	EventQPS *int32 `json:"eventQPS,omitempty" flag:"event-qps" flag-empty:"0"`
+	// EventBurst temporarily allows event records to burst to this number, while still not exceeding EventQPS. Only used if EventQPS > 0.
+	EventBurst *int32 `json:"eventBurst,omitempty" flag:"event-burst"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4567,6 +4567,8 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.ProtectKernelDefaults = in.ProtectKernelDefaults
 	out.CgroupDriver = in.CgroupDriver
 	out.HousekeepingInterval = in.HousekeepingInterval
+	out.EventQPS = in.EventQPS
+	out.EventBurst = in.EventBurst
 	return nil
 }
 
@@ -4656,6 +4658,8 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.ProtectKernelDefaults = in.ProtectKernelDefaults
 	out.CgroupDriver = in.CgroupDriver
 	out.HousekeepingInterval = in.HousekeepingInterval
+	out.EventQPS = in.EventQPS
+	out.EventBurst = in.EventBurst
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3074,6 +3074,16 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.EventQPS != nil {
+		in, out := &in.EventQPS, &out.EventQPS
+		*out = new(int32)
+		**out = **in
+	}
+	if in.EventBurst != nil {
+		in, out := &in.EventBurst, &out.EventBurst
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3256,6 +3256,16 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.EventQPS != nil {
+		in, out := &in.EventQPS, &out.EventQPS
+		*out = new(int32)
+		**out = **in
+	}
+	if in.EventBurst != nil {
+		in, out := &in.EventBurst, &out.EventBurst
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Cherry pick of #10486 on release-1.19.

#10486: Added event-qps to kubelet flags Change default value for

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.