### PR TITLE
Automated cherry pick of #10471: addons(cluster-autoscaler): Add newPodScaleUpDelay in

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -356,6 +356,9 @@ spec:
                   image:
                     description: 'Image is the docker container used. Default: the latest supported image for the specified kubernetes version.'
                     type: string
+                  newPodScaleUpDelay:
+                    description: 'NewPodScaleUpDelay causes cluster autoscaler to ignore unschedulable pods until they are a certain "age", regardless of the scan-interval Default: 0s'
+                    type: string
                   scaleDownUtilizationThreshold:
                     description: 'ScaleDownUtilizationThreshold determines the utilization threshold for node scale-down. Default: 0.5'
                     type: string

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -818,6 +818,9 @@ type ClusterAutoscalerConfig struct {
 	// SkipNodesWithLocalStorage makes cluster autoscaler skip scale-down of nodes with local storage.
 	// Default: true
 	SkipNodesWithLocalStorage *bool `json:"skipNodesWithLocalStorage,omitempty"`
+	// NewPodScaleUpDelay causes cluster autoscaler to ignore unschedulable pods until they are a certain "age", regardless of the scan-interval
+	// Default: 0s
+	NewPodScaleUpDelay *string `json:"newPodScaleUpDelay,omitempty"`
 	// Image is the docker container used.
 	// Default: the latest supported image for the specified kubernetes version.
 	Image *string `json:"image,omitempty"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -819,6 +819,9 @@ type ClusterAutoscalerConfig struct {
 	// SkipNodesWithLocalStorage makes cluster autoscaler skip scale-down of nodes with local storage.
 	// Default: true
 	SkipNodesWithLocalStorage *bool `json:"skipNodesWithLocalStorage,omitempty"`
+	// NewPodScaleUpDelay causes cluster autoscaler to ignore unschedulable pods until they are a certain "age", regardless of the scan-interval
+	// Default: 0s
+	NewPodScaleUpDelay *string `json:"newPodScaleUpDelay,omitempty"`
 	// Image is the docker container used.
 	// Default: the latest supported image for the specified kubernetes version.
 	Image *string `json:"image,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1809,6 +1809,7 @@ func autoConvert_v1alpha2_ClusterAutoscalerConfig_To_kops_ClusterAutoscalerConfi
 	out.ScaleDownUtilizationThreshold = in.ScaleDownUtilizationThreshold
 	out.SkipNodesWithSystemPods = in.SkipNodesWithSystemPods
 	out.SkipNodesWithLocalStorage = in.SkipNodesWithLocalStorage
+	out.NewPodScaleUpDelay = in.NewPodScaleUpDelay
 	out.Image = in.Image
 	return nil
 }
@@ -1825,6 +1826,7 @@ func autoConvert_kops_ClusterAutoscalerConfig_To_v1alpha2_ClusterAutoscalerConfi
 	out.ScaleDownUtilizationThreshold = in.ScaleDownUtilizationThreshold
 	out.SkipNodesWithSystemPods = in.SkipNodesWithSystemPods
 	out.SkipNodesWithLocalStorage = in.SkipNodesWithLocalStorage
+	out.NewPodScaleUpDelay = in.NewPodScaleUpDelay
 	out.Image = in.Image
 	return nil
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -612,6 +612,11 @@ func (in *ClusterAutoscalerConfig) DeepCopyInto(out *ClusterAutoscalerConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.NewPodScaleUpDelay != nil {
+		in, out := &in.NewPodScaleUpDelay, &out.NewPodScaleUpDelay
+		*out = new(string)
+		**out = **in
+	}
 	if in.Image != nil {
 		in, out := &in.Image, &out.Image
 		*out = new(string)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -712,6 +712,11 @@ func (in *ClusterAutoscalerConfig) DeepCopyInto(out *ClusterAutoscalerConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.NewPodScaleUpDelay != nil {
+		in, out := &in.NewPodScaleUpDelay, &out.NewPodScaleUpDelay
+		*out = new(string)
+		**out = **in
+	}
 	if in.Image != nil {
 		in, out := &in.Image, &out.Image
 		*out = new(string)

--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -80,6 +80,9 @@ func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o interface{}) error {
 	if cas.BalanceSimilarNodeGroups == nil {
 		cas.BalanceSimilarNodeGroups = fi.Bool(false)
 	}
+	if cas.NewPodScaleUpDelay == nil {
+		cas.NewPodScaleUpDelay = fi.String("0s")
+	}
 
 	return nil
 }

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -1040,6 +1040,7 @@ spec:
             - --scale-down-utilization-threshold={{ .ScaleDownUtilizationThreshold }}
             - --skip-nodes-with-local-storage={{ .SkipNodesWithLocalStorage }}
             - --skip-nodes-with-system-pods={{ .SkipNodesWithSystemPods }}
+            - --new-pod-scale-up-delay={{ .NewPodScaleUpDelay }}
             - --stderrthreshold=info
             - --v=2
           ports:

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -159,6 +159,7 @@ spec:
             - --scale-down-utilization-threshold={{ .ScaleDownUtilizationThreshold }}
             - --skip-nodes-with-local-storage={{ .SkipNodesWithLocalStorage }}
             - --skip-nodes-with-system-pods={{ .SkipNodesWithSystemPods }}
+            - --new-pod-scale-up-delay={{ .NewPodScaleUpDelay }}
             - --stderrthreshold=info
             - --v=2
           ports:


### PR DESCRIPTION
Cherry pick of #10471 on release-1.19.

#10471: addons(cluster-autoscaler): Add newPodScaleUpDelay in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.