### PR TITLE
Automated cherry pick of #10501: Remove support for Kubenet with containerd

### DIFF
--- a/cmd/kops/BUILD.bazel
+++ b/cmd/kops/BUILD.bazel
@@ -79,6 +79,7 @@ go_library(
         "//pkg/kopscodecs:go_default_library",
         "//pkg/kubeconfig:go_default_library",
         "//pkg/kubemanifest:go_default_library",
+        "//pkg/model/components:go_default_library",
         "//pkg/pki:go_default_library",
         "//pkg/pretty:go_default_library",
         "//pkg/resources:go_default_library",

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/kubeconfig"
 	"k8s.io/kops/pkg/kubemanifest"
+	"k8s.io/kops/pkg/model/components"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"k8s.io/kops/upup/pkg/fi/utils"
@@ -479,6 +480,9 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 
 	if c.ContainerRuntime != "" {
 		cluster.Spec.ContainerRuntime = c.ContainerRuntime
+	}
+	if c.ContainerRuntime == "containerd" && components.UsesKubenet(cluster.Spec.Networking) {
+		return fmt.Errorf("--networking with CNI plugin is required for containerd")
 	}
 
 	if c.NetworkCIDR != "" {

--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/kops/nodeup/pkg/model/resources"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/flagbuilder"
-	"k8s.io/kops/pkg/model/components"
 	"k8s.io/kops/pkg/systemd"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
@@ -132,14 +131,6 @@ func (b *ContainerdBuilder) Build(c *fi.ModelBuilderContext) error {
 
 	if err := b.buildSysconfig(c); err != nil {
 		return err
-	}
-
-	// Using containerd with Kubenet requires special configuration. This is a temporary backwards-compatible solution
-	// and will be deprecated when Kubenet is deprecated:
-	// https://github.com/containerd/cri/blob/master/docs/config.md#cni-config-template
-	usesKubenet := components.UsesKubenet(b.Cluster.Spec.Networking)
-	if b.Cluster.Spec.ContainerRuntime == "containerd" && usesKubenet {
-		b.buildKubenetCNIConfigTemplate(c)
 	}
 
 	return nil
@@ -257,40 +248,6 @@ func (b *ContainerdBuilder) buildSysconfig(c *fi.ModelBuilderContext) error {
 	})
 
 	return nil
-}
-
-// buildKubenetCNIConfigTemplate is responsible for creating a special template for setups using Kubenet
-func (b *ContainerdBuilder) buildKubenetCNIConfigTemplate(c *fi.ModelBuilderContext) {
-	lines := []string{
-		"{",
-		"    \"cniVersion\": \"0.3.1\",",
-		"    \"name\": \"kubenet\",",
-		"    \"plugins\": [",
-		"        {",
-		"            \"type\": \"bridge\",",
-		"            \"bridge\": \"cbr0\",",
-		"            \"mtu\": 1460,",
-		"            \"addIf\": \"eth0\",",
-		"            \"isGateway\": true,",
-		"            \"ipMasq\": true,",
-		"            \"promiscMode\": true,",
-		"            \"ipam\": {",
-		"                \"type\": \"host-local\",",
-		"                \"subnet\": \"{{.PodCIDR}}\",",
-		"                \"routes\": [{ \"dst\": \"0.0.0.0/0\" }]",
-		"            }",
-		"        }",
-		"    ]",
-		"}",
-	}
-	contents := strings.Join(lines, "\n")
-	klog.V(8).Infof("Built kubenet CNI config file\n%s", contents)
-
-	c.AddTask(&nodetasks.File{
-		Path:     "/etc/containerd/cni-config.template",
-		Contents: fi.NewStringResource(contents),
-		Type:     nodetasks.FileType_File,
-	})
 }
 
 // skipInstall determines if kops should skip the installation and configuration of containerd

--- a/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
@@ -1,27 +1,3 @@
-contents: |-
-  {
-      "cniVersion": "0.3.1",
-      "name": "kubenet",
-      "plugins": [
-          {
-              "type": "bridge",
-              "bridge": "cbr0",
-              "mtu": 1460,
-              "addIf": "eth0",
-              "isGateway": true,
-              "ipMasq": true,
-              "promiscMode": true,
-              "ipam": {
-                  "type": "host-local",
-                  "subnet": "{{.PodCIDR}}",
-                  "routes": [{ "dst": "0.0.0.0/0" }]
-              }
-          }
-      ]
-  }
-path: /etc/containerd/cni-config.template
-type: file
----
 contents: ""
 path: /etc/containerd/config-kops.toml
 type: file

--- a/nodeup/pkg/model/tests/protokube/containerd/cluster.yaml
+++ b/nodeup/pkg/model/tests/protokube/containerd/cluster.yaml
@@ -31,7 +31,7 @@ spec:
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16
   networking:
-    kubenet: {}
+    calico: {}
   nonMasqueradeCIDR: 100.64.0.0/10
   sshAccess:
     - 0.0.0.0/0

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -552,10 +552,16 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 	}
 
 	if v.Kubenet != nil {
+		if c.ContainerRuntime == "containerd" {
+			allErrs = append(allErrs, field.Invalid(fldPath, "kubenet", "kubenet networking is not supported with containerd"))
+		}
 		optionTaken = true
 	}
 
 	if v.External != nil {
+		if c.ContainerRuntime == "containerd" {
+			allErrs = append(allErrs, field.Invalid(fldPath, "external", "external networking is not supported with containerd"))
+		}
 		if optionTaken {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("external"), "only one networking option permitted"))
 		}
