### PR TITLE
Automated cherry pick of #10424: Don't allow ebs volume TF resource names to begin with digit

### DIFF
--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -759,7 +759,7 @@
         ]
       }
     },
-    "AWSEC2Volumeustest1aetcdeventscomplexexamplecom": {
+    "AWSEC2Volume1aetcdeventscomplexexamplecom": {
       "Type": "AWS::EC2::Volume",
       "Properties": {
         "AvailabilityZone": "us-test-1a",
@@ -773,7 +773,7 @@
           },
           {
             "Key": "Name",
-            "Value": "us-test-1a.etcd-events.complex.example.com"
+            "Value": "1a.etcd-events.complex.example.com"
           },
           {
             "Key": "Owner",
@@ -785,7 +785,7 @@
           },
           {
             "Key": "k8s.io/etcd/events",
-            "Value": "us-test-1a/us-test-1a"
+            "Value": "1a/1a"
           },
           {
             "Key": "k8s.io/role/master",
@@ -798,7 +798,7 @@
         ]
       }
     },
-    "AWSEC2Volumeustest1aetcdmaincomplexexamplecom": {
+    "AWSEC2Volume1aetcdmaincomplexexamplecom": {
       "Type": "AWS::EC2::Volume",
       "Properties": {
         "AvailabilityZone": "us-test-1a",
@@ -812,7 +812,7 @@
           },
           {
             "Key": "Name",
-            "Value": "us-test-1a.etcd-main.complex.example.com"
+            "Value": "1a.etcd-main.complex.example.com"
           },
           {
             "Key": "Owner",
@@ -824,7 +824,7 @@
           },
           {
             "Key": "k8s.io/etcd/main",
-            "Value": "us-test-1a/us-test-1a"
+            "Value": "1a/1a"
           },
           {
             "Key": "k8s.io/role/master",

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -21,11 +21,11 @@ spec:
   etcdClusters:
   - etcdMembers:
     - instanceGroup: master-us-test-1a
-      name: us-test-1a
+      name: 1a
     name: main
   - etcdMembers:
     - instanceGroup: master-us-test-1a
-      name: us-test-1a
+      name: 1a
     name: events
   kubeAPIServer:
     serviceNodePortRange: 28000-32767

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -21,11 +21,11 @@ spec:
   etcdClusters:
   - etcdMembers:
     - instanceGroup: master-us-test-1a
-      name: us-test-1a
+      name: 1a
     name: main
   - etcdMembers:
     - instanceGroup: master-us-test-1a
-      name: us-test-1a
+      name: 1a
     name: events
   kubeAPIServer:
     serviceNodePortRange: 28000-32767

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -172,32 +172,32 @@ resource "aws_autoscaling_group" "nodes-complex-example-com" {
   vpc_zone_identifier = [aws_subnet.us-test-1a-complex-example-com.id]
 }
 
-resource "aws_ebs_volume" "us-test-1a-etcd-events-complex-example-com" {
+resource "aws_ebs_volume" "ebs-1a-etcd-events-complex-example-com" {
   availability_zone = "us-test-1a"
   encrypted         = false
   size              = 20
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
-    "Name"                                      = "us-test-1a.etcd-events.complex.example.com"
+    "Name"                                      = "1a.etcd-events.complex.example.com"
     "Owner"                                     = "John Doe"
     "foo/bar"                                   = "fib+baz"
-    "k8s.io/etcd/events"                        = "us-test-1a/us-test-1a"
+    "k8s.io/etcd/events"                        = "1a/1a"
     "k8s.io/role/master"                        = "1"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
   type = "gp2"
 }
 
-resource "aws_ebs_volume" "us-test-1a-etcd-main-complex-example-com" {
+resource "aws_ebs_volume" "ebs-1a-etcd-main-complex-example-com" {
   availability_zone = "us-test-1a"
   encrypted         = false
   size              = 20
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
-    "Name"                                      = "us-test-1a.etcd-main.complex.example.com"
+    "Name"                                      = "1a.etcd-main.complex.example.com"
     "Owner"                                     = "John Doe"
     "foo/bar"                                   = "fib+baz"
-    "k8s.io/etcd/main"                          = "us-test-1a/us-test-1a"
+    "k8s.io/etcd/main"                          = "1a/1a"
     "k8s.io/role/master"                        = "1"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }

--- a/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
+++ b/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
@@ -217,11 +217,18 @@ func (_ *EBSVolume) RenderTerraform(t *terraform.TerraformTarget, a, e, changes 
 		Tags:             e.Tags,
 	}
 
-	return t.RenderResource("aws_ebs_volume", *e.Name, tf)
+	return t.RenderResource("aws_ebs_volume", e.TerraformName(), tf)
 }
 
 func (e *EBSVolume) TerraformLink() *terraform.Literal {
-	return terraform.LiteralSelfLink("aws_ebs_volume", *e.Name)
+	return terraform.LiteralSelfLink("aws_ebs_volume", e.TerraformName())
+}
+
+func (e *EBSVolume) TerraformName() string {
+	if (*e.Name)[0] >= '0' && (*e.Name)[0] <= '9' {
+		return fmt.Sprintf("ebs-%v", *e.Name)
+	}
+	return *e.Name
 }
 
 type cloudformationVolume struct {


### PR DESCRIPTION
Cherry pick of #10424 on release-1.18.

#10424: Don't allow ebs volume TF resource names to begin with digit

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.