### PR TITLE
Automated cherry pick of #10508: Treat InvalidDhcpOptionsId.NotFound as already-deleted

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -933,7 +933,10 @@ func DeleteDhcpOptions(cloud fi.Cloud, r *resources.Resource) error {
 	}
 	_, err := c.EC2().DeleteDhcpOptions(request)
 	if err != nil {
-		if IsDependencyViolation(err) {
+		if awsup.AWSErrorCode(err) == "InvalidDhcpOptionsID.NotFound" {
+			klog.V(2).Infof("Got InvalidDhcpOptionsID.NotFound error deleting DhcpOptions %q; will treat as already-deleted", id)
+			return nil
+		} else if IsDependencyViolation(err) {
 			return err
 		}
 		return fmt.Errorf("error deleting DhcpOptions %q: %v", id, err)


### PR DESCRIPTION
Cherry pick of #10508 on release-1.19.

#10508: Treat InvalidDhcpOptionsId.NotFound as already-deleted

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.