@@ -570,6 +576,9 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 	}
 
 	if v.Kopeio != nil {
+		if c.ContainerRuntime == "containerd" {
+			allErrs = append(allErrs, field.Invalid(fldPath, "kopeio", "kopeio networking is not supported with containerd"))
+		}
 		if optionTaken {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("kopeio"), "only one networking option permitted"))
 		}
@@ -654,6 +663,9 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 	}
 
 	if v.GCE != nil {
+		if c.ContainerRuntime == "containerd" {
+			allErrs = append(allErrs, field.Invalid(fldPath, "gce", "gce networking is not supported with containerd"))
+		}
 		if optionTaken {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("gce"), "only one networking option permitted"))
 		}

--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -18,10 +18,8 @@ package components
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/blang/semver/v4"
-
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
@@ -61,23 +59,7 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 
 		// Apply defaults for containerd running in container runtime mode
 		containerd.LogLevel = fi.String("info")
-		usesKubenet := UsesKubenet(clusterSpec.Networking)
-		if clusterSpec.Networking != nil && usesKubenet {
-			// Using containerd with Kubenet requires special configuration. This is a temporary backwards-compatible solution
-			// and will be deprecated when Kubenet is deprecated:
-			// https://github.com/containerd/cri/blob/master/docs/config.md#cni-config-template
-			lines := []string{
-				"version = 2",
-				"[plugins]",
-				"  [plugins.\"io.containerd.grpc.v1.cri\"]",
-				"    [plugins.\"io.containerd.grpc.v1.cri\".cni]",
-				"      conf_template = \"/etc/containerd/cni-config.template\"",
-			}
-			contents := strings.Join(lines, "\n")
-			containerd.ConfigOverride = fi.String(contents)
-		} else {
-			containerd.ConfigOverride = fi.String("")
-		}
+		containerd.ConfigOverride = fi.String("version = 2")
 
 	} else if clusterSpec.ContainerRuntime == "docker" {
 		// Docker version should always be available

--- a/tests/integration/update_cluster/containerd-custom/cloudformation.json
+++ b/tests/integration/update_cluster/containerd-custom/cloudformation.json
@@ -538,6 +538,20 @@
         "CidrIp": "0.0.0.0/0"
       }
     },
+    "AWSEC2SecurityGroupIngressnodetomasterprotocolipip": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmasterscontainerdexamplecom"
+        },
+        "SourceSecurityGroupId": {
+          "Ref": "AWSEC2SecurityGroupnodescontainerdexamplecom"
+        },
+        "FromPort": 0,
+        "ToPort": 65535,
+        "IpProtocol": "4"
+      }
+    },
     "AWSEC2SecurityGroupIngressnodetomastertcp12379": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {

--- a/tests/integration/update_cluster/containerd-custom/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd-custom/cloudformation.json.extracted.yaml
@@ -137,12 +137,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
   cloudConfig: null
   containerRuntime: containerd
   containerd:
-    configOverride: |-
-      version = 2
-      [plugins]
-        [plugins."io.containerd.grpc.v1.cri"]
-          [plugins."io.containerd.grpc.v1.cri".cni]
-            conf_template = "/etc/containerd/cni-config.template"
+    configOverride: version = 2
     logLevel: info
     packages:
       hashAmd64: "0000000000000000000000000000000000000000000000000000000000000000"
@@ -201,7 +196,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     cloudProvider: aws
     clusterCIDR: 100.96.0.0/11
     clusterName: containerd.example.com
-    configureCloudRoutes: true
+    configureCloudRoutes: false
     image: k8s.gcr.io/kube-controller-manager:v1.19.0
     leaderElection:
       leaderElect: true
@@ -229,6 +224,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
+    networkPluginName: cni
     nonMasqueradeCIDR: 100.64.0.0/10
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
@@ -242,6 +238,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
+    networkPluginName: cni
     nonMasqueradeCIDR: 100.64.0.0/10
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
@@ -280,6 +277,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
+    networkPluginName: cni
     nodeLabels:
       kubernetes.io/role: master
       node-role.kubernetes.io/master: ""
@@ -453,12 +451,7 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
   cloudConfig: null
   containerRuntime: containerd
   containerd:
-    configOverride: |-
-      version = 2
-      [plugins]
-        [plugins."io.containerd.grpc.v1.cri"]
-          [plugins."io.containerd.grpc.v1.cri".cni]
-            conf_template = "/etc/containerd/cni-config.template"
+    configOverride: version = 2
     logLevel: info
     packages:
       hashAmd64: "0000000000000000000000000000000000000000000000000000000000000000"
@@ -483,6 +476,7 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
+    networkPluginName: cni
     nonMasqueradeCIDR: 100.64.0.0/10
     podManifestPath: /etc/kubernetes/manifests
 
@@ -520,6 +514,7 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
+    networkPluginName: cni
     nodeLabels:
       kubernetes.io/role: node
       node-role.kubernetes.io/node: ""

--- a/tests/integration/update_cluster/containerd-custom/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/containerd-custom/in-v1alpha2.yaml
@@ -31,7 +31,7 @@ spec:
   masterPublicName: api.containerd.example.com
   networkCIDR: 172.20.0.0/16
   networking:
-    kubenet: {}
+    calico: {}
   nonMasqueradeCIDR: 100.64.0.0/10
   sshAccess:
     - 0.0.0.0/0

--- a/tests/integration/update_cluster/containerd/cloudformation.json
+++ b/tests/integration/update_cluster/containerd/cloudformation.json
@@ -538,6 +538,20 @@
         "CidrIp": "0.0.0.0/0"
       }
     },
