### PR TITLE
COS/GCE: exec on kubelet/flexvolume dirs

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -109,8 +109,8 @@ func (b *KubeletBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 	{
 		// We always create the directory, avoids circular dependency on a bind-mount
-		c.AddTask(&nodetasks.File{
-			Path: filepath.Dir(b.KubeletKubeConfig()),
+		c.EnsureTask(&nodetasks.File{
+			Path: filepath.Dir(b.KubeletKubeConfig()), // e.g. "/var/lib/kubelet"
 			Type: nodetasks.FileType_Directory,
 			Mode: s("0755"),
 		})

--- a/upup/pkg/fi/nodeup/nodetasks/bindmount.go
+++ b/upup/pkg/fi/nodeup/nodetasks/bindmount.go
@@ -201,7 +201,7 @@ func (e *BindMount) execute(t Executor) error {
 		case "rshared":
 			makeOptions = append(makeOptions, "--make-rshared")
 
-		case "exec", "noexec", "nosuid", "nodev":
+		case "exec", "noexec", "suid", "nosuid", "dev", "nodev":
 			remountOptions = append(remountOptions, option)
 
 		default:


### PR DESCRIPTION
Upstream bind mounts /var/lib/kubelet with exec, dev and suid
permissions, because emptyDirs end up inheriting these permissions.

Similarly, /home/kubernetes/flexvolume needs exec permission to
support flexdrivers.