### PR TITLE
Add containerd config file to Flatcar based instances

### DIFF
--- a/nodeup/pkg/model/containerd_test.go
+++ b/nodeup/pkg/model/containerd_test.go
@@ -29,15 +29,19 @@ import (
 )
 
 func TestContainerdBuilder_Docker_19_03_13(t *testing.T) {
-	runContainerdBuilderTest(t, "from_docker_19.03.11")
+	runContainerdBuilderTest(t, "from_docker_19.03.11", distributions.DistributionUbuntu2004)
 }
 
 func TestContainerdBuilder_Docker_19_03_14(t *testing.T) {
-	runContainerdBuilderTest(t, "from_docker_19.03.14")
+	runContainerdBuilderTest(t, "from_docker_19.03.14", distributions.DistributionUbuntu2004)
 }
 
 func TestContainerdBuilder_Simple(t *testing.T) {
-	runContainerdBuilderTest(t, "simple")
+	runContainerdBuilderTest(t, "simple", distributions.DistributionUbuntu2004)
+}
+
+func TestContainerdBuilder_Flatcar(t *testing.T) {
+	runContainerdBuilderTest(t, "flatcar", distributions.DistributionFlatcar)
 }
 
 func TestContainerdBuilder_SkipInstall(t *testing.T) {
@@ -123,7 +127,7 @@ func TestContainerdBuilder_BuildFlags(t *testing.T) {
 	}
 }
 
-func runContainerdBuilderTest(t *testing.T, key string) {
+func runContainerdBuilderTest(t *testing.T, key string, distro distributions.Distribution) {
 	basedir := path.Join("tests/containerdbuilder/", key)
 
 	nodeUpModelContext, err := BuildNodeupModelContext(basedir)
@@ -132,7 +136,7 @@ func runContainerdBuilderTest(t *testing.T, key string) {
 		return
 	}
 
-	nodeUpModelContext.Distribution = distributions.DistributionUbuntu1604
+	nodeUpModelContext.Distribution = distro
 
 	nodeUpModelContext.Assets = fi.NewAssetStore("")
 	nodeUpModelContext.Assets.AddForTest("containerd", "usr/local/bin/containerd", "testing containerd content")

--- a/nodeup/pkg/model/tests/containerdbuilder/flatcar/cluster.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/flatcar/cluster.yaml
@@ -1,0 +1,39 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  name: minimal.example.com
+spec:
+  kubernetesApiAccess:
+    - 0.0.0.0/0
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  containerRuntime: containerd
+  containerd:
+    version: 1.4.3
+  etcdClusters:
+    - etcdMembers:
+        - instanceGroup: master-us-test-1a
+          name: master-us-test-1a
+      name: main
+    - etcdMembers:
+        - instanceGroup: master-us-test-1a
+          name: master-us-test-1a
+      name: events
+  kubernetesVersion: v1.19.0
+  masterInternalName: api.internal.minimal.example.com
+  masterPublicName: api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+    - 0.0.0.0/0
+  topology:
+    masters: public
+    nodes: public
+  subnets:
+    - cidr: 172.20.32.0/19
+      name: us-test-1a
+      type: Public
+      zone: us-test-1a

--- a/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
@@ -1,0 +1,20 @@
+contents: ""
+path: /etc/containerd/config-kops.toml
+type: file
+---
+contents: |-
+  [Service]
+  Environment=CONTAINERD_CONFIG=/etc/containerd/config-kops.toml
+  EnvironmentFile=/etc/environment
+onChangeExecute:
+- - systemctl
+  - daemon-reload
+- - systemctl
+  - restart
+  - containerd.service
+- - systemctl
+  - restart
+  - kops-configuration.service
+  - '&'
+path: /etc/systemd/system/containerd.service.d/10-kops.conf
+type: file


### PR DESCRIPTION
This makes it possible to configure Flatcar from kOps and also fixes the issue of custom socket location (different approach to #10518).