+    "AWSEC2SecurityGroupIngressnodetomasterprotocolipip": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmasterscontainerdexamplecom"
+        },
+        "SourceSecurityGroupId": {
+          "Ref": "AWSEC2SecurityGroupnodescontainerdexamplecom"
+        },
+        "FromPort": 0,
+        "ToPort": 65535,
+        "IpProtocol": "4"
+      }
+    },
     "AWSEC2SecurityGroupIngressnodetomastertcp12379": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {

--- a/tests/integration/update_cluster/containerd/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd/cloudformation.json.extracted.yaml
@@ -137,12 +137,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
   cloudConfig: null
   containerRuntime: containerd
   containerd:
-    configOverride: |-
-      version = 2
-      [plugins]
-        [plugins."io.containerd.grpc.v1.cri"]
-          [plugins."io.containerd.grpc.v1.cri".cni]
-            conf_template = "/etc/containerd/cni-config.template"
+    configOverride: version = 2
     logLevel: info
     version: 1.4.3
   docker:
@@ -198,7 +193,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     cloudProvider: aws
     clusterCIDR: 100.96.0.0/11
     clusterName: containerd.example.com
-    configureCloudRoutes: true
+    configureCloudRoutes: false
     image: k8s.gcr.io/kube-controller-manager:v1.19.0
     leaderElection:
       leaderElect: true
@@ -226,6 +221,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
+    networkPluginName: cni
     nonMasqueradeCIDR: 100.64.0.0/10
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
@@ -239,6 +235,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
+    networkPluginName: cni
     nonMasqueradeCIDR: 100.64.0.0/10
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
@@ -277,6 +274,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
+    networkPluginName: cni
     nodeLabels:
       kubernetes.io/role: master
       node-role.kubernetes.io/master: ""
@@ -450,12 +448,7 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
   cloudConfig: null
   containerRuntime: containerd
   containerd:
-    configOverride: |-
-      version = 2
-      [plugins]
-        [plugins."io.containerd.grpc.v1.cri"]
-          [plugins."io.containerd.grpc.v1.cri".cni]
-            conf_template = "/etc/containerd/cni-config.template"
+    configOverride: version = 2
     logLevel: info
     version: 1.4.3
   docker:
@@ -477,6 +470,7 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
+    networkPluginName: cni
     nonMasqueradeCIDR: 100.64.0.0/10
     podManifestPath: /etc/kubernetes/manifests
 
@@ -514,6 +508,7 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
     hostnameOverride: '@aws'
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
+    networkPluginName: cni
     nodeLabels:
       kubernetes.io/role: node
       node-role.kubernetes.io/node: ""

--- a/tests/integration/update_cluster/containerd/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/containerd/in-v1alpha2.yaml
@@ -27,7 +27,7 @@ spec:
   masterPublicName: api.containerd.example.com
   networkCIDR: 172.20.0.0/16
   networking:
-    kubenet: {}
+    calico: {}
   nonMasqueradeCIDR: 100.64.0.0/10
   sshAccess:
     - 0.0.0.0/0


### PR DESCRIPTION
Cherry pick of #10501 on release-1.19.

#10501: Remove support for Kubenet with containerd

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.