### PR TITLE
e2e - dump cluster manifests into artifacts and add --kubernetes-version 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,7 @@ test-e2e:
 		--build --up --down \
 		--cloud-provider=aws \
 		--kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
+		--kubernetes-version=v1.19.4 \
 		--test=ginkgo \
 		-- \
 		--test-package-version=v1.19.4 \

--- a/tests/e2e/kubetest2-kops/deployer/build.go
+++ b/tests/e2e/kubetest2-kops/deployer/build.go
@@ -44,7 +44,7 @@ func (d *deployer) verifyBuildFlags() error {
 		if goPath := os.Getenv("GOPATH"); goPath != "" {
 			d.KopsRoot = path.Join(goPath, "src", "k8s.io", "kops")
 		} else {
-			return errors.New("required kops-root when building from source")
+			return errors.New("required --kops-root when building from source")
 		}
 	}
 	if d.StageLocation != "" {
@@ -63,7 +63,7 @@ func (d *deployer) verifyBuildFlags() error {
 		return err
 	}
 	if !fi.Mode().IsDir() {
-		return errors.New("kops-root must be a directory")
+		return errors.New("--kops-root must be a directory")
 	}
 
 	d.BuildOptions.KopsRoot = d.KopsRoot

--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -50,6 +50,11 @@ func (d *deployer) initialize() error {
 			return fmt.Errorf("init failed to check up flags: %v", err)
 		}
 	}
+	if d.commonOptions.ShouldUp() || d.commonOptions.ShouldTest() {
+		if d.KubernetesVersion == "" {
+			return errors.New("missing required --kubernetes-version flag")
+		}
+	}
 	return nil
 }
 

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -47,6 +47,8 @@ type deployer struct {
 	KopsBinaryPath string   `flag:"kops-binary-path" desc:"The path to kops executable used for testing"`
 	StateStore     string   `flag:"-"`
 
+	KubernetesVersion string `flag:"kubernetes-version" desc:"The kubernetes version to use in the cluster"`
+
 	SSHPrivateKeyPath string   `flag:"ssh-private-key" desc:"The path to the private key used for SSH access to instances"`
 	SSHPublicKeyPath  string   `flag:"ssh-public-key" desc:"The path to the public key passed to the cloud provider"`
 	SSHUser           []string `flag:"ssh-user" desc:"The SSH users to use for SSH access to instances"`

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -47,6 +47,7 @@ func (d *deployer) Up() error {
 		"--name", d.ClusterName,
 		"--admin-access", publicIP,
 		"--cloud", d.CloudProvider,
+		"--kubernetes-version", d.KubernetesVersion,
 		"--master-count", "1",
 		"--master-size", "c5.large",
 		"--master-volume-size", "48",
@@ -57,6 +58,7 @@ func (d *deployer) Up() error {
 		"--zones", strings.Join(zones, ","),
 		"--yes",
 	}
+
 	klog.Info(strings.Join(args, " "))
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.SetEnv(d.env()...)


### PR DESCRIPTION
the cluster manifest will be useful when we add e2e templating support to confirm it is rendered as intended.