### PR TITLE
Use custom containerd socket with Flatcar

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -226,7 +226,11 @@ func (b *KubeletBuilder) buildSystemdEnvironmentFile(kubeletConfig *kops.Kubelet
 		flags += " --container-runtime=remote"
 		flags += " --runtime-request-timeout=15m"
 		if b.Cluster.Spec.Containerd == nil || b.Cluster.Spec.Containerd.Address == nil {
-			flags += " --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+			if b.Distribution == distributions.DistributionFlatcar {
+				flags += " --container-runtime-endpoint=unix:///run/docker/libcontainerd/docker-containerd.sock"
+			} else {
+				flags += " --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+			}
 		} else {
 			flags += " --container-runtime-endpoint=unix://" + fi.StringValue(b.Cluster.Spec.Containerd.Address)
 		}

--- a/nodeup/pkg/model/protokube_test.go
+++ b/nodeup/pkg/model/protokube_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/kops/pkg/apis/nodeup"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/util/pkg/architectures"
+	"k8s.io/kops/util/pkg/distributions"
 )
 
 func TestProtokubeBuilder_Docker(t *testing.T) {
@@ -40,7 +41,18 @@ func TestProtokubeBuilder_containerd(t *testing.T) {
 	})
 }
 
+func TestProtokubeBuilder_containerd_flatcar(t *testing.T) {
+	RunGoldenTest(t, "tests/protokube/containerd-flatcar", "protokube", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+		builder := ProtokubeBuilder{NodeupModelContext: nodeupModelContext}
+		populateImage(nodeupModelContext)
+		nodeupModelContext.Distribution = distributions.DistributionFlatcar
+		return builder.Build(target)
+	})
+}
+
 func populateImage(ctx *NodeupModelContext) {
+	ctx.Architecture = architectures.ArchitectureAmd64
+	ctx.Distribution = distributions.DistributionUbuntu2004
 	if ctx.NodeupConfig == nil {
 		ctx.NodeupConfig = &nodeup.Config{}
 	}

--- a/nodeup/pkg/model/tests/protokube/containerd-flatcar/cluster.yaml
+++ b/nodeup/pkg/model/tests/protokube/containerd-flatcar/cluster.yaml
@@ -1,0 +1,64 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2016-12-10T22:42:27Z"
+  name: minimal.example.com
+spec:
+  kubernetesApiAccess:
+    - 0.0.0.0/0
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  containerd:
+    version: 1.3.4
+  containerRuntime: containerd
+  etcdClusters:
+    - etcdMembers:
+        - instanceGroup: master-us-test-1a
+          name: master-us-test-1a
+      name: main
+      provider: Manager
+    - etcdMembers:
+        - instanceGroup: master-us-test-1a
+          name: master-us-test-1a
+      name: events
+      provider: Manager
+  iam: {}
+  kubelet:
+    hostnameOverride: master.hostname.invalid
+  kubernetesVersion: v1.17.0
+  masterInternalName: api.internal.minimal.example.com
+  masterPublicName: api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    calico: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+    - 0.0.0.0/0
+  topology:
+    masters: public
+    nodes: public
+  subnets:
+    - cidr: 172.20.32.0/19
+      name: us-test-1a
+      type: Public
+      zone: us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2016-12-10T22:42:28Z"
+  name: master-1a
+  labels:
+    kops.k8s.io/cluster: minimal.example.com
+spec:
+  associatePublicIp: true
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  machineType: t2.medium
+  maxSize: 2
+  minSize: 2
+  role: Master
+  subnets:
+    - us-test-1a

--- a/nodeup/pkg/model/tests/protokube/containerd-flatcar/tasks-protokube.yaml
+++ b/nodeup/pkg/model/tests/protokube/containerd-flatcar/tasks-protokube.yaml
@@ -1,0 +1,99 @@
+contents:
+  task:
+    CA:
+      task:
+        Name: kops
+        signer: ca
+        subject:
+          CommonName: kops
+          Organization:
+          - system:masters
+        type: client
+    Cert:
+      task:
+        Name: kops
+        signer: ca
+        subject:
+          CommonName: kops
+          Organization:
+          - system:masters
+        type: client
+    Key:
+      task:
+        Name: kops
+        signer: ca
+        subject:
+          CommonName: kops
+          Organization:
+          - system:masters
+        type: client
+    Name: kops
+    ServerURL: https://127.0.0.1
+mode: "0400"
+path: /var/lib/kops/kubeconfig
+type: file
+---
+Name: kops
+signer: ca
+subject:
+  CommonName: kops
+  Organization:
+  - system:masters
+type: client
+---
+CA:
+  task:
+    Name: kops
+    signer: ca
+    subject:
+      CommonName: kops
+      Organization:
+      - system:masters
+    type: client
+Cert:
+  task:
+    Name: kops
+    signer: ca
+    subject:
+      CommonName: kops
+      Organization:
+      - system:masters
+    type: client
+Key:
+  task:
+    Name: kops
+    signer: ca
+    subject:
+      CommonName: kops
+      Organization:
+      - system:masters
+    type: client
+Name: kops
+ServerURL: https://127.0.0.1
+---
+Distro: flatcar
+Hash: ""
+Name: protokube
+Runtime: containerd
+Sources: null
+---
+Name: protokube.service
+definition: |
+  [Unit]
+  Description=Kubernetes Protokube Service
+  Documentation=https://github.com/kubernetes/kops
+
+  [Service]
+  ExecStartPre=/bin/true
+  ExecStartPre=-/usr/bin/ctr --address /run/docker/libcontainerd/docker-containerd.sock --namespace k8s.io container rm protokube
+  ExecStart=/usr/bin/ctr --address /run/docker/libcontainerd/docker-containerd.sock --namespace k8s.io run --net-host --with-ns pid:/proc/1/ns/pid --privileged --mount type=bind,src=/,dst=/rootfs,options=rbind:rslave --env KUBECONFIG=/rootfs/var/lib/kops/kubeconfig --mount type=bind,src=/bin,dst=/bin,options=rbind:ro:rprivate --mount type=bind,src=/lib,dst=/lib,options=rbind:ro:rprivate --mount type=bind,src=/sbin,dst=/sbin,options=rbind:ro:rprivate --mount type=bind,src=/usr/bin,dst=/usr/bin,options=rbind:ro:rprivate --mount type=bind,src=/var/run/dbus,dst=/var/run/dbus,options=rbind:rprivate --mount type=bind,src=/run/systemd,dst=/run/systemd,options=rbind:rprivate --mount type=bind,src=/lib64,dst=/lib64,options=rbind:ro:rprivate --mount type=bind,src=/opt/bin,dst=/opt/kops/bin,options=rbind:ro:rprivate --env PATH=/opt/kops/bin:/usr/bin:/sbin:/bin docker.io/library/protokube image name protokube /protokube --bootstrap-master-node-labels=true --cloud=aws --containerized=true --dns-internal-suffix=.internal.minimal.example.com --dns=aws-route53 --etcd-backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main --etcd-image=k8s.gcr.io/etcd:3.4.3 --initialize-rbac=true --manage-etcd=true --master=true --node-name=master.hostname.invalid --peer-ca=/srv/kubernetes/ca.crt --peer-cert=/srv/kubernetes/etcd-peer.pem --peer-key=/srv/kubernetes/etcd-peer-key.pem --tls-auth=true --tls-ca=/srv/kubernetes/ca.crt --tls-cert=/srv/kubernetes/etcd.pem --tls-key=/srv/kubernetes/etcd-key.pem --v=4 --zone=*/Z1AFAKE1ZON3YO
+  Restart=always
+  RestartSec=3s
+  StartLimitInterval=0
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+manageState: true
+running: true
+smartRestart: true

--- a/nodeup/pkg/model/tests/protokube/containerd/tasks-protokube.yaml
+++ b/nodeup/pkg/model/tests/protokube/containerd/tasks-protokube.yaml
@@ -71,6 +71,7 @@ Key:
 Name: kops
 ServerURL: https://127.0.0.1
 ---
+Distro: focal
 Hash: ""
 Name: protokube
 Runtime: containerd

--- a/nodeup/pkg/model/tests/protokube/docker/tasks-protokube.yaml
+++ b/nodeup/pkg/model/tests/protokube/docker/tasks-protokube.yaml
@@ -71,6 +71,7 @@ Key:
 Name: kops
 ServerURL: https://127.0.0.1
 ---
+Distro: focal
 Hash: ""
 Name: protokube
 Runtime: docker

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -262,6 +262,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 		taskMap["LoadImage."+strconv.Itoa(i)] = &nodetasks.LoadImageTask{
 			Sources: image.Sources,
 			Hash:    image.Hash,
+			Distro:  distribution,
 			Runtime: c.cluster.Spec.ContainerRuntime,
 		}
 	}


### PR DESCRIPTION
Flatar uses `/run/docker/libcontainerd/docker-containerd.sock` for the containerd socket as mentioned in https://github.com/kinvolk/Flatcar/issues/284.

This should fix the failing periodic test:
https://testgrid.k8s.io/kops-distros#kops-aws-distro-flatcar