### PR TITLE
Automated cherry pick of #10365: Add integration test for creating an HA cluster in shared #10361: Prefix etcd cluster names with letters

### DIFF
--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -73,6 +73,11 @@ func TestCreateClusterGCE(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/gce_byo_sa", "v1alpha2")
 }
 
+// TestCreateClusterHASharedZone tests kops create cluster when the master count is bigger than the number of zones
+func TestCreateClusterHASharedZone(t *testing.T) {
+	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/ha_shared_zone", "v1alpha2")
+}
+
 // TestCreateClusterHASharedZones tests kops create cluster when the master count is bigger than the number of zones
 func TestCreateClusterHASharedZones(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/ha_shared_zones", "v1alpha2")

--- a/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
@@ -16,21 +16,21 @@ spec:
   - cpuRequest: 200m
     etcdMembers:
     - instanceGroup: master-us-test-1a-1
-      name: "1"
+      name: etcd-1
     - instanceGroup: master-us-test-1a-2
-      name: "2"
+      name: etcd-2
     - instanceGroup: master-us-test-1a-3
-      name: "3"
+      name: etcd-3
     memoryRequest: 100Mi
     name: main
   - cpuRequest: 100m
     etcdMembers:
     - instanceGroup: master-us-test-1a-1
-      name: "1"
+      name: etcd-1
     - instanceGroup: master-us-test-1a-2
-      name: "2"
+      name: etcd-2
     - instanceGroup: master-us-test-1a-3
-      name: "3"
+      name: etcd-3
     memoryRequest: 100Mi
     name: events
   iam:

--- a/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
@@ -1,0 +1,140 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  name: ha.example.com
+spec:
+  api:
+    dns: {}
+  authorization:
+    rbac: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://tests/ha.example.com
+  containerRuntime: docker
+  etcdClusters:
+  - cpuRequest: 200m
+    etcdMembers:
+    - instanceGroup: master-us-test-1a-1
+      name: "1"
+    - instanceGroup: master-us-test-1a-2
+      name: "2"
+    - instanceGroup: master-us-test-1a-3
+      name: "3"
+    memoryRequest: 100Mi
+    name: main
+  - cpuRequest: 100m
+    etcdMembers:
+    - instanceGroup: master-us-test-1a-1
+      name: "1"
+    - instanceGroup: master-us-test-1a-2
+      name: "2"
+    - instanceGroup: master-us-test-1a-3
+      name: "3"
+    memoryRequest: 100Mi
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubelet:
+    anonymousAuth: false
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  kubernetesVersion: v1.15.6
+  masterPublicName: api.ha.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a
+  topology:
+    dns:
+      type: Public
+    masters: public
+    nodes: public
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha.example.com
+  name: master-us-test-1a-1
+spec:
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a-1
+  role: Master
+  subnets:
+  - us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha.example.com
+  name: master-us-test-1a-2
+spec:
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a-2
+  role: Master
+  subnets:
+  - us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha.example.com
+  name: master-us-test-1a-3
+spec:
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a-3
+  role: Master
+  subnets:
+  - us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha.example.com
+  name: nodes-us-test-1a
+spec:
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-07-20
+  machineType: t2.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
+  role: Node
+  subnets:
+  - us-test-1a

--- a/tests/integration/create_cluster/ha_shared_zone/options.yaml
+++ b/tests/integration/create_cluster/ha_shared_zone/options.yaml
@@ -1,0 +1,6 @@
+ClusterName: ha.example.com
+Zones:
+- us-test-1a
+MasterCount: 3
+CloudProvider: aws
+KubernetesVersion: v1.15.6

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -692,6 +692,13 @@ func trimCommonPrefix(names []string) []string {
 		}
 	}
 
+	for i := range names {
+		_, err := strconv.Atoi(names[i])
+		if err == nil {
+			names[i] = "etcd-" + names[i]
+		}
+	}
+
 	return names
 }
 

--- a/upup/pkg/fi/cloudup/new_cluster_test.go
+++ b/upup/pkg/fi/cloudup/new_cluster_test.go
@@ -50,6 +50,10 @@ func TestRemoveSharedPrefix(t *testing.T) {
 			Output: []string{"zza", "zzb", ""},
 		},
 		{
+			Input:  []string{"us-test-1a-1", "us-test-1a-2", "us-test-1a-3"},
+			Output: []string{"etcd-1", "etcd-2", "etcd-3"},
+		},
+		{
 			Input:  []string{"us-test-1a-1", "us-test-1b-1", "us-test-1a-2", "us-test-1b-2", "us-test-1a-3"},
 			Output: []string{"a-1", "b-1", "a-2", "b-2", "a-3"},
 		},


### PR DESCRIPTION
Cherry pick of #10365 #10361 on release-1.19.

#10365: Add integration test for creating an HA cluster in shared
#10361: Prefix etcd cluster names with letters

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.