### PR TITLE
WIP: AWS Race: Process deletions in a separate phase

### DIFF
--- a/upup/pkg/fi/default_methods.go
+++ b/upup/pkg/fi/default_methods.go
@@ -83,26 +83,6 @@ func DefaultDeltaRunMethod(e Task, c *Context) error {
 		}
 	}
 
-	if producesDeletions, ok := e.(ProducesDeletions); ok && c.Target.ProcessDeletions() {
-		var deletions []Deletion
-		deletions, err = producesDeletions.FindDeletions(c)
-		if err != nil {
-			return err
-		}
-		for _, deletion := range deletions {
-			if _, ok := c.Target.(*DryRunTarget); ok {
-				err = c.Target.(*DryRunTarget).Delete(deletion)
-			} else if _, ok := c.Target.(*DryRunTarget); ok {
-				err = c.Target.(*DryRunTarget).Delete(deletion)
-			} else {
-				err = deletion.Delete(c.Target)
-			}
-			if err != nil {
-				return err
-			}
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This avoids a data-race (see #10506) which is actually a logic race -
we need the other tasks to have completed before we can process
SecurityRule deletions.