### PR TITLE
GCE/Refactoring the scopes- cloud-platform ftw

### DIFF
--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -92,7 +92,7 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.ModelBuilderC
 					// See https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances
 					// For current best practices. Grant cloud-platform scope on instance and use Cloud IAM on the
 					// Service Account to grant/restrict access to googleapis.
-					"cloud-platform",
+					"https://www.googleapis.com/auth/cloud-platform",
 					// We might need to do some checks to ensure the node service account has appropriate permissions?
 				},
 				Metadata: map[string]fi.Resource{
@@ -126,7 +126,7 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.ModelBuilderC
 			case kops.InstanceGroupRoleMaster:
 				// Grant DNS permissions
 				// TODO: migrate to IAM permissions instead of oldschool scopes?
-				t.Scopes = append(t.Scopes, "https://www.googleapis.com/auth/ndev.clouddns.readwrite")
+				// t.Scopes = append(t.Scopes, "https://www.googleapis.com/auth/ndev.clouddns.readwrite")
 				t.Tags = append(t.Tags, b.GCETagForRole(kops.InstanceGroupRoleMaster))
 
 			case kops.InstanceGroupRoleNode:

--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -126,7 +126,6 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.ModelBuilderC
 			case kops.InstanceGroupRoleMaster:
 				// Grant DNS permissions
 				// TODO: migrate to IAM permissions instead of oldschool scopes?
-				// t.Scopes = append(t.Scopes, "https://www.googleapis.com/auth/ndev.clouddns.readwrite")
 				t.Tags = append(t.Tags, b.GCETagForRole(kops.InstanceGroupRoleMaster))
 
 			case kops.InstanceGroupRoleNode:

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -365,7 +365,7 @@ resource "google_compute_instance_template" "master-us-test1-a-ha-gce-example-co
   }
   service_account {
     email  = "default"
-    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
   }
   tags = ["ha-gce-example-com-k8s-io-role-master"]
 }
@@ -405,7 +405,7 @@ resource "google_compute_instance_template" "master-us-test1-b-ha-gce-example-co
   }
   service_account {
     email  = "default"
-    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
   }
   tags = ["ha-gce-example-com-k8s-io-role-master"]
 }
@@ -445,7 +445,7 @@ resource "google_compute_instance_template" "master-us-test1-c-ha-gce-example-co
   }
   service_account {
     email  = "default"
-    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
   }
   tags = ["ha-gce-example-com-k8s-io-role-master"]
 }
@@ -485,7 +485,7 @@ resource "google_compute_instance_template" "nodes-ha-gce-example-com" {
   }
   service_account {
     email  = "default"
-    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_only"]
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
   }
   tags = ["ha-gce-example-com-k8s-io-role-node"]
 }

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -277,7 +277,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-examp
   }
   service_account {
     email  = "default"
-    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
   }
   tags = ["minimal-gce-example-com-k8s-io-role-master"]
 }
@@ -317,7 +317,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-example-com" {
   }
   service_account {
     email  = "default"
-    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_only"]
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
   }
   tags = ["minimal-gce-example-com-k8s-io-role-node"]
 }

--- a/upup/pkg/fi/cloudup/gcetasks/instance.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instance.go
@@ -157,13 +157,7 @@ func (_ *Instance) CheckChanges(a, e, changes *Instance) error {
 
 func init() {
 	scopeAliases = map[string]string{
-		"storage-ro":       "https://www.googleapis.com/auth/devstorage.read_only",
-		"storage-rw":       "https://www.googleapis.com/auth/devstorage.read_write",
-		"compute-ro":       "https://www.googleapis.com/auth/compute.read_only",
-		"compute-rw":       "https://www.googleapis.com/auth/compute",
-		"monitoring":       "https://www.googleapis.com/auth/monitoring",
-		"monitoring-write": "https://www.googleapis.com/auth/monitoring.write",
-		"logging-write":    "https://www.googleapis.com/auth/logging.write",
+		"cloud-platform": "https://www.googleapis.com/auth/cloud-platform",
 	}
 }
 


### PR DESCRIPTION
I think we should update our node authz model for GCE to leverage CLoud IAM instead of the old-school scopes. Ie: https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances

This will probably need some iteration before it looks good.