### PR TITLE
GCE: Don't warn about NVME

### DIFF
--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -223,8 +223,6 @@ func (e *InstanceTemplate) mapToGCE(project string, region string) (*compute.Ins
 		}
 	}
 
-	klog.Infof("We should be using NVME for GCE")
-
 	var disks []*compute.AttachedDisk
 	disks = append(disks, &compute.AttachedDisk{
 		Kind: "compute#attachedDisk",


### PR DESCRIPTION
NVME only works with Local SSDs, which have their own restrictions;
it isn't a must-support GA blocker (which is why we had the log
previously)