### PR TITLE
kubetest2: support specifying admin-access value

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -55,6 +55,8 @@ type deployer struct {
 
 	ArtifactsDir string `flag:"-"`
 
+	AdminAccess string `flag:"admin-access" desc:"The CIDR to restrict kubernetes API access"`
+
 	BuildOptions *builder.BuildOptions
 }
 

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -38,10 +38,15 @@ func (d *deployer) Up() error {
 		return err
 	}
 
+	adminAccess := d.AdminAccess
+	if adminAccess == "" {
+		adminAccess = publicIP
+	}
+
 	args := []string{
 		d.KopsBinaryPath, "create", "cluster",
 		"--name", d.ClusterName,
-		"--admin-access", publicIP,
+		"--admin-access", adminAccess,
 		"--cloud", d.CloudProvider,
 		"--kubernetes-version", d.KubernetesVersion,
 		"--master-count", "1",


### PR DESCRIPTION
Otherwise I was getting my IPv6 address, which doesn't work well.