### PR TITLE
Add required toleration to gpu documentation

### DIFF
--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -61,6 +61,10 @@ dcgmExporter:
 gfd:
   nodeSelector:
     kops.k8s.io/instancegroup: gpu-nodes
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
 
 node-feature-discovery:
   worker:


### PR DESCRIPTION
As the example sets a taint on the gpu-node, a toleration is required for the *gpu-feature-discovery* (gfd) daemonset to be able to run.