### PR TITLE
Updates GCE channels to use ubuntu over COS

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -53,6 +53,10 @@ spec:
     - providerID: gce
       kubernetesVersion: ">=1.16.0-alpha.1"
       name: "cos-cloud/cos-stable-77-12371-114-0"
+    # Note: Updated from cos to ubuntu for parity with aws.
+    - providerID: gce
+      kubernetesVersion: ">=1.17.0"
+      name: "ubuntu-os-cloud/ubuntu-2004-focal-v20210108"
   cluster:
     kubernetesVersion: v1.5.8
     networking:

--- a/channels/stable
+++ b/channels/stable
@@ -53,6 +53,10 @@ spec:
     - providerID: gce
       kubernetesVersion: ">=1.16.0-alpha.1"
       name: "cos-cloud/cos-stable-77-12371-114-0"
+      # Note: Updated from cos to ubuntu for parity with aws.
+    - providerID: gce
+      kubernetesVersion: ">=1.17.0"
+      name: "ubuntu-os-cloud/ubuntu-2004-focal-v20210108"
   cluster:
     kubernetesVersion: v1.5.8
     networking:

--- a/docs/releases/1.20-NOTES.md
+++ b/docs/releases/1.20-NOTES.md
@@ -10,6 +10,8 @@
 
 * Following kubeadm, control plane nodes are now labelled with `node-role.kubernetes.io/control-plane=""`
 
+* Default node image for GCE changed from COS to Ubuntu for K8s versions >= 1.17.0. This is to more closely align with the AWS implementation (the most mature support) and because COS limits the ability to modify files on its disk.
+
 # Breaking changes
 
 * Support for Kubernetes 1.11 and 1.12 has been removed.

--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -328,5 +328,6 @@ func RecommendedKubernetesVersion(c *Channel, kopsVersionString string) *semver.
 func (c *Channel) HasUpstreamImagePrefix(image string) bool {
 	return strings.HasPrefix(image, "kope.io/k8s-") ||
 		strings.HasPrefix(image, "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-") ||
-		strings.HasPrefix(image, "cos-cloud/cos-stable-")
+		strings.HasPrefix(image, "cos-cloud/cos-stable-") ||
+		strings.HasPrefix(image, "ubuntu-os-cloud/ubuntu-")
 }


### PR DESCRIPTION
I didn't realize we were defaulting to COS on GCE- this changes the default for >=1.17.0. I discovered this while researching #9832. When I tried to use calico on COS on GCE, I ran into the same  filesystem mount issues we saw with coreos on https://github.com/kubernetes/kops/issues/7931. 
Changing to this image fixes everything and calico comes up properly :) 