### PR TITLE
Refactor and centralize distribution logic

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -513,8 +513,7 @@ func (b *KubeletBuilder) buildKubeletConfigSpec() (*kops.KubeletConfigSpec, erro
 	// In certain configurations systemd-resolved will put the loopback address 127.0.0.53 as a nameserver into /etc/resolv.conf
 	// https://github.com/coredns/coredns/blob/master/plugin/loop/README.md#troubleshooting-loops-in-kubernetes-clusters
 	if c.ResolverConfig == nil {
-		switch b.Distribution {
-		case distributions.DistributionUbuntu1804, distributions.DistributionUbuntu2004, distributions.DistributionUbuntu2010:
+		if b.Distribution.HasLoopbackEtcResolvConf() {
 			c.ResolverConfig = s("/run/systemd/resolve/resolv.conf")
 		}
 	}

--- a/nodeup/pkg/model/miscutils.go
+++ b/nodeup/pkg/model/miscutils.go
@@ -51,10 +51,9 @@ func (b *MiscUtilsBuilder) Build(c *fi.ModelBuilderContext) error {
 			packages = append(packages, "apt-transport-https")
 
 			// TODO: Do we really need python-apt?
-			switch b.Distribution {
-			case distributions.DistributionUbuntu2010:
+			if b.Distribution.IsUbuntu() && b.Distribution.Version() >= 20.10 {
 				// python-apt not available (though python3-apt is)
-			default:
+			} else {
 				packages = append(packages, "python-apt")
 			}
 		}

--- a/util/pkg/distributions/identify.go
+++ b/util/pkg/distributions/identify.go
@@ -41,7 +41,7 @@ func FindDistribution(rootfs string) (Distribution, error) {
 			}
 		}
 	} else {
-		return "", fmt.Errorf("reading /etc/os-release: %v", err)
+		return Distribution{}, fmt.Errorf("reading /etc/os-release: %v", err)
 	}
 
 	distro := fmt.Sprintf("%s-%s", osRelease["ID"], osRelease["VERSION_ID"])
@@ -84,5 +84,5 @@ func FindDistribution(rootfs string) (Distribution, error) {
 
 	// Some distros are not supported
 	klog.V(2).Infof("Contents of /etc/os-release:\n%s", osReleaseBytes)
-	return "", fmt.Errorf("unsupported distro: %s", distro)
+	return Distribution{}, fmt.Errorf("unsupported distro: %s", distro)
 }

--- a/util/pkg/distributions/identify_test.go
+++ b/util/pkg/distributions/identify_test.go
@@ -47,7 +47,7 @@ func TestFindDistribution(t *testing.T) {
 		{
 			rootfs:   "coreos",
 			err:      fmt.Errorf("unsupported distro: coreos-2247.7.0"),
-			expected: "",
+			expected: Distribution{},
 		},
 		{
 			rootfs:   "containeros",
@@ -57,7 +57,7 @@ func TestFindDistribution(t *testing.T) {
 		{
 			rootfs:   "debian8",
 			err:      fmt.Errorf("unsupported distro: debian-8"),
-			expected: "",
+			expected: Distribution{},
 		},
 		{
 			rootfs:   "debian9",
@@ -107,7 +107,7 @@ func TestFindDistribution(t *testing.T) {
 		{
 			rootfs:   "notfound",
 			err:      fmt.Errorf("reading /etc/os-release: open tests/notfound/etc/os-release: no such file or directory"),
-			expected: "",
+			expected: Distribution{},
 		},
 	}
 
@@ -118,7 +118,7 @@ func TestFindDistribution(t *testing.T) {
 			continue
 		}
 		if actual != test.expected {
-			t.Errorf("unexpected distribution, actual=%q, expected=%q", actual, test.expected)
+			t.Errorf("unexpected distribution, actual=%v, expected=%v", actual, test.expected)
 		}
 	}
 }


### PR DESCRIPTION
Use of a struct makes it more sustainable, centralizing into the 
distribution package makes it simpler to follow